### PR TITLE
Optimize intersections of unions of unit types

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3674,6 +3674,8 @@ namespace ts {
         ContainsAnyFunctionType = 1 << 26,  // Type is or contains the anyFunctionType
         NonPrimitive            = 1 << 27,  // intrinsic object type
         /* @internal */
+        UnionOfUnitTypes        = 1 << 28,  // Type is union of unit types
+        /* @internal */
         GenericMappedType       = 1 << 29,  // Flag used by maybeTypeOfKind
 
         /* @internal */
@@ -3710,6 +3712,8 @@ namespace ts {
         // This *should* be every type other than null, undefined, void, and never
         Narrowable = Any | StructuredOrInstantiable | StringLike | NumberLike | BooleanLike | ESSymbol | UniqueESSymbol | NonPrimitive,
         NotUnionOrUnit = Any | ESSymbol | Object | NonPrimitive,
+        /* @internal */
+        NotUnit = Any | String | Number | Boolean | Enum | ESSymbol | Void | Never | StructuredOrInstantiable,
         /* @internal */
         RequiresWidening = ContainsWideningType | ContainsObjectLiteral,
         /* @internal */

--- a/tests/baselines/reference/intersectionsOfLargeUnions.errors.txt
+++ b/tests/baselines/reference/intersectionsOfLargeUnions.errors.txt
@@ -1,0 +1,35 @@
+tests/cases/compiler/intersectionsOfLargeUnions.ts(21,15): error TS2536: Type 'T' cannot be used to index type 'HTMLElementTagNameMap'.
+tests/cases/compiler/intersectionsOfLargeUnions.ts(21,15): error TS2536: Type 'P' cannot be used to index type 'HTMLElementTagNameMap[T]'.
+
+
+==== tests/cases/compiler/intersectionsOfLargeUnions.ts (2 errors) ====
+    // Repro from #23977
+    
+    export function assertIsElement(node: Node | null): node is Element {
+        let nodeType = node === null ? null : node.nodeType;
+        return nodeType === 1;
+    }
+      
+    export function assertNodeTagName<
+        T extends keyof ElementTagNameMap,
+        U extends ElementTagNameMap[T]>(node: Node | null, tagName: T): node is U {
+        if (assertIsElement(node)) {
+            const nodeTagName = node.tagName.toLowerCase();
+             return nodeTagName === tagName;
+        }
+        return false;
+    }
+      
+    export function assertNodeProperty<
+        T extends keyof ElementTagNameMap,
+        P extends keyof ElementTagNameMap[T],
+        V extends HTMLElementTagNameMap[T][P]>(node: Node | null, tagName: T, prop: P, value: V) {
+                  ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2536: Type 'T' cannot be used to index type 'HTMLElementTagNameMap'.
+                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2536: Type 'P' cannot be used to index type 'HTMLElementTagNameMap[T]'.
+        if (assertNodeTagName(node, tagName)) {
+            node[prop];
+        }
+    }
+    

--- a/tests/baselines/reference/intersectionsOfLargeUnions.js
+++ b/tests/baselines/reference/intersectionsOfLargeUnions.js
@@ -1,0 +1,51 @@
+//// [intersectionsOfLargeUnions.ts]
+// Repro from #23977
+
+export function assertIsElement(node: Node | null): node is Element {
+    let nodeType = node === null ? null : node.nodeType;
+    return nodeType === 1;
+}
+  
+export function assertNodeTagName<
+    T extends keyof ElementTagNameMap,
+    U extends ElementTagNameMap[T]>(node: Node | null, tagName: T): node is U {
+    if (assertIsElement(node)) {
+        const nodeTagName = node.tagName.toLowerCase();
+         return nodeTagName === tagName;
+    }
+    return false;
+}
+  
+export function assertNodeProperty<
+    T extends keyof ElementTagNameMap,
+    P extends keyof ElementTagNameMap[T],
+    V extends HTMLElementTagNameMap[T][P]>(node: Node | null, tagName: T, prop: P, value: V) {
+    if (assertNodeTagName(node, tagName)) {
+        node[prop];
+    }
+}
+
+
+//// [intersectionsOfLargeUnions.js]
+"use strict";
+// Repro from #23977
+exports.__esModule = true;
+function assertIsElement(node) {
+    var nodeType = node === null ? null : node.nodeType;
+    return nodeType === 1;
+}
+exports.assertIsElement = assertIsElement;
+function assertNodeTagName(node, tagName) {
+    if (assertIsElement(node)) {
+        var nodeTagName = node.tagName.toLowerCase();
+        return nodeTagName === tagName;
+    }
+    return false;
+}
+exports.assertNodeTagName = assertNodeTagName;
+function assertNodeProperty(node, tagName, prop, value) {
+    if (assertNodeTagName(node, tagName)) {
+        node[prop];
+    }
+}
+exports.assertNodeProperty = assertNodeProperty;

--- a/tests/baselines/reference/intersectionsOfLargeUnions.symbols
+++ b/tests/baselines/reference/intersectionsOfLargeUnions.symbols
@@ -1,0 +1,95 @@
+=== tests/cases/compiler/intersectionsOfLargeUnions.ts ===
+// Repro from #23977
+
+export function assertIsElement(node: Node | null): node is Element {
+>assertIsElement : Symbol(assertIsElement, Decl(intersectionsOfLargeUnions.ts, 0, 0))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 2, 32))
+>Node : Symbol(Node, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 2, 32))
+>Element : Symbol(Element, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+    let nodeType = node === null ? null : node.nodeType;
+>nodeType : Symbol(nodeType, Decl(intersectionsOfLargeUnions.ts, 3, 7))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 2, 32))
+>node.nodeType : Symbol(Node.nodeType, Decl(lib.d.ts, --, --))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 2, 32))
+>nodeType : Symbol(Node.nodeType, Decl(lib.d.ts, --, --))
+
+    return nodeType === 1;
+>nodeType : Symbol(nodeType, Decl(intersectionsOfLargeUnions.ts, 3, 7))
+}
+  
+export function assertNodeTagName<
+>assertNodeTagName : Symbol(assertNodeTagName, Decl(intersectionsOfLargeUnions.ts, 5, 1))
+
+    T extends keyof ElementTagNameMap,
+>T : Symbol(T, Decl(intersectionsOfLargeUnions.ts, 7, 34))
+>ElementTagNameMap : Symbol(ElementTagNameMap, Decl(lib.d.ts, --, --))
+
+    U extends ElementTagNameMap[T]>(node: Node | null, tagName: T): node is U {
+>U : Symbol(U, Decl(intersectionsOfLargeUnions.ts, 8, 38))
+>ElementTagNameMap : Symbol(ElementTagNameMap, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(intersectionsOfLargeUnions.ts, 7, 34))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 9, 36))
+>Node : Symbol(Node, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(intersectionsOfLargeUnions.ts, 9, 54))
+>T : Symbol(T, Decl(intersectionsOfLargeUnions.ts, 7, 34))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 9, 36))
+>U : Symbol(U, Decl(intersectionsOfLargeUnions.ts, 8, 38))
+
+    if (assertIsElement(node)) {
+>assertIsElement : Symbol(assertIsElement, Decl(intersectionsOfLargeUnions.ts, 0, 0))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 9, 36))
+
+        const nodeTagName = node.tagName.toLowerCase();
+>nodeTagName : Symbol(nodeTagName, Decl(intersectionsOfLargeUnions.ts, 11, 13))
+>node.tagName.toLowerCase : Symbol(String.toLowerCase, Decl(lib.d.ts, --, --))
+>node.tagName : Symbol(Element.tagName, Decl(lib.d.ts, --, --))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 9, 36))
+>tagName : Symbol(Element.tagName, Decl(lib.d.ts, --, --))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.d.ts, --, --))
+
+         return nodeTagName === tagName;
+>nodeTagName : Symbol(nodeTagName, Decl(intersectionsOfLargeUnions.ts, 11, 13))
+>tagName : Symbol(tagName, Decl(intersectionsOfLargeUnions.ts, 9, 54))
+    }
+    return false;
+}
+  
+export function assertNodeProperty<
+>assertNodeProperty : Symbol(assertNodeProperty, Decl(intersectionsOfLargeUnions.ts, 15, 1))
+
+    T extends keyof ElementTagNameMap,
+>T : Symbol(T, Decl(intersectionsOfLargeUnions.ts, 17, 35))
+>ElementTagNameMap : Symbol(ElementTagNameMap, Decl(lib.d.ts, --, --))
+
+    P extends keyof ElementTagNameMap[T],
+>P : Symbol(P, Decl(intersectionsOfLargeUnions.ts, 18, 38))
+>ElementTagNameMap : Symbol(ElementTagNameMap, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(intersectionsOfLargeUnions.ts, 17, 35))
+
+    V extends HTMLElementTagNameMap[T][P]>(node: Node | null, tagName: T, prop: P, value: V) {
+>V : Symbol(V, Decl(intersectionsOfLargeUnions.ts, 19, 41))
+>HTMLElementTagNameMap : Symbol(HTMLElementTagNameMap, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(intersectionsOfLargeUnions.ts, 17, 35))
+>P : Symbol(P, Decl(intersectionsOfLargeUnions.ts, 18, 38))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 20, 43))
+>Node : Symbol(Node, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(intersectionsOfLargeUnions.ts, 20, 61))
+>T : Symbol(T, Decl(intersectionsOfLargeUnions.ts, 17, 35))
+>prop : Symbol(prop, Decl(intersectionsOfLargeUnions.ts, 20, 73))
+>P : Symbol(P, Decl(intersectionsOfLargeUnions.ts, 18, 38))
+>value : Symbol(value, Decl(intersectionsOfLargeUnions.ts, 20, 82))
+>V : Symbol(V, Decl(intersectionsOfLargeUnions.ts, 19, 41))
+
+    if (assertNodeTagName(node, tagName)) {
+>assertNodeTagName : Symbol(assertNodeTagName, Decl(intersectionsOfLargeUnions.ts, 5, 1))
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 20, 43))
+>tagName : Symbol(tagName, Decl(intersectionsOfLargeUnions.ts, 20, 61))
+
+        node[prop];
+>node : Symbol(node, Decl(intersectionsOfLargeUnions.ts, 20, 43))
+>prop : Symbol(prop, Decl(intersectionsOfLargeUnions.ts, 20, 73))
+    }
+}
+

