### PR TITLE
Add noGetErrOnBackgroundUpdate session option to not queue diagnostics check for open files

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -7445,10 +7445,17 @@ namespace ts.projectSystem {
         });
 
         describe("when event handler is not set but session is created with canUseEvents = true", () => {
-            verifyProjectsUpdatedInBackgroundEvent(createSessionThatUsesEvents);
+            describe("without noGetErrOnBackgroundUpdate, diagnostics for open files are queued", () => {
+                verifyProjectsUpdatedInBackgroundEvent(createSessionThatUsesEvents);
+            });
 
-            function createSessionThatUsesEvents(host: TestServerHost): ProjectsUpdatedInBackgroundEventVerifier {
-                const session = createSession(host, { canUseEvents: true });
+            describe("with noGetErrOnBackgroundUpdate, diagnostics for open file are not queued", () => {
+                verifyProjectsUpdatedInBackgroundEvent(host => createSessionThatUsesEvents(host, /*noGetErrOnBackgroundUpdate*/ true));
+            });
+
+
+            function createSessionThatUsesEvents(host: TestServerHost, noGetErrOnBackgroundUpdate?: boolean): ProjectsUpdatedInBackgroundEventVerifier {
+                const session = createSession(host, { canUseEvents: true, noGetErrOnBackgroundUpdate });
 
                 return {
                     session,
@@ -7480,6 +7487,10 @@ namespace ts.projectSystem {
 
                     // Verified the events, reset them
                     session.clearMessages();
+
+                    if (events.length) {
+                        host.checkTimeoutQueueLength(noGetErrOnBackgroundUpdate ? 0 : 1); // Error checking queued only if not noGetErrOnBackgroundUpdate
+                    }
                 }
             }
         });

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -505,6 +505,7 @@ namespace ts.server {
                 canUseEvents: true,
                 suppressDiagnosticEvents,
                 syntaxOnly,
+                noGetErrOnBackgroundUpdate,
                 globalPlugins,
                 pluginProbeLocations,
                 allowLocalPluginLoads,
@@ -939,6 +940,7 @@ namespace ts.server {
     const suppressDiagnosticEvents = hasArgument("--suppressDiagnosticEvents");
     const syntaxOnly = hasArgument("--syntaxOnly");
     const telemetryEnabled = hasArgument(Arguments.EnableTelemetry);
+    const noGetErrOnBackgroundUpdate = hasArgument("--noGetErrOnBackgroundUpdate");
 
     logger.info(`Starting TS Server`);
     logger.info(`Version: ${version}`);

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -295,6 +295,7 @@ namespace ts.server {
         suppressDiagnosticEvents?: boolean;
         syntaxOnly?: boolean;
         throttleWaitMilliseconds?: number;
+        noGetErrOnBackgroundUpdate?: boolean;
 
         globalPlugins?: ReadonlyArray<string>;
         pluginProbeLocations?: ReadonlyArray<string>;
@@ -319,6 +320,7 @@ namespace ts.server {
         protected canUseEvents: boolean;
         private suppressDiagnosticEvents?: boolean;
         private eventHandler: ProjectServiceEventHandler;
+        private readonly noGetErrOnBackgroundUpdate?: boolean;
 
         constructor(opts: SessionOptions) {
             this.host = opts.host;
@@ -329,6 +331,7 @@ namespace ts.server {
             this.logger = opts.logger;
             this.canUseEvents = opts.canUseEvents;
             this.suppressDiagnosticEvents = opts.suppressDiagnosticEvents;
+            this.noGetErrOnBackgroundUpdate = opts.noGetErrOnBackgroundUpdate;
 
             const { throttleWaitMilliseconds } = opts;
 
@@ -404,7 +407,7 @@ namespace ts.server {
         private projectsUpdatedInBackgroundEvent(openFiles: string[]): void {
             this.projectService.logger.info(`got projects updated in background, updating diagnostics for ${openFiles}`);
             if (openFiles.length) {
-                if (!this.suppressDiagnosticEvents) {
+                if (!this.suppressDiagnosticEvents && !this.noGetErrOnBackgroundUpdate) {
                     const checkList = this.createCheckList(openFiles);
 
                     // For now only queue error checking for open files. We can change this to include non open files as well

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8391,6 +8391,7 @@ declare namespace ts.server {
         suppressDiagnosticEvents?: boolean;
         syntaxOnly?: boolean;
         throttleWaitMilliseconds?: number;
+        noGetErrOnBackgroundUpdate?: boolean;
         globalPlugins?: ReadonlyArray<string>;
         pluginProbeLocations?: ReadonlyArray<string>;
         allowLocalPluginLoads?: boolean;
@@ -8410,6 +8411,7 @@ declare namespace ts.server {
         protected canUseEvents: boolean;
         private suppressDiagnosticEvents?;
         private eventHandler;
+        private readonly noGetErrOnBackgroundUpdate?;
         constructor(opts: SessionOptions);
         private sendRequestCompletedEvent;
         private defaultEventHandler;


### PR DESCRIPTION
This will ensure that the getErr will be queued in by host and hence would make sure that it is cancellable.
Handles one of the scenario delaying completions in #19458 wherein the getErr gets scheduled on eg setTypings and the getErr that would be started by tsserver would not be cancellable and hence amid the current ongoing semantic check which could take few seconds depending on file size, tsserver cant even receive the message and hence causing delay in the completion/change processing.