### PR TITLE
Use symbolToTypeNode for class & interface references

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2672,7 +2672,7 @@ namespace ts {
                     // if the symbolFromSymbolTable is not external module (it could be if it was determined as ambient external module and would be in globals table)
                     // and if symbolFromSymbolTable or alias resolution matches the symbol,
                     // check the symbol can be qualified, it is only then this symbol is accessible
-                    !some(symbolFromSymbolTable.declarations, hasExternalModuleSymbol) &&
+                    !some(symbolFromSymbolTable.declarations, hasNonGlobalAugmentationExternalModuleSymbol) &&
                     (ignoreQualification || canQualifySymbol(symbolFromSymbolTable, meaning));
             }
 
@@ -2704,6 +2704,11 @@ namespace ts {
                             return [symbolFromSymbolTable].concat(accessibleSymbolsFromExports);
                         }
                     }
+                    if (symbolFromSymbolTable.escapedName === symbol.escapedName && symbolFromSymbolTable.exportSymbol) {
+                        if (isAccessible(getMergedSymbol(symbolFromSymbolTable.exportSymbol), /*aliasSymbol*/ undefined, ignoreQualification)) {
+                            return [symbol];
+                        }
+                    }
                 });
             }
         }
@@ -2712,7 +2717,7 @@ namespace ts {
             let qualify = false;
             forEachSymbolTableInScope(enclosingDeclaration, symbolTable => {
                 // If symbol of this name is not available in the symbol table we are ok
-                let symbolFromSymbolTable = symbolTable.get(symbol.escapedName);
+                let symbolFromSymbolTable = getMergedSymbol(symbolTable.get(symbol.escapedName));
                 if (!symbolFromSymbolTable) {
                     // Continue to the next symbol table
                     return false;
@@ -2792,7 +2797,7 @@ namespace ts {
                         return hasAccessibleDeclarations;
                     }
                     else {
-                        if (some(symbol.declarations, hasExternalModuleSymbol)) {
+                        if (some(symbol.declarations, hasNonGlobalAugmentationExternalModuleSymbol)) {
                             // Any meaning of a module symbol is always accessible via an `import` type
                             return {
                                 accessibility: SymbolAccessibility.Accessible
@@ -2848,6 +2853,10 @@ namespace ts {
 
         function hasExternalModuleSymbol(declaration: Node) {
             return isAmbientModule(declaration) || (declaration.kind === SyntaxKind.SourceFile && isExternalOrCommonJsModule(<SourceFile>declaration));
+        }
+
+        function hasNonGlobalAugmentationExternalModuleSymbol(declaration: Node) {
+            return isModuleWithStringLiteralName(declaration) || (declaration.kind === SyntaxKind.SourceFile && isExternalOrCommonJsModule(<SourceFile>declaration));
         }
 
         function hasVisibleDeclarations(symbol: Symbol, shouldComputeAliasToMakeVisible: boolean): SymbolVisibilityResult {
@@ -3164,9 +3173,10 @@ namespace ts {
                         !isTypeSymbolAccessible(type.symbol, context.enclosingDeclaration)) {
                         return createTypeReferenceNode(getGeneratedNameForNode((type.symbol.declarations[0] as TypeParameterDeclaration).name, GeneratedIdentifierFlags.Optimistic | GeneratedIdentifierFlags.ReservedInNestedScopes), /*typeArguments*/ undefined);
                     }
-                    const name = type.symbol ? symbolToName(type.symbol, context, SymbolFlags.Type, /*expectsIdentifier*/ false) : createIdentifier("?");
                     // Ignore constraint/default when creating a usage (as opposed to declaration) of a type parameter.
-                    return createTypeReferenceNode(name, /*typeArguments*/ undefined);
+                    return type.symbol
+                        ? symbolToTypeNode(type.symbol, context, SymbolFlags.Type)
+                        : createTypeReferenceNode(createIdentifier("?"), /*typeArguments*/ undefined);
                 }
                 if (!inTypeAlias && type.aliasSymbol && (context.flags & NodeBuilderFlags.UseAliasDefinedOutsideCurrentScope || isTypeSymbolAccessible(type.aliasSymbol, context.enclosingDeclaration))) {
                     const typeArgumentNodes = mapToTypeNodes(type.aliasTypeArguments, context);
@@ -3712,7 +3722,7 @@ namespace ts {
                         // If this is the last part of outputting the symbol, always output. The cases apply only to parent symbols.
                         endOfChain ||
                         // If a parent symbol is an external module, don't write it. (We prefer just `x` vs `"foo/bar".x`.)
-                        (yieldModuleSymbol || !(!parentSymbol && forEach(symbol.declarations, hasExternalModuleSymbol))) &&
+                        (yieldModuleSymbol || !(!parentSymbol && forEach(symbol.declarations, hasNonGlobalAugmentationExternalModuleSymbol))) &&
                         // If a parent symbol is an anonymous type, don't write it.
                         !(symbol.flags & (SymbolFlags.TypeLiteral | SymbolFlags.ObjectLiteral))) {
 

--- a/tests/baselines/reference/ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndGenericClassStaticFunctionOfTheSameName.symbols
+++ b/tests/baselines/reference/ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndGenericClassStaticFunctionOfTheSameName.symbols
@@ -22,7 +22,7 @@ module clodule {
 
     // error: duplicate identifier expected
     export function fn<T>(x: T, y: T): T {
->fn : Symbol(clodule.fn, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndGenericClassStaticFunctionOfTheSameName.ts, 7, 16))
+>fn : Symbol(fn, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndGenericClassStaticFunctionOfTheSameName.ts, 7, 16))
 >T : Symbol(T, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndGenericClassStaticFunctionOfTheSameName.ts, 9, 23))
 >x : Symbol(x, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndGenericClassStaticFunctionOfTheSameName.ts, 9, 26))
 >T : Symbol(T, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndGenericClassStaticFunctionOfTheSameName.ts, 9, 23))

--- a/tests/baselines/reference/ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndNonGenericClassStaticFunctionOfTheSameName.symbols
+++ b/tests/baselines/reference/ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndNonGenericClassStaticFunctionOfTheSameName.symbols
@@ -20,7 +20,7 @@ module clodule {
 
     // error: duplicate identifier expected
     export function fn<T>(x: T, y: T): T {
->fn : Symbol(clodule.fn, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndNonGenericClassStaticFunctionOfTheSameName.ts, 7, 16))
+>fn : Symbol(fn, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndNonGenericClassStaticFunctionOfTheSameName.ts, 7, 16))
 >T : Symbol(T, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndNonGenericClassStaticFunctionOfTheSameName.ts, 9, 23))
 >x : Symbol(x, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndNonGenericClassStaticFunctionOfTheSameName.ts, 9, 26))
 >T : Symbol(T, Decl(ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndNonGenericClassStaticFunctionOfTheSameName.ts, 9, 23))

--- a/tests/baselines/reference/ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.symbols
+++ b/tests/baselines/reference/ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.symbols
@@ -17,7 +17,7 @@ module Point {
 >Point : Symbol(Point, Decl(ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts, 0, 0), Decl(ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts, 4, 1))
 
     export function Origin() { return null; } //expected duplicate identifier error
->Origin : Symbol(Point.Origin, Decl(ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts, 6, 14))
+>Origin : Symbol(Origin, Decl(ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts, 6, 14))
 }
 
 
@@ -42,6 +42,6 @@ module A {
 >Point : Symbol(Point, Decl(ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts, 11, 10), Decl(ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts, 16, 5))
 
         export function Origin() { return ""; }//expected duplicate identifier error
->Origin : Symbol(Point.Origin, Decl(ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts, 18, 25))
+>Origin : Symbol(Origin, Decl(ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts, 18, 25))
     }
 }

--- a/tests/baselines/reference/ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.symbols
+++ b/tests/baselines/reference/ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.symbols
@@ -17,7 +17,7 @@ module Point {
 >Point : Symbol(Point, Decl(ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.ts, 0, 0), Decl(ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.ts, 4, 1))
 
     export var Origin = ""; //expected duplicate identifier error
->Origin : Symbol(Point.Origin, Decl(ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.ts, 7, 14))
+>Origin : Symbol(Origin, Decl(ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.ts, 7, 14))
 }
 
 
@@ -42,6 +42,6 @@ module A {
 >Point : Symbol(Point, Decl(ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.ts, 11, 10), Decl(ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.ts, 16, 5))
 
         export var Origin = ""; //expected duplicate identifier error
->Origin : Symbol(Point.Origin, Decl(ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.ts, 19, 18))
+>Origin : Symbol(Origin, Decl(ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.ts, 19, 18))
     }
 }

--- a/tests/baselines/reference/TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.symbols
+++ b/tests/baselines/reference/TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.symbols
@@ -18,13 +18,13 @@ module A{
 
     // expected error
     export class Point {
->Point : Symbol(A.Point, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 7, 9))
+>Point : Symbol(Point, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 7, 9))
 
         origin: number;
->origin : Symbol(A.Point.origin, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 9, 24))
+>origin : Symbol(Point.origin, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 9, 24))
 
         angle: number;
->angle : Symbol(A.Point.angle, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 10, 23))
+>angle : Symbol(Point.angle, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 10, 23))
     }
 }
 
@@ -52,10 +52,10 @@ module X {
 
             // expected error
             export class Line {
->Line : Symbol(Z.Line, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 23, 25))
+>Line : Symbol(Line, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 23, 25))
 
                 name: string;
->name : Symbol(Z.Line.name, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 25, 31))
+>name : Symbol(Line.name, Decl(TwoInternalModulesThatMergeEachWithExportedClassesOfTheSameName.ts, 25, 31))
             }
         }
     }

