### PR TITLE
Preserver jsx imports even when the compiler option is not set

### DIFF
--- a/src/harness/unittests/organizeImports.ts
+++ b/src/harness/unittests/organizeImports.ts
@@ -517,6 +517,26 @@ import { React, Other } from "react";
                 },
                 reactLibFile);
 
+            testOrganizeImports("JsxFactoryUnusedJsx",
+                {
+                    path: "/test.jsx",
+                    content: `
+import { React, Other } from "react";
+`,
+                },
+                reactLibFile);
+
+            // Note: Since the file extension does not end with "x", the jsx compiler option
+            // will not be enabled.  The import should be retained regardless.
+            testOrganizeImports("JsxFactoryUnusedJs",
+                {
+                    path: "/test.js",
+                    content: `
+import { React, Other } from "react";
+`,
+                },
+                reactLibFile);
+
             // This is descriptive, rather than normative
             testOrganizeImports("JsxFactoryUnusedTsx",
                 {

--- a/src/services/organizeImports.ts
+++ b/src/services/organizeImports.ts
@@ -92,7 +92,7 @@ namespace ts.OrganizeImports {
     function removeUnusedImports(oldImports: ReadonlyArray<ImportDeclaration>, sourceFile: SourceFile, program: Program) {
         const typeChecker = program.getTypeChecker();
         const jsxNamespace = typeChecker.getJsxNamespace();
-        const jsxContext = sourceFile.languageVariant === LanguageVariant.JSX && program.getCompilerOptions().jsx;
+        const jsxContext = sourceFile.languageVariant === LanguageVariant.JSX;
 
         const usedImports: ImportDeclaration[] = [];
 

--- a/tests/baselines/reference/organizeImports/JsxFactoryUnusedJs.ts
+++ b/tests/baselines/reference/organizeImports/JsxFactoryUnusedJs.ts
@@ -1,0 +1,7 @@
+// ==ORIGINAL==
+
+import { React, Other } from "react";
+
+// ==ORGANIZED==
+
+import { React } from "react";

--- a/tests/baselines/reference/organizeImports/JsxFactoryUnusedJsx.ts
+++ b/tests/baselines/reference/organizeImports/JsxFactoryUnusedJsx.ts
@@ -1,0 +1,7 @@
+// ==ORIGINAL==
+
+import { React, Other } from "react";
+
+// ==ORGANIZED==
+
+import { React } from "react";


### PR DESCRIPTION
...based on feedback from VS Code users.

Fixes #23287