### PR TITLE
add quick fix for import type missing typeof

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4257,5 +4257,9 @@
     "Remove all unreachable code": {
         "category": "Message",
         "code": 95051
+    },
+    "Add missing typeof": {
+        "category": "Message",
+        "code": 95052
     }
 }

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -116,6 +116,7 @@
         "../services/codefixes/moduleSpecifiers.ts",
         "../services/codefixes/requireInTs.ts",
         "../services/codefixes/useDefaultImport.ts",
+        "../services/codefixes/fixAddModuleReferTypeMissingTypeof.ts",
         "../services/refactors/extractSymbol.ts",
         "../services/refactors/generateGetAccessorAndSetAccessor.ts",
         "../services/refactors/moveToNewFile.ts",

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -112,6 +112,7 @@
         "../services/codefixes/moduleSpecifiers.ts",
         "../services/codefixes/requireInTs.ts",
         "../services/codefixes/useDefaultImport.ts",
+        "../services/codefixes/fixAddModuleReferTypeMissingTypeof.ts",
         "../services/refactors/extractSymbol.ts",
         "../services/refactors/generateGetAccessorAndSetAccessor.ts",
         "../services/refactors/moveToNewFile.ts",

--- a/src/server/tsconfig.library.json
+++ b/src/server/tsconfig.library.json
@@ -118,6 +118,7 @@
         "../services/codefixes/moduleSpecifiers.ts",
         "../services/codefixes/requireInTs.ts",
         "../services/codefixes/useDefaultImport.ts",
+        "../services/codefixes/fixAddModuleReferTypeMissingTypeof.ts",
         "../services/refactors/extractSymbol.ts",
         "../services/refactors/generateGetAccessorAndSetAccessor.ts",
         "../services/refactors/moveToNewFile.ts",

--- a/src/services/codefixes/fixAddModuleReferTypeMissingTypeof.ts
+++ b/src/services/codefixes/fixAddModuleReferTypeMissingTypeof.ts
@@ -1,0 +1,32 @@
+/* @internal */
+namespace ts.codefix {
+    const fixIdAddMissingTypeof = "fixAddModuleReferTypeMissingTypeof";
+    const fixId = fixIdAddMissingTypeof;
+    const errorCodes = [Diagnostics.Module_0_does_not_refer_to_a_type_but_is_used_as_a_type_here.code];
+    registerCodeFix({
+        errorCodes,
+        getCodeActions: context => {
+            const { sourceFile, span } = context;
+            const typeContainer = getImportTypeNode(sourceFile, span.start);
+            if (!typeContainer) return undefined;
+
+            const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, typeContainer));
+            return [createCodeFixAction(fixId, changes, Diagnostics.Add_missing_typeof, fixId, Diagnostics.Add_missing_typeof)];
+        },
+        fixIds: [fixId],
+        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) =>
+            doChange(changes, context.sourceFile, getImportTypeNode(diag.file, diag.start!))),
+    });
+
+    function getImportTypeNode(sourceFile: SourceFile, pos: number): ImportTypeNode | undefined {
+        const token = getTokenAtPosition(sourceFile, pos, /*includeJsDocComment*/ false);
+        Debug.assert(token.kind === SyntaxKind.ImportKeyword);
+        Debug.assert(token.parent.kind === SyntaxKind.ImportType);
+        return <ImportTypeNode>token.parent;
+    }
+
+    function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, typeContainer: ImportTypeNode) {
+        const newTypeNode = updateImportTypeNode(typeContainer, typeContainer.argument, typeContainer.qualifier, typeContainer.typeArguments, /* isTypeOf */ true);
+        changes.replaceNode(sourceFile, typeContainer, newTypeNode);
+    }
+}

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -109,6 +109,7 @@
         "codefixes/moduleSpecifiers.ts",
         "codefixes/requireInTs.ts",
         "codefixes/useDefaultImport.ts",
+        "codefixes/fixAddModuleReferTypeMissingTypeof.ts",
         "refactors/extractSymbol.ts",
         "refactors/generateGetAccessorAndSetAccessor.ts",
         "refactors/moveToNewFile.ts",

--- a/tests/cases/fourslash/codeFixAddMissingTypeof1.ts
+++ b/tests/cases/fourslash/codeFixAddMissingTypeof1.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+//// declare module "foo" {
+////     const a = "foo"
+////     export = a
+//// }
+//// const x: import("foo") = import("foo");
+
+verify.codeFix({
+    description: "Add missing typeof",
+    newFileContent: `declare module "foo" {
+    const a = "foo"
+    export = a
+}
+const x: typeof import("foo") = import("foo");`
+});

--- a/tests/cases/fourslash/codeFixAddMissingTypeof2.ts
+++ b/tests/cases/fourslash/codeFixAddMissingTypeof2.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: a.ts
+//// export = 1;
+
+// @Filename: b.ts
+//// const a: import("./a") = import("./a")
+
+goTo.file("b.ts")
+verify.codeFix({
+    description: "Add missing typeof",
+    newFileContent: `const a: typeof import("./a") = import("./a")`
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #24172 

