### PR TITLE
Disallow nested object param syntax in callback tag

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6707,7 +6707,7 @@ namespace ts {
                         <JSDocParameterTag>createNode(SyntaxKind.JSDocParameterTag, atToken.pos);
                     let comment: string | undefined;
                     if (indent !== undefined) comment = parseTagComments(indent + scanner.getStartPos() - atToken.pos);
-                    const nestedTypeLiteral = parseNestedTypeLiteral(typeExpression, name, target);
+                    const nestedTypeLiteral = target !== PropertyLikeParse.CallbackParameter && parseNestedTypeLiteral(typeExpression, name, target);
                     if (nestedTypeLiteral) {
                         typeExpression = nestedTypeLiteral;
                         isNameFirst = true;

--- a/tests/baselines/reference/callbackTagNamespace.symbols
+++ b/tests/baselines/reference/callbackTagNamespace.symbols
@@ -1,8 +1,8 @@
 === tests/cases/conformance/jsdoc/namespaced.js ===
 /**
  * @callback NS.Nested.Inner
- * @param {string} space - spaaaaaaaaace
- * @param {string} peace - peaaaaaaaaace
+ * @param {Object} space - spaaaaaaaaace
+ * @param {Object} peace - peaaaaaaaaace
  * @return {string | number}
  */
 var x = 1;

--- a/tests/baselines/reference/callbackTagNamespace.types
+++ b/tests/baselines/reference/callbackTagNamespace.types
@@ -1,8 +1,8 @@
 === tests/cases/conformance/jsdoc/namespaced.js ===
 /**
  * @callback NS.Nested.Inner
- * @param {string} space - spaaaaaaaaace
- * @param {string} peace - peaaaaaaaaace
+ * @param {Object} space - spaaaaaaaaace
+ * @param {Object} peace - peaaaaaaaaace
  * @return {string | number}
  */
 var x = 1;
@@ -11,9 +11,9 @@ var x = 1;
 
 /** @type {NS.Nested.Inner} */
 function f(space, peace) {
->f : (space: string, peace: string) => string
->space : string
->peace : string
+>f : (space: any, peace: any) => string
+>space : any
+>peace : any
 
     return '1'
 >'1' : "1"

--- a/tests/cases/conformance/jsdoc/callbackTagNamespace.ts
+++ b/tests/cases/conformance/jsdoc/callbackTagNamespace.ts
@@ -4,8 +4,8 @@
 // @Filename: namespaced.js
 /**
  * @callback NS.Nested.Inner
- * @param {string} space - spaaaaaaaaace
- * @param {string} peace - peaaaaaaaaace
+ * @param {Object} space - spaaaaaaaaace
+ * @param {Object} peace - peaaaaaaaaace
  * @return {string | number}
  */
 var x = 1;


### PR DESCRIPTION
Previously this caused a crash in parsing. If/when we want to support this syntax, we will need to fix this crash. For now, it's enough to skip the code path and continue parsing in a non-nested fashion.

Fixes #24389
