### PR TITLE
Dump fork output on unclean exit

### DIFF
--- a/src/harness/parallel/host.ts
+++ b/src/harness/parallel/host.ts
@@ -179,6 +179,7 @@ namespace Harness.Parallel.Host {
                 return process.exit(2);
             });
             child.on("exit", (code, _signal) => {
+                clearTimeout(timer);
                 if (code !== 0) {
                     console.error(`Test worker process exited with nonzero exit code! Output:
 ${child.accumulatedOutput}`);
@@ -237,6 +238,7 @@ ${child.accumulatedOutput}`);
                                 // No more tasks to distribute
                                 child.send({ type: "close" });
                                 closedWorkers++;
+                                clearTimeout(timer);
                                 if (closedWorkers === workerCount) {
                                     outputFinalResult();
                                 }


### PR DESCRIPTION
Hopefully this will give some indication while the travis `node6` build likes to sporadically fail with a process exiting.
