### PR TITLE
Skip IntrinsicAttributes elaboration in JSX errors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10592,6 +10592,16 @@ namespace ts {
                     else if (source.symbol && source.flags & TypeFlags.Object && globalObjectType === source) {
                         reportError(Diagnostics.The_Object_type_is_assignable_to_very_few_other_types_Did_you_mean_to_use_the_any_type_instead);
                     }
+                    else if (getObjectFlags(source) & ObjectFlags.JsxAttributes && target.flags & TypeFlags.Intersection) {
+                        const targetTypes = (target as IntersectionType).types;
+                        const intrinsicAttributes = getJsxType(JsxNames.IntrinsicAttributes, errorNode);
+                        const intrinsicClassAttributes = getJsxType(JsxNames.IntrinsicClassAttributes, errorNode);
+                        if (intrinsicAttributes !== unknownType && intrinsicClassAttributes !== unknownType &&
+                            (contains(targetTypes, intrinsicAttributes) || contains(targetTypes, intrinsicClassAttributes))) {
+                            // do not report top error
+                            return result;
+                        }
+                    }
                     reportRelationError(headMessage, source, target);
                 }
                 return result;
@@ -16274,7 +16284,7 @@ namespace ts {
             return createJsxAttributesTypeFromAttributesProperty(node.parent, checkMode);
         }
 
