### PR TITLE
For type emit, walk non-parent containers when those containers have aliases leading to the target

### DIFF
--- a/tests/baselines/reference/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.js
@@ -1,0 +1,37 @@
+//// [tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts] ////
+
+//// [color.ts]
+interface Color {
+    c: string;
+}
+export default Color;
+//// [file1.ts]
+import Color from "./color";
+export declare function styled(): Color;
+//// [file2.ts]
+import { styled }  from "./file1";
+export const A = styled();
+
+//// [color.js]
+"use strict";
+exports.__esModule = true;
+//// [file1.js]
+"use strict";
+exports.__esModule = true;
+//// [file2.js]
+"use strict";
+exports.__esModule = true;
+var file1_1 = require("./file1");
+exports.A = file1_1.styled();
+
+
+//// [color.d.ts]
+interface Color {
+    c: string;
+}
+export default Color;
+//// [file1.d.ts]
+import Color from "./color";
+export declare function styled(): Color;
+//// [file2.d.ts]
+export declare const A: import("./color").default;

--- a/tests/baselines/reference/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.symbols
+++ b/tests/baselines/reference/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/color.ts ===
+interface Color {
+>Color : Symbol(Color, Decl(color.ts, 0, 0))
+
+    c: string;
+>c : Symbol(Color.c, Decl(color.ts, 0, 17))
+}
+export default Color;
+>Color : Symbol(Color, Decl(color.ts, 0, 0))
+
+=== tests/cases/compiler/file1.ts ===
+import Color from "./color";
+>Color : Symbol(Color, Decl(file1.ts, 0, 6))
+
+export declare function styled(): Color;
+>styled : Symbol(styled, Decl(file1.ts, 0, 28))
+>Color : Symbol(Color, Decl(file1.ts, 0, 6))
+
+=== tests/cases/compiler/file2.ts ===
+import { styled }  from "./file1";
+>styled : Symbol(styled, Decl(file2.ts, 0, 8))
+
+export const A = styled();
+>A : Symbol(A, Decl(file2.ts, 1, 12))
+>styled : Symbol(styled, Decl(file2.ts, 0, 8))
+

--- a/tests/baselines/reference/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.types
+++ b/tests/baselines/reference/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/color.ts ===
+interface Color {
+>Color : Color
+
+    c: string;
+>c : string
+}
+export default Color;
+>Color : Color
+
+=== tests/cases/compiler/file1.ts ===
+import Color from "./color";
+>Color : any
+
+export declare function styled(): Color;
+>styled : () => Color
+>Color : Color
+
+=== tests/cases/compiler/file2.ts ===
+import { styled }  from "./file1";
+>styled : () => import("tests/cases/compiler/color").default
+
+export const A = styled();
+>A : import("tests/cases/compiler/color").default
+>styled() : import("tests/cases/compiler/color").default
+>styled : () => import("tests/cases/compiler/color").default
+

--- a/tests/baselines/reference/importTypeGenericTypes.types
+++ b/tests/baselines/reference/importTypeGenericTypes.types
@@ -89,9 +89,9 @@ export const x: import("./foo")<{x: number}> = { x: 0, y: 0, data: {x: 12} };
 >12 : 12
 
 export let y: import("./foo2").Bar.I<{x: number}> = { a: "", b: 0, data: {x: 12} };
->y : Bar.I<{ x: number; }>
+>y : import("tests/cases/conformance/types/import/foo2").Bar.I<{ x: number; }>
 >Bar : any
->I : Bar.I<T>
+>I : import("tests/cases/conformance/types/import/foo2").Bar.I<T>
 >x : number
 >{ a: "", b: 0, data: {x: 12} } : { a: string; b: number; data: { x: number; }; }
 >a : string

--- a/tests/baselines/reference/importTypeLocal.types
+++ b/tests/baselines/reference/importTypeLocal.types
@@ -66,9 +66,9 @@ export const x: import("./foo") = { x: 0, y: 0 };
 >0 : 0
 
 export let y: import("./foo2").Bar.I = { a: "", b: 0 };
->y : Bar.I
+>y : import("tests/cases/conformance/types/import/foo2").Bar.I
 >Bar : any
->I : Bar.I
+>I : import("tests/cases/conformance/types/import/foo2").Bar.I
 >{ a: "", b: 0 } : { a: string; b: number; }
 >a : string
 >"" : ""

--- a/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
+++ b/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
@@ -1,0 +1,12 @@
+// @declaration: true
+// @filename: color.ts
+interface Color {
+    c: string;
+}
+export default Color;
+// @filename: file1.ts
+import Color from "./color";
+export declare function styled(): Color;
+// @filename: file2.ts
+import { styled }  from "./file1";
+export const A = styled();


### PR DESCRIPTION
This way aliases can expose paths to local types in `getAccessibleSymbolChain`.

Fixes [this issue reported in this comment](https://github.com/Microsoft/TypeScript/issues/9944#issuecomment-392262120).

