### PR TITLE
Better fix for bogus duplicate identifier in module exports

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20428,7 +20428,7 @@ namespace ts {
                         if (propType.symbol && propType.symbol.flags & SymbolFlags.Class) {
                             const name = prop.escapedName;
                             const symbol = resolveName(prop.valueDeclaration, name, SymbolFlags.Type, undefined, name, /*isUse*/ false);
-                            if (symbol && propType.symbol !== symbol) {
+                            if (symbol && symbol.declarations.some(d => d.kind === SyntaxKind.JSDocTypedefTag)) {
                                 grammarErrorOnNode(symbol.declarations[0], Diagnostics.Duplicate_identifier_0, unescapeLeadingUnderscores(name));
                                 return grammarErrorOnNode(prop.valueDeclaration, Diagnostics.Duplicate_identifier_0, unescapeLeadingUnderscores(name));
                             }

--- a/tests/baselines/reference/moduleExportAlias4.symbols
+++ b/tests/baselines/reference/moduleExportAlias4.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/salsa/bug24024.js ===
+// #24024
+var wat = require('./bug24024')
+>wat : Symbol(wat, Decl(bug24024.js, 1, 3))
+>require : Symbol(require)
+>'./bug24024' : Symbol("tests/cases/conformance/salsa/bug24024", Decl(bug24024.js, 0, 0))
+
+module.exports = class C {}
+>module : Symbol(export=, Decl(bug24024.js, 1, 31))
+>exports : Symbol(export=, Decl(bug24024.js, 1, 31))
+>C : Symbol(C, Decl(bug24024.js, 2, 16))
+
+module.exports.D = class D { }
+>module.exports : Symbol(D, Decl(bug24024.js, 2, 27))
+>module : Symbol(module)
+>D : Symbol(D, Decl(bug24024.js, 2, 27))
+>D : Symbol(D, Decl(bug24024.js, 3, 18))
+

--- a/tests/baselines/reference/moduleExportAlias4.types
+++ b/tests/baselines/reference/moduleExportAlias4.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/salsa/bug24024.js ===
+// #24024
+var wat = require('./bug24024')
+>wat : typeof C
+>require('./bug24024') : typeof C
+>require : any
+>'./bug24024' : "./bug24024"
+
+module.exports = class C {}
+>module.exports = class C {} : typeof C
+>module.exports : any
+>module : any
+>exports : any
+>class C {} : typeof C
+>C : typeof C
+
+module.exports.D = class D { }
+>module.exports.D = class D { } : typeof D
+>module.exports.D : any
+>module.exports : any
+>module : any
+>exports : any
+>D : any
+>class D { } : typeof D
+>D : typeof D
+

--- a/tests/cases/conformance/salsa/moduleExportAlias4.ts
+++ b/tests/cases/conformance/salsa/moduleExportAlias4.ts
@@ -1,0 +1,8 @@
+// @checkJs: true
+// @allowJS: true
+// @noEmit: true
+// @Filename: bug24024.js
+// #24024
+var wat = require('./bug24024')
+module.exports = class C {}
+module.exports.D = class D { }


### PR DESCRIPTION
The only situation the checker-based duplicate identifier check should fire is a conflict between a class type and a typedef type. The check works by starting from a class type and trying to resolve the class's name. Now, if a symbol with that name is found, the error is only logged if the resolved symbol is a typedef. 
This avoids bogus self-duplicates in a more robust way than the previous fix, because `===` is not a good test for equality of symbols &mdash; symbols might be merged or part of a special JS assignment, or both.

Fixes #24024 and #24062