--- a/tests/baselines/reference/augmentedClassWithPrototypePropertyOnModule.symbols
+++ b/tests/baselines/reference/augmentedClassWithPrototypePropertyOnModule.symbols
@@ -6,7 +6,7 @@ declare module m {
 >f : Symbol(f, Decl(augmentedClassWithPrototypePropertyOnModule.ts, 1, 7))
 
     var prototype; // This should be error since prototype would be static property on class m
->prototype : Symbol(m.prototype, Decl(augmentedClassWithPrototypePropertyOnModule.ts, 2, 7))
+>prototype : Symbol(prototype, Decl(augmentedClassWithPrototypePropertyOnModule.ts, 2, 7))
 }
 declare class m {
 >m : Symbol(m, Decl(augmentedClassWithPrototypePropertyOnModule.ts, 0, 0), Decl(augmentedClassWithPrototypePropertyOnModule.ts, 3, 1))

--- a/tests/baselines/reference/cloduleWithDuplicateMember1.symbols
+++ b/tests/baselines/reference/cloduleWithDuplicateMember1.symbols
@@ -18,14 +18,14 @@ module C {
 >C : Symbol(C, Decl(cloduleWithDuplicateMember1.ts, 0, 0), Decl(cloduleWithDuplicateMember1.ts, 6, 1), Decl(cloduleWithDuplicateMember1.ts, 10, 1))
 
     export var x = 1;
->x : Symbol(C.x, Decl(cloduleWithDuplicateMember1.ts, 9, 14))
+>x : Symbol(x, Decl(cloduleWithDuplicateMember1.ts, 9, 14))
 }
 module C {
 >C : Symbol(C, Decl(cloduleWithDuplicateMember1.ts, 0, 0), Decl(cloduleWithDuplicateMember1.ts, 6, 1), Decl(cloduleWithDuplicateMember1.ts, 10, 1))
 
     export function foo() { }
->foo : Symbol(C.foo, Decl(cloduleWithDuplicateMember1.ts, 11, 10))
+>foo : Symbol(foo, Decl(cloduleWithDuplicateMember1.ts, 11, 10))
 
     export function x() { }
->x : Symbol(C.x, Decl(cloduleWithDuplicateMember1.ts, 12, 29))
+>x : Symbol(x, Decl(cloduleWithDuplicateMember1.ts, 12, 29))
 }

--- a/tests/baselines/reference/cloduleWithDuplicateMember2.symbols
+++ b/tests/baselines/reference/cloduleWithDuplicateMember2.symbols
@@ -21,5 +21,5 @@ module C {
 >C : Symbol(C, Decl(cloduleWithDuplicateMember2.ts, 0, 0), Decl(cloduleWithDuplicateMember2.ts, 3, 1), Decl(cloduleWithDuplicateMember2.ts, 7, 1))
 
     export function x() { }
->x : Symbol(C.x, Decl(cloduleWithDuplicateMember2.ts, 8, 10))
+>x : Symbol(x, Decl(cloduleWithDuplicateMember2.ts, 8, 10))
 }

--- a/tests/baselines/reference/constructorOverloads4.symbols
+++ b/tests/baselines/reference/constructorOverloads4.symbols
@@ -3,7 +3,7 @@ declare module M {
 >M : Symbol(M, Decl(constructorOverloads4.ts, 0, 0))
 
     export class Function {
->Function : Symbol(M.Function, Decl(constructorOverloads4.ts, 0, 18))
+>Function : Symbol(Function, Decl(constructorOverloads4.ts, 0, 18))
 
         constructor(...args: string[]);
 >args : Symbol(args, Decl(constructorOverloads4.ts, 2, 20))

--- a/tests/baselines/reference/constructorOverloads5.symbols
+++ b/tests/baselines/reference/constructorOverloads5.symbols
@@ -17,7 +17,7 @@
 >RegExp : Symbol(RegExp, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
     export class RegExp {
->RegExp : Symbol(M.RegExp, Decl(constructorOverloads5.ts, 4, 67))
+>RegExp : Symbol(RegExp, Decl(constructorOverloads5.ts, 4, 67))
 
         constructor(pattern: string);
 >pattern : Symbol(pattern, Decl(constructorOverloads5.ts, 6, 20))
@@ -27,27 +27,27 @@
 >flags : Symbol(flags, Decl(constructorOverloads5.ts, 7, 36))
 
         exec(string: string): string[];
->exec : Symbol(M.RegExp.exec, Decl(constructorOverloads5.ts, 7, 52))
+>exec : Symbol(RegExp.exec, Decl(constructorOverloads5.ts, 7, 52))
 >string : Symbol(string, Decl(constructorOverloads5.ts, 8, 13))
 
         test(string: string): boolean;
->test : Symbol(M.RegExp.test, Decl(constructorOverloads5.ts, 8, 39))
+>test : Symbol(RegExp.test, Decl(constructorOverloads5.ts, 8, 39))
 >string : Symbol(string, Decl(constructorOverloads5.ts, 9, 13))
 
         source: string;
->source : Symbol(M.RegExp.source, Decl(constructorOverloads5.ts, 9, 38))
+>source : Symbol(RegExp.source, Decl(constructorOverloads5.ts, 9, 38))
 
         global: boolean;
->global : Symbol(M.RegExp.global, Decl(constructorOverloads5.ts, 10, 23))
+>global : Symbol(RegExp.global, Decl(constructorOverloads5.ts, 10, 23))
 
         ignoreCase: boolean;
->ignoreCase : Symbol(M.RegExp.ignoreCase, Decl(constructorOverloads5.ts, 11, 24))
+>ignoreCase : Symbol(RegExp.ignoreCase, Decl(constructorOverloads5.ts, 11, 24))
 
         multiline: boolean;
->multiline : Symbol(M.RegExp.multiline, Decl(constructorOverloads5.ts, 12, 28))
+>multiline : Symbol(RegExp.multiline, Decl(constructorOverloads5.ts, 12, 28))
 
         lastIndex: boolean;
->lastIndex : Symbol(M.RegExp.lastIndex, Decl(constructorOverloads5.ts, 13, 27))
+>lastIndex : Symbol(RegExp.lastIndex, Decl(constructorOverloads5.ts, 13, 27))
     }
 }
 

--- a/tests/baselines/reference/declarationEmitForTypesWhichNeedImportTypes.js
+++ b/tests/baselines/reference/declarationEmitForTypesWhichNeedImportTypes.js
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/declarationEmitForTypesWhichNeedImportTypes.ts] ////
+
+//// [b.ts]
+export interface Named {}
+
+export function createNamed(): Named {
+  return {};
+}
+//// [a.ts]
+import { createNamed } from "./b";
+
+export const Value = createNamed();
+
+
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+function createNamed() {
+    return {};
+}
+exports.createNamed = createNamed;
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+var b_1 = require("./b");
+exports.Value = b_1.createNamed();
+
+
+//// [b.d.ts]
+export interface Named {
+}
+export declare function createNamed(): Named;
+//// [a.d.ts]
+export declare const Value: import("./b").Named;

--- a/tests/baselines/reference/declarationEmitForTypesWhichNeedImportTypes.symbols
+++ b/tests/baselines/reference/declarationEmitForTypesWhichNeedImportTypes.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/b.ts ===
+export interface Named {}
+>Named : Symbol(Named, Decl(b.ts, 0, 0))
+
+export function createNamed(): Named {
+>createNamed : Symbol(createNamed, Decl(b.ts, 0, 25))
+>Named : Symbol(Named, Decl(b.ts, 0, 0))
+
+  return {};
+}
+=== tests/cases/compiler/a.ts ===
+import { createNamed } from "./b";
+>createNamed : Symbol(createNamed, Decl(a.ts, 0, 8))
+
+export const Value = createNamed();
+>Value : Symbol(Value, Decl(a.ts, 2, 12))
+>createNamed : Symbol(createNamed, Decl(a.ts, 0, 8))
+

--- a/tests/baselines/reference/declarationEmitForTypesWhichNeedImportTypes.types
+++ b/tests/baselines/reference/declarationEmitForTypesWhichNeedImportTypes.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/b.ts ===
+export interface Named {}
+>Named : Named
+
+export function createNamed(): Named {
+>createNamed : () => Named
+>Named : Named
+
+  return {};
+>{} : {}
+}
+=== tests/cases/compiler/a.ts ===
+import { createNamed } from "./b";
+>createNamed : () => import("tests/cases/compiler/b").Named
+
+export const Value = createNamed();
+>Value : import("tests/cases/compiler/b").Named
+>createNamed() : import("tests/cases/compiler/b").Named
+>createNamed : () => import("tests/cases/compiler/b").Named
+

--- a/tests/baselines/reference/declarationEmitImportInExportAssignmentModule.symbols
+++ b/tests/baselines/reference/declarationEmitImportInExportAssignmentModule.symbols
@@ -3,7 +3,7 @@ module m {
 >m : Symbol(m, Decl(declarationEmitImportInExportAssignmentModule.ts, 0, 0))
 
     export module c {
->c : Symbol(x, Decl(declarationEmitImportInExportAssignmentModule.ts, 0, 10))
+>c : Symbol(c, Decl(declarationEmitImportInExportAssignmentModule.ts, 0, 10))
 
         export class c {
 >c : Symbol(c, Decl(declarationEmitImportInExportAssignmentModule.ts, 1, 21))
@@ -11,7 +11,7 @@ module m {
     }
     import x = c;
 >x : Symbol(x, Decl(declarationEmitImportInExportAssignmentModule.ts, 4, 5))
->c : Symbol(x, Decl(declarationEmitImportInExportAssignmentModule.ts, 0, 10))
+>c : Symbol(c, Decl(declarationEmitImportInExportAssignmentModule.ts, 0, 10))
 
     export var a: typeof x;
 >a : Symbol(a, Decl(declarationEmitImportInExportAssignmentModule.ts, 6, 14))

--- a/tests/baselines/reference/declarationEmitImportInExportAssignmentModule.types
+++ b/tests/baselines/reference/declarationEmitImportInExportAssignmentModule.types
@@ -3,19 +3,19 @@ module m {
 >m : typeof m
 
     export module c {
->c : typeof x
+>c : typeof m.c
 
         export class c {
 >c : c
         }
     }
     import x = c;
->x : typeof x
->c : typeof x
+>x : typeof c
+>c : typeof c
 
     export var a: typeof x;
->a : typeof x
->x : typeof x
+>a : typeof c
+>x : typeof c
 }
 export = m;
 >m : typeof m

--- a/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.symbols
+++ b/tests/baselines/reference/defaultDeclarationEmitShadowedNamedCorrectly.symbols
@@ -16,7 +16,7 @@ export interface Things<P, T> {
 >T : Symbol(T, Decl(this.ts, 1, 26))
 }
 export function make<P, CTor>(x: { new (): CTor & {props: P} }): Things<P, CTor> {
->make : Symbol(me.make, Decl(this.ts, 4, 1))
+>make : Symbol(make, Decl(this.ts, 4, 1))
 >P : Symbol(P, Decl(this.ts, 5, 21))
 >CTor : Symbol(CTor, Decl(this.ts, 5, 23))
 >x : Symbol(x, Decl(this.ts, 5, 30))
@@ -49,7 +49,7 @@ export namespace Something {
 
     export const create = make(me.default);
 >create : Symbol(create, Decl(this.ts, 17, 16))
->make : Symbol(me.make, Decl(this.ts, 4, 1))
+>make : Symbol(make, Decl(this.ts, 4, 1))
 >me.default : Symbol(me.default, Decl(this.ts, 10, 1))
 >me : Symbol(me, Decl(this.ts, 0, 6))
 >default : Symbol(me.default, Decl(this.ts, 10, 1))

--- a/tests/baselines/reference/defaultExportsCannotMerge04.types
+++ b/tests/baselines/reference/defaultExportsCannotMerge04.types
@@ -15,5 +15,5 @@ interface Foo {
 }
 
 export interface Foo {
->Foo : Foo
+>Foo : import("tests/cases/conformance/es6/modules/defaultExportsCannotMerge04").Foo
 }

--- a/tests/baselines/reference/duplicateIdentifiersAcrossContainerBoundaries.symbols
+++ b/tests/baselines/reference/duplicateIdentifiersAcrossContainerBoundaries.symbols
@@ -22,7 +22,7 @@ module M {
 >M : Symbol(M, Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 0, 0), Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 2, 1), Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 5, 1), Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 9, 1), Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 12, 1) ... and 5 more)
 
     export class f { } // error
->f : Symbol(M.f, Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 10, 10))
+>f : Symbol(f, Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 10, 10))
 }
 
 module M {
@@ -75,7 +75,7 @@ module Foo {
 >Foo : Symbol(Foo, Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 33, 1), Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 37, 1))
 
     export var x: number; // error for redeclaring var in a different parent
->x : Symbol(Foo.x, Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 40, 14))
+>x : Symbol(x, Decl(duplicateIdentifiersAcrossContainerBoundaries.ts, 40, 14))
 }
 
 module N {

--- a/tests/baselines/reference/duplicateIdentifiersAcrossContainerBoundaries.types
+++ b/tests/baselines/reference/duplicateIdentifiersAcrossContainerBoundaries.types
@@ -22,7 +22,7 @@ module M {
 >M : typeof M
 
     export class f { } // error
->f : M.f
+>f : f
 }
 
 module M {

--- a/tests/baselines/reference/duplicateIdentifiersAcrossFileBoundaries.symbols
+++ b/tests/baselines/reference/duplicateIdentifiersAcrossFileBoundaries.symbols
@@ -52,7 +52,7 @@ module Foo {
 >Foo : Symbol(Foo, Decl(file1.ts, 4, 10), Decl(file2.ts, 4, 10))
 
     export var x: number; // error for redeclaring var in a different parent
->x : Symbol(Foo.x, Decl(file2.ts, 7, 14))
+>x : Symbol(x, Decl(file2.ts, 7, 14))
 }
 
 declare module N {

--- a/tests/baselines/reference/duplicateSymbolsExportMatching.types
+++ b/tests/baselines/reference/duplicateSymbolsExportMatching.types
@@ -131,5 +131,5 @@ interface D { }
 >D : D
 
 export interface D { }
->D : D
+>D : import("tests/cases/compiler/duplicateSymbolsExportMatching").D
 

--- a/tests/baselines/reference/es5ExportEquals.types
+++ b/tests/baselines/reference/es5ExportEquals.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/es5ExportEquals.ts ===
 export function f() { }
->f : typeof import("tests/cases/compiler/es5ExportEquals").f
+>f : typeof f
 
 export = f;
 >f : () => void

--- a/tests/baselines/reference/es6ExportEquals.types
+++ b/tests/baselines/reference/es6ExportEquals.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/es6ExportEquals.ts ===
 export function f() { }
->f : typeof import("tests/cases/compiler/es6ExportEquals").f
+>f : typeof f
 
 export = f;
 >f : () => void

--- a/tests/baselines/reference/extension.symbols
+++ b/tests/baselines/reference/extension.symbols
@@ -28,10 +28,10 @@ declare module M {
 >M : Symbol(M, Decl(extension.ts, 6, 1), Decl(extension.ts, 12, 1))
 
     export extension class C {
->C : Symbol(M.C, Decl(extension.ts, 15, 20))
+>C : Symbol(C, Decl(extension.ts, 15, 20))
 
         public pe:string;
->pe : Symbol(M.C.pe, Decl(extension.ts, 15, 30))
+>pe : Symbol(C.pe, Decl(extension.ts, 15, 30))
     }
 }
 

--- a/tests/baselines/reference/genericClassesRedeclaration.symbols
+++ b/tests/baselines/reference/genericClassesRedeclaration.symbols
@@ -262,34 +262,34 @@ declare module TypeScript {
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 5, 25), Decl(genericClassesRedeclaration.ts, 44, 25))
     }
     class StringHashTable<T> implements IHashTable<T> {
->StringHashTable : Symbol(TypeScript.StringHashTable, Decl(genericClassesRedeclaration.ts, 53, 5))
+>StringHashTable : Symbol(StringHashTable, Decl(genericClassesRedeclaration.ts, 53, 5))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 54, 26))
 >IHashTable : Symbol(IHashTable, Decl(genericClassesRedeclaration.ts, 4, 56), Decl(genericClassesRedeclaration.ts, 43, 56))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 54, 26))
 
         private itemCount;
