### PR TITLE
implementations: Use declaration name for the span

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -24,7 +24,7 @@ namespace ts.FindAllReferences {
         textSpan: TextSpan;
     }
     export function nodeEntry(node: Node, isInString?: true): NodeEntry {
-        return { type: "node", node, isInString };
+        return { type: "node", node: (node as NamedDeclaration).name || node, isInString };
     }
 
     export interface Options {
@@ -76,7 +76,7 @@ namespace ts.FindAllReferences {
             // References to and accesses on the super keyword only have one possible implementation, so no
             // need to "Find all References"
             const symbol = checker.getSymbolAtLocation(node)!;
-            return symbol.valueDeclaration && [nodeEntry((symbol.valueDeclaration as NamedDeclaration).name || symbol.valueDeclaration)];
+            return symbol.valueDeclaration && [nodeEntry(symbol.valueDeclaration)];
         }
         else {
             // Perform "Find all References" and retrieve only those that are implementations
@@ -1112,7 +1112,7 @@ namespace ts.FindAllReferences.Core {
         // Check if the node is within an extends or implements clause
         const containingClass = getContainingClassIfInHeritageClause(refNode);
         if (containingClass) {
-            addReference(containingClass.name || containingClass);
+            addReference(containingClass);
             return;
         }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -76,7 +76,7 @@ namespace ts.FindAllReferences {
             // References to and accesses on the super keyword only have one possible implementation, so no
             // need to "Find all References"
             const symbol = checker.getSymbolAtLocation(node)!;
-            return symbol.valueDeclaration && [nodeEntry(symbol.valueDeclaration)];
+            return symbol.valueDeclaration && [nodeEntry((symbol.valueDeclaration as NamedDeclaration).name || symbol.valueDeclaration)];
         }
         else {
             // Perform "Find all References" and retrieve only those that are implementations
@@ -1096,7 +1096,7 @@ namespace ts.FindAllReferences.Core {
     function addImplementationReferences(refNode: Node, addReference: (node: Node) => void, state: State): void {
         // Check if we found a function/propertyAssignment/method with an implementation or initializer
         if (isDeclarationName(refNode) && isImplementation(refNode.parent)) {
-            addReference(refNode.parent);
+            addReference(refNode);
             return;
         }
 
@@ -1112,7 +1112,7 @@ namespace ts.FindAllReferences.Core {
         // Check if the node is within an extends or implements clause
         const containingClass = getContainingClassIfInHeritageClause(refNode);
         if (containingClass) {
-            addReference(containingClass);
+            addReference(containingClass.name || containingClass);
             return;
         }
 

--- a/tests/cases/fourslash/goToImplementationClassMethod_00.ts
+++ b/tests/cases/fourslash/goToImplementationClassMethod_00.ts
@@ -3,7 +3,7 @@
 // Should handle calls made on members declared in a class
 
 //// class Bar {
-////     [|{|"parts": ["(","method",")"," ","Bar",".","hello","(",")",":"," ","void"], "kind": "method"|}hello() {}|]
+////     [|{|"parts": ["(","method",")"," ","Bar",".","hello","(",")",":"," ","void"], "kind": "method"|}hello|]() {}
 //// }
 ////
 //// new Bar().hel/*reference*/lo;

--- a/tests/cases/fourslash/goToImplementationClassMethod_01.ts
+++ b/tests/cases/fourslash/goToImplementationClassMethod_01.ts
@@ -7,7 +7,7 @@
 //// }
 ////
 //// class Bar extends AbstractBar{
-////     [|hello() {}|]
+////     [|hello|]() {}
 //// }
 ////
 //// function whatever(x: AbstractBar) {

--- a/tests/cases/fourslash/goToImplementationEnum_00.ts
+++ b/tests/cases/fourslash/goToImplementationEnum_00.ts
@@ -3,7 +3,7 @@
 // Should handle calls made on members of an enum
 
 //// enum Foo {
-////     [|Foo1 = function initializer() { return 5 } ()|],
+////     [|Foo1|] = function initializer() { return 5 } (),
 ////     Foo2 = 6
 //// }
 ////

--- a/tests/cases/fourslash/goToImplementationEnum_01.ts
+++ b/tests/cases/fourslash/goToImplementationEnum_01.ts
@@ -2,10 +2,10 @@
 
 // Should handle calls made on enum name
 
-//// [|enum Foo {
+//// enum [|Foo|] {
 ////     Foo1 = function initializer() { return 5 } (),
 ////     Foo2 = 6
-//// }|]
+//// }
 ////
 //// Fo/*reference*/o;
 

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_00.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_00.ts
@@ -6,19 +6,19 @@
 ////     he/*declaration*/llo: () => void
 //// }
 ////
-//// var bar: Foo = { [|hello: helloImpl|] };
-//// var baz: Foo = { [|"hello": helloImpl|] };
+//// var bar: Foo = { [|hello|]: helloImpl };
+//// var baz: Foo = { "[|hello|]": helloImpl };
 ////
 //// function helloImpl () {}
 ////
-//// function whatever(x: Foo = { [|hello() {/**1*/}|] }) {
+//// function whatever(x: Foo = { [|hello|]() {/**1*/} }) {
 ////     x.he/*function_call*/llo()
 //// }
 ////
 //// class Bar {
-////     x: Foo = { [|hello() {/*2*/}|] }
+////     x: Foo = { [|hello|]() {/*2*/} }
 ////
-////     constructor(public f: Foo = { [|hello() {/**3*/}|] } ) {}
+////     constructor(public f: Foo = { [|hello|]() {/**3*/} } ) {}
 //// }
 
 verify.allRangesAppearInImplementationList("function_call");

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_01.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_01.ts
@@ -8,7 +8,7 @@
 //// }
 ////
 //// class Bar implements Foo {
-////     [|hello() {}|]
+////     [|hello|]() {}
 ////     public sure() {}
 //// }
 ////

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_02.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_02.ts
@@ -11,7 +11,7 @@
 //// }
 ////
 //// class Bar extends AbstractBar {
-////     [|hello() {}|]
+////     [|hello|]() {}
 //// }
 ////
 //// function whatever(a: AbstractBar) {

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_03.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_03.ts
@@ -7,7 +7,7 @@
 //// }
 ////
 //// class Bar extends SuperBar {
-////     [|hello() {}|]
+////     [|hello|]() {}
 //// }
 ////
 //// class SuperBar implements Foo {

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_04.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_04.ts
@@ -7,11 +7,11 @@
 //// }
 ////
 //// class Bar extends SuperBar {
-////     [|hello() {}|]
+////     [|hello|]() {}
 //// }
 ////
 //// class SuperBar implements Foo {
-////     [|hello() {}|]
+////     [|hello|]() {}
 //// }
 ////
 //// class OtherBar implements Foo {

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_05.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_05.ts
@@ -7,7 +7,7 @@
 //// }
 ////
 //// class SuperBar implements Foo {
-////     [|hello() {}|]
+////     [|hello|]() {}
 //// }
 ////
 //// class Bar extends SuperBar {

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_06.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_06.ts
@@ -11,19 +11,19 @@
 //// }
 ////
 //// class Bar implements Foo {
-////      [|hello() {}|]
+////      [|hello|]() {}
 ////      someOtherFunction() {}
 //// }
 ////
 //// function createFoo(): Foo {
 ////     return {
-////         [|hello() {}|],
+////         [|hello|]() {},
 ////         someOtherFunction() {}
 ////     };
 //// }
 ////
 //// var y: Foo = {
-////     [|hello() {}|],
+////     [|hello|]() {},
 ////     someOtherFunction() {}
 //// };
 ////

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_08.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_08.ts
@@ -7,7 +7,7 @@
 //// }
 ////
 //// class SuperBar implements Foo {
-////    [|hello() {}|]
+////    [|hello|]() {}
 //// }
 ////
 //// class Bar extends SuperBar {
@@ -15,7 +15,7 @@
 //// }
 ////
 //// class SubBar extends Bar {
-////    [|hello() {}|]
+////    [|hello|]() {}
 //// }
 
 

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_09.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_09.ts
@@ -20,7 +20,7 @@
 //// }
 ////
 //// class SuperBar extends MegaBar {
-////     [|hello() {}|]
+////     [|hello|]() {}
 //// }
 ////
 //// class MegaBar implements Foo {

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_10.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_10.ts
@@ -16,7 +16,7 @@
 //// }
 ////
 //// class FooImpl implements Foo {
-////  	 [|hello() {/**FooImpl*/}|]
+////  	 [|hello|]() {/**FooImpl*/}
 ////  	 aloha() {}
 //// }
 ////
@@ -25,12 +25,12 @@
 //// }
 ////
 //// class BarImpl implements Bar {
-//// 	 [|hello() {/**BarImpl*/}|]
+//// 	 [|hello|]() {/**BarImpl*/}
 //// 	 goodbye() {}
 //// }
 ////
 //// class FooAndBarImpl implements Foo, Bar {
-//// 	 [|hello() {/**FooAndBarImpl*/}|]
+//// 	 [|hello|]() {/**FooAndBarImpl*/}
 //// 	 aloha() {}
 //// 	 goodbye() {}
 //// }

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_11.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_11.ts
@@ -6,7 +6,7 @@
 ////    hel/*reference*/lo(): void;
 //// }
 ////
-//// var x = <Foo> { [|hello: () => {}|] };
-//// var y = <Foo> (((({ [|hello: () => {}|] }))));
+//// var x = <Foo> { [|hello|]: () => {} };
+//// var y = <Foo> (((({ [|hello|]: () => {} }))));
 
 verify.allRangesAppearInImplementationList("reference");

--- a/tests/cases/fourslash/goToImplementationInterfaceProperty_00.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceProperty_00.ts
@@ -6,17 +6,17 @@
 ////     hello: number
 //// }
 ////
-//// var bar: Foo = { [|hello: 5|] };
+//// var bar: Foo = { [|hello|]: 5 };
 ////
 ////
-//// function whatever(x: Foo = { [|hello: 5 * 9|] }) {
+//// function whatever(x: Foo = { [|hello|]: 5 * 9 }) {
 ////     x.he/*reference*/llo
 //// }
 ////
 //// class Bar {
-////     x: Foo = { [|hello: 6|] }
+////     x: Foo = { [|hello|]: 6 }
 ////
-////     constructor(public f: Foo = { [|hello: 7|] } ) {}
+////     constructor(public f: Foo = { [|hello|]: 7 } ) {}
 //// }
 
 verify.allRangesAppearInImplementationList("reference");

--- a/tests/cases/fourslash/goToImplementationInterfaceProperty_01.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceProperty_01.ts
@@ -5,7 +5,7 @@
 //// interface Foo { hello: number }
 ////
 //// class Bar implements Foo {
-////     [|hello = 5 * 9;|]
+////     [|hello|] = 5 * 9;
 //// }
 ////
 //// function whatever(foo: Foo) {

--- a/tests/cases/fourslash/goToImplementationInterface_01.ts
+++ b/tests/cases/fourslash/goToImplementationInterface_01.ts
@@ -2,13 +2,13 @@
 
 //// interface Fo/*interface_definition*/o { hello(): void }
 ////
-//// [|class SuperBar implements Foo {
+//// class [|SuperBar|] implements Foo {
 ////     hello () {}
-//// }|]
+//// }
 ////
-//// [|abstract class AbstractBar implements Foo {
+//// abstract class [|AbstractBar|] implements Foo {
 ////     abstract hello (): void;
-//// }|]
+//// }
 ////
 //// class Bar extends SuperBar {
 //// }

--- a/tests/cases/fourslash/goToImplementationInterface_07.ts
+++ b/tests/cases/fourslash/goToImplementationInterface_07.ts
@@ -20,7 +20,7 @@
 //// let x8: Foo[]          = [|[{ hello ()         { /**arrayType*/} }]|];
 //// let x9: { y: Foo }     = [|{ y: { hello ()     { /**typeLiteral*/} } }|];
 //// let x10 = [|{|"parts": ["(","anonymous local class",")"], "kind": "local class"|}class implements Foo { hello() {} }|]
-//// let x11 = [|{|"parts": ["(","local class",")"," ","C"], "kind": "local class"|}class C implements Foo { hello() {} }|]
+//// let x11 = class [|{|"parts": ["(","local class",")"," ","C"], "kind": "local class"|}C|] implements Foo { hello() {} }
 ////
 //// // Should not do anything for type predicates
 //// function isFoo(a: any): a is Foo {

--- a/tests/cases/fourslash/goToImplementationInterface_08.ts
+++ b/tests/cases/fourslash/goToImplementationInterface_08.ts
@@ -11,7 +11,7 @@
 //// interface C extends B, A {}
 ////
 //// class X implements B {
-////     [|hello() {}|]
+////     [|hello|]() {}
 //// }
 ////
 //// function someFunction(d : A) {

--- a/tests/cases/fourslash/goToImplementationLocal_00.ts
+++ b/tests/cases/fourslash/goToImplementationLocal_00.ts
@@ -3,6 +3,6 @@
 // Should return definition of locally declared functions
 
 //// he/*function_call*/llo();
-//// [|function hello() {}|]
+//// function [|hello|]() {}
 
 verify.allRangesAppearInImplementationList("function_call");

--- a/tests/cases/fourslash/goToImplementationLocal_01.ts
+++ b/tests/cases/fourslash/goToImplementationLocal_01.ts
@@ -2,7 +2,7 @@
 
 // Should return the defintion of locally defined variables
 
-//// const [|hello = function() {}|];
+//// const [|hello|] = function() {};
 //// he/*function_call*/llo();
 
 verify.allRangesAppearInImplementationList("function_call");

--- a/tests/cases/fourslash/goToImplementationLocal_02.ts
+++ b/tests/cases/fourslash/goToImplementationLocal_02.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
-//// const x = { [|hello: () => {}|] };
+//// const x = { [|hello|]: () => {} };
 ////
 //// x.he/*function_call*/llo();
 ////

--- a/tests/cases/fourslash/goToImplementationLocal_03.ts
+++ b/tests/cases/fourslash/goToImplementationLocal_03.ts
@@ -2,7 +2,7 @@
 
 // Should return the definition when invoked on variable assignment
 
-//// let [|he/*local_var*/llo = {}|];
+//// let [|he/*local_var*/llo|] = {};
 ////
 //// x.hello();
 ////

--- a/tests/cases/fourslash/goToImplementationLocal_04.ts
+++ b/tests/cases/fourslash/goToImplementationLocal_04.ts
@@ -2,7 +2,7 @@
 
 // Should return definition of function when invoked on the declaration
 
-//// [|function he/*local_var*/llo() {}|]
+//// function [|he/*local_var*/llo|]() {}
 ////
 //// hello();
 ////

--- a/tests/cases/fourslash/goToImplementationLocal_05.ts
+++ b/tests/cases/fourslash/goToImplementationLocal_05.ts
@@ -6,7 +6,7 @@
 ////     public hello() {}
 //// }
 ////
-//// var [|someVar = new Bar()|];
+//// var [|someVar|] = new Bar();
 //// someVa/*reference*/r.hello();
 
 verify.allRangesAppearInImplementationList("reference");

--- a/tests/cases/fourslash/goToImplementationLocal_06.ts
+++ b/tests/cases/fourslash/goToImplementationLocal_06.ts
@@ -2,7 +2,7 @@
 
 // Should be able to go to ambient variable declarations
 
-//// declare var [|someVar: string|];
+//// declare var [|someVar|]: string;
 //// someVa/*reference*/r
 
 verify.allRangesAppearInImplementationList("reference");

--- a/tests/cases/fourslash/goToImplementationLocal_07.ts
+++ b/tests/cases/fourslash/goToImplementationLocal_07.ts
@@ -2,7 +2,7 @@
 
 // Should be able to go to ambient function declarations
 
-//// [|declare function someFunction(): () => void;|]
+//// declare function [|someFunction|](): () => void;
 //// someFun/*reference*/ction();
 
 verify.allRangesAppearInImplementationList("reference");

--- a/tests/cases/fourslash/goToImplementationLocal_08.ts
+++ b/tests/cases/fourslash/goToImplementationLocal_08.ts
@@ -2,7 +2,7 @@
 
 // Should be able to go to ambient function declarations
 
-//// [|declare function someFunction(): () => void;|]
+//// declare function [|someFunction|](): () => void;
 //// someFun/*reference*/ction();
 
 verify.allRangesAppearInImplementationList("reference");

--- a/tests/cases/fourslash/goToImplementationNamespace_00.ts
+++ b/tests/cases/fourslash/goToImplementationNamespace_00.ts
@@ -2,11 +2,11 @@
 
 // Should handle namespace and module implementations
 
-//// /*implementation0*/namespace Foo {
+//// namespace /*implementation0*/Foo {
 ////     export function hello() {}
 //// }
 ////
-//// /*implementation1*/module Bar {
+//// module /*implementation1*/Bar {
 ////     export function sure() {}
 //// }
 ////

--- a/tests/cases/fourslash/goToImplementationNamespace_01.ts
+++ b/tests/cases/fourslash/goToImplementationNamespace_01.ts
@@ -3,7 +3,7 @@
 // Should handle property access expressions on namespaces
 
 //// namespace Foo {
-////     [|export function hello() {}|]
+////     export function [|hello|]() {}
 //// }
 ////
 //// Foo.hell/*reference*/o();

--- a/tests/cases/fourslash/goToImplementationNamespace_02.ts
+++ b/tests/cases/fourslash/goToImplementationNamespace_02.ts
@@ -3,7 +3,7 @@
 // Should handle property access expressions on namespaces
 
 //// module Foo {
-////     [|export function hello() {}|]
+////     export function [|hello|]() {}
 //// }
 ////
 //// Foo.hell/*reference*/o();

--- a/tests/cases/fourslash/goToImplementationNamespace_03.ts
+++ b/tests/cases/fourslash/goToImplementationNamespace_03.ts
@@ -7,14 +7,14 @@
 ////         hello(): void;
 ////     }
 ////
-////     [|class BarImpl implements Bar {
+////     class [|BarImpl|] implements Bar {
 ////         hello() {}
-////     }|]
+////     }
 //// }
 ////
-//// [|class Baz implements Foo.Bar {
+//// class [|Baz|] implements Foo.Bar {
 ////     hello() {}
-//// }|]
+//// }
 ////
 //// var someVar1 : Foo.Bar = [|{ hello: () => {/**1*/} }|];
 ////

--- a/tests/cases/fourslash/goToImplementationNamespace_04.ts
+++ b/tests/cases/fourslash/goToImplementationNamespace_04.ts
@@ -7,14 +7,14 @@
 ////         hello(): void;
 ////     }
 ////
-////     [|class BarImpl implements Bar {
+////     class [|BarImpl|] implements Bar {
 ////         hello() {}
-////     }|]
+////     }
 //// }
 ////
-//// [|class Baz implements Foo.Bar {
+//// class [|Baz|] implements Foo.Bar {
 ////     hello() {}
-//// }|]
+//// }
 ////
 //// var someVar1 : Foo.Bar = [|{ hello: () => {/**1*/} }|];
 ////

--- a/tests/cases/fourslash/goToImplementationNamespace_05.ts
+++ b/tests/cases/fourslash/goToImplementationNamespace_05.ts
@@ -2,11 +2,11 @@
 
 // Should handle namespace and module implementations with qualified names
 
-//// /*implementation0*/namespace Foo./*implementation2*/Baz {
+//// namespace /*implementation0*/Foo./*implementation2*/Baz {
 ////     export function hello() {}
 //// }
 ////
-//// /*implementation1*/module Bar./*implementation3*/Baz {
+//// module /*implementation1*/Bar./*implementation3*/Baz {
 ////     export function sure() {}
 //// }
 ////

--- a/tests/cases/fourslash/goToImplementationNamespace_06.ts
+++ b/tests/cases/fourslash/goToImplementationNamespace_06.ts
@@ -2,9 +2,9 @@
 
 // Should handle type queries
 
-//// [|namespace F/*declaration*/oo {
+//// namespace [|F/*declaration*/oo|] {
 ////     declare function hello(): void;
-//// }|]
+//// }
 ////
 ////
 //// let x: typeof Foo = [|{ hello() {} }|];

--- a/tests/cases/fourslash/goToImplementationShorthandPropertyAssignment_00.ts
+++ b/tests/cases/fourslash/goToImplementationShorthandPropertyAssignment_00.ts
@@ -14,7 +14,7 @@
 ////     Foo: FooConstructor;
 //// }
 ////
-//// var x = /*classExpression*/class Foo {
+//// var x = class /*classExpression*/Foo {
 ////     createBarInClassExpression(): Bar {
 ////         return {
 ////             Fo/*classExpressionRef*/o
@@ -24,7 +24,7 @@
 ////     someFunction() {}
 //// }
 ////
-//// /*declaredClass*/class Foo {
+//// class /*declaredClass*/Foo {
 ////
 //// }
 ////

--- a/tests/cases/fourslash/goToImplementationShorthandPropertyAssignment_01.ts
+++ b/tests/cases/fourslash/goToImplementationShorthandPropertyAssignment_01.ts
@@ -15,7 +15,7 @@
 //// }
 ////
 //// // Class expression that gets used in a bar implementation
-//// var x = [|class Foo {
+//// var x = class [|Foo|] {
 ////     createBarInClassExpression(): Bar {
 ////         return {
 ////             Foo
@@ -23,13 +23,13 @@
 ////     }
 ////
 ////     someFunction() {}
-//// }|];
+//// };
 ////
 //// // Class declaration that gets used in a bar implementation. This class has multiple definitions
 //// // (the class declaration and the interface above), but we only want the class returned
-//// [|class Foo {
+//// class [|Foo|] {
 ////
-//// }|]
+//// }
 ////
 //// function createBarUsingClassDeclaration(): Bar {
 ////     return {

--- a/tests/cases/fourslash/goToImplementationShorthandPropertyAssignment_02.ts
+++ b/tests/cases/fourslash/goToImplementationShorthandPropertyAssignment_02.ts
@@ -11,7 +11,7 @@
 ////          hello
 ////     };
 ////
-////     [|function hello() {}|]
+////     function [|hello|]() {}
 //// }
 ////
 //// function whatever(x: Foo) {

--- a/tests/cases/fourslash/goToImplementationSuper_00.ts
+++ b/tests/cases/fourslash/goToImplementationSuper_00.ts
@@ -2,9 +2,9 @@
 
 // Should go to super class declaration when invoked on a super call expression
 
-//// [|class Foo {
+//// class [|Foo|] {
 ////     constructor() {}
-//// }|]
+//// }
 ////
 //// class Bar extends Foo {
 ////     constructor() {

--- a/tests/cases/fourslash/goToImplementationSuper_01.ts
+++ b/tests/cases/fourslash/goToImplementationSuper_01.ts
@@ -2,9 +2,9 @@
 
 // Should go to the super class declaration when invoked on the super keyword in a property access expression
 
-//// [|class Foo {
+//// class [|Foo|] {
 ////     hello() {}
-//// }|]
+//// }
 ////
 //// class Bar extends Foo {
 ////     hello() {

--- a/tests/cases/fourslash/goToImplementationThis_00.ts
+++ b/tests/cases/fourslash/goToImplementationThis_00.ts
@@ -2,12 +2,12 @@
 
 // Should go to class declaration when invoked on this keyword in property access expression
 
-//// [|class Bar extends Foo {
+//// class [|Bar|] extends Foo {
 ////     hello() {
 ////         thi/*this_call*/s.whatever();
 ////     }
 ////
 ////     whatever() {}
-//// }|]
+//// }
 
 verify.allRangesAppearInImplementationList("this_call");

--- a/tests/cases/fourslash/goToImplementationThis_01.ts
+++ b/tests/cases/fourslash/goToImplementationThis_01.ts
@@ -2,10 +2,10 @@
 
 // Should go to class declaration when invoked on a this type reference
 
-//// [|class Bar extends Foo {
+//// class [|Bar|] extends Foo {
 ////     hello(): th/*this_type*/is {
 ////         return this;
 ////     }
-//// }|]
+//// }
 
 verify.allRangesAppearInImplementationList("this_type");

--- a/tests/cases/fourslash/server/goToImplementation_inDifferentFiles.ts
+++ b/tests/cases/fourslash/server/goToImplementation_inDifferentFiles.ts
@@ -3,13 +3,13 @@
 // @Filename: /bar.ts
 ////import {Foo} from './foo'
 ////
-////[|class A implements Foo {
+////class [|A|] implements Foo {
 ////    func() {}
-////}|]
+////}
 ////
-////[|class B implements Foo {
+////class [|B|] implements Foo {
 ////    func() {}
-////}|]
+////}
 
 // @Filename: /foo.ts
 ////export interface /**/Foo {

--- a/tests/cases/fourslash/server/implementation01.ts
+++ b/tests/cases/fourslash/server/implementation01.ts
@@ -1,8 +1,7 @@
 /// <reference path="../fourslash.ts"/>
 
-// @Filename: a.ts
-//// interface Fo/*1*/o {}
-//// /*2*/class Bar implements Foo {}
+////interface Fo/*1*/o {}
+////class /*2*/Bar implements Foo {}
 
 goTo.marker('1');
 goTo.implementation();

--- a/tests/cases/fourslash/shims-pp/getImplementationAtPosition.ts
+++ b/tests/cases/fourslash/shims-pp/getImplementationAtPosition.ts
@@ -1,9 +1,9 @@
-/// <reference path='fourslash.ts' />
+/// <reference path='../fourslash.ts' />
 
 // @Filename: goToImplementationDifferentFile_Implementation.ts
-//// /*fooClassImplementation*/class FooImpl implements Foo {}
+//// class /*fooClassImplementation*/FooImpl implements Foo {}
 ////
-//// /*barClassImplementation*/class Bar {
+//// class /*barClassImplementation*/Bar {
 ////     /*barHelloFunctionImplementation*/hello() {}
 //// }
 ////
@@ -15,21 +15,14 @@
 ////
 //// x.hel/*barHelloFunctionReference*/lo();
 ////
-//// /*thisImplementation*/class SomeClass {
+//// class /*thisImplementation*/SomeClass {
 ////     someMethod() {
 ////         thi/*thisReference*/s.someMethod();
 ////     }
 //// }
 
-var markerList = [
-    "fooClass",
-    "barClass",
-    "barHelloFunction",
-    "this"
-];
-
-markerList.forEach((marker) => {
+for (const marker of ["fooClass", "barClass", "barHelloFunction", "this"]) {
     goTo.marker(marker + 'Reference');
     goTo.implementation();
     verify.caretAtMarker(marker + 'Implementation');
-});
+};

--- a/tests/cases/fourslash/shims/getImplementationAtPosition.ts
+++ b/tests/cases/fourslash/shims/getImplementationAtPosition.ts
@@ -1,9 +1,9 @@
-/// <reference path='fourslash.ts' />
+/// <reference path='../fourslash.ts' />
 
 // @Filename: goToImplementationDifferentFile_Implementation.ts
-//// /*fooClassImplementation*/class FooImpl implements Foo {}
+//// class /*fooClassImplementation*/FooImpl implements Foo {}
 ////
-//// /*barClassImplementation*/class Bar {
+//// class /*barClassImplementation*/Bar {
 ////     /*barHelloFunctionImplementation*/hello() {}
 //// }
 ////
@@ -15,21 +15,14 @@
 ////
 //// x.hel/*barHelloFunctionReference*/lo();
 ////
-//// /*thisImplementation*/class SomeClass {
+//// class /*thisImplementation*/SomeClass {
 ////     someMethod() {
 ////         thi/*thisReference*/s.someMethod();
 ////     }
 //// }
 
-var markerList = [
-    "fooClass",
-    "barClass",
-    "barHelloFunction",
-    "this"
-];
-
-markerList.forEach((marker) => {
+for (const marker of ["fooClass", "barClass", "barHelloFunction", "this"]) {
     goTo.marker(marker + 'Reference');
     goTo.implementation();
     verify.caretAtMarker(marker + 'Implementation');
-});
+};


### PR DESCRIPTION
Fixes the implementations part of #15109

Instead of adding a second span, I don't think there's a particular reason we used the full declaration span in the first place -- the rest of find-all-references uses the name span.