### PR TITLE
Fix issue with formatting object literal csharp style

### DIFF
--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -505,7 +505,6 @@ namespace ts.formatting {
                 case SyntaxKind.CallExpression:
                 case SyntaxKind.NewExpression:
                 case SyntaxKind.VariableStatement:
-                case SyntaxKind.VariableDeclaration:
                 case SyntaxKind.ExportAssignment:
                 case SyntaxKind.ReturnStatement:
                 case SyntaxKind.ConditionalExpression:
@@ -528,7 +527,6 @@ namespace ts.formatting {
                 case SyntaxKind.NamedImports:
                 case SyntaxKind.ExportSpecifier:
                 case SyntaxKind.ImportSpecifier:
-                case SyntaxKind.PropertyAssignment:
                 case SyntaxKind.PropertyDeclaration:
                     return true;
             }
@@ -541,7 +539,6 @@ namespace ts.formatting {
             switch (parent.kind) {
                 case SyntaxKind.VariableDeclaration:
                 case SyntaxKind.PropertyAssignment:
-                case SyntaxKind.ObjectLiteralExpression:
                     if (!settings.indentMultiLineObjectLiteralBeginningOnBlankLine && sourceFile && childKind === SyntaxKind.ObjectLiteralExpression) {
                         return rangeIsOnOneLine(sourceFile, child);
                     }

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -482,8 +482,10 @@ namespace ts.formatting {
             return findFirstNonWhitespaceCharacterAndColumn(startPos, endPos, sourceFile, options).column;
         }
 
-        function nodeContentIsAlwaysIndented(kind: SyntaxKind): boolean {
-            switch (kind) {
+        export function nodeWillIndentChild(settings: FormatCodeSettings | undefined, parent: TextRangeWithKind, child: TextRangeWithKind | undefined, sourceFile: SourceFileLike | undefined, indentByDefault: boolean): boolean {
+            const childKind = child ? child.kind : SyntaxKind.Unknown;
+
+            switch (parent.kind) {
                 case SyntaxKind.ExpressionStatement:
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.ClassExpression:
@@ -529,20 +531,12 @@ namespace ts.formatting {
                 case SyntaxKind.ImportSpecifier:
                 case SyntaxKind.PropertyDeclaration:
                     return true;
-            }
-            return false;
-        }
-
-        export function nodeWillIndentChild(settings: FormatCodeSettings | undefined, parent: TextRangeWithKind, child: TextRangeWithKind | undefined, sourceFile: SourceFileLike | undefined, indentByDefault: boolean): boolean {
-            const childKind = child ? child.kind : SyntaxKind.Unknown;
-
-            switch (parent.kind) {
                 case SyntaxKind.VariableDeclaration:
                 case SyntaxKind.PropertyAssignment:
                     if (!settings.indentMultiLineObjectLiteralBeginningOnBlankLine && sourceFile && childKind === SyntaxKind.ObjectLiteralExpression) {
                         return rangeIsOnOneLine(sourceFile, child);
                     }
-                    break;
+                    return true;
                 case SyntaxKind.DoStatement:
                 case SyntaxKind.WhileStatement:
                 case SyntaxKind.ForInStatement:
@@ -595,7 +589,7 @@ namespace ts.formatting {
          * @param isNextChild If true, we are judging indent of a hypothetical child *after* this one, not the current child.
          */
         export function shouldIndentChildNode(settings: FormatCodeSettings | undefined, parent: TextRangeWithKind, child?: Node, sourceFile?: SourceFileLike, isNextChild = false): boolean {
-            return (nodeContentIsAlwaysIndented(parent.kind) || nodeWillIndentChild(settings, parent, child, sourceFile, /*indentByDefault*/ false))
+            return nodeWillIndentChild(settings, parent, child, sourceFile, /*indentByDefault*/ false)
                 && !(isNextChild && child && isControlFlowEndingStatement(child.kind, parent));
         }
 

--- a/tests/cases/fourslash/smartIndentObjectLiteralOpenBracketNewLine.ts
+++ b/tests/cases/fourslash/smartIndentObjectLiteralOpenBracketNewLine.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts'/>
+
+//// var a =
+////     {/*1*/}
+////
+//// var b = {
+////     outer:
+////            {/*2*/}
+//// }
+
+function verifyIndentationAfterNewLine(marker: string, indentation: number): void {
+    goTo.marker(marker);
+    edit.insert("\n");
+    verify.indentationIs(indentation);
+}
+
+verifyIndentationAfterNewLine("1", 0);
+verifyIndentationAfterNewLine("2", 4);


### PR DESCRIPTION
Fixes feedback: https://developercommunity.visualstudio.com/content/problem/253676/js-and-ts-indentation-issue.html.

Current formatting:
```js
var clear =
    {
        outerKey:
            {
                innerKey: 1
            }
    };
```

Expected formatting:
```js
var clear =
{
    outerKey:
    {
        innerKey: 1
    }
};
```