->itemCount : Symbol(TypeScript.StringHashTable.itemCount, Decl(genericClassesRedeclaration.ts, 54, 55))
+>itemCount : Symbol(StringHashTable.itemCount, Decl(genericClassesRedeclaration.ts, 54, 55))
 
         private table;
->table : Symbol(TypeScript.StringHashTable.table, Decl(genericClassesRedeclaration.ts, 55, 26))
+>table : Symbol(StringHashTable.table, Decl(genericClassesRedeclaration.ts, 55, 26))
 
         public getAllKeys(): string[];
->getAllKeys : Symbol(TypeScript.StringHashTable.getAllKeys, Decl(genericClassesRedeclaration.ts, 56, 22))
+>getAllKeys : Symbol(StringHashTable.getAllKeys, Decl(genericClassesRedeclaration.ts, 56, 22))
 
         public add(key: string, data: T): boolean;
->add : Symbol(TypeScript.StringHashTable.add, Decl(genericClassesRedeclaration.ts, 57, 38))
+>add : Symbol(StringHashTable.add, Decl(genericClassesRedeclaration.ts, 57, 38))
 >key : Symbol(key, Decl(genericClassesRedeclaration.ts, 58, 19))
 >data : Symbol(data, Decl(genericClassesRedeclaration.ts, 58, 31))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 54, 26))
 
         public addOrUpdate(key: string, data: T): boolean;
->addOrUpdate : Symbol(TypeScript.StringHashTable.addOrUpdate, Decl(genericClassesRedeclaration.ts, 58, 50))
+>addOrUpdate : Symbol(StringHashTable.addOrUpdate, Decl(genericClassesRedeclaration.ts, 58, 50))
 >key : Symbol(key, Decl(genericClassesRedeclaration.ts, 59, 27))
 >data : Symbol(data, Decl(genericClassesRedeclaration.ts, 59, 39))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 54, 26))
 
         public map(fn: (k: string, value: T, context: any) => void, context: any): void;
->map : Symbol(TypeScript.StringHashTable.map, Decl(genericClassesRedeclaration.ts, 59, 58))
+>map : Symbol(StringHashTable.map, Decl(genericClassesRedeclaration.ts, 59, 58))
 >fn : Symbol(fn, Decl(genericClassesRedeclaration.ts, 60, 19))
 >k : Symbol(k, Decl(genericClassesRedeclaration.ts, 60, 24))
 >value : Symbol(value, Decl(genericClassesRedeclaration.ts, 60, 34))
@@ -298,7 +298,7 @@ declare module TypeScript {
 >context : Symbol(context, Decl(genericClassesRedeclaration.ts, 60, 67))
 
         public every(fn: (k: string, value: T, context: any) => void, context: any): boolean;
->every : Symbol(TypeScript.StringHashTable.every, Decl(genericClassesRedeclaration.ts, 60, 88))
+>every : Symbol(StringHashTable.every, Decl(genericClassesRedeclaration.ts, 60, 88))
 >fn : Symbol(fn, Decl(genericClassesRedeclaration.ts, 61, 21))
 >k : Symbol(k, Decl(genericClassesRedeclaration.ts, 61, 26))
 >value : Symbol(value, Decl(genericClassesRedeclaration.ts, 61, 36))
@@ -307,7 +307,7 @@ declare module TypeScript {
 >context : Symbol(context, Decl(genericClassesRedeclaration.ts, 61, 69))
 
         public some(fn: (k: string, value: T, context: any) => void, context: any): boolean;
->some : Symbol(TypeScript.StringHashTable.some, Decl(genericClassesRedeclaration.ts, 61, 93))
+>some : Symbol(StringHashTable.some, Decl(genericClassesRedeclaration.ts, 61, 93))
 >fn : Symbol(fn, Decl(genericClassesRedeclaration.ts, 62, 20))
 >k : Symbol(k, Decl(genericClassesRedeclaration.ts, 62, 25))
 >value : Symbol(value, Decl(genericClassesRedeclaration.ts, 62, 35))
@@ -316,40 +316,40 @@ declare module TypeScript {
 >context : Symbol(context, Decl(genericClassesRedeclaration.ts, 62, 68))
 
         public count(): number;
->count : Symbol(TypeScript.StringHashTable.count, Decl(genericClassesRedeclaration.ts, 62, 92))
+>count : Symbol(StringHashTable.count, Decl(genericClassesRedeclaration.ts, 62, 92))
 
         public lookup(key: string): T;
->lookup : Symbol(TypeScript.StringHashTable.lookup, Decl(genericClassesRedeclaration.ts, 63, 31))
+>lookup : Symbol(StringHashTable.lookup, Decl(genericClassesRedeclaration.ts, 63, 31))
 >key : Symbol(key, Decl(genericClassesRedeclaration.ts, 64, 22))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 54, 26))
 
         public remove(key: string): void;
->remove : Symbol(TypeScript.StringHashTable.remove, Decl(genericClassesRedeclaration.ts, 64, 38))
+>remove : Symbol(StringHashTable.remove, Decl(genericClassesRedeclaration.ts, 64, 38))
 >key : Symbol(key, Decl(genericClassesRedeclaration.ts, 65, 22))
     }
     class IdentiferNameHashTable<T> extends StringHashTable<T> {
->IdentiferNameHashTable : Symbol(TypeScript.IdentiferNameHashTable, Decl(genericClassesRedeclaration.ts, 66, 5))
+>IdentiferNameHashTable : Symbol(IdentiferNameHashTable, Decl(genericClassesRedeclaration.ts, 66, 5))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 67, 33))
 >StringHashTable : Symbol(StringHashTable, Decl(genericClassesRedeclaration.ts, 14, 5))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 67, 33))
 
         public getAllKeys(): string[];
->getAllKeys : Symbol(TypeScript.IdentiferNameHashTable.getAllKeys, Decl(genericClassesRedeclaration.ts, 67, 64))
+>getAllKeys : Symbol(IdentiferNameHashTable.getAllKeys, Decl(genericClassesRedeclaration.ts, 67, 64))
 
         public add(key: string, data: T): boolean;
->add : Symbol(TypeScript.IdentiferNameHashTable.add, Decl(genericClassesRedeclaration.ts, 68, 38))
+>add : Symbol(IdentiferNameHashTable.add, Decl(genericClassesRedeclaration.ts, 68, 38))
 >key : Symbol(key, Decl(genericClassesRedeclaration.ts, 69, 19))
 >data : Symbol(data, Decl(genericClassesRedeclaration.ts, 69, 31))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 67, 33))
 
         public addOrUpdate(key: string, data: T): boolean;
->addOrUpdate : Symbol(TypeScript.IdentiferNameHashTable.addOrUpdate, Decl(genericClassesRedeclaration.ts, 69, 50))
+>addOrUpdate : Symbol(IdentiferNameHashTable.addOrUpdate, Decl(genericClassesRedeclaration.ts, 69, 50))
 >key : Symbol(key, Decl(genericClassesRedeclaration.ts, 70, 27))
 >data : Symbol(data, Decl(genericClassesRedeclaration.ts, 70, 39))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 67, 33))
 
         public map(fn: (k: string, value: T, context: any) => void, context: any): void;
->map : Symbol(TypeScript.IdentiferNameHashTable.map, Decl(genericClassesRedeclaration.ts, 70, 58))
+>map : Symbol(IdentiferNameHashTable.map, Decl(genericClassesRedeclaration.ts, 70, 58))
 >fn : Symbol(fn, Decl(genericClassesRedeclaration.ts, 71, 19))
 >k : Symbol(k, Decl(genericClassesRedeclaration.ts, 71, 24))
 >value : Symbol(value, Decl(genericClassesRedeclaration.ts, 71, 34))