--- a/tests/baselines/reference/intersectionsOfLargeUnions.types
+++ b/tests/baselines/reference/intersectionsOfLargeUnions.types
@@ -1,0 +1,110 @@
+=== tests/cases/compiler/intersectionsOfLargeUnions.ts ===
+// Repro from #23977
+
+export function assertIsElement(node: Node | null): node is Element {
+>assertIsElement : (node: Node | null) => node is Element
+>node : Node | null
+>Node : Node
+>null : null
+>node : any
+>Element : Element
+
+    let nodeType = node === null ? null : node.nodeType;
+>nodeType : number | null
+>node === null ? null : node.nodeType : number | null
+>node === null : boolean
+>node : Node | null
+>null : null
+>null : null
+>node.nodeType : number
+>node : Node
+>nodeType : number
+
+    return nodeType === 1;
+>nodeType === 1 : boolean
+>nodeType : number | null
+>1 : 1
+}
+  
+export function assertNodeTagName<
+>assertNodeTagName : <T extends "symbol" | "object" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "div" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "span" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp" | "circle" | "clippath" | "defs" | "desc" | "ellipse" | "feblend" | "fecolormatrix" | "fecomponenttransfer" | "fecomposite" | "feconvolvematrix" | "fediffuselighting" | "fedisplacementmap" | "fedistantlight" | "feflood" | "fefunca" | "fefuncb" | "fefuncg" | "fefuncr" | "fegaussianblur" | "feimage" | "femerge" | "femergenode" | "femorphology" | "feoffset" | "fepointlight" | "fespecularlighting" | "fespotlight" | "fetile" | "feturbulence" | "filter" | "foreignobject" | "g" | "image" | "line" | "lineargradient" | "marker" | "mask" | "metadata" | "path" | "pattern" | "polygon" | "polyline" | "radialgradient" | "rect" | "stop" | "svg" | "switch" | "text" | "textpath" | "tspan" | "use" | "view", U extends ElementTagNameMap[T]>(node: Node | null, tagName: T) => node is U
+
+    T extends keyof ElementTagNameMap,
+>T : T
+>ElementTagNameMap : ElementTagNameMap
+
+    U extends ElementTagNameMap[T]>(node: Node | null, tagName: T): node is U {
+>U : U
+>ElementTagNameMap : ElementTagNameMap
+>T : T
+>node : Node | null
+>Node : Node
+>null : null
+>tagName : T
+>T : T
+>node : any
+>U : U
+
+    if (assertIsElement(node)) {
+>assertIsElement(node) : boolean
+>assertIsElement : (node: Node | null) => node is Element
+>node : Node | null
+
+        const nodeTagName = node.tagName.toLowerCase();
+>nodeTagName : string
+>node.tagName.toLowerCase() : string
+>node.tagName.toLowerCase : () => string
+>node.tagName : string
+>node : Element
+>tagName : string
+>toLowerCase : () => string
+
+         return nodeTagName === tagName;
+>nodeTagName === tagName : boolean
+>nodeTagName : string
+>tagName : T
+    }
+    return false;
+>false : false
+}
+  
+export function assertNodeProperty<
+>assertNodeProperty : <T extends "symbol" | "object" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "div" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "span" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp" | "circle" | "clippath" | "defs" | "desc" | "ellipse" | "feblend" | "fecolormatrix" | "fecomponenttransfer" | "fecomposite" | "feconvolvematrix" | "fediffuselighting" | "fedisplacementmap" | "fedistantlight" | "feflood" | "fefunca" | "fefuncb" | "fefuncg" | "fefuncr" | "fegaussianblur" | "feimage" | "femerge" | "femergenode" | "femorphology" | "feoffset" | "fepointlight" | "fespecularlighting" | "fespotlight" | "fetile" | "feturbulence" | "filter" | "foreignobject" | "g" | "image" | "line" | "lineargradient" | "marker" | "mask" | "metadata" | "path" | "pattern" | "polygon" | "polyline" | "radialgradient" | "rect" | "stop" | "svg" | "switch" | "text" | "textpath" | "tspan" | "use" | "view", P extends keyof ElementTagNameMap[T], V extends HTMLElementTagNameMap[T][P]>(node: Node | null, tagName: T, prop: P, value: V) => void
+
+    T extends keyof ElementTagNameMap,
+>T : T
+>ElementTagNameMap : ElementTagNameMap
+
+    P extends keyof ElementTagNameMap[T],
+>P : P
+>ElementTagNameMap : ElementTagNameMap
+>T : T
+
+    V extends HTMLElementTagNameMap[T][P]>(node: Node | null, tagName: T, prop: P, value: V) {
+>V : V
+>HTMLElementTagNameMap : HTMLElementTagNameMap
+>T : T
+>P : P
+>node : Node | null
+>Node : Node
+>null : null
+>tagName : T
+>T : T
+>prop : P
+>P : P
+>value : V
+>V : V
+
+    if (assertNodeTagName(node, tagName)) {
+>assertNodeTagName(node, tagName) : boolean
+>assertNodeTagName : <T extends "symbol" | "object" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "div" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "span" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp" | "circle" | "clippath" | "defs" | "desc" | "ellipse" | "feblend" | "fecolormatrix" | "fecomponenttransfer" | "fecomposite" | "feconvolvematrix" | "fediffuselighting" | "fedisplacementmap" | "fedistantlight" | "feflood" | "fefunca" | "fefuncb" | "fefuncg" | "fefuncr" | "fegaussianblur" | "feimage" | "femerge" | "femergenode" | "femorphology" | "feoffset" | "fepointlight" | "fespecularlighting" | "fespotlight" | "fetile" | "feturbulence" | "filter" | "foreignobject" | "g" | "image" | "line" | "lineargradient" | "marker" | "mask" | "metadata" | "path" | "pattern" | "polygon" | "polyline" | "radialgradient" | "rect" | "stop" | "svg" | "switch" | "text" | "textpath" | "tspan" | "use" | "view", U extends ElementTagNameMap[T]>(node: Node | null, tagName: T) => node is U
+>node : Node | null
+>tagName : T
+
+        node[prop];
+>node[prop] : ElementTagNameMap[T][P]
+>node : ElementTagNameMap[T]
+>prop : P
+    }
+}
+

