### PR TITLE
Fix exported type resolution in commonjs

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1322,8 +1322,14 @@ namespace ts {
                             }
                         }
 
+                        // ES6 exports are also visible locally (except for 'default'), but commonjs exports are not (except typedefs)
                         if (name !== InternalSymbolName.Default && (result = lookup(moduleExports, name, meaning & SymbolFlags.ModuleMember))) {
-                            break loop;
+                            if ((location as SourceFile).commonJsModuleIndicator && !result.declarations.some(d => d.kind === SyntaxKind.JSDocTypedefTag)) {
+                                result = undefined;
+                            }
+                            else {
+                                break loop;
+                            }
                         }
                         break;
                     case SyntaxKind.EnumDeclaration:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1324,7 +1324,7 @@ namespace ts {
 
                         // ES6 exports are also visible locally (except for 'default'), but commonjs exports are not (except typedefs)
                         if (name !== InternalSymbolName.Default && (result = lookup(moduleExports, name, meaning & SymbolFlags.ModuleMember))) {
-                            if ((location as SourceFile).commonJsModuleIndicator && !result.declarations.some(d => d.kind === SyntaxKind.JSDocTypedefTag)) {
+                            if ((location as SourceFile).commonJsModuleIndicator && !result.declarations.some(isJSDocTypeAlias)) {
                                 result = undefined;
                             }
                             else {

--- a/tests/baselines/reference/exportPropertyAssignmentNameResolution.errors.txt
+++ b/tests/baselines/reference/exportPropertyAssignmentNameResolution.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/salsa/bug24492.js(2,5): error TS2304: Cannot find name 'D'.
+
+
+==== tests/cases/conformance/salsa/bug24492.js (1 errors) ====
+    module.exports.D = class { }
+    new D()
+        ~
+!!! error TS2304: Cannot find name 'D'.
+    

--- a/tests/baselines/reference/exportPropertyAssignmentNameResolution.symbols
+++ b/tests/baselines/reference/exportPropertyAssignmentNameResolution.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/salsa/bug24492.js ===
+module.exports.D = class { }
+>module.exports : Symbol(D, Decl(bug24492.js, 0, 0))
+>module : Symbol(module)
+>D : Symbol(D, Decl(bug24492.js, 0, 0))
+
+new D()
+

--- a/tests/baselines/reference/exportPropertyAssignmentNameResolution.types
+++ b/tests/baselines/reference/exportPropertyAssignmentNameResolution.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/salsa/bug24492.js ===
+module.exports.D = class { }
+>module.exports.D = class { } : typeof D
+>module.exports.D : any
+>module.exports : any
+>module : any
+>exports : any
+>D : any
+>class { } : typeof D
+
+new D()
+>new D() : any
+>D : any
+

--- a/tests/cases/conformance/salsa/exportPropertyAssignmentNameResolution.ts
+++ b/tests/cases/conformance/salsa/exportPropertyAssignmentNameResolution.ts
@@ -1,0 +1,6 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: bug24492.js
+module.exports.D = class { }
+new D()

--- a/tests/cases/fourslash/refactorConvertToEs6Module_export_named.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_export_named.ts
@@ -21,9 +21,7 @@ verify.codeFix({
     description: "Convert to ES6 module",
     newFileContent:
 `export function f() {}
-const _C = class {
-};
-export { _C as C };
+export class C {}
 export const x = 0;
 export function a1() {}
 export function a2() { return 0; }

--- a/tests/cases/fourslash/refactorConvertToEs6Module_export_namedClassExpression.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_export_namedClassExpression.ts
@@ -10,12 +10,6 @@
 verify.codeFix({
     description: "Convert to ES6 module",
     newFileContent:
-`const _C = class E {
-    static instance = new E();
-};
-export { _C as C };
-const _D = class D {
-    static instance = new D();
-};
-export { _D as D };`,
+`export const C = class E { static instance = new E(); }
+export class D { static instance = new D(); }`,
 });

--- a/tests/cases/fourslash/refactorConvertToEs6Module_expressionToDeclaration.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_expressionToDeclaration.ts
@@ -4,13 +4,17 @@
 // @target: esnext
 
 // @Filename: /a.js
+////var C = {};
+////console.log(C);
 ////exports.f = async function* f(p) { p; }
 ////exports.C = class C extends D { m() {} }
 
 verify.codeFix({
     description: "Convert to ES6 module",
     newFileContent:
-`export async function* f(p) { p; }
+`var C = {};
+console.log(C);
+export async function* f(p) { p; }
 const _C = class C extends D {
     m() { }
 };


### PR DESCRIPTION
It is fine to resolve the types of exported classes in ES6:

```js
export class C {
}
var c = new C()
```

But not for commonjs exported classes:

```js
module.exports.C = class {
}
var c = new C() // should error
```

JSDoc type aliases are an exception since they are always exported implicitly, not by [property] assignment to `module.exports` or `exports`.

Fixes #24492 
