### PR TITLE
addMethodDeclaration: add after quickfix location if possible

### DIFF
--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -199,6 +199,34 @@ namespace ts.codefix {
         preferences: UserPreferences,
     ): void {
         const methodDeclaration = createMethodFromCallExpression(callExpression, token.text, inJs, makeStatic, preferences);
-        changeTracker.insertNodeAtClassStart(classDeclarationSourceFile, classDeclaration, methodDeclaration);
+        const currentMethod = getNodeToInsertMethodAfter(classDeclaration, callExpression);
+
+        if (currentMethod) {
+            changeTracker.insertNodeAfter(classDeclarationSourceFile, currentMethod, methodDeclaration);
+        }
+        else {
+            changeTracker.insertNodeAtClassStart(classDeclarationSourceFile, classDeclaration, methodDeclaration);
+        }
+    }
+
+    // Gets the MethodDeclaration of a method of the cls class that contains the node, or undefined if the node is not in a method or that method is not in the cls class.
+    function getNodeToInsertMethodAfter(cls: ClassLikeDeclaration, node: Node): MethodDeclaration | undefined {
+        const nodeMethod = getParentMethodDeclaration(node);
+        if (nodeMethod) {
+            const isClsMethod = contains(cls.members, nodeMethod);
+            if (isClsMethod) {
+                return nodeMethod;
+            }
+        }
+        return undefined;
+    }
+
+    // Gets the MethodDeclaration of the method that contains the node, or undefined if the node is not in a method.
+    function getParentMethodDeclaration(node: Node): MethodDeclaration | undefined {
+        while (node) {
+            if (isMethodDeclaration(node)) break;
+            node = node.parent;
+        }
+        return node;
     }
 }

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -199,34 +199,13 @@ namespace ts.codefix {
         preferences: UserPreferences,
     ): void {
         const methodDeclaration = createMethodFromCallExpression(callExpression, token.text, inJs, makeStatic, preferences);
-        const currentMethod = getNodeToInsertMethodAfter(classDeclaration, callExpression);
+        const containingMethodDeclaration = getAncestor(callExpression, SyntaxKind.MethodDeclaration);
 
-        if (currentMethod) {
-            changeTracker.insertNodeAfter(classDeclarationSourceFile, currentMethod, methodDeclaration);
+        if (containingMethodDeclaration && containingMethodDeclaration.parent === classDeclaration) {
+            changeTracker.insertNodeAfter(classDeclarationSourceFile, containingMethodDeclaration, methodDeclaration);
         }
         else {
             changeTracker.insertNodeAtClassStart(classDeclarationSourceFile, classDeclaration, methodDeclaration);
         }
-    }
-
-    // Gets the MethodDeclaration of a method of the cls class that contains the node, or undefined if the node is not in a method or that method is not in the cls class.
-    function getNodeToInsertMethodAfter(cls: ClassLikeDeclaration, node: Node): MethodDeclaration | undefined {
-        const nodeMethod = getParentMethodDeclaration(node);
-        if (nodeMethod) {
-            const isClsMethod = contains(cls.members, nodeMethod);
-            if (isClsMethod) {
-                return nodeMethod;
-            }
-        }
-        return undefined;
-    }
-
-    // Gets the MethodDeclaration of the method that contains the node, or undefined if the node is not in a method.
-    function getParentMethodDeclaration(node: Node): MethodDeclaration | undefined {
-        while (node) {
-            if (isMethodDeclaration(node)) break;
-            node = node.parent;
-        }
-        return node;
     }
 }

--- a/tests/cases/fourslash/codeFixAddMissingMember_all.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember_all.ts
@@ -14,13 +14,13 @@ verify.codeFixAll({
     newFileContent:
 `class C {
     x: number;
-    y(): any {
-        throw new Error("Method not implemented.");
-    }
     method() {
         this.x = 0;
         this.y();
         this.x = "";
+    }
+    y(): any {
+        throw new Error("Method not implemented.");
     }
 }`,
 });

