### PR TITLE
Fix stack overflow in merge symbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -919,11 +919,11 @@ namespace ts {
                     const sourceInitializer = getJSInitializerSymbol(source);
                     const init = getDeclaredJavascriptInitializer(targetValueDeclaration) || getAssignedJavascriptInitializer(targetValueDeclaration);
                     let targetInitializer = init && init.symbol ? init.symbol : target;
+                    if (!(targetInitializer.flags & SymbolFlags.Transient)) {
+                        const mergedInitializer = getMergedSymbol(targetInitializer);
+                        targetInitializer = mergedInitializer === targetInitializer ? cloneSymbol(targetInitializer) : mergedInitializer;
+                    }
                     if (sourceInitializer !== source || targetInitializer !== target) {
-                        if (!(targetInitializer.flags & SymbolFlags.Transient)) {
-                            const mergedInitializer = getMergedSymbol(targetInitializer);
-                            targetInitializer = mergedInitializer === targetInitializer ? cloneSymbol(targetInitializer) : mergedInitializer;
-                        }
                         mergeSymbol(targetInitializer, sourceInitializer);
                     }
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -892,6 +892,7 @@ namespace ts {
         function mergeSymbol(target: Symbol, source: Symbol) {
             if (!(target.flags & getExcludedSymbolFlags(source.flags)) ||
                 (source.flags | target.flags) & SymbolFlags.JSContainer) {
+                const targetValueDeclaration = target.valueDeclaration;
                 Debug.assert(!!(target.flags & SymbolFlags.Transient));
                 // Javascript static-property-assignment declarations always merge, even though they are also values
                 if (source.flags & SymbolFlags.ValueModule && target.flags & SymbolFlags.ValueModule && target.constEnumOnlyModule && !source.constEnumOnlyModule) {
@@ -916,7 +917,8 @@ namespace ts {
                 }
                 if ((source.flags | target.flags) & SymbolFlags.JSContainer) {
                     const sourceInitializer = getJSInitializerSymbol(source);
-                    let targetInitializer = getJSInitializerSymbol(target);
+                    const init = getDeclaredJavascriptInitializer(targetValueDeclaration) || getAssignedJavascriptInitializer(targetValueDeclaration);
+                    let targetInitializer = init && init.symbol ? init.symbol : target;
                     if (sourceInitializer !== source || targetInitializer !== target) {
                         if (!(targetInitializer.flags & SymbolFlags.Transient)) {
                             const mergedInitializer = getMergedSymbol(targetInitializer);

--- a/tests/baselines/reference/jsContainerMergeJsContainer.symbols
+++ b/tests/baselines/reference/jsContainerMergeJsContainer.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/salsa/a.js ===
+// #24131
+const a = {};
+>a : Symbol(a, Decl(a.js, 1, 5), Decl(a.js, 1, 13), Decl(b.js, 0, 0))
+
+a.d = function() {};
+>a.d : Symbol(d, Decl(a.js, 1, 13), Decl(b.js, 0, 2))
+>a : Symbol(a, Decl(a.js, 1, 5), Decl(a.js, 1, 13), Decl(b.js, 0, 0))
+>d : Symbol(d, Decl(a.js, 1, 13), Decl(b.js, 0, 2))
+
+=== tests/cases/conformance/salsa/b.js ===
+a.d.prototype = {};
+>a.d.prototype : Symbol(d.prototype, Decl(b.js, 0, 0))
+>a.d : Symbol(d, Decl(a.js, 1, 13), Decl(b.js, 0, 2))
+>a : Symbol(a, Decl(a.js, 1, 5), Decl(a.js, 1, 13), Decl(b.js, 0, 0))
+>d : Symbol(d, Decl(a.js, 1, 13), Decl(b.js, 0, 2))
+>prototype : Symbol(d.prototype, Decl(b.js, 0, 0))
+

--- a/tests/baselines/reference/jsContainerMergeJsContainer.types
+++ b/tests/baselines/reference/jsContainerMergeJsContainer.types
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/salsa/a.js ===
+// #24131
+const a = {};
+>a : { [x: string]: any; d: typeof d; }
+>{} : { [x: string]: any; d: typeof d; }
+
+a.d = function() {};
+>a.d = function() {} : typeof d
+>a.d : typeof d
+>a : { [x: string]: any; d: typeof d; }
+>d : typeof d
+>function() {} : typeof d
+
+=== tests/cases/conformance/salsa/b.js ===
+a.d.prototype = {};
+>a.d.prototype = {} : { [x: string]: any; }
+>a.d.prototype : { [x: string]: any; }
+>a.d : typeof d
+>a : { [x: string]: any; d: typeof d; }
+>d : typeof d
+>prototype : { [x: string]: any; }
+>{} : { [x: string]: any; }
+

--- a/tests/cases/conformance/salsa/jsContainerMergeJsContainer.ts
+++ b/tests/cases/conformance/salsa/jsContainerMergeJsContainer.ts
@@ -1,0 +1,10 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+// #24131
+// @Filename: a.js
+const a = {};
+a.d = function() {};
+// @Filename: b.js
+a.d.prototype = {};


### PR DESCRIPTION
Fixes #24131 

1. targetInitializer needs to be merged before comparing to target. Transient symbols are never equal to non-transient symbols.
2. Target's valueDeclaration mutates while mergeSymbol is running, but getJSInitializerSymbol depends on it. mergeSymbol needs to save the original value of target.valueDeclaration before looking for a js initializer.