### PR TITLE
Rename ESNext `flatten` to `flat`

### DIFF
--- a/src/lib/esnext.array.d.ts
+++ b/src/lib/esnext.array.d.ts
@@ -3,7 +3,7 @@ interface ReadonlyArray<T> {
     /**
      * Calls a defined callback function on each element of an array. Then, flattens the result into
      * a new array.
-     * This is identical to a map followed by a flatten of depth 1.
+     * This is identical to a map followed by flat with depth 1.
      *
      * @param callback A function that accepts up to three arguments. The flatMap method calls the
      * callback function one time for each element in the array.
@@ -22,7 +22,7 @@ interface ReadonlyArray<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this:
+    flat<U>(this:
         ReadonlyArray<U[][][][]> |
 
         ReadonlyArray<ReadonlyArray<U[][][]>> |
@@ -51,7 +51,7 @@ interface ReadonlyArray<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this:
+    flat<U>(this:
         ReadonlyArray<U[][][]> |
 
         ReadonlyArray<ReadonlyArray<U>[][]> |
@@ -71,7 +71,7 @@ interface ReadonlyArray<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this:
+    flat<U>(this:
         ReadonlyArray<U[][]> |
 
         ReadonlyArray<ReadonlyArray<U[]>> |
@@ -86,7 +86,7 @@ interface ReadonlyArray<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this:
+    flat<U>(this:
         ReadonlyArray<U[]> |
         ReadonlyArray<ReadonlyArray<U>>,
         depth?: 1
@@ -98,18 +98,18 @@ interface ReadonlyArray<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this:
+    flat<U>(this:
         ReadonlyArray<U>,
         depth: 0
     ): U[];
 
     /**
      * Returns a new array with all sub-array elements concatenated into it recursively up to the
-     * specified depth. If no depth is provided, flatten method defaults to the depth of 1.
+     * specified depth. If no depth is provided, flat method defaults to the depth of 1.
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(depth?: number): any[];
+    flat<U>(depth?: number): any[];
   }
 
 interface Array<T> {
@@ -117,7 +117,7 @@ interface Array<T> {
     /**
      * Calls a defined callback function on each element of an array. Then, flattens the result into
      * a new array.
-     * This is identical to a map followed by a flatten of depth 1.
+     * This is identical to a map followed by flat with depth 1.
      *
      * @param callback A function that accepts up to three arguments. The flatMap method calls the
      * callback function one time for each element in the array.
@@ -135,7 +135,7 @@ interface Array<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this: U[][][][][][][][], depth: 7): U[];
+    flat<U>(this: U[][][][][][][][], depth: 7): U[];
 
     /**
      * Returns a new array with all sub-array elements concatenated into it recursively up to the
@@ -143,7 +143,7 @@ interface Array<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this: U[][][][][][][], depth: 6): U[];
+    flat<U>(this: U[][][][][][][], depth: 6): U[];
 
     /**
      * Returns a new array with all sub-array elements concatenated into it recursively up to the
@@ -151,7 +151,7 @@ interface Array<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this: U[][][][][][], depth: 5): U[];
+    flat<U>(this: U[][][][][][], depth: 5): U[];
 
     /**
      * Returns a new array with all sub-array elements concatenated into it recursively up to the
@@ -159,7 +159,7 @@ interface Array<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this: U[][][][][], depth: 4): U[];
+    flat<U>(this: U[][][][][], depth: 4): U[];
 
     /**
      * Returns a new array with all sub-array elements concatenated into it recursively up to the
@@ -167,7 +167,7 @@ interface Array<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this: U[][][][], depth: 3): U[];
+    flat<U>(this: U[][][][], depth: 3): U[];
 
     /**
      * Returns a new array with all sub-array elements concatenated into it recursively up to the
@@ -175,7 +175,7 @@ interface Array<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this: U[][][], depth: 2): U[];
+    flat<U>(this: U[][][], depth: 2): U[];
 
     /**
      * Returns a new array with all sub-array elements concatenated into it recursively up to the
@@ -183,7 +183,7 @@ interface Array<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this: U[][], depth?: 1): U[];
+    flat<U>(this: U[][], depth?: 1): U[];
 
     /**
      * Returns a new array with all sub-array elements concatenated into it recursively up to the
@@ -191,13 +191,13 @@ interface Array<T> {
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(this: U[], depth: 0): U[];
+    flat<U>(this: U[], depth: 0): U[];
 
     /**
      * Returns a new array with all sub-array elements concatenated into it recursively up to the
-     * specified depth. If no depth is provided, flatten method defaults to the depth of 1.
+     * specified depth. If no depth is provided, flat method defaults to the depth of 1.
      *
      * @param depth The maximum recursion depth
      */
-    flatten<U>(depth?: number): any[];
+    flat<U>(depth?: number): any[];
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #24526

This PR renames ESNext's Array `flatten` to `flat`, as per the [updated proposal](https://github.com/tc39/proposal-flatMap).