@@ -358,7 +358,7 @@ declare module TypeScript {
 >context : Symbol(context, Decl(genericClassesRedeclaration.ts, 71, 67))
 
         public every(fn: (k: string, value: T, context: any) => void, context: any): boolean;
->every : Symbol(TypeScript.IdentiferNameHashTable.every, Decl(genericClassesRedeclaration.ts, 71, 88))
+>every : Symbol(IdentiferNameHashTable.every, Decl(genericClassesRedeclaration.ts, 71, 88))
 >fn : Symbol(fn, Decl(genericClassesRedeclaration.ts, 72, 21))
 >k : Symbol(k, Decl(genericClassesRedeclaration.ts, 72, 26))
 >value : Symbol(value, Decl(genericClassesRedeclaration.ts, 72, 36))
@@ -367,7 +367,7 @@ declare module TypeScript {
 >context : Symbol(context, Decl(genericClassesRedeclaration.ts, 72, 69))
 
         public some(fn: (k: string, value: any, context: any) => void, context: any): boolean;
->some : Symbol(TypeScript.IdentiferNameHashTable.some, Decl(genericClassesRedeclaration.ts, 72, 93))
+>some : Symbol(IdentiferNameHashTable.some, Decl(genericClassesRedeclaration.ts, 72, 93))
 >fn : Symbol(fn, Decl(genericClassesRedeclaration.ts, 73, 20))
 >k : Symbol(k, Decl(genericClassesRedeclaration.ts, 73, 25))
 >value : Symbol(value, Decl(genericClassesRedeclaration.ts, 73, 35))
@@ -375,7 +375,7 @@ declare module TypeScript {
 >context : Symbol(context, Decl(genericClassesRedeclaration.ts, 73, 70))
 
         public lookup(key: string): T;
->lookup : Symbol(TypeScript.IdentiferNameHashTable.lookup, Decl(genericClassesRedeclaration.ts, 73, 94))
+>lookup : Symbol(IdentiferNameHashTable.lookup, Decl(genericClassesRedeclaration.ts, 73, 94))
 >key : Symbol(key, Decl(genericClassesRedeclaration.ts, 74, 22))
 >T : Symbol(T, Decl(genericClassesRedeclaration.ts, 67, 33))
     }

--- a/tests/baselines/reference/implicitAnyAmbients.symbols
+++ b/tests/baselines/reference/implicitAnyAmbients.symbols
@@ -51,7 +51,7 @@ declare module m {
     }
 
     module n {
->n : Symbol(m2, Decl(implicitAnyAmbients.ts, 18, 5))
+>n : Symbol(n, Decl(implicitAnyAmbients.ts, 18, 5))
 
         var y; // error
 >y : Symbol(y, Decl(implicitAnyAmbients.ts, 21, 11))
@@ -59,5 +59,5 @@ declare module m {
 
     import m2 = n;
 >m2 : Symbol(m2, Decl(implicitAnyAmbients.ts, 22, 5))
->n : Symbol(m2, Decl(implicitAnyAmbients.ts, 18, 5))
+>n : Symbol(n, Decl(implicitAnyAmbients.ts, 18, 5))
 }

--- a/tests/baselines/reference/implicitAnyAmbients.types
+++ b/tests/baselines/reference/implicitAnyAmbients.types
@@ -51,13 +51,13 @@ declare module m {
     }
 
     module n {
->n : typeof m2
+>n : typeof n
 
         var y; // error
 >y : any
     }
 
     import m2 = n;
->m2 : typeof m2
->n : typeof m2
+>m2 : typeof n
+>n : typeof n
 }

--- a/tests/baselines/reference/importTypeAmbient.types
+++ b/tests/baselines/reference/importTypeAmbient.types
@@ -69,9 +69,9 @@ declare module "foo2" {
 }
 
 let y: import("foo2").Bar.I = { a: "", b: 0 };
->y : Bar.I
+>y : import("foo2").Bar.I
 >Bar : any
->I : Bar.I
+>I : import("foo2").Bar.I
 >{ a: "", b: 0 } : { a: string; b: number; }
 >a : string
 >"" : ""

--- a/tests/baselines/reference/importTypeAmdBundleRewrite.types
+++ b/tests/baselines/reference/importTypeAmdBundleRewrite.types
@@ -7,22 +7,22 @@ export interface Foo {
 }
 === tests/cases/conformance/types/import/a/inner.ts ===
 const c: import("./b/c").Foo = {x: 12};
->c : Foo
->Foo : Foo
+>c : import("tests/cases/conformance/types/import/a/b/c").Foo
+>Foo : import("tests/cases/conformance/types/import/a/b/c").Foo
 >{x: 12} : { x: 12; }
 >x : 12
 >12 : 12
 
 export {c};
->c : Foo
+>c : import("tests/cases/conformance/types/import/a/b/c").Foo
 
 === tests/cases/conformance/types/import/index.ts ===
 const d: typeof import("./a/inner")["c"] = {x: 12};
->d : Foo
+>d : import("tests/cases/conformance/types/import/a/b/c").Foo
 >{x: 12} : { x: 12; }
 >x : 12
 >12 : 12
 
 export {d};
->d : Foo
+>d : import("tests/cases/conformance/types/import/a/b/c").Foo
 

--- a/tests/baselines/reference/importTypeResolutionJSDocEOF.types
+++ b/tests/baselines/reference/importTypeResolutionJSDocEOF.types
@@ -9,6 +9,6 @@ export interface Bar {
 === tests/cases/compiler/usage.js ===
 /** @type {Bar} */
 export let bar;
->bar : Bar
+>bar : import("tests/cases/compiler/interfaces").Bar
 
 /** @typedef {import('./interfaces').Bar} Bar */

--- a/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.errors.txt
+++ b/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.errors.txt
@@ -1,19 +1,19 @@
-tests/cases/conformance/jsx/inline/index.tsx(5,1): error TS2322: Type 'dom.JSX.Element' is not assignable to type 'predom.JSX.Element'.
+tests/cases/conformance/jsx/inline/index.tsx(5,1): error TS2322: Type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element'.
   Property '__predomBrand' is missing in type 'Element'.
 tests/cases/conformance/jsx/inline/index.tsx(21,21): error TS2605: JSX element type 'Element' is not a constructor function for JSX elements.
   Property 'render' is missing in type 'Element'.
 tests/cases/conformance/jsx/inline/index.tsx(21,22): error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ children?: Element[]; }'.
   Types of property 'children' are incompatible.
-    Type 'dom.JSX.Element[]' is not assignable to type 'predom.JSX.Element[]'.
-      Type 'dom.JSX.Element' is not assignable to type 'predom.JSX.Element'.
+    Type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element[]' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element[]'.
+      Type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element'.
 tests/cases/conformance/jsx/inline/index.tsx(21,40): error TS2605: JSX element type 'MyClass' is not a constructor function for JSX elements.
 tests/cases/conformance/jsx/inline/index.tsx(21,40): error TS2605: JSX element type 'MyClass' is not a constructor function for JSX elements.
   Property '__domBrand' is missing in type 'MyClass'.
 tests/cases/conformance/jsx/inline/index.tsx(21,63): error TS2605: JSX element type 'MyClass' is not a constructor function for JSX elements.
 tests/cases/conformance/jsx/inline/index.tsx(24,23): error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ x: number; y: number; children?: Element[]; }'.
   Types of property 'children' are incompatible.
-    Type 'predom.JSX.Element[]' is not assignable to type 'dom.JSX.Element[]'.
-      Type 'predom.JSX.Element' is not assignable to type 'dom.JSX.Element'.
+    Type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element[]' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element[]'.
+      Type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element'.
         Property '__domBrand' is missing in type 'Element'.
 
 
@@ -84,7 +84,7 @@ tests/cases/conformance/jsx/inline/index.tsx(24,23): error TS2322: Type '{ child
     let elem = prerendered;
     elem = <h></h>; // Expect assignability error here
     ~~~~
-!!! error TS2322: Type 'dom.JSX.Element' is not assignable to type 'predom.JSX.Element'.
+!!! error TS2322: Type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element'.
 !!! error TS2322:   Property '__predomBrand' is missing in type 'Element'.
     
     const DOMSFC = (props: {x: number, y: number, children?: dom.JSX.Element[]}) => <p>{props.x} + {props.y} = {props.x + props.y}{props.children}</p>;
@@ -108,8 +108,8 @@ tests/cases/conformance/jsx/inline/index.tsx(24,23): error TS2322: Type '{ child
                          ~~~~~
 !!! error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ children?: Element[]; }'.
 !!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type 'dom.JSX.Element[]' is not assignable to type 'predom.JSX.Element[]'.
-!!! error TS2322:       Type 'dom.JSX.Element' is not assignable to type 'predom.JSX.Element'.
+!!! error TS2322:     Type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element[]' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element[]'.
+!!! error TS2322:       Type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element'.
                                            ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2605: JSX element type 'MyClass' is not a constructor function for JSX elements.
                                            ~~~~~~~~~~~~~~~~~~~~~~~
@@ -123,7 +123,7 @@ tests/cases/conformance/jsx/inline/index.tsx(24,23): error TS2322: Type '{ child
                           ~~~~~~
 !!! error TS2322: Type '{ children: Element[]; x: number; y: number; }' is not assignable to type '{ x: number; y: number; children?: Element[]; }'.
 !!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type 'predom.JSX.Element[]' is not assignable to type 'dom.JSX.Element[]'.
-!!! error TS2322:       Type 'predom.JSX.Element' is not assignable to type 'dom.JSX.Element'.
+!!! error TS2322:     Type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element[]' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element[]'.
+!!! error TS2322:       Type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer").dom.JSX.Element'.
 !!! error TS2322:         Property '__domBrand' is missing in type 'Element'.
     

--- a/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.types
+++ b/tests/baselines/reference/inlineJsxFactoryDeclarationsLocalTypes.types
@@ -231,18 +231,18 @@ import { dom } from "./renderer"
 >dom : () => dom.JSX.Element
 
 import prerendered, {MySFC, MyClass, tree} from "./component";
->prerendered : predom.JSX.Element
->MySFC : (props: { x: number; y: number; children?: predom.JSX.Element[]; }) => predom.JSX.Element
+>prerendered : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
+>MySFC : (props: { x: number; y: number; children?: import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element[]; }) => import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 >MyClass : typeof MyClass
->tree : predom.JSX.Element
+>tree : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 
 let elem = prerendered;
->elem : predom.JSX.Element
->prerendered : predom.JSX.Element
+>elem : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
+>prerendered : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 
 elem = <h></h>; // Expect assignability error here
 >elem = <h></h> : dom.JSX.Element
->elem : predom.JSX.Element
+>elem : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 ><h></h> : dom.JSX.Element
 >h : any
 >h : any
@@ -360,7 +360,7 @@ const _tree = <DOMSFC x={1} y={2}><DOMClass x={3} y={4} /><DOMClass x={5} y={6} 
 const _brokenTree = <MySFC x={1} y={2}><MyClass x={3} y={4} /><MyClass x={5} y={6} /></MySFC>
 >_brokenTree : dom.JSX.Element
 ><MySFC x={1} y={2}><MyClass x={3} y={4} /><MyClass x={5} y={6} /></MySFC> : dom.JSX.Element
->MySFC : (props: { x: number; y: number; children?: predom.JSX.Element[]; }) => predom.JSX.Element
+>MySFC : (props: { x: number; y: number; children?: import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element[]; }) => import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 >x : number
 >1 : 1
 >y : number
@@ -377,7 +377,7 @@ const _brokenTree = <MySFC x={1} y={2}><MyClass x={3} y={4} /><MyClass x={5} y={
 >5 : 5
 >y : number
 >6 : 6
->MySFC : (props: { x: number; y: number; children?: predom.JSX.Element[]; }) => predom.JSX.Element
+>MySFC : (props: { x: number; y: number; children?: import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element[]; }) => import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 
 // Should fail, nondom isn't allowed as children of dom
 const _brokenTree2 = <DOMSFC x={1} y={2}>{tree}{tree}</DOMSFC>
@@ -388,7 +388,7 @@ const _brokenTree2 = <DOMSFC x={1} y={2}>{tree}{tree}</DOMSFC>
 >1 : 1
 >y : number
 >2 : 2
->tree : predom.JSX.Element
->tree : predom.JSX.Element
+>tree : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
+>tree : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 >DOMSFC : (props: { x: number; y: number; children?: dom.JSX.Element[]; }) => dom.JSX.Element
 

--- a/tests/baselines/reference/inlineJsxFactoryLocalTypeGlobalFallback.errors.txt
+++ b/tests/baselines/reference/inlineJsxFactoryLocalTypeGlobalFallback.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/inline/index.tsx(5,1): error TS2322: Type 'JSX.Element' is not assignable to type 'predom.JSX.Element'.
+tests/cases/conformance/jsx/inline/index.tsx(5,1): error TS2322: Type 'JSX.Element' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element'.
   Property '__predomBrand' is missing in type 'Element'.
 
 
@@ -46,6 +46,6 @@ tests/cases/conformance/jsx/inline/index.tsx(5,1): error TS2322: Type 'JSX.Eleme
     let elem = prerendered;
     elem = <h></h>; // Expect assignability error here
     ~~~~
-!!! error TS2322: Type 'JSX.Element' is not assignable to type 'predom.JSX.Element'.
+!!! error TS2322: Type 'JSX.Element' is not assignable to type 'import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element'.
 !!! error TS2322:   Property '__predomBrand' is missing in type 'Element'.
     

--- a/tests/baselines/reference/inlineJsxFactoryLocalTypeGlobalFallback.types
+++ b/tests/baselines/reference/inlineJsxFactoryLocalTypeGlobalFallback.types
@@ -95,15 +95,15 @@ import { dom } from "./renderer"
 >dom : () => JSX.Element
 
 import prerendered from "./component";
->prerendered : predom.JSX.Element
+>prerendered : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 
 let elem = prerendered;
->elem : predom.JSX.Element
->prerendered : predom.JSX.Element
+>elem : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
+>prerendered : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 
 elem = <h></h>; // Expect assignability error here
 >elem = <h></h> : JSX.Element
->elem : predom.JSX.Element
+>elem : import("tests/cases/conformance/jsx/inline/renderer2").predom.JSX.Element
 ><h></h> : JSX.Element
 >h : any
 >h : any

--- a/tests/baselines/reference/invalidInstantiatedModule.symbols
+++ b/tests/baselines/reference/invalidInstantiatedModule.symbols
@@ -8,7 +8,7 @@ module M {
 >y : Symbol(Point.y, Decl(invalidInstantiatedModule.ts, 1, 35))
 
     export var Point = 1;  // Error
->Point : Symbol(M.Point, Decl(invalidInstantiatedModule.ts, 2, 14))
+>Point : Symbol(Point, Decl(invalidInstantiatedModule.ts, 2, 14))
 }
 
 module M2 {

--- a/tests/baselines/reference/invalidNestedModules.symbols
+++ b/tests/baselines/reference/invalidNestedModules.symbols
@@ -50,7 +50,7 @@ module M2 {
 >X : Symbol(X, Decl(invalidNestedModules.ts, 15, 10), Decl(invalidNestedModules.ts, 21, 11))
 
         export var Point: number; // Error
->Point : Symbol(X.Point, Decl(invalidNestedModules.ts, 23, 18))
+>Point : Symbol(Point, Decl(invalidNestedModules.ts, 23, 18))
     }
 }
 

--- a/tests/baselines/reference/mergedClassWithNamespacePrototype.symbols
+++ b/tests/baselines/reference/mergedClassWithNamespacePrototype.symbols
@@ -7,7 +7,7 @@ declare namespace Foo {
 >Foo : Symbol(Foo, Decl(a.d.ts, 0, 0), Decl(b.ts, 0, 0))
 
     namespace prototype {
->prototype : Symbol(Foo.prototype, Decl(b.ts, 0, 23))
+>prototype : Symbol(prototype, Decl(b.ts, 0, 23))
 
         function f(): void;
 >f : Symbol(f, Decl(b.ts, 1, 25))

--- a/tests/baselines/reference/mergedDeclarationExports.types
+++ b/tests/baselines/reference/mergedDeclarationExports.types
@@ -26,7 +26,7 @@ interface c {}
 >c : c
 
 export interface c {}
->c : c
+>c : import("tests/cases/compiler/mergedDeclarationExports").c
 
 // both types (class is also value, but that doesn't matter)
 interface d {}

--- a/tests/baselines/reference/missingFunctionImplementation.symbols
+++ b/tests/baselines/reference/missingFunctionImplementation.symbols
@@ -97,7 +97,7 @@ namespace C8 {
 >C8 : Symbol(C8, Decl(missingFunctionImplementation.ts, 42, 1), Decl(missingFunctionImplementation.ts, 48, 1))
 
   export function m(a?, b?): void { }
->m : Symbol(C8.m, Decl(missingFunctionImplementation.ts, 49, 14))
+>m : Symbol(m, Decl(missingFunctionImplementation.ts, 49, 14))
 >a : Symbol(a, Decl(missingFunctionImplementation.ts, 50, 20))
 >b : Symbol(b, Decl(missingFunctionImplementation.ts, 50, 23))
 }
@@ -114,7 +114,7 @@ namespace C9 {
 >C9 : Symbol(C9, Decl(missingFunctionImplementation.ts, 51, 1), Decl(missingFunctionImplementation.ts, 56, 1))
 
   export function m(a): void;
->m : Symbol(C9.m, Decl(missingFunctionImplementation.ts, 57, 14))
+>m : Symbol(m, Decl(missingFunctionImplementation.ts, 57, 14))
 >a : Symbol(a, Decl(missingFunctionImplementation.ts, 58, 20))
 }
 

--- a/tests/baselines/reference/moduleAugmentationDuringSyntheticDefaultCheck.types
+++ b/tests/baselines/reference/moduleAugmentationDuringSyntheticDefaultCheck.types
@@ -6,9 +6,9 @@ import moment = require("moment-timezone");
 
 === tests/cases/compiler/node_modules/moment/index.d.ts ===
 declare function moment(): moment.Moment;
->moment : () => Moment
+>moment : () => moment.Moment
 >moment : any
->Moment : Moment
+>Moment : moment.Moment
 
 declare namespace moment {
 >moment : () => Moment
@@ -22,7 +22,7 @@ declare namespace moment {
   }
 }
 export = moment;
->moment : () => Moment
+>moment : () => moment.Moment
 
 === tests/cases/compiler/node_modules/moment-timezone/index.d.ts ===
 import * as moment from 'moment';

--- a/tests/baselines/reference/moduleAugmentationImportsAndExports6.types
+++ b/tests/baselines/reference/moduleAugmentationImportsAndExports6.types
@@ -90,18 +90,18 @@ let b = a.foo().n;
 let c = a.bar().a;
 >c : number
 >a.bar().a : number
->a.bar() : N.Ifc
->a.bar : () => N.Ifc
+>a.bar() : import("tests/cases/compiler/f3").N.Ifc
+>a.bar : () => import("tests/cases/compiler/f3").N.Ifc
 >a : A
->bar : () => N.Ifc
+>bar : () => import("tests/cases/compiler/f3").N.Ifc
 >a : number
 
 let d = a.baz().b;
 >d : number
 >a.baz().b : number
->a.baz() : N.Cls
->a.baz : () => N.Cls
+>a.baz() : import("tests/cases/compiler/f3").N.Cls
+>a.baz : () => import("tests/cases/compiler/f3").N.Cls
 >a : A
->baz : () => N.Cls
+>baz : () => import("tests/cases/compiler/f3").N.Cls
 >b : number
 

--- a/tests/baselines/reference/privacyGloImport.symbols
+++ b/tests/baselines/reference/privacyGloImport.symbols
@@ -3,7 +3,7 @@ module m1 {
 >m1 : Symbol(m1, Decl(privacyGloImport.ts, 0, 0))
 
     export module m1_M1_public {
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyGloImport.ts, 0, 11))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyGloImport.ts, 0, 11))
 
         export class c1 {
 >c1 : Symbol(c1, Decl(privacyGloImport.ts, 1, 32))
@@ -62,7 +62,7 @@ module m1 {
 
     import m1_im1_private = m1_M1_public;
 >m1_im1_private : Symbol(m1_im1_private, Decl(privacyGloImport.ts, 19, 5))
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyGloImport.ts, 0, 11))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyGloImport.ts, 0, 11))
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : Symbol(m1_im1_private_v1_public, Decl(privacyGloImport.ts, 38, 14))
@@ -187,7 +187,7 @@ module m1 {
 
     export import m1_im1_public = m1_M1_public;
 >m1_im1_public : Symbol(m1_im1_public, Decl(privacyGloImport.ts, 56, 56))
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyGloImport.ts, 0, 11))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyGloImport.ts, 0, 11))
 
     export import m1_im2_public = m1_M2_private;
 >m1_im2_public : Symbol(m1_im2_public, Decl(privacyGloImport.ts, 78, 47))

