### PR TITLE
Use external aliases in quickinfo and signature help return types (#24391)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2980,7 +2980,7 @@ namespace ts {
             }
         }
 
-        function typeToString(type: Type, enclosingDeclaration?: Node, flags: TypeFormatFlags = TypeFormatFlags.AllowUniqueESSymbolType, writer: EmitTextWriter = createTextWriter("")): string {
+        function typeToString(type: Type, enclosingDeclaration?: Node, flags: TypeFormatFlags = TypeFormatFlags.AllowUniqueESSymbolType | TypeFormatFlags.UseAliasDefinedOutsideCurrentScope, writer: EmitTextWriter = createTextWriter("")): string {
             const typeNode = nodeBuilder.typeToTypeNode(type, enclosingDeclaration, toNodeBuilderFlags(flags) | NodeBuilderFlags.IgnoreErrors, writer);
             Debug.assert(typeNode !== undefined, "should always get typenode");
             const options = { removeComments: true };
@@ -3927,7 +3927,7 @@ namespace ts {
             }
         }
 
-        function typePredicateToString(typePredicate: TypePredicate, enclosingDeclaration?: Node, flags?: TypeFormatFlags, writer?: EmitTextWriter): string {
+        function typePredicateToString(typePredicate: TypePredicate, enclosingDeclaration?: Node, flags: TypeFormatFlags = TypeFormatFlags.UseAliasDefinedOutsideCurrentScope, writer?: EmitTextWriter): string {
             return writer ? typePredicateToStringWorker(writer).getText() : usingSingleLineStringWriter(typePredicateToStringWorker);
 
             function typePredicateToStringWorker(writer: EmitTextWriter) {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1461,7 +1461,7 @@ namespace ts {
 
     export function typeToDisplayParts(typechecker: TypeChecker, type: Type, enclosingDeclaration?: Node, flags?: TypeFormatFlags): SymbolDisplayPart[] {
         return mapToDisplayParts(writer => {
-            typechecker.writeType(type, enclosingDeclaration, flags | TypeFormatFlags.MultilineObjectLiterals, writer);
+            typechecker.writeType(type, enclosingDeclaration, flags | TypeFormatFlags.MultilineObjectLiterals | TypeFormatFlags.UseAliasDefinedOutsideCurrentScope, writer);
         });
     }
 

--- a/tests/cases/fourslash/crossFileQuickInfoExportedTypeDoesNotUseImportType.ts
+++ b/tests/cases/fourslash/crossFileQuickInfoExportedTypeDoesNotUseImportType.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: b.ts
+////export interface B {}
+////export function foob(): {
+////    x: B,
+////    y: B
+////} {
+////    return null as any;
+////}
+// @Filename: a.ts
+////import { foob } from "./b";
+////const thing/*1*/ = foob(/*2*/);
+
+verify.quickInfoAt("1", "const thing: {\n    x: B;\n    y: B;\n}");
+verify.signatureHelp({
+    marker: "2",
+    text: "foob(): { x: B; y: B; }"
+});


### PR DESCRIPTION
Ports https://github.com/Microsoft/TypeScript/pull/24391 to `release-2.9`