### PR TITLE
Fix bug: Get merged module symbol in forEachExternalModule

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -498,7 +498,7 @@ namespace ts.codefix {
         }
         for (const sourceFile of allSourceFiles) {
             if (isExternalOrCommonJsModule(sourceFile)) {
-                cb(sourceFile.symbol, sourceFile);
+                cb(checker.getMergedSymbol(sourceFile.symbol), sourceFile);
             }
         }
     }

--- a/tests/cases/fourslash/completionsImport_augmentation.ts
+++ b/tests/cases/fourslash/completionsImport_augmentation.ts
@@ -1,0 +1,36 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.ts
+////export const foo = 0;
+
+// @Filename: /bar.ts
+////export {};
+////declare module "./a" {
+////    export const bar = 0;
+////}
+
+// @Filename: /user.ts
+/////**/
+
+verify.completions({
+    marker: "",
+    includes: [
+        {
+            name: "foo",
+            text: "const foo: 0",
+            source: "/a",
+            sourceDisplay: "./a",
+            hasAction: true,
+        },
+        {
+            name: "bar",
+            text: "const bar: 0",
+            source: "/a",
+            sourceDisplay: "./a",
+            hasAction: true,
+        },
+    ],
+    preferences: {
+        includeCompletionsForModuleExports: true,
+    },
+});


### PR DESCRIPTION
Fixes #24267