-        function getJsxType(name: __String, location: Node) {
+        function getJsxType(name: __String, location: Node | undefined) {
             const namespace = getJsxNamespaceAt(location);
             const exports = namespace && getExportsOfSymbol(namespace);
             const typeSymbol = exports && getSymbol(exports, name, SymbolFlags.Type);
@@ -16372,7 +16382,7 @@ namespace ts {
             return getSignatureInstantiation(signature, args, isJavascript);
         }
 
-        function getJsxNamespaceAt(location: Node): Symbol {
+        function getJsxNamespaceAt(location: Node | undefined): Symbol {
             const namespaceName = getJsxNamespace(location);
             const resolvedNamespace = resolveName(location, namespaceName, SymbolFlags.Namespace, /*diagnosticMessage*/ undefined, namespaceName, /*isUse*/ false);
             if (resolvedNamespace) {

--- a/tests/baselines/reference/checkJsxChildrenProperty14.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty14.errors.txt
@@ -1,8 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(42,11): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & SingleChildProp'.
-  Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
-    Types of property 'children' are incompatible.
-      Type 'Element[]' is not assignable to type 'Element'.
-        Property 'type' is missing in type 'Element[]'.
+tests/cases/conformance/jsx/file.tsx(42,11): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
+  Types of property 'children' are incompatible.
+    Type 'Element[]' is not assignable to type 'Element'.
+      Property 'type' is missing in type 'Element[]'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -49,8 +48,7 @@ tests/cases/conformance/jsx/file.tsx(42,11): error TS2322: Type '{ children: Ele
     // Error
     let k5 = <SingleChildComp a={10} b="hi"><></><Button /><AnotherButton /></SingleChildComp>;
               ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & SingleChildProp'.
-!!! error TS2322:   Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type 'Element[]' is not assignable to type 'Element'.
-!!! error TS2322:         Property 'type' is missing in type 'Element[]'.
+!!! error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type 'Element[]' is not assignable to type 'Element'.
+!!! error TS2322:       Property 'type' is missing in type 'Element[]'.

--- a/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
@@ -1,31 +1,26 @@
-tests/cases/conformance/jsx/file.tsx(14,10): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
-    Property 'children' is missing in type '{ a: number; b: string; }'.
+tests/cases/conformance/jsx/file.tsx(14,10): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+  Property 'children' is missing in type '{ a: number; b: string; }'.
 tests/cases/conformance/jsx/file.tsx(17,11): error TS2710: 'children' are specified twice. The attribute named 'children' will be overwritten.
-tests/cases/conformance/jsx/file.tsx(31,6): error TS2322: Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
-    Types of property 'children' are incompatible.
-      Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
-        Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
-          Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
-tests/cases/conformance/jsx/file.tsx(37,6): error TS2322: Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-    Types of property 'children' are incompatible.
-      Type '(number | Element)[]' is not assignable to type 'string | Element'.
-        Type '(number | Element)[]' is not assignable to type 'Element'.
-          Property 'type' is missing in type '(number | Element)[]'.
-tests/cases/conformance/jsx/file.tsx(43,6): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-    Types of property 'children' are incompatible.
-      Type '(string | Element)[]' is not assignable to type 'string | Element'.
-        Type '(string | Element)[]' is not assignable to type 'Element'.
-          Property 'type' is missing in type '(string | Element)[]'.
-tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
-    Types of property 'children' are incompatible.
-      Type 'Element[]' is not assignable to type 'string | Element'.
-        Type 'Element[]' is not assignable to type 'Element'.
-          Property 'type' is missing in type 'Element[]'.
+tests/cases/conformance/jsx/file.tsx(31,6): error TS2322: Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
+  Types of property 'children' are incompatible.
+    Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
+      Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
+        Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
+tests/cases/conformance/jsx/file.tsx(37,6): error TS2322: Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+  Types of property 'children' are incompatible.
+    Type '(number | Element)[]' is not assignable to type 'string | Element'.
+      Type '(number | Element)[]' is not assignable to type 'Element'.
+        Property 'type' is missing in type '(number | Element)[]'.
+tests/cases/conformance/jsx/file.tsx(43,6): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+  Types of property 'children' are incompatible.
+    Type '(string | Element)[]' is not assignable to type 'string | Element'.
+      Type '(string | Element)[]' is not assignable to type 'Element'.
+        Property 'type' is missing in type '(string | Element)[]'.
+tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
+  Types of property 'children' are incompatible.
+    Type 'Element[]' is not assignable to type 'string | Element'.
+      Type 'Element[]' is not assignable to type 'Element'.
+        Property 'type' is missing in type 'Element[]'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (6 errors) ====
@@ -44,9 +39,8 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
     // Error: missing children
     let k = <Comp a={10} b="hi" />;
              ~~~~
-!!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Property 'children' is missing in type '{ a: number; b: string; }'.
+!!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Property 'children' is missing in type '{ a: number; b: string; }'.
     
     let k0 =
         <Comp a={10} b="hi" children="Random" >
@@ -67,12 +61,11 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
     let k2 =
         <Comp a={10} b="hi">
          ~~~~
-!!! error TS2322: Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
-!!! error TS2322:         Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
-!!! error TS2322:           Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
+!!! error TS2322: Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
+!!! error TS2322:       Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
+!!! error TS2322:         Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
             <div> My Div </div>
             {(name: string) => <div> My name {name} </div>}
         </Comp>;
@@ -80,12 +73,11 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
     let k3 =
         <Comp a={10} b="hi">
          ~~~~
-!!! error TS2322: Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '(number | Element)[]' is not assignable to type 'string | Element'.
-!!! error TS2322:         Type '(number | Element)[]' is not assignable to type 'Element'.
-!!! error TS2322:           Property 'type' is missing in type '(number | Element)[]'.
+!!! error TS2322: Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type '(number | Element)[]' is not assignable to type 'string | Element'.
+!!! error TS2322:       Type '(number | Element)[]' is not assignable to type 'Element'.
+!!! error TS2322:         Property 'type' is missing in type '(number | Element)[]'.
             <div> My Div </div>
             {1000000}
         </Comp>;
@@ -93,12 +85,11 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
     let k4 =
         <Comp a={10} b="hi" >
          ~~~~
-!!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'string | Element'.
-!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element'.
-!!! error TS2322:           Property 'type' is missing in type '(string | Element)[]'.
+!!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type '(string | Element)[]' is not assignable to type 'string | Element'.
+!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element'.
+!!! error TS2322:         Property 'type' is missing in type '(string | Element)[]'.
             <div> My Div </div>
             hi hi hi!
         </Comp>;
@@ -106,12 +97,11 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
     let k5 =
         <Comp a={10} b="hi" >
          ~~~~
-!!! error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type 'Element[]' is not assignable to type 'string | Element'.
-!!! error TS2322:         Type 'Element[]' is not assignable to type 'Element'.
-!!! error TS2322:           Property 'type' is missing in type 'Element[]'.
+!!! error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type 'Element[]' is not assignable to type 'string | Element'.
+!!! error TS2322:       Type 'Element[]' is not assignable to type 'Element'.
+!!! error TS2322:         Property 'type' is missing in type 'Element[]'.
             <div> My Div </div>
             <div> My Div </div>
         </Comp>;

--- a/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
@@ -1,9 +1,8 @@
 tests/cases/conformance/jsx/file.tsx(24,28): error TS2551: Property 'NAme' does not exist on type 'IUser'. Did you mean 'Name'?
-tests/cases/conformance/jsx/file.tsx(32,10): error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<FetchUser> & IFetchUserProps & { children?: ReactNode; }'.
-  Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
-    Types of property 'children' are incompatible.
-      Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
-        Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
+tests/cases/conformance/jsx/file.tsx(32,10): error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
+  Types of property 'children' are incompatible.
+    Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
+      Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -42,11 +41,10 @@ tests/cases/conformance/jsx/file.tsx(32,10): error TS2322: Type '{ children: ((u
         return (
             <FetchUser>
              ~~~~~~~~~
-!!! error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<FetchUser> & IFetchUserProps & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
-!!! error TS2322:         Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
+!!! error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
+!!! error TS2322:       Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
     
     
                 

--- a/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
@@ -1,16 +1,13 @@
-tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
-    Property 'children' is missing in type '{ a: number; b: string; }'.
-tests/cases/conformance/jsx/file.tsx(24,6): error TS2322: Type '{ children: Element; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
-    Types of property 'children' are incompatible.
-      Type 'Element' is not assignable to type 'Button'.
-        Property 'render' is missing in type 'Element'.
-tests/cases/conformance/jsx/file.tsx(28,6): error TS2322: Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
-    Types of property 'children' are incompatible.
-      Type 'typeof Button' is not assignable to type 'Button'.
-        Property 'render' is missing in type 'typeof Button'.
+tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+  Property 'children' is missing in type '{ a: number; b: string; }'.
+tests/cases/conformance/jsx/file.tsx(24,6): error TS2322: Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
+  Types of property 'children' are incompatible.
+    Type 'Element' is not assignable to type 'Button'.
+      Property 'render' is missing in type 'Element'.
+tests/cases/conformance/jsx/file.tsx(28,6): error TS2322: Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
+  Types of property 'children' are incompatible.
+    Type 'typeof Button' is not assignable to type 'Button'.
+      Property 'render' is missing in type 'typeof Button'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -35,28 +32,25 @@ tests/cases/conformance/jsx/file.tsx(28,6): error TS2322: Type '{ children: type
     // Error: no children specified
     let k = <Comp a={10} b="hi" />;
              ~~~~
-!!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Property 'children' is missing in type '{ a: number; b: string; }'.
+!!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Property 'children' is missing in type '{ a: number; b: string; }'.
     
     // Error: JSX.element is not the same as JSX.ElementClass
     let k1 =
         <Comp a={10} b="hi">
          ~~~~
-!!! error TS2322: Type '{ children: Element; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type 'Element' is not assignable to type 'Button'.
-!!! error TS2322:         Property 'render' is missing in type 'Element'.
+!!! error TS2322: Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type 'Element' is not assignable to type 'Button'.
+!!! error TS2322:       Property 'render' is missing in type 'Element'.
             <Button />
         </Comp>;
     let k2 =
         <Comp a={10} b="hi">
          ~~~~
-!!! error TS2322: Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type 'typeof Button' is not assignable to type 'Button'.
-!!! error TS2322:         Property 'render' is missing in type 'typeof Button'.
+!!! error TS2322: Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type 'typeof Button' is not assignable to type 'Button'.
+!!! error TS2322:       Property 'render' is missing in type 'typeof Button'.
             {Button}
         </Comp>;

--- a/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
@@ -1,20 +1,17 @@
-tests/cases/conformance/jsx/file.tsx(24,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-    Types of property 'children' are incompatible.
-      Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-        Type '(string | Element)[]' is not assignable to type 'Element[]'.
-          Type 'string | Element' is not assignable to type 'Element'.
-            Type 'string' is not assignable to type 'Element'.
-tests/cases/conformance/jsx/file.tsx(25,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-    Types of property 'children' are incompatible.
-      Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-        Type '(string | Element)[]' is not assignable to type 'Element[]'.
-tests/cases/conformance/jsx/file.tsx(27,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-  Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-    Types of property 'children' are incompatible.
-      Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-        Type '(string | Element)[]' is not assignable to type 'Element[]'.
+tests/cases/conformance/jsx/file.tsx(24,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+  Types of property 'children' are incompatible.
+    Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+      Type '(string | Element)[]' is not assignable to type 'Element[]'.
+        Type 'string | Element' is not assignable to type 'Element'.
+          Type 'string' is not assignable to type 'Element'.
+tests/cases/conformance/jsx/file.tsx(25,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+  Types of property 'children' are incompatible.
+    Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+      Type '(string | Element)[]' is not assignable to type 'Element[]'.
+tests/cases/conformance/jsx/file.tsx(27,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+  Types of property 'children' are incompatible.
+    Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+      Type '(string | Element)[]' is not assignable to type 'Element[]'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -43,26 +40,23 @@ tests/cases/conformance/jsx/file.tsx(27,11): error TS2322: Type '{ children: (st
     // Error: whitespaces matters
     let k1 = <Comp a={10} b="hi"><Button />  <AnotherButton /></Comp>;
               ~~~~
-!!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
-!!! error TS2322:           Type 'string | Element' is not assignable to type 'Element'.
-!!! error TS2322:             Type 'string' is not assignable to type 'Element'.
+!!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element[]'.
+!!! error TS2322:         Type 'string | Element' is not assignable to type 'Element'.
+!!! error TS2322:           Type 'string' is not assignable to type 'Element'.
     let k2 = <Comp a={10} b="hi"><Button />
               ~~~~
-!!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
+!!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element[]'.
         <AnotherButton />  </Comp>;
     let k3 = <Comp a={10} b="hi">    <Button />
               ~~~~
-!!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'IntrinsicAttributes & Prop'.
-!!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
+!!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element[]'.
         <AnotherButton /></Comp>;

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,13): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-  Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
-    Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,13): error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-  Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
-    Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,13): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
+  Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,13): error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
+  Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,43): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(30,36): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(33,65): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
@@ -39,14 +37,12 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,44): err
     
     const b0 = <MainButton {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type "left" | "right"
                 ~~~~~~~~~~
-!!! error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2322:   Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
-!!! error TS2322:     Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
+!!! error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
+!!! error TS2322:   Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
     const b2 = <MainButton onClick={(k)=>{console.log(k)}} extra />;  // k has type "left" | "right"
                 ~~~~~~~~~~
-!!! error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2322:   Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
-!!! error TS2322:     Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
+!!! error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
+!!! error TS2322:   Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
     const b3 = <MainButton {...{goTo:"home"}} extra />;  // goTo has type"home" | "contact"
                                               ~~~~~
 !!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.

--- a/tests/baselines/reference/tsxIntrinsicAttributeErrors.errors.txt
+++ b/tests/baselines/reference/tsxIntrinsicAttributeErrors.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx(29,6): error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx(29,2): error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes'.
   Property 'key' is missing in type '{ x: number; }'.
 
 
@@ -31,8 +31,8 @@ tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx(29,6): error TS2322:
         }
     }
     var E: I;
-        <E x={10} />
-         ~
+    <E x={10} />
+     ~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes'.
 !!! error TS2322:   Property 'key' is missing in type '{ x: number; }'.
     

--- a/tests/baselines/reference/tsxIntrinsicAttributeErrors.errors.txt
+++ b/tests/baselines/reference/tsxIntrinsicAttributeErrors.errors.txt
@@ -1,0 +1,38 @@
+tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx(29,6): error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes'.
+  Property 'key' is missing in type '{ x: number; }'.
+
+
+==== tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx (1 errors) ====
+    declare namespace JSX {
+        interface Element { }
+        interface ElementClass {
+            render: any;
+        }
+        interface IntrinsicAttributes {
+            key: string | number
+        }
+        interface IntrinsicClassAttributes<T> {
+            ref: T
+        }
+        interface IntrinsicElements {
+            div: {
+                text?: string;
+                width?: number;
+            }
+    
+            span: any;
+        }
+    }
+    
+    interface I {
+        new(n: string): {
+            x: number
+            render(): void
+        }
+    }
+    var E: I;
+        <E x={10} />
+         ~
+!!! error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes'.
+!!! error TS2322:   Property 'key' is missing in type '{ x: number; }'.
+    

--- a/tests/baselines/reference/tsxIntrinsicAttributeErrors.js
+++ b/tests/baselines/reference/tsxIntrinsicAttributeErrors.js
@@ -1,0 +1,35 @@
+//// [tsxIntrinsicAttributeErrors.tsx]
+declare namespace JSX {
+    interface Element { }
+    interface ElementClass {
+        render: any;
+    }
+    interface IntrinsicAttributes {
+        key: string | number
+    }
+    interface IntrinsicClassAttributes<T> {
+        ref: T
+    }
+    interface IntrinsicElements {
+        div: {
+            text?: string;
+            width?: number;
+        }
+
+        span: any;
+    }
+}
+
+interface I {
+    new(n: string): {
+        x: number
+        render(): void
+    }
+}
+var E: I;
+    <E x={10} />
+
+
+//// [tsxIntrinsicAttributeErrors.jsx]
+var E;
+<E x={10}/>;

--- a/tests/baselines/reference/tsxIntrinsicAttributeErrors.js
+++ b/tests/baselines/reference/tsxIntrinsicAttributeErrors.js
@@ -27,7 +27,7 @@ interface I {
     }
 }
 var E: I;
-    <E x={10} />
+<E x={10} />
 
 
 //// [tsxIntrinsicAttributeErrors.jsx]

--- a/tests/baselines/reference/tsxIntrinsicAttributeErrors.symbols
+++ b/tests/baselines/reference/tsxIntrinsicAttributeErrors.symbols
@@ -60,7 +60,7 @@ var E: I;
 >E : Symbol(E, Decl(tsxIntrinsicAttributeErrors.tsx, 27, 3))
 >I : Symbol(I, Decl(tsxIntrinsicAttributeErrors.tsx, 19, 1))
 
-    <E x={10} />
+<E x={10} />
 >E : Symbol(E, Decl(tsxIntrinsicAttributeErrors.tsx, 27, 3))
->x : Symbol(x, Decl(tsxIntrinsicAttributeErrors.tsx, 28, 6))
+>x : Symbol(x, Decl(tsxIntrinsicAttributeErrors.tsx, 28, 2))
 

--- a/tests/baselines/reference/tsxIntrinsicAttributeErrors.symbols
+++ b/tests/baselines/reference/tsxIntrinsicAttributeErrors.symbols
@@ -1,0 +1,66 @@
+=== tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx ===
+declare namespace JSX {
+>JSX : Symbol(JSX, Decl(tsxIntrinsicAttributeErrors.tsx, 0, 0))
+
+    interface Element { }
+>Element : Symbol(Element, Decl(tsxIntrinsicAttributeErrors.tsx, 0, 23))
+
+    interface ElementClass {
+>ElementClass : Symbol(ElementClass, Decl(tsxIntrinsicAttributeErrors.tsx, 1, 25))
+
+        render: any;
+>render : Symbol(ElementClass.render, Decl(tsxIntrinsicAttributeErrors.tsx, 2, 28))
+    }
+    interface IntrinsicAttributes {
+>IntrinsicAttributes : Symbol(IntrinsicAttributes, Decl(tsxIntrinsicAttributeErrors.tsx, 4, 5))
+
+        key: string | number
+>key : Symbol(IntrinsicAttributes.key, Decl(tsxIntrinsicAttributeErrors.tsx, 5, 35))
+    }
+    interface IntrinsicClassAttributes<T> {
+>IntrinsicClassAttributes : Symbol(IntrinsicClassAttributes, Decl(tsxIntrinsicAttributeErrors.tsx, 7, 5))
+>T : Symbol(T, Decl(tsxIntrinsicAttributeErrors.tsx, 8, 39))
+
+        ref: T
+>ref : Symbol(IntrinsicClassAttributes.ref, Decl(tsxIntrinsicAttributeErrors.tsx, 8, 43))
+>T : Symbol(T, Decl(tsxIntrinsicAttributeErrors.tsx, 8, 39))
+    }
+    interface IntrinsicElements {
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(tsxIntrinsicAttributeErrors.tsx, 10, 5))
+
+        div: {
+>div : Symbol(IntrinsicElements.div, Decl(tsxIntrinsicAttributeErrors.tsx, 11, 33))
+
+            text?: string;
+>text : Symbol(text, Decl(tsxIntrinsicAttributeErrors.tsx, 12, 14))
+
+            width?: number;
+>width : Symbol(width, Decl(tsxIntrinsicAttributeErrors.tsx, 13, 26))
+        }
+
+        span: any;
+>span : Symbol(IntrinsicElements.span, Decl(tsxIntrinsicAttributeErrors.tsx, 15, 9))
+    }
+}
+
+interface I {
+>I : Symbol(I, Decl(tsxIntrinsicAttributeErrors.tsx, 19, 1))
+
+    new(n: string): {
+>n : Symbol(n, Decl(tsxIntrinsicAttributeErrors.tsx, 22, 8))
+
+        x: number
+>x : Symbol(x, Decl(tsxIntrinsicAttributeErrors.tsx, 22, 21))
+
+        render(): void
+>render : Symbol(render, Decl(tsxIntrinsicAttributeErrors.tsx, 23, 17))
+    }
+}
+var E: I;
+>E : Symbol(E, Decl(tsxIntrinsicAttributeErrors.tsx, 27, 3))
+>I : Symbol(I, Decl(tsxIntrinsicAttributeErrors.tsx, 19, 1))
+
+    <E x={10} />
+>E : Symbol(E, Decl(tsxIntrinsicAttributeErrors.tsx, 27, 3))
+>x : Symbol(x, Decl(tsxIntrinsicAttributeErrors.tsx, 28, 6))
+

--- a/tests/baselines/reference/tsxIntrinsicAttributeErrors.types
+++ b/tests/baselines/reference/tsxIntrinsicAttributeErrors.types
@@ -60,7 +60,7 @@ var E: I;
 >E : I
 >I : I
 
-    <E x={10} />
+<E x={10} />
 ><E x={10} /> : JSX.Element
 >E : I
 >x : number

--- a/tests/baselines/reference/tsxIntrinsicAttributeErrors.types
+++ b/tests/baselines/reference/tsxIntrinsicAttributeErrors.types
@@ -1,0 +1,68 @@
+=== tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx ===
+declare namespace JSX {
+>JSX : any
+
+    interface Element { }
+>Element : Element
+
+    interface ElementClass {
+>ElementClass : ElementClass
+
+        render: any;
+>render : any
+    }
+    interface IntrinsicAttributes {
+>IntrinsicAttributes : IntrinsicAttributes
+
+        key: string | number
+>key : string | number
+    }
+    interface IntrinsicClassAttributes<T> {
+>IntrinsicClassAttributes : IntrinsicClassAttributes<T>
+>T : T
+
+        ref: T
+>ref : T
+>T : T
+    }
+    interface IntrinsicElements {
+>IntrinsicElements : IntrinsicElements
+
+        div: {
+>div : { text?: string; width?: number; }
+
+            text?: string;
+>text : string
+
+            width?: number;
+>width : number
+        }
+
+        span: any;
+>span : any
+    }
+}
+
+interface I {
+>I : I
+
+    new(n: string): {
+>n : string
+
+        x: number
+>x : number
+
+        render(): void
+>render : () => void
+    }
+}
+var E: I;
+>E : I
+>I : I
+
+    <E x={10} />
+><E x={10} /> : JSX.Element
+>E : I
+>x : number
+>10 : 10
+

--- a/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
+++ b/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
@@ -1,6 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(13,11): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-  Type '{}' is not assignable to type 'Prop'.
-    Property 'a' is missing in type '{}'.
+tests/cases/conformance/jsx/file.tsx(13,11): error TS2322: Type '{}' is not assignable to type 'Prop'.
+  Property 'a' is missing in type '{}'.
 tests/cases/conformance/jsx/file.tsx(19,18): error TS2326: Types of property 'a' are incompatible.
   Type 'string' is not assignable to type 'number'.
 
@@ -20,9 +19,8 @@ tests/cases/conformance/jsx/file.tsx(19,18): error TS2326: Types of property 'a'
     // Error
     let x1 = <MyComp />
               ~~~~~~
-!!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<Prop>> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{}' is not assignable to type 'Prop'.
-!!! error TS2322:     Property 'a' is missing in type '{}'.
+!!! error TS2322: Type '{}' is not assignable to type 'Prop'.
+!!! error TS2322:   Property 'a' is missing in type '{}'.
     
     // OK
     let x = <MyComp a={10} b="hi" />

--- a/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
@@ -2,10 +2,9 @@ tests/cases/conformance/jsx/file.tsx(27,33): error TS2326: Types of property 'y'
   Type 'true' is not assignable to type 'false'.
 tests/cases/conformance/jsx/file.tsx(28,50): error TS2326: Types of property 'x' are incompatible.
   Type '3' is not assignable to type '2'.
-tests/cases/conformance/jsx/file.tsx(30,11): error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-  Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
-    Types of property 'y' are incompatible.
-      Type 'true' is not assignable to type 'false'.
+tests/cases/conformance/jsx/file.tsx(30,11): error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
+  Types of property 'y' are incompatible.
+    Type 'true' is not assignable to type 'false'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -46,9 +45,8 @@ tests/cases/conformance/jsx/file.tsx(30,11): error TS2322: Type '{ y: true; x: 2
     let x2 = <OverWriteAttr {...anyobj} x={3} />
     let x3 = <OverWriteAttr overwrite="hi" {...obj1} {...{y: true}} />
               ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:     Types of property 'y' are incompatible.
-!!! error TS2322:       Type 'true' is not assignable to type 'false'.
+!!! error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:   Types of property 'y' are incompatible.
+!!! error TS2322:     Type 'true' is not assignable to type 'false'.
     
     

--- a/tests/baselines/reference/tsxSpreadAttributesResolution16.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution16.errors.txt
@@ -1,6 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
-  Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
-    Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
+tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
+  Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -16,9 +15,8 @@ tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ property1: st
             // Error: missing property
             <AnotherComponent {...props} />
              ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
-!!! error TS2322:   Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
-!!! error TS2322:     Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
+!!! error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
+!!! error TS2322:   Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
         );
     }
     

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
@@ -1,21 +1,17 @@
-tests/cases/conformance/jsx/file.tsx(17,10): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-  Type '{}' is not assignable to type 'PoisonedProp'.
-    Property 'x' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(18,10): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-  Type '{}' is not assignable to type 'PoisonedProp'.
-    Property 'x' is missing in type '{}'.
+tests/cases/conformance/jsx/file.tsx(17,10): error TS2322: Type '{}' is not assignable to type 'PoisonedProp'.
+  Property 'x' is missing in type '{}'.
+tests/cases/conformance/jsx/file.tsx(18,10): error TS2322: Type '{}' is not assignable to type 'PoisonedProp'.
+  Property 'x' is missing in type '{}'.
 tests/cases/conformance/jsx/file.tsx(19,19): error TS2326: Types of property 'x' are incompatible.
   Type 'true' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(19,21): error TS2326: Types of property 'y' are incompatible.
   Type 'true' is not assignable to type '"2"'.
-tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-  Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
-    Types of property 'x' are incompatible.
-      Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(21,11): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-  Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
-    Types of property 'x' are incompatible.
-      Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+  Types of property 'x' are incompatible.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(21,11): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+  Types of property 'x' are incompatible.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (6 errors) ====
@@ -37,14 +33,12 @@ tests/cases/conformance/jsx/file.tsx(21,11): error TS2322: Type '{ X: string; x:
     // Error
     let p = <Poisoned {...obj} />;
              ~~~~~~~~
-!!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{}' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:     Property 'x' is missing in type '{}'.
+!!! error TS2322: Type '{}' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:   Property 'x' is missing in type '{}'.
     let y = <Poisoned />;
              ~~~~~~~~
-!!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{}' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:     Property 'x' is missing in type '{}'.
+!!! error TS2322: Type '{}' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:   Property 'x' is missing in type '{}'.
     let z = <Poisoned x y/>;
                       ~
 !!! error TS2326: Types of property 'x' are incompatible.
@@ -54,13 +48,11 @@ tests/cases/conformance/jsx/file.tsx(21,11): error TS2322: Type '{ X: string; x:
 !!! error TS2326:   Type 'true' is not assignable to type '"2"'.
     let w = <Poisoned {...{x: 5, y: "2"}}/>;
              ~~~~~~~~
-!!! error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+!!! error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:   Types of property 'x' are incompatible.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
               ~~~~~~~~
-!!! error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:     Types of property 'x' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+!!! error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:   Types of property 'x' are incompatible.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution5.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution5.errors.txt
@@ -1,7 +1,6 @@
-tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-  Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
-    Types of property 'y' are incompatible.
-      Type 'number' is not assignable to type '2'.
+tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
+  Types of property 'y' are incompatible.
+    Type 'number' is not assignable to type '2'.
 tests/cases/conformance/jsx/file.tsx(33,10): error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<EmptyProp> & { children?: ReactNode; }'.
 
 
@@ -27,10 +26,9 @@ tests/cases/conformance/jsx/file.tsx(33,10): error TS2559: Type '{ prop1: boolea
     // Error as "obj" has type { x: string; y: number }
     let p = <Poisoned {...obj} />;
              ~~~~~~~~
-!!! error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
-!!! error TS2322:   Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:     Types of property 'y' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type '2'.
+!!! error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:   Types of property 'y' are incompatible.
+!!! error TS2322:     Type 'number' is not assignable to type '2'.
     
     class EmptyProp extends React.Component<{}, {}> {
         render() {

--- a/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
@@ -1,7 +1,6 @@
 tests/cases/conformance/jsx/file.tsx(13,10): error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
-  Type '{ editable: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
-    Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
-      Property 'onEdit' is missing in type '{ editable: true; }'.
+  Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
+    Property 'onEdit' is missing in type '{ editable: true; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -20,9 +19,8 @@ tests/cases/conformance/jsx/file.tsx(13,10): error TS2322: Type '{ editable: tru
     let x = <TextComponent editable={true} />
              ~~~~~~~~~~~~~
 !!! error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
-!!! error TS2322:   Type '{ editable: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; }'.
-!!! error TS2322:     Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
-!!! error TS2322:       Property 'onEdit' is missing in type '{ editable: true; }'.
+!!! error TS2322:   Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
+!!! error TS2322:     Property 'onEdit' is missing in type '{ editable: true; }'.
     
     const textProps: TextProps = {
         editable: false

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -1,19 +1,15 @@
-tests/cases/conformance/jsx/file.tsx(12,13): error TS2322: Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-  Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
-    Property 'yy' is missing in type '{ extraProp: true; }'.
-tests/cases/conformance/jsx/file.tsx(13,13): error TS2322: Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-  Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
-    Property 'yy1' is missing in type '{ yy: number; }'.
+tests/cases/conformance/jsx/file.tsx(12,13): error TS2322: Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
+  Property 'yy' is missing in type '{ extraProp: true; }'.
+tests/cases/conformance/jsx/file.tsx(13,13): error TS2322: Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
+  Property 'yy1' is missing in type '{ yy: number; }'.
 tests/cases/conformance/jsx/file.tsx(14,31): error TS2326: Types of property 'yy1' are incompatible.
   Type 'true' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(16,31): error TS2339: Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-tests/cases/conformance/jsx/file.tsx(17,13): error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-  Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
-    Types of property 'yy' are incompatible.
-      Type 'boolean' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(25,13): error TS2322: Type '{ extra-data: true; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
-  Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
-    Property 'yy' is missing in type '{ extra-data: true; }'.
+tests/cases/conformance/jsx/file.tsx(17,13): error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
+  Types of property 'yy' are incompatible.
+    Type 'boolean' is not assignable to type 'number'.
+tests/cases/conformance/jsx/file.tsx(25,13): error TS2322: Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
+  Property 'yy' is missing in type '{ extra-data: true; }'.
 tests/cases/conformance/jsx/file.tsx(26,40): error TS2326: Types of property 'direction' are incompatible.
   Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/jsx/file.tsx(33,32): error TS2326: Types of property 'y3' are incompatible.
@@ -40,14 +36,12 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2326: Types of property 'y1
     // Error
     const c0 = <OneThing extraProp />;  // extra property;
                 ~~~~~~~~
-!!! error TS2322: Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2322:   Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
-!!! error TS2322:     Property 'yy' is missing in type '{ extraProp: true; }'.
+!!! error TS2322: Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
+!!! error TS2322:   Property 'yy' is missing in type '{ extraProp: true; }'.
     const c1 = <OneThing yy={10}/>;  // missing property;
                 ~~~~~~~~
-!!! error TS2322: Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2322:   Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
-!!! error TS2322:     Property 'yy1' is missing in type '{ yy: number; }'.
+!!! error TS2322: Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
+!!! error TS2322:   Property 'yy1' is missing in type '{ yy: number; }'.
     const c2 = <OneThing {...obj} yy1 />; // type incompatible;
                                   ~~~
 !!! error TS2326: Types of property 'yy1' are incompatible.
@@ -58,10 +52,9 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2326: Types of property 'y1
 !!! error TS2339: Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
     const c5 = <OneThing {...obj} {...{yy: true}} />;  // type incompatible;
                 ~~~~~~~~
-!!! error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2322:   Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
-!!! error TS2322:     Types of property 'yy' are incompatible.
-!!! error TS2322:       Type 'boolean' is not assignable to type 'number'.
+!!! error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
+!!! error TS2322:   Types of property 'yy' are incompatible.
+!!! error TS2322:     Type 'boolean' is not assignable to type 'number'.
     const c6 = <OneThing {...obj2} {...{extra: "extra attr"}} />;  // Should error as there is extra attribute that doesn't match any. Current it is not
     const c7 = <OneThing {...obj2} yy />;  // Should error as there is extra attribute that doesn't match any. Current it is not
     
@@ -71,9 +64,8 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2326: Types of property 'y1
     // Error
     const d1 = <TestingOneThing extra-data />
                 ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ extra-data: true; }' is not assignable to type 'IntrinsicAttributes & { yy: string; direction?: number; }'.
-!!! error TS2322:   Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
-!!! error TS2322:     Property 'yy' is missing in type '{ extra-data: true; }'.
+!!! error TS2322: Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
+!!! error TS2322:   Property 'yy' is missing in type '{ extra-data: true; }'.
     const d2 = <TestingOneThing yy="hello" direction="left" />
                                            ~~~~~~~~~~~~~~~~
 !!! error TS2326: Types of property 'direction' are incompatible.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,18 +1,13 @@
-tests/cases/conformance/jsx/file.tsx(48,13): error TS2322: Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
-tests/cases/conformance/jsx/file.tsx(49,13): error TS2322: Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
-tests/cases/conformance/jsx/file.tsx(50,13): error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
-tests/cases/conformance/jsx/file.tsx(51,13): error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
-tests/cases/conformance/jsx/file.tsx(53,13): error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-    Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
+tests/cases/conformance/jsx/file.tsx(48,13): error TS2322: Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
+  Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
+tests/cases/conformance/jsx/file.tsx(49,13): error TS2322: Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
+  Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
+tests/cases/conformance/jsx/file.tsx(50,13): error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
+  Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
+tests/cases/conformance/jsx/file.tsx(51,13): error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
+  Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
+tests/cases/conformance/jsx/file.tsx(53,13): error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+  Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
 tests/cases/conformance/jsx/file.tsx(54,51): error TS2326: Types of property 'children' are incompatible.
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(55,68): error TS2326: Types of property 'className' are incompatible.
@@ -71,30 +66,25 @@ tests/cases/conformance/jsx/file.tsx(56,24): error TS2326: Types of property 'da
     // Error
     const b0 = <MainButton to='/some/path' onClick={(e)=>{}}>GO</MainButton>;  // extra property;
                 ~~~~~~~~~~
-!!! error TS2322: Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
+!!! error TS2322: Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:   Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
     const b1 = <MainButton onClick={(e: any)=> {}} {...obj0}>Hello world</MainButton>;  // extra property;
                 ~~~~~~~~~~
-!!! error TS2322: Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
+!!! error TS2322: Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:   Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
     const b2 = <MainButton {...{to: "10000"}} {...obj2} />;  // extra property
                 ~~~~~~~~~~
-!!! error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
+!!! error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:   Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
     const b3 = <MainButton {...{to: "10000"}} {...{onClick: (k) => {}}} />;  // extra property
                 ~~~~~~~~~~
-!!! error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
+!!! error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:   Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
     const b4 = <MainButton {...obj3} to />;  // Should error because Incorrect type; but attributes are any so everything is allowed
     const b5 = <MainButton {...{ onClick(e: any) { } }} {...obj0} />;  // Spread retain method declaration (see GitHub #13365), so now there is an extra attributes
                 ~~~~~~~~~~
-!!! error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:     Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
+!!! error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:   Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
     const b6 = <MainButton {...{ onClick(e: any){} }} children={10} />;  // incorrect type for optional attribute
                                                       ~~~~~~~~~~~~~
 !!! error TS2326: Types of property 'children' are incompatible.

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
@@ -1,12 +1,10 @@
-tests/cases/conformance/jsx/file.tsx(19,10): error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
-  Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
-    Property 'name' is missing in type '{ naaame: string; }'.
+tests/cases/conformance/jsx/file.tsx(19,10): error TS2322: Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
+  Property 'name' is missing in type '{ naaame: string; }'.
 tests/cases/conformance/jsx/file.tsx(27,15): error TS2326: Types of property 'name' are incompatible.
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(29,10): error TS2559: Type '{ naaaaaaame: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
-tests/cases/conformance/jsx/file.tsx(34,10): error TS2322: Type '{ extra-prop-name: string; }' is not assignable to type 'IntrinsicAttributes & { "prop-name": string; }'.
-  Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
-    Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
+tests/cases/conformance/jsx/file.tsx(34,10): error TS2322: Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
+  Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
 tests/cases/conformance/jsx/file.tsx(37,10): error TS2559: Type '{ prop1: true; }' has no properties in common with type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(38,11): error TS2559: Type '{ ref: (x: any) => any; }' has no properties in common with type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(41,16): error TS1005: ',' expected.
@@ -34,9 +32,8 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
     // Error
     let b = <Greet naaame='world' />;
              ~~~~~
-!!! error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
-!!! error TS2322:   Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
-!!! error TS2322:     Property 'name' is missing in type '{ naaame: string; }'.
+!!! error TS2322: Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
+!!! error TS2322:   Property 'name' is missing in type '{ naaame: string; }'.
     
     // OK
     let c = <Meet />;
@@ -58,9 +55,8 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
     // Error
     let h = <MeetAndGreet extra-prop-name="World" />;
              ~~~~~~~~~~~~
-!!! error TS2322: Type '{ extra-prop-name: string; }' is not assignable to type 'IntrinsicAttributes & { "prop-name": string; }'.
-!!! error TS2322:   Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
-!!! error TS2322:     Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
+!!! error TS2322: Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
+!!! error TS2322:   Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
     
     // Error
     let i = <EmptyPropSFC prop1 />

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
@@ -1,6 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(9,15): error TS2322: Type '{ a: number; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: number; }'.
-  Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
-    Property 'b' is missing in type '{ a: number; }'.
+tests/cases/conformance/jsx/file.tsx(9,15): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
+  Property 'b' is missing in type '{ a: number; }'.
 tests/cases/conformance/jsx/file.tsx(10,15): error TS2322: Type 'T & { ignore-prop: true; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: {}; }'.
   Type 'T & { ignore-prop: true; }' is not assignable to type '{ b: {}; a: {}; }'.
     Property 'a' is missing in type '{ b: number; } & { ignore-prop: true; }'.
@@ -17,9 +16,8 @@ tests/cases/conformance/jsx/file.tsx(10,15): error TS2322: Type 'T & { ignore-pr
     function Baz<T extends {b: number}, U extends {a: boolean, b:string}>(arg1: T, arg2: U) {
         let a0 = <OverloadComponent a={arg1.b}/>
                   ~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: number; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: number; }'.
-!!! error TS2322:   Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
-!!! error TS2322:     Property 'b' is missing in type '{ a: number; }'.
+!!! error TS2322: Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
+!!! error TS2322:   Property 'b' is missing in type '{ a: number; }'.
         let a2 = <OverloadComponent {...arg1} ignore-prop />  // missing a
                   ~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'T & { ignore-prop: true; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: {}; }'.

--- a/tests/baselines/reference/tsxUnionElementType6.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType6.errors.txt
@@ -1,12 +1,10 @@
 tests/cases/conformance/jsx/file.tsx(18,10): error TS2559: Type '{ x: true; }' has no properties in common with type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(19,27): error TS2326: Types of property 'x' are incompatible.
   Type 'string' is not assignable to type 'boolean'.
-tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-  Type '{}' is not assignable to type '{ x: boolean; }'.
-    Property 'x' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(21,10): error TS2322: Type '{ data-prop: true; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-  Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
-    Property 'x' is missing in type '{ data-prop: true; }'.
+tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{}' is not assignable to type '{ x: boolean; }'.
+  Property 'x' is missing in type '{}'.
+tests/cases/conformance/jsx/file.tsx(21,10): error TS2322: Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
+  Property 'x' is missing in type '{ data-prop: true; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (4 errors) ====
@@ -36,13 +34,11 @@ tests/cases/conformance/jsx/file.tsx(21,10): error TS2322: Type '{ data-prop: tr
 !!! error TS2326:   Type 'string' is not assignable to type 'boolean'.
     let c = <SFC2AndEmptyComp />;
              ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-!!! error TS2322:   Type '{}' is not assignable to type '{ x: boolean; }'.
-!!! error TS2322:     Property 'x' is missing in type '{}'.
+!!! error TS2322: Type '{}' is not assignable to type '{ x: boolean; }'.
+!!! error TS2322:   Property 'x' is missing in type '{}'.
     let d = <SFC2AndEmptyComp data-prop />;
              ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ data-prop: true; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
-!!! error TS2322:   Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
-!!! error TS2322:     Property 'x' is missing in type '{ data-prop: true; }'.
+!!! error TS2322: Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
+!!! error TS2322:   Property 'x' is missing in type '{ data-prop: true; }'.
     
     

--- a/tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx
+++ b/tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx
@@ -1,0 +1,31 @@
+// @jsx: preserve
+
+declare namespace JSX {
+    interface Element { }
+    interface ElementClass {
+        render: any;
+    }
+    interface IntrinsicAttributes {
+        key: string | number
+    }
+    interface IntrinsicClassAttributes<T> {
+        ref: T
+    }
+    interface IntrinsicElements {
+        div: {
+            text?: string;
+            width?: number;
+        }
+
+        span: any;
+    }
+}
+
+interface I {
+    new(n: string): {
+        x: number
+        render(): void
+    }
+}
+var E: I;
+<E x={10} />


### PR DESCRIPTION
Do not issue an error message for a source type that comes from JSX attributes and a target type that is an intersection containing IntrinsicAttributes or IntrinsicClassAttributes. This will make error messages simpler and less confusing.

Note:
1. There will always be elaboration under the skipped message, so this won't elide errors completely.
2. Rarely (once in the tests) the intersection type will have more that one non-Intrinsic* member. However, these additional members don't provide useful information either, so it's fine to skip them.

Might fix all the confusion in #15643 that happened *after* the actual fix to that bug. Or at least help.