### PR TITLE
Fix unused diagnostic for rename-destructuring `{ a: b }`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22619,11 +22619,11 @@ namespace ts {
                 const kind = tryGetRootParameterDeclaration(bindingPattern.parent) ? UnusedKind.Parameter : UnusedKind.Local;
                 if (!bindingPattern.elements.every(e => contains(bindingElements, e))) {
                     for (const e of bindingElements) {
-                        addDiagnostic(kind, createDiagnosticForNode(e, Diagnostics._0_is_declared_but_its_value_is_never_read, getBindingElementNameText(e)));
+                        addDiagnostic(kind, createDiagnosticForNode(e, Diagnostics._0_is_declared_but_its_value_is_never_read, idText(cast(e.name, isIdentifier))));
                     }
                 }
                 else if (bindingElements.length === 1) {
-                    addDiagnostic(kind, createDiagnosticForNode(bindingPattern, Diagnostics._0_is_declared_but_its_value_is_never_read, getBindingElementNameText(first(bindingElements))));
+                    addDiagnostic(kind, createDiagnosticForNode(bindingPattern, Diagnostics._0_is_declared_but_its_value_is_never_read, idText(cast(first(bindingElements).name, isIdentifier))));
                 }
                 else {
                     addDiagnostic(kind, createDiagnosticForNode(bindingPattern, Diagnostics.All_destructured_elements_are_unused));

--- a/tests/baselines/reference/unusedDestructuring.errors.txt
+++ b/tests/baselines/reference/unusedDestructuring.errors.txt
@@ -1,13 +1,14 @@
 tests/cases/compiler/unusedDestructuring.ts(3,7): error TS6198: All destructured elements are unused.
 tests/cases/compiler/unusedDestructuring.ts(4,9): error TS6133: 'c' is declared but its value is never read.
 tests/cases/compiler/unusedDestructuring.ts(6,7): error TS6133: 'e' is declared but its value is never read.
-tests/cases/compiler/unusedDestructuring.ts(8,1): error TS6133: 'f' is declared but its value is never read.
-tests/cases/compiler/unusedDestructuring.ts(8,12): error TS6198: All destructured elements are unused.
-tests/cases/compiler/unusedDestructuring.ts(8,24): error TS6133: 'c' is declared but its value is never read.
-tests/cases/compiler/unusedDestructuring.ts(8,32): error TS6133: 'e' is declared but its value is never read.
+tests/cases/compiler/unusedDestructuring.ts(7,7): error TS6133: 'g' is declared but its value is never read.
+tests/cases/compiler/unusedDestructuring.ts(9,1): error TS6133: 'f' is declared but its value is never read.
+tests/cases/compiler/unusedDestructuring.ts(9,12): error TS6198: All destructured elements are unused.
+tests/cases/compiler/unusedDestructuring.ts(9,24): error TS6133: 'c' is declared but its value is never read.
+tests/cases/compiler/unusedDestructuring.ts(9,32): error TS6133: 'e' is declared but its value is never read.
 
 
-==== tests/cases/compiler/unusedDestructuring.ts (7 errors) ====
+==== tests/cases/compiler/unusedDestructuring.ts (8 errors) ====
     export {};
     declare const o: any;
     const { a, b } = o;
@@ -20,6 +21,9 @@ tests/cases/compiler/unusedDestructuring.ts(8,32): error TS6133: 'e' is declared
     const { e } = o;
           ~~~~~
 !!! error TS6133: 'e' is declared but its value is never read.
+    const { f: g } = o;
+          ~~~~~~~~
+!!! error TS6133: 'g' is declared but its value is never read.
     
     function f({ a, b }, { c, d }, { e }) {
     ~~~~~~~~~~

--- a/tests/baselines/reference/unusedDestructuring.js
+++ b/tests/baselines/reference/unusedDestructuring.js
@@ -5,6 +5,7 @@ const { a, b } = o;
 const { c, d }  = o;
 d;
 const { e } = o;
+const { f: g } = o;
 
 function f({ a, b }, { c, d }, { e }) {
     d;
@@ -18,6 +19,7 @@ var a = o.a, b = o.b;
 var c = o.c, d = o.d;
 d;
 var e = o.e;
+var g = o.f;
 function f(_a, _b, _c) {
     var a = _a.a, b = _a.b;
     var c = _b.c, d = _b.d;

--- a/tests/baselines/reference/unusedDestructuring.symbols
+++ b/tests/baselines/reference/unusedDestructuring.symbols
@@ -20,15 +20,19 @@ const { e } = o;
 >e : Symbol(e, Decl(unusedDestructuring.ts, 5, 7))
 >o : Symbol(o, Decl(unusedDestructuring.ts, 1, 13))
 
+const { f: g } = o;
+>g : Symbol(g, Decl(unusedDestructuring.ts, 6, 7))
+>o : Symbol(o, Decl(unusedDestructuring.ts, 1, 13))
+
 function f({ a, b }, { c, d }, { e }) {
->f : Symbol(f, Decl(unusedDestructuring.ts, 5, 16))
->a : Symbol(a, Decl(unusedDestructuring.ts, 7, 12))
->b : Symbol(b, Decl(unusedDestructuring.ts, 7, 15))
->c : Symbol(c, Decl(unusedDestructuring.ts, 7, 22))
->d : Symbol(d, Decl(unusedDestructuring.ts, 7, 25))
->e : Symbol(e, Decl(unusedDestructuring.ts, 7, 32))
+>f : Symbol(f, Decl(unusedDestructuring.ts, 6, 19))
+>a : Symbol(a, Decl(unusedDestructuring.ts, 8, 12))
+>b : Symbol(b, Decl(unusedDestructuring.ts, 8, 15))
+>c : Symbol(c, Decl(unusedDestructuring.ts, 8, 22))
+>d : Symbol(d, Decl(unusedDestructuring.ts, 8, 25))
+>e : Symbol(e, Decl(unusedDestructuring.ts, 8, 32))
 
     d;
->d : Symbol(d, Decl(unusedDestructuring.ts, 7, 25))
+>d : Symbol(d, Decl(unusedDestructuring.ts, 8, 25))
 }
 

--- a/tests/baselines/reference/unusedDestructuring.types
+++ b/tests/baselines/reference/unusedDestructuring.types
@@ -20,6 +20,11 @@ const { e } = o;
 >e : any
 >o : any
 
+const { f: g } = o;
+>f : any
+>g : any
+>o : any
+
 function f({ a, b }, { c, d }, { e }) {
 >f : ({ a, b }: { a: any; b: any; }, { c, d }: { c: any; d: any; }, { e }: { e: any; }) => void
 >a : any

--- a/tests/cases/compiler/unusedDestructuring.ts
+++ b/tests/cases/compiler/unusedDestructuring.ts
@@ -7,6 +7,7 @@ const { a, b } = o;
 const { c, d }  = o;
 d;
 const { e } = o;
+const { f: g } = o;
 
 function f({ a, b }, { c, d }, { e }) {
     d;


### PR DESCRIPTION
Fixes #24142