--- a/tests/cases/compiler/intersectionsOfLargeUnions.ts
+++ b/tests/cases/compiler/intersectionsOfLargeUnions.ts
@@ -1,0 +1,27 @@
+// @strict: true
+
+// Repro from #23977
+
+export function assertIsElement(node: Node | null): node is Element {
+    let nodeType = node === null ? null : node.nodeType;
+    return nodeType === 1;
+}
+  
+export function assertNodeTagName<
+    T extends keyof ElementTagNameMap,
+    U extends ElementTagNameMap[T]>(node: Node | null, tagName: T): node is U {
+    if (assertIsElement(node)) {
+        const nodeTagName = node.tagName.toLowerCase();
+         return nodeTagName === tagName;
+    }
+    return false;
+}
+  
+export function assertNodeProperty<
+    T extends keyof ElementTagNameMap,
+    P extends keyof ElementTagNameMap[T],
+    V extends HTMLElementTagNameMap[T][P]>(node: Node | null, tagName: T, prop: P, value: V) {
+    if (assertNodeTagName(node, tagName)) {
+        node[prop];
+    }
+}


### PR DESCRIPTION
This PR optimizes creation of intersection types containing unions of unit types. Such types occur for example when obtaining `keyof X` where `X` is large union of object types with many properties.

Fixes #23977.
