### PR TITLE
Remove deprecated internal method

### DIFF
--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -794,7 +794,7 @@ namespace Harness.LanguageService {
                                 const proxy = makeDefaultProxy(info);
                                 proxy.getSemanticDiagnostics = filename => {
                                     const prev = info.languageService.getSemanticDiagnostics(filename);
-                                    const sourceFile: ts.SourceFile = info.languageService.getSourceFile(filename);
+                                    const sourceFile: ts.SourceFile = info.project.getSourceFile(ts.toPath(filename, /*basePath*/ undefined, ts.createGetCanonicalFileName(info.serverHost.useCaseSensitiveFileNames)))!;
                                     prev.push({
                                         category: ts.DiagnosticCategory.Warning,
                                         file: sourceFile,

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1780,10 +1780,6 @@ namespace ts {
             return syntaxTreeCache.getCurrentSourceFile(fileName);
         }
 
-        function getSourceFile(fileName: string): SourceFile {
-            return getNonBoundSourceFile(fileName);
-        }
-
         function getNameOrDottedNameSpan(fileName: string, startPos: number, _endPos: number): TextSpan | undefined {
             const sourceFile = syntaxTreeCache.getCurrentSourceFile(fileName);
 
@@ -2291,7 +2287,6 @@ namespace ts {
             getEditsForFileRename,
             getEmitOutput,
             getNonBoundSourceFile,
-            getSourceFile,
             getProgram,
             getApplicableRefactors,
             getEditsForRefactor,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -350,12 +350,6 @@ namespace ts {
 
         /* @internal */ getNonBoundSourceFile(fileName: string): SourceFile;
 
-        /**
-         * @internal
-         * @deprecated Use ts.createSourceFile instead.
-         */
-        getSourceFile(fileName: string): SourceFile;
-
         dispose(): void;
     }
 


### PR DESCRIPTION
The only history I can find on this is https://github.com/Microsoft/TypeScript/commit/af5148d4f35533df55e61f87f0c0419b97a64a48 -- since this method is internal there should be no problem removing it?