### PR TITLE
Avoid duplicate import completions when a namespace is exported by two different modules

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -868,7 +868,7 @@ namespace FourSlash {
             for (const entry of actualCompletions.entries) {
                 if (actualByName.has(entry.name)) {
                     // TODO: GH#23587
-                    if (entry.name !== "undefined" && entry.name !== "require") this.raiseError(`Duplicate completions for ${entry.name}`);
+                    if (entry.name !== "undefined" && entry.name !== "require") this.raiseError(`Duplicate (${actualCompletions.entries.filter(a => a.name === entry.name).length}) completions for ${entry.name}`);
                 }
                 else {
                     actualByName.set(entry.name, entry);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1320,9 +1320,17 @@ namespace ts.Completions {
         function getSymbolsFromOtherSourceFileExports(symbols: Symbol[], tokenText: string, target: ScriptTarget): void {
             const tokenTextLowerCase = tokenText.toLowerCase();
 
+            const seenResolvedModules = createMap<true>();
+
             codefix.forEachExternalModuleToImportFrom(typeChecker, sourceFile, program.getSourceFiles(), moduleSymbol => {
                 // Perf -- ignore other modules if this is a request for details
                 if (detailsEntryId && detailsEntryId.source && stripQuotes(moduleSymbol.name) !== detailsEntryId.source) {
+                    return;
+                }
+
+                const resolvedModuleSymbol = typeChecker.resolveExternalModuleSymbol(moduleSymbol);
+                // resolvedModuleSymbol may be a namespace. A namespace may be `export =` by multiple module declarations, but only keep the first one.
+                if (!addToSeen(seenResolvedModules, getSymbolId(resolvedModuleSymbol))) {
                     return;
                 }
 
@@ -1333,7 +1341,7 @@ namespace ts.Completions {
                     //
                     // If `symbol.parent !== ...`, this comes from an `export * from "foo"` re-export. Those don't create new symbols.
                     // If `some(...)`, this comes from an `export { foo } from "foo"` re-export, which creates a new symbol (thus isn't caught by the first check).
-                    if (typeChecker.getMergedSymbol(symbol.parent!) !== typeChecker.resolveExternalModuleSymbol(moduleSymbol)
+                    if (typeChecker.getMergedSymbol(symbol.parent!) !== resolvedModuleSymbol
                         || some(symbol.declarations, d => isExportSpecifier(d) && !!d.parent.parent.moduleSpecifier)) {
                         continue;
                     }

--- a/tests/cases/fourslash/completionsImport_exportEqualsNamespace_noDuplicate.ts
+++ b/tests/cases/fourslash/completionsImport_exportEqualsNamespace_noDuplicate.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: /node_modules/a/index.d.ts
+////declare namespace core {
+////    const foo: number;
+////}
+////declare module "a" {
+////    export = core;
+////}
+////declare module "a/alias" {
+////    export = core;
+////}
+
+// @Filename: /user.ts
+////import * as a from "a";
+/////**/foo;
+
+verify.completions({
+    marker: "",
+    // Tester will assert that it is only included once
+    includes: [{ name: "foo", hasAction: true }],
+    preferences: {
+        includeCompletionsForModuleExports: true,
+    }
+});


### PR DESCRIPTION
Fixes the import completions issue from #13373 -- does not fix the path completions issue.