### PR TITLE
Support import completion for merged declaration exports

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -633,7 +633,7 @@ namespace ts.Completions {
         }
 
         const { moduleSymbol } = symbolOriginInfo;
-        const exportedSymbol = skipAlias(symbol.exportSymbol || symbol, checker);
+        const exportedSymbol = checker.getMergedSymbol(skipAlias(symbol.exportSymbol || symbol, checker));
         const { moduleSpecifier, codeAction } = codefix.getImportCompletionAction(
             exportedSymbol,
             moduleSymbol,

--- a/tests/cases/fourslash/completionsImport_default_fromMergedDeclarations.ts
+++ b/tests/cases/fourslash/completionsImport_default_fromMergedDeclarations.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+// @module: esnext
+
+// @Filename: /a.ts
+////declare module "m" {
+////    export default class M {}
+////}
+
+// @Filename: /b.ts
+////declare module "m" {
+////    export default interface M {}
+////}
+
+// @Filename: /c.ts
+/////**/
+
+goTo.marker("");
+verify.completionListContains({ name: "M", source: "m" }, "class M", "", "class", /*spanIndex*/ undefined, /*hasAction*/ true, {
+    includeCompletionsForModuleExports: true,
+    sourceDisplay: "m",
+});
+
+verify.applyCodeActionFromCompletion("", {
+    name: "M",
+    source: "m",
+    description: `Import 'M' from module "m"`,
+    newFileContent: `import M from "m";
+
+`,
+});


### PR DESCRIPTION
Fixes #24535 

I'm frankly not familiar enough with the codebase to be positive that this is a correct fix, but 
[this assertion](https://github.com/Microsoft/TypeScript/blob/e9dda76874235a8b638efafff2d52e12ae6c0714/src/services/codefixes/importFixes.ts#L99) was failing because the result of `getAllReExportingModules` was empty. The included test failed without this change, and the full suite passes locally with it.