### PR TITLE
Lookup type arguments correcly for taged templates when checking generic arity (#24496)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17646,7 +17646,7 @@ namespace ts {
                 // Even if the call is incomplete, we'll have a missing expression as our last argument,
                 // so we can say the count is just the arg list length
                 argCount = args.length;
-                typeArguments = undefined;
+                typeArguments = node.typeArguments;
 
                 if (node.template.kind === SyntaxKind.TemplateExpression) {
                     // If a tagged template expression lacks a tail literal, the call is incomplete.

--- a/tests/baselines/reference/genericTemplateOverloadResolution.js
+++ b/tests/baselines/reference/genericTemplateOverloadResolution.js
@@ -1,0 +1,19 @@
+//// [genericTemplateOverloadResolution.ts]
+interface IFooFn {
+    (strings: TemplateStringsArray): Promise<{}>;
+    <T>(strings: TemplateStringsArray): Promise<T>;
+}
+
+declare const fooFn: IFooFn;
+
+declare function expect(x: Promise<number>): void;
+
+expect(fooFn<number>``);
+
+
+//// [genericTemplateOverloadResolution.js]
+var __makeTemplateObject = (this && this.__makeTemplateObject) || function (cooked, raw) {
+    if (Object.defineProperty) { Object.defineProperty(cooked, "raw", { value: raw }); } else { cooked.raw = raw; }
+    return cooked;
+};
+expect(fooFn(__makeTemplateObject([""], [""])));

--- a/tests/baselines/reference/genericTemplateOverloadResolution.symbols
+++ b/tests/baselines/reference/genericTemplateOverloadResolution.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/genericTemplateOverloadResolution.ts ===
+interface IFooFn {
+>IFooFn : Symbol(IFooFn, Decl(genericTemplateOverloadResolution.ts, 0, 0))
+
+    (strings: TemplateStringsArray): Promise<{}>;
+>strings : Symbol(strings, Decl(genericTemplateOverloadResolution.ts, 1, 5))
+>TemplateStringsArray : Symbol(TemplateStringsArray, Decl(lib.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --))
+
+    <T>(strings: TemplateStringsArray): Promise<T>;
+>T : Symbol(T, Decl(genericTemplateOverloadResolution.ts, 2, 5))
+>strings : Symbol(strings, Decl(genericTemplateOverloadResolution.ts, 2, 8))
+>TemplateStringsArray : Symbol(TemplateStringsArray, Decl(lib.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(genericTemplateOverloadResolution.ts, 2, 5))
+}
+
+declare const fooFn: IFooFn;
+>fooFn : Symbol(fooFn, Decl(genericTemplateOverloadResolution.ts, 5, 13))
+>IFooFn : Symbol(IFooFn, Decl(genericTemplateOverloadResolution.ts, 0, 0))
+
+declare function expect(x: Promise<number>): void;
+>expect : Symbol(expect, Decl(genericTemplateOverloadResolution.ts, 5, 28))
+>x : Symbol(x, Decl(genericTemplateOverloadResolution.ts, 7, 24))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --))
+
+expect(fooFn<number>``);
+>expect : Symbol(expect, Decl(genericTemplateOverloadResolution.ts, 5, 28))
+>fooFn : Symbol(fooFn, Decl(genericTemplateOverloadResolution.ts, 5, 13))
+

--- a/tests/baselines/reference/genericTemplateOverloadResolution.types
+++ b/tests/baselines/reference/genericTemplateOverloadResolution.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/genericTemplateOverloadResolution.ts ===
+interface IFooFn {
+>IFooFn : IFooFn
+
+    (strings: TemplateStringsArray): Promise<{}>;
+>strings : TemplateStringsArray
+>TemplateStringsArray : TemplateStringsArray
+>Promise : Promise<T>
+
+    <T>(strings: TemplateStringsArray): Promise<T>;
+>T : T
+>strings : TemplateStringsArray
+>TemplateStringsArray : TemplateStringsArray
+>Promise : Promise<T>
+>T : T
+}
+
+declare const fooFn: IFooFn;
+>fooFn : IFooFn
+>IFooFn : IFooFn
+
+declare function expect(x: Promise<number>): void;
+>expect : (x: Promise<number>) => void
+>x : Promise<number>
+>Promise : Promise<T>
+
+expect(fooFn<number>``);
+>expect(fooFn<number>``) : void
+>expect : (x: Promise<number>) => void
+>fooFn<number>`` : Promise<number>
+>fooFn : IFooFn
+>`` : ""
+

--- a/tests/cases/compiler/genericTemplateOverloadResolution.ts
+++ b/tests/cases/compiler/genericTemplateOverloadResolution.ts
@@ -1,0 +1,10 @@
+interface IFooFn {
+    (strings: TemplateStringsArray): Promise<{}>;
+    <T>(strings: TemplateStringsArray): Promise<T>;
+}
+
+declare const fooFn: IFooFn;
+
+declare function expect(x: Promise<number>): void;
+
+expect(fooFn<number>``);


### PR DESCRIPTION
Ports #24496 to `release-2.9`.