--- a/tests/baselines/reference/privacyGloImport.types
+++ b/tests/baselines/reference/privacyGloImport.types
@@ -3,7 +3,7 @@ module m1 {
 >m1 : typeof m1
 
     export module m1_M1_public {
->m1_M1_public : typeof m1_im1_private
+>m1_M1_public : typeof m1_M1_public
 
         export class c1 {
 >c1 : c1
@@ -63,59 +63,59 @@ module m1 {
     //}
 
     import m1_im1_private = m1_M1_public;
->m1_im1_private : typeof m1_im1_private
->m1_M1_public : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
+>m1_M1_public : typeof m1_M1_public
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v2_public = new m1_im1_private.c1();
 >m1_im1_private_v2_public : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v3_public = m1_im1_private.f1;
 >m1_im1_private_v3_public : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     export var m1_im1_private_v4_public = m1_im1_private.f1();
 >m1_im1_private_v4_public : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v1_private = m1_im1_private.c1;
 >m1_im1_private_v1_private : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v2_private = new m1_im1_private.c1();
 >m1_im1_private_v2_private : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v3_private = m1_im1_private.f1;
 >m1_im1_private_v3_private : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v4_private = m1_im1_private.f1();
 >m1_im1_private_v4_private : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
 
@@ -196,8 +196,8 @@ module m1 {
     //var m1_im4_private_v4_private = m1_im4_private.f1();
 
     export import m1_im1_public = m1_M1_public;
->m1_im1_public : typeof m1_im1_private
->m1_M1_public : typeof m1_im1_private
+>m1_im1_public : typeof m1_M1_public
+>m1_M1_public : typeof m1_M1_public
 
     export import m1_im2_public = m1_M2_private;
 >m1_im2_public : typeof m1_M2_private

--- a/tests/baselines/reference/privacyGloImportParseErrors.symbols
+++ b/tests/baselines/reference/privacyGloImportParseErrors.symbols
@@ -3,7 +3,7 @@ module m1 {
 >m1 : Symbol(m1, Decl(privacyGloImportParseErrors.ts, 0, 0))
 
     export module m1_M1_public {
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyGloImportParseErrors.ts, 0, 11))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyGloImportParseErrors.ts, 0, 11))
 
         export class c1 {
 >c1 : Symbol(c1, Decl(privacyGloImportParseErrors.ts, 1, 32))
@@ -82,7 +82,7 @@ module m1 {
 
     import m1_im1_private = m1_M1_public;
 >m1_im1_private : Symbol(m1_im1_private, Decl(privacyGloImportParseErrors.ts, 35, 5))
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyGloImportParseErrors.ts, 0, 11))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyGloImportParseErrors.ts, 0, 11))
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : Symbol(m1_im1_private_v1_public, Decl(privacyGloImportParseErrors.ts, 38, 14))
@@ -257,7 +257,7 @@ module m1 {
 
     export import m1_im1_public = m1_M1_public;
 >m1_im1_public : Symbol(m1_im1_public, Decl(privacyGloImportParseErrors.ts, 76, 56))
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyGloImportParseErrors.ts, 0, 11))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyGloImportParseErrors.ts, 0, 11))
 
     export import m1_im2_public = m1_M2_private;
 >m1_im2_public : Symbol(m1_im2_public, Decl(privacyGloImportParseErrors.ts, 78, 47))

--- a/tests/baselines/reference/privacyGloImportParseErrors.types
+++ b/tests/baselines/reference/privacyGloImportParseErrors.types
@@ -3,7 +3,7 @@ module m1 {
 >m1 : typeof m1
 
     export module m1_M1_public {
->m1_M1_public : typeof m1_im1_private
+>m1_M1_public : typeof m1_M1_public
 
         export class c1 {
 >c1 : c1
@@ -83,59 +83,59 @@ module m1 {
     }
 
     import m1_im1_private = m1_M1_public;
->m1_im1_private : typeof m1_im1_private
->m1_M1_public : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
+>m1_M1_public : typeof m1_M1_public
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v2_public = new m1_im1_private.c1();
 >m1_im1_private_v2_public : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v3_public = m1_im1_private.f1;
 >m1_im1_private_v3_public : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     export var m1_im1_private_v4_public = m1_im1_private.f1();
 >m1_im1_private_v4_public : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v1_private = m1_im1_private.c1;
 >m1_im1_private_v1_private : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v2_private = new m1_im1_private.c1();
 >m1_im1_private_v2_private : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v3_private = m1_im1_private.f1;
 >m1_im1_private_v3_private : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v4_private = m1_im1_private.f1();
 >m1_im1_private_v4_private : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
 
@@ -306,8 +306,8 @@ module m1 {
 >f1 : any
 
     export import m1_im1_public = m1_M1_public;
->m1_im1_public : typeof m1_im1_private
->m1_M1_public : typeof m1_im1_private
+>m1_im1_public : typeof m1_M1_public
+>m1_M1_public : typeof m1_M1_public
 
     export import m1_im2_public = m1_M2_private;
 >m1_im2_public : typeof m1_M2_private

--- a/tests/baselines/reference/privacyImport.symbols
+++ b/tests/baselines/reference/privacyImport.symbols
@@ -3,7 +3,7 @@ export module m1 {
 >m1 : Symbol(m1, Decl(privacyImport.ts, 0, 0))
 
     export module m1_M1_public {
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyImport.ts, 0, 18))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyImport.ts, 0, 18))
 
         export class c1 {
 >c1 : Symbol(c1, Decl(privacyImport.ts, 1, 32))
@@ -62,7 +62,7 @@ export module m1 {
 
     import m1_im1_private = m1_M1_public;
 >m1_im1_private : Symbol(m1_im1_private, Decl(privacyImport.ts, 19, 5))
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyImport.ts, 0, 18))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyImport.ts, 0, 18))
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : Symbol(m1_im1_private_v1_public, Decl(privacyImport.ts, 38, 14))
@@ -187,7 +187,7 @@ export module m1 {
 
     export import m1_im1_public = m1_M1_public;
 >m1_im1_public : Symbol(m1_im1_public, Decl(privacyImport.ts, 56, 56))
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyImport.ts, 0, 18))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyImport.ts, 0, 18))
 
     export import m1_im2_public = m1_M2_private;
 >m1_im2_public : Symbol(m1_im2_public, Decl(privacyImport.ts, 78, 47))
