### PR TITLE
Sort exports when organizeImports is run

### DIFF
--- a/src/harness/unittests/organizeImports.ts
+++ b/src/harness/unittests/organizeImports.ts
@@ -181,6 +181,85 @@ namespace ts {
             });
         });
 
+        describe("Coalesce exports", () => {
+            it("No exports", () => {
+                assert.isEmpty(OrganizeImports.coalesceExports([]));
+            });
+
+            it("Sort specifiers", () => {
+                const sortedExports = parseExports(`export { default as m, a as n, b, y, z as o } from "lib";`);
+                const actualCoalescedExports = OrganizeImports.coalesceExports(sortedExports);
+                const expectedCoalescedExports = parseExports(`export { a as n, b, default as m, y, z as o } from "lib";`);
+                assertListEqual(actualCoalescedExports, expectedCoalescedExports);
+            });
+
+            it("Sort specifiers - case-insensitive", () => {
+                const sortedExports = parseExports(`export { default as M, a as n, B, y, Z as O } from "lib";`);
+                const actualCoalescedExports = OrganizeImports.coalesceExports(sortedExports);
+                const expectedCoalescedExports = parseExports(`export { a as n, B, default as M, y, Z as O } from "lib";`);
+                assertListEqual(actualCoalescedExports, expectedCoalescedExports);
+            });
+
+            it("Combine namespace re-exports", () => {
+                const sortedExports = parseExports(
+                    `export * from "lib";`,
+                    `export * from "lib";`);
+                const actualCoalescedExports = OrganizeImports.coalesceExports(sortedExports);
+                const expectedCoalescedExports = parseExports(`export * from "lib";`);
+                assertListEqual(actualCoalescedExports, expectedCoalescedExports);
+            });
+
+            it("Combine property exports", () => {
+                const sortedExports = parseExports(
+                    `export { x };`,
+                    `export { y as z };`);
+                const actualCoalescedExports = OrganizeImports.coalesceExports(sortedExports);
+                const expectedCoalescedExports = parseExports(`export { x, y as z };`);
+                assertListEqual(actualCoalescedExports, expectedCoalescedExports);
+            });
+
+            it("Combine property re-exports", () => {
+                const sortedExports = parseExports(
+                    `export { x } from "lib";`,
+                    `export { y as z } from "lib";`);
+                const actualCoalescedExports = OrganizeImports.coalesceExports(sortedExports);
+                const expectedCoalescedExports = parseExports(`export { x, y as z } from "lib";`);
+                assertListEqual(actualCoalescedExports, expectedCoalescedExports);
+            });
+
+            it("Combine namespace re-export with property re-export", () => {
+                const sortedExports = parseExports(
+                    `export * from "lib";`,
+                    `export { y } from "lib";`);
+                const actualCoalescedExports = OrganizeImports.coalesceExports(sortedExports);
+                const expectedCoalescedExports = sortedExports;
+                assertListEqual(actualCoalescedExports, expectedCoalescedExports);
+            });
+
+            it("Combine many exports", () => {
+                const sortedExports = parseExports(
+                    `export { x };`,
+                    `export { y as w, z as default };`,
+                    `export { w as q };`);
+                const actualCoalescedExports = OrganizeImports.coalesceExports(sortedExports);
+                const expectedCoalescedExports = parseExports(
+                    `export { w as q, x, y as w, z as default };`);
+                assertListEqual(actualCoalescedExports, expectedCoalescedExports);
+            });
+
+            it("Combine many re-exports", () => {
+                const sortedExports = parseExports(
+                    `export { x as a, y } from "lib";`,
+                    `export * from "lib";`,
+                    `export { z as b } from "lib";`);
+                const actualCoalescedExports = OrganizeImports.coalesceExports(sortedExports);
+                const expectedCoalescedExports = parseExports(
+                    `export * from "lib";`,
+                    `export { x as a, y, z as b } from "lib";`);
+                assertListEqual(actualCoalescedExports, expectedCoalescedExports);
+            });
+        });
+
         describe("Baselines", () => {
 
             const libFile = {
@@ -471,6 +550,154 @@ import { React, Other } from "react";
                 },
                 reactLibFile);
 
+            describe("Exports", () => {
+
+                testOrganizeExports("MoveToTop",
+                    {
+                        path: "/test.ts",
+                        content: `
+export { F1, F2 } from "lib";
+1;
+export * from "lib";
+2;
+`,
+                    },
+                    libFile);
+
+                // tslint:disable no-invalid-template-strings
+                testOrganizeExports("MoveToTop_Invalid",
+                    {
+                        path: "/test.ts",
+                        content: `
+export { F1, F2 } from "lib";
+1;
+export * from "lib";
+2;
+export { b } from ${"`${'lib'}`"};
+export { a } from ${"`${'lib'}`"};
+export { D } from "lib";
+3;
+`,
+                    },
+                    libFile);
+                // tslint:enable no-invalid-template-strings
+
+                testOrganizeExports("MoveToTop_WithImportsFirst",
+                    {
+                        path: "/test.ts",
+                        content: `
+import { F1, F2 } from "lib";
+1;
+export { F1, F2 } from "lib";
+2;
+import * as NS from "lib";
+3;
+export * from "lib";
+4;
+F1(); F2(); NS.F1();
+`,
+                    },
+                    libFile);
+
+                testOrganizeExports("MoveToTop_WithExportsFirst",
+                    {
+                        path: "/test.ts",
+                        content: `
+export { F1, F2 } from "lib";
+1;
+import { F1, F2 } from "lib";
+2;
+export * from "lib";
+3;
+import * as NS from "lib";
+4;
+F1(); F2(); NS.F1();
+`,
+                    },
+                    libFile);
+
+                testOrganizeExports("CoalesceMultipleModules",
+                    {
+                        path: "/test.ts",
+                        content: `
+export { d } from "lib1";
+export { b } from "lib1";
+export { c } from "lib2";
+export { a } from "lib2";
+`,
+                    },
+                    { path: "/lib1.ts", content: "export const b = 1, d = 2;" },
+                    { path: "/lib2.ts", content: "export const a = 3, c = 4;" });
+
+                testOrganizeExports("CoalesceTrivia",
+                    {
+                        path: "/test.ts",
+                        content: `
+/*A*/export /*B*/ { /*C*/ F2 /*D*/ } /*E*/ from /*F*/ "lib" /*G*/;/*H*/ //I
+/*J*/export /*K*/ { /*L*/ F1 /*M*/ } /*N*/ from /*O*/ "lib" /*P*/;/*Q*/ //R
+`,
+                    },
+                    libFile);
+
+                testOrganizeExports("SortTrivia",
+                    {
+                        path: "/test.ts",
+                        content: `
+/*A*/export /*B*/ * /*C*/ from /*D*/ "lib2" /*E*/;/*F*/ //G
+/*H*/export /*I*/ * /*J*/ from /*K*/ "lib1" /*L*/;/*M*/ //N
+`,
+                    },
+                    { path: "/lib1.ts", content: "" },
+                    { path: "/lib2.ts", content: "" });
+
+                testOrganizeExports("SortHeaderComment",
+                    {
+                        path: "/test.ts",
+                        content: `
+// Header
+export * from "lib2";
+export * from "lib1";
+`,
+                    },
+                    { path: "/lib1.ts", content: "" },
+                    { path: "/lib2.ts", content: "" });
+
+                testOrganizeExports("AmbientModule",
+                    {
+                        path: "/test.ts",
+                        content: `
+declare module "mod" {
+    export { F1 } from "lib";
+    export * from "lib";
+    export { F2 } from "lib";
+}
+    `,
+                    },
+                    libFile);
+
+                testOrganizeExports("TopLevelAndAmbientModule",
+                    {
+                        path: "/test.ts",
+                        content: `
+export { D } from "lib";
+
+declare module "mod" {
+    export { F1 } from "lib";
+    export * from "lib";
+    export { F2 } from "lib";
+}
+
+export { E } from "lib";
+export * from "lib";
+`,
+                    },
+                    libFile);
+            });
+
+            function testOrganizeExports(testName: string, testFile: TestFSWithWatch.File, ...otherFiles: TestFSWithWatch.File[]) {
+                testOrganizeImports(`${testName}.exports`, testFile, ...otherFiles);
+            }
+
             function testOrganizeImports(testName: string, testFile: TestFSWithWatch.File, ...otherFiles: TestFSWithWatch.File[]) {
                 it(testName, () => runBaseline(`organizeImports/${testName}.ts`, testFile, ...otherFiles));
             }
@@ -507,6 +734,13 @@ import { React, Other } from "react";
             const imports = filter(sourceFile.statements, isImportDeclaration);
             assert.equal(imports.length, importStrings.length);
             return imports;
+        }
+
+        function parseExports(...exportStrings: string[]): ReadonlyArray<ExportDeclaration> {
+            const sourceFile = createSourceFile("a.ts", exportStrings.join("\n"), ScriptTarget.ES2015, /*setParentNodes*/ true, ScriptKind.TS);
+            const exports = filter(sourceFile.statements, isExportDeclaration);
+            assert.equal(exports.length, exportStrings.length);
+            return exports;
         }
 
         function assertEqual(node1?: Node, node2?: Node) {
@@ -549,6 +783,23 @@ import { React, Other } from "react";
                     const is2 = node2 as ImportSpecifier;
                     assertEqual(is1.name, is2.name);
                     assertEqual(is1.propertyName, is2.propertyName);
+                    break;
+                case SyntaxKind.ExportDeclaration:
+                    const ed1 = node1 as ExportDeclaration;
+                    const ed2 = node2 as ExportDeclaration;
+                    assertEqual(ed1.exportClause, ed2.exportClause);
+                    assertEqual(ed1.moduleSpecifier, ed2.moduleSpecifier);
+                    break;
+                case SyntaxKind.NamedExports:
+                    const ne1 = node1 as NamedExports;
+                    const ne2 = node2 as NamedExports;
+                    assertListEqual(ne1.elements, ne2.elements);
+                    break;
+                case SyntaxKind.ExportSpecifier:
+                    const es1 = node1 as ExportSpecifier;
+                    const es2 = node2 as ExportSpecifier;
+                    assertEqual(es1.name, es2.name);
+                    assertEqual(es1.propertyName, es2.propertyName);
                     break;
                 case SyntaxKind.Identifier:
                     const id1 = node1 as Identifier;

--- a/src/harness/unittests/organizeImports.ts
+++ b/src/harness/unittests/organizeImports.ts
@@ -44,13 +44,6 @@ namespace ts {
                 assert.isEmpty(OrganizeImports.coalesceImports([]));
             });
 
