### PR TITLE
getEffectiveTypeParameterDeclarations: Always return a defined result

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3101,9 +3101,9 @@ namespace ts {
      * Gets the effective type parameters. If the node was parsed in a
      * JavaScript file, gets the type parameters from the `@template` tag from JSDoc.
      */
-    export function getEffectiveTypeParameterDeclarations(node: DeclarationWithTypeParameters) {
+    export function getEffectiveTypeParameterDeclarations(node: DeclarationWithTypeParameters): ReadonlyArray<TypeParameterDeclaration> {
         if (isJSDocSignature(node)) {
-            return undefined;
+            return emptyArray;
         }
         if (isJSDocTypeAlias(node)) {
             Debug.assert(node.parent.kind === SyntaxKind.JSDocComment);
@@ -3114,17 +3114,14 @@ namespace ts {
             templateTagNodes.hasTrailingComma = false;
             return templateTagNodes;
         }
-        return node.typeParameters || (isInJavaScriptFile(node) ? getJSDocTypeParameterDeclarations(node) : undefined);
+        return node.typeParameters || (isInJavaScriptFile(node) ? getJSDocTypeParameterDeclarations(node) : emptyArray);
     }
 
-    export function getJSDocTypeParameterDeclarations(node: DeclarationWithTypeParameters) {
+    export function getJSDocTypeParameterDeclarations(node: DeclarationWithTypeParameters): ReadonlyArray<TypeParameterDeclaration> {
         const tags = filter(getJSDocTags(node), isJSDocTemplateTag);
-        for (const tag of tags) {
-            if (!(tag.parent.kind === SyntaxKind.JSDocComment && find(tag.parent.tags, isJSDocTypeAlias))) {
-                // template tags are only available when a typedef isn't already using them
-                return tag.typeParameters;
-            }
-        }
+        // template tags are only available when a typedef isn't already using them
+        const tag = find(tags, tag => !(tag.parent.kind === SyntaxKind.JSDocComment && find(tag.parent.tags, isJSDocTypeAlias)));
+        return (tag && tag.typeParameters) || emptyArray;
     }
 
     /**

--- a/src/services/codefixes/annotateWithTypeFromJSDoc.ts
+++ b/src/services/codefixes/annotateWithTypeFromJSDoc.ts
@@ -43,7 +43,7 @@ namespace ts.codefix {
         if (isFunctionLikeDeclaration(decl) && (getJSDocReturnType(decl) || decl.parameters.some(p => !!getJSDocType(p)))) {
             if (!decl.typeParameters) {
                 const typeParameters = getJSDocTypeParameterDeclarations(decl);
-                if (typeParameters) changes.insertTypeParameters(sourceFile, decl, typeParameters);
+                if (typeParameters.length) changes.insertTypeParameters(sourceFile, decl, typeParameters);
             }
             const needParens = isArrowFunction(decl) && !findChildOfKind(decl, SyntaxKind.OpenParenToken, sourceFile);
             if (needParens) changes.insertNodeBefore(sourceFile, first(decl.parameters), createToken(SyntaxKind.OpenParenToken));

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -166,8 +166,9 @@ namespace ts.codefix {
             case SyntaxKind.TypeParameter:
                 const typeParameters = getEffectiveTypeParameterDeclarations(<DeclarationWithTypeParameters>parent.parent);
                 if (typeParameters.length === 1) {
-                    const previousToken = getTokenAtPosition(sourceFile, typeParameters.pos - 1, /*includeJsDocComment*/ false);
-                    const nextToken = getTokenAtPosition(sourceFile, typeParameters.end, /*includeJsDocComment*/ false);
+                    const { pos, end } = cast(typeParameters, isNodeArray);
+                    const previousToken = getTokenAtPosition(sourceFile, pos - 1, /*includeJsDocComment*/ false);
+                    const nextToken = getTokenAtPosition(sourceFile, end, /*includeJsDocComment*/ false);
                     Debug.assert(previousToken.kind === SyntaxKind.LessThanToken);
                     Debug.assert(nextToken.kind === SyntaxKind.GreaterThanToken);
 

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -1464,7 +1464,7 @@ namespace ts.refactor.extractSymbol {
                 }
 
                 // Note that we add the current node's type parameters *after* updating the corresponding scope.
-                if (isDeclarationWithTypeParameters(curr) && getEffectiveTypeParameterDeclarations(curr)) {
+                if (isDeclarationWithTypeParameters(curr)) {
                     for (const typeParameterDecl of getEffectiveTypeParameterDeclarations(curr)) {
                         const typeParameter = checker.getTypeAtLocation(typeParameterDecl) as TypeParameter;
                         if (allTypeParameterUsages.has(typeParameter.id.toString())) {
@@ -1534,20 +1534,8 @@ namespace ts.refactor.extractSymbol {
 
         return { target, usagesPerScope, functionErrorsPerScope, constantErrorsPerScope, exposedVariableDeclarations };
 
-        function hasTypeParameters(node: Node) {
-            return isDeclarationWithTypeParameters(node) &&
-                getEffectiveTypeParameterDeclarations(node) &&
-                getEffectiveTypeParameterDeclarations(node).length > 0;
-        }
-
         function isInGenericContext(node: Node) {
-            for (; node; node = node.parent) {
-                if (hasTypeParameters(node)) {
-                    return true;
-                }
-            }
-
-            return false;
+            return !!findAncestor(node, n => isDeclarationWithTypeParameters(n) && getEffectiveTypeParameterDeclarations(n).length !== 0);
         }
 
         function recordTypeParameterUsages(type: Type) {


### PR DESCRIPTION
This simplifies most of the uses of this function and helps with `--strictNullChecks`.

