### PR TITLE
Fixes Number.is* signatures to accept any input.

### DIFF
--- a/lib/lib.es2015.core.d.ts
+++ b/lib/lib.es2015.core.d.ts
@@ -222,29 +222,29 @@ interface NumberConstructor {
      * Returns true if passed value is finite.
      * Unlike the global isFinite, Number.isFinite doesn't forcibly convert the parameter to a
      * number. Only finite values of the type number, result in true.
-     * @param number A numeric value.
+     * @param value The value you want to test.
      */
-    isFinite(number: number): boolean;
+    isFinite(value: any): boolean;
 
     /**
      * Returns true if the value passed is an integer, false otherwise.
-     * @param number A numeric value.
+     * @param value The value you want to test.
      */
-    isInteger(number: number): boolean;
+    isInteger(value: any): boolean;
 
     /**
      * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a
      * number). Unlike the global isNaN(), Number.isNaN() doesn't forcefully convert the parameter
      * to a number. Only values of the type number, that are also NaN, result in true.
-     * @param number A numeric value.
+     * @param value The value you want to test.
      */
-    isNaN(number: number): boolean;
+    isNaN(number: any): boolean;
 
     /**
      * Returns true if the value passed is a safe integer.
-     * @param number A numeric value.
+     * @param value The value you want to test
      */
-    isSafeInteger(number: number): boolean;
+    isSafeInteger(value: any): boolean;
 
     /**
      * The value of the largest integer n such that n and n + 1 are both exactly representable as


### PR DESCRIPTION
I skipped straight to a PR rather than opening an issue first because this is such a small change and a PR illustrates the problem well IMO.  I can open a separate issue if that is desirable.

These functions are incredibly useful for testing to see if a value is a number that meets certain constraints as they return false for _any_ input that doesn't satisfy the constraints explicitly.  Tested in NodeJS and Firefox and both of them work properly when you give a range of values.  MDN also indicates that they will return false for any non-number input.