-            it("Sort specifiers", () => {
-                const sortedImports = parseImports(`import { default as m, a as n, b, y, z as o } from "lib";`);
-                const actualCoalescedImports = OrganizeImports.coalesceImports(sortedImports);
-                const expectedCoalescedImports = parseImports(`import { a as n, b, default as m, y, z as o } from "lib";`);
-                assertListEqual(actualCoalescedImports, expectedCoalescedImports);
-            });
-
             it("Sort specifiers - case-insensitive", () => {
                 const sortedImports = parseImports(`import { default as M, a as n, B, y, Z as O } from "lib";`);
                 const actualCoalescedImports = OrganizeImports.coalesceImports(sortedImports);
@@ -184,13 +177,6 @@ namespace ts {
         describe("Coalesce exports", () => {
             it("No exports", () => {
                 assert.isEmpty(OrganizeImports.coalesceExports([]));
-            });
-
-            it("Sort specifiers", () => {
-                const sortedExports = parseExports(`export { default as m, a as n, b, y, z as o } from "lib";`);
-                const actualCoalescedExports = OrganizeImports.coalesceExports(sortedExports);
-                const expectedCoalescedExports = parseExports(`export { a as n, b, default as m, y, z as o } from "lib";`);
-                assertListEqual(actualCoalescedExports, expectedCoalescedExports);
             });
 
             it("Sort specifiers - case-insensitive", () => {

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -204,9 +204,7 @@ namespace ts.OrganizeImports {
 
         newImportSpecifiers.push(...flatMap(namedImports, i => (i.importClause.namedBindings as NamedImports).elements));
 
-        const sortedImportSpecifiers = stableSort(newImportSpecifiers, (s1, s2) =>
-            compareIdentifiers(s1.propertyName || s1.name, s2.propertyName || s2.name) ||
-            compareIdentifiers(s1.name, s2.name));
+        const sortedImportSpecifiers = sortSpecifiers(newImportSpecifiers);
 
         const importDecl = defaultImports.length > 0
             ? defaultImports[0]
@@ -295,9 +293,7 @@ namespace ts.OrganizeImports {
         const newExportSpecifiers: ExportSpecifier[] = [];
         newExportSpecifiers.push(...flatMap(namedExports, i => (i.exportClause).elements));
 
-        const sortedExportSpecifiers = stableSort(newExportSpecifiers, (s1, s2) =>
-            compareIdentifiers(s1.propertyName || s1.name, s2.propertyName || s2.name) ||
-            compareIdentifiers(s1.name, s2.name));
+        const sortedExportSpecifiers = sortSpecifiers(newExportSpecifiers);
 
         const exportDecl = namedExports[0];
         coalescedExports.push(
@@ -348,6 +344,12 @@ namespace ts.OrganizeImports {
             importDeclaration.modifiers,
             updateImportClause(importDeclaration.importClause, name, namedBindings),
             importDeclaration.moduleSpecifier);
+    }
+
+    function sortSpecifiers<T extends ImportOrExportSpecifier>(specifiers: ReadonlyArray<T>) {
+        return stableSort(specifiers, (s1, s2) =>
+            compareIdentifiers(s1.propertyName || s1.name, s2.propertyName || s2.name) ||
+            compareIdentifiers(s1.name, s2.name));
     }
 
     /* internal */ // Exported for testing

--- a/tests/baselines/reference/organizeImports/AmbientModule.exports.ts
+++ b/tests/baselines/reference/organizeImports/AmbientModule.exports.ts
@@ -1,0 +1,15 @@
+// ==ORIGINAL==
+
+declare module "mod" {
+    export { F1 } from "lib";
+    export * from "lib";
+    export { F2 } from "lib";
+}
+    
+// ==ORGANIZED==
+
+declare module "mod" {
+    export * from "lib";
+    export { F1, F2 } from "lib";
+}
+    

--- a/tests/baselines/reference/organizeImports/CoalesceMultipleModules.exports.ts
+++ b/tests/baselines/reference/organizeImports/CoalesceMultipleModules.exports.ts
@@ -1,0 +1,11 @@
+// ==ORIGINAL==
+
+export { d } from "lib1";
+export { b } from "lib1";
+export { c } from "lib2";
+export { a } from "lib2";
+
+// ==ORGANIZED==
+
+export { b, d } from "lib1";
+export { a, c } from "lib2";

--- a/tests/baselines/reference/organizeImports/CoalesceTrivia.exports.ts
+++ b/tests/baselines/reference/organizeImports/CoalesceTrivia.exports.ts
@@ -1,0 +1,8 @@
+// ==ORIGINAL==
+
+/*A*/export /*B*/ { /*C*/ F2 /*D*/ } /*E*/ from /*F*/ "lib" /*G*/;/*H*/ //I
+/*J*/export /*K*/ { /*L*/ F1 /*M*/ } /*N*/ from /*O*/ "lib" /*P*/;/*Q*/ //R
+
+// ==ORGANIZED==
+
+/*A*/export /*B*/ { /*L*/ F1 /*M*/, /*C*/ F2 /*D*/ } /*E*/ from /*F*/ "lib" /*G*/; /*H*/ //I

--- a/tests/baselines/reference/organizeImports/MoveToTop.exports.ts
+++ b/tests/baselines/reference/organizeImports/MoveToTop.exports.ts
@@ -1,0 +1,13 @@
+// ==ORIGINAL==
+
+export { F1, F2 } from "lib";
+1;
+export * from "lib";
+2;
+
+// ==ORGANIZED==
+
+export * from "lib";
+export { F1, F2 } from "lib";
+1;
+2;

--- a/tests/baselines/reference/organizeImports/MoveToTop_Invalid.exports.ts
+++ b/tests/baselines/reference/organizeImports/MoveToTop_Invalid.exports.ts
@@ -1,0 +1,20 @@
+// ==ORIGINAL==
+
+export { F1, F2 } from "lib";
+1;
+export * from "lib";
+2;
+export { b } from `${'lib'}`;
+export { a } from `${'lib'}`;
+export { D } from "lib";
+3;
+
+// ==ORGANIZED==
+
+export * from "lib";
+export { D, F1, F2 } from "lib";
+export { b } from `${'lib'}`;
+export { a } from `${'lib'}`;
+1;
+2;
+3;

--- a/tests/baselines/reference/organizeImports/MoveToTop_WithExportsFirst.exports.ts
+++ b/tests/baselines/reference/organizeImports/MoveToTop_WithExportsFirst.exports.ts
@@ -1,0 +1,23 @@
+// ==ORIGINAL==
+
+export { F1, F2 } from "lib";
+1;
+import { F1, F2 } from "lib";
+2;
+export * from "lib";
+3;
+import * as NS from "lib";
+4;
+F1(); F2(); NS.F1();
+
+// ==ORGANIZED==
+
+export * from "lib";
+export { F1, F2 } from "lib";
+1;
+import * as NS from "lib";
+import { F1, F2 } from "lib";
+2;
+3;
+4;
+F1(); F2(); NS.F1();

--- a/tests/baselines/reference/organizeImports/MoveToTop_WithImportsFirst.exports.ts
+++ b/tests/baselines/reference/organizeImports/MoveToTop_WithImportsFirst.exports.ts
@@ -1,0 +1,23 @@
+// ==ORIGINAL==
+
+import { F1, F2 } from "lib";
+1;
+export { F1, F2 } from "lib";
+2;
+import * as NS from "lib";
+3;
+export * from "lib";
+4;
+F1(); F2(); NS.F1();
+
+// ==ORGANIZED==
+
+import * as NS from "lib";
+import { F1, F2 } from "lib";
+1;
+export * from "lib";
+export { F1, F2 } from "lib";
+2;
+3;
+4;
+F1(); F2(); NS.F1();

--- a/tests/baselines/reference/organizeImports/SortHeaderComment.exports.ts
+++ b/tests/baselines/reference/organizeImports/SortHeaderComment.exports.ts
@@ -1,0 +1,11 @@
+// ==ORIGINAL==
+
+// Header
+export * from "lib2";
+export * from "lib1";
+
+// ==ORGANIZED==
+
+// Header
+export * from "lib1";
+export * from "lib2";

--- a/tests/baselines/reference/organizeImports/SortTrivia.exports.ts
+++ b/tests/baselines/reference/organizeImports/SortTrivia.exports.ts
@@ -1,0 +1,9 @@
+// ==ORIGINAL==
+
+/*A*/export /*B*/ * /*C*/ from /*D*/ "lib2" /*E*/;/*F*/ //G
+/*H*/export /*I*/ * /*J*/ from /*K*/ "lib1" /*L*/;/*M*/ //N
+
+// ==ORGANIZED==
+
+/*A*//*H*/ export /*I*/ * /*J*/ from /*K*/ "lib1" /*L*/; /*M*/ //N
+export /*B*/ * /*C*/ from /*D*/ "lib2" /*E*/; /*F*/ //G

--- a/tests/baselines/reference/organizeImports/TopLevelAndAmbientModule.exports.ts
+++ b/tests/baselines/reference/organizeImports/TopLevelAndAmbientModule.exports.ts
@@ -1,0 +1,23 @@
+// ==ORIGINAL==
+
+export { D } from "lib";
+
+declare module "mod" {
+    export { F1 } from "lib";
+    export * from "lib";
+    export { F2 } from "lib";
+}
+
+export { E } from "lib";
+export * from "lib";
+
+// ==ORGANIZED==
+
+export * from "lib";
+export { D, E } from "lib";
+
+declare module "mod" {
+    export * from "lib";
+    export { F1, F2 } from "lib";
+}
+


### PR DESCRIPTION
Note that there's no attempt to remove unused exports.  I also didn't move the existing import tests into a corresponding `describe` for consistency because I wanted to avoid blowing up the diff.

Fixes #23640 