--- a/tests/cases/fourslash/codeFixAddMissingMember_all_js.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember_all_js.ts
@@ -18,9 +18,6 @@ verify.codeFixAll({
     fixAllDescription: "Add all missing members",
     newFileContent:
 `class C {
-    y() {
-        throw new Error("Method not implemented.");
-    }
     constructor() {
         this.x = undefined;
     }
@@ -28,6 +25,9 @@ verify.codeFixAll({
         this.x;
         this.y();
         this.x;
+    }
+    y() {
+        throw new Error("Method not implemented.");
     }
 }`,
 });

--- a/tests/cases/fourslash/codeFixUndeclaredInStaticMethod.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredInStaticMethod.ts
@@ -14,14 +14,14 @@ verify.codeFix({
     index: 0,
     newFileContent:
 `class A {
-    static m1(arg0: any, arg1: any, arg2: any): any {
-        throw new Error("Method not implemented.");
-    }
     static foo0() {
         this.m1(1,2,3);
         A.m2(1,2);
         this.prop1 = 10;
         A.prop2 = "asdf";
+    }
+    static m1(arg0: any, arg1: any, arg2: any): any {
+        throw new Error("Method not implemented.");
     }
 }`,
 });
@@ -31,17 +31,17 @@ verify.codeFix({
     index: 0,
     newFileContent:
 `class A {
-    static m2(arg0: any, arg1: any): any {
-        throw new Error("Method not implemented.");
-    }
-    static m1(arg0: any, arg1: any, arg2: any): any {
-        throw new Error("Method not implemented.");
-    }
     static foo0() {
         this.m1(1,2,3);
         A.m2(1,2);
         this.prop1 = 10;
         A.prop2 = "asdf";
+    }
+    static m2(arg0: any, arg1: any): any {
+        throw new Error("Method not implemented.");
+    }
+    static m1(arg0: any, arg1: any, arg2: any): any {
+        throw new Error("Method not implemented.");
     }
 }`,
 });
@@ -52,17 +52,17 @@ verify.codeFix({
     newFileContent:
 `class A {
     static prop1: number;
-    static m2(arg0: any, arg1: any): any {
-        throw new Error("Method not implemented.");
-    }
-    static m1(arg0: any, arg1: any, arg2: any): any {
-        throw new Error("Method not implemented.");
-    }
     static foo0() {
         this.m1(1,2,3);
         A.m2(1,2);
         this.prop1 = 10;
         A.prop2 = "asdf";
+    }
+    static m2(arg0: any, arg1: any): any {
+        throw new Error("Method not implemented.");
+    }
+    static m1(arg0: any, arg1: any, arg2: any): any {
+        throw new Error("Method not implemented.");
     }
 }`,
 });
@@ -74,17 +74,17 @@ verify.codeFix({
 `class A {
     static prop1: number;
     static prop2: string;
-    static m2(arg0: any, arg1: any): any {
-        throw new Error("Method not implemented.");
-    }
-    static m1(arg0: any, arg1: any, arg2: any): any {
-        throw new Error("Method not implemented.");
-    }
     static foo0() {
         this.m1(1,2,3);
         A.m2(1,2);
         this.prop1 = 10;
         A.prop2 = "asdf";
+    }
+    static m2(arg0: any, arg1: any): any {
+        throw new Error("Method not implemented.");
+    }
+    static m1(arg0: any, arg1: any, arg2: any): any {
+        throw new Error("Method not implemented.");
     }
 }`,
 });


### PR DESCRIPTION
Fixes #22674

Declare method quickfix/codeaction now inserts method after the current location.

**Current behavior:**
```typescript
class Foo {
    b(): any {
        throw new Error("Method not implemented.");
    }
    a() {
        this.b()
    }
}
```

**Changed behavior:**
```typescript
class Foo {
    a() {
        this.b()
    }
    b(): any {
        throw new Error("Method not implemented.");
    }
}
```

The old behavior is preserved if quickfix is applied outside of the class. In that case the method is inserted at the start of the class.

```typescript
class Foo {
    b(): any {
        throw new Error("Method not implemented.");
    }
    f() {

    }
}

// quickfix is called inside of another class
class Bar {
    b() {
        let foo = new Foo();
        foo.b();
    }
}

// or outside of the class
let fooer = new Foo();
fooer.b();
```

This is my first contribution to TypeScript, so please review carefully :)