@@ -201,7 +201,7 @@ module m2 {
 >m2 : Symbol(m2, Decl(privacyImport.ts, 82, 1), Decl(privacyImport.ts, 249, 46))
 
     export module m2_M1_public {
->m2_M1_public : Symbol(m1_im1_private, Decl(privacyImport.ts, 84, 11))
+>m2_M1_public : Symbol(m2_M1_public, Decl(privacyImport.ts, 84, 11))
 
         export class c1 {
 >c1 : Symbol(c1, Decl(privacyImport.ts, 85, 32))
@@ -260,7 +260,7 @@ module m2 {
 
     import m1_im1_private = m2_M1_public;
 >m1_im1_private : Symbol(m1_im1_private, Decl(privacyImport.ts, 103, 5))
->m2_M1_public : Symbol(m1_im1_private, Decl(privacyImport.ts, 84, 11))
+>m2_M1_public : Symbol(m2_M1_public, Decl(privacyImport.ts, 84, 11))
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : Symbol(m1_im1_private_v1_public, Decl(privacyImport.ts, 122, 14))
@@ -386,7 +386,7 @@ module m2 {
     // Parse error to export module
     export import m1_im1_public = m2_M1_public;
 >m1_im1_public : Symbol(m1_im1_public, Decl(privacyImport.ts, 140, 56))
->m2_M1_public : Symbol(m1_im1_private, Decl(privacyImport.ts, 84, 11))
+>m2_M1_public : Symbol(m2_M1_public, Decl(privacyImport.ts, 84, 11))
 
     export import m1_im2_public = m2_M2_private;
 >m1_im2_public : Symbol(m1_im2_public, Decl(privacyImport.ts, 163, 47))
@@ -397,7 +397,7 @@ module m2 {
 }
 
 export module glo_M1_public {
->glo_M1_public : Symbol(glo_im1_private, Decl(privacyImport.ts, 167, 1))
+>glo_M1_public : Symbol(glo_M1_public, Decl(privacyImport.ts, 167, 1))
 
     export class c1 {
 >c1 : Symbol(c1, Decl(privacyImport.ts, 169, 29))
@@ -426,7 +426,7 @@ export module glo_M1_public {
 //}
 
 export module glo_M3_private {
->glo_M3_private : Symbol(glo_im3_private, Decl(privacyImport.ts, 177, 1))
+>glo_M3_private : Symbol(glo_M3_private, Decl(privacyImport.ts, 177, 1))
 
     export class c1 {
 >c1 : Symbol(c1, Decl(privacyImport.ts, 187, 30))
@@ -457,7 +457,7 @@ export module glo_M3_private {
 
 import glo_im1_private = glo_M1_public;
 >glo_im1_private : Symbol(glo_im1_private, Decl(privacyImport.ts, 195, 1))
->glo_M1_public : Symbol(glo_im1_private, Decl(privacyImport.ts, 167, 1))
+>glo_M1_public : Symbol(glo_M1_public, Decl(privacyImport.ts, 167, 1))
 
 export var glo_im1_private_v1_public = glo_im1_private.c1;
 >glo_im1_private_v1_public : Symbol(glo_im1_private_v1_public, Decl(privacyImport.ts, 207, 10))
@@ -520,7 +520,7 @@ var glo_im1_private_v4_private = glo_im1_private.f1();
 
 import glo_im3_private = glo_M3_private;
 >glo_im3_private : Symbol(glo_im3_private, Decl(privacyImport.ts, 214, 54))
->glo_M3_private : Symbol(glo_im3_private, Decl(privacyImport.ts, 177, 1))
+>glo_M3_private : Symbol(glo_M3_private, Decl(privacyImport.ts, 177, 1))
 
 export var glo_im3_private_v1_public = glo_im3_private.c1;
 >glo_im3_private_v1_public : Symbol(glo_im3_private_v1_public, Decl(privacyImport.ts, 228, 10))
@@ -583,11 +583,11 @@ var glo_im3_private_v4_private = glo_im3_private.f1();
 // Parse error to export module
 export import glo_im1_public = glo_M1_public;
 >glo_im1_public : Symbol(glo_im1_public, Decl(privacyImport.ts, 235, 54))
->glo_M1_public : Symbol(glo_im1_private, Decl(privacyImport.ts, 167, 1))
+>glo_M1_public : Symbol(glo_M1_public, Decl(privacyImport.ts, 167, 1))
 
 export import glo_im2_public = glo_M3_private;
 >glo_im2_public : Symbol(glo_im2_public, Decl(privacyImport.ts, 248, 45))
->glo_M3_private : Symbol(glo_im3_private, Decl(privacyImport.ts, 177, 1))
+>glo_M3_private : Symbol(glo_M3_private, Decl(privacyImport.ts, 177, 1))
 
 //export import glo_im3_public = require("glo_M2_public");
 //export import glo_im4_public = require("glo_M4_private");

--- a/tests/baselines/reference/privacyImport.types
+++ b/tests/baselines/reference/privacyImport.types
@@ -3,7 +3,7 @@ export module m1 {
 >m1 : typeof m1
 
     export module m1_M1_public {
->m1_M1_public : typeof m1_im1_private
+>m1_M1_public : typeof m1_M1_public
 
         export class c1 {
 >c1 : c1
@@ -63,59 +63,59 @@ export module m1 {
     //}
 
     import m1_im1_private = m1_M1_public;
->m1_im1_private : typeof m1_im1_private
->m1_M1_public : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
+>m1_M1_public : typeof m1_M1_public
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v2_public = new m1_im1_private.c1();
 >m1_im1_private_v2_public : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v3_public = m1_im1_private.f1;
 >m1_im1_private_v3_public : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     export var m1_im1_private_v4_public = m1_im1_private.f1();
 >m1_im1_private_v4_public : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v1_private = m1_im1_private.c1;
 >m1_im1_private_v1_private : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v2_private = new m1_im1_private.c1();
 >m1_im1_private_v2_private : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v3_private = m1_im1_private.f1;
 >m1_im1_private_v3_private : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v4_private = m1_im1_private.f1();
 >m1_im1_private_v4_private : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
 
@@ -196,8 +196,8 @@ export module m1 {
     //var m1_im4_private_v4_private = m1_im4_private.f1();
 
     export import m1_im1_public = m1_M1_public;
->m1_im1_public : typeof m1_im1_private
->m1_M1_public : typeof m1_im1_private
+>m1_im1_public : typeof m1_M1_public
+>m1_M1_public : typeof m1_M1_public
 
     export import m1_im2_public = m1_M2_private;
 >m1_im2_public : typeof m1_M2_private
@@ -211,7 +211,7 @@ module m2 {
 >m2 : typeof m2
 
     export module m2_M1_public {
->m2_M1_public : typeof m1_im1_private
+>m2_M1_public : typeof m2_M1_public
 
         export class c1 {
 >c1 : c1
@@ -271,59 +271,59 @@ module m2 {
     //}
 
     import m1_im1_private = m2_M1_public;
->m1_im1_private : typeof m1_im1_private
->m2_M1_public : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
+>m2_M1_public : typeof m2_M1_public
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v2_public = new m1_im1_private.c1();
 >m1_im1_private_v2_public : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v3_public = m1_im1_private.f1;
 >m1_im1_private_v3_public : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >f1 : () => m1_im1_private.c1
 
     export var m1_im1_private_v4_public = m1_im1_private.f1();
 >m1_im1_private_v4_public : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v1_private = m1_im1_private.c1;
 >m1_im1_private_v1_private : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v2_private = new m1_im1_private.c1();
 >m1_im1_private_v2_private : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v3_private = m1_im1_private.f1;
 >m1_im1_private_v3_private : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v4_private = m1_im1_private.f1();
 >m1_im1_private_v4_private : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >f1 : () => m1_im1_private.c1
 
 
@@ -405,8 +405,8 @@ module m2 {
 
     // Parse error to export module
     export import m1_im1_public = m2_M1_public;
->m1_im1_public : typeof m1_im1_private
->m2_M1_public : typeof m1_im1_private
+>m1_im1_public : typeof m2_M1_public
+>m2_M1_public : typeof m2_M1_public
 
     export import m1_im2_public = m2_M2_private;
 >m1_im2_public : typeof m2_M2_private
@@ -417,7 +417,7 @@ module m2 {
 }
 
 export module glo_M1_public {
->glo_M1_public : typeof glo_im1_private
+>glo_M1_public : typeof glo_M1_public
 
     export class c1 {
 >c1 : c1
@@ -447,7 +447,7 @@ export module glo_M1_public {
 //}
 
 export module glo_M3_private {
->glo_M3_private : typeof glo_im3_private
+>glo_M3_private : typeof glo_M3_private
 
     export class c1 {
 >c1 : c1
@@ -478,59 +478,59 @@ export module glo_M3_private {
 
 
 import glo_im1_private = glo_M1_public;
->glo_im1_private : typeof glo_im1_private
->glo_M1_public : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
+>glo_M1_public : typeof glo_M1_public
 
 export var glo_im1_private_v1_public = glo_im1_private.c1;
 >glo_im1_private_v1_public : typeof glo_im1_private.c1
 >glo_im1_private.c1 : typeof glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >c1 : typeof glo_im1_private.c1
 
 export var glo_im1_private_v2_public = new glo_im1_private.c1();
 >glo_im1_private_v2_public : glo_im1_private.c1
 >new glo_im1_private.c1() : glo_im1_private.c1
 >glo_im1_private.c1 : typeof glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >c1 : typeof glo_im1_private.c1
 
 export var glo_im1_private_v3_public = glo_im1_private.f1;
 >glo_im1_private_v3_public : () => glo_im1_private.c1
 >glo_im1_private.f1 : () => glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >f1 : () => glo_im1_private.c1
 
 export var glo_im1_private_v4_public = glo_im1_private.f1();
 >glo_im1_private_v4_public : glo_im1_private.c1
 >glo_im1_private.f1() : glo_im1_private.c1
 >glo_im1_private.f1 : () => glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >f1 : () => glo_im1_private.c1
 
 var glo_im1_private_v1_private = glo_im1_private.c1;
 >glo_im1_private_v1_private : typeof glo_im1_private.c1
 >glo_im1_private.c1 : typeof glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >c1 : typeof glo_im1_private.c1
 
 var glo_im1_private_v2_private = new glo_im1_private.c1();
 >glo_im1_private_v2_private : glo_im1_private.c1
 >new glo_im1_private.c1() : glo_im1_private.c1
 >glo_im1_private.c1 : typeof glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >c1 : typeof glo_im1_private.c1
 
 var glo_im1_private_v3_private = glo_im1_private.f1;
 >glo_im1_private_v3_private : () => glo_im1_private.c1
 >glo_im1_private.f1 : () => glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >f1 : () => glo_im1_private.c1
 
 var glo_im1_private_v4_private = glo_im1_private.f1();
 >glo_im1_private_v4_private : glo_im1_private.c1
 >glo_im1_private.f1() : glo_im1_private.c1
 >glo_im1_private.f1 : () => glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >f1 : () => glo_im1_private.c1
 
 
@@ -545,59 +545,59 @@ var glo_im1_private_v4_private = glo_im1_private.f1();
 //var glo_im2_private_v4_private = glo_im2_private.f1();
 
 import glo_im3_private = glo_M3_private;
->glo_im3_private : typeof glo_im3_private
->glo_M3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
+>glo_M3_private : typeof glo_M3_private
 
 export var glo_im3_private_v1_public = glo_im3_private.c1;
 >glo_im3_private_v1_public : typeof glo_im3_private.c1
 >glo_im3_private.c1 : typeof glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >c1 : typeof glo_im3_private.c1
 
 export var glo_im3_private_v2_public = new glo_im3_private.c1();
 >glo_im3_private_v2_public : glo_im3_private.c1
 >new glo_im3_private.c1() : glo_im3_private.c1
 >glo_im3_private.c1 : typeof glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >c1 : typeof glo_im3_private.c1
 
 export var glo_im3_private_v3_public = glo_im3_private.f1;
 >glo_im3_private_v3_public : () => glo_im3_private.c1
 >glo_im3_private.f1 : () => glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >f1 : () => glo_im3_private.c1
 
 export var glo_im3_private_v4_public = glo_im3_private.f1();
 >glo_im3_private_v4_public : glo_im3_private.c1
 >glo_im3_private.f1() : glo_im3_private.c1
 >glo_im3_private.f1 : () => glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >f1 : () => glo_im3_private.c1
 
 var glo_im3_private_v1_private = glo_im3_private.c1;
 >glo_im3_private_v1_private : typeof glo_im3_private.c1
 >glo_im3_private.c1 : typeof glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >c1 : typeof glo_im3_private.c1
 
 var glo_im3_private_v2_private = new glo_im3_private.c1();
 >glo_im3_private_v2_private : glo_im3_private.c1
 >new glo_im3_private.c1() : glo_im3_private.c1
 >glo_im3_private.c1 : typeof glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >c1 : typeof glo_im3_private.c1
 
 var glo_im3_private_v3_private = glo_im3_private.f1;
 >glo_im3_private_v3_private : () => glo_im3_private.c1
 >glo_im3_private.f1 : () => glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >f1 : () => glo_im3_private.c1
 
 var glo_im3_private_v4_private = glo_im3_private.f1();
 >glo_im3_private_v4_private : glo_im3_private.c1
 >glo_im3_private.f1() : glo_im3_private.c1
 >glo_im3_private.f1 : () => glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >f1 : () => glo_im3_private.c1
 
 //import glo_im4_private = require("glo_M4_private");
@@ -612,12 +612,12 @@ var glo_im3_private_v4_private = glo_im3_private.f1();
 
 // Parse error to export module
 export import glo_im1_public = glo_M1_public;
->glo_im1_public : typeof glo_im1_private
->glo_M1_public : typeof glo_im1_private
+>glo_im1_public : typeof glo_M1_public
+>glo_M1_public : typeof glo_M1_public
 
 export import glo_im2_public = glo_M3_private;
->glo_im2_public : typeof glo_im3_private
->glo_M3_private : typeof glo_im3_private
+>glo_im2_public : typeof glo_M3_private
+>glo_M3_private : typeof glo_M3_private
 
 //export import glo_im3_public = require("glo_M2_public");
 //export import glo_im4_public = require("glo_M4_private");

--- a/tests/baselines/reference/privacyImportParseErrors.symbols
+++ b/tests/baselines/reference/privacyImportParseErrors.symbols
@@ -3,7 +3,7 @@ export module m1 {
 >m1 : Symbol(m1, Decl(privacyImportParseErrors.ts, 0, 0))
 
     export module m1_M1_public {
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyImportParseErrors.ts, 0, 18))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyImportParseErrors.ts, 0, 18))
 
         export class c1 {
 >c1 : Symbol(c1, Decl(privacyImportParseErrors.ts, 1, 32))
@@ -82,7 +82,7 @@ export module m1 {
 
     import m1_im1_private = m1_M1_public;
 >m1_im1_private : Symbol(m1_im1_private, Decl(privacyImportParseErrors.ts, 35, 5))
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyImportParseErrors.ts, 0, 18))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyImportParseErrors.ts, 0, 18))
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : Symbol(m1_im1_private_v1_public, Decl(privacyImportParseErrors.ts, 38, 14))
@@ -257,7 +257,7 @@ export module m1 {
 
     export import m1_im1_public = m1_M1_public;
 >m1_im1_public : Symbol(m1_im1_public, Decl(privacyImportParseErrors.ts, 76, 56))
->m1_M1_public : Symbol(m1_im1_private, Decl(privacyImportParseErrors.ts, 0, 18))
+>m1_M1_public : Symbol(m1_M1_public, Decl(privacyImportParseErrors.ts, 0, 18))
 
     export import m1_im2_public = m1_M2_private;
 >m1_im2_public : Symbol(m1_im2_public, Decl(privacyImportParseErrors.ts, 78, 47))
@@ -274,7 +274,7 @@ module m2 {
 >m2 : Symbol(m2, Decl(privacyImportParseErrors.ts, 82, 1), Decl(privacyImportParseErrors.ts, 337, 1))
 
     export module m2_M1_public {
->m2_M1_public : Symbol(m1_im1_private, Decl(privacyImportParseErrors.ts, 84, 11))
+>m2_M1_public : Symbol(m2_M1_public, Decl(privacyImportParseErrors.ts, 84, 11))
 
         export class c1 {
 >c1 : Symbol(c1, Decl(privacyImportParseErrors.ts, 85, 32))
@@ -353,7 +353,7 @@ module m2 {
 
     import m1_im1_private = m2_M1_public;
 >m1_im1_private : Symbol(m1_im1_private, Decl(privacyImportParseErrors.ts, 119, 5))
->m2_M1_public : Symbol(m1_im1_private, Decl(privacyImportParseErrors.ts, 84, 11))
+>m2_M1_public : Symbol(m2_M1_public, Decl(privacyImportParseErrors.ts, 84, 11))
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : Symbol(m1_im1_private_v1_public, Decl(privacyImportParseErrors.ts, 122, 14))
@@ -529,7 +529,7 @@ module m2 {
     // Parse error to export module
     export import m1_im1_public = m2_M1_public;
 >m1_im1_public : Symbol(m1_im1_public, Decl(privacyImportParseErrors.ts, 160, 56))
->m2_M1_public : Symbol(m1_im1_private, Decl(privacyImportParseErrors.ts, 84, 11))
+>m2_M1_public : Symbol(m2_M1_public, Decl(privacyImportParseErrors.ts, 84, 11))
 
     export import m1_im2_public = m2_M2_private;
 >m1_im2_public : Symbol(m1_im2_public, Decl(privacyImportParseErrors.ts, 163, 47))
@@ -543,7 +543,7 @@ module m2 {
 }
 
 export module glo_M1_public {
->glo_M1_public : Symbol(glo_im1_private, Decl(privacyImportParseErrors.ts, 167, 1))
+>glo_M1_public : Symbol(glo_M1_public, Decl(privacyImportParseErrors.ts, 167, 1))
 
     export class c1 {
 >c1 : Symbol(c1, Decl(privacyImportParseErrors.ts, 169, 29))
@@ -582,7 +582,7 @@ export declare module "glo_M2_public" {
 }
 
 export module glo_M3_private {
->glo_M3_private : Symbol(glo_im3_private, Decl(privacyImportParseErrors.ts, 185, 1))
+>glo_M3_private : Symbol(glo_M3_private, Decl(privacyImportParseErrors.ts, 185, 1))
 
     export class c1 {
 >c1 : Symbol(c1, Decl(privacyImportParseErrors.ts, 187, 30))
@@ -623,7 +623,7 @@ export declare module "glo_M4_private" {
 
 import glo_im1_private = glo_M1_public;
 >glo_im1_private : Symbol(glo_im1_private, Decl(privacyImportParseErrors.ts, 203, 1))
->glo_M1_public : Symbol(glo_im1_private, Decl(privacyImportParseErrors.ts, 167, 1))
+>glo_M1_public : Symbol(glo_M1_public, Decl(privacyImportParseErrors.ts, 167, 1))
 
 export var glo_im1_private_v1_public = glo_im1_private.c1;
 >glo_im1_private_v1_public : Symbol(glo_im1_private_v1_public, Decl(privacyImportParseErrors.ts, 207, 10))
@@ -711,7 +711,7 @@ var glo_im2_private_v4_private = glo_im2_private.f1();
 
 import glo_im3_private = glo_M3_private;
 >glo_im3_private : Symbol(glo_im3_private, Decl(privacyImportParseErrors.ts, 225, 54))
->glo_M3_private : Symbol(glo_im3_private, Decl(privacyImportParseErrors.ts, 185, 1))
+>glo_M3_private : Symbol(glo_M3_private, Decl(privacyImportParseErrors.ts, 185, 1))
 
 export var glo_im3_private_v1_public = glo_im3_private.c1;
 >glo_im3_private_v1_public : Symbol(glo_im3_private_v1_public, Decl(privacyImportParseErrors.ts, 228, 10))
@@ -799,11 +799,11 @@ var glo_im4_private_v4_private = glo_im4_private.f1();
 // Parse error to export module
 export import glo_im1_public = glo_M1_public;
 >glo_im1_public : Symbol(glo_im1_public, Decl(privacyImportParseErrors.ts, 245, 54))
->glo_M1_public : Symbol(glo_im1_private, Decl(privacyImportParseErrors.ts, 167, 1))
+>glo_M1_public : Symbol(glo_M1_public, Decl(privacyImportParseErrors.ts, 167, 1))
 
 export import glo_im2_public = glo_M3_private;
 >glo_im2_public : Symbol(glo_im2_public, Decl(privacyImportParseErrors.ts, 248, 45))
->glo_M3_private : Symbol(glo_im3_private, Decl(privacyImportParseErrors.ts, 185, 1))
+>glo_M3_private : Symbol(glo_M3_private, Decl(privacyImportParseErrors.ts, 185, 1))
 
 export import glo_im3_public = require("glo_M2_public");
 >glo_im3_public : Symbol(glo_im3_public, Decl(privacyImportParseErrors.ts, 249, 46))

--- a/tests/baselines/reference/privacyImportParseErrors.types
+++ b/tests/baselines/reference/privacyImportParseErrors.types
@@ -3,7 +3,7 @@ export module m1 {
 >m1 : typeof m1
 
     export module m1_M1_public {
->m1_M1_public : typeof m1_im1_private
+>m1_M1_public : typeof m1_M1_public
 
         export class c1 {
 >c1 : c1
@@ -83,59 +83,59 @@ export module m1 {
     }
 
     import m1_im1_private = m1_M1_public;
->m1_im1_private : typeof m1_im1_private
->m1_M1_public : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
+>m1_M1_public : typeof m1_M1_public
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v2_public = new m1_im1_private.c1();
 >m1_im1_private_v2_public : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v3_public = m1_im1_private.f1;
 >m1_im1_private_v3_public : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     export var m1_im1_private_v4_public = m1_im1_private.f1();
 >m1_im1_private_v4_public : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v1_private = m1_im1_private.c1;
 >m1_im1_private_v1_private : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v2_private = new m1_im1_private.c1();
 >m1_im1_private_v2_private : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v3_private = m1_im1_private.f1;
 >m1_im1_private_v3_private : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v4_private = m1_im1_private.f1();
 >m1_im1_private_v4_private : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m1_M1_public
 >f1 : () => m1_im1_private.c1
 
 
@@ -306,8 +306,8 @@ export module m1 {
 >f1 : any
 
     export import m1_im1_public = m1_M1_public;
->m1_im1_public : typeof m1_im1_private
->m1_M1_public : typeof m1_im1_private
+>m1_im1_public : typeof m1_M1_public
+>m1_M1_public : typeof m1_M1_public
 
     export import m1_im2_public = m1_M2_private;
 >m1_im2_public : typeof m1_M2_private
@@ -324,7 +324,7 @@ module m2 {
 >m2 : typeof m2
 
     export module m2_M1_public {
->m2_M1_public : typeof m1_im1_private
+>m2_M1_public : typeof m2_M1_public
 
         export class c1 {
 >c1 : c1
@@ -404,59 +404,59 @@ module m2 {
     }
 
     import m1_im1_private = m2_M1_public;
->m1_im1_private : typeof m1_im1_private
->m2_M1_public : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
+>m2_M1_public : typeof m2_M1_public
 
     export var m1_im1_private_v1_public = m1_im1_private.c1;
 >m1_im1_private_v1_public : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v2_public = new m1_im1_private.c1();
 >m1_im1_private_v2_public : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >c1 : typeof m1_im1_private.c1
 
     export var m1_im1_private_v3_public = m1_im1_private.f1;
 >m1_im1_private_v3_public : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >f1 : () => m1_im1_private.c1
 
     export var m1_im1_private_v4_public = m1_im1_private.f1();
 >m1_im1_private_v4_public : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v1_private = m1_im1_private.c1;
 >m1_im1_private_v1_private : typeof m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v2_private = new m1_im1_private.c1();
 >m1_im1_private_v2_private : m1_im1_private.c1
 >new m1_im1_private.c1() : m1_im1_private.c1
 >m1_im1_private.c1 : typeof m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >c1 : typeof m1_im1_private.c1
 
     var m1_im1_private_v3_private = m1_im1_private.f1;
 >m1_im1_private_v3_private : () => m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >f1 : () => m1_im1_private.c1
 
     var m1_im1_private_v4_private = m1_im1_private.f1();
 >m1_im1_private_v4_private : m1_im1_private.c1
 >m1_im1_private.f1() : m1_im1_private.c1
 >m1_im1_private.f1 : () => m1_im1_private.c1
->m1_im1_private : typeof m1_im1_private
+>m1_im1_private : typeof m2_M1_public
 >f1 : () => m1_im1_private.c1
 
 
@@ -628,8 +628,8 @@ module m2 {
 
     // Parse error to export module
     export import m1_im1_public = m2_M1_public;
->m1_im1_public : typeof m1_im1_private
->m2_M1_public : typeof m1_im1_private
+>m1_im1_public : typeof m2_M1_public
+>m2_M1_public : typeof m2_M1_public
 
     export import m1_im2_public = m2_M2_private;
 >m1_im2_public : typeof m2_M2_private
@@ -643,7 +643,7 @@ module m2 {
 }
 
 export module glo_M1_public {
->glo_M1_public : typeof glo_im1_private
+>glo_M1_public : typeof glo_M1_public
 
     export class c1 {
 >c1 : c1
@@ -683,7 +683,7 @@ export declare module "glo_M2_public" {
 }
 
 export module glo_M3_private {
->glo_M3_private : typeof glo_im3_private
+>glo_M3_private : typeof glo_M3_private
 
     export class c1 {
 >c1 : c1
@@ -724,59 +724,59 @@ export declare module "glo_M4_private" {
 
 
 import glo_im1_private = glo_M1_public;
->glo_im1_private : typeof glo_im1_private
->glo_M1_public : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
+>glo_M1_public : typeof glo_M1_public
 
 export var glo_im1_private_v1_public = glo_im1_private.c1;
 >glo_im1_private_v1_public : typeof glo_im1_private.c1
 >glo_im1_private.c1 : typeof glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >c1 : typeof glo_im1_private.c1
 
 export var glo_im1_private_v2_public = new glo_im1_private.c1();
 >glo_im1_private_v2_public : glo_im1_private.c1
 >new glo_im1_private.c1() : glo_im1_private.c1
 >glo_im1_private.c1 : typeof glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >c1 : typeof glo_im1_private.c1
 
 export var glo_im1_private_v3_public = glo_im1_private.f1;
 >glo_im1_private_v3_public : () => glo_im1_private.c1
 >glo_im1_private.f1 : () => glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >f1 : () => glo_im1_private.c1
 
 export var glo_im1_private_v4_public = glo_im1_private.f1();
 >glo_im1_private_v4_public : glo_im1_private.c1
 >glo_im1_private.f1() : glo_im1_private.c1
 >glo_im1_private.f1 : () => glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >f1 : () => glo_im1_private.c1
 
 var glo_im1_private_v1_private = glo_im1_private.c1;
 >glo_im1_private_v1_private : typeof glo_im1_private.c1
 >glo_im1_private.c1 : typeof glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >c1 : typeof glo_im1_private.c1
 
 var glo_im1_private_v2_private = new glo_im1_private.c1();
 >glo_im1_private_v2_private : glo_im1_private.c1
 >new glo_im1_private.c1() : glo_im1_private.c1
 >glo_im1_private.c1 : typeof glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >c1 : typeof glo_im1_private.c1
 
 var glo_im1_private_v3_private = glo_im1_private.f1;
 >glo_im1_private_v3_private : () => glo_im1_private.c1
 >glo_im1_private.f1 : () => glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >f1 : () => glo_im1_private.c1
 
 var glo_im1_private_v4_private = glo_im1_private.f1();
 >glo_im1_private_v4_private : glo_im1_private.c1
 >glo_im1_private.f1() : glo_im1_private.c1
 >glo_im1_private.f1 : () => glo_im1_private.c1
->glo_im1_private : typeof glo_im1_private
+>glo_im1_private : typeof glo_M1_public
 >f1 : () => glo_im1_private.c1
 
 
@@ -836,59 +836,59 @@ var glo_im2_private_v4_private = glo_im2_private.f1();
 >f1 : any
 
 import glo_im3_private = glo_M3_private;
->glo_im3_private : typeof glo_im3_private
->glo_M3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
+>glo_M3_private : typeof glo_M3_private
 
 export var glo_im3_private_v1_public = glo_im3_private.c1;
 >glo_im3_private_v1_public : typeof glo_im3_private.c1
 >glo_im3_private.c1 : typeof glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >c1 : typeof glo_im3_private.c1
 
 export var glo_im3_private_v2_public = new glo_im3_private.c1();
 >glo_im3_private_v2_public : glo_im3_private.c1
 >new glo_im3_private.c1() : glo_im3_private.c1
 >glo_im3_private.c1 : typeof glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >c1 : typeof glo_im3_private.c1
 
 export var glo_im3_private_v3_public = glo_im3_private.f1;
 >glo_im3_private_v3_public : () => glo_im3_private.c1
 >glo_im3_private.f1 : () => glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >f1 : () => glo_im3_private.c1
 
 export var glo_im3_private_v4_public = glo_im3_private.f1();
 >glo_im3_private_v4_public : glo_im3_private.c1
 >glo_im3_private.f1() : glo_im3_private.c1
 >glo_im3_private.f1 : () => glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >f1 : () => glo_im3_private.c1
 
 var glo_im3_private_v1_private = glo_im3_private.c1;
 >glo_im3_private_v1_private : typeof glo_im3_private.c1
 >glo_im3_private.c1 : typeof glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >c1 : typeof glo_im3_private.c1
 
 var glo_im3_private_v2_private = new glo_im3_private.c1();
 >glo_im3_private_v2_private : glo_im3_private.c1
 >new glo_im3_private.c1() : glo_im3_private.c1
 >glo_im3_private.c1 : typeof glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >c1 : typeof glo_im3_private.c1
 
 var glo_im3_private_v3_private = glo_im3_private.f1;
 >glo_im3_private_v3_private : () => glo_im3_private.c1
 >glo_im3_private.f1 : () => glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >f1 : () => glo_im3_private.c1
 
 var glo_im3_private_v4_private = glo_im3_private.f1();
 >glo_im3_private_v4_private : glo_im3_private.c1
 >glo_im3_private.f1() : glo_im3_private.c1
 >glo_im3_private.f1 : () => glo_im3_private.c1
->glo_im3_private : typeof glo_im3_private
+>glo_im3_private : typeof glo_M3_private
 >f1 : () => glo_im3_private.c1
 
 import glo_im4_private = require("glo_M4_private");
@@ -948,12 +948,12 @@ var glo_im4_private_v4_private = glo_im4_private.f1();
 
 // Parse error to export module
 export import glo_im1_public = glo_M1_public;
->glo_im1_public : typeof glo_im1_private
->glo_M1_public : typeof glo_im1_private
+>glo_im1_public : typeof glo_M1_public
+>glo_M1_public : typeof glo_M1_public
 
 export import glo_im2_public = glo_M3_private;
->glo_im2_public : typeof glo_im3_private
->glo_M3_private : typeof glo_im3_private
+>glo_im2_public : typeof glo_M3_private
+>glo_M3_private : typeof glo_M3_private
 
 export import glo_im3_public = require("glo_M2_public");
 >glo_im3_public : any

--- a/tests/baselines/reference/reservedNameOnInterfaceImport.symbols
+++ b/tests/baselines/reference/reservedNameOnInterfaceImport.symbols
@@ -3,12 +3,12 @@ declare module test {
 >test : Symbol(test, Decl(reservedNameOnInterfaceImport.ts, 0, 0))
 
     interface istring { }
->istring : Symbol(string, Decl(reservedNameOnInterfaceImport.ts, 0, 21))
+>istring : Symbol(istring, Decl(reservedNameOnInterfaceImport.ts, 0, 21))
 
     // Should error; 'test.istring' is a type, so this import conflicts with the 'string' type.
     import string = test.istring;
 >string : Symbol(string, Decl(reservedNameOnInterfaceImport.ts, 1, 25))
 >test : Symbol(test, Decl(reservedNameOnInterfaceImport.ts, 0, 0))
->istring : Symbol(string, Decl(reservedNameOnInterfaceImport.ts, 0, 21))
+>istring : Symbol(istring, Decl(reservedNameOnInterfaceImport.ts, 0, 21))
 }
 

--- a/tests/baselines/reference/reservedNameOnInterfaceImport.types
+++ b/tests/baselines/reference/reservedNameOnInterfaceImport.types
@@ -3,12 +3,12 @@ declare module test {
 >test : any
 
     interface istring { }
->istring : string
+>istring : istring
 
     // Should error; 'test.istring' is a type, so this import conflicts with the 'string' type.
     import string = test.istring;
 >string : any
 >test : any
->istring : string
+>istring : istring
 }
 

--- a/tests/baselines/reference/reservedNameOnModuleImportWithInterface.symbols
+++ b/tests/baselines/reference/reservedNameOnModuleImportWithInterface.symbols
@@ -3,14 +3,14 @@ declare module test {
 >test : Symbol(test, Decl(reservedNameOnModuleImportWithInterface.ts, 0, 0))
 
     interface mi_string { }
->mi_string : Symbol(string, Decl(reservedNameOnModuleImportWithInterface.ts, 0, 21), Decl(reservedNameOnModuleImportWithInterface.ts, 1, 27))
+>mi_string : Symbol(mi_string, Decl(reservedNameOnModuleImportWithInterface.ts, 0, 21), Decl(reservedNameOnModuleImportWithInterface.ts, 1, 27))
 
     module mi_string { }
->mi_string : Symbol(string, Decl(reservedNameOnModuleImportWithInterface.ts, 0, 21), Decl(reservedNameOnModuleImportWithInterface.ts, 1, 27))
+>mi_string : Symbol(mi_string, Decl(reservedNameOnModuleImportWithInterface.ts, 0, 21), Decl(reservedNameOnModuleImportWithInterface.ts, 1, 27))
 
     // Should error; imports both a type and a module, which means it conflicts with the 'string' type.
     import string = mi_string;
 >string : Symbol(string, Decl(reservedNameOnModuleImportWithInterface.ts, 2, 24))
->mi_string : Symbol(string, Decl(reservedNameOnModuleImportWithInterface.ts, 0, 21), Decl(reservedNameOnModuleImportWithInterface.ts, 1, 27))
+>mi_string : Symbol(mi_string, Decl(reservedNameOnModuleImportWithInterface.ts, 0, 21), Decl(reservedNameOnModuleImportWithInterface.ts, 1, 27))
 }
 

--- a/tests/baselines/reference/reservedNameOnModuleImportWithInterface.types
+++ b/tests/baselines/reference/reservedNameOnModuleImportWithInterface.types
@@ -3,7 +3,7 @@ declare module test {
 >test : any
 
     interface mi_string { }
->mi_string : string
+>mi_string : mi_string
 
     module mi_string { }
 >mi_string : any
@@ -11,6 +11,6 @@ declare module test {
     // Should error; imports both a type and a module, which means it conflicts with the 'string' type.
     import string = mi_string;
 >string : any
->mi_string : string
+>mi_string : mi_string
 }
 

--- a/tests/baselines/reference/visibilityOfCrossModuleTypeUsage.types
+++ b/tests/baselines/reference/visibilityOfCrossModuleTypeUsage.types
@@ -11,14 +11,14 @@ function run(configuration: commands.IConfiguration) {
     var absoluteWorkspacePath = configuration.workspace.toAbsolutePath(configuration.server);
 >absoluteWorkspacePath : string
 >configuration.workspace.toAbsolutePath(configuration.server) : string
->configuration.workspace.toAbsolutePath : (server: IServer, workspaceRelativePath?: string) => string
->configuration.workspace : IWorkspace
+>configuration.workspace.toAbsolutePath : (server: import("tests/cases/compiler/visibilityOfCrossModuleTypeUsage_server").IServer, workspaceRelativePath?: string) => string
+>configuration.workspace : import("tests/cases/compiler/visibilityOfCrossModuleTypeUsage_server").IWorkspace
 >configuration : commands.IConfiguration
->workspace : IWorkspace
->toAbsolutePath : (server: IServer, workspaceRelativePath?: string) => string
->configuration.server : IServer
+>workspace : import("tests/cases/compiler/visibilityOfCrossModuleTypeUsage_server").IWorkspace
+>toAbsolutePath : (server: import("tests/cases/compiler/visibilityOfCrossModuleTypeUsage_server").IServer, workspaceRelativePath?: string) => string
+>configuration.server : import("tests/cases/compiler/visibilityOfCrossModuleTypeUsage_server").IServer
 >configuration : commands.IConfiguration
->server : IServer
+>server : import("tests/cases/compiler/visibilityOfCrossModuleTypeUsage_server").IServer
 }
 === tests/cases/compiler/visibilityOfCrossModuleTypeUsage_commands.ts ===
 //visibilityOfCrossModuleTypeUsage

--- a/tests/cases/compiler/declarationEmitForTypesWhichNeedImportTypes.ts
+++ b/tests/cases/compiler/declarationEmitForTypesWhichNeedImportTypes.ts
@@ -1,0 +1,11 @@
+// @declaration: true
+// @filename: b.ts
+export interface Named {}
+
+export function createNamed(): Named {
+  return {};
+}
+// @filename: a.ts
+import { createNamed } from "./b";
+
+export const Value = createNamed();

--- a/tests/cases/compiler/moduleAugmentationGlobal5.ts
+++ b/tests/cases/compiler/moduleAugmentationGlobal5.ts
@@ -1,6 +1,5 @@
 // @module: commonjs
 // @declaration: true
-
 // @filename: f1.d.ts
 declare module "A" {
     global {


### PR DESCRIPTION
Fixes #24287

Non-alias class and interface references were still using `symbolToName`, which drops the module symbol. With this change they now also use `symbolToTypeNode`, bringing them inline with aliases and everything else (`symbolToName` is still used for property names).  Once fixed, this exposed an issue that showed that we weren't calculating visibility chains for merged globals within their containing ambient global augmentation correctly (they had just been defaulting to unqualified in baselines because the top of the chain was always elided), and fixing _that_ issue (which meant accounting for merged symbols and `exportSymbol`s in `trySymbolTable`) happened to improve a bunch of our symbol baselines to correctly see/use their own name, rather than falling back to some alias or qualification in scope.