### PR TITLE
fix wrong formatting with multiline type literals with IntersectionTy…

### DIFF
--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -569,6 +569,12 @@ namespace ts.formatting {
                     return childKind !== SyntaxKind.JsxClosingElement;
                 case SyntaxKind.JsxFragment:
                     return childKind !== SyntaxKind.JsxClosingFragment;
+                case SyntaxKind.IntersectionType:
+                case SyntaxKind.UnionType:
+                    if (childKind === SyntaxKind.TypeLiteral) {
+                        return false;
+                    }
+                    // falls through
             }
             // No explicit rule for given nodes so the result will follow the default value argument
             return indentByDefault;

--- a/tests/cases/fourslash/formatLiteralTypeInUnionOrIntersectionType.ts
+++ b/tests/cases/fourslash/formatLiteralTypeInUnionOrIntersectionType.ts
@@ -1,0 +1,37 @@
+/// <reference path='fourslash.ts' />
+
+//// type NumberAndString = {
+////     a: number
+//// } & {
+////     b: string
+//// };
+//// 
+//// type NumberOrString = {
+////     a: number
+//// } | {
+////     b: string
+//// };
+//// 
+//// type Complexed =
+////     Foo &
+////     Bar |
+////     Baz;
+
+
+format.document();
+verify.currentFileContentIs(`type NumberAndString = {
+    a: number
+} & {
+    b: string
+};
+
+type NumberOrString = {
+    a: number
+} | {
+    b: string
+};
+
+type Complexed =
+    Foo &
+    Bar |
+    Baz;`);


### PR DESCRIPTION
…pe and UnionType

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #24294 

