### PR TITLE
Fix duplicate identifier error with module.exports

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20418,7 +20418,7 @@ namespace ts {
                         if (propType.symbol && propType.symbol.flags & SymbolFlags.Class) {
                             const name = prop.escapedName;
                             const symbol = resolveName(prop.valueDeclaration, name, SymbolFlags.Type, undefined, name, /*isUse*/ false);
-                            if (symbol) {
+                            if (symbol && propType.symbol !== symbol) {
                                 grammarErrorOnNode(symbol.declarations[0], Diagnostics.Duplicate_identifier_0, unescapeLeadingUnderscores(name));
                                 return grammarErrorOnNode(prop.valueDeclaration, Diagnostics.Duplicate_identifier_0, unescapeLeadingUnderscores(name));
                             }

--- a/tests/baselines/reference/moduleExportAlias3.symbols
+++ b/tests/baselines/reference/moduleExportAlias3.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/salsa/bug24062.js ===
+// #24062
+class C {
+>C : Symbol(C, Decl(bug24062.js, 0, 0))
+}
+module.exports = {
+>module : Symbol(export=, Decl(bug24062.js, 2, 1))
+>exports : Symbol(export=, Decl(bug24062.js, 2, 1))
+
+    C
+>C : Symbol(C, Decl(bug24062.js, 3, 18))
+
+};
+

--- a/tests/baselines/reference/moduleExportAlias3.types
+++ b/tests/baselines/reference/moduleExportAlias3.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/salsa/bug24062.js ===
+// #24062
+class C {
+>C : C
+}
+module.exports = {
+>module.exports = {    C} : { [x: string]: any; C: typeof C; }
+>module.exports : any
+>module : any
+>exports : any
+>{    C} : { [x: string]: any; C: typeof C; }
+
+    C
+>C : typeof C
+
+};
+

--- a/tests/cases/conformance/salsa/moduleExportAlias3.ts
+++ b/tests/cases/conformance/salsa/moduleExportAlias3.ts
@@ -1,0 +1,10 @@
+// @checkJs: true
+// @allowJS: true
+// @noEmit: true
+// @Filename: bug24062.js
+// #24062
+class C {
+}
+module.exports = {
+    C
+};


### PR DESCRIPTION
A bug in checkSpecialAssignment added bogus duplicate identifier errors when using module.exports assignment to export a class.

Fixes #24062