### PR TITLE
More robust circularity detection in node builder

### DIFF
--- a/tests/baselines/reference/classExpressionInClassStaticDeclarations.js
+++ b/tests/baselines/reference/classExpressionInClassStaticDeclarations.js
@@ -1,0 +1,37 @@
+//// [classExpressionInClassStaticDeclarations.ts]
+class C {
+    static D = class extends C {};
+}
+
+//// [classExpressionInClassStaticDeclarations.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var C = /** @class */ (function () {
+    function C() {
+    }
+    C.D = /** @class */ (function (_super) {
+        __extends(class_1, _super);
+        function class_1() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        return class_1;
+    }(C));
+    return C;
+}());
+
+
+//// [classExpressionInClassStaticDeclarations.d.ts]
+declare class C {
+    static D: {
+        new (): {};
+        D: any;
+    };
+}

--- a/tests/baselines/reference/classExpressionInClassStaticDeclarations.symbols
+++ b/tests/baselines/reference/classExpressionInClassStaticDeclarations.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/classExpressionInClassStaticDeclarations.ts ===
+class C {
+>C : Symbol(C, Decl(classExpressionInClassStaticDeclarations.ts, 0, 0))
+
+    static D = class extends C {};
+>D : Symbol(C.D, Decl(classExpressionInClassStaticDeclarations.ts, 0, 9))
+>C : Symbol(C, Decl(classExpressionInClassStaticDeclarations.ts, 0, 0))
+}

--- a/tests/baselines/reference/classExpressionInClassStaticDeclarations.types
+++ b/tests/baselines/reference/classExpressionInClassStaticDeclarations.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/classExpressionInClassStaticDeclarations.ts ===
+class C {
+>C : C
+
+    static D = class extends C {};
+>D : typeof (Anonymous class)
+>class extends C {} : typeof (Anonymous class)
+>C : C
+}

--- a/tests/cases/compiler/classExpressionInClassStaticDeclarations.ts
+++ b/tests/cases/compiler/classExpressionInClassStaticDeclarations.ts
@@ -1,0 +1,4 @@
+// @declaration: true
+class C {
+    static D = class extends C {};
+}


### PR DESCRIPTION
Namely also checking for circularity involving just the constructor side, rather than only detecting circular instances.

Fixes #24194

