### PR TITLE
Do not emit 'use strict' prologue in .json files with --alwaysStrict

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -552,7 +552,9 @@ namespace ts {
 
         function visitSourceFile(node: SourceFile) {
             const alwaysStrict = getStrictOptionValue(compilerOptions, "alwaysStrict") &&
-                !(isExternalModule(node) && moduleKind >= ModuleKind.ES2015);
+                !(isExternalModule(node) && moduleKind >= ModuleKind.ES2015) &&
+                !isJsonSourceFile(node);
+
             return updateSourceFileNode(
                 node,
                 visitLexicalEnvironment(node.statements, sourceElementVisitor, context, /*start*/ 0, alwaysStrict));

--- a/tests/baselines/reference/requireOfJsonFileWithAlwaysStrictWithoutErrors.js
+++ b/tests/baselines/reference/requireOfJsonFileWithAlwaysStrictWithoutErrors.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts] ////
+
+//// [file1.ts]
+import b1 = require('./b.json');
+let x = b1.a;
+import b2 = require('./b.json');
+if (x) {
+    let b = b2.b;
+    x = (b1.b === b);
+}
+
+//// [b.json]
+{
+    "a": true,
+    "b": "hello"
+}
+
+//// [b.json]
+{
+    "a": true,
+    "b": "hello"
+}
+//// [file1.js]
+"use strict";
+exports.__esModule = true;
+var b1 = require("./b.json");
+var x = b1.a;
+var b2 = require("./b.json");
+if (x) {
+    var b = b2.b;
+    x = (b1.b === b);
+}

--- a/tests/baselines/reference/requireOfJsonFileWithAlwaysStrictWithoutErrors.symbols
+++ b/tests/baselines/reference/requireOfJsonFileWithAlwaysStrictWithoutErrors.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/file1.ts ===
+import b1 = require('./b.json');
+>b1 : Symbol(b1, Decl(file1.ts, 0, 0))
+
+let x = b1.a;
+>x : Symbol(x, Decl(file1.ts, 1, 3))
+>b1.a : Symbol("a", Decl(b.json, 0, 1))
+>b1 : Symbol(b1, Decl(file1.ts, 0, 0))
+>a : Symbol("a", Decl(b.json, 0, 1))
+
+import b2 = require('./b.json');
+>b2 : Symbol(b2, Decl(file1.ts, 1, 13))
+
+if (x) {
+>x : Symbol(x, Decl(file1.ts, 1, 3))
+
+    let b = b2.b;
+>b : Symbol(b, Decl(file1.ts, 4, 7))
+>b2.b : Symbol("b", Decl(b.json, 1, 14))
+>b2 : Symbol(b2, Decl(file1.ts, 1, 13))
+>b : Symbol("b", Decl(b.json, 1, 14))
+
+    x = (b1.b === b);
+>x : Symbol(x, Decl(file1.ts, 1, 3))
+>b1.b : Symbol("b", Decl(b.json, 1, 14))
+>b1 : Symbol(b1, Decl(file1.ts, 0, 0))
+>b : Symbol("b", Decl(b.json, 1, 14))
+>b : Symbol(b, Decl(file1.ts, 4, 7))
+}
+
+=== tests/cases/compiler/b.json ===
+{
+    "a": true,
+>"a" : Symbol("a", Decl(b.json, 0, 1))
+
+    "b": "hello"
+>"b" : Symbol("b", Decl(b.json, 1, 14))
+}

--- a/tests/baselines/reference/requireOfJsonFileWithAlwaysStrictWithoutErrors.types
+++ b/tests/baselines/reference/requireOfJsonFileWithAlwaysStrictWithoutErrors.types
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/file1.ts ===
+import b1 = require('./b.json');
+>b1 : { "a": boolean; "b": string; }
+
+let x = b1.a;
+>x : boolean
+>b1.a : boolean
+>b1 : { "a": boolean; "b": string; }
+>a : boolean
+
+import b2 = require('./b.json');
+>b2 : { "a": boolean; "b": string; }
+
+if (x) {
+>x : boolean
+
+    let b = b2.b;
+>b : string
+>b2.b : string
+>b2 : { "a": boolean; "b": string; }
+>b : string
+
+    x = (b1.b === b);
+>x = (b1.b === b) : boolean
+>x : boolean
+>(b1.b === b) : boolean
+>b1.b === b : boolean
+>b1.b : string
+>b1 : { "a": boolean; "b": string; }
+>b : string
+>b : string
+}
+
+=== tests/cases/compiler/b.json ===
+{
+>{    "a": true,    "b": "hello"} : { "a": boolean; "b": string; }
+
+    "a": true,
+>"a" : boolean
+>true : true
+
+    "b": "hello"
+>"b" : string
+>"hello" : "hello"
+}

--- a/tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts
+++ b/tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts
@@ -1,0 +1,19 @@
+// @module: commonjs
+// @outdir: out/
+// @resolveJsonModule: true
+// @alwaysStrict: true
+
+// @Filename: file1.ts
+import b1 = require('./b.json');
+let x = b1.a;
+import b2 = require('./b.json');
+if (x) {
+    let b = b2.b;
+    x = (b1.b === b);
+}
+
+// @Filename: b.json
+{
+    "a": true,
+    "b": "hello"
+}


### PR DESCRIPTION
Fixes #24514