### PR TITLE
Simplify calculation of sourceFiles for getReferences

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1735,17 +1735,9 @@ namespace ts {
             synchronizeHostData();
 
             // Exclude default library when renaming as commonly user don't want to change that file.
-            let sourceFiles: SourceFile[] = [];
-            if (options && options.isForRename) {
-                for (const sourceFile of program.getSourceFiles()) {
-                    if (!program.isSourceFileDefaultLibrary(sourceFile)) {
-                        sourceFiles.push(sourceFile);
-                    }
-                }
-            }
-            else {
-                sourceFiles = program.getSourceFiles().slice();
-            }
+            const sourceFiles = options && options.isForRename
+                ? program.getSourceFiles().filter(sourceFile => !program.isSourceFileDefaultLibrary(sourceFile))
+                : program.getSourceFiles();
 
             return FindAllReferences.findReferencedEntries(program, cancellationToken, sourceFiles, getValidSourceFile(fileName), position, options);
         }


### PR DESCRIPTION
* First case is just a filter.
* In the second case, the `slice()` is unnecessary, since `sourceFiles` is used as a `ReadonlyArray`.
