### PR TITLE
Use unknown serialization kind when type symbol isnt resolved

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26667,7 +26667,7 @@ namespace ts {
 
             // We might not be able to resolve type symbol so use unknown type in that case (eg error case)
             if (!typeSymbol) {
-                return TypeReferenceSerializationKind.ObjectType;
+                return TypeReferenceSerializationKind.Unknown;
             }
             const type = getDeclaredTypeOfSymbol(typeSymbol);
             if (type === unknownType) {

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1964,7 +1964,8 @@ namespace ts {
          * @param node The type reference node.
          */
         function serializeTypeReferenceNode(node: TypeReferenceNode): SerializedTypeNode {
-            switch (resolver.getTypeReferenceSerializationKind(node.typeName, currentScope)) {
+            const kind = resolver.getTypeReferenceSerializationKind(node.typeName, currentScope);
+            switch (kind) {
                 case TypeReferenceSerializationKind.Unknown:
                     const serialized = serializeEntityNameAsExpression(node.typeName, /*useFallback*/ true);
                     const temp = createTempVariable(hoistVariableDeclaration);
@@ -2006,8 +2007,9 @@ namespace ts {
                     return createIdentifier("Promise");
 
                 case TypeReferenceSerializationKind.ObjectType:
-                default:
                     return createIdentifier("Object");
+                default:
+                    return Debug.assertNever(kind);
             }
         }
 

--- a/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.errors.txt
+++ b/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.errors.txt
@@ -1,0 +1,30 @@
+error TS2318: Cannot find global type 'Array'.
+error TS2318: Cannot find global type 'Boolean'.
+error TS2318: Cannot find global type 'Function'.
+error TS2318: Cannot find global type 'IArguments'.
+error TS2318: Cannot find global type 'Number'.
+error TS2318: Cannot find global type 'Object'.
+error TS2318: Cannot find global type 'RegExp'.
+error TS2318: Cannot find global type 'String'.
+tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts(2,6): error TS2304: Cannot find name 'Decorate'.
+tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts(3,13): error TS2304: Cannot find name 'Map'.
+
+
+!!! error TS2318: Cannot find global type 'Array'.
+!!! error TS2318: Cannot find global type 'Boolean'.
+!!! error TS2318: Cannot find global type 'Function'.
+!!! error TS2318: Cannot find global type 'IArguments'.
+!!! error TS2318: Cannot find global type 'Number'.
+!!! error TS2318: Cannot find global type 'Object'.
+!!! error TS2318: Cannot find global type 'RegExp'.
+!!! error TS2318: Cannot find global type 'String'.
+==== tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts (2 errors) ====
+    export class B {
+        @Decorate
+         ~~~~~~~~
+!!! error TS2304: Cannot find name 'Decorate'.
+        member: Map<string, number>;
+                ~~~
+!!! error TS2304: Cannot find name 'Map'.
+    }
+    

--- a/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.js
+++ b/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.js
@@ -1,0 +1,30 @@
+//// [decoratorMetadataNoLibIsolatedModulesTypes.ts]
+export class B {
+    @Decorate
+    member: Map<string, number>;
+}
+
+
+//// [decoratorMetadataNoLibIsolatedModulesTypes.js]
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+exports.__esModule = true;
+var B = /** @class */ (function () {
+    function B() {
+    }
+    var _a;
+    __decorate([
+        Decorate,
+        __metadata("design:type", typeof (_a = typeof Map !== "undefined" && Map) === "function" && _a || Object)
+    ], B.prototype, "member");
+    return B;
+}());
+exports.B = B;

--- a/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.symbols
+++ b/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts ===
+export class B {
+>B : Symbol(B, Decl(decoratorMetadataNoLibIsolatedModulesTypes.ts, 0, 0))
+
+    @Decorate
+    member: Map<string, number>;
+>member : Symbol(B.member, Decl(decoratorMetadataNoLibIsolatedModulesTypes.ts, 0, 16))
+}
+

--- a/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.types
+++ b/tests/baselines/reference/decoratorMetadataNoLibIsolatedModulesTypes.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts ===
+export class B {
+>B : B
+
+    @Decorate
+>Decorate : any
+
+    member: Map<string, number>;
+>member : any
+>Map : No type information available!
+}
+

--- a/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision7.js
+++ b/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision7.js
@@ -46,9 +46,10 @@ var MyClass = /** @class */ (function () {
         this.db = db;
         this.db.doSomething();
     }
+    var _a;
     MyClass = __decorate([
         someDecorator,
-        __metadata("design:paramtypes", [Object])
+        __metadata("design:paramtypes", [typeof (_a = (typeof db_1.default !== "undefined" && db_1.default).db) === "function" && _a || Object])
     ], MyClass);
     return MyClass;
 }());

--- a/tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts
+++ b/tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts
@@ -1,0 +1,9 @@
+// @experimentalDecorators: true
+// @emitDecoratorMetadata: true
+// @noLib: true
+// @isolatedModules: true
+
+export class B {
+    @Decorate
+    member: Map<string, number>;
+}


### PR DESCRIPTION
This way when a lib isn't present (eg, under `noLib`), you can still get more accurate runtime type information.

Our metadata emit will still differ between an `isolatedModules` and `noLib` build and a normal one (the emit is type directed), but now they should have the same runtime functionality, at least.

Fixes #16872

