### PR TITLE
getEditsForFileRename: Handle old file still being present

### DIFF
--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -63,6 +63,7 @@
         "../services/documentRegistry.ts",
         "../services/importTracker.ts",
         "../services/findAllReferences.ts",
+        "../services/getEditsForFileRename.ts",
         "../services/goToDefinition.ts",
         "../services/jsDoc.ts",
         "../services/semver.ts",

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -59,6 +59,7 @@
         "../services/documentRegistry.ts",
         "../services/importTracker.ts",
         "../services/findAllReferences.ts",
+        "../services/getEditsForFileRename.ts",
         "../services/goToDefinition.ts",
         "../services/jsDoc.ts",
         "../services/semver.ts",

--- a/src/server/tsconfig.library.json
+++ b/src/server/tsconfig.library.json
@@ -65,6 +65,7 @@
         "../services/documentRegistry.ts",
         "../services/importTracker.ts",
         "../services/findAllReferences.ts",
+        "../services/getEditsForFileRename.ts",
         "../services/goToDefinition.ts",
         "../services/jsDoc.ts",
         "../services/semver.ts",

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -44,7 +44,7 @@ namespace ts {
                     ? host.getResolvedModuleWithFailedLookupLocationsFromCache && host.getResolvedModuleWithFailedLookupLocationsFromCache(importStringLiteral.text, sourceFile.fileName)
                     : program.getResolvedModuleWithFailedLookupLocationsFromCache(importStringLiteral.text, sourceFile.fileName);
                 // We may or may not have picked up on the file being renamed, so maybe successfully resolved to oldFilePath, or maybe that's in failedLookupLocations
-                if (resolved && contains([resolved.resolvedModule && resolved.resolvedModule.resolvedFileName, ...resolved.failedLookupLocations], oldFilePath)) {
+                if (resolved && contains(resolved.resolvedModule ? [resolved.resolvedModule.resolvedFileName] : resolved.failedLookupLocations, oldFilePath)) {
                     result.push({ sourceFile, toUpdate: importStringLiteral });
                 }
             }

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -56,6 +56,7 @@
         "documentRegistry.ts",
         "importTracker.ts",
         "findAllReferences.ts",
+        "getEditsForFileRename.ts",
         "goToDefinition.ts",
         "jsDoc.ts",
         "semver.ts",

--- a/tests/cases/fourslash/getEditsForFileRename_oldFileStillPresent.ts
+++ b/tests/cases/fourslash/getEditsForFileRename_oldFileStillPresent.ts
@@ -1,6 +1,9 @@
 /// <reference path='fourslash.ts' />
 
-// See also `getEditsForFileRename_oldFileStillPresent.ts`
+// Same test as `getEditsForFileRename.ts`, but with the old file not yet renamed.
+
+// @Filename: /src/old.ts
+////stuff
 
 // @Filename: /a.ts
 /////// <reference path="./src/old.ts" />


### PR DESCRIPTION
@mjbvz Mentioned having issues with this -- one possibility is that we don't update the program soon enough. This PR would make `getEditsForFileRename` work even if the program still contains the old file.

@mjbvz Please test this out.
