### PR TITLE
Fix jsdoc type resolution [merge to master]

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2153,19 +2153,14 @@ namespace ts {
          */
         function resolveEntityNameFromJSSpecialAssignment(name: Identifier, meaning: SymbolFlags) {
             if (isJSDocTypeReference(name.parent)) {
-                const secondaryLocation = getJSSpecialAssignmentSymbol(name.parent);
+                const secondaryLocation = getJSSpecialAssignmentLocation(name.parent);
                 if (secondaryLocation) {
                     return resolveName(secondaryLocation, name.escapedText, meaning, /*nameNotFoundMessage*/ undefined, name, /*isUse*/ true);
                 }
             }
         }
 
-        function getJSSpecialAssignmentSymbol(node: TypeReferenceNode): Declaration | undefined {
-            const sig = getHostSignatureFromJSDoc(node);
-            if (sig) {
-                const symbol = getSymbolOfNode(sig);
-                return symbol && symbol.valueDeclaration;
-            }
+        function getJSSpecialAssignmentLocation(node: TypeReferenceNode): Declaration | undefined {
             const host = getJSDocHost(node);
             if (host &&
                 isExpressionStatement(host) &&
@@ -2173,6 +2168,11 @@ namespace ts {
                 getSpecialPropertyAssignmentKind(host.expression) === SpecialPropertyAssignmentKind.PrototypeProperty) {
                 const symbol = getSymbolOfNode(host.expression.left);
                 return symbol && symbol.parent.valueDeclaration;
+            }
+            const sig = getHostSignatureFromJSDoc(node);
+            if (sig) {
+                const symbol = getSymbolOfNode(sig);
+                return symbol && symbol.valueDeclaration;
             }
         }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1866,7 +1866,7 @@ namespace ts {
             //   */
             // var x = function(name) { return name.length; }
             if (parent.parent &&
-                (getSingleVariableOfVariableStatement(parent.parent) === node)) {
+                (getSingleVariableOfVariableStatement(parent.parent) === node || getSourceOfAssignment(parent.parent))) {
                 getJSDocCommentsAndTagsWorker(parent.parent);
             }
             if (parent.parent && parent.parent.parent &&
@@ -1875,8 +1875,8 @@ namespace ts {
                     getSourceOfDefaultedAssignment(parent.parent.parent))) {
                 getJSDocCommentsAndTagsWorker(parent.parent.parent);
             }
-            if (isBinaryExpression(node) && node.operatorToken.kind === SyntaxKind.EqualsToken ||
-                isBinaryExpression(parent) && parent.operatorToken.kind === SyntaxKind.EqualsToken ||
+            if (isBinaryExpression(node) && getSpecialPropertyAssignmentKind(node) !== SpecialPropertyAssignmentKind.None ||
+                isBinaryExpression(parent) && getSpecialPropertyAssignmentKind(parent) !== SpecialPropertyAssignmentKind.None ||
                 node.kind === SyntaxKind.PropertyAccessExpression && node.parent && node.parent.kind === SyntaxKind.ExpressionStatement) {
                 getJSDocCommentsAndTagsWorker(parent);
             }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1913,7 +1913,7 @@ namespace ts {
         return parameter && parameter.symbol;
     }
 
-    export function getHostSignatureFromJSDoc(node: JSDocTag): SignatureDeclaration | undefined {
+    export function getHostSignatureFromJSDoc(node: Node): SignatureDeclaration | undefined {
         const host = getJSDocHost(node);
         const decl = getSourceOfDefaultedAssignment(host) ||
             getSourceOfAssignment(host) ||

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1914,7 +1914,10 @@ namespace ts {
     }
 
     export function getHostSignatureFromJSDoc(node: Node): SignatureDeclaration | undefined {
-        const host = getJSDocHost(node);
+        return getHostSignatureFromJSDocHost(getJSDocHost(node));
+    }
+
+    export function getHostSignatureFromJSDocHost(host: HasJSDoc): SignatureDeclaration | undefined {
         const decl = getSourceOfDefaultedAssignment(host) ||
             getSourceOfAssignment(host) ||
             getSingleInitializerOfVariableStatementOrPropertyDeclaration(host) ||

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1865,8 +1865,7 @@ namespace ts {
             //   * @returns {number}
             //   */
             // var x = function(name) { return name.length; }
-            if (parent.parent &&
-                (getSingleVariableOfVariableStatement(parent.parent) === node || getSourceOfAssignment(parent.parent))) {
+            if (parent.parent && (getSingleVariableOfVariableStatement(parent.parent) === node)) {
                 getJSDocCommentsAndTagsWorker(parent.parent);
             }
             if (parent.parent && parent.parent.parent &&
@@ -1875,8 +1874,8 @@ namespace ts {
                     getSourceOfDefaultedAssignment(parent.parent.parent))) {
                 getJSDocCommentsAndTagsWorker(parent.parent.parent);
             }
-            if (isBinaryExpression(node) && getSpecialPropertyAssignmentKind(node) !== SpecialPropertyAssignmentKind.None ||
-                isBinaryExpression(parent) && getSpecialPropertyAssignmentKind(parent) !== SpecialPropertyAssignmentKind.None ||
+            if (isBinaryExpression(node) && node.operatorToken.kind === SyntaxKind.EqualsToken ||
+                isBinaryExpression(parent) && parent.operatorToken.kind === SyntaxKind.EqualsToken ||
                 node.kind === SyntaxKind.PropertyAccessExpression && node.parent && node.parent.kind === SyntaxKind.ExpressionStatement) {
                 getJSDocCommentsAndTagsWorker(parent);
             }

--- a/tests/baselines/reference/paramTagTypeResolution.symbols
+++ b/tests/baselines/reference/paramTagTypeResolution.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/jsdoc/main.js ===
+var f = require('./first');
+>f : Symbol(f, Decl(main.js, 0, 3))
+>require : Symbol(require)
+>'./first' : Symbol("tests/cases/conformance/jsdoc/first", Decl(first.js, 0, 0))
+
+f(1, n => { })
+>f : Symbol(f, Decl(main.js, 0, 3))
+>n : Symbol(n, Decl(main.js, 1, 4))
+
+=== tests/cases/conformance/jsdoc/first.js ===
+/** @template T
+ * @param {T} x
+ * @param {(t: T) => void} k
+ */
+module.exports = function (x, k) { return k(x) }
+>module : Symbol(export=, Decl(first.js, 0, 0))
+>exports : Symbol(export=, Decl(first.js, 0, 0))
+>x : Symbol(x, Decl(first.js, 4, 27))
+>k : Symbol(k, Decl(first.js, 4, 29))
+>k : Symbol(k, Decl(first.js, 4, 29))
+>x : Symbol(x, Decl(first.js, 4, 27))
+

--- a/tests/baselines/reference/paramTagTypeResolution.types
+++ b/tests/baselines/reference/paramTagTypeResolution.types
@@ -1,0 +1,31 @@
+=== tests/cases/conformance/jsdoc/main.js ===
+var f = require('./first');
+>f : <T>(x: T, k: (t: T) => void) => void
+>require('./first') : <T>(x: T, k: (t: T) => void) => void
+>require : any
+>'./first' : "./first"
+
+f(1, n => { })
+>f(1, n => { }) : void
+>f : <T>(x: T, k: (t: T) => void) => void
+>1 : 1
+>n => { } : (n: number) => void
+>n : number
+
+=== tests/cases/conformance/jsdoc/first.js ===
+/** @template T
+ * @param {T} x
+ * @param {(t: T) => void} k
+ */
+module.exports = function (x, k) { return k(x) }
+>module.exports = function (x, k) { return k(x) } : <T>(x: T, k: (t: T) => void) => void
+>module.exports : any
+>module : any
+>exports : any
+>function (x, k) { return k(x) } : <T>(x: T, k: (t: T) => void) => void
+>x : T
+>k : (t: T) => void
+>k(x) : void
+>k : (t: T) => void
+>x : T
+

--- a/tests/baselines/reference/typedefTagTypeResolution.errors.txt
+++ b/tests/baselines/reference/typedefTagTypeResolution.errors.txt
@@ -1,0 +1,37 @@
+tests/cases/conformance/jsdoc/github20832.js(2,15): error TS2304: Cannot find name 'U'.
+tests/cases/conformance/jsdoc/github20832.js(17,12): error TS2304: Cannot find name 'V'.
+
+
+==== tests/cases/conformance/jsdoc/github20832.js (2 errors) ====
+    // #20832
+    /** @typedef {U} T - should be "error, can't find type named 'U' */
+                  ~
+!!! error TS2304: Cannot find name 'U'.
+    /**
+     * @template U
+     * @param {U} x
+     * @return {T}
+     */
+    function f(x) {
+        return x;
+    }
+    
+    /** @type T - should be fine, since T will be any */
+    const x = 3;
+    
+    /**
+     * @callback Cb
+     * @param {V} firstParam
+               ~
+!!! error TS2304: Cannot find name 'V'.
+     */
+    /**
+     * @template V
+     * @param {V} vvvvv
+     */
+    function g(vvvvv) {
+    }
+    
+    /** @type {Cb} */
+    const cb = x => {}
+    

--- a/tests/baselines/reference/typedefTagTypeResolution.symbols
+++ b/tests/baselines/reference/typedefTagTypeResolution.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/conformance/jsdoc/github20832.js ===
+// #20832
+/** @typedef {U} T - should be "error, can't find type named 'U' */
+/**
+ * @template U
+ * @param {U} x
+ * @return {T}
+ */
+function f(x) {
+>f : Symbol(f, Decl(github20832.js, 0, 0))
+>x : Symbol(x, Decl(github20832.js, 7, 11))
+
+    return x;
+>x : Symbol(x, Decl(github20832.js, 7, 11))
+}
+
+/** @type T - should be fine, since T will be any */
+const x = 3;
+>x : Symbol(x, Decl(github20832.js, 12, 5))
+
+/**
+ * @callback Cb
+ * @param {V} firstParam
+ */
+/**
+ * @template V
+ * @param {V} vvvvv
+ */
+function g(vvvvv) {
+>g : Symbol(g, Decl(github20832.js, 12, 12))
+>vvvvv : Symbol(vvvvv, Decl(github20832.js, 22, 11))
+}
+
+/** @type {Cb} */
+const cb = x => {}
+>cb : Symbol(cb, Decl(github20832.js, 26, 5))
+>x : Symbol(x, Decl(github20832.js, 26, 10))
+

--- a/tests/baselines/reference/typedefTagTypeResolution.types
+++ b/tests/baselines/reference/typedefTagTypeResolution.types
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/jsdoc/github20832.js ===
+// #20832
+/** @typedef {U} T - should be "error, can't find type named 'U' */
+/**
+ * @template U
+ * @param {U} x
+ * @return {T}
+ */
+function f(x) {
+>f : <U>(x: U) => any
+>x : U
+
+    return x;
+>x : U
+}
+
+/** @type T - should be fine, since T will be any */
+const x = 3;
+>x : any
+>3 : 3
+
+/**
+ * @callback Cb
+ * @param {V} firstParam
+ */
+/**
+ * @template V
+ * @param {V} vvvvv
+ */
+function g(vvvvv) {
+>g : <V>(vvvvv: V) => void
+>vvvvv : V
+}
+
+/** @type {Cb} */
+const cb = x => {}
+>cb : (firstParam: any) => any
+>x => {} : (x: any) => void
+>x : any
+

--- a/tests/baselines/reference/typedefTagTypeResolution.types
+++ b/tests/baselines/reference/typedefTagTypeResolution.types
@@ -34,7 +34,7 @@ function g(vvvvv) {
 
 /** @type {Cb} */
 const cb = x => {}
->cb : (firstParam: any) => any
+>cb : Cb
 >x => {} : (x: any) => void
 >x : any
 

--- a/tests/cases/conformance/jsdoc/paramTagTypeResolution.ts
+++ b/tests/cases/conformance/jsdoc/paramTagTypeResolution.ts
@@ -1,0 +1,13 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: first.js
+/** @template T
+ * @param {T} x
+ * @param {(t: T) => void} k
+ */
+module.exports = function (x, k) { return k(x) }
+
+// @Filename: main.js
+var f = require('./first');
+f(1, n => { })

--- a/tests/cases/conformance/jsdoc/typedefTagTypeResolution.ts
+++ b/tests/cases/conformance/jsdoc/typedefTagTypeResolution.ts
@@ -1,0 +1,32 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: github20832.js
+
+// #20832
+/** @typedef {U} T - should be "error, can't find type named 'U' */
+/**
+ * @template U
+ * @param {U} x
+ * @return {T}
+ */
+function f(x) {
+    return x;
+}
+
+/** @type T - should be fine, since T will be any */
+const x = 3;
+
+/**
+ * @callback Cb
+ * @param {V} firstParam
+ */
+/**
+ * @template V
+ * @param {V} vvvvv
+ */
+function g(vvvvv) {
+}
+
+/** @type {Cb} */
+const cb = x => {}


### PR DESCRIPTION
This PR is just like #24106, except that it merges to master instead of jsdoc/callback. I'll merge it once CI passes.

1. Type resolution did not check for all special assignment kinds. Now it does.
2. Type parameter resolution in `@param` tags previously used the default walk up the syntax tree, which is incorrect. Type parameters are bound by the containing function, so the walk should start from the parameter itself, not the `@param` tag.

### Notes ###

1. This branch is based on jsdoc/callback because it relies on the already-improved jsdoc type resolution there.
2. Note that in `getJSSpecialAssignment`, the predicate for prototype methods is a subset of the predicate in `getHostSignatureFromJSDoc`, so the prototype method check needs to come first in order to correctly look up types on the source constructor function. 

An example of prototype method type resolution is something like this:

```js
/** @template T */
function Z() {
}
/** @param {T} t */
function Z.prototype.M = function(t) { }
```

Fixes #22621

Edit: Now also fixes #20832