### PR TITLE
External runner fixes

### DIFF
--- a/src/harness/externalCompileRunner.ts
+++ b/src/harness/externalCompileRunner.ts
@@ -2,6 +2,7 @@
 /// <reference path="runnerbase.ts" />
 const fs = require("fs");
 const path = require("path");
+const del = require("del");
 
 interface ExecResult {
     stdout: Buffer;
@@ -27,9 +28,28 @@ abstract class ExternalCompileRunnerBase extends RunnerBase {
         const testList = this.tests && this.tests.length ? this.tests : this.enumerateTestFiles();
 
         describe(`${this.kind()} code samples`, () => {
+            const cwd = path.join(Harness.IO.getWorkspaceRoot(), this.testDir);
+            const placeholderName = ".node_modules";
+            const moduleDirName = "node_modules";
+            before(() => {
+                ts.forEachAncestorDirectory(cwd, dir => {
+                    try {
+                        fs.renameSync(path.join(dir, moduleDirName), path.join(dir, placeholderName));
+                    }
+                    catch {}
+                });
+            });
             for (const test of testList) {
                 this.runTest(typeof test === "string" ? test : test.file);
             }
+            after(() => {
+                ts.forEachAncestorDirectory(cwd, dir => {
+                    try {
+                        fs.renameSync(path.join(dir, placeholderName), path.join(dir, moduleDirName));
+                    }
+                    catch {}
+                });
+            });
         });
     }
     private runTest(directoryName: string) {
@@ -42,6 +62,7 @@ abstract class ExternalCompileRunnerBase extends RunnerBase {
 
             it("should build successfully", () => {
                 let cwd = path.join(Harness.IO.getWorkspaceRoot(), cls.testDir, directoryName);
+                const originalCwd = cwd;
                 const stdio = isWorker ? "pipe" : "inherit";
                 let types: string[];
                 if (fs.existsSync(path.join(cwd, "test.json"))) {
@@ -64,7 +85,7 @@ abstract class ExternalCompileRunnerBase extends RunnerBase {
                         fs.unlinkSync(path.join(cwd, "package-lock.json"));
                     }
                     if (fs.existsSync(path.join(cwd, "node_modules"))) {
-                        require("del").sync(path.join(cwd, "node_modules"), { force: true });
+                        del.sync(path.join(cwd, "node_modules"), { force: true });
                     }
                     const install = cp.spawnSync(`npm`, ["i", "--ignore-scripts"], { cwd, timeout: timeout / 2, shell: true, stdio }); // NPM shouldn't take the entire timeout - if it takes a long time, it should be terminated and we should log the failure
                     if (install.status !== 0) throw new Error(`NPM Install for ${directoryName} failed: ${install.stderr.toString()}`);
@@ -72,6 +93,9 @@ abstract class ExternalCompileRunnerBase extends RunnerBase {
                 const args = [path.join(Harness.IO.getWorkspaceRoot(), "built/local/tsc.js")];
                 if (types) {
                     args.push("--types", types.join(","));
+                    // Also actually install those types (for, eg, the js projects which need node)
+                    const install = cp.spawnSync(`npm`, ["i", ...types.map(t => `@types/${t}`), "--no-save", "--ignore-scripts"], { cwd: originalCwd, timeout: timeout / 2, shell: true, stdio }); // NPM shouldn't take the entire timeout - if it takes a long time, it should be terminated and we should log the failure
+                    if (install.status !== 0) throw new Error(`NPM Install types for ${directoryName} failed: ${install.stderr.toString()}`);
                 }
                 args.push("--noEmit");
                 Harness.Baseline.runBaseline(`${cls.kind()}/${directoryName}.log`, () => {
@@ -91,7 +115,7 @@ class UserCodeRunner extends ExternalCompileRunnerBase {
         // tslint:disable-next-line:no-null-keyword
         return result.status === 0 && !result.stdout.length && !result.stderr.length ? null : `Exit Code: ${result.status}
 Standard output:
-${stripAbsoluteImportPaths(result.stdout.toString().replace(/\r\n/g, "\n"))}
+${sortErrors(stripAbsoluteImportPaths(result.stdout.toString().replace(/\r\n/g, "\n")))}
 
 
 Standard error:
@@ -107,6 +131,29 @@ function stripAbsoluteImportPaths(result: string) {
     return result
         .replace(/import\(".*?\/tests\/cases\/user\//g, `import("/`)
         .replace(/Module '".*?\/tests\/cases\/user\//g, `Module '"/`);
+}
+
+function sortErrors(result: string) {
+    return ts.flatten(splitBy(result.split("\n"), s => /^\S+/.test(s)).sort(compareErrorStrings)).join("\n");
+}
+
+const errorRegexp = /^(.+\.[tj]sx?)\((\d+),(\d+)\): error TS/;
+function compareErrorStrings(a: string[], b: string[]) {
+    ts.Debug.assertGreaterThanOrEqual(a.length, 1);
+    ts.Debug.assertGreaterThanOrEqual(b.length, 1);
+    const matchA = a[0].match(errorRegexp);
+    if (!matchA) {
+        return -1;
+    }
+    const matchB = b[0].match(errorRegexp);
+    if (!matchB) {
+        return 1;
+    }
+    const [, errorFileA, lineNumberStringA, columnNumberStringA] = matchA;
+    const [, errorFileB, lineNumberStringB, columnNumberStringB] = matchB;
+    return ts.comparePathsCaseSensitive(errorFileA, errorFileB) ||
+        ts.compareValues(parseInt(lineNumberStringA), parseInt(lineNumberStringB)) ||
+        ts.compareValues(parseInt(columnNumberStringA), parseInt(columnNumberStringB));
 }
 
 class DefinitelyTypedRunner extends ExternalCompileRunnerBase {

--- a/src/harness/externalCompileRunner.ts
+++ b/src/harness/externalCompileRunner.ts
@@ -36,7 +36,9 @@ abstract class ExternalCompileRunnerBase extends RunnerBase {
                     try {
                         fs.renameSync(path.join(dir, moduleDirName), path.join(dir, placeholderName));
                     }
-                    catch {}
+                    catch {
+                        // empty
+                    }
                 });
             });
             for (const test of testList) {
@@ -47,7 +49,9 @@ abstract class ExternalCompileRunnerBase extends RunnerBase {
                     try {
                         fs.renameSync(path.join(dir, placeholderName), path.join(dir, moduleDirName));
                     }
-                    catch {}
+                    catch {
+                        // empty
+                    }
                 });
             });
         });

--- a/tests/baselines/reference/user/adonis-framework.log
+++ b/tests/baselines/reference/user/adonis-framework.log
@@ -146,6 +146,12 @@ node_modules/adonis-framework/src/Session/Drivers/File/index.js(79,15): error TS
 node_modules/adonis-framework/src/Session/Drivers/Redis/index.js(23,14): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 node_modules/adonis-framework/src/Session/Drivers/Redis/index.js(59,15): error TS2322: Type 'IterableIterator<any>' is not assignable to type 'boolean'.
 node_modules/adonis-framework/src/Session/Drivers/Redis/index.js(72,15): error TS2322: Type 'IterableIterator<any>' is not assignable to type 'boolean'.
+node_modules/adonis-framework/src/Session/SessionManager.js(13,21): error TS2307: Cannot find module 'adonis-fold'.
+node_modules/adonis-framework/src/Session/SessionManager.js(69,22): error TS2339: Property 'drivers' does not exist on type 'Function'.
+node_modules/adonis-framework/src/Session/SessionManager.js(69,49): error TS2339: Property 'drivers' does not exist on type 'Function'.
+node_modules/adonis-framework/src/Session/SessionManager.js(71,76): error TS2339: Property 'drivers' does not exist on type 'Function'.
+node_modules/adonis-framework/src/Session/Store.js(28,13): error TS2304: Cannot find name 'Mixed'.
+node_modules/adonis-framework/src/Session/Store.js(80,13): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/Session/index.js(10,14): error TS2304: Cannot find name 'SessionDriver'.
 node_modules/adonis-framework/src/Session/index.js(11,2): error TS1003: Identifier expected.
 node_modules/adonis-framework/src/Session/index.js(11,11): error TS2304: Cannot find name 'Class'.
@@ -173,12 +179,6 @@ node_modules/adonis-framework/src/Session/index.js(249,15): error TS2304: Cannot
 node_modules/adonis-framework/src/Session/index.js(267,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/Session/index.js(287,15): error TS2322: Type 'IterableIterator<any>' is not assignable to type 'boolean'.
 node_modules/adonis-framework/src/Session/index.js(293,12): error TS2532: Object is possibly 'undefined'.
-node_modules/adonis-framework/src/Session/SessionManager.js(13,21): error TS2307: Cannot find module 'adonis-fold'.
-node_modules/adonis-framework/src/Session/SessionManager.js(69,22): error TS2339: Property 'drivers' does not exist on type 'Function'.
-node_modules/adonis-framework/src/Session/SessionManager.js(69,49): error TS2339: Property 'drivers' does not exist on type 'Function'.
-node_modules/adonis-framework/src/Session/SessionManager.js(71,76): error TS2339: Property 'drivers' does not exist on type 'Function'.
-node_modules/adonis-framework/src/Session/Store.js(28,13): error TS2304: Cannot find name 'Mixed'.
-node_modules/adonis-framework/src/Session/Store.js(80,13): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/View/Form/index.js(75,11): error TS2532: Object is possibly 'undefined'.
 node_modules/adonis-framework/src/View/Form/index.js(115,15): error TS2304: Cannot find name 'Mixed'.
 node_modules/adonis-framework/src/View/Form/index.js(147,63): error TS2345: Argument of type 'string | any[]' is not assignable to parameter of type 'any[]'.

--- a/tests/baselines/reference/user/async.log
+++ b/tests/baselines/reference/user/async.log
@@ -43,8 +43,8 @@ node_modules/async/auto.js(159,18): error TS2695: Left side of comma operator is
 node_modules/async/auto.js(159,50): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/autoInject.js(44,17): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/autoInject.js(134,6): error TS2695: Left side of comma operator is unused and has no side effects.
-node_modules/async/autoInject.js(136,25): error TS2532: Object is possibly 'undefined'.
 node_modules/async/autoInject.js(136,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/autoInject.js(136,25): error TS2532: Object is possibly 'undefined'.
 node_modules/async/autoInject.js(136,26): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/autoInject.js(139,14): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/autoInject.js(160,28): error TS2695: Left side of comma operator is unused and has no side effects.
@@ -145,9 +145,9 @@ node_modules/async/dist/async.js(2963,25): error TS2722: Cannot invoke an object
 node_modules/async/dist/async.js(2970,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(2971,28): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(3005,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
-node_modules/async/dist/async.js(3008,9): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(3008,9): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
   Type 'undefined' is not assignable to type 'Function'.
+node_modules/async/dist/async.js(3008,9): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(3081,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(3086,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(3087,28): error TS2722: Cannot invoke an object which is possibly 'undefined'.
@@ -175,18 +175,18 @@ node_modules/async/dist/async.js(4153,14): error TS2339: Property 'unshift' does
 node_modules/async/dist/async.js(4367,5): error TS2322: Type 'any[] | {}' is not assignable to type 'any[]'.
   Type '{}' is not assignable to type 'any[]'.
     Property 'flatMap' is missing in type '{}'.
-node_modules/async/dist/async.js(4603,17): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(4603,17): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
   Type 'undefined' is not assignable to type 'Function'.
+node_modules/async/dist/async.js(4603,17): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(4917,19): error TS2339: Property 'code' does not exist on type 'Error'.
 node_modules/async/dist/async.js(4919,23): error TS2339: Property 'info' does not exist on type 'Error'.
 node_modules/async/dist/async.js(5090,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(5146,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/async/dist/async.js(5165,20): error TS2339: Property 'unmemoized' does not exist on type 'Function'.
 node_modules/async/dist/async.js(5208,25): error TS2722: Cannot invoke an object which is possibly 'undefined'.
-node_modules/async/dist/async.js(5211,9): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(5211,9): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
   Type 'undefined' is not assignable to type 'Function'.
+node_modules/async/dist/async.js(5211,9): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(5315,20): error TS2532: Object is possibly 'undefined'.
 node_modules/async/dist/async.js(5315,20): error TS2684: The 'this' context of type 'Function | undefined' is not assignable to method's 'this' of type 'Function'.
   Type 'undefined' is not assignable to type 'Function'.
@@ -240,8 +240,8 @@ node_modules/async/eachSeries.js(28,12): error TS2304: Cannot find name 'AsyncFu
 node_modules/async/eachSeries.js(36,20): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/ensureAsync.js(34,12): error TS2304: Cannot find name 'AsyncFunction'.
 node_modules/async/ensureAsync.js(36,14): error TS2304: Cannot find name 'AsyncFunction'.
-node_modules/async/ensureAsync.js(56,9): error TS2532: Object is possibly 'undefined'.
 node_modules/async/ensureAsync.js(56,9): error TS2722: Cannot invoke an object which is possibly 'undefined'.
+node_modules/async/ensureAsync.js(56,9): error TS2532: Object is possibly 'undefined'.
 node_modules/async/ensureAsync.js(56,10): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/ensureAsync.js(57,13): error TS2695: Left side of comma operator is unused and has no side effects.
 node_modules/async/ensureAsync.js(62,18): error TS2695: Left side of comma operator is unused and has no side effects.

--- a/tests/baselines/reference/user/bcryptjs.log
+++ b/tests/baselines/reference/user/bcryptjs.log
@@ -3,13 +3,6 @@ Standard output:
 node_modules/bcryptjs/scripts/build.js(1,26): error TS2307: Cannot find module 'metascript'.
 node_modules/bcryptjs/scripts/build.js(32,1): error TS2322: Type '{ VERSION: any; }' is not assignable to type '{ [x: string]: any; VERSION: any; ISAAC: boolean; }'.
   Property 'ISAAC' is missing in type '{ VERSION: any; }'.
-node_modules/bcryptjs/src/bcrypt.js(25,13): error TS2322: Type 'Buffer' is not assignable to type 'number[]'.
-  Property 'flatMap' is missing in type 'Buffer'.
-node_modules/bcryptjs/src/bcrypt.js(94,14): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
-node_modules/bcryptjs/src/bcrypt.js(150,5): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
-  Type 'undefined' is not assignable to type 'string'.
-node_modules/bcryptjs/src/bcrypt.js(160,14): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
-node_modules/bcryptjs/src/bcrypt.js(238,14): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
 node_modules/bcryptjs/src/bcrypt/impl.js(516,22): error TS2345: Argument of type 'Int32Array | number[]' is not assignable to parameter of type 'number[]'.
   Type 'Int32Array' is not assignable to type 'number[]'.
     Property 'flatMap' is missing in type 'Int32Array'.
@@ -27,6 +20,13 @@ node_modules/bcryptjs/src/bcrypt/prng/accum.js(65,74): error TS2339: Property 'd
 node_modules/bcryptjs/src/bcrypt/prng/accum.js(66,22): error TS2339: Property 'detachEvent' does not exist on type 'Document'.
 node_modules/bcryptjs/src/bcrypt/prng/accum.js(67,22): error TS2339: Property 'detachEvent' does not exist on type 'Document'.
 node_modules/bcryptjs/src/bcrypt/util.js(20,5): error TS2304: Cannot find name 'utfx'.
+node_modules/bcryptjs/src/bcrypt.js(25,13): error TS2322: Type 'Buffer' is not assignable to type 'number[]'.
+  Property 'flatMap' is missing in type 'Buffer'.
+node_modules/bcryptjs/src/bcrypt.js(94,14): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
+node_modules/bcryptjs/src/bcrypt.js(150,5): error TS2322: Type 'string | undefined' is not assignable to type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
+node_modules/bcryptjs/src/bcrypt.js(160,14): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
+node_modules/bcryptjs/src/bcrypt.js(238,14): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
 node_modules/bcryptjs/src/wrap.js(37,26): error TS2304: Cannot find name 'define'.
 node_modules/bcryptjs/src/wrap.js(37,51): error TS2304: Cannot find name 'define'.
 node_modules/bcryptjs/src/wrap.js(38,9): error TS2304: Cannot find name 'define'.

--- a/tests/baselines/reference/user/chrome-devtools-frontend.log
+++ b/tests/baselines/reference/user/chrome-devtools-frontend.log
@@ -15,6 +15,154 @@ Standard output:
 ../../../../built/local/lib.es5.d.ts(1346,11): error TS2300: Duplicate identifier 'ArrayLike'.
 ../../../../built/local/lib.es5.d.ts(1382,6): error TS2300: Duplicate identifier 'Record'.
 ../../../../node_modules/@types/node/index.d.ts(150,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'module' must be of type '{ [x: string]: any; }', but here has type 'NodeModule'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(43,8): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(95,28): error TS2339: Property 'response' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(147,37): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(158,21): error TS2345: Argument of type 'Promise<string>' is not assignable to parameter of type 'Promise<undefined>'.
+  Type 'string' is not assignable to type 'undefined'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(161,5): error TS2322: Type 'Promise<undefined[]>' is not assignable to type 'Promise<undefined>'.
+  Type 'undefined[]' is not assignable to type 'undefined'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(187,12): error TS2339: Property 'eval' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(197,5): error TS2322: Type 'Promise<string>' is not assignable to type 'Promise<undefined>'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(267,14): error TS2339: Property 'runtime' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(269,59): error TS2339: Property 'runtime' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(270,9): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
+  Type 'void' is not assignable to type 'undefined'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(280,5): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(283,7): error TS2554: Expected 2-3 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(398,24): error TS1138: Parameter declaration expected.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(398,24): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(527,9): error TS2322: Type 'Function' is not assignable to type 'new () => any'.
+  Type 'Function' provides no match for the signature 'new (): any'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(527,49): error TS2352: Type 'Window' cannot be converted to type 'Function'.
+  Property 'apply' is missing in type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(539,20): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(693,7): error TS2322: Type 'Promise<boolean>' is not assignable to type 'Promise<undefined>'.
+  Type 'boolean' is not assignable to type 'undefined'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(693,7): error TS2322: Type 'Promise<boolean>' is not assignable to type 'Promise<undefined>'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(705,5): error TS2322: Type 'Promise<boolean>' is not assignable to type 'Promise<undefined>'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(715,7): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(721,5): error TS2322: Type 'Promise<undefined[]>' is not assignable to type 'Promise<undefined>'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(729,7): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(854,36): error TS2339: Property 'eval' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(1083,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
+node_modules/chrome-devtools-frontend/front_end/Runtime.js(1088,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(107,5): error TS2322: Type 'Timer' is not assignable to type 'number'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(208,5): error TS2554: Expected 4 arguments, but got 3.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(221,7): error TS2554: Expected 4 arguments, but got 3.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(378,10): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
+node_modules/chrome-devtools-frontend/front_end/Tests.js(397,5): error TS2554: Expected 4 arguments, but got 3.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(416,5): error TS2554: Expected 4 arguments, but got 3.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(440,5): error TS2554: Expected 4 arguments, but got 3.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(475,5): error TS2554: Expected 4 arguments, but got 3.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(571,33): error TS2339: Property 'deprecatedRunAfterPendingDispatches' does not exist on type 'typeof InspectorBackend'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(590,27): error TS2554: Expected 0 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(687,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(711,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(735,5): error TS2554: Expected 4 arguments, but got 3.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(769,28): error TS2339: Property 'networkPresets' does not exist on type 'typeof MobileThrottling'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(775,28): error TS2339: Property 'networkPresets' does not exist on type 'typeof MobileThrottling'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(781,28): error TS2339: Property 'networkPresets' does not exist on type 'typeof MobileThrottling'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(814,31): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
+node_modules/chrome-devtools-frontend/front_end/Tests.js(816,7): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(847,9): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(848,9): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(886,29): error TS2339: Property 'getPreferences' does not exist on type 'typeof InspectorFrontendHost'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(890,17): error TS2339: Property '_instanceForTest' does not exist on type 'typeof Main'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(893,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(894,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(895,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(897,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(898,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(899,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(917,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(918,7): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(929,33): error TS2339: Property 'ConsoleView' does not exist on type '{ new (): Console; prototype: Console; }'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(934,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(935,7): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(959,11): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(960,11): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(961,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(965,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(966,11): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(967,11): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(968,11): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(969,11): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(970,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(974,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(975,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(976,11): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(977,11): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(978,11): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(986,5): error TS2554: Expected 3 arguments, but got 2.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(988,5): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1033,25): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1040,23): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1084,20): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1139,33): error TS2339: Property 'ConsoleView' does not exist on type '{ new (): Console; prototype: Console; }'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1142,31): error TS2339: Property 'ConsoleView' does not exist on type '{ new (): Console; prototype: Console; }'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1186,5): error TS2554: Expected 4 arguments, but got 3.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1199,9): error TS2554: Expected 4 arguments, but got 3.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1199,28): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1229,10): error TS2339: Property 'uiTests' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/Tests.js(1229,41): error TS2339: Property 'domAutomationController' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(9,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(11,46): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(45,27): error TS2694: Namespace 'DOMNode' has no exported member 'Attribute'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(64,18): error TS2339: Property 'setTextContentTruncatedIfNeeded' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(77,26): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(79,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(109,11): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(128,31): error TS2339: Property 'textContent' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(139,18): error TS2339: Property 'getComponentSelection' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(171,15): error TS2339: Property 'handled' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(175,43): error TS2339: Property 'textContent' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(176,13): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(180,15): error TS2339: Property 'keyCode' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(180,70): error TS2339: Property 'keyIdentifier' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(182,13): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(209,39): error TS2694: Namespace 'SuggestBox' has no exported member 'Suggestions'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(213,36): error TS2339: Property '_isEditingName' does not exist on type 'ARIAAttributePrompt'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAConfig.js(5,28): error TS2339: Property '_config' does not exist on type 'typeof ARIAMetadata'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(56,35): error TS2339: Property '_instance' does not exist on type 'typeof ARIAMetadata'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(57,32): error TS2339: Property '_instance' does not exist on type 'typeof ARIAMetadata'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(57,102): error TS2339: Property '_config' does not exist on type 'typeof ARIAMetadata'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(58,37): error TS2339: Property '_instance' does not exist on type 'typeof ARIAMetadata'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(10,11): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(14,18): error TS2339: Property 'tabIndex' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(24,38): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(40,51): error TS2339: Property 'focus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(42,20): error TS2339: Property 'focus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(50,33): error TS2339: Property 'hasFocus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(115,16): error TS2339: Property 'path' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(117,15): error TS2339: Property 'shiftKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(117,33): error TS2339: Property 'metaKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(117,50): error TS2339: Property 'ctrlKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(121,16): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(121,43): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(121,74): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(123,21): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(123,50): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(123,82): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(129,13): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(160,33): error TS2339: Property 'hasFocus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(184,42): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(208,42): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(265,42): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(274,42): error TS2554: Expected 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(298,19): error TS2339: Property 'breadcrumb' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(302,23): error TS2339: Property 'tabIndex' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(314,15): error TS1110: Type expected.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(323,23): error TS2339: Property 'style' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(330,27): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(391,50): error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(393,50): error TS2345: Argument of type '-1' is not assignable to parameter of type 'string'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(396,27): error TS2339: Property 'focus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(447,26): error TS2339: Property 'breadcrumb' does not exist on type 'Node'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(457,30): error TS2339: Property 'breadcrumb' does not exist on type 'Node'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(473,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(481,17): error TS2339: Property 'setTextContentTruncatedIfNeeded' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(488,38): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel.js(10,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel.js(54,32): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityModel.js(61,25): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
@@ -101,63 +249,6 @@ node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilityNodeV
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilitySidebarView.js(129,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilitySidebarView.js(141,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/accessibility/AccessibilitySidebarView.js(195,29): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(9,11): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(11,46): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(45,27): error TS2694: Namespace 'DOMNode' has no exported member 'Attribute'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(64,18): error TS2339: Property 'setTextContentTruncatedIfNeeded' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(77,26): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(79,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(109,11): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(128,31): error TS2339: Property 'textContent' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(139,18): error TS2339: Property 'getComponentSelection' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(171,15): error TS2339: Property 'handled' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(175,43): error TS2339: Property 'textContent' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(176,13): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(180,15): error TS2339: Property 'keyCode' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(180,70): error TS2339: Property 'keyIdentifier' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(182,13): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(209,39): error TS2694: Namespace 'SuggestBox' has no exported member 'Suggestions'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAAttributesView.js(213,36): error TS2339: Property '_isEditingName' does not exist on type 'ARIAAttributePrompt'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAConfig.js(5,28): error TS2339: Property '_config' does not exist on type 'typeof ARIAMetadata'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(56,35): error TS2339: Property '_instance' does not exist on type 'typeof ARIAMetadata'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(57,32): error TS2339: Property '_instance' does not exist on type 'typeof ARIAMetadata'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(57,102): error TS2339: Property '_config' does not exist on type 'typeof ARIAMetadata'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/ARIAMetadata.js(58,37): error TS2339: Property '_instance' does not exist on type 'typeof ARIAMetadata'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(10,11): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(14,18): error TS2339: Property 'tabIndex' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(24,38): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(40,51): error TS2339: Property 'focus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(42,20): error TS2339: Property 'focus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(50,33): error TS2339: Property 'hasFocus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(115,16): error TS2339: Property 'path' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(117,15): error TS2339: Property 'shiftKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(117,33): error TS2339: Property 'metaKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(117,50): error TS2339: Property 'ctrlKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(121,16): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(121,43): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(121,74): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(123,21): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(123,50): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(123,82): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(129,13): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(160,33): error TS2339: Property 'hasFocus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(184,42): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(208,42): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(265,42): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(274,42): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(298,19): error TS2339: Property 'breadcrumb' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(302,23): error TS2339: Property 'tabIndex' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(314,15): error TS1110: Type expected.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(323,23): error TS2339: Property 'style' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(330,27): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(391,50): error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(393,50): error TS2345: Argument of type '-1' is not assignable to parameter of type 'string'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(396,27): error TS2339: Property 'focus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(447,26): error TS2339: Property 'breadcrumb' does not exist on type 'Node'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(457,30): error TS2339: Property 'breadcrumb' does not exist on type 'Node'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(473,24): error TS2694: Namespace 'Protocol' has no exported member 'Accessibility'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(481,17): error TS2339: Property 'setTextContentTruncatedIfNeeded' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/accessibility/AXBreadcrumbsPane.js(488,38): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/accessibility_test_runner/AccessibilityPaneTestRunner.js(11,15): error TS2339: Property 'runtime' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/accessibility_test_runner/AccessibilityPaneTestRunner.js(17,12): error TS2339: Property 'runtime' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/animation/AnimationGroupPreviewUI.js(7,11): error TS2339: Property 'AnimationGroupPreviewUI' does not exist on type '{ new (effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation; prototype: Ani...'.
@@ -410,6 +501,14 @@ node_modules/chrome-devtools-frontend/front_end/application_test_runner/IndexedD
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/IndexedDBTestRunner.js(47,35): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/IndexedDBTestRunner.js(140,24): error TS2554: Expected 1 arguments, but got 2.
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/IndexedDBTestRunner.js(140,96): error TS2339: Property 'securityOriginManager' does not exist on type 'typeof TestRunner'.
+node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(20,14): error TS2339: Property 'resourceTreeModel' does not exist on type 'typeof TestRunner'.
+node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(34,14): error TS2339: Property 'resourceTreeModel' does not exist on type 'typeof TestRunner'.
+node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(37,59): error TS2339: Property 'resourceTreeModel' does not exist on type 'typeof TestRunner'.
+node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(69,11): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
+node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(71,30): error TS2339: Property '_testSourceNavigator' does not exist on type 'typeof ApplicationTestRunner'.
+node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(72,27): error TS2339: Property '_testSourceNavigator' does not exist on type 'typeof ApplicationTestRunner'.
+node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(73,27): error TS2339: Property '_testSourceNavigator' does not exist on type 'typeof ApplicationTestRunner'.
+node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(76,71): error TS2339: Property '_testSourceNavigator' does not exist on type 'typeof ApplicationTestRunner'.
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourcesTestRunner.js(18,20): error TS2339: Property 'mainTarget' does not exist on type 'typeof TestRunner'.
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourcesTestRunner.js(30,19): error TS2339: Property 'resourceTreeModel' does not exist on type 'typeof TestRunner'.
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourcesTestRunner.js(31,16): error TS2339: Property 'resourceTreeModel' does not exist on type 'typeof TestRunner'.
@@ -421,14 +520,6 @@ node_modules/chrome-devtools-frontend/front_end/application_test_runner/Resource
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourcesTestRunner.js(103,21): error TS2339: Property 'mainTarget' does not exist on type 'typeof TestRunner'.
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourcesTestRunner.js(107,21): error TS2339: Property 'mainTarget' does not exist on type 'typeof TestRunner'.
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourcesTestRunner.js(111,21): error TS2339: Property 'mainTarget' does not exist on type 'typeof TestRunner'.
-node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(20,14): error TS2339: Property 'resourceTreeModel' does not exist on type 'typeof TestRunner'.
-node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(34,14): error TS2339: Property 'resourceTreeModel' does not exist on type 'typeof TestRunner'.
-node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(37,59): error TS2339: Property 'resourceTreeModel' does not exist on type 'typeof TestRunner'.
-node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(69,11): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
-node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(71,30): error TS2339: Property '_testSourceNavigator' does not exist on type 'typeof ApplicationTestRunner'.
-node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(72,27): error TS2339: Property '_testSourceNavigator' does not exist on type 'typeof ApplicationTestRunner'.
-node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(73,27): error TS2339: Property '_testSourceNavigator' does not exist on type 'typeof ApplicationTestRunner'.
-node_modules/chrome-devtools-frontend/front_end/application_test_runner/ResourceTreeTestRunner.js(76,71): error TS2339: Property '_testSourceNavigator' does not exist on type 'typeof ApplicationTestRunner'.
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/ServiceWorkersTestRunner.js(44,19): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/ServiceWorkersTestRunner.js(55,14): error TS2339: Property 'serviceWorkerManager' does not exist on type 'typeof TestRunner'.
 node_modules/chrome-devtools-frontend/front_end/application_test_runner/ServiceWorkersTestRunner.js(57,18): error TS2339: Property 'serviceWorkerManager' does not exist on type 'typeof TestRunner'.
@@ -660,8 +751,6 @@ node_modules/chrome-devtools-frontend/front_end/audits2_test_runner/Audits2TestR
 node_modules/chrome-devtools-frontend/front_end/audits2_test_runner/Audits2TestRunner.js(77,40): error TS2339: Property 'checkboxElement' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/audits2_test_runner/Audits2TestRunner.js(89,29): error TS2339: Property 'disabled' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/audits2_test_runner/Audits2TestRunner.js(102,24): error TS2488: Type 'NodeListOf<Element>' must have a '[Symbol.iterator]()' method that returns an iterator.
-node_modules/chrome-devtools-frontend/front_end/audits2_worker.js(5,11): error TS2339: Property 'Runtime' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/audits2_worker.js(6,8): error TS2339: Property 'importScripts' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/audits2_worker/Audits2Service.js(33,31): error TS1003: Identifier expected.
 node_modules/chrome-devtools-frontend/front_end/audits2_worker/Audits2Service.js(33,31): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/chrome-devtools-frontend/front_end/audits2_worker/Audits2Service.js(40,25): error TS2503: Cannot find namespace 'ReportRenderer'.
@@ -3076,6 +3165,8 @@ node_modules/chrome-devtools-frontend/front_end/audits2_worker/lighthouse/lighth
 node_modules/chrome-devtools-frontend/front_end/audits2_worker/lighthouse/lighthouse-background.js(70756,10): error TS2531: Object is possibly 'null'.
 node_modules/chrome-devtools-frontend/front_end/audits2_worker/lighthouse/lighthouse-background.js(70756,45): error TS2531: Object is possibly 'null'.
 node_modules/chrome-devtools-frontend/front_end/audits2_worker/lighthouse/lighthouse-background.js(70848,34): error TS2304: Cannot find name 'fs'.
+node_modules/chrome-devtools-frontend/front_end/audits2_worker.js(5,11): error TS2339: Property 'Runtime' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/audits2_worker.js(6,8): error TS2339: Property 'importScripts' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/bindings/BlackboxManager.js(22,21): error TS1005: '>' expected.
 node_modules/chrome-devtools-frontend/front_end/bindings/BlackboxManager.js(25,71): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
 node_modules/chrome-devtools-frontend/front_end/bindings/BlackboxManager.js(69,72): error TS2339: Property 'getAsArray' does not exist on type 'Setting<any>'.
@@ -3124,15 +3215,6 @@ node_modules/chrome-devtools-frontend/front_end/bindings/BreakpointManager.js(66
 node_modules/chrome-devtools-frontend/front_end/bindings/BreakpointManager.js(713,51): error TS2339: Property 'valuesArray' does not exist on type 'Map<DebuggerModel, ModelBreakpoint>'.
 node_modules/chrome-devtools-frontend/front_end/bindings/BreakpointManager.js(863,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
 node_modules/chrome-devtools-frontend/front_end/bindings/BreakpointManager.js(905,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(48,52): error TS2345: Argument of type 'string' is not assignable to parameter of type '{ [x: string]: any; Debugger: string; Formatter: string; Network: string; Snippets: string; FileS...'.
-node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(50,62): error TS2345: Argument of type 'string' is not assignable to parameter of type '{ [x: string]: any; Debugger: string; Formatter: string; Network: string; Snippets: string; FileS...'.
-node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(59,56): error TS2345: Argument of type 'string' is not assignable to parameter of type '{ [x: string]: any; Debugger: string; Formatter: string; Network: string; Snippets: string; FileS...'.
-node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(184,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(194,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(202,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(218,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/bindings/ContentProviderBasedProject.js(39,25): error TS2694: Namespace 'Workspace' has no exported member 'projectTypes'.
-node_modules/chrome-devtools-frontend/front_end/bindings/ContentProviderBasedProject.js(180,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/bindings/CSSWorkspaceBinding.js(64,19): error TS2365: Operator '!==' cannot be applied to types '{ [x: string]: any; Regular: string; Inline: string; Attributes: string; }' and 'string'.
 node_modules/chrome-devtools-frontend/front_end/bindings/CSSWorkspaceBinding.js(104,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'rawLocations' must be of type 'CSSLocation[]', but here has type 'any[]'.
 node_modules/chrome-devtools-frontend/front_end/bindings/CSSWorkspaceBinding.js(106,20): error TS2339: Property 'pushAll' does not exist on type 'CSSLocation[]'.
@@ -3152,6 +3234,15 @@ node_modules/chrome-devtools-frontend/front_end/bindings/CSSWorkspaceBinding.js(
 node_modules/chrome-devtools-frontend/front_end/bindings/CSSWorkspaceBinding.js(218,30): error TS2339: Property 'set' does not exist on type 'Multimap'.
 node_modules/chrome-devtools-frontend/front_end/bindings/CSSWorkspaceBinding.js(221,21): error TS2339: Property 'deleteAll' does not exist on type 'Multimap'.
 node_modules/chrome-devtools-frontend/front_end/bindings/CSSWorkspaceBinding.js(232,41): error TS2551: Property 'resourceMapping' does not exist on type 'typeof Bindings'. Did you mean 'ResourceMapping'?
+node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(48,52): error TS2345: Argument of type 'string' is not assignable to parameter of type '{ [x: string]: any; Debugger: string; Formatter: string; Network: string; Snippets: string; FileS...'.
+node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(50,62): error TS2345: Argument of type 'string' is not assignable to parameter of type '{ [x: string]: any; Debugger: string; Formatter: string; Network: string; Snippets: string; FileS...'.
+node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(59,56): error TS2345: Argument of type 'string' is not assignable to parameter of type '{ [x: string]: any; Debugger: string; Formatter: string; Network: string; Snippets: string; FileS...'.
+node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(184,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(194,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(202,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/bindings/CompilerScriptMapping.js(218,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/bindings/ContentProviderBasedProject.js(39,25): error TS2694: Namespace 'Workspace' has no exported member 'projectTypes'.
+node_modules/chrome-devtools-frontend/front_end/bindings/ContentProviderBasedProject.js(180,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/bindings/DebuggerWorkspaceBinding.js(51,31): error TS2339: Property 'remove' does not exist on type 'Map<DebuggerModel, ModelData>'.
 node_modules/chrome-devtools-frontend/front_end/bindings/DebuggerWorkspaceBinding.js(85,5): error TS2322: Type 'StackTraceTopFrameLocation' is not assignable to type '{ [x: string]: any; update(): void; uiLocation(): UILocation; dispose(): void; isBlackboxed(): bo...'.
 node_modules/chrome-devtools-frontend/front_end/bindings/DebuggerWorkspaceBinding.js(85,5): error TS2322: Type 'StackTraceTopFrameLocation' is not assignable to type '{ [x: string]: any; update(): void; uiLocation(): UILocation; dispose(): void; isBlackboxed(): bo...'.
@@ -3498,6 +3589,7 @@ node_modules/chrome-devtools-frontend/front_end/cm_headless/headlesscodemirror.j
 node_modules/chrome-devtools-frontend/front_end/cm_headless/headlesscodemirror.js(153,32): error TS2339: Property 'blankLine' does not exist on type 'void'.
 node_modules/chrome-devtools-frontend/front_end/cm_headless/headlesscodemirror.js(153,48): error TS2339: Property 'blankLine' does not exist on type 'void'.
 node_modules/chrome-devtools-frontend/front_end/cm_headless/headlesscodemirror.js(155,24): error TS2339: Property 'token' does not exist on type 'void'.
+node_modules/chrome-devtools-frontend/front_end/cm_modes/DefaultCodeMirrorMimeMode.js(22,14): error TS2339: Property 'eval' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/cm_modes/clike.js(6,17): error TS2307: Cannot find module '../../lib/codemirror'.
 node_modules/chrome-devtools-frontend/front_end/cm_modes/clike.js(7,19): error TS2304: Cannot find name 'define'.
 node_modules/chrome-devtools-frontend/front_end/cm_modes/clike.js(7,43): error TS2304: Cannot find name 'define'.
@@ -3513,7 +3605,6 @@ node_modules/chrome-devtools-frontend/front_end/cm_modes/coffeescript.js(12,5): 
 node_modules/chrome-devtools-frontend/front_end/cm_modes/coffeescript.js(41,3): error TS2322: Type 'RegExp' is not assignable to type 'string[]'.
   Property 'flatMap' is missing in type 'RegExp'.
 node_modules/chrome-devtools-frontend/front_end/cm_modes/coffeescript.js(282,24): error TS2339: Property 'exec' does not exist on type 'string[]'.
-node_modules/chrome-devtools-frontend/front_end/cm_modes/DefaultCodeMirrorMimeMode.js(22,14): error TS2339: Property 'eval' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/cm_modes/jsx.js(6,5): error TS2554: Expected 0-1 arguments, but got 3.
 node_modules/chrome-devtools-frontend/front_end/cm_modes/jsx.js(6,17): error TS2307: Cannot find module '../../lib/codemirror'.
 node_modules/chrome-devtools-frontend/front_end/cm_modes/jsx.js(6,50): error TS2307: Cannot find module '../xml/xml'.
@@ -3836,19 +3927,6 @@ node_modules/chrome-devtools-frontend/front_end/common/UIString.js(81,54): error
 node_modules/chrome-devtools-frontend/front_end/common/UIString.js(93,6): error TS2339: Property 'ls' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/common/Worker.js(52,30): error TS2339: Property 'data' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/common/Worker.js(82,25): error TS2315: Type 'MessageEvent' is not generic.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(42,46): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(44,62): error TS2339: Property 'closeWindow' does not exist on type 'typeof InspectorFrontendHost'.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(70,7): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(70,41): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(70,76): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(71,7): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(116,33): error TS2339: Property 'deepActiveElement' does not exist on type 'Document'.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(122,27): error TS2339: Property 'setIsDocked' does not exist on type 'typeof InspectorFrontendHost'.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(193,5): error TS2322: Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-  Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-node_modules/chrome-devtools-frontend/front_end/components/DockController.js(193,5): error TS2322: Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-  Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-    Property 'item' is missing in type 'ToolbarButton'.
 node_modules/chrome-devtools-frontend/front_end/components/DOMBreakpointsSidebarPane.js(39,45): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/components/DOMBreakpointsSidebarPane.js(40,46): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/components/DOMBreakpointsSidebarPane.js(41,38): error TS2555: Expected at least 2 arguments, but got 1.
@@ -3905,6 +3983,19 @@ node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.
 node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(259,13): error TS2554: Expected 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(643,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/components/DOMPresentationUtils.js(657,19): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(42,46): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(44,62): error TS2339: Property 'closeWindow' does not exist on type 'typeof InspectorFrontendHost'.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(70,7): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(70,41): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(70,76): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(71,7): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(116,33): error TS2339: Property 'deepActiveElement' does not exist on type 'Document'.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(122,27): error TS2339: Property 'setIsDocked' does not exist on type 'typeof InspectorFrontendHost'.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(193,5): error TS2322: Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+  Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
+    Property 'item' is missing in type 'ToolbarButton'.
+node_modules/chrome-devtools-frontend/front_end/components/DockController.js(193,5): error TS2322: Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+  Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
 node_modules/chrome-devtools-frontend/front_end/components/Linkifier.js(62,24): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/components/Linkifier.js(125,94): error TS2339: Property 'remove' does not exist on type 'Map<Target, LiveLocationPool>'.
 node_modules/chrome-devtools-frontend/front_end/components/Linkifier.js(127,41): error TS2339: Property 'remove' does not exist on type 'Map<Target, Element[]>'.
@@ -4965,10 +5056,10 @@ node_modules/chrome-devtools-frontend/front_end/data_grid/ViewportDataGrid.js(9,
 node_modules/chrome-devtools-frontend/front_end/data_grid/ViewportDataGrid.js(9,29): error TS2417: Class static side 'typeof ViewportDataGrid' incorrectly extends base class static side 'typeof DataGrid'.
   Types of property 'Events' are incompatible.
     Type '{ [x: string]: any; ViewportCalculated: symbol; }' is not assignable to type '{ [x: string]: any; SelectedNode: symbol; DeselectedNode: symbol; OpenedNode: symbol; SortingChan...'.
+      Property 'SelectedNode' is missing in type '{ [x: string]: any; ViewportCalculated: symbol; }'.
 node_modules/chrome-devtools-frontend/front_end/data_grid/ViewportDataGrid.js(9,29): error TS2417: Class static side 'typeof ViewportDataGrid' incorrectly extends base class static side 'typeof DataGrid'.
   Types of property 'Events' are incompatible.
     Type '{ [x: string]: any; ViewportCalculated: symbol; }' is not assignable to type '{ [x: string]: any; SelectedNode: symbol; DeselectedNode: symbol; OpenedNode: symbol; SortingChan...'.
-      Property 'SelectedNode' is missing in type '{ [x: string]: any; ViewportCalculated: symbol; }'.
 node_modules/chrome-devtools-frontend/front_end/data_grid/ViewportDataGrid.js(11,41): error TS2694: Namespace 'DataGrid' has no exported member 'ColumnDescriptor'.
 node_modules/chrome-devtools-frontend/front_end/data_grid/ViewportDataGrid.js(32,22): error TS2345: Argument of type 'ViewportDataGridNode<any>' is not assignable to parameter of type 'NODE_TYPE'.
 node_modules/chrome-devtools-frontend/front_end/data_grid/ViewportDataGrid.js(43,41): error TS2339: Property 'flatChildren' does not exist on type 'NODE_TYPE'.
@@ -5065,9 +5156,9 @@ node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(283,88): 
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(285,36): error TS2694: Namespace 'Adb' has no exported member 'PortForwardingRule'.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(286,5): error TS2322: Type 'ListWidget<any>' is not assignable to type '{ [x: string]: any; renderItem(item: T, editable: boolean): Element; removeItemRequested(item: T,...'.
   Type 'ListWidget<any>' is not assignable to type '{ [x: string]: any; renderItem(item: T, editable: boolean): Element; removeItemRequested(item: T,...'.
+    Property 'renderItem' is missing in type 'ListWidget<any>'.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(286,5): error TS2322: Type 'ListWidget<any>' is not assignable to type '{ [x: string]: any; renderItem(item: T, editable: boolean): Element; removeItemRequested(item: T,...'.
   Type 'ListWidget<any>' is not assignable to type '{ [x: string]: any; renderItem(item: T, editable: boolean): Element; removeItemRequested(item: T,...'.
-    Property 'renderItem' is missing in type 'ListWidget<any>'.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(290,31): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(293,43): error TS2694: Namespace 'Adb' has no exported member 'PortForwardingRule'.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(297,29): error TS2555: Expected at least 2 arguments, but got 1.
@@ -5097,9 +5188,9 @@ node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(466,64): 
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(469,36): error TS2694: Namespace 'Adb' has no exported member 'PortForwardingRule'.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(470,5): error TS2322: Type 'ListWidget<any>' is not assignable to type '{ [x: string]: any; renderItem(item: T, editable: boolean): Element; removeItemRequested(item: T,...'.
   Type 'ListWidget<any>' is not assignable to type '{ [x: string]: any; renderItem(item: T, editable: boolean): Element; removeItemRequested(item: T,...'.
+    Property 'renderItem' is missing in type 'ListWidget<any>'.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(470,5): error TS2322: Type 'ListWidget<any>' is not assignable to type '{ [x: string]: any; renderItem(item: T, editable: boolean): Element; removeItemRequested(item: T,...'.
   Type 'ListWidget<any>' is not assignable to type '{ [x: string]: any; renderItem(item: T, editable: boolean): Element; removeItemRequested(item: T,...'.
-    Property 'renderItem' is missing in type 'ListWidget<any>'.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(475,24): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(475,70): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/devices/DevicesView.js(478,43): error TS2694: Namespace 'Adb' has no exported member 'PortForwardingRule'.
@@ -5441,9 +5532,9 @@ node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleModel.js(6
 node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleModel.js(73,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleModel.js(84,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleModel.js(122,5): error TS2322: Type 'Promise<Map<string, string>>' is not assignable to type 'Promise<ComputedStyle>'.
-node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleModel.js(122,5): error TS2322: Type 'Promise<Map<string, string>>' is not assignable to type 'Promise<ComputedStyle>'.
   Type 'Map<string, string>' is not assignable to type 'ComputedStyle'.
     Property 'node' is missing in type 'Map<string, string>'.
+node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleModel.js(122,5): error TS2322: Type 'Promise<Map<string, string>>' is not assignable to type 'Promise<ComputedStyle>'.
 node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleWidget.js(48,36): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleWidget.js(51,9): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleWidget.js(52,49): error TS2555: Expected at least 2 arguments, but got 1.
@@ -5479,6 +5570,21 @@ node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleWidget.js(
 node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleWidget.js(281,35): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleWidget.js(282,49): error TS2339: Property 'selectorText' does not exist on type 'CSSRule'.
 node_modules/chrome-devtools-frontend/front_end/elements/ComputedStyleWidget.js(286,30): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(12,25): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(12,60): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(25,70): error TS2339: Property 'state' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(25,90): error TS2339: Property 'checked' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(36,13): error TS2339: Property 'state' does not exist on type 'HTMLInputElement'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(43,20): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(47,16): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(51,16): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(108,41): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(109,26): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(124,5): error TS2322: Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+  Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
+    Property 'item' is missing in type 'ToolbarToggle'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(124,5): error TS2322: Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+  Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsBreadcrumbs.js(12,46): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsBreadcrumbs.js(86,37): error TS2339: Property 'nextSiblingElement' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsBreadcrumbs.js(104,16): error TS2555: Expected at least 2 arguments, but got 1.
@@ -5488,8 +5594,8 @@ node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(58,40)
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(90,32): error TS2339: Property 'addEventListener' does not exist on type 'typeof extensionServer'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(98,57): error TS2339: Property 'runtime' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(116,5): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(116,5): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
   Property 'appendApplicableItems' is missing in type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }'.
+node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(116,5): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(159,24): error TS2339: Property 'remove' does not exist on type 'ElementsTreeOutline[]'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(180,12): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(181,12): error TS2339: Property 'createChild' does not exist on type 'Element'.
@@ -5543,21 +5649,6 @@ node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(884,11
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(905,15): error TS2339: Property '_pendingNodeReveal' does not exist on type 'ElementsPanel'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsPanel.js(912,15): error TS2339: Property '_pendingNodeReveal' does not exist on type 'ElementsPanel'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsSidebarPane.js(66,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(12,25): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(12,60): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(25,70): error TS2339: Property 'state' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(25,90): error TS2339: Property 'checked' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(36,13): error TS2339: Property 'state' does not exist on type 'HTMLInputElement'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(43,20): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(47,16): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(51,16): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(108,41): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(109,26): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(124,5): error TS2322: Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-  Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-node_modules/chrome-devtools-frontend/front_end/elements/ElementStatePaneWidget.js(124,5): error TS2322: Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-  Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-    Property 'item' is missing in type 'ToolbarToggle'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(44,50): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(111,66): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElement.js(239,29): error TS2339: Property 'style' does not exist on type 'Element'.
@@ -5673,10 +5764,10 @@ node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeElementHigh
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeOutline.js(34,32): error TS2417: Class static side 'typeof ElementsTreeOutline' incorrectly extends base class static side 'typeof TreeOutline'.
   Types of property 'Events' are incompatible.
     Type '{ [x: string]: any; SelectedNodeChanged: symbol; ElementsTreeUpdated: symbol; }' is not assignable to type '{ [x: string]: any; ElementAttached: symbol; ElementExpanded: symbol; ElementCollapsed: symbol; E...'.
+      Property 'ElementAttached' is missing in type '{ [x: string]: any; SelectedNodeChanged: symbol; ElementsTreeUpdated: symbol; }'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeOutline.js(34,32): error TS2417: Class static side 'typeof ElementsTreeOutline' incorrectly extends base class static side 'typeof TreeOutline'.
   Types of property 'Events' are incompatible.
     Type '{ [x: string]: any; SelectedNodeChanged: symbol; ElementsTreeUpdated: symbol; }' is not assignable to type '{ [x: string]: any; ElementAttached: symbol; ElementExpanded: symbol; ElementCollapsed: symbol; E...'.
-      Property 'ElementAttached' is missing in type '{ [x: string]: any; SelectedNodeChanged: symbol; ElementsTreeUpdated: symbol; }'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeOutline.js(45,53): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeOutline.js(49,51): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/elements/ElementsTreeOutline.js(120,24): error TS2694: Namespace 'Elements' has no exported member 'MultilineEditorController'.
@@ -6690,67 +6781,6 @@ node_modules/chrome-devtools-frontend/front_end/formatter/ScriptFormatter.js(127
 node_modules/chrome-devtools-frontend/front_end/formatter/ScriptFormatter.js(134,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/formatter/ScriptFormatter.js(173,45): error TS2694: Namespace 'FormatterWorkerPool' has no exported member 'FormatMapping'.
 node_modules/chrome-devtools-frontend/front_end/formatter/ScriptFormatter.js(215,28): error TS2339: Property 'upperBound' does not exist on type 'number[]'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker.js(5,11): error TS2339: Property 'Runtime' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker.js(6,8): error TS2339: Property 'importScripts' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(4,10): error TS2304: Cannot find name 'define'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(4,35): error TS2304: Cannot find name 'define'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(4,48): error TS2304: Cannot find name 'define'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(527,43): error TS2339: Property 'startNode' does not exist on type 'Parser'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(528,8): error TS2339: Property 'nextToken' does not exist on type 'Parser'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(529,15): error TS2339: Property 'parseTopLevel' does not exist on type 'Parser'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(1674,55): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2451,7): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2451,22): error TS2339: Property 'loc' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2451,37): error TS2339: Property 'raisedAt' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2564,12): error TS2339: Property 'context' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2565,10): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2568,18): error TS2339: Property 'context' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2569,36): error TS2339: Property 'curContext' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2570,10): error TS2339: Property 'context' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2571,10): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2573,10): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2575,10): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2580,8): error TS2339: Property 'context' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2580,26): error TS2339: Property 'braceIsBlock' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2581,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2585,8): error TS2339: Property 'context' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2586,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2591,8): error TS2339: Property 'context' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2592,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2601,67): error TS2339: Property 'curContext' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2602,10): error TS2339: Property 'context' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2603,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2607,12): error TS2339: Property 'curContext' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2608,10): error TS2339: Property 'context' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2610,10): error TS2339: Property 'context' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2611,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2634,22): error TS2304: Cannot find name 'Packages'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2634,77): error TS2304: Cannot find name 'Packages'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(3362,5): error TS2339: Property 'nextToken' does not exist on type 'Parser'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(3363,12): error TS2339: Property 'parseExpression' does not exist on type 'Parser'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(4,10): error TS2304: Cannot find name 'define'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(4,35): error TS2304: Cannot find name 'define'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(4,48): error TS2304: Cannot find name 'define'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(85,10): error TS2339: Property 'next' does not exist on type 'LooseParser'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(114,16): error TS2339: Property 'lookAhead' does not exist on type 'LooseParser'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(115,42): error TS2339: Property 'next' does not exist on type 'LooseParser'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(217,36): error TS2339: Property 'raisedAt' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(219,32): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(221,11): error TS2322: Type '{ start: any; end: any; type: any; value: any; }' is not assignable to type 'boolean'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(221,31): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(221,105): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(223,41): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(225,11): error TS2322: Type '{ start: any; end: any; type: any; value: any; }' is not assignable to type 'boolean'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(225,31): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(227,11): error TS2322: Type '{ start: any; end: any; type: any; value: any; }' is not assignable to type 'boolean'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(228,22): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(231,41): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(252,29): error TS2322: Type '{ start: any; end: any; type: any; value: string; }' is not assignable to type 'boolean'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(255,19): error TS2339: Property 'loc' does not exist on type 'true'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(257,55): error TS2339: Property 'start' does not exist on type 'true'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(258,55): error TS2339: Property 'end' does not exist on type 'true'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(1365,5): error TS2339: Property 'next' does not exist on type 'LooseParser'.
-node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(1366,12): error TS2339: Property 'parseTopLevel' does not exist on type 'LooseParser'.
 node_modules/chrome-devtools-frontend/front_end/formatter_worker/AcornTokenizer.js(14,54): error TS2345: Argument of type '{ ecmaVersion: number; onComment: any[]; }' is not assignable to parameter of type '{ [x: string]: boolean; }'.
   Property 'ecmaVersion' is incompatible with index signature.
     Type 'number' is not assignable to type 'boolean'.
@@ -6917,6 +6947,67 @@ node_modules/chrome-devtools-frontend/front_end/formatter_worker/RelaxedJSONPars
 node_modules/chrome-devtools-frontend/front_end/formatter_worker/RelaxedJSONParser.js(179,103): error TS2694: Namespace '__object' has no exported member 'States'.
 node_modules/chrome-devtools-frontend/front_end/formatter_worker/RelaxedJSONParser.js(180,2): error TS1003: Identifier expected.
 node_modules/chrome-devtools-frontend/front_end/formatter_worker/RelaxedJSONParser.js(181,35): error TS2300: Duplicate identifier 'Context'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(4,10): error TS2304: Cannot find name 'define'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(4,35): error TS2304: Cannot find name 'define'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(4,48): error TS2304: Cannot find name 'define'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(527,43): error TS2339: Property 'startNode' does not exist on type 'Parser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(528,8): error TS2339: Property 'nextToken' does not exist on type 'Parser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(529,15): error TS2339: Property 'parseTopLevel' does not exist on type 'Parser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(1674,55): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2451,7): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2451,22): error TS2339: Property 'loc' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2451,37): error TS2339: Property 'raisedAt' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2564,12): error TS2339: Property 'context' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2565,10): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2568,18): error TS2339: Property 'context' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2569,36): error TS2339: Property 'curContext' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2570,10): error TS2339: Property 'context' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2571,10): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2573,10): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2575,10): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2580,8): error TS2339: Property 'context' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2580,26): error TS2339: Property 'braceIsBlock' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2581,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2585,8): error TS2339: Property 'context' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2586,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2591,8): error TS2339: Property 'context' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2592,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2601,67): error TS2339: Property 'curContext' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2602,10): error TS2339: Property 'context' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2603,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2607,12): error TS2339: Property 'curContext' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2608,10): error TS2339: Property 'context' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2610,10): error TS2339: Property 'context' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2611,8): error TS2339: Property 'exprAllowed' does not exist on type 'TokenType'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2634,22): error TS2304: Cannot find name 'Packages'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(2634,77): error TS2304: Cannot find name 'Packages'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(3362,5): error TS2339: Property 'nextToken' does not exist on type 'Parser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn.js(3363,12): error TS2339: Property 'parseExpression' does not exist on type 'Parser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(4,10): error TS2304: Cannot find name 'define'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(4,35): error TS2304: Cannot find name 'define'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(4,48): error TS2304: Cannot find name 'define'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(85,10): error TS2339: Property 'next' does not exist on type 'LooseParser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(114,16): error TS2339: Property 'lookAhead' does not exist on type 'LooseParser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(115,42): error TS2339: Property 'next' does not exist on type 'LooseParser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(217,36): error TS2339: Property 'raisedAt' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(219,32): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(221,11): error TS2322: Type '{ start: any; end: any; type: any; value: any; }' is not assignable to type 'boolean'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(221,31): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(221,105): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(223,41): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(225,11): error TS2322: Type '{ start: any; end: any; type: any; value: any; }' is not assignable to type 'boolean'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(225,31): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(227,11): error TS2322: Type '{ start: any; end: any; type: any; value: any; }' is not assignable to type 'boolean'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(228,22): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(231,41): error TS2339: Property 'pos' does not exist on type 'SyntaxError'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(252,29): error TS2322: Type '{ start: any; end: any; type: any; value: string; }' is not assignable to type 'boolean'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(255,19): error TS2339: Property 'loc' does not exist on type 'true'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(257,55): error TS2339: Property 'start' does not exist on type 'true'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(258,55): error TS2339: Property 'end' does not exist on type 'true'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(1365,5): error TS2339: Property 'next' does not exist on type 'LooseParser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker/acorn/acorn_loose.js(1366,12): error TS2339: Property 'parseTopLevel' does not exist on type 'LooseParser'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker.js(5,11): error TS2339: Property 'Runtime' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/formatter_worker.js(6,8): error TS2339: Property 'importScripts' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/har_importer/HARImporter.js(26,11): error TS2403: Subsequent variable declarations must have the same type.  Variable 'page' must be of type 'any', but here has type 'HARPage'.
 node_modules/chrome-devtools-frontend/front_end/har_importer/HARImporter.js(46,5): error TS2322: Type 'Date' is not assignable to type 'number'.
 node_modules/chrome-devtools-frontend/front_end/heap_profiler_test_runner/HeapProfilerTestRunner.js(11,26): error TS2339: Property 'createJSHeapSnapshotMockObject' does not exist on type 'typeof HeapProfilerTestRunner'.
@@ -7007,8 +7098,6 @@ node_modules/chrome-devtools-frontend/front_end/heap_profiler_test_runner/HeapPr
 node_modules/chrome-devtools-frontend/front_end/heap_profiler_test_runner/HeapProfilerTestRunner.js(682,36): error TS2339: Property 'instance' does not exist on type 'typeof SamplingHeapProfileType'.
 node_modules/chrome-devtools-frontend/front_end/heap_snapshot_model/HeapSnapshotModel.js(31,19): error TS2339: Property 'HeapSnapshotProgressEvent' does not exist on type 'typeof HeapSnapshotModel'.
 node_modules/chrome-devtools-frontend/front_end/heap_snapshot_model/HeapSnapshotModel.js(36,19): error TS2339: Property 'baseSystemDistance' does not exist on type 'typeof HeapSnapshotModel'.
-node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker.js(5,11): error TS2339: Property 'Runtime' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker.js(6,8): error TS2339: Property 'importScripts' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker/HeapSnapshot.js(37,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker/HeapSnapshot.js(87,5): error TS2322: Type 'void' is not assignable to type 'HeapSnapshotNode'.
 node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker/HeapSnapshot.js(144,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
@@ -7132,6 +7221,8 @@ node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker/HeapSnapsho
 node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker/HeapSnapshotLoader.js(132,47): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
 node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker/HeapSnapshotWorker.js(31,3): error TS2554: Expected 2-3 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker/HeapSnapshotWorkerDispatcher.js(87,36): error TS2339: Property 'eval' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker.js(5,11): error TS2339: Property 'Runtime' does not exist on type 'Window'.
+node_modules/chrome-devtools-frontend/front_end/heap_snapshot_worker.js(6,8): error TS2339: Property 'importScripts' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/help/Help.js(6,19): error TS2694: Namespace 'Help' has no exported member 'ReleaseNote'.
 node_modules/chrome-devtools-frontend/front_end/help/Help.js(9,13): error TS2551: Property '_latestReleaseNote' does not exist on type 'typeof Help'. Did you mean 'latestReleaseNote'?
 node_modules/chrome-devtools-frontend/front_end/help/Help.js(11,10): error TS2551: Property '_latestReleaseNote' does not exist on type 'typeof Help'. Did you mean 'latestReleaseNote'?
@@ -7250,29 +7341,6 @@ node_modules/chrome-devtools-frontend/front_end/inline_editor/BezierUI.js(100,31
 node_modules/chrome-devtools-frontend/front_end/inline_editor/BezierUI.js(101,32): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/BezierUI.js(102,9): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/BezierUI.js(103,21): error TS2339: Property 'createSVGChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(16,35): error TS2339: Property '_constructor' does not exist on type 'typeof ColorSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(17,32): error TS2339: Property '_constructor' does not exist on type 'typeof ColorSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(21,83): error TS2339: Property '_constructor' does not exist on type 'typeof ColorSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(96,29): error TS2694: Namespace 'Color' has no exported member 'Format'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(103,28): error TS2694: Namespace 'Color' has no exported member 'Format'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(131,30): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(132,31): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(138,10): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(139,36): error TS2339: Property 'createChild' does not exist on type 'ColorSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(146,16): error TS2339: Property 'shiftKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(148,18): error TS2339: Property 'parentNode' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(149,11): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(166,36): error TS2339: Property '_constructor' does not exist on type 'typeof BezierSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(167,33): error TS2339: Property '_constructor' does not exist on type 'typeof BezierSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(171,85): error TS2339: Property '_constructor' does not exist on type 'typeof BezierSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(209,30): error TS2339: Property 'createChild' does not exist on type 'BezierSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(210,10): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(227,39): error TS2339: Property '_constructor' does not exist on type 'typeof CSSShadowSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(228,36): error TS2339: Property '_constructor' does not exist on type 'typeof CSSShadowSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(232,91): error TS2339: Property '_constructor' does not exist on type 'typeof CSSShadowSwatch'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(248,29): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(290,10): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
-node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(291,33): error TS2339: Property 'createChild' does not exist on type 'CSSShadowSwatch'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/CSSShadowEditor.js(11,25): error TS2339: Property 'tabIndex' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/CSSShadowEditor.js(14,43): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/CSSShadowEditor.js(15,79): error TS2555: Expected at least 2 arguments, but got 1.
@@ -7330,6 +7398,29 @@ node_modules/chrome-devtools-frontend/front_end/inline_editor/CSSShadowEditor.js
 node_modules/chrome-devtools-frontend/front_end/inline_editor/CSSShadowEditor.js(367,20): error TS2339: Property 'value' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/CSSShadowModel.js(46,28): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/CSSShadowModel.js(63,31): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(16,35): error TS2339: Property '_constructor' does not exist on type 'typeof ColorSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(17,32): error TS2339: Property '_constructor' does not exist on type 'typeof ColorSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(21,83): error TS2339: Property '_constructor' does not exist on type 'typeof ColorSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(96,29): error TS2694: Namespace 'Color' has no exported member 'Format'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(103,28): error TS2694: Namespace 'Color' has no exported member 'Format'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(131,30): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(132,31): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(138,10): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(139,36): error TS2339: Property 'createChild' does not exist on type 'ColorSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(146,16): error TS2339: Property 'shiftKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(148,18): error TS2339: Property 'parentNode' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(149,11): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(166,36): error TS2339: Property '_constructor' does not exist on type 'typeof BezierSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(167,33): error TS2339: Property '_constructor' does not exist on type 'typeof BezierSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(171,85): error TS2339: Property '_constructor' does not exist on type 'typeof BezierSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(209,30): error TS2339: Property 'createChild' does not exist on type 'BezierSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(210,10): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(227,39): error TS2339: Property '_constructor' does not exist on type 'typeof CSSShadowSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(228,36): error TS2339: Property '_constructor' does not exist on type 'typeof CSSShadowSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(232,91): error TS2339: Property '_constructor' does not exist on type 'typeof CSSShadowSwatch'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(248,29): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(290,10): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
+node_modules/chrome-devtools-frontend/front_end/inline_editor/ColorSwatch.js(291,33): error TS2339: Property 'createChild' does not exist on type 'CSSShadowSwatch'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/SwatchPopoverHelper.js(12,35): error TS2345: Argument of type 'symbol' is not assignable to parameter of type '{ [x: string]: any; SetExactSize: symbol; SetExactWidthMaxHeight: symbol; MeasureContent: symbol; }'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/SwatchPopoverHelper.js(13,37): error TS2345: Argument of type 'symbol' is not assignable to parameter of type 'boolean'.
 node_modules/chrome-devtools-frontend/front_end/inline_editor/SwatchPopoverHelper.js(14,64): error TS2339: Property 'consume' does not exist on type 'Event'.
@@ -7396,6 +7487,32 @@ node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerDetailsView.js
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerDetailsView.js(295,48): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerDetailsView.js(296,48): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerDetailsView.js(297,47): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(65,31): error TS2538: Type 'symbol' cannot be used as an index type.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(78,31): error TS2538: Type 'symbol' cannot be used as an index type.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(118,24): error TS2538: Type 'symbol' cannot be used as an index type.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(123,83): error TS2538: Type 'symbol' cannot be used as an index type.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(150,61): error TS2339: Property 'root' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(151,31): error TS2339: Property '_layer' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(164,25): error TS2538: Type 'symbol' cannot be used as an index type.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(199,25): error TS2339: Property '_layer' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(199,80): error TS2339: Property '_layer' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(215,17): error TS2538: Type 'symbol' cannot be used as an index type.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(222,11): error TS2339: Property 'createTextChild' does not exist on type 'DocumentFragment'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(223,25): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(33,47): error TS2694: Namespace 'Selection' has no exported member 'Type'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(51,48): error TS2694: Namespace 'Selection' has no exported member 'Type'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(92,11): error TS2345: Argument of type 'symbol' is not assignable to parameter of type '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(101,12): error TS2365: Operator '===' cannot be applied to types '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }' and 'symbol'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(114,11): error TS2345: Argument of type 'symbol' is not assignable to parameter of type '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(124,12): error TS2365: Operator '===' cannot be applied to types '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }' and 'symbol'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(125,84): error TS2339: Property 'scrollRectIndex' does not exist on type 'Selection'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(135,19): error TS2694: Namespace 'SDK' has no exported member 'SnapshotWithRect'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(138,11): error TS2345: Argument of type 'symbol' is not assignable to parameter of type '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(148,12): error TS2365: Operator '===' cannot be applied to types '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }' and 'symbol'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(149,34): error TS2339: Property '_snapshot' does not exist on type 'Selection'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(153,20): error TS2694: Namespace 'SDK' has no exported member 'SnapshotWithRect'.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(231,9): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(235,7): error TS2554: Expected 3 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/Layers3DView.js(44,30): error TS2339: Property 'createTextChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/Layers3DView.js(44,46): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/Layers3DView.js(54,47): error TS2339: Property 'createChild' does not exist on type 'Element'.
@@ -7474,32 +7591,6 @@ node_modules/chrome-devtools-frontend/front_end/layer_viewer/Layers3DView.js(932
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/Layers3DView.js(1080,24): error TS2694: Namespace 'Protocol' has no exported member 'DOM'.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/Layers3DView.js(1098,15): error TS2304: Cannot find name 'CSSMatrix'.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/Layers3DView.js(1143,19): error TS2694: Namespace 'SDK' has no exported member 'SnapshotWithRect'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(65,31): error TS2538: Type 'symbol' cannot be used as an index type.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(78,31): error TS2538: Type 'symbol' cannot be used as an index type.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(118,24): error TS2538: Type 'symbol' cannot be used as an index type.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(123,83): error TS2538: Type 'symbol' cannot be used as an index type.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(150,61): error TS2339: Property 'root' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(151,31): error TS2339: Property '_layer' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(164,25): error TS2538: Type 'symbol' cannot be used as an index type.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(199,25): error TS2339: Property '_layer' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(199,80): error TS2339: Property '_layer' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(215,17): error TS2538: Type 'symbol' cannot be used as an index type.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(222,11): error TS2339: Property 'createTextChild' does not exist on type 'DocumentFragment'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerTreeOutline.js(223,25): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(33,47): error TS2694: Namespace 'Selection' has no exported member 'Type'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(51,48): error TS2694: Namespace 'Selection' has no exported member 'Type'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(92,11): error TS2345: Argument of type 'symbol' is not assignable to parameter of type '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(101,12): error TS2365: Operator '===' cannot be applied to types '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }' and 'symbol'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(114,11): error TS2345: Argument of type 'symbol' is not assignable to parameter of type '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(124,12): error TS2365: Operator '===' cannot be applied to types '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }' and 'symbol'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(125,84): error TS2339: Property 'scrollRectIndex' does not exist on type 'Selection'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(135,19): error TS2694: Namespace 'SDK' has no exported member 'SnapshotWithRect'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(138,11): error TS2345: Argument of type 'symbol' is not assignable to parameter of type '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(148,12): error TS2365: Operator '===' cannot be applied to types '{ [x: string]: any; Layer: symbol; ScrollRect: symbol; Snapshot: symbol; }' and 'symbol'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(149,34): error TS2339: Property '_snapshot' does not exist on type 'Selection'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(153,20): error TS2694: Namespace 'SDK' has no exported member 'SnapshotWithRect'.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(231,9): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/layer_viewer/LayerViewHost.js(235,7): error TS2554: Expected 3 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/PaintProfilerView.js(42,49): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/PaintProfilerView.js(43,48): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/PaintProfilerView.js(44,40): error TS2555: Expected at least 2 arguments, but got 1.
@@ -7556,12 +7647,6 @@ node_modules/chrome-devtools-frontend/front_end/layer_viewer/TransformController
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/TransformController.js(283,29): error TS2339: Property 'clientX' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/TransformController.js(284,29): error TS2339: Property 'clientY' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/layer_viewer/TransformController.js(292,18): error TS2339: Property 'focus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(63,53): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(138,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(150,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(160,58): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(169,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(187,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/layers/LayerTreeModel.js(79,32): error TS2694: Namespace 'Protocol' has no exported member 'LayerTree'.
 node_modules/chrome-devtools-frontend/front_end/layers/LayerTreeModel.js(88,32): error TS2694: Namespace 'Protocol' has no exported member 'LayerTree'.
 node_modules/chrome-devtools-frontend/front_end/layers/LayerTreeModel.js(107,24): error TS2694: Namespace 'Protocol' has no exported member 'LayerTree'.
@@ -7581,6 +7666,12 @@ node_modules/chrome-devtools-frontend/front_end/layers/LayerTreeModel.js(518,15)
 node_modules/chrome-devtools-frontend/front_end/layers/LayerTreeModel.js(552,32): error TS2694: Namespace 'Protocol' has no exported member 'LayerTree'.
 node_modules/chrome-devtools-frontend/front_end/layers/LayerTreeModel.js(560,24): error TS2694: Namespace 'Protocol' has no exported member 'LayerTree'.
 node_modules/chrome-devtools-frontend/front_end/layers/LayerTreeModel.js(561,24): error TS2694: Namespace 'Protocol' has no exported member 'DOM'.
+node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(63,53): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(138,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(150,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(160,58): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(169,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/layers/LayersPanel.js(187,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/layers_test_runner/LayersTestRunner.js(11,25): error TS2551: Property '_layerTreeModel' does not exist on type 'typeof LayersTestRunner'. Did you mean 'layerTreeModel'?
 node_modules/chrome-devtools-frontend/front_end/layers_test_runner/LayersTestRunner.js(12,22): error TS2551: Property '_layerTreeModel' does not exist on type 'typeof LayersTestRunner'. Did you mean 'layerTreeModel'?
 node_modules/chrome-devtools-frontend/front_end/layers_test_runner/LayersTestRunner.js(12,51): error TS2339: Property 'mainTarget' does not exist on type 'typeof TestRunner'.
@@ -7650,9 +7741,9 @@ node_modules/chrome-devtools-frontend/front_end/main/Main.js(567,65): error TS23
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(591,25): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(599,5): error TS2322: Type 'ToolbarMenuButton' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
   Type 'ToolbarMenuButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
+    Property 'item' is missing in type 'ToolbarMenuButton'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(599,5): error TS2322: Type 'ToolbarMenuButton' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
   Type 'ToolbarMenuButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-    Property 'item' is missing in type 'ToolbarMenuButton'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(608,42): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(609,34): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/main/Main.js(616,41): error TS2555: Expected at least 2 arguments, but got 1.
@@ -8307,6 +8398,8 @@ node_modules/chrome-devtools-frontend/front_end/network/RequestCookiesView.js(55
 node_modules/chrome-devtools-frontend/front_end/network/RequestCookiesView.js(81,26): error TS2554: Expected 4 arguments, but got 0.
 node_modules/chrome-devtools-frontend/front_end/network/RequestCookiesView.js(83,20): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/network/RequestCookiesView.js(84,20): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/network/RequestHTMLView.js(56,18): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/network/RequestHTMLView.js(62,18): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/network/RequestHeadersView.js(56,84): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/network/RequestHeadersView.js(71,73): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/network/RequestHeadersView.js(112,14): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
@@ -8359,8 +8452,6 @@ node_modules/chrome-devtools-frontend/front_end/network/RequestHeadersView.js(48
 node_modules/chrome-devtools-frontend/front_end/network/RequestHeadersView.js(496,11): error TS2339: Property 'consume' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/network/RequestHeadersView.js(514,44): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/network/RequestHeadersView.js(514,77): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/network/RequestHTMLView.js(56,18): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/network/RequestHTMLView.js(62,18): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/network/RequestPreviewView.js(60,33): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/network/RequestPreviewView.js(93,31): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/network/RequestResponseView.js(46,34): error TS2694: Namespace 'NetworkRequest' has no exported member 'ContentData'.
@@ -9122,8 +9213,8 @@ node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(943,8): er
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(944,41): error TS2339: Property 'standardFormatters' does not exist on type 'StringConstructor'.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(954,13): error TS2315: Type 'Object' is not generic.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(954,27): error TS1009: Trailing comma not allowed.
-node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(954,29): error TS1005: '>' expected.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(954,29): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
+node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(954,29): error TS1005: '>' expected.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(961,8): error TS2339: Property 'format' does not exist on type 'StringConstructor'.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(963,51): error TS2345: Argument of type 'string' is not assignable to parameter of type 'Q'.
 node_modules/chrome-devtools-frontend/front_end/platform/utilities.js(978,42): error TS2339: Property 'tokenizeFormatString' does not exist on type 'StringConstructor'.
@@ -9243,19 +9334,11 @@ node_modules/chrome-devtools-frontend/front_end/profiler/CPUProfileView.js(404,7
 node_modules/chrome-devtools-frontend/front_end/profiler/CPUProfileView.js(405,22): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/profiler/CPUProfileView.js(405,71): error TS2339: Property 'secondsToString' does not exist on type 'NumberConstructor'.
 node_modules/chrome-devtools-frontend/front_end/profiler/CPUProfileView.js(407,24): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfilerPanel.js(14,9): error TS2345: Argument of type '(HeapSnapshotProfileType | SamplingHeapProfileType)[]' is not assignable to parameter of type '({ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: an...'.
-  Type 'HeapSnapshotProfileType | SamplingHeapProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
-    Type 'HeapSnapshotProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
-      Type 'HeapSnapshotProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
-        Property 'showProfile' is missing in type 'HeapSnapshotProfileType'.
-node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfilerPanel.js(56,9): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfilerPanel.js(88,24): error TS2694: Namespace 'Protocol' has no exported member 'HeapProfiler'.
-node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfilerPanel.js(100,14): error TS2339: Property 'selectLiveObject' does not exist on type 'Widget'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(31,16): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(33,16): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(43,5): error TS2322: Type 'HeapFlameChartDataProvider' is not assignable to type '{ [x: string]: any; minimumBoundary(): number; totalTime(): number; formatValue(value: number, pr...'.
-node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(43,5): error TS2322: Type 'HeapFlameChartDataProvider' is not assignable to type '{ [x: string]: any; minimumBoundary(): number; totalTime(): number; formatValue(value: number, pr...'.
   Property '_profile' does not exist on type '{ [x: string]: any; minimumBoundary(): number; totalTime(): number; formatValue(value: number, pr...'.
+node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(43,5): error TS2322: Type 'HeapFlameChartDataProvider' is not assignable to type '{ [x: string]: any; minimumBoundary(): number; totalTime(): number; formatValue(value: number, pr...'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(52,52): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(54,38): error TS2339: Property 'instance' does not exist on type 'typeof SamplingHeapProfileType'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(82,30): error TS2555: Expected at least 2 arguments, but got 1.
@@ -9279,13 +9362,21 @@ node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(389,
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(390,22): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(390,60): error TS2339: Property 'bytesToString' does not exist on type 'NumberConstructor'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfileView.js(395,24): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotDataGrids.js(34,41): error TS2417: Class static side 'typeof HeapSnapshotSortableDataGrid' incorrectly extends base class static side 'typeof DataGrid'.
-  Types of property 'Events' are incompatible.
-    Type '{ [x: string]: any; ContentShown: symbol; SortingComplete: symbol; }' is not assignable to type '{ [x: string]: any; SelectedNode: symbol; DeselectedNode: symbol; OpenedNode: symbol; SortingChan...'.
+node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfilerPanel.js(14,9): error TS2345: Argument of type '(HeapSnapshotProfileType | SamplingHeapProfileType)[]' is not assignable to parameter of type '({ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: an...'.
+  Type 'HeapSnapshotProfileType | SamplingHeapProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
+    Type 'HeapSnapshotProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
+      Type 'HeapSnapshotProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
+        Property 'showProfile' is missing in type 'HeapSnapshotProfileType'.
+node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfilerPanel.js(56,9): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfilerPanel.js(88,24): error TS2694: Namespace 'Protocol' has no exported member 'HeapProfiler'.
+node_modules/chrome-devtools-frontend/front_end/profiler/HeapProfilerPanel.js(100,14): error TS2339: Property 'selectLiveObject' does not exist on type 'Widget'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotDataGrids.js(34,41): error TS2417: Class static side 'typeof HeapSnapshotSortableDataGrid' incorrectly extends base class static side 'typeof DataGrid'.
   Types of property 'Events' are incompatible.
     Type '{ [x: string]: any; ContentShown: symbol; SortingComplete: symbol; }' is not assignable to type '{ [x: string]: any; SelectedNode: symbol; DeselectedNode: symbol; OpenedNode: symbol; SortingChan...'.
       Property 'SelectedNode' is missing in type '{ [x: string]: any; ContentShown: symbol; SortingComplete: symbol; }'.
+node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotDataGrids.js(34,41): error TS2417: Class static side 'typeof HeapSnapshotSortableDataGrid' incorrectly extends base class static side 'typeof DataGrid'.
+  Types of property 'Events' are incompatible.
+    Type '{ [x: string]: any; ContentShown: symbol; SortingComplete: symbol; }' is not assignable to type '{ [x: string]: any; SelectedNode: symbol; DeselectedNode: symbol; OpenedNode: symbol; SortingChan...'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotDataGrids.js(37,41): error TS2694: Namespace 'DataGrid' has no exported member 'ColumnDescriptor'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotDataGrids.js(124,27): error TS2339: Property 'enclosingNodeOrSelfWithNodeName' does not exist on type 'EventTarget'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotDataGrids.js(137,46): error TS2555: Expected at least 2 arguments, but got 1.
@@ -9363,9 +9454,9 @@ node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.j
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(155,48): error TS2339: Property 'baseSystemDistance' does not exist on type 'typeof HeapSnapshotModel'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(156,95): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(163,5): error TS2322: Type '({ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; is...' is not assignable to type 'DataGridNode<any>[]'.
-node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(163,5): error TS2322: Type '({ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; is...' is not assignable to type 'DataGridNode<any>[]'.
   Type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...' is not assignable to type 'DataGridNode<any>'.
     Property '_element' is missing in type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
+node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(163,5): error TS2322: Type '({ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; is...' is not assignable to type 'DataGridNode<any>[]'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(170,39): error TS2345: Argument of type 'this' is not assignable to parameter of type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
   Type 'HeapSnapshotGridNode' is not assignable to type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
     Type 'HeapSnapshotGridNode' is not assignable to type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
@@ -9399,17 +9490,17 @@ node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.j
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(602,75): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(682,3): error TS2416: Property 'createProvider' in type 'HeapSnapshotObjectNode' is not assignable to the same property in base type 'HeapSnapshotGenericObjectNode'.
   Type '() => HeapSnapshotProviderProxy' is not assignable to type '() => { [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number...'.
-node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(682,3): error TS2416: Property 'createProvider' in type 'HeapSnapshotObjectNode' is not assignable to the same property in base type 'HeapSnapshotGenericObjectNode'.
-  Type '() => HeapSnapshotProviderProxy' is not assignable to type '() => { [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number...'.
     Type 'HeapSnapshotProviderProxy' is not assignable to type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
       Property '_worker' does not exist on type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
+node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(682,3): error TS2416: Property 'createProvider' in type 'HeapSnapshotObjectNode' is not assignable to the same property in base type 'HeapSnapshotGenericObjectNode'.
+  Type '() => HeapSnapshotProviderProxy' is not assignable to type '() => { [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number...'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(871,36): error TS2339: Property 'withThousandsSeparator' does not exist on type 'NumberConstructor'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(874,34): error TS2339: Property 'withThousandsSeparator' does not exist on type 'NumberConstructor'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(892,3): error TS2416: Property 'createProvider' in type 'HeapSnapshotInstanceNode' is not assignable to the same property in base type 'HeapSnapshotGenericObjectNode'.
   Type '() => HeapSnapshotProviderProxy' is not assignable to type '() => { [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number...'.
+    Type 'HeapSnapshotProviderProxy' is not assignable to type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(892,3): error TS2416: Property 'createProvider' in type 'HeapSnapshotInstanceNode' is not assignable to the same property in base type 'HeapSnapshotGenericObjectNode'.
   Type '() => HeapSnapshotProviderProxy' is not assignable to type '() => { [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number...'.
-    Type 'HeapSnapshotProviderProxy' is not assignable to type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(966,23): error TS2339: Property 'withThousandsSeparator' does not exist on type 'NumberConstructor'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(968,29): error TS2339: Property 'withThousandsSeparator' does not exist on type 'NumberConstructor'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(969,30): error TS2339: Property 'withThousandsSeparator' does not exist on type 'NumberConstructor'.
@@ -9442,10 +9533,10 @@ node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.j
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(1183,65): error TS2339: Property 'withThousandsSeparator' does not exist on type 'NumberConstructor'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(1191,3): error TS2416: Property 'createProvider' in type 'HeapSnapshotDiffNode' is not assignable to the same property in base type 'HeapSnapshotGridNode'.
   Type '() => HeapSnapshotDiffNodesProvider' is not assignable to type '() => { [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number...'.
-node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(1191,3): error TS2416: Property 'createProvider' in type 'HeapSnapshotDiffNode' is not assignable to the same property in base type 'HeapSnapshotGridNode'.
-  Type '() => HeapSnapshotDiffNodesProvider' is not assignable to type '() => { [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number...'.
     Type 'HeapSnapshotDiffNodesProvider' is not assignable to type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
       Property '_addedNodesProvider' does not exist on type '{ [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number>; isE...'.
+node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(1191,3): error TS2416: Property 'createProvider' in type 'HeapSnapshotDiffNode' is not assignable to the same property in base type 'HeapSnapshotGridNode'.
+  Type '() => HeapSnapshotDiffNodesProvider' is not assignable to type '() => { [x: string]: any; dispose(): void; nodePosition(snapshotObjectId: number): Promise<number...'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(1194,14): error TS2339: Property 'snapshot' does not exist on type 'HeapSnapshotSortableDataGrid'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(1194,53): error TS2339: Property 'baseSnapshot' does not exist on type 'HeapSnapshotSortableDataGrid'.
 node_modules/chrome-devtools-frontend/front_end/profiler/HeapSnapshotGridNodes.js(1195,14): error TS2339: Property 'baseSnapshot' does not exist on type 'HeapSnapshotSortableDataGrid'.
@@ -9689,54 +9780,6 @@ node_modules/chrome-devtools-frontend/front_end/profiler/ProfileLauncherView.js(
 node_modules/chrome-devtools-frontend/front_end/profiler/ProfileLauncherView.js(131,34): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/profiler/ProfileLauncherView.js(140,45): error TS2339: Property 'checked' does not exist on type 'HTMLOptionElement'.
 node_modules/chrome-devtools-frontend/front_end/profiler/ProfileLauncherView.js(141,56): error TS2339: Property '_profileType' does not exist on type 'HTMLOptionElement'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(72,31): error TS2345: Argument of type 'ToolbarToggle' is not assignable to parameter of type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-  Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(74,52): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(76,31): error TS2345: Argument of type 'ToolbarButton' is not assignable to parameter of type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-  Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(78,31): error TS2345: Argument of type 'ToolbarToggle' is not assignable to parameter of type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-  Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(109,15): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(109,45): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(111,20): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(111,48): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(114,13): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(129,28): error TS2339: Property '_fileSelectorElement' does not exist on type 'typeof ProfilesPanel'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(157,28): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(210,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(233,23): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(261,24): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(269,24): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(277,24): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(302,36): error TS2339: Property 'isSelfOrAncestor' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(304,11): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(304,68): error TS2339: Property 'click' does not exist on type 'Node'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(310,31): error TS2339: Property 'click' does not exist on type 'Node'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(374,29): error TS2339: Property 'syncToolbarItems' does not exist on type 'Widget'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(383,24): error TS2694: Namespace 'Protocol' has no exported member 'HeapProfiler'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(494,9): error TS2322: Type 'ProfileGroupSidebarTreeElement' is not assignable to type 'this'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(530,9): error TS2322: Type 'ProfileGroupSidebarTreeElement' is not assignable to type 'this'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(596,48): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(598,49): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(614,41): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(623,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(650,33): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(701,26): error TS2339: Property 'appendChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(713,9): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(714,32): error TS2339: Property '_fileSelectorElement' does not exist on type 'typeof ProfilesPanel'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(714,87): error TS2339: Property '_fileSelectorElement' does not exist on type 'typeof ProfilesPanel'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(716,44): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(717,44): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(766,62): error TS2339: Property 'profile' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(775,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(776,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(807,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(808,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(811,24): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(821,26): error TS2345: Argument of type 'CPUProfileType[]' is not assignable to parameter of type '({ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: an...'.
-  Type 'CPUProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
-    Type 'CPUProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
-      Property 'showProfile' is missing in type 'CPUProfileType'.
 node_modules/chrome-devtools-frontend/front_end/profiler/ProfileType.js(239,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/profiler/ProfileType.js(244,24): error TS2694: Namespace 'Protocol' has no exported member 'HeapProfiler'.
 node_modules/chrome-devtools-frontend/front_end/profiler/ProfileView.js(10,11): error TS2555: Expected at least 2 arguments, but got 1.
@@ -9789,6 +9832,54 @@ node_modules/chrome-devtools-frontend/front_end/profiler/ProfileView.js(485,23):
 node_modules/chrome-devtools-frontend/front_end/profiler/ProfileView.js(488,44): error TS2694: Namespace 'Protocol' has no exported member 'Profiler'.
 node_modules/chrome-devtools-frontend/front_end/profiler/ProfileView.js(490,25): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/profiler/ProfileView.js(503,24): error TS2694: Namespace 'Protocol' has no exported member 'Profiler'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(72,31): error TS2345: Argument of type 'ToolbarToggle' is not assignable to parameter of type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+  Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(74,52): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(76,31): error TS2345: Argument of type 'ToolbarButton' is not assignable to parameter of type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+  Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(78,31): error TS2345: Argument of type 'ToolbarToggle' is not assignable to parameter of type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+  Type 'ToolbarToggle' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(109,15): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(109,45): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(111,20): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(111,48): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(114,13): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(129,28): error TS2339: Property '_fileSelectorElement' does not exist on type 'typeof ProfilesPanel'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(157,28): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(210,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(233,23): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(261,24): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(269,24): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(277,24): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(302,36): error TS2339: Property 'isSelfOrAncestor' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(304,11): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(304,68): error TS2339: Property 'click' does not exist on type 'Node'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(310,31): error TS2339: Property 'click' does not exist on type 'Node'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(374,29): error TS2339: Property 'syncToolbarItems' does not exist on type 'Widget'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(383,24): error TS2694: Namespace 'Protocol' has no exported member 'HeapProfiler'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(494,9): error TS2322: Type 'ProfileGroupSidebarTreeElement' is not assignable to type 'this'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(530,9): error TS2322: Type 'ProfileGroupSidebarTreeElement' is not assignable to type 'this'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(596,48): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(598,49): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(614,41): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(623,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(650,33): error TS2339: Property 'enclosingNodeOrSelfWithClass' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(701,26): error TS2339: Property 'appendChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(713,9): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(714,32): error TS2339: Property '_fileSelectorElement' does not exist on type 'typeof ProfilesPanel'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(714,87): error TS2339: Property '_fileSelectorElement' does not exist on type 'typeof ProfilesPanel'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(716,44): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(717,44): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(766,62): error TS2339: Property 'profile' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(775,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(776,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(807,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(808,26): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(811,24): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/profiler/ProfilesPanel.js(821,26): error TS2345: Argument of type 'CPUProfileType[]' is not assignable to parameter of type '({ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: an...'.
+  Type 'CPUProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
+    Type 'CPUProfileType' is not assignable to type '{ [x: string]: any; showProfile(profile: ProfileHeader): Widget; showObject(snapshotObjectId: any...'.
+      Property 'showProfile' is missing in type 'CPUProfileType'.
 node_modules/chrome-devtools-frontend/front_end/profiler/TargetsComboBoxController.js(31,38): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/profiler/TargetsComboBoxController.js(36,27): error TS2339: Property 'selectedIndex' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/profiler/TargetsComboBoxController.js(49,39): error TS2339: Property 'remove' does not exist on type 'Map<Target, Element>'.
@@ -9876,6 +9967,28 @@ node_modules/chrome-devtools-frontend/front_end/quick_open/HelpQuickOpen.js(58,1
 node_modules/chrome-devtools-frontend/front_end/quick_open/QuickOpen.js(9,29): error TS1005: '>' expected.
 node_modules/chrome-devtools-frontend/front_end/quick_open/QuickOpen.js(14,10): error TS2339: Property 'runtime' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/quick_open/QuickOpen.js(26,39): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(13,42): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(17,9): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(23,42): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(27,58): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(28,60): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(32,30): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(32,79): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(34,31): error TS2345: Argument of type 'ToolbarButton' is not assignable to parameter of type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+  Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(36,64): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(37,57): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(39,57): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(40,62): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(42,65): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(44,65): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(48,70): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(52,68): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(53,64): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(88,31): error TS2694: Namespace 'Protocol' has no exported member 'Page'.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(116,25): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(139,32): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(158,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/resources/ApplicationCacheItemsView.js(31,11): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/resources/ApplicationCacheItemsView.js(37,47): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/resources/ApplicationCacheItemsView.js(42,28): error TS2339: Property 'style' does not exist on type 'Element'.
@@ -9949,28 +10062,6 @@ node_modules/chrome-devtools-frontend/front_end/resources/ApplicationPanelSideba
 node_modules/chrome-devtools-frontend/front_end/resources/ApplicationPanelSidebar.js(1518,45): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/resources/ApplicationPanelSidebar.js(1530,55): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/resources/ApplicationPanelSidebar.js(1555,9): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(13,42): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(17,9): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(23,42): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(27,58): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(28,60): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(32,30): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(32,79): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(34,31): error TS2345: Argument of type 'ToolbarButton' is not assignable to parameter of type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-  Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(36,64): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(37,57): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(39,57): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(40,62): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(42,65): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(44,65): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(48,70): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(52,68): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(53,64): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(88,31): error TS2694: Namespace 'Protocol' has no exported member 'Page'.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(116,25): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(139,32): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/resources/AppManifestView.js(158,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/resources/ClearStorageView.js(11,26): error TS2339: Property 'Storage' does not exist on type 'typeof Protocol'.
 node_modules/chrome-devtools-frontend/front_end/resources/ClearStorageView.js(22,42): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/resources/ClearStorageView.js(37,48): error TS2555: Expected at least 2 arguments, but got 1.
@@ -10023,28 +10114,6 @@ node_modules/chrome-devtools-frontend/front_end/resources/ClearStorageView.js(25
 node_modules/chrome-devtools-frontend/front_end/resources/CookieItemsView.js(36,11): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/resources/CookieItemsView.js(47,43): error TS2694: Namespace 'EventTarget' has no exported member 'EventDescriptor'.
 node_modules/chrome-devtools-frontend/front_end/resources/CookieItemsView.js(101,42): error TS2339: Property 'asParsedURL' does not exist on type 'string'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(98,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(112,17): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(130,26): error TS2339: Property 'databaseAgent' does not exist on type 'Target'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(131,19): error TS2339: Property 'registerDatabaseDispatcher' does not exist on type 'Target'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(191,24): error TS2694: Namespace 'Protocol' has no exported member 'Database'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseQueryView.js(38,42): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseQueryView.js(52,62): error TS2339: Property 'hasSelection' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseQueryView.js(60,39): error TS2694: Namespace 'SuggestBox' has no exported member 'Suggestions'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseQueryView.js(151,19): error TS2339: Property 'createTextChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(31,11): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(40,47): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(42,53): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(58,5): error TS2322: Type '(ToolbarButton | ToolbarInput)[]' is not assignable to type '({ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; })[]'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(58,5): error TS2322: Type '(ToolbarButton | ToolbarInput)[]' is not assignable to type '({ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; })[]'.
-  Type 'ToolbarButton | ToolbarInput' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-    Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
-      Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
-        Property 'item' is missing in type 'ToolbarButton'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(77,18): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(114,37): error TS2339: Property 'valuesArray' does not exist on type 'Set<any>'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(130,18): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(139,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/resources/DOMStorageItemsView.js(32,11): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/resources/DOMStorageItemsView.js(38,56): error TS2694: Namespace 'DataGrid' has no exported member 'ColumnDescriptor'.
 node_modules/chrome-devtools-frontend/front_end/resources/DOMStorageItemsView.js(39,26): error TS2555: Expected at least 2 arguments, but got 1.
@@ -10072,6 +10141,28 @@ node_modules/chrome-devtools-frontend/front_end/resources/DOMStorageModel.js(298
 node_modules/chrome-devtools-frontend/front_end/resources/DOMStorageModel.js(306,24): error TS2694: Namespace 'Protocol' has no exported member 'DOMStorage'.
 node_modules/chrome-devtools-frontend/front_end/resources/DOMStorageModel.js(315,24): error TS2694: Namespace 'Protocol' has no exported member 'DOMStorage'.
 node_modules/chrome-devtools-frontend/front_end/resources/DOMStorageModel.js(325,24): error TS2694: Namespace 'Protocol' has no exported member 'DOMStorage'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(98,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(112,17): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(130,26): error TS2339: Property 'databaseAgent' does not exist on type 'Target'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(131,19): error TS2339: Property 'registerDatabaseDispatcher' does not exist on type 'Target'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseModel.js(191,24): error TS2694: Namespace 'Protocol' has no exported member 'Database'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseQueryView.js(38,42): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseQueryView.js(52,62): error TS2339: Property 'hasSelection' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseQueryView.js(60,39): error TS2694: Namespace 'SuggestBox' has no exported member 'Suggestions'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseQueryView.js(151,19): error TS2339: Property 'createTextChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(31,11): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(40,47): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(42,53): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(58,5): error TS2322: Type '(ToolbarButton | ToolbarInput)[]' is not assignable to type '({ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; })[]'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(58,5): error TS2322: Type '(ToolbarButton | ToolbarInput)[]' is not assignable to type '({ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; })[]'.
+  Type 'ToolbarButton | ToolbarInput' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+    Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
+      Type 'ToolbarButton' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
+        Property 'item' is missing in type 'ToolbarButton'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(77,18): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(114,37): error TS2339: Property 'valuesArray' does not exist on type 'Set<any>'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(130,18): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/resources/DatabaseTableView.js(139,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/resources/IndexedDBModel.js(41,12): error TS2339: Property 'registerStorageDispatcher' does not exist on type 'Target'.
 node_modules/chrome-devtools-frontend/front_end/resources/IndexedDBModel.js(43,35): error TS2339: Property 'indexedDBAgent' does not exist on type 'Target'.
 node_modules/chrome-devtools-frontend/front_end/resources/IndexedDBModel.js(44,33): error TS2339: Property 'storageAgent' does not exist on type 'Target'.
@@ -10266,38 +10357,6 @@ node_modules/chrome-devtools-frontend/front_end/resources/StorageItemsView.js(40
   Type 'Function' provides no match for the signature '(arg0: any): any'.
 node_modules/chrome-devtools-frontend/front_end/resources/StorageItemsView.js(49,45): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/resources/StorageItemsView.js(54,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(43,8): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(95,28): error TS2339: Property 'response' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(147,37): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(158,21): error TS2345: Argument of type 'Promise<string>' is not assignable to parameter of type 'Promise<undefined>'.
-  Type 'string' is not assignable to type 'undefined'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(161,5): error TS2322: Type 'Promise<undefined[]>' is not assignable to type 'Promise<undefined>'.
-  Type 'undefined[]' is not assignable to type 'undefined'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(187,12): error TS2339: Property 'eval' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(197,5): error TS2322: Type 'Promise<string>' is not assignable to type 'Promise<undefined>'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(267,14): error TS2339: Property 'runtime' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(269,59): error TS2339: Property 'runtime' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(270,9): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
-  Type 'void' is not assignable to type 'undefined'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(280,5): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(283,7): error TS2554: Expected 2-3 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(398,24): error TS1138: Parameter declaration expected.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(398,24): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(527,9): error TS2322: Type 'Function' is not assignable to type 'new () => any'.
-  Type 'Function' provides no match for the signature 'new (): any'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(527,49): error TS2352: Type 'Window' cannot be converted to type 'Function'.
-  Property 'apply' is missing in type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(539,20): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(693,7): error TS2322: Type 'Promise<boolean>' is not assignable to type 'Promise<undefined>'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(693,7): error TS2322: Type 'Promise<boolean>' is not assignable to type 'Promise<undefined>'.
-  Type 'boolean' is not assignable to type 'undefined'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(705,5): error TS2322: Type 'Promise<boolean>' is not assignable to type 'Promise<undefined>'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(715,7): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(721,5): error TS2322: Type 'Promise<undefined[]>' is not assignable to type 'Promise<undefined>'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(729,7): error TS2322: Type 'Promise<void>' is not assignable to type 'Promise<undefined>'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(854,36): error TS2339: Property 'eval' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(1083,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
-node_modules/chrome-devtools-frontend/front_end/Runtime.js(1088,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/screencast/InputModel.js(11,31): error TS2339: Property 'inputAgent' does not exist on type 'Target'.
 node_modules/chrome-devtools-frontend/front_end/screencast/InputModel.js(36,70): error TS2339: Property 'charCode' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/screencast/InputModel.js(43,28): error TS2339: Property 'keyIdentifier' does not exist on type 'Event'.
@@ -10367,28 +10426,6 @@ node_modules/chrome-devtools-frontend/front_end/screencast/ScreencastView.js(675
 node_modules/chrome-devtools-frontend/front_end/screencast/ScreencastView.js(676,25): error TS2339: Property 'select' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/screencast/ScreencastView.js(737,17): error TS2339: Property 'type' does not exist on type 'NetworkRequest'.
 node_modules/chrome-devtools-frontend/front_end/screencast/ScreencastView.js(766,19): error TS2339: Property 'style' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(10,52): error TS2694: Namespace 'Connection' has no exported member 'Params'.
-node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(30,29): error TS2339: Property 'sendMessageToBackend' does not exist on type 'typeof InspectorFrontendHost'.
-node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(34,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(41,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(71,27): error TS2339: Property 'reattach' does not exist on type 'typeof InspectorFrontendHost'.
-node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(87,52): error TS2694: Namespace 'Connection' has no exported member 'Params'.
-node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(168,52): error TS2694: Namespace 'Connection' has no exported member 'Params'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(14,24): error TS2694: Namespace 'Protocol' has no exported member 'Network'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(40,27): error TS2339: Property 'asParsedURL' does not exist on type 'string'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(65,26): error TS2339: Property 'networkAgent' does not exist on type 'Target'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(95,39): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(97,10): error TS2339: Property 'networkAgent' does not exist on type 'Target'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(114,38): error TS2339: Property 'asParsedURL' does not exist on type 'string'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(129,38): error TS2339: Property 'networkAgent' does not exist on type 'Target'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(79,29): error TS2345: Argument of type 'number' is not assignable to parameter of type '{ [x: string]: any; Request: number; Response: number; }'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(97,29): error TS2345: Argument of type 'number' is not assignable to parameter of type '{ [x: string]: any; Request: number; Response: number; }'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(161,26): error TS2694: Namespace 'Cookie' has no exported member 'Type'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(200,26): error TS2694: Namespace 'Cookie' has no exported member 'Type'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(225,27): error TS2694: Namespace 'Cookie' has no exported member 'Type'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(246,25): error TS2694: Namespace 'Protocol' has no exported member 'Network'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(250,33): error TS2694: Namespace 'Protocol' has no exported member 'Network'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(325,53): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 node_modules/chrome-devtools-frontend/front_end/sdk/CPUProfileDataModel.js(9,24): error TS2694: Namespace 'Protocol' has no exported member 'Profiler'.
 node_modules/chrome-devtools-frontend/front_end/sdk/CPUProfileDataModel.js(13,60): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
 node_modules/chrome-devtools-frontend/front_end/sdk/CPUProfileDataModel.js(35,24): error TS2694: Namespace 'Protocol' has no exported member 'Profiler'.
@@ -10556,114 +10593,30 @@ node_modules/chrome-devtools-frontend/front_end/sdk/CSSStyleDeclaration.js(41,47
 node_modules/chrome-devtools-frontend/front_end/sdk/CSSStyleDeclaration.js(50,24): error TS2694: Namespace 'Protocol' has no exported member 'CSS'.
 node_modules/chrome-devtools-frontend/front_end/sdk/CSSStyleSheetHeader.js(11,24): error TS2694: Namespace 'Protocol' has no exported member 'CSS'.
 node_modules/chrome-devtools-frontend/front_end/sdk/CSSStyleSheetHeader.js(40,5): error TS2322: Type 'StaticContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
-node_modules/chrome-devtools-frontend/front_end/sdk/CSSStyleSheetHeader.js(40,5): error TS2322: Type 'StaticContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
   Property '_contentURL' does not exist on type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(41,12): error TS2339: Property 'registerDebuggerDispatcher' does not exist on type 'Target'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(42,26): error TS2339: Property 'debuggerAgent' does not exist on type 'Target'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(231,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(250,43): error TS2694: Namespace 'DebuggerModel' has no exported member 'SetBreakpointResult'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(267,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(281,43): error TS2694: Namespace 'DebuggerModel' has no exported member 'SetBreakpointResult'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(286,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(304,43): error TS2694: Namespace 'DebuggerModel' has no exported member 'SetBreakpointResult'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(310,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(319,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(324,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(325,73): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(340,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(346,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(347,34): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(351,30): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(355,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(356,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(389,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(419,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(421,33): error TS2694: Namespace 'Protocol' has no exported member 'Error'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(429,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(431,33): error TS2694: Namespace 'Protocol' has no exported member 'Error'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(431,50): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(432,24): error TS2694: Namespace 'Protocol' has no exported member 'Error'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(433,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(434,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(435,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(436,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(498,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(502,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(503,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(504,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(521,31): error TS2339: Property '_continueToLocationCallback' does not exist on type 'DebuggerModel'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(522,27): error TS2339: Property '_continueToLocationCallback' does not exist on type 'DebuggerModel'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(523,19): error TS2339: Property '_continueToLocationCallback' does not exist on type 'DebuggerModel'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(540,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(546,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(700,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(711,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(763,32): error TS2694: Namespace 'RuntimeModel' has no exported member 'EvaluationOptions'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(764,42): error TS2694: Namespace 'RuntimeModel' has no exported member 'EvaluationResult'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(772,43): error TS2694: Namespace 'DebuggerModel' has no exported member 'FunctionDetails'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(780,36): error TS2694: Namespace 'DebuggerModel' has no exported member 'FunctionDetails'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(816,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(822,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(829,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(830,31): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(838,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(839,31): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(852,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(899,22): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(907,78): error TS1003: Identifier expected.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(908,19): error TS2339: Property 'FunctionDetails' does not exist on type 'typeof DebuggerModel'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(967,2): error TS1131: Property or signature expected.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(971,19): error TS2339: Property 'SetBreakpointResult' does not exist on type 'typeof DebuggerModel'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(987,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(991,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(992,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(993,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1009,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1015,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1034,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1040,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1058,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1059,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1085,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1093,25): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1111,26): error TS2339: Property '_continueToLocationCallback' does not exist on type 'DebuggerModel'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1148,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1158,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1174,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1186,37): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1197,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1263,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1266,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1294,32): error TS2694: Namespace 'RuntimeModel' has no exported member 'EvaluationOptions'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1295,42): error TS2694: Namespace 'RuntimeModel' has no exported member 'EvaluationResult'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1308,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1321,28): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1368,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1369,16): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1370,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1371,16): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1372,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1373,16): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1374,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1375,16): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1376,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1377,16): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1378,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1379,16): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1380,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1381,16): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1382,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1383,16): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1419,33): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1419,84): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1435,33): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1435,84): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1446,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1450,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1451,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1472,30): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1476,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
-node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1477,25): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CSSStyleSheetHeader.js(40,5): error TS2322: Type 'StaticContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
+node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(10,52): error TS2694: Namespace 'Connection' has no exported member 'Params'.
+node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(30,29): error TS2339: Property 'sendMessageToBackend' does not exist on type 'typeof InspectorFrontendHost'.
+node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(34,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(41,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(71,27): error TS2339: Property 'reattach' does not exist on type 'typeof InspectorFrontendHost'.
+node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(87,52): error TS2694: Namespace 'Connection' has no exported member 'Params'.
+node_modules/chrome-devtools-frontend/front_end/sdk/Connections.js(168,52): error TS2694: Namespace 'Connection' has no exported member 'Params'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(14,24): error TS2694: Namespace 'Protocol' has no exported member 'Network'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(40,27): error TS2339: Property 'asParsedURL' does not exist on type 'string'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(65,26): error TS2339: Property 'networkAgent' does not exist on type 'Target'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(95,39): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(97,10): error TS2339: Property 'networkAgent' does not exist on type 'Target'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(114,38): error TS2339: Property 'asParsedURL' does not exist on type 'string'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieModel.js(129,38): error TS2339: Property 'networkAgent' does not exist on type 'Target'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(79,29): error TS2345: Argument of type 'number' is not assignable to parameter of type '{ [x: string]: any; Request: number; Response: number; }'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(97,29): error TS2345: Argument of type 'number' is not assignable to parameter of type '{ [x: string]: any; Request: number; Response: number; }'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(161,26): error TS2694: Namespace 'Cookie' has no exported member 'Type'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(200,26): error TS2694: Namespace 'Cookie' has no exported member 'Type'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(225,27): error TS2694: Namespace 'Cookie' has no exported member 'Type'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(246,25): error TS2694: Namespace 'Protocol' has no exported member 'Network'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(250,33): error TS2694: Namespace 'Protocol' has no exported member 'Network'.
+node_modules/chrome-devtools-frontend/front_end/sdk/CookieParser.js(325,53): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 node_modules/chrome-devtools-frontend/front_end/sdk/DOMDebuggerModel.js(11,26): error TS2339: Property 'domdebuggerAgent' does not exist on type 'Target'.
 node_modules/chrome-devtools-frontend/front_end/sdk/DOMDebuggerModel.js(69,50): error TS2694: Namespace 'DOMBreakpoint' has no exported member 'Type'.
 node_modules/chrome-devtools-frontend/front_end/sdk/DOMDebuggerModel.js(78,50): error TS2694: Namespace 'DOMBreakpoint' has no exported member 'Type'.
@@ -10833,6 +10786,112 @@ node_modules/chrome-devtools-frontend/front_end/sdk/DOMModel.js(1715,24): error 
 node_modules/chrome-devtools-frontend/front_end/sdk/DOMModel.js(1723,24): error TS2694: Namespace 'Protocol' has no exported member 'DOM'.
 node_modules/chrome-devtools-frontend/front_end/sdk/DOMModel.js(1724,32): error TS2694: Namespace 'Protocol' has no exported member 'DOM'.
 node_modules/chrome-devtools-frontend/front_end/sdk/DOMModel.js(1801,17): error TS2339: Property 'remove' does not exist on type 'DOMModel[]'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(41,12): error TS2339: Property 'registerDebuggerDispatcher' does not exist on type 'Target'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(42,26): error TS2339: Property 'debuggerAgent' does not exist on type 'Target'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(231,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(250,43): error TS2694: Namespace 'DebuggerModel' has no exported member 'SetBreakpointResult'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(267,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(281,43): error TS2694: Namespace 'DebuggerModel' has no exported member 'SetBreakpointResult'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(286,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(304,43): error TS2694: Namespace 'DebuggerModel' has no exported member 'SetBreakpointResult'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(310,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(319,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(324,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(325,73): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(340,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(346,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(347,34): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(351,30): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(355,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(356,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(389,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(419,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(421,33): error TS2694: Namespace 'Protocol' has no exported member 'Error'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(429,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(431,33): error TS2694: Namespace 'Protocol' has no exported member 'Error'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(431,50): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(432,24): error TS2694: Namespace 'Protocol' has no exported member 'Error'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(433,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(434,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(435,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(436,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(498,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(502,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(503,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(504,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(521,31): error TS2339: Property '_continueToLocationCallback' does not exist on type 'DebuggerModel'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(522,27): error TS2339: Property '_continueToLocationCallback' does not exist on type 'DebuggerModel'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(523,19): error TS2339: Property '_continueToLocationCallback' does not exist on type 'DebuggerModel'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(540,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(546,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(700,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(711,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(763,32): error TS2694: Namespace 'RuntimeModel' has no exported member 'EvaluationOptions'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(764,42): error TS2694: Namespace 'RuntimeModel' has no exported member 'EvaluationResult'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(772,43): error TS2694: Namespace 'DebuggerModel' has no exported member 'FunctionDetails'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(780,36): error TS2694: Namespace 'DebuggerModel' has no exported member 'FunctionDetails'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(816,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(822,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(829,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(830,31): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(838,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(839,31): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(852,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(899,22): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(907,78): error TS1003: Identifier expected.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(908,19): error TS2339: Property 'FunctionDetails' does not exist on type 'typeof DebuggerModel'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(967,2): error TS1131: Property or signature expected.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(971,19): error TS2339: Property 'SetBreakpointResult' does not exist on type 'typeof DebuggerModel'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(987,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(991,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(992,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(993,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1009,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1015,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1034,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1040,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1058,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1059,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1085,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1093,25): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1111,26): error TS2339: Property '_continueToLocationCallback' does not exist on type 'DebuggerModel'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1148,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1158,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1174,24): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1186,37): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1197,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1263,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1266,27): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1294,32): error TS2694: Namespace 'RuntimeModel' has no exported member 'EvaluationOptions'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1295,42): error TS2694: Namespace 'RuntimeModel' has no exported member 'EvaluationResult'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1308,35): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1321,28): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1368,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1369,16): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1370,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1371,16): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1372,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1373,16): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1374,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1375,16): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1376,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1377,16): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1378,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1379,16): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1380,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1381,16): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1382,21): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1383,16): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1419,33): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1419,84): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1435,33): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1435,84): error TS2339: Property 'Debugger' does not exist on type 'typeof Protocol'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1446,32): error TS2694: Namespace 'Protocol' has no exported member 'Debugger'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1450,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1451,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1472,30): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1476,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
+node_modules/chrome-devtools-frontend/front_end/sdk/DebuggerModel.js(1477,25): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
 node_modules/chrome-devtools-frontend/front_end/sdk/EmulationModel.js(11,35): error TS2339: Property 'emulationAgent' does not exist on type 'Target'.
 node_modules/chrome-devtools-frontend/front_end/sdk/EmulationModel.js(12,30): error TS2339: Property 'pageAgent' does not exist on type 'Target'.
 node_modules/chrome-devtools-frontend/front_end/sdk/EmulationModel.js(13,43): error TS2339: Property 'deviceOrientationAgent' does not exist on type 'Target'.
@@ -11210,9 +11269,9 @@ node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(718,33): err
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(728,32): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(731,3): error TS2416: Property 'callFunctionJSON' in type 'RemoteObjectImpl' is not assignable to the same property in base type 'RemoteObject'.
   Type '(functionDeclaration: (this: any) => any, args: any[], callback: (arg0: any) => any) => void' is not assignable to type '<T>(functionDeclaration: (this: any, ...arg1: any[]) => T, args: any[], callback: (arg0: T) => an...'.
+    Types of parameters 'functionDeclaration' and 'functionDeclaration' are incompatible.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(731,3): error TS2416: Property 'callFunctionJSON' in type 'RemoteObjectImpl' is not assignable to the same property in base type 'RemoteObject'.
   Type '(functionDeclaration: (this: any) => any, args: any[], callback: (arg0: any) => any) => void' is not assignable to type '<T>(functionDeclaration: (this: any, ...arg1: any[]) => T, args: any[], callback: (arg0: T) => an...'.
-    Types of parameters 'functionDeclaration' and 'functionDeclaration' are incompatible.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(741,52): error TS2339: Property 'Error' does not exist on type 'typeof Protocol'.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(795,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(797,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
@@ -11232,9 +11291,9 @@ node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(1179,3): err
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(1234,21): error TS2694: Namespace 'SDK' has no exported member 'CallFunctionResult'.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(1265,21): error TS2694: Namespace 'SDK' has no exported member 'CallFunctionResult'.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(1325,5): error TS2322: Type 'Promise<{ properties: RemoteObjectProperty[]; internalProperties: RemoteObjectProperty[]; }>' is not assignable to type 'Promise<RemoteObject>'.
-node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(1325,5): error TS2322: Type 'Promise<{ properties: RemoteObjectProperty[]; internalProperties: RemoteObjectProperty[]; }>' is not assignable to type 'Promise<RemoteObject>'.
   Type '{ properties: RemoteObjectProperty[]; internalProperties: RemoteObjectProperty[]; }' is not assignable to type 'RemoteObject'.
     Property 'customPreview' is missing in type '{ properties: RemoteObjectProperty[]; internalProperties: RemoteObjectProperty[]; }'.
+node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(1325,5): error TS2322: Type 'Promise<{ properties: RemoteObjectProperty[]; internalProperties: RemoteObjectProperty[]; }>' is not assignable to type 'Promise<RemoteObject>'.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(1345,43): error TS2694: Namespace 'DebuggerModel' has no exported member 'FunctionDetails'.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(1352,45): error TS2694: Namespace 'DebuggerModel' has no exported member 'FunctionDetails'.
 node_modules/chrome-devtools-frontend/front_end/sdk/RemoteObject.js(1363,35): error TS2694: Namespace 'DebuggerModel' has no exported member 'FunctionDetails'.
@@ -11378,8 +11437,8 @@ node_modules/chrome-devtools-frontend/front_end/sdk/ScreenCaptureModel.js(160,24
 node_modules/chrome-devtools-frontend/front_end/sdk/Script.js(39,24): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
 node_modules/chrome-devtools-frontend/front_end/sdk/Script.js(143,52): error TS2339: Property 'debuggerAgent' does not exist on type 'Target'.
 node_modules/chrome-devtools-frontend/front_end/sdk/Script.js(159,5): error TS2322: Type 'StaticContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
-node_modules/chrome-devtools-frontend/front_end/sdk/Script.js(159,5): error TS2322: Type 'StaticContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
   Property '_contentURL' does not exist on type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
+node_modules/chrome-devtools-frontend/front_end/sdk/Script.js(159,5): error TS2322: Type 'StaticContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
 node_modules/chrome-devtools-frontend/front_end/sdk/Script.js(174,43): error TS2339: Property 'debuggerAgent' does not exist on type 'Target'.
 node_modules/chrome-devtools-frontend/front_end/sdk/Script.js(190,33): error TS2694: Namespace 'Protocol' has no exported member 'Error'.
 node_modules/chrome-devtools-frontend/front_end/sdk/Script.js(190,50): error TS2694: Namespace 'Protocol' has no exported member 'Runtime'.
@@ -11467,8 +11526,8 @@ node_modules/chrome-devtools-frontend/front_end/sdk/SourceMap.js(284,7): error T
 node_modules/chrome-devtools-frontend/front_end/sdk/SourceMap.js(284,7): error TS2322: Type 'StaticContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
   Property '_contentURL' does not exist on type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
 node_modules/chrome-devtools-frontend/front_end/sdk/SourceMap.js(285,5): error TS2322: Type 'CompilerSourceMappingContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
-node_modules/chrome-devtools-frontend/front_end/sdk/SourceMap.js(285,5): error TS2322: Type 'CompilerSourceMappingContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
   Property '_sourceURL' does not exist on type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
+node_modules/chrome-devtools-frontend/front_end/sdk/SourceMap.js(285,5): error TS2322: Type 'CompilerSourceMappingContentProvider' is not assignable to type '{ [x: string]: any; contentURL(): string; contentType(): ResourceType; contentEncoded(): Promise<...'.
 node_modules/chrome-devtools-frontend/front_end/sdk/SourceMap.js(325,26): error TS2339: Property 'upperBound' does not exist on type 'SourceMapEntry[]'.
 node_modules/chrome-devtools-frontend/front_end/sdk/SourceMap.js(338,26): error TS2339: Property 'lowerBound' does not exist on type 'SourceMapEntry[]'.
 node_modules/chrome-devtools-frontend/front_end/sdk/SourceMap.js(339,25): error TS2339: Property 'upperBound' does not exist on type 'SourceMapEntry[]'.
@@ -11539,8 +11598,8 @@ node_modules/chrome-devtools-frontend/front_end/sdk/TargetManager.js(347,36): er
 node_modules/chrome-devtools-frontend/front_end/sdk/TargetManager.js(351,35): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/sdk/TargetManager.js(356,52): error TS2694: Namespace 'Connection' has no exported member 'Params'.
 node_modules/chrome-devtools-frontend/front_end/sdk/TargetManager.js(364,7): error TS2322: Type 'WebSocketConnection' is not assignable to type '{ [x: string]: any; sendMessage(message: string): void; disconnect(): Promise<any>; }'.
-node_modules/chrome-devtools-frontend/front_end/sdk/TargetManager.js(364,7): error TS2322: Type 'WebSocketConnection' is not assignable to type '{ [x: string]: any; sendMessage(message: string): void; disconnect(): Promise<any>; }'.
   Property '_socket' does not exist on type '{ [x: string]: any; sendMessage(message: string): void; disconnect(): Promise<any>; }'.
+node_modules/chrome-devtools-frontend/front_end/sdk/TargetManager.js(364,7): error TS2322: Type 'WebSocketConnection' is not assignable to type '{ [x: string]: any; sendMessage(message: string): void; disconnect(): Promise<any>; }'.
 node_modules/chrome-devtools-frontend/front_end/sdk/TargetManager.js(365,38): error TS2339: Property 'isHostedMode' does not exist on type 'typeof InspectorFrontendHost'.
 node_modules/chrome-devtools-frontend/front_end/sdk/TargetManager.js(366,7): error TS2322: Type 'StubConnection' is not assignable to type '{ [x: string]: any; sendMessage(message: string): void; disconnect(): Promise<any>; }'.
 node_modules/chrome-devtools-frontend/front_end/sdk/TargetManager.js(366,7): error TS2322: Type 'StubConnection' is not assignable to type '{ [x: string]: any; sendMessage(message: string): void; disconnect(): Promise<any>; }'.
@@ -11842,8 +11901,8 @@ node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(51,48
 node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(54,43): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(69,55): error TS2339: Property 'runtime' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(85,5): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
-node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(85,5): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
   Property 'appendApplicableItems' is missing in type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }'.
+node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(85,5): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
 node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(100,15): error TS2339: Property 'keyCode' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(119,31): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(121,42): error TS2339: Property 'createChild' does not exist on type 'Element'.
@@ -11869,8 +11928,8 @@ node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(336,3
 node_modules/chrome-devtools-frontend/front_end/settings/SettingsScreen.js(351,31): error TS2339: Property 'bringToFront' does not exist on type 'typeof InspectorFrontendHost'.
 node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(70,35): error TS2339: Property 'remove' does not exist on type 'Map<DebuggerModel, SnippetScriptMapping>'.
 node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(113,5): error TS2322: Type 'SnippetsProject' is not assignable to type '{ [x: string]: any; workspace(): Workspace; id(): string; type(): string; isServiceProject(): boo...'.
-node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(113,5): error TS2322: Type 'SnippetsProject' is not assignable to type '{ [x: string]: any; workspace(): Workspace; id(): string; type(): string; isServiceProject(): boo...'.
   Property '_model' does not exist on type '{ [x: string]: any; workspace(): Workspace; id(): string; type(): string; isServiceProject(): boo...'.
+node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(113,5): error TS2322: Type 'SnippetsProject' is not assignable to type '{ [x: string]: any; workspace(): Workspace; id(): string; type(): string; isServiceProject(): boo...'.
 node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(137,18): error TS2339: Property 'addEventListener' does not exist on type 'UISourceCode'.
 node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(146,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(165,36): error TS2339: Property 'remove' does not exist on type 'Map<UISourceCode, string>'.
@@ -11883,8 +11942,8 @@ node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(3
 node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(379,33): error TS2339: Property 'remove' does not exist on type 'Map<UISourceCode, Script>'.
 node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(380,42): error TS2339: Property 'remove' does not exist on type 'Map<UISourceCode, number>'.
 node_modules/chrome-devtools-frontend/front_end/snippets/ScriptSnippetModel.js(534,35): error TS2345: Argument of type 'string' is not assignable to parameter of type '{ [x: string]: any; Debugger: string; Formatter: string; Network: string; Snippets: string; FileS...'.
-node_modules/chrome-devtools-frontend/front_end/snippets/SnippetsQuickOpen.js(30,12): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/snippets/SnippetStorage.js(62,27): error TS2339: Property 'valuesArray' does not exist on type 'Map<string, Snippet>'.
+node_modules/chrome-devtools-frontend/front_end/snippets/SnippetsQuickOpen.js(30,12): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/source_frame/FontView.js(38,11): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/source_frame/FontView.js(52,5): error TS2322: Type 'ToolbarText[]' is not assignable to type '({ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; })[]'.
 node_modules/chrome-devtools-frontend/front_end/source_frame/FontView.js(52,5): error TS2322: Type 'ToolbarText[]' is not assignable to type '({ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; })[]'.
@@ -11959,10 +12018,10 @@ node_modules/chrome-devtools-frontend/front_end/source_frame/SourceCodeDiff.js(2
 node_modules/chrome-devtools-frontend/front_end/source_frame/SourceCodeDiff.js(284,22): error TS2339: Property 'toggleLineClass' does not exist on type 'CodeMirrorTextEditor'.
 node_modules/chrome-devtools-frontend/front_end/source_frame/SourceFrame.js(41,11): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/source_frame/SourceFrame.js(115,5): error TS2322: Type 'ToolbarText[]' is not assignable to type '({ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; })[]'.
-node_modules/chrome-devtools-frontend/front_end/source_frame/SourceFrame.js(115,5): error TS2322: Type 'ToolbarText[]' is not assignable to type '({ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; })[]'.
   Type 'ToolbarText' is not assignable to type '{ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; }'.
     Type 'ToolbarText' is not assignable to type '{ [x: string]: any; item(): any & any; }'.
       Property 'item' is missing in type 'ToolbarText'.
+node_modules/chrome-devtools-frontend/front_end/source_frame/SourceFrame.js(115,5): error TS2322: Type 'ToolbarText[]' is not assignable to type '({ [x: string]: any; item(): any & any; } & { [x: string]: any; item(): any & any; })[]'.
 node_modules/chrome-devtools-frontend/front_end/source_frame/SourceFrame.js(371,32): error TS2339: Property 'lowerBound' does not exist on type 'any[]'.
 node_modules/chrome-devtools-frontend/front_end/source_frame/SourceFrame.js(435,15): error TS2339: Property '__fromRegExpQuery' does not exist on type 'RegExp'.
 node_modules/chrome-devtools-frontend/front_end/source_frame/SourceFrame.js(459,15): error TS2339: Property '__fromRegExpQuery' does not exist on type 'RegExp'.
@@ -12089,6 +12148,23 @@ node_modules/chrome-devtools-frontend/front_end/sources/AdvancedSearchView.js(29
 node_modules/chrome-devtools-frontend/front_end/sources/AdvancedSearchView.js(296,58): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/sources/AdvancedSearchView.js(318,19): error TS2339: Property 'keyCode' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/sources/AdvancedSearchView.js(397,46): error TS2339: Property 'window' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(84,13): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(102,19): error TS2339: Property 'sprintf' does not exist on type 'StringConstructor'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(150,31): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(197,26): error TS2339: Property 'title' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(197,34): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(212,26): error TS2339: Property 'title' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(212,34): error TS2555: Expected at least 2 arguments, but got 1.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(223,11): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(247,45): error TS2345: Argument of type '{ [x: string]: any; Original: string; Nickname: string; HEX: string; ShortHEX: string; HEXA: stri...' is not assignable to parameter of type 'string'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(252,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(259,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(266,25): error TS2339: Property 'setColor' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(288,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(292,25): error TS2339: Property 'setBezierText' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(315,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(327,22): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
+node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(333,40): error TS2694: Namespace 'SuggestBox' has no exported member 'Suggestions'.
 node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(33,11): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(39,57): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(40,49): error TS2555: Expected at least 2 arguments, but got 1.
@@ -12125,25 +12201,8 @@ node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(
 node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(415,65): error TS1138: Parameter declaration expected.
 node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(415,65): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
 node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(429,2): error TS1131: Property or signature expected.
-node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(435,30): error TS2300: Duplicate identifier 'Item'.
 node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(435,30): error TS2339: Property 'Item' does not exist on type 'typeof CallStackSidebarPane'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(84,13): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(102,19): error TS2339: Property 'sprintf' does not exist on type 'StringConstructor'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(150,31): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(197,26): error TS2339: Property 'title' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(197,34): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(212,26): error TS2339: Property 'title' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(212,34): error TS2555: Expected at least 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(223,11): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(247,45): error TS2345: Argument of type '{ [x: string]: any; Original: string; Nickname: string; HEX: string; ShortHEX: string; HEXA: stri...' is not assignable to parameter of type 'string'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(252,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(259,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(266,25): error TS2339: Property 'setColor' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(288,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(292,25): error TS2339: Property 'setBezierText' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(315,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(327,22): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
-node_modules/chrome-devtools-frontend/front_end/sources/CSSPlugin.js(333,40): error TS2694: Namespace 'SuggestBox' has no exported member 'Suggestions'.
+node_modules/chrome-devtools-frontend/front_end/sources/CallStackSidebarPane.js(435,30): error TS2300: Duplicate identifier 'Item'.
 node_modules/chrome-devtools-frontend/front_end/sources/DebuggerPausedMessage.js(11,33): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
 node_modules/chrome-devtools-frontend/front_end/sources/DebuggerPausedMessage.js(54,37): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/sources/DebuggerPausedMessage.js(56,37): error TS2555: Expected at least 2 arguments, but got 1.
@@ -12162,8 +12221,8 @@ node_modules/chrome-devtools-frontend/front_end/sources/EventListenerBreakpoints
 node_modules/chrome-devtools-frontend/front_end/sources/EventListenerBreakpointsSidebarPane.js(24,113): error TS2694: Namespace 'EventListenerBreakpointsSidebarPane' has no exported member 'Item'.
 node_modules/chrome-devtools-frontend/front_end/sources/EventListenerBreakpointsSidebarPane.js(57,33): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/sources/EventListenerBreakpointsSidebarPane.js(125,64): error TS1003: Identifier expected.
-node_modules/chrome-devtools-frontend/front_end/sources/EventListenerBreakpointsSidebarPane.js(126,45): error TS2300: Duplicate identifier 'Item'.
 node_modules/chrome-devtools-frontend/front_end/sources/EventListenerBreakpointsSidebarPane.js(126,45): error TS2339: Property 'Item' does not exist on type 'typeof EventListenerBreakpointsSidebarPane'.
+node_modules/chrome-devtools-frontend/front_end/sources/EventListenerBreakpointsSidebarPane.js(126,45): error TS2300: Duplicate identifier 'Item'.
 node_modules/chrome-devtools-frontend/front_end/sources/FilteredUISourceCodeListProvider.js(20,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/sources/FilteredUISourceCodeListProvider.js(140,21): error TS2339: Property 'title' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/sources/FilteredUISourceCodeListProvider.js(159,13): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
@@ -12573,8 +12632,8 @@ node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(108,25): 
 node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(113,15): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(113,48): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(134,52): error TS2694: Namespace 'KeyboardShortcut' has no exported member 'Descriptor'.
-node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(134,65): error TS1138: Parameter declaration expected.
 node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(134,65): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
+node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(134,65): error TS1138: Parameter declaration expected.
 node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(139,45): error TS2694: Namespace 'KeyboardShortcut' has no exported member 'Descriptor'.
 node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(190,43): error TS2694: Namespace 'KeyboardShortcut' has no exported member 'Descriptor'.
 node_modules/chrome-devtools-frontend/front_end/sources/SourcesView.js(287,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
@@ -13062,8 +13121,8 @@ node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1016,1
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1025,32): error TS2339: Property '_pageLoadedCallback' does not exist on type 'typeof TestRunner'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1031,14): error TS2339: Property '_pageLoadedCallback' does not exist on type 'typeof TestRunner'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1035,18): error TS1099: Type argument list cannot be empty.
-node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1035,19): error TS1005: '>' expected.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1035,19): error TS8024: JSDoc '@param' tag has name 'function', but there is no parameter with that name.
+node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1035,19): error TS1005: '>' expected.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1129,21): error TS2339: Property 'resourceTreeModel' does not exist on type 'typeof TestRunner'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1192,15): error TS2339: Property 'runtime' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1203,19): error TS2339: Property 'naturalOrderComparator' does not exist on type 'StringConstructor'.
@@ -13079,65 +13138,6 @@ node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1424,1
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1425,37): error TS2339: Property '_instanceForTest' does not exist on type 'typeof Main'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1426,27): error TS2339: Property '_instanceForTest' does not exist on type 'typeof Main'.
 node_modules/chrome-devtools-frontend/front_end/test_runner/TestRunner.js(1427,48): error TS2339: Property '_instanceForTest' does not exist on type 'typeof Main'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(107,5): error TS2322: Type 'Timer' is not assignable to type 'number'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(208,5): error TS2554: Expected 4 arguments, but got 3.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(221,7): error TS2554: Expected 4 arguments, but got 3.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(378,10): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
-node_modules/chrome-devtools-frontend/front_end/Tests.js(397,5): error TS2554: Expected 4 arguments, but got 3.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(416,5): error TS2554: Expected 4 arguments, but got 3.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(440,5): error TS2554: Expected 4 arguments, but got 3.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(475,5): error TS2554: Expected 4 arguments, but got 3.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(571,33): error TS2339: Property 'deprecatedRunAfterPendingDispatches' does not exist on type 'typeof InspectorBackend'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(590,27): error TS2554: Expected 0 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(687,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(711,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(735,5): error TS2554: Expected 4 arguments, but got 3.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(769,28): error TS2339: Property 'networkPresets' does not exist on type 'typeof MobileThrottling'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(775,28): error TS2339: Property 'networkPresets' does not exist on type 'typeof MobileThrottling'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(781,28): error TS2339: Property 'networkPresets' does not exist on type 'typeof MobileThrottling'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(814,31): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
-node_modules/chrome-devtools-frontend/front_end/Tests.js(816,7): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(847,9): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(848,9): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(886,29): error TS2339: Property 'getPreferences' does not exist on type 'typeof InspectorFrontendHost'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(890,17): error TS2339: Property '_instanceForTest' does not exist on type 'typeof Main'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(893,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(894,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(895,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(897,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(898,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(899,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(917,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(918,7): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(929,33): error TS2339: Property 'ConsoleView' does not exist on type '{ new (): Console; prototype: Console; }'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(934,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(935,7): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(959,11): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(960,11): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(961,11): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(965,11): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(966,11): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(967,11): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(968,11): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(969,11): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(970,11): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(974,11): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(975,11): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(976,11): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(977,11): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(978,11): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(986,5): error TS2554: Expected 3 arguments, but got 2.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(988,5): error TS2554: Expected 2 arguments, but got 1.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1033,25): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1040,23): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1084,20): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1139,33): error TS2339: Property 'ConsoleView' does not exist on type '{ new (): Console; prototype: Console; }'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1142,31): error TS2339: Property 'ConsoleView' does not exist on type '{ new (): Console; prototype: Console; }'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1186,5): error TS2554: Expected 4 arguments, but got 3.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1199,9): error TS2554: Expected 4 arguments, but got 3.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1199,28): error TS2551: Property 'panels' does not exist on type 'typeof UI'. Did you mean 'Panel'?
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1229,10): error TS2339: Property 'uiTests' does not exist on type 'Window'.
-node_modules/chrome-devtools-frontend/front_end/Tests.js(1229,41): error TS2339: Property 'domAutomationController' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(36,29): error TS2694: Namespace 'TextEditor' has no exported member 'Options'.
 node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(47,35): error TS2339: Property 'CodeMirror' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(165,18): error TS2339: Property 'style' does not exist on type 'Element'.
@@ -13186,8 +13186,8 @@ node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor
 node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(1052,23): error TS2339: Property 'valuesArray' does not exist on type 'Multimap'.
 node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(1053,23): error TS2339: Property 'clear' does not exist on type 'Multimap'.
 node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(1261,5): error TS2322: Type 'CodeMirrorPositionHandle' is not assignable to type '{ [x: string]: any; resolve(): { lineNumber: number; columnNumber: number; }; equal(positionHandl...'.
-node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(1261,5): error TS2322: Type 'CodeMirrorPositionHandle' is not assignable to type '{ [x: string]: any; resolve(): { lineNumber: number; columnNumber: number; }; equal(positionHandl...'.
   Property '_codeMirror' does not exist on type '{ [x: string]: any; resolve(): { lineNumber: number; columnNumber: number; }; equal(positionHandl...'.
+node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(1261,5): error TS2322: Type 'CodeMirrorPositionHandle' is not assignable to type '{ [x: string]: any; resolve(): { lineNumber: number; columnNumber: number; }; equal(positionHandl...'.
 node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(1301,31): error TS2339: Property 'listSelections' does not exist on type 'CodeMirror'.
 node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(1305,38): error TS2339: Property 'findMatchingBracket' does not exist on type 'CodeMirror'.
 node_modules/chrome-devtools-frontend/front_end/text_editor/CodeMirrorTextEditor.js(1313,14): error TS2339: Property 'setSelections' does not exist on type 'CodeMirror'.
@@ -13273,8 +13273,8 @@ node_modules/chrome-devtools-frontend/front_end/text_utils/Text.js(21,39): error
 node_modules/chrome-devtools-frontend/front_end/text_utils/Text.js(51,31): error TS2694: Namespace 'Text' has no exported member 'Position'.
 node_modules/chrome-devtools-frontend/front_end/text_utils/Text.js(55,34): error TS2339: Property 'lowerBound' does not exist on type 'number[]'.
 node_modules/chrome-devtools-frontend/front_end/text_utils/Text.js(121,59): error TS1003: Identifier expected.
-node_modules/chrome-devtools-frontend/front_end/text_utils/Text.js(122,16): error TS2300: Duplicate identifier 'Position'.
 node_modules/chrome-devtools-frontend/front_end/text_utils/Text.js(122,16): error TS2339: Property 'Position' does not exist on type 'typeof Text'.
+node_modules/chrome-devtools-frontend/front_end/text_utils/Text.js(122,16): error TS2300: Duplicate identifier 'Position'.
 node_modules/chrome-devtools-frontend/front_end/text_utils/Text.js(160,42): error TS2339: Property 'lowerBound' does not exist on type 'number[]'.
 node_modules/chrome-devtools-frontend/front_end/text_utils/TextRange.js(84,31): error TS2339: Property 'computeLineEndings' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/text_utils/TextUtils.js(30,11): error TS2339: Property 'TextUtils' does not exist on type 'typeof TextUtils'.
@@ -13436,9 +13436,9 @@ node_modules/chrome-devtools-frontend/front_end/timeline/TimelineEventOverview.j
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineEventOverview.js(246,68): error TS2339: Property 'peekLast' does not exist on type 'any[]'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineEventOverview.js(248,81): error TS2339: Property '_overviewIndex' does not exist on type 'TimelineCategory'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineEventOverview.js(384,7): error TS2322: Type 'Promise<new (width?: number, height?: number) => HTMLImageElement>' is not assignable to type 'Promise<HTMLImageElement>'.
-node_modules/chrome-devtools-frontend/front_end/timeline/TimelineEventOverview.js(384,7): error TS2322: Type 'Promise<new (width?: number, height?: number) => HTMLImageElement>' is not assignable to type 'Promise<HTMLImageElement>'.
   Type 'new (width?: number, height?: number) => HTMLImageElement' is not assignable to type 'HTMLImageElement'.
     Property 'align' is missing in type 'new (width?: number, height?: number) => HTMLImageElement'.
+node_modules/chrome-devtools-frontend/front_end/timeline/TimelineEventOverview.js(384,7): error TS2322: Type 'Promise<new (width?: number, height?: number) => HTMLImageElement>' is not assignable to type 'Promise<HTMLImageElement>'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineEventOverview.js(457,17): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineEventOverview.js(483,24): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineEventOverview.js(524,28): error TS2339: Property 'peekLast' does not exist on type 'TimelineFrame[]'.
@@ -13777,20 +13777,20 @@ node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(717
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(717,9): error TS2322: Type '{ name: string; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
   Property 'icon' is missing in type '{ name: string; color: string; }'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(727,9): error TS2322: Type '{ name: string; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
-node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(727,9): error TS2322: Type '{ name: string; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
   Property 'icon' is missing in type '{ name: string; color: string; }'.
+node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(727,9): error TS2322: Type '{ name: string; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(731,13): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(733,9): error TS2322: Type '{ name: any; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
-node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(733,9): error TS2322: Type '{ name: any; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
   Property 'icon' is missing in type '{ name: any; color: string; }'.
+node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(733,9): error TS2322: Type '{ name: any; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(743,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'name' must be of type 'any', but here has type 'string'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(753,91): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(754,9): error TS2322: Type '{ name: any; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
-node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(754,9): error TS2322: Type '{ name: any; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
   Property 'icon' is missing in type '{ name: any; color: string; }'.
-node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(759,5): error TS2322: Type '{ name: string; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
+node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(754,9): error TS2322: Type '{ name: any; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(759,5): error TS2322: Type '{ name: string; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
   Property 'icon' is missing in type '{ name: string; color: string; }'.
+node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(759,5): error TS2322: Type '{ name: string; color: string; }' is not assignable to type '{ name: string; color: string; icon: Element; }'.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(770,15): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(771,15): error TS2555: Expected at least 2 arguments, but got 1.
 node_modules/chrome-devtools-frontend/front_end/timeline/TimelineTreeView.js(772,15): error TS2555: Expected at least 2 arguments, but got 1.
@@ -14395,13 +14395,13 @@ node_modules/chrome-devtools-frontend/front_end/timeline_model/TracingLayerTree.
 node_modules/chrome-devtools-frontend/front_end/timeline_model/TracingLayerTree.js(448,90): error TS2339: Property 'name' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/timeline_model/TracingLayerTree.js(452,90): error TS2339: Property 'name' does not exist on type 'string'.
 node_modules/chrome-devtools-frontend/front_end/timeline_model/TracingLayerTree.js(456,90): error TS2339: Property 'name' does not exist on type 'string'.
+node_modules/chrome-devtools-frontend/front_end/ui/ARIAUtils.js(91,41): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
+node_modules/chrome-devtools-frontend/front_end/ui/ARIAUtils.js(109,41): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
+node_modules/chrome-devtools-frontend/front_end/ui/ARIAUtils.js(120,40): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
 node_modules/chrome-devtools-frontend/front_end/ui/ActionRegistry.js(15,10): error TS2339: Property 'runtime' does not exist on type 'Window'.
 node_modules/chrome-devtools-frontend/front_end/ui/ActionRegistry.js(33,53): error TS2339: Property 'keysArray' does not exist on type 'Map<string, Action>'.
 node_modules/chrome-devtools-frontend/front_end/ui/ActionRegistry.js(48,53): error TS2339: Property 'valuesArray' does not exist on type 'Set<Extension>'.
 node_modules/chrome-devtools-frontend/front_end/ui/ActionRegistry.js(210,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
-node_modules/chrome-devtools-frontend/front_end/ui/ARIAUtils.js(91,41): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
-node_modules/chrome-devtools-frontend/front_end/ui/ARIAUtils.js(109,41): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
-node_modules/chrome-devtools-frontend/front_end/ui/ARIAUtils.js(120,40): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
 node_modules/chrome-devtools-frontend/front_end/ui/Context.js(14,33): error TS1110: Type expected.
 node_modules/chrome-devtools-frontend/front_end/ui/Context.js(25,21): error TS2339: Property 'remove' does not exist on type 'Map<any, any>'.
 node_modules/chrome-devtools-frontend/front_end/ui/Context.js(31,33): error TS1110: Type expected.
@@ -14487,8 +14487,8 @@ node_modules/chrome-devtools-frontend/front_end/ui/FilterBar.js(351,46): error T
 node_modules/chrome-devtools-frontend/front_end/ui/FilterBar.js(351,59): error TS2339: Property 'shiftKey' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/ui/FilterBar.js(352,37): error TS2339: Property 'typeName' does not exist on type 'EventTarget'.
 node_modules/chrome-devtools-frontend/front_end/ui/FilterBar.js(374,73): error TS1003: Identifier expected.
-node_modules/chrome-devtools-frontend/front_end/ui/FilterBar.js(375,24): error TS2300: Duplicate identifier 'Item'.
 node_modules/chrome-devtools-frontend/front_end/ui/FilterBar.js(375,24): error TS2339: Property 'Item' does not exist on type 'typeof NamedBitSetFilterUI'.
+node_modules/chrome-devtools-frontend/front_end/ui/FilterBar.js(375,24): error TS2300: Duplicate identifier 'Item'.
 node_modules/chrome-devtools-frontend/front_end/ui/FilterSuggestionBuilder.js(21,39): error TS2694: Namespace 'SuggestBox' has no exported member 'Suggestions'.
 node_modules/chrome-devtools-frontend/front_end/ui/ForwardedInputEventHandler.js(14,22): error TS2694: Namespace 'Common' has no exported member 'Event'.
 node_modules/chrome-devtools-frontend/front_end/ui/Fragment.js(12,49): error TS2694: Namespace 'Fragment' has no exported member '_State'.
@@ -14599,8 +14599,8 @@ node_modules/chrome-devtools-frontend/front_end/ui/InspectorView.js(116,7): erro
 node_modules/chrome-devtools-frontend/front_end/ui/InspectorView.js(116,7): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
   Property 'appendApplicableItems' is missing in type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }'.
 node_modules/chrome-devtools-frontend/front_end/ui/InspectorView.js(118,7): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
-node_modules/chrome-devtools-frontend/front_end/ui/InspectorView.js(118,7): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
   Property 'appendApplicableItems' is missing in type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }'.
+node_modules/chrome-devtools-frontend/front_end/ui/InspectorView.js(118,7): error TS2322: Type '{ [x: string]: any; tabbedPane(): TabbedPane; enableMoreTabsButton(): void; }' is not assignable to type '{ [x: string]: any; appendApplicableItems(locationName: string): void; appendView(view: { [x: str...'.
 node_modules/chrome-devtools-frontend/front_end/ui/InspectorView.js(247,73): error TS2339: Property 'altKey' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/ui/InspectorView.js(247,89): error TS2339: Property 'shiftKey' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/ui/InspectorView.js(254,17): error TS2339: Property 'keyCode' does not exist on type 'Event'.
@@ -14995,8 +14995,8 @@ node_modules/chrome-devtools-frontend/front_end/ui/TextEditor.js(58,15): error T
 node_modules/chrome-devtools-frontend/front_end/ui/TextEditor.js(70,18): error TS2694: Namespace 'UI' has no exported member 'AutocompleteConfig'.
 node_modules/chrome-devtools-frontend/front_end/ui/TextEditor.js(79,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/ui/TextEditor.js(91,2): error TS1131: Property or signature expected.
-node_modules/chrome-devtools-frontend/front_end/ui/TextEditor.js(101,15): error TS2300: Duplicate identifier 'Options'.
 node_modules/chrome-devtools-frontend/front_end/ui/TextEditor.js(101,15): error TS2339: Property 'Options' does not exist on type '{ (): void; Events: { [x: string]: any; TextChanged: symbol; }; }'.
+node_modules/chrome-devtools-frontend/front_end/ui/TextEditor.js(101,15): error TS2300: Duplicate identifier 'Options'.
 node_modules/chrome-devtools-frontend/front_end/ui/TextEditor.js(105,2): error TS1131: Property or signature expected.
 node_modules/chrome-devtools-frontend/front_end/ui/TextEditor.js(111,4): error TS2339: Property 'AutocompleteConfig' does not exist on type 'typeof UI'.
 node_modules/chrome-devtools-frontend/front_end/ui/TextPrompt.js(52,74): error TS2694: Namespace 'SuggestBox' has no exported member 'Suggestions'.
@@ -15028,8 +15028,8 @@ node_modules/chrome-devtools-frontend/front_end/ui/TextPrompt.js(601,32): error 
 node_modules/chrome-devtools-frontend/front_end/ui/TextPrompt.js(610,54): error TS2339: Property 'isAncestor' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/ui/TextPrompt.js(622,35): error TS2339: Property 'getComponentSelection' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/ui/TextPrompt.js(627,7): error TS2322: Type 'Node' is not assignable to type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/TextPrompt.js(627,7): error TS2322: Type 'Node' is not assignable to type 'Element'.
   Property 'assignedSlot' is missing in type 'Node'.
+node_modules/chrome-devtools-frontend/front_end/ui/TextPrompt.js(627,7): error TS2322: Type 'Node' is not assignable to type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/ui/Toolbar.js(43,50): error TS2339: Property 'createChild' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/ui/Toolbar.js(48,45): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
 node_modules/chrome-devtools-frontend/front_end/ui/Toolbar.js(75,24): error TS2694: Namespace 'Common' has no exported member 'Event'.
@@ -15095,63 +15095,6 @@ node_modules/chrome-devtools-frontend/front_end/ui/Tooltip.js(134,24): error TS2
 node_modules/chrome-devtools-frontend/front_end/ui/Tooltip.js(135,17): error TS2339: Property 'y' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/ui/Tooltip.js(136,17): error TS2339: Property 'y' does not exist on type 'Event'.
 node_modules/chrome-devtools-frontend/front_end/ui/Tooltip.js(178,17): error TS2304: Cannot find name 'ObjectPropertyDescriptor'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(49,52): error TS2345: Argument of type '-1' is not assignable to parameter of type 'string'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(61,23): error TS2339: Property 'root' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(123,50): error TS2551: Property 'deepElementFromPoint' does not exist on type 'Document'. Did you mean 'msElementsFromPoint'?
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(138,52): error TS2339: Property 'pageX' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(138,65): error TS2339: Property 'pageY' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(154,52): error TS2345: Argument of type '-1' is not assignable to parameter of type 'string'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(167,48): error TS2339: Property 'focus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(169,27): error TS2339: Property 'focus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(257,105): error TS2339: Property 'shiftKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(258,15): error TS2339: Property 'metaKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(258,32): error TS2339: Property 'ctrlKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(262,15): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(262,43): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(264,22): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(264,52): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(266,22): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(267,65): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(268,22): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(273,66): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(275,22): error TS2339: Property 'keyCode' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(275,61): error TS2339: Property 'keyCode' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(279,22): error TS2339: Property 'keyCode' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(281,22): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(283,22): error TS2339: Property 'key' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(288,13): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(297,20): error TS2339: Property 'window' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(330,48): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(369,45): error TS2339: Property 'createChild' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(370,24): error TS2339: Property 'treeElement' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(379,28): error TS2339: Property 'parentTreeElement' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(470,39): error TS2339: Property 'lowerBound' does not exist on type 'any[]'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(582,15): error TS2339: Property 'root' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(650,24): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(675,22): error TS2339: Property '_shadowRoot' does not exist on type 'TreeOutline'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(690,31): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(707,32): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(727,24): error TS2339: Property 'title' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(805,48): error TS2339: Property '_renderSelection' does not exist on type 'TreeOutline'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(810,30): error TS2339: Property 'style' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(819,17): error TS2339: Property 'treeElement' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(819,49): error TS2339: Property 'hasSelection' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(822,30): error TS2339: Property 'toggleOnClick' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(828,17): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(833,17): error TS2339: Property 'altKey' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(838,11): error TS2339: Property 'consume' does not exist on type 'Event'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(850,17): error TS2339: Property 'treeElement' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(864,29): error TS2339: Property 'treeElement' does not exist on type 'EventTarget'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(896,7): error TS2322: Type 'TreeElement' is not assignable to type 'this'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(945,7): error TS2322: Type 'TreeElement' is not assignable to type 'this'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1063,55): error TS2339: Property 'hasFocus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1064,28): error TS2339: Property 'focus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1078,51): error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1105,39): error TS2339: Property 'hasFocus' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1209,32): error TS2339: Property 'root' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1217,29): error TS2339: Property 'root' does not exist on type 'TreeElement'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1259,35): error TS2339: Property 'totalOffsetLeft' does not exist on type 'Element'.
-node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1273,18): error TS2339: Property '_imagePreload' does not exist on type 'typeof TreeElement'.
 node_modules/chrome-devtools-frontend/front_end/ui/UIUtils.js(31,4): error TS2339: Property 'highlightedSearchResultClassName' does not exist on type 'typeof UI'.
 node_modules/chrome-devtools-frontend/front_end/ui/UIUtils.js(32,4): error TS2339: Property 'highlightedCurrentSearchResultClassName' does not exist on type 'typeof UI'.
 node_modules/chrome-devtools-frontend/front_end/ui/UIUtils.js(69,13): error TS2339: Property 'style' does not exist on type 'Element'.
@@ -15470,6 +15413,63 @@ node_modules/chrome-devtools-frontend/front_end/ui/XWidget.js(156,29): error TS2
 node_modules/chrome-devtools-frontend/front_end/ui/XWidget.js(161,15): error TS2339: Property 'focus' does not exist on type 'Element'.
 node_modules/chrome-devtools-frontend/front_end/ui/ZoomManager.js(15,43): error TS2339: Property 'zoomFactor' does not exist on type 'typeof InspectorFrontendHostAPI'.
 node_modules/chrome-devtools-frontend/front_end/ui/ZoomManager.js(44,43): error TS2339: Property 'zoomFactor' does not exist on type 'typeof InspectorFrontendHostAPI'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(49,52): error TS2345: Argument of type '-1' is not assignable to parameter of type 'string'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(61,23): error TS2339: Property 'root' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(123,50): error TS2551: Property 'deepElementFromPoint' does not exist on type 'Document'. Did you mean 'msElementsFromPoint'?
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(138,52): error TS2339: Property 'pageX' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(138,65): error TS2339: Property 'pageY' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(154,52): error TS2345: Argument of type '-1' is not assignable to parameter of type 'string'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(167,48): error TS2339: Property 'focus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(169,27): error TS2339: Property 'focus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(257,105): error TS2339: Property 'shiftKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(258,15): error TS2339: Property 'metaKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(258,32): error TS2339: Property 'ctrlKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(262,15): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(262,43): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(264,22): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(264,52): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(266,22): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(267,65): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(268,22): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(273,66): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(275,22): error TS2339: Property 'keyCode' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(275,61): error TS2339: Property 'keyCode' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(279,22): error TS2339: Property 'keyCode' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(281,22): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(283,22): error TS2339: Property 'key' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(288,13): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(297,20): error TS2339: Property 'window' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(330,48): error TS2339: Property 'createChild' does not exist on type 'DocumentFragment'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(369,45): error TS2339: Property 'createChild' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(370,24): error TS2339: Property 'treeElement' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(379,28): error TS2339: Property 'parentTreeElement' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(470,39): error TS2339: Property 'lowerBound' does not exist on type 'any[]'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(582,15): error TS2339: Property 'root' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(650,24): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(675,22): error TS2339: Property '_shadowRoot' does not exist on type 'TreeOutline'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(690,31): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(707,32): error TS2339: Property 'removeChildren' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(727,24): error TS2339: Property 'title' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(805,48): error TS2339: Property '_renderSelection' does not exist on type 'TreeOutline'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(810,30): error TS2339: Property 'style' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(819,17): error TS2339: Property 'treeElement' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(819,49): error TS2339: Property 'hasSelection' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(822,30): error TS2339: Property 'toggleOnClick' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(828,17): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(833,17): error TS2339: Property 'altKey' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(838,11): error TS2339: Property 'consume' does not exist on type 'Event'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(850,17): error TS2339: Property 'treeElement' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(864,29): error TS2339: Property 'treeElement' does not exist on type 'EventTarget'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(896,7): error TS2322: Type 'TreeElement' is not assignable to type 'this'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(945,7): error TS2322: Type 'TreeElement' is not assignable to type 'this'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1063,55): error TS2339: Property 'hasFocus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1064,28): error TS2339: Property 'focus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1078,51): error TS2345: Argument of type '0' is not assignable to parameter of type 'string'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1105,39): error TS2339: Property 'hasFocus' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1209,32): error TS2339: Property 'root' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1217,29): error TS2339: Property 'root' does not exist on type 'TreeElement'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1259,35): error TS2339: Property 'totalOffsetLeft' does not exist on type 'Element'.
+node_modules/chrome-devtools-frontend/front_end/ui/treeoutline.js(1273,18): error TS2339: Property '_imagePreload' does not exist on type 'typeof TreeElement'.
 node_modules/chrome-devtools-frontend/front_end/worker_service/ServiceDispatcher.js(12,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/worker_service/ServiceDispatcher.js(17,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/worker_service/ServiceDispatcher.js(34,16): error TS2339: Property 'setHandlers' does not exist on type 'typeof ServicePort'.
@@ -15537,9 +15537,9 @@ node_modules/chrome-devtools-frontend/front_end/workspace/Workspace.js(199,15): 
 node_modules/chrome-devtools-frontend/front_end/workspace/Workspace.js(204,15): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 node_modules/chrome-devtools-frontend/front_end/workspace/Workspace.js(229,25): error TS2694: Namespace 'Workspace' has no exported member 'projectTypes'.
 node_modules/chrome-devtools-frontend/front_end/workspace/Workspace.js(243,25): error TS2352: Type 'this' cannot be converted to type '{ [x: string]: any; workspace(): Workspace; id(): string; type(): string; isServiceProject(): boo...'.
-node_modules/chrome-devtools-frontend/front_end/workspace/Workspace.js(243,25): error TS2352: Type 'this' cannot be converted to type '{ [x: string]: any; workspace(): Workspace; id(): string; type(): string; isServiceProject(): boo...'.
   Type 'ProjectStore' is not comparable to type '{ [x: string]: any; workspace(): Workspace; id(): string; type(): string; isServiceProject(): boo...'.
     Property 'isServiceProject' is missing in type 'ProjectStore'.
+node_modules/chrome-devtools-frontend/front_end/workspace/Workspace.js(243,25): error TS2352: Type 'this' cannot be converted to type '{ [x: string]: any; workspace(): Workspace; id(): string; type(): string; isServiceProject(): boo...'.
 node_modules/chrome-devtools-frontend/front_end/workspace/Workspace.js(257,5): error TS2322: Type '{ [x: string]: any; Debugger: string; Formatter: string; Network: string; Snippets: string; FileS...' is not assignable to type 'string'.
 node_modules/chrome-devtools-frontend/front_end/workspace/Workspace.js(432,27): error TS2339: Property 'valuesArray' does not exist on type 'Map<string, { [x: string]: any; workspace(): Workspace; id(): string; type(): string; isServicePr...'.
 node_modules/chrome-devtools-frontend/front_end/workspace_diff/WorkspaceDiff.js(30,30): error TS2694: Namespace 'Diff' has no exported member 'Diff'.

--- a/tests/baselines/reference/user/create-react-app.log
+++ b/tests/baselines/reference/user/create-react-app.log
@@ -29,6 +29,12 @@ packages/create-react-app/createReactApp.js(771,20): error TS2345: Argument of t
   Type 'undefined' is not assignable to type 'string'.
 packages/create-react-app/index.js(45,5): error TS2365: Operator '<' cannot be applied to types 'string' and 'number'.
 packages/eslint-config-react-app/index.js(24,33): error TS2307: Cannot find module 'confusing-browser-globals'.
+packages/react-dev-utils/FileSizeReporter.js(13,24): error TS2307: Cannot find module 'filesize'.
+packages/react-dev-utils/FileSizeReporter.js(14,25): error TS2307: Cannot find module 'recursive-readdir'.
+packages/react-dev-utils/FileSizeReporter.js(16,24): error TS2307: Cannot find module 'gzip-size'.
+packages/react-dev-utils/WebpackDevServerUtils.js(9,25): error TS2307: Cannot find module 'address'.
+packages/react-dev-utils/WebpackDevServerUtils.js(14,24): error TS2307: Cannot find module 'detect-port-alt'.
+packages/react-dev-utils/WebpackDevServerUtils.js(15,24): error TS2307: Cannot find module 'is-root'.
 packages/react-dev-utils/__tests__/ignoredFiles.test.js(12,1): error TS2304: Cannot find name 'describe'.
 packages/react-dev-utils/__tests__/ignoredFiles.test.js(13,3): error TS2304: Cannot find name 'it'.
 packages/react-dev-utils/__tests__/ignoredFiles.test.js(18,5): error TS2304: Cannot find name 'expect'.
@@ -49,16 +55,10 @@ packages/react-dev-utils/browsersHelper.js(97,25): error TS2538: Type 'undefined
 packages/react-dev-utils/checkRequiredFiles.js(19,34): error TS2339: Property 'F_OK' does not exist on type 'typeof import("fs")'.
 packages/react-dev-utils/checkRequiredFiles.js(23,32): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string'.
 packages/react-dev-utils/checkRequiredFiles.js(24,34): error TS2345: Argument of type 'undefined' is not assignable to parameter of type 'string'.
-packages/react-dev-utils/FileSizeReporter.js(13,24): error TS2307: Cannot find module 'filesize'.
-packages/react-dev-utils/FileSizeReporter.js(14,25): error TS2307: Cannot find module 'recursive-readdir'.
-packages/react-dev-utils/FileSizeReporter.js(16,24): error TS2307: Cannot find module 'gzip-size'.
 packages/react-dev-utils/getProcessForPort.js(29,6): error TS2339: Property 'split' does not exist on type 'Buffer'.
 packages/react-dev-utils/getProcessForPort.js(49,21): error TS2339: Property 'replace' does not exist on type 'Buffer'.
 packages/react-dev-utils/getProcessForPort.js(63,5): error TS2339: Property 'trim' does not exist on type 'Buffer'.
 packages/react-dev-utils/openBrowser.js(13,19): error TS2307: Cannot find module 'opn'.
-packages/react-dev-utils/WebpackDevServerUtils.js(9,25): error TS2307: Cannot find module 'address'.
-packages/react-dev-utils/WebpackDevServerUtils.js(14,24): error TS2307: Cannot find module 'detect-port-alt'.
-packages/react-dev-utils/WebpackDevServerUtils.js(15,24): error TS2307: Cannot find module 'is-root'.
 packages/react-dev-utils/webpackHotDevClient.js(19,22): error TS2307: Cannot find module 'sockjs-client'.
 packages/react-dev-utils/webpackHotDevClient.js(24,28): error TS2307: Cannot find module 'react-error-overlay'.
 packages/react-dev-utils/webpackHotDevClient.js(31,14): error TS2339: Property 'encodeURIComponent' does not exist on type 'Window'.

--- a/tests/baselines/reference/user/enhanced-resolve.log
+++ b/tests/baselines/reference/user/enhanced-resolve.log
@@ -16,15 +16,15 @@ node_modules/enhanced-resolve/lib/CachedInputFileSystem.js(209,4): error TS2322:
 node_modules/enhanced-resolve/lib/CachedInputFileSystem.js(220,4): error TS2322: Type 'null' is not assignable to type '(path: any) => any'.
 node_modules/enhanced-resolve/lib/CachedInputFileSystem.js(224,23): error TS2322: Type 'null' is not assignable to type '(path: any, callback: any) => void'.
 node_modules/enhanced-resolve/lib/CachedInputFileSystem.js(227,27): error TS2322: Type 'null' is not assignable to type '(path: any) => any'.
-node_modules/enhanced-resolve/lib/concord.js(75,30): error TS2531: Object is possibly 'null'.
-node_modules/enhanced-resolve/lib/concord.js(76,17): error TS2531: Object is possibly 'null'.
-node_modules/enhanced-resolve/lib/createInnerCallback.js(16,20): error TS2339: Property 'stack' does not exist on type '(...args: any[]) => any'.
-node_modules/enhanced-resolve/lib/createInnerCallback.js(17,20): error TS2339: Property 'missing' does not exist on type '(...args: any[]) => any'.
 node_modules/enhanced-resolve/lib/Resolver.js(162,17): error TS2339: Property 'push' does not exist on type 'Set<any>'.
 node_modules/enhanced-resolve/lib/Resolver.js(178,11): error TS2339: Property 'details' does not exist on type 'Error'.
 node_modules/enhanced-resolve/lib/Resolver.js(179,11): error TS2339: Property 'missing' does not exist on type 'Error'.
 node_modules/enhanced-resolve/lib/Resolver.js(213,20): error TS2339: Property 'recursion' does not exist on type 'Error'.
 
+node_modules/enhanced-resolve/lib/concord.js(75,30): error TS2531: Object is possibly 'null'.
+node_modules/enhanced-resolve/lib/concord.js(76,17): error TS2531: Object is possibly 'null'.
+node_modules/enhanced-resolve/lib/createInnerCallback.js(16,20): error TS2339: Property 'stack' does not exist on type '(...args: any[]) => any'.
+node_modules/enhanced-resolve/lib/createInnerCallback.js(17,20): error TS2339: Property 'missing' does not exist on type '(...args: any[]) => any'.
 
 
 Standard error:

--- a/tests/baselines/reference/user/lodash.log
+++ b/tests/baselines/reference/user/lodash.log
@@ -1,5 +1,10 @@
 Exit Code: 1
 Standard output:
+node_modules/lodash/_Hash.js(20,17): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_ListCache.js(20,17): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_MapCache.js(20,17): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_SetCache.js(19,14): error TS2532: Object is possibly 'undefined'.
+node_modules/lodash/_Stack.js(17,20): error TS2339: Property 'size' does not exist on type 'ListCache'.
 node_modules/lodash/_arrayAggregator.js(16,17): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_arrayEach.js(15,18): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_arrayEach.js(19,3): error TS2322: Type 'any[] | undefined' is not assignable to type 'any[]'.
@@ -130,9 +135,8 @@ node_modules/lodash/_equalObjects.js(70,18): error TS2322: Type 'boolean' is not
 node_modules/lodash/_getHolder.js(10,17): error TS2339: Property 'placeholder' does not exist on type 'Function'.
 node_modules/lodash/_getRawTag.js(36,7): error TS2454: Variable 'unmasked' is used before being assigned.
 node_modules/lodash/_getSymbolsIn.js(19,23): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/_Hash.js(20,17): error TS2532: Object is possibly 'undefined'.
-node_modules/lodash/_hashDelete.js(7,20): error TS8024: JSDoc '@param' tag has name 'hash', but there is no parameter with that name.
 node_modules/lodash/_hasPath.js(35,50): error TS2454: Variable 'key' is used before being assigned.
+node_modules/lodash/_hashDelete.js(7,20): error TS8024: JSDoc '@param' tag has name 'hash', but there is no parameter with that name.
 node_modules/lodash/_initCloneArray.js(16,16): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 node_modules/lodash/_initCloneArray.js(20,26): error TS2339: Property 'index' does not exist on type 'any[]'.
 node_modules/lodash/_initCloneArray.js(21,26): error TS2339: Property 'input' does not exist on type 'any[]'.
@@ -140,8 +144,6 @@ node_modules/lodash/_insertWrapDetails.js(10,5): error TS1223: 'returns' tag alr
 node_modules/lodash/_insertWrapDetails.js(15,5): error TS2322: Type 'string' is not assignable to type 'any[]'.
 node_modules/lodash/_insertWrapDetails.js(20,3): error TS2322: Type 'string' is not assignable to type 'any[]'.
 node_modules/lodash/_isLaziable.js(24,14): error TS2554: Expected 0 arguments, but got 1.
-node_modules/lodash/_ListCache.js(20,17): error TS2532: Object is possibly 'undefined'.
-node_modules/lodash/_MapCache.js(20,17): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_memoizeCapped.js(22,22): error TS2339: Property 'cache' does not exist on type 'Function'.
 node_modules/lodash/_mergeData.js(60,26): error TS2554: Expected 4 arguments, but got 3.
 node_modules/lodash/_mergeData.js(67,26): error TS2554: Expected 4 arguments, but got 3.
@@ -155,8 +157,6 @@ node_modules/lodash/_overRest.js(27,27): error TS2532: Object is possibly 'undef
 node_modules/lodash/_overRest.js(28,22): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/_overRest.js(31,15): error TS2538: Type 'undefined' cannot be used as an index type.
 node_modules/lodash/_root.js(4,56): error TS2339: Property 'Object' does not exist on type 'Window'.
-node_modules/lodash/_SetCache.js(19,14): error TS2532: Object is possibly 'undefined'.
-node_modules/lodash/_Stack.js(17,20): error TS2339: Property 'size' does not exist on type 'ListCache'.
 node_modules/lodash/_unicodeWords.js(62,20): error TS8024: JSDoc '@param' tag has name 'The', but there is no parameter with that name.
 node_modules/lodash/_updateWrapDetails.js(34,5): error TS1223: 'returns' tag already specified.
 node_modules/lodash/ary.js(16,10): error TS1003: Identifier expected.
@@ -181,8 +181,8 @@ node_modules/lodash/core.js(77,82): error TS2339: Property 'nodeType' does not e
 node_modules/lodash/core.js(540,19): error TS2322: Type '(value: any) => boolean' is not assignable to type 'boolean | undefined'.
   Type '(value: any) => boolean' is not assignable to type 'false'.
 node_modules/lodash/core.js(545,24): error TS2532: Object is possibly 'undefined'.
-node_modules/lodash/core.js(545,24): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/core.js(545,24): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'Boolean' has no compatible call signatures.
+node_modules/lodash/core.js(545,24): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/core.js(664,42): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'number'.
 node_modules/lodash/core.js(721,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'result' must be of type 'boolean', but here has type 'any'.
 node_modules/lodash/core.js(749,18): error TS8024: JSDoc '@param' tag has name 'value', but there is no parameter with that name.
@@ -218,8 +218,8 @@ node_modules/lodash/core.js(1566,33): error TS2554: Expected 1 arguments, but go
 node_modules/lodash/core.js(1709,41): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/core.js(1872,12): error TS1003: Identifier expected.
 node_modules/lodash/core.js(1872,12): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/core.js(2142,12): error TS1003: Identifier expected.
 node_modules/lodash/core.js(2142,12): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/core.js(2142,12): error TS1003: Identifier expected.
 node_modules/lodash/core.js(2183,41): error TS8024: JSDoc '@param' tag has name 'iteratees', but there is no parameter with that name.
 node_modules/lodash/core.js(2473,21): error TS2554: Expected 0 arguments, but got 1.
 node_modules/lodash/core.js(2609,39): error TS2554: Expected 0 arguments, but got 1.
@@ -235,11 +235,11 @@ node_modules/lodash/core.js(3830,45): error TS2304: Cannot find name 'define'.
 node_modules/lodash/core.js(3830,71): error TS2304: Cannot find name 'define'.
 node_modules/lodash/core.js(3839,5): error TS2304: Cannot find name 'define'.
 node_modules/lodash/core.js(3846,35): error TS2339: Property '_' does not exist on type 'typeof lodash'.
-node_modules/lodash/curry.js(24,10): error TS1003: Identifier expected.
 node_modules/lodash/curry.js(24,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/curry.js(24,10): error TS1003: Identifier expected.
 node_modules/lodash/curry.js(50,10): error TS2339: Property 'placeholder' does not exist on type 'Function'.
-node_modules/lodash/curryRight.js(21,10): error TS1003: Identifier expected.
 node_modules/lodash/curryRight.js(21,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/curryRight.js(21,10): error TS1003: Identifier expected.
 node_modules/lodash/curryRight.js(47,10): error TS2339: Property 'placeholder' does not exist on type 'Function'.
 node_modules/lodash/debounce.js(83,17): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/debounce.js(84,27): error TS2532: Object is possibly 'undefined'.
@@ -255,22 +255,21 @@ node_modules/lodash/differenceBy.js(40,52): error TS2345: Argument of type '(val
 node_modules/lodash/differenceBy.js(40,78): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/differenceWith.js(36,52): error TS2345: Argument of type '(value: any) => boolean' is not assignable to parameter of type 'boolean | undefined'.
   Type '(value: any) => boolean' is not assignable to type 'false'.
-node_modules/lodash/drop.js(13,10): error TS1003: Identifier expected.
 node_modules/lodash/drop.js(13,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/drop.js(13,10): error TS1003: Identifier expected.
 node_modules/lodash/dropRight.js(13,10): error TS1003: Identifier expected.
 node_modules/lodash/dropRight.js(13,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/dropRightWhile.js(41,24): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/dropWhile.js(41,24): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/escape.js(39,39): error TS2345: Argument of type 'Function' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
-node_modules/lodash/every.js(23,10): error TS1003: Identifier expected.
 node_modules/lodash/every.js(23,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/every.js(23,10): error TS1003: Identifier expected.
 node_modules/lodash/every.js(53,27): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/filter.js(45,27): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/findIndex.js(52,31): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/findKey.js(41,30): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/findLastIndex.js(56,31): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/findLastKey.js(41,30): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/fp.js(2,18): error TS2554: Expected 3-4 arguments, but got 2.
 node_modules/lodash/fp/_baseConvert.js(144,5): error TS2322: Type 'Function' is not assignable to type '{ cap?: boolean; curry?: boolean; fixed?: boolean; immutable?: boolean; rearg?: boolean; } | unde...'.
   Type 'Function' has no properties in common with type '{ cap?: boolean; curry?: boolean; fixed?: boolean; immutable?: boolean; rearg?: boolean; }'.
 node_modules/lodash/fp/_baseConvert.js(145,5): error TS2322: Type 'string' is not assignable to type 'Function'.
@@ -326,6 +325,7 @@ node_modules/lodash/fp/object.js(2,26): error TS2345: Argument of type '{ [x: st
 node_modules/lodash/fp/seq.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'at': Function; 'chain': (value: any) => any; 'commit': () => any; 'lodash': ...' is not assignable to parameter of type 'string'.
 node_modules/lodash/fp/string.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'camelCase': Function; 'capitalize': (string?: string | undefined) => string;...' is not assignable to parameter of type 'string'.
 node_modules/lodash/fp/util.js(2,26): error TS2345: Argument of type '{ [x: string]: any; 'attempt': Function; 'bindAll': Function; 'cond': (pairs: any[]) => Function;...' is not assignable to parameter of type 'string'.
+node_modules/lodash/fp.js(2,18): error TS2554: Expected 3-4 arguments, but got 2.
 node_modules/lodash/includes.js(24,10): error TS1003: Identifier expected.
 node_modules/lodash/includes.js(24,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/intersectionBy.js(41,32): error TS2554: Expected 0-1 arguments, but got 2.
@@ -371,10 +371,10 @@ node_modules/lodash/remove.js(41,15): error TS2554: Expected 0-1 arguments, but 
 node_modules/lodash/repeat.js(15,10): error TS1003: Identifier expected.
 node_modules/lodash/repeat.js(15,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/replace.js(15,29): error TS8029: JSDoc '@param' tag has name 'replacement', but there is no parameter with that name. It would match 'arguments' if it had an array type.
-node_modules/lodash/sampleSize.js(17,10): error TS1003: Identifier expected.
 node_modules/lodash/sampleSize.js(17,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/some.js(18,10): error TS1003: Identifier expected.
+node_modules/lodash/sampleSize.js(17,10): error TS1003: Identifier expected.
 node_modules/lodash/some.js(18,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/some.js(18,10): error TS1003: Identifier expected.
 node_modules/lodash/some.js(48,27): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/sortedIndexBy.js(30,42): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/sortedLastIndexBy.js(30,42): error TS2554: Expected 0-1 arguments, but got 2.
@@ -388,8 +388,8 @@ node_modules/lodash/takeRight.js(13,10): error TS1003: Identifier expected.
 node_modules/lodash/takeRight.js(13,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/takeRightWhile.js(41,24): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/lodash/takeWhile.js(41,24): error TS2554: Expected 0-1 arguments, but got 2.
-node_modules/lodash/template.js(65,10): error TS1003: Identifier expected.
 node_modules/lodash/template.js(65,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/template.js(65,10): error TS1003: Identifier expected.
 node_modules/lodash/template.js(146,34): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/template.js(153,21): error TS2532: Object is possibly 'undefined'.
 node_modules/lodash/template.js(158,6): error TS2532: Object is possibly 'undefined'.
@@ -414,8 +414,8 @@ node_modules/lodash/transform.js(59,3): error TS2349: Cannot invoke an expressio
 node_modules/lodash/transform.js(60,12): error TS2722: Cannot invoke an object which is possibly 'undefined'.
 node_modules/lodash/trim.js(20,10): error TS1003: Identifier expected.
 node_modules/lodash/trim.js(20,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
-node_modules/lodash/trimEnd.js(19,10): error TS1003: Identifier expected.
 node_modules/lodash/trimEnd.js(19,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
+node_modules/lodash/trimEnd.js(19,10): error TS1003: Identifier expected.
 node_modules/lodash/trimStart.js(19,10): error TS1003: Identifier expected.
 node_modules/lodash/trimStart.js(19,10): error TS8024: JSDoc '@param' tag has name '', but there is no parameter with that name.
 node_modules/lodash/truncate.js(60,36): error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/user/log4js.log
+++ b/tests/baselines/reference/user/log4js.log
@@ -1,0 +1,12 @@
+Exit Code: 1
+Standard output:
+node_modules/log4js/types/log4js.d.ts(4,2): error TS7008: Member 'getLogger' implicitly has an 'any' type.
+node_modules/log4js/types/log4js.d.ts(5,2): error TS7008: Member 'configure' implicitly has an 'any' type.
+node_modules/log4js/types/log4js.d.ts(6,2): error TS7008: Member 'addLayout' implicitly has an 'any' type.
+node_modules/log4js/types/log4js.d.ts(7,2): error TS7008: Member 'connectLogger' implicitly has an 'any' type.
+node_modules/log4js/types/log4js.d.ts(8,2): error TS7008: Member 'levels' implicitly has an 'any' type.
+node_modules/log4js/types/log4js.d.ts(9,2): error TS7008: Member 'shutdown' implicitly has an 'any' type.
+
+
+
+Standard error:

--- a/tests/baselines/reference/user/npm.log
+++ b/tests/baselines/reference/user/npm.log
@@ -2,28 +2,33 @@ Exit Code: 1
 Standard output:
 node_modules/npm/bin/npm-cli.js(6,13): error TS2551: Property 'echo' does not exist on type '{ Echo(s: any): void; StdErr: TextStreamWriter; StdOut: TextStreamWriter; Arguments: { length: nu...'. Did you mean 'Echo'?
 node_modules/npm/bin/npm-cli.js(13,13): error TS2551: Property 'quit' does not exist on type '{ Echo(s: any): void; StdErr: TextStreamWriter; StdOut: TextStreamWriter; Arguments: { length: nu...'. Did you mean 'Quit'?
-node_modules/npm/bin/npm-cli.js(30,23): error TS2307: Cannot find module '../package.json'.
-node_modules/npm/bin/npm-cli.js(54,7): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(55,11): error TS2339: Property 'deref' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(55,21): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(55,35): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(55,49): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(59,21): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(64,9): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(66,9): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(69,35): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(74,25): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(75,9): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(75,26): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(76,9): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(82,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(84,9): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(84,22): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(84,35): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(86,23): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(86,55): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(86,82): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/bin/npm-cli.js(86,113): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(47,7): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(48,11): error TS2339: Property 'deref' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(48,21): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(48,35): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(48,49): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(52,21): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(57,9): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(59,9): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(62,35): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(67,25): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(68,9): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(68,26): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(69,9): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(75,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(78,27): error TS2307: Cannot find module '../package.json'.
+node_modules/npm/bin/npm-cli.js(85,30): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(86,32): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(121,9): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(121,22): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(121,35): error TS2339: Property 'argv' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(125,13): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(126,14): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(127,14): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(128,13): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(132,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(134,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/bin/npm-cli.js(136,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/html/static/toc.js(3,40): error TS2531: Object is possibly 'null'.
 node_modules/npm/lib/access.js(58,46): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/access.js(65,18): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
@@ -39,6 +44,16 @@ node_modules/npm/lib/adduser.js(44,9): error TS2339: Property 'config' does not 
 node_modules/npm/lib/adduser.js(45,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/adduser.js(46,9): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/adduser.js(47,9): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/audit.js(29,23): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/audit.js(47,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/audit.js(49,9): error TS2339: Property 'code' does not exist on type 'Error'.
+node_modules/npm/lib/audit.js(60,11): error TS2339: Property 'code' does not exist on type 'Error'.
+node_modules/npm/lib/audit.js(65,11): error TS2339: Property 'code' does not exist on type 'Error'.
+node_modules/npm/lib/audit.js(75,27): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/audit.js(81,11): error TS2339: Property 'code' does not exist on type 'Error'.
+node_modules/npm/lib/audit.js(88,61): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/audit.js(89,10): error TS2339: Property 'code' does not exist on type 'Error'.
+node_modules/npm/lib/audit.js(90,10): error TS2339: Property 'wrapped' does not exist on type 'Error'.
 node_modules/npm/lib/auth/legacy.js(12,30): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/auth/legacy.js(35,16): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/auth/legacy.js(69,33): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
@@ -73,40 +88,15 @@ node_modules/npm/lib/ci.js(13,31): error TS2339: Property 'config' does not exis
 node_modules/npm/lib/ci.js(14,12): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/ci.js(15,12): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/ci.js(27,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/completion.js(26,24): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
+node_modules/npm/lib/completion.js(30,24): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
 node_modules/npm/lib/completion.js(51,7): error TS2339: Property 'code' does not exist on type 'Error'.
 node_modules/npm/lib/completion.js(52,7): error TS2339: Property 'errno' does not exist on type 'Error'.
 node_modules/npm/lib/completion.js(129,9): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/completion.js(135,13): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/completion.js(247,23): error TS2339: Property 'fullList' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(72,18): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(81,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(82,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(83,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(85,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(91,25): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(103,37): error TS2339: Property 'defaults' does not exist on type 'typeof import("/npm/node_modules/npm/lib/config/core")'.
-node_modules/npm/lib/config.js(105,28): error TS2339: Property 'defaults' does not exist on type 'typeof import("/npm/node_modules/npm/lib/config/core")'.
-node_modules/npm/lib/config.js(130,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(131,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(132,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(151,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(153,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(154,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(162,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(181,26): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(182,21): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(205,27): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(218,18): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(220,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(233,52): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(236,21): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(240,45): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(240,75): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(243,47): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(243,79): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(246,21): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/config.js(262,26): error TS2339: Property 'defaults' does not exist on type 'typeof import("/npm/node_modules/npm/lib/config/core")'.
-node_modules/npm/lib/config.js(268,29): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/config/bin-links.js(11,24): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/config/bin-links.js(12,16): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/config/bin-links.js(13,20): error TS2339: Property 'globalBin' does not exist on type 'EventEmitter'.
@@ -142,19 +132,19 @@ node_modules/npm/lib/config/core.js(144,10): error TS2339: Property 'once' does 
 node_modules/npm/lib/config/core.js(145,10): error TS2339: Property 'once' does not exist on type 'Conf'.
 node_modules/npm/lib/config/core.js(154,14): error TS2339: Property 'get' does not exist on type 'Conf'.
 node_modules/npm/lib/config/core.js(155,35): error TS2339: Property 'get' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(167,23): error TS2339: Property 'get' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(172,10): error TS2339: Property 'once' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(183,23): error TS2339: Property 'get' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(197,5): error TS2323: Cannot redeclare exported variable 'loaded'.
-node_modules/npm/lib/config/core.js(220,28): error TS2339: Property 'defaults' does not exist on type 'typeof import("/npm/node_modules/npm/lib/config/defaults")'.
-node_modules/npm/lib/config/core.js(244,21): error TS2339: Property 'sources' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(252,17): error TS2339: Property 'emit' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(286,8): error TS2339: Property '_saving' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(314,8): error TS2339: Property 'sources' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(315,8): error TS2339: Property 'push' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(316,8): error TS2339: Property '_await' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(340,10): error TS2339: Property 'emit' does not exist on type 'Conf'.
-node_modules/npm/lib/config/core.js(416,29): error TS2345: Argument of type '(orig: string, esc: any, name: any) => string | undefined' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
+node_modules/npm/lib/config/core.js(160,23): error TS2339: Property 'get' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(165,10): error TS2339: Property 'once' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(176,23): error TS2339: Property 'get' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(190,5): error TS2323: Cannot redeclare exported variable 'loaded'.
+node_modules/npm/lib/config/core.js(213,28): error TS2339: Property 'defaults' does not exist on type 'typeof import("/npm/node_modules/npm/lib/config/defaults")'.
+node_modules/npm/lib/config/core.js(237,21): error TS2339: Property 'sources' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(245,17): error TS2339: Property 'emit' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(279,8): error TS2339: Property '_saving' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(307,8): error TS2339: Property 'sources' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(308,8): error TS2339: Property 'push' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(309,8): error TS2339: Property '_await' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(333,10): error TS2339: Property 'emit' does not exist on type 'Conf'.
+node_modules/npm/lib/config/core.js(409,29): error TS2345: Argument of type '(orig: string, esc: any, name: any) => string | undefined' is not assignable to parameter of type '(substring: string, ...args: any[]) => string'.
   Type 'string | undefined' is not assignable to type 'string'.
     Type 'undefined' is not assignable to type 'string'.
 node_modules/npm/lib/config/gentle-fs.js(16,11): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
@@ -216,6 +206,35 @@ node_modules/npm/lib/config/pacote.js(84,31): error TS2339: Property 'config' do
 node_modules/npm/lib/config/pacote.js(89,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/config/pacote.js(90,38): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/config/pacote.js(110,60): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(74,18): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(83,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(84,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(85,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(87,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(93,25): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(105,37): error TS2339: Property 'defaults' does not exist on type 'typeof import("/npm/node_modules/npm/lib/config/core")'.
+node_modules/npm/lib/config.js(107,28): error TS2339: Property 'defaults' does not exist on type 'typeof import("/npm/node_modules/npm/lib/config/core")'.
+node_modules/npm/lib/config.js(135,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(136,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(137,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(156,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(158,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(159,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(167,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(186,26): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(187,21): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(210,27): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(223,18): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(225,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(238,52): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(241,21): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(245,45): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(245,75): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(248,47): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(248,79): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(251,21): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/config.js(267,26): error TS2339: Property 'defaults' does not exist on type 'typeof import("/npm/node_modules/npm/lib/config/core")'.
+node_modules/npm/lib/config.js(273,29): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/dedupe.js(35,32): error TS2339: Property 'dir' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/dedupe.js(37,11): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/dedupe.js(38,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
@@ -253,6 +272,9 @@ node_modules/npm/lib/dist-tag.js(109,11): error TS2339: Property 'registry' does
 node_modules/npm/lib/dist-tag.js(142,26): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/dist-tag.js(149,9): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/docs.js(40,38): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/doctor/check-files-permission.js(11,14): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/doctor/check-files-permission.js(11,38): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/doctor/verify-cached-files.js(10,90): error TS2345: Argument of type '2' is not assignable to parameter of type '(string | number)[] | null | undefined'.
 node_modules/npm/lib/doctor.js(6,54): error TS2339: Property 'defaults' does not exist on type 'typeof import("/npm/node_modules/npm/lib/config/defaults")'.
 node_modules/npm/lib/doctor.js(23,41): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/doctor.js(24,40): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
@@ -262,9 +284,6 @@ node_modules/npm/lib/doctor.js(55,13): error TS2339: Property 'color' does not e
 node_modules/npm/lib/doctor.js(88,20): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/doctor.js(90,24): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/doctor.js(108,92): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/doctor/check-files-permission.js(11,14): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/doctor/check-files-permission.js(11,38): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/doctor/verify-cached-files.js(10,90): error TS2345: Argument of type '2' is not assignable to parameter of type '(string | number)[] | null | undefined'.
 node_modules/npm/lib/edit.js(18,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/edit.js(27,28): error TS2339: Property 'dir' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/edit.js(32,11): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
@@ -296,6 +315,7 @@ node_modules/npm/lib/help.js(146,7): error TS2322: Type '"cli"' is not assignabl
 node_modules/npm/lib/help.js(149,7): error TS2322: Type '"api"' is not assignable to type 'number'.
 node_modules/npm/lib/help.js(152,7): error TS2322: Type '"files"' is not assignable to type 'number'.
 node_modules/npm/lib/help.js(155,7): error TS2322: Type '"misc"' is not assignable to type 'number'.
+node_modules/npm/lib/help.js(160,55): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
 node_modules/npm/lib/help.js(164,7): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/help.js(170,9): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/help.js(179,18): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
@@ -306,51 +326,9 @@ node_modules/npm/lib/help.js(196,26): error TS2339: Property 'commands' does not
 node_modules/npm/lib/help.js(197,22): error TS2339: Property 'deref' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/help.js(199,14): error TS2345: Argument of type 'any[]' is not assignable to parameter of type 'never'.
 node_modules/npm/lib/help.js(199,22): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/init.js(16,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/init.js(17,25): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/init.js(31,31): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(181,36): error TS2339: Property 'globalDir' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(183,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(185,17): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(189,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(191,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(199,36): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(223,24): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(225,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(226,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(229,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(234,34): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(235,63): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(236,51): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(238,85): error TS2339: Property 'globalDir' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(266,26): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(267,9): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(270,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(271,7): error TS2532: Object is possibly 'undefined'.
-node_modules/npm/lib/install.js(271,7): error TS2684: The 'this' context of type '((err: any, ...args: any[]) => any) | undefined' is not assignable to method's 'this' of type 'Function'.
-  Type 'undefined' is not assignable to type 'Function'.
-node_modules/npm/lib/install.js(336,25): error TS2339: Property 'failing' does not exist on type 'Installer'.
-node_modules/npm/lib/install.js(365,18): error TS2345: Argument of type '"time"' is not assignable to parameter of type '"warning"'.
-node_modules/npm/lib/install.js(372,16): error TS2345: Argument of type '"timeEnd"' is not assignable to parameter of type '"warning"'.
-node_modules/npm/lib/install.js(523,40): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(601,12): error TS2339: Property 'failing' does not exist on type 'Installer'.
-node_modules/npm/lib/install.js(618,12): error TS2339: Property 'failing' does not exist on type 'Installer'.
-node_modules/npm/lib/install.js(637,12): error TS2339: Property 'failing' does not exist on type 'Installer'.
-node_modules/npm/lib/install.js(678,12): error TS2339: Property 'code' does not exist on type 'Error'.
-node_modules/npm/lib/install.js(679,12): error TS2339: Property 'errno' does not exist on type 'Error'.
-node_modules/npm/lib/install.js(739,32): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(745,12): error TS2339: Property 'failing' does not exist on type 'Installer'.
-node_modules/npm/lib/install.js(757,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(759,18): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(877,26): error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
-node_modules/npm/lib/install.js(884,26): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
-node_modules/npm/lib/install.js(886,25): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
-node_modules/npm/lib/install.js(888,27): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
-node_modules/npm/lib/install.js(890,25): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
-node_modules/npm/lib/install.js(892,27): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
-node_modules/npm/lib/install.js(936,8): error TS2454: Variable 'previousPath' is used before being assigned.
-node_modules/npm/lib/install.js(974,53): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install.js(996,53): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/init.js(38,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/init.js(39,25): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/init.js(53,31): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/install/access-error.js(4,18): error TS2554: Expected 0-1 arguments, but got 2.
 node_modules/npm/lib/install/action/build.js(10,50): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/install/action/extract.js(39,40): error TS2339: Property 'limit' does not exist on type 'EventEmitter'.
@@ -366,27 +344,43 @@ node_modules/npm/lib/install/actions.js(126,24): error TS2339: Property 'limit' 
 node_modules/npm/lib/install/actions.js(168,16): error TS2345: Argument of type '"time"' is not assignable to parameter of type '"warning"'.
 node_modules/npm/lib/install/actions.js(171,16): error TS2345: Argument of type '"timeEnd"' is not assignable to parameter of type '"warning"'.
 node_modules/npm/lib/install/and-add-parent-to-errors.js(9,10): error TS2339: Property 'parent' does not exist on type 'Error'.
+node_modules/npm/lib/install/audit.js(32,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/audit.js(89,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/audit.js(91,23): error TS2339: Property 'projectScope' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/audit.js(100,20): error TS2339: Property 'color' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/audit.js(101,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/audit.js(109,20): error TS2339: Property 'color' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/audit.js(110,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/audit.js(172,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/audit.js(216,26): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/install/check-permissions.js(36,9): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/decompose-actions.js(35,30): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/deps.js(243,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/deps.js(298,14): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/deps.js(299,29): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/deps.js(434,27): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/deps.js(479,14): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/deps.js(580,9): error TS2339: Property 'code' does not exist on type 'Error'.
-node_modules/npm/lib/install/deps.js(795,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/deps.js(796,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/diff-trees.js(233,26): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/diff-trees.js(234,34): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/diff-trees.js(234,62): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/diff-trees.js(235,33): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/diff-trees.js(236,33): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/diff-trees.js(237,52): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/decompose-actions.js(47,30): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(253,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(309,14): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(310,29): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(401,28): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(402,36): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(402,64): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(403,35): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(404,35): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(409,54): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(459,27): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(599,9): error TS2339: Property 'code' does not exist on type 'Error'.
+node_modules/npm/lib/install/deps.js(814,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/deps.js(815,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/diff-trees.js(242,26): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/diff-trees.js(243,26): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/diff-trees.js(244,34): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/diff-trees.js(244,62): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/diff-trees.js(245,33): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/diff-trees.js(246,33): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/diff-trees.js(247,52): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/install/exists.js(20,21): error TS2339: Property 'F_OK' does not exist on type 'typeof import("fs")'.
 node_modules/npm/lib/install/flatten-tree.js(16,15): error TS2532: Object is possibly 'undefined'.
 node_modules/npm/lib/install/flatten-tree.js(18,16): error TS2532: Object is possibly 'undefined'.
-node_modules/npm/lib/install/inflate-shrinkwrap.js(29,12): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/install/inflate-shrinkwrap.js(29,45): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/inflate-shrinkwrap.js(30,12): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/inflate-shrinkwrap.js(30,45): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install/inflate-shrinkwrap.js(77,34): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/install/mutate-into-logical-tree.js(137,86): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/install/read-shrinkwrap.js(11,46): error TS2339: Property 'lockfileVersion' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/install/save.js(48,12): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
@@ -414,6 +408,51 @@ node_modules/npm/lib/install/validate-tree.js(70,25): error TS2339: Property 'co
 node_modules/npm/lib/install/validate-tree.js(74,13): error TS2339: Property 'code' does not exist on type 'Error'.
 node_modules/npm/lib/install/validate-tree.js(89,15): error TS2339: Property 'code' does not exist on type 'Error'.
 node_modules/npm/lib/install/writable.js(22,21): error TS2339: Property 'W_OK' does not exist on type 'typeof import("fs")'.
+node_modules/npm/lib/install.js(182,36): error TS2339: Property 'globalDir' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(184,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(186,17): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(190,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(192,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(200,36): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(224,24): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(226,19): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(227,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(230,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(235,34): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(236,63): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(237,51): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(239,85): error TS2339: Property 'globalDir' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(240,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(268,26): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(269,9): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(272,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(273,7): error TS2532: Object is possibly 'undefined'.
+node_modules/npm/lib/install.js(273,7): error TS2684: The 'this' context of type '((err: any, ...args: any[]) => any) | undefined' is not assignable to method's 'this' of type 'Function'.
+  Type 'undefined' is not assignable to type 'Function'.
+node_modules/npm/lib/install.js(340,25): error TS2339: Property 'failing' does not exist on type 'Installer'.
+node_modules/npm/lib/install.js(369,18): error TS2345: Argument of type '"time"' is not assignable to parameter of type '"warning"'.
+node_modules/npm/lib/install.js(376,16): error TS2345: Argument of type '"timeEnd"' is not assignable to parameter of type '"warning"'.
+node_modules/npm/lib/install.js(519,40): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(597,12): error TS2339: Property 'failing' does not exist on type 'Installer'.
+node_modules/npm/lib/install.js(614,12): error TS2339: Property 'failing' does not exist on type 'Installer'.
+node_modules/npm/lib/install.js(634,88): error TS2339: Property 'remove' does not exist on type 'Installer'.
+node_modules/npm/lib/install.js(643,12): error TS2339: Property 'failing' does not exist on type 'Installer'.
+node_modules/npm/lib/install.js(684,12): error TS2339: Property 'code' does not exist on type 'Error'.
+node_modules/npm/lib/install.js(685,12): error TS2339: Property 'errno' does not exist on type 'Error'.
+node_modules/npm/lib/install.js(745,32): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(751,12): error TS2339: Property 'failing' does not exist on type 'Installer'.
+node_modules/npm/lib/install.js(768,13): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(770,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(771,14): error TS2554: Expected 0-1 arguments, but got 2.
+node_modules/npm/lib/install.js(890,26): error TS2345: Argument of type 'any' is not assignable to parameter of type 'never'.
+node_modules/npm/lib/install.js(897,26): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
+node_modules/npm/lib/install.js(899,25): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
+node_modules/npm/lib/install.js(901,27): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
+node_modules/npm/lib/install.js(903,25): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
+node_modules/npm/lib/install.js(905,27): error TS2345: Argument of type '{ [x: string]: any; action: any; name: any; version: any; path: any; }' is not assignable to parameter of type 'never'.
+node_modules/npm/lib/install.js(948,8): error TS2454: Variable 'previousPath' is used before being assigned.
+node_modules/npm/lib/install.js(985,53): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/install.js(1007,53): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/link.js(25,17): error TS2339: Property 'globalDir' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/link.js(39,9): error TS2339: Property 'code' does not exist on type 'Error'.
 node_modules/npm/lib/link.js(40,9): error TS2339: Property 'errno' does not exist on type 'Error'.
@@ -495,31 +534,31 @@ node_modules/npm/lib/npm.js(228,11): error TS2339: Property 'config' does not ex
 node_modules/npm/lib/npm.js(231,30): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/npm.js(234,19): error TS2345: Argument of type 'true' is not assignable to parameter of type 'string'.
 node_modules/npm/lib/npm.js(253,17): error TS2339: Property 'installPrefix' does not exist on type 'Process'.
-node_modules/npm/lib/npm.js(343,52): error TS2345: Argument of type 'PropertyDescriptor | undefined' is not assignable to parameter of type 'PropertyDescriptor & ThisType<any>'.
+node_modules/npm/lib/npm.js(347,52): error TS2345: Argument of type 'PropertyDescriptor | undefined' is not assignable to parameter of type 'PropertyDescriptor & ThisType<any>'.
   Type 'undefined' is not assignable to type 'PropertyDescriptor & ThisType<any>'.
     Type 'undefined' is not assignable to type 'PropertyDescriptor'.
-node_modules/npm/lib/npm.js(346,51): error TS2345: Argument of type 'PropertyDescriptor | undefined' is not assignable to parameter of type 'PropertyDescriptor & ThisType<any>'.
+node_modules/npm/lib/npm.js(350,51): error TS2345: Argument of type 'PropertyDescriptor | undefined' is not assignable to parameter of type 'PropertyDescriptor & ThisType<any>'.
   Type 'undefined' is not assignable to type 'PropertyDescriptor & ThisType<any>'.
     Type 'undefined' is not assignable to type 'PropertyDescriptor'.
-node_modules/npm/lib/npm.js(373,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(373,47): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(373,66): error TS2339: Property 'localPrefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(376,21): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(386,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(386,50): error TS2339: Property 'globalBin' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(387,33): error TS2339: Property 'root' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(395,21): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(404,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(404,50): error TS2339: Property 'globalDir' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(405,33): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(414,33): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(415,33): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(421,37): error TS2339: Property 'dir' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(424,37): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(425,38): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(435,33): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(441,34): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/npm.js(456,13): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(377,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(377,47): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(377,66): error TS2339: Property 'localPrefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(380,21): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(390,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(390,50): error TS2339: Property 'globalBin' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(391,33): error TS2339: Property 'root' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(399,21): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(408,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(408,50): error TS2339: Property 'globalDir' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(409,33): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(418,33): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(419,33): error TS2339: Property 'globalPrefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(425,37): error TS2339: Property 'dir' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(428,37): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(429,38): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(439,33): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(445,34): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/npm.js(460,13): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/outdated.js(36,16): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/outdated.js(71,30): error TS2339: Property 'dir' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/outdated.js(74,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
@@ -559,15 +598,22 @@ node_modules/npm/lib/owner.js(223,28): error TS2339: Property 'config' does not 
 node_modules/npm/lib/owner.js(226,11): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/owner.js(246,37): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/owner.js(254,15): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/pack.js(87,32): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/pack.js(95,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/pack.js(115,36): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/pack.js(169,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/pack.js(170,20): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
-node_modules/npm/lib/pack.js(170,36): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/pack.js(205,17): error TS2339: Property 'code' does not exist on type 'Error'.
-node_modules/npm/lib/pack.js(206,17): error TS2339: Property 'signal' does not exist on type 'Error'.
-node_modules/npm/lib/pack.js(224,36): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(53,24): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(72,40): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(79,21): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(86,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(88,40): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(102,39): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(119,32): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(127,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(147,36): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(177,25): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(299,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(300,20): error TS2345: Argument of type 'string' is not assignable to parameter of type 'never'.
+node_modules/npm/lib/pack.js(300,36): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/pack.js(335,17): error TS2339: Property 'code' does not exist on type 'Error'.
+node_modules/npm/lib/pack.js(336,17): error TS2339: Property 'signal' does not exist on type 'Error'.
+node_modules/npm/lib/pack.js(354,36): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/ping.js(13,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/ping.js(15,18): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/ping.js(17,7): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
@@ -592,15 +638,20 @@ node_modules/npm/lib/prune.js(58,22): error TS2339: Property 'idealTree' does no
 node_modules/npm/lib/prune.js(61,32): error TS2339: Property 'idealTree' does not exist on type 'Pruner'.
 node_modules/npm/lib/prune.js(62,27): error TS2339: Property 'idealTree' does not exist on type 'Pruner'.
 node_modules/npm/lib/publish.js(45,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/publish.js(62,11): error TS2339: Property 'code' does not exist on type 'Error'.
-node_modules/npm/lib/publish.js(86,36): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/publish.js(102,34): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/publish.js(126,9): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/publish.js(127,9): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/publish.js(132,25): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/publish.js(174,13): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/publish.js(179,15): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/publish.js(196,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(53,24): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(68,11): error TS2339: Property 'code' does not exist on type 'Error'.
+node_modules/npm/lib/publish.js(93,36): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(97,25): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(111,34): error TS2339: Property 'tmp' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(120,24): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(138,9): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(139,9): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(144,25): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(166,18): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(180,13): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(191,13): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(196,15): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/publish.js(213,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/rebuild.js(20,26): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/rebuild.js(21,21): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/rebuild.js(26,24): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
@@ -623,6 +674,14 @@ node_modules/npm/lib/run-script.js(77,21): error TS2345: Argument of type 'strin
 node_modules/npm/lib/run-script.js(94,13): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/run-script.js(99,13): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/run-script.js(148,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/search/all-package-metadata.js(33,30): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/search/all-package-metadata.js(36,35): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/search/all-package-metadata.js(146,7): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/search/all-package-metadata.js(239,20): error TS2339: Property 'cache' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/search/esearch.js(15,36): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/search/esearch.js(35,7): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/search/format-package-stream.js(130,31): error TS2339: Property 'fd' does not exist on type 'WriteStream'.
+node_modules/npm/lib/search/format-package-stream.js(130,63): error TS2339: Property 'getWindowSize' does not exist on type 'WriteStream'.
 node_modules/npm/lib/search.js(25,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/search.js(26,34): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/search.js(27,40): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
@@ -636,33 +695,26 @@ node_modules/npm/lib/search.js(71,20): error TS2339: Property 'config' does not 
 node_modules/npm/lib/search.js(72,16): error TS2339: Property 'color' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/search.js(82,28): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/search.js(82,55): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/search/all-package-metadata.js(33,30): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/search/all-package-metadata.js(36,35): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/search/all-package-metadata.js(146,7): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/search/all-package-metadata.js(239,20): error TS2339: Property 'cache' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/search/esearch.js(15,36): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/search/esearch.js(35,7): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/search/format-package-stream.js(130,31): error TS2339: Property 'fd' does not exist on type 'WriteStream'.
-node_modules/npm/lib/search/format-package-stream.js(130,63): error TS2339: Property 'getWindowSize' does not exist on type 'WriteStream'.
 node_modules/npm/lib/set.js(8,22): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/set.js(12,7): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/shrinkwrap.js(30,29): error TS2339: Property 'lockfileVersion' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/shrinkwrap.js(48,22): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/shrinkwrap.js(49,22): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/shrinkwrap.js(53,38): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/shrinkwrap.js(60,34): error TS2339: Property 'localPrefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/shrinkwrap.js(115,13): error TS2339: Property 'version' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(117,15): error TS2339: Property 'bundled' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(120,17): error TS2339: Property 'resolved' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(126,17): error TS2339: Property 'integrity' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(127,22): error TS2339: Property 'integrity' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(128,19): error TS2339: Property 'integrity' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(132,33): error TS2339: Property 'dev' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(133,40): error TS2339: Property 'optional' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(135,15): error TS2339: Property 'requires' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(138,17): error TS2339: Property 'requires' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(142,15): error TS2339: Property 'dependencies' does not exist on type '{}'.
-node_modules/npm/lib/shrinkwrap.js(143,30): error TS2339: Property 'dependencies' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(50,22): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/shrinkwrap.js(51,22): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/shrinkwrap.js(55,38): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/shrinkwrap.js(62,34): error TS2339: Property 'localPrefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/shrinkwrap.js(117,13): error TS2339: Property 'version' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(119,15): error TS2339: Property 'from' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(122,15): error TS2339: Property 'bundled' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(125,17): error TS2339: Property 'resolved' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(131,17): error TS2339: Property 'integrity' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(132,22): error TS2339: Property 'integrity' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(133,19): error TS2339: Property 'integrity' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(137,33): error TS2339: Property 'dev' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(138,40): error TS2339: Property 'optional' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(140,15): error TS2339: Property 'requires' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(143,17): error TS2339: Property 'requires' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(147,15): error TS2339: Property 'dependencies' does not exist on type '{}'.
+node_modules/npm/lib/shrinkwrap.js(148,30): error TS2339: Property 'dependencies' does not exist on type '{}'.
 node_modules/npm/lib/star.js(24,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/star.js(25,15): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/star.js(26,21): error TS2339: Property 'command' does not exist on type 'EventEmitter'.
@@ -753,9 +805,9 @@ node_modules/npm/lib/utils/error-handler.js(216,18): error TS2339: Property 'err
 node_modules/npm/lib/utils/error-handler.js(216,42): error TS2339: Property 'errno' does not exist on type 'Error'.
 node_modules/npm/lib/utils/error-handler.js(231,34): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/utils/error-handler.js(236,7): error TS2322: Type 'string' is not assignable to type 'any[]'.
-node_modules/npm/lib/utils/error-message.js(66,37): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/utils/error-message.js(295,24): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/utils/error-message.js(296,25): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/utils/error-message.js(77,37): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/utils/error-message.js(300,24): error TS2339: Property 'version' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/utils/error-message.js(301,25): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/utils/git.js(9,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/utils/is-windows-bash.js(3,53): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
   Type 'undefined' is not assignable to type 'string'.
@@ -782,7 +834,6 @@ node_modules/npm/lib/utils/metrics.js(65,9): error TS2339: Property 'registry' d
 node_modules/npm/lib/utils/parse-json.js(7,11): error TS2339: Property 'noExceptions' does not exist on type '(content: any) => any'.
 node_modules/npm/lib/utils/perf.js(9,12): error TS2345: Argument of type '"time"' is not assignable to parameter of type 'Signals'.
 node_modules/npm/lib/utils/perf.js(10,12): error TS2345: Argument of type '"timeEnd"' is not assignable to parameter of type 'Signals'.
-node_modules/npm/lib/utils/perf.js(21,18): error TS2345: Argument of type '"timing"' is not assignable to parameter of type '"removeListener"'.
 node_modules/npm/lib/utils/read-local-package.js(7,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/utils/read-local-package.js(9,29): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/utils/spawn.js(26,8): error TS2339: Property 'file' does not exist on type 'Error'.
@@ -814,21 +865,23 @@ node_modules/npm/lib/version.js(297,20): error TS2339: Property 'config' does no
 node_modules/npm/lib/version.js(306,20): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/version.js(324,44): error TS2339: Property 'localPrefix' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/version.js(336,19): error TS2339: Property 'localPrefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(26,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(27,47): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(30,9): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(80,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(85,19): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(107,35): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(109,27): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(112,9): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(257,13): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(260,38): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(264,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(267,74): error TS2339: Property 'color' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(269,47): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(272,16): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
-node_modules/npm/lib/view.js(281,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(35,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(36,47): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(39,9): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(89,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(94,19): error TS2339: Property 'prefix' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(116,35): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(118,27): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(121,9): error TS2339: Property 'registry' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(168,14): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(185,23): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(405,13): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(408,38): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(412,17): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(415,74): error TS2339: Property 'color' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(417,47): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(420,16): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
+node_modules/npm/lib/view.js(429,11): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/visnup.js(41,14): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/whoami.js(15,22): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
 node_modules/npm/lib/whoami.js(18,18): error TS2339: Property 'config' does not exist on type 'EventEmitter'.
@@ -851,9 +904,9 @@ node_modules/npm/test/broken-under-nyc-and-travis/whoami.js(7,20): error TS2307:
 node_modules/npm/test/common-tap.js(5,47): error TS2339: Property '_extend' does not exist on type 'typeof import("util")'.
 node_modules/npm/test/common-tap.js(10,3): error TS2322: Type '(...args: any[]) => void' is not assignable to type 'typeof setImmediate'.
   Property '__promisify__' is missing in type '(...args: any[]) => void'.
-node_modules/npm/test/common-tap.js(170,17): error TS2339: Property '_storage' does not exist on type 'Environment'.
-node_modules/npm/test/common-tap.js(176,31): error TS2339: Property '_storage' does not exist on type 'Environment'.
-node_modules/npm/test/common-tap.js(187,12): error TS2339: Property '_storage' does not exist on type 'Environment'.
+node_modules/npm/test/common-tap.js(175,17): error TS2339: Property '_storage' does not exist on type 'Environment'.
+node_modules/npm/test/common-tap.js(181,31): error TS2339: Property '_storage' does not exist on type 'Environment'.
+node_modules/npm/test/common-tap.js(192,12): error TS2339: Property '_storage' does not exist on type 'Environment'.
 node_modules/npm/test/need-npm5-update/belongs-in-pacote/add-remote-git-get-resolved.js(2,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/need-npm5-update/belongs-in-pacote/add-remote-git-get-resolved.js(4,19): error TS2307: Cannot find module '../../lib/npm.js'.
 node_modules/npm/test/need-npm5-update/belongs-in-pacote/add-remote-git-get-resolved.js(5,22): error TS2307: Cannot find module '../common-tap.js'.
@@ -1133,8 +1186,6 @@ node_modules/npm/test/tap/false-name.js(17,20): error TS2307: Cannot find module
 node_modules/npm/test/tap/fetch-package-metadata.js(5,18): error TS2307: Cannot find module 'npm-registry-mock'.
 node_modules/npm/test/tap/fetch-package-metadata.js(9,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/fetch-package-metadata.js(36,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
-node_modules/npm/test/tap/files-and-ignores.js(2,20): error TS2307: Cannot find module 'tap'.
-node_modules/npm/test/tap/files-and-ignores.js(12,21): error TS2307: Cannot find module 'tacks'.
 node_modules/npm/test/tap/full-warning-messages.js(2,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/gently-rm-cmdshims.js(4,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/gently-rm-cmdshims.js(107,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
@@ -1185,6 +1236,14 @@ node_modules/npm/test/tap/graceful-restart.js(7,20): error TS2307: Cannot find m
 node_modules/npm/test/tap/help.js(1,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/ignore-install-link.js(6,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/ignore-scripts.js(6,20): error TS2307: Cannot find module 'tap'.
+node_modules/npm/test/tap/init-create.js(2,20): error TS2307: Cannot find module 'tap'.
+node_modules/npm/test/tap/init-create.js(3,29): error TS2307: Cannot find module 'require-inject'.
+node_modules/npm/test/tap/init-create.js(25,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
+node_modules/npm/test/tap/init-create.js(42,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
+node_modules/npm/test/tap/init-create.js(47,16): error TS2339: Property 'parseArgs' does not exist on type '() => Promise<void>'.
+node_modules/npm/test/tap/init-create.js(53,16): error TS2339: Property 'parseArgs' does not exist on type '() => Promise<void>'.
+node_modules/npm/test/tap/init-create.js(68,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
+node_modules/npm/test/tap/init-create.js(74,16): error TS2339: Property 'parseArgs' does not exist on type '() => Promise<void>'.
 node_modules/npm/test/tap/init-interrupt.js(3,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/init-interrupt.js(8,29): error TS2307: Cannot find module 'require-inject'.
 node_modules/npm/test/tap/init-interrupt.js(28,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
@@ -1251,11 +1310,12 @@ node_modules/npm/test/tap/install-scoped-with-bundled-dependency.js(3,20): error
 node_modules/npm/test/tap/install-scoped-with-bundled-dependency.js(4,21): error TS2307: Cannot find module 'tacks'.
 node_modules/npm/test/tap/install-scoped-with-bundled-dependency.js(7,47): error TS2339: Property '_extend' does not exist on type 'typeof import("util")'.
 node_modules/npm/test/tap/install-scoped-with-peer-dependency.js(7,20): error TS2307: Cannot find module 'tap'.
-node_modules/npm/test/tap/install-shrinkwrapped-git.js(7,20): error TS2307: Cannot find module 'tap'.
-node_modules/npm/test/tap/install-shrinkwrapped-git.js(53,12): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
-node_modules/npm/test/tap/install-shrinkwrapped-git.js(57,12): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
-node_modules/npm/test/tap/install-shrinkwrapped-git.js(62,12): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
-node_modules/npm/test/tap/install-shrinkwrapped-git.js(94,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
+node_modules/npm/test/tap/install-shrinkwrapped-git.js(9,20): error TS2307: Cannot find module 'tap'.
+node_modules/npm/test/tap/install-shrinkwrapped-git.js(56,12): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
+node_modules/npm/test/tap/install-shrinkwrapped-git.js(60,12): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
+node_modules/npm/test/tap/install-shrinkwrapped-git.js(65,12): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
+node_modules/npm/test/tap/install-shrinkwrapped-git.js(106,7): error TS2339: Property 'load' does not exist on type 'EventEmitter'.
+node_modules/npm/test/tap/install-test-cli-without-package-lock.js(7,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/install-windows-newlines.js(3,40): error TS2339: Property 'existsSync' does not exist on type 'typeof import("path")'.
 node_modules/npm/test/tap/install-windows-newlines.js(7,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/install-with-dev-dep-duplicate.js(5,18): error TS2307: Cannot find module 'npm-registry-mock'.
@@ -1389,7 +1449,10 @@ node_modules/npm/test/tap/outdated.js(105,15): error TS2339: Property 'outdated'
 node_modules/npm/test/tap/override-bundled.js(3,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/owner.js(1,18): error TS2307: Cannot find module 'npm-registry-mock'.
 node_modules/npm/test/tap/owner.js(2,20): error TS2307: Cannot find module 'tap'.
+node_modules/npm/test/tap/pack-files-and-ignores.js(2,20): error TS2307: Cannot find module 'tap'.
+node_modules/npm/test/tap/pack-files-and-ignores.js(12,21): error TS2307: Cannot find module 'tacks'.
 node_modules/npm/test/tap/pack-scoped.js(2,20): error TS2307: Cannot find module 'tap'.
+node_modules/npm/test/tap/pack.js(5,22): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/peer-deps.js(5,18): error TS2307: Cannot find module 'npm-registry-mock'.
 node_modules/npm/test/tap/peer-deps.js(8,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/pick-manifest-from-registry-metadata.js(2,20): error TS2307: Cannot find module 'tap'.
@@ -1449,6 +1512,10 @@ node_modules/npm/test/tap/publish-invalid-semver-tag.js(64,7): error TS2339: Pro
 node_modules/npm/test/tap/publish-invalid-semver-tag.js(65,7): error TS2339: Property 'commands' does not exist on type 'EventEmitter'.
 node_modules/npm/test/tap/publish-scoped.js(4,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/publish-scoped.js(8,18): error TS2307: Cannot find module 'npm-registry-mock'.
+node_modules/npm/test/tap/publish.js(8,33): error TS2307: Cannot find module 'npm-registry-mock'.
+node_modules/npm/test/tap/publish.js(11,22): error TS2307: Cannot find module 'tap'.
+node_modules/npm/test/tap/publish.js(56,47): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string | RegExp'.
+node_modules/npm/test/tap/publish.js(117,45): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string | RegExp'.
 node_modules/npm/test/tap/pwd-prefix.js(5,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/referer.js(2,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/repo.js(2,18): error TS2307: Cannot find module 'npm-registry-mock'.
@@ -1463,6 +1530,10 @@ node_modules/npm/test/tap/run-script.js(213,18): error TS2345: Argument of type 
   Type 'undefined' is not assignable to type 'string'.
 node_modules/npm/test/tap/run-script.js(256,18): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
   Type 'undefined' is not assignable to type 'string'.
+node_modules/npm/test/tap/save-optional.js(3,22): error TS2307: Cannot find module 'tap'.
+node_modules/npm/test/tap/save-optional.js(4,20): error TS2307: Cannot find module 'npm-registry-mock'.
+node_modules/npm/test/tap/save-optional.js(5,23): error TS2307: Cannot find module 'tacks'.
+node_modules/npm/test/tap/save-optional.js(70,30): error TS2345: Argument of type 'Buffer' is not assignable to parameter of type 'string'.
 node_modules/npm/test/tap/scope-header.js(3,20): error TS2307: Cannot find module 'tap'.
 node_modules/npm/test/tap/scope-header.js(4,18): error TS2307: Cannot find module 'npm-registry-mock'.
 node_modules/npm/test/tap/scope-header.js(5,21): error TS2307: Cannot find module 'tacks'.

--- a/tests/baselines/reference/user/puppeteer.log
+++ b/tests/baselines/reference/user/puppeteer.log
@@ -25,15 +25,6 @@ lib/ExecutionContext.js(19,7): error TS2300: Duplicate identifier 'ExecutionCont
 lib/ExecutionContext.js(22,15): error TS2503: Cannot find namespace 'Protocol'.
 lib/ExecutionContext.js(132,15): error TS2503: Cannot find namespace 'Protocol'.
 lib/ExecutionContext.js(225,19): error TS2300: Duplicate identifier 'ExecutionContext'.
-lib/externs.d.ts(2,30): error TS2497: Module '"/puppeteer/puppeteer/lib/Browser"' resolves to a non-module entity and cannot be imported using this construct.
-lib/externs.d.ts(3,29): error TS2497: Module '"/puppeteer/puppeteer/lib/Target"' resolves to a non-module entity and cannot be imported using this construct.
-lib/externs.d.ts(5,32): error TS2497: Module '"/puppeteer/puppeteer/lib/TaskQueue"' resolves to a non-module entity and cannot be imported using this construct.
-lib/externs.d.ts(9,37): error TS2497: Module '"/puppeteer/puppeteer/lib/ElementHandle"' resolves to a non-module entity and cannot be imported using this construct.
-lib/externs.d.ts(16,26): error TS2503: Cannot find namespace 'Protocol'.
-lib/externs.d.ts(16,69): error TS2503: Cannot find namespace 'Protocol'.
-lib/externs.d.ts(17,28): error TS2503: Cannot find namespace 'Protocol'.
-lib/externs.d.ts(17,81): error TS2503: Cannot find namespace 'Protocol'.
-lib/externs.d.ts(17,121): error TS2503: Cannot find namespace 'Protocol'.
 lib/FrameManager.js(25,7): error TS2300: Duplicate identifier 'FrameManager'.
 lib/FrameManager.js(28,15): error TS2503: Cannot find namespace 'Protocol'.
 lib/FrameManager.js(54,15): error TS2503: Cannot find namespace 'Protocol'.
@@ -41,9 +32,6 @@ lib/FrameManager.js(76,15): error TS2503: Cannot find namespace 'Protocol'.
 lib/FrameManager.js(127,15): error TS2503: Cannot find namespace 'Protocol'.
 lib/FrameManager.js(773,15): error TS2503: Cannot find namespace 'Protocol'.
 lib/FrameManager.js(998,19): error TS2300: Duplicate identifier 'FrameManager'.
-lib/helper.js(59,15): error TS2503: Cannot find namespace 'Protocol'.
-lib/helper.js(77,15): error TS2503: Cannot find namespace 'Protocol'.
-lib/helper.js(101,15): error TS2503: Cannot find namespace 'Protocol'.
 lib/Input.js(29,7): error TS2300: Duplicate identifier 'Keyboard'.
 lib/Input.js(306,20): error TS2300: Duplicate identifier 'Keyboard'.
 lib/NetworkManager.js(129,15): error TS2503: Cannot find namespace 'Protocol'.
@@ -62,6 +50,18 @@ lib/Page.js(185,15): error TS2503: Cannot find namespace 'Protocol'.
 lib/Page.js(394,22): error TS2503: Cannot find namespace 'Protocol'.
 lib/Page.js(407,15): error TS2503: Cannot find namespace 'Protocol'.
 lib/Page.js(731,19): error TS2503: Cannot find namespace 'Protocol'.
+lib/externs.d.ts(2,30): error TS2497: Module '"/puppeteer/puppeteer/lib/Browser"' resolves to a non-module entity and cannot be imported using this construct.
+lib/externs.d.ts(3,29): error TS2497: Module '"/puppeteer/puppeteer/lib/Target"' resolves to a non-module entity and cannot be imported using this construct.
+lib/externs.d.ts(5,32): error TS2497: Module '"/puppeteer/puppeteer/lib/TaskQueue"' resolves to a non-module entity and cannot be imported using this construct.
+lib/externs.d.ts(9,37): error TS2497: Module '"/puppeteer/puppeteer/lib/ElementHandle"' resolves to a non-module entity and cannot be imported using this construct.
+lib/externs.d.ts(16,26): error TS2503: Cannot find namespace 'Protocol'.
+lib/externs.d.ts(16,69): error TS2503: Cannot find namespace 'Protocol'.
+lib/externs.d.ts(17,28): error TS2503: Cannot find namespace 'Protocol'.
+lib/externs.d.ts(17,81): error TS2503: Cannot find namespace 'Protocol'.
+lib/externs.d.ts(17,121): error TS2503: Cannot find namespace 'Protocol'.
+lib/helper.js(59,15): error TS2503: Cannot find namespace 'Protocol'.
+lib/helper.js(77,15): error TS2503: Cannot find namespace 'Protocol'.
+lib/helper.js(101,15): error TS2503: Cannot find namespace 'Protocol'.
 node_modules/@types/node/index.d.ts(911,22): error TS2300: Duplicate identifier 'EventEmitter'.
 
 

--- a/tests/baselines/reference/user/uglify-js.log
+++ b/tests/baselines/reference/user/uglify-js.log
@@ -5,67 +5,67 @@ node_modules/uglify-js/lib/ast.js(329,33): error TS2339: Property 'transform' do
 node_modules/uglify-js/lib/ast.js(857,5): error TS2322: Type '{ [x: string]: any; _visit: (node: any, descend: any) => any; parent: (n: any) => any; push: type...' is not assignable to type 'TreeWalker'.
   Object literal may only specify known properties, but '_visit' does not exist in type 'TreeWalker'. Did you mean to write 'visit'?
 node_modules/uglify-js/lib/compress.js(165,27): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(500,26): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(813,18): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(1061,38): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
-node_modules/uglify-js/lib/compress.js(1075,51): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'true | ((node: any) => any)' has no compatible call signatures.
-node_modules/uglify-js/lib/compress.js(1139,53): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
-node_modules/uglify-js/lib/compress.js(1181,112): error TS2532: Object is possibly 'undefined'.
-node_modules/uglify-js/lib/compress.js(1182,29): error TS2532: Object is possibly 'undefined'.
-node_modules/uglify-js/lib/compress.js(1191,87): error TS2322: Type 'false' is not assignable to type 'number'.
-node_modules/uglify-js/lib/compress.js(1199,29): error TS2322: Type 'false' is not assignable to type 'never'.
-node_modules/uglify-js/lib/compress.js(1297,38): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(1390,38): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
-node_modules/uglify-js/lib/compress.js(1487,27): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(1519,26): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(1933,44): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(2125,19): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(2385,27): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(3125,23): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(3138,33): error TS2322: Type '"f"' is not assignable to type 'boolean'.
-node_modules/uglify-js/lib/compress.js(3275,18): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(3285,33): error TS2339: Property 'add' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3289,32): error TS2339: Property 'add' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3295,40): error TS2339: Property 'add' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3304,41): error TS2339: Property 'add' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3321,14): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(3323,40): error TS2339: Property 'get' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3331,33): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
-node_modules/uglify-js/lib/compress.js(3405,63): error TS2339: Property 'get' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3594,23): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(3611,36): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
-node_modules/uglify-js/lib/compress.js(3617,38): error TS2339: Property 'set' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3621,40): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
-node_modules/uglify-js/lib/compress.js(3646,22): error TS2339: Property 'each' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3651,30): error TS2339: Property 'del' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3656,30): error TS2339: Property 'set' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3667,41): error TS2339: Property 'has' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3669,48): error TS2339: Property 'get' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(506,26): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(820,18): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(1075,38): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
+node_modules/uglify-js/lib/compress.js(1089,51): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'true | ((node: any) => any)' has no compatible call signatures.
+node_modules/uglify-js/lib/compress.js(1153,53): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
+node_modules/uglify-js/lib/compress.js(1195,112): error TS2532: Object is possibly 'undefined'.
+node_modules/uglify-js/lib/compress.js(1196,29): error TS2532: Object is possibly 'undefined'.
+node_modules/uglify-js/lib/compress.js(1205,87): error TS2322: Type 'false' is not assignable to type 'number'.
+node_modules/uglify-js/lib/compress.js(1213,29): error TS2322: Type 'false' is not assignable to type 'never'.
+node_modules/uglify-js/lib/compress.js(1311,38): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(1404,38): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
+node_modules/uglify-js/lib/compress.js(1501,27): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(1533,26): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(1947,44): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(2139,19): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(2399,27): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3139,23): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3152,33): error TS2322: Type '"f"' is not assignable to type 'boolean'.
+node_modules/uglify-js/lib/compress.js(3289,18): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3299,33): error TS2339: Property 'add' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3303,32): error TS2339: Property 'add' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3309,40): error TS2339: Property 'add' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3318,41): error TS2339: Property 'add' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3335,14): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3337,40): error TS2339: Property 'get' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3345,33): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
+node_modules/uglify-js/lib/compress.js(3419,63): error TS2339: Property 'get' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3608,23): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3625,36): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
+node_modules/uglify-js/lib/compress.js(3631,38): error TS2339: Property 'set' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3635,40): error TS2339: Property 'parent' does not exist on type 'TreeTransformer'.
+node_modules/uglify-js/lib/compress.js(3660,22): error TS2339: Property 'each' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3665,30): error TS2339: Property 'del' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3670,30): error TS2339: Property 'set' does not exist on type 'Dictionary'.
 node_modules/uglify-js/lib/compress.js(3681,41): error TS2339: Property 'has' does not exist on type 'Dictionary'.
 node_modules/uglify-js/lib/compress.js(3683,48): error TS2339: Property 'get' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3789,21): error TS2403: Subsequent variable declarations must have the same type.  Variable 'defs' must be of type 'Dictionary', but here has type 'any'.
-node_modules/uglify-js/lib/compress.js(3791,36): error TS2339: Property 'get' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3820,22): error TS2339: Property 'set' does not exist on type 'Dictionary'.
-node_modules/uglify-js/lib/compress.js(3840,17): error TS2447: The '|=' operator is not allowed for boolean types. Consider using '||' instead.
-node_modules/uglify-js/lib/compress.js(3865,30): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(4003,18): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(4302,17): error TS2403: Subsequent variable declarations must have the same type.  Variable 'body' must be of type 'any[]', but here has type 'any'.
-node_modules/uglify-js/lib/compress.js(4386,22): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(4734,30): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(4741,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'code' must be of type 'string', but here has type '{ [x: string]: any; get: () => string; toString: () => string; indent: () => void; indentation: (...'.
-node_modules/uglify-js/lib/compress.js(4745,36): error TS2532: Object is possibly 'undefined'.
-node_modules/uglify-js/lib/compress.js(4750,41): error TS2339: Property 'get' does not exist on type 'string'.
-node_modules/uglify-js/lib/compress.js(5237,18): error TS2454: Variable 'is_strict_comparison' is used before being assigned.
-node_modules/uglify-js/lib/compress.js(5676,25): error TS2365: Operator '==' cannot be applied to types 'boolean' and '"f"'.
-node_modules/uglify-js/lib/compress.js(5703,32): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(5763,24): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(5835,24): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(5841,26): error TS2554: Expected 0 arguments, but got 1.
-node_modules/uglify-js/lib/compress.js(6191,43): error TS2454: Variable 'property' is used before being assigned.
-node_modules/uglify-js/lib/compress.js(6205,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'value' must be of type 'number', but here has type 'any'.
-node_modules/uglify-js/lib/compress.js(6208,46): error TS2339: Property 'has_side_effects' does not exist on type 'number'.
-node_modules/uglify-js/lib/compress.js(6215,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'value' must be of type 'number', but here has type 'any'.
-node_modules/uglify-js/lib/compress.js(6268,19): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(3695,41): error TS2339: Property 'has' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3697,48): error TS2339: Property 'get' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3803,21): error TS2403: Subsequent variable declarations must have the same type.  Variable 'defs' must be of type 'Dictionary', but here has type 'any'.
+node_modules/uglify-js/lib/compress.js(3805,36): error TS2339: Property 'get' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3834,22): error TS2339: Property 'set' does not exist on type 'Dictionary'.
+node_modules/uglify-js/lib/compress.js(3854,17): error TS2447: The '|=' operator is not allowed for boolean types. Consider using '||' instead.
+node_modules/uglify-js/lib/compress.js(3879,30): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(4017,18): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(4316,17): error TS2403: Subsequent variable declarations must have the same type.  Variable 'body' must be of type 'any[]', but here has type 'any'.
+node_modules/uglify-js/lib/compress.js(4400,22): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(4748,30): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(4755,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'code' must be of type 'string', but here has type '{ [x: string]: any; get: () => string; toString: () => string; indent: () => void; indentation: (...'.
+node_modules/uglify-js/lib/compress.js(4759,36): error TS2532: Object is possibly 'undefined'.
+node_modules/uglify-js/lib/compress.js(4764,41): error TS2339: Property 'get' does not exist on type 'string'.
+node_modules/uglify-js/lib/compress.js(5251,18): error TS2454: Variable 'is_strict_comparison' is used before being assigned.
+node_modules/uglify-js/lib/compress.js(5690,25): error TS2365: Operator '==' cannot be applied to types 'boolean' and '"f"'.
+node_modules/uglify-js/lib/compress.js(5717,32): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(5777,24): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(5849,24): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(5855,26): error TS2554: Expected 0 arguments, but got 1.
+node_modules/uglify-js/lib/compress.js(6205,43): error TS2454: Variable 'property' is used before being assigned.
+node_modules/uglify-js/lib/compress.js(6219,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'value' must be of type 'number', but here has type 'any'.
+node_modules/uglify-js/lib/compress.js(6222,46): error TS2339: Property 'has_side_effects' does not exist on type 'number'.
+node_modules/uglify-js/lib/compress.js(6229,25): error TS2403: Subsequent variable declarations must have the same type.  Variable 'value' must be of type 'number', but here has type 'any'.
+node_modules/uglify-js/lib/compress.js(6282,19): error TS2554: Expected 0 arguments, but got 1.
 node_modules/uglify-js/lib/minify.js(166,75): error TS2339: Property 'compress' does not exist on type 'Compressor'.
 node_modules/uglify-js/lib/mozilla-ast.js(569,18): error TS2554: Expected 0 arguments, but got 1.
 node_modules/uglify-js/lib/output.js(481,22): error TS2554: Expected 0 arguments, but got 1.

--- a/tests/cases/user/acorn/package.json
+++ b/tests/cases/user/acorn/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "acorn": "^5.5.3"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/adonis-framework/package.json
+++ b/tests/cases/user/adonis-framework/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "adonis-framework": "^3.0.14"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/assert/package.json
+++ b/tests/cases/user/assert/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "assert": "^1.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/async/package.json
+++ b/tests/cases/user/async/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "async": "^2.6.0"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/bcryptjs/package.json
+++ b/tests/cases/user/bcryptjs/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bcryptjs": "^2.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/bluebird/package.json
+++ b/tests/cases/user/bluebird/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "bluebird": "^3.5.1"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/clear-require/package.json
+++ b/tests/cases/user/clear-require/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "clear-require": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/clone/package.json
+++ b/tests/cases/user/clone/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "clone": "^2.1.1"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/content-disposition/package.json
+++ b/tests/cases/user/content-disposition/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "content-disposition": "^0.5.2"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/debug/package.json
+++ b/tests/cases/user/debug/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "debug": "^3.1.0"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/enhanced-resolve/package.json
+++ b/tests/cases/user/enhanced-resolve/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "enhanced-resolve": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/follow-redirects/package.json
+++ b/tests/cases/user/follow-redirects/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "follow-redirects": "^1.4.1"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/graceful-fs/package.json
+++ b/tests/cases/user/graceful-fs/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "graceful-fs": "^4.1.11"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/jimp/package.json
+++ b/tests/cases/user/jimp/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "jimp": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/lodash/package.json
+++ b/tests/cases/user/lodash/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "lodash": "^4.17.5"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/minimatch/package.json
+++ b/tests/cases/user/minimatch/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "minimatch": "^3.0.4"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/npm/package.json
+++ b/tests/cases/user/npm/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "npm": "^5.7.1"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/npmlog/package.json
+++ b/tests/cases/user/npmlog/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "npmlog": "^4.1.2"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/octokit-rest/package.json
+++ b/tests/cases/user/octokit-rest/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@octokit/rest": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/uglify-js/package.json
+++ b/tests/cases/user/uglify-js/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "uglify-js": "^3.3.13"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/url-search-params/package.json
+++ b/tests/cases/user/url-search-params/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "url-search-params": "^0.10.0"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }

--- a/tests/cases/user/util/package.json
+++ b/tests/cases/user/util/package.json
@@ -7,5 +7,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "util": "^0.10.3"
+  },
+  "devDependencies": {
+    "@types/node": "latest"
   }
 }


### PR DESCRIPTION
Follow up to #24100, which I'll now close.

Fixes #24104
Fixes #24105

The tests didn't need `typeRoots`, unfortunately (that only affects implicit inclusion) - they needed all parent `node_modules` fully removed from the tree. (Which then showed how we were failing to include `@types/node` actually in a bunch of projects, which now do.) Also, the diagnostics are now sorted in case-sensitive path order (if they have a path - otherwise they should stay wherever they are - usually at the top), so the baseline file should match between platforms. I hope.