### PR TITLE
Support getting references even if quickInfo failed

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1025,13 +1025,10 @@ namespace ts.server {
             const position = this.getPosition(args, scriptInfo);
             if (simplifiedResult) {
                 const nameInfo = defaultProject.getLanguageService().getQuickInfoAtPosition(file, position);
-                if (!nameInfo) {
-                    return undefined;
-                }
-                const displayString = displayPartsToString(nameInfo.displayParts);
-                const nameSpan = nameInfo.textSpan;
-                const nameColStart = scriptInfo.positionToLineOffset(nameSpan.start).offset;
-                const nameText = scriptInfo.getSnapshot().getText(nameSpan.start, textSpanEnd(nameSpan));
+                const displayString = nameInfo ? displayPartsToString(nameInfo.displayParts) : "";
+                const nameSpan = nameInfo && nameInfo.textSpan;
+                const nameColStart = nameSpan ? scriptInfo.positionToLineOffset(nameSpan.start).offset : 0;
+                const nameText = nameSpan ? scriptInfo.getSnapshot().getText(nameSpan.start, textSpanEnd(nameSpan)) : "";
                 const refs = combineProjectOutput<NormalizedPath, protocol.ReferencesResponseItem>(
                     file,
                     path => this.projectService.getScriptInfoForPath(path)!.fileName,

--- a/tests/cases/fourslash/server/findAllRefsForStringLiteralTypes.ts
+++ b/tests/cases/fourslash/server/findAllRefsForStringLiteralTypes.ts
@@ -1,0 +1,17 @@
+/// <reference path='../fourslash.ts'/>
+
+// @Filename: /a.ts
+////type Options = "[|{| "isInString": true |}option 1|]" | "option 2";
+////let myOption: Options = "[|{| "isInString": true |}option 1|]";
+
+const [r0, r1] = test.ranges();
+goTo.eachRange(() => {
+    verify.getReferencesForServerTest([
+        { fileName: "/a.ts", isDefinition: false, isWriteAccess: false, textSpan: toSpan(r0) },
+        { fileName: "/a.ts", isDefinition: false, isWriteAccess: false, textSpan: toSpan(r1) },
+    ]);
+});
+
+function toSpan(r: FourSlashInterface.Range) {
+    return { start: r.pos, length: r.end - r.pos };
+}


### PR DESCRIPTION
Test this in vscode:
```ts
"a";
"a";
```

Getting references doesn't succeed currently, but will with this PR. The reason is that the code for getting references apparently calls `getQuickInfoAtPosition` too in order to get some additional info. For a string literal we don't provide quickInfo, so that made it impossible to get references for the string literal.