### PR TITLE
Dont count duplicated errors in case-insensitive duped files in rwc

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1469,7 +1469,14 @@ namespace Harness {
 
                 // Verify we didn't miss any errors in this file
                 assert.equal(markedErrorCount, fileErrors.length, "count of errors in " + inputFile.unitName);
+                const isDupe = dupeCase.has(sanitizeTestFilePath(inputFile.unitName));
                 yield [checkDuplicatedFileName(inputFile.unitName, dupeCase), outputLines, errorsReported];
+                if (isDupe && !(options && options.caseSensitive)) {
+                    // Case-duplicated files on a case-insensitive build will have errors reported in both the dupe and the original
+                    // thanks to the canse-insensitive path comparison on the error file path - We only want to count those errors once
+                    // for the assert below, so we subtract them here.
+                    totalErrorsReportedInNonLibraryFiles -= errorsReported;
+                }
                 outputLines = "";
                 errorsReported = 0;
             }


### PR DESCRIPTION
I left a change out of my prior PR by accident, which left two rwc tests failing from an assertion failure. 🤷‍♂️ 

