### PR TITLE
Move synthetic comments from arrow body expressions to return statement

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2900,6 +2900,15 @@ namespace ts {
         return setSyntheticTrailingComments(node, append<SynthesizedComment>(getSyntheticTrailingComments(node), { kind, pos: -1, end: -1, hasTrailingNewLine, text }));
     }
 
+    export function moveSyntheticComments<T extends Node>(node: T, original: Node): T {
+        setSyntheticLeadingComments(node, getSyntheticLeadingComments(original));
+        setSyntheticTrailingComments(node, getSyntheticTrailingComments(original));
+        const emit = getOrCreateEmitNode(original);
+        emit.leadingComments = undefined;
+        emit.trailingComments = undefined;
+        return node;
+    }
+
     /**
      * Gets the constant value to emit for an expression.
      */

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -1885,6 +1885,7 @@ namespace ts {
                 const expression = visitNode(body, visitor, isExpression);
                 const returnStatement = createReturn(expression);
                 setTextRange(returnStatement, body);
+                moveSyntheticComments(returnStatement, body);
                 setEmitFlags(returnStatement, EmitFlags.NoTokenSourceMaps | EmitFlags.NoTrailingSourceMap | EmitFlags.NoTrailingComments);
                 statements.push(returnStatement);
 

--- a/src/harness/unittests/transform.ts
+++ b/src/harness/unittests/transform.ts
@@ -270,6 +270,35 @@ namespace ts {
             program.emit(program.getSourceFiles()[1], (p, s, bom) => host.writeFile(p, s, bom), /*cancellationToken*/ undefined, /*onlyDts*/ true, opts.transformers);
             return fs.readFileSync("/.src/index.d.ts").toString();
         }
+
+        // https://github.com/Microsoft/TypeScript/issues/24096
+        testBaseline("transformAddCommentToArrowReturnValue", () => {
+            return transpileModule(`const foo = () =>
+    void 0
+`, {
+                transformers: {
+                    before: [addSyntheticComment],
+                },
+                compilerOptions: {
+                    target: ScriptTarget.ES5,
+                    newLine: NewLineKind.CarriageReturnLineFeed,
+                }
+            }).outputText;
+
+            function addSyntheticComment(context: TransformationContext) {
+                return (sourceFile: SourceFile): SourceFile => {
+                    return visitNode(sourceFile, rootTransform, isSourceFile);
+                };
+                function rootTransform<T extends Node>(node: T): VisitResult<T> {
+                    if (isVoidExpression(node)) {
+                        setEmitFlags(node, EmitFlags.NoLeadingComments);
+                        setSyntheticLeadingComments(node, [{ kind: SyntaxKind.SingleLineCommentTrivia, text: "// comment!", pos: -1, end: -1, hasTrailingNewLine: true }]);
+                        return node;
+                    }
+                    return visitEachChild(node, rootTransform, context);
+                }
+            }
+        });
     });
 }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3860,6 +3860,7 @@ declare namespace ts {
     function getSyntheticTrailingComments(node: Node): SynthesizedComment[] | undefined;
     function setSyntheticTrailingComments<T extends Node>(node: T, comments: SynthesizedComment[]): T;
     function addSyntheticTrailingComment<T extends Node>(node: T, kind: SyntaxKind.SingleLineCommentTrivia | SyntaxKind.MultiLineCommentTrivia, text: string, hasTrailingNewLine?: boolean): T;
+    function moveSyntheticComments<T extends Node>(node: T, original: Node): T;
     /**
      * Gets the constant value to emit for an expression.
      */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3860,6 +3860,7 @@ declare namespace ts {
     function getSyntheticTrailingComments(node: Node): SynthesizedComment[] | undefined;
     function setSyntheticTrailingComments<T extends Node>(node: T, comments: SynthesizedComment[]): T;
     function addSyntheticTrailingComment<T extends Node>(node: T, kind: SyntaxKind.SingleLineCommentTrivia | SyntaxKind.MultiLineCommentTrivia, text: string, hasTrailingNewLine?: boolean): T;
+    function moveSyntheticComments<T extends Node>(node: T, original: Node): T;
     /**
      * Gets the constant value to emit for an expression.
      */

--- a/tests/baselines/reference/transformApi/transformsCorrectly.transformAddCommentToArrowReturnValue.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.transformAddCommentToArrowReturnValue.js
@@ -1,0 +1,4 @@
+var foo = function () {
+    //// comment!
+    return void 0;
+};


### PR DESCRIPTION
Fixes #24096
