### PR TITLE
fixUnusedIdentifier: fix "Remove variable statement" codefix 

### DIFF
--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -29,7 +29,7 @@ namespace ts.codefix {
             }
             const delVar = textChanges.ChangeTracker.with(context, t => tryDeleteFullVariableStatement(t, sourceFile, startToken, /*deleted*/ undefined));
             if (delVar.length) {
-                return [createCodeFixAction(fixName, delDestructure, Diagnostics.Remove_variable_statement, fixIdDelete, Diagnostics.Delete_all_unused_declarations)];
+                return [createCodeFixAction(fixName, delVar, Diagnostics.Remove_variable_statement, fixIdDelete, Diagnostics.Delete_all_unused_declarations)];
             }
 
             const token = getToken(sourceFile, textSpanEnd(context.span));

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_removeVariableStatement.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_removeVariableStatement.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @noUnusedLocals: true
+
+////function f() {
+////    let a = 1, b = 2, c = 3;
+////}
+
+verify.codeFix({
+    description: "Remove variable statement",
+    newFileContent:
+`function f() {
+}`,
+});


### PR DESCRIPTION
Discovered that "Remove variable statement" codefix currently does nothing if this is the only codefix available in the current file due to the typo in the code. The tests didn't catch it because they had multiple codefixes available in one file.

Fixed the typo and added a new test.

Fixes #22352 (not directly, but "Remove variable statement" is currently broken and the issue gets fixed by this pull request)

