### PR TITLE
Add autoCloseTag language service

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4147,27 +4147,6 @@ namespace ts {
             return finishNode(node);
         }
 
-        function tagNamesAreEquivalent(lhs: JsxTagNameExpression, rhs: JsxTagNameExpression): boolean {
-            if (lhs.kind !== rhs.kind) {
-                return false;
-            }
-
-            if (lhs.kind === SyntaxKind.Identifier) {
-                return (<Identifier>lhs).escapedText === (<Identifier>rhs).escapedText;
-            }
-
-            if (lhs.kind === SyntaxKind.ThisKeyword) {
-                return true;
-            }
-
-            // If we are at this statement then we must have PropertyAccessExpression and because tag name in Jsx element can only
-            // take forms of JsxTagNameExpression which includes an identifier, "this" expression, or another propertyAccessExpression
-            // it is safe to case the expression property as such. See parseJsxElementName for how we parse tag name in Jsx element
-            return (<PropertyAccessExpression>lhs).name.escapedText === (<PropertyAccessExpression>rhs).name.escapedText &&
-                tagNamesAreEquivalent((<PropertyAccessExpression>lhs).expression as JsxTagNameExpression, (<PropertyAccessExpression>rhs).expression as JsxTagNameExpression);
-        }
-
-
         function parseJsxElementOrSelfClosingElementOrFragment(inExpressionContext: boolean): JsxElement | JsxSelfClosingElement | JsxFragment {
             const opening = parseJsxOpeningOrSelfClosingElementOrOpeningFragment(inExpressionContext);
             let result: JsxElement | JsxSelfClosingElement | JsxFragment;
@@ -7905,5 +7884,26 @@ namespace ts {
             argMap[argument.name] = args[i];
         }
         return argMap;
+    }
+
+    /** @internal */
+    export function tagNamesAreEquivalent(lhs: JsxTagNameExpression, rhs: JsxTagNameExpression): boolean {
+        if (lhs.kind !== rhs.kind) {
+            return false;
+        }
+
+        if (lhs.kind === SyntaxKind.Identifier) {
+            return (<Identifier>lhs).escapedText === (<Identifier>rhs).escapedText;
+        }
+
+        if (lhs.kind === SyntaxKind.ThisKeyword) {
+            return true;
+        }
+
+        // If we are at this statement then we must have PropertyAccessExpression and because tag name in Jsx element can only
+        // take forms of JsxTagNameExpression which includes an identifier, "this" expression, or another propertyAccessExpression
+        // it is safe to case the expression property as such. See parseJsxElementName for how we parse tag name in Jsx element
+        return (<PropertyAccessExpression>lhs).name.escapedText === (<PropertyAccessExpression>rhs).name.escapedText &&
+            tagNamesAreEquivalent((<PropertyAccessExpression>lhs).expression as JsxTagNameExpression, (<PropertyAccessExpression>rhs).expression as JsxTagNameExpression);
     }
 }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2743,11 +2743,11 @@ Actual: ${stringify(fullActual)}`);
             }
         }
 
-        public verifyAutoCloseTag(map: { [markerName: string]: string | undefined }): void {
+        public verifyJsxClosingTag(map: { [markerName: string]: ts.JsxClosingTagInfo | undefined }): void {
             for (const markerName in map) {
                 this.goToMarker(markerName);
-                const actual = this.languageService.getAutoCloseTagAtPosition(this.activeFile.fileName, this.currentCaretPosition);
-                assert.equal(actual, map[markerName]);
+                const actual = this.languageService.getJsxClosingTagAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+                assert.deepEqual(actual, map[markerName]);
             }
         }
 
@@ -4087,8 +4087,8 @@ namespace FourSlashInterface {
             this.state.verifyBraceCompletionAtPosition(this.negative, openingBrace);
         }
 
-        public autoCloseTag(map: { [markerName: string]: string | undefined }): void {
-            this.state.verifyAutoCloseTag(map);
+        public jsxClosingTag(map: { [markerName: string]: ts.JsxClosingTagInfo | undefined }): void {
+            this.state.verifyJsxClosingTag(map);
         }
 
         public isInCommentAtPosition(onlyMultiLineDiverges?: boolean) {

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2743,6 +2743,14 @@ Actual: ${stringify(fullActual)}`);
             }
         }
 
+        public verifyAutoCloseTag(map: { [markerName: string]: string | undefined }): void {
+            for (const markerName in map) {
+                this.goToMarker(markerName);
+                const actual = this.languageService.getAutoCloseTagAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+                assert.equal(actual, map[markerName]);
+            }
+        }
+
         public verifyMatchingBracePosition(bracePosition: number, expectedMatchPosition: number) {
             const actual = this.languageService.getBraceMatchingAtPosition(this.activeFile.fileName, bracePosition);
 
@@ -4077,6 +4085,10 @@ namespace FourSlashInterface {
 
         public isValidBraceCompletionAtPosition(openingBrace: string) {
             this.state.verifyBraceCompletionAtPosition(this.negative, openingBrace);
+        }
+
+        public autoCloseTag(map: { [markerName: string]: string | undefined }): void {
+            this.state.verifyAutoCloseTag(map);
         }
 
         public isInCommentAtPosition(onlyMultiLineDiverges?: boolean) {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -509,7 +509,7 @@ namespace Harness.LanguageService {
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean {
             return unwrapJSONCallResult(this.shim.isValidBraceCompletionAtPosition(fileName, position, openingBrace));
         }
-        getAutoCloseTagAtPosition(): string | undefined {
+        getJsxClosingTagAtPosition(): never {
             throw new Error("Not supported on the shim.");
         }
         getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): ts.TextSpan {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -509,6 +509,9 @@ namespace Harness.LanguageService {
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean {
             return unwrapJSONCallResult(this.shim.isValidBraceCompletionAtPosition(fileName, position, openingBrace));
         }
+        getAutoCloseTagAtPosition(): string | undefined {
+            throw new Error("Not supported on the shim.");
+        }
         getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): ts.TextSpan {
             return unwrapJSONCallResult(this.shim.getSpanOfEnclosingComment(fileName, position, onlyMultiLine));
         }

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -188,7 +188,6 @@ namespace ts.server {
 
         describe("onMessage", () => {
             const allCommandNames: CommandNames[] = [
-                CommandNames.AutoCloseTag,
                 CommandNames.Brace,
                 CommandNames.BraceFull,
                 CommandNames.BraceCompletion,
@@ -225,6 +224,7 @@ namespace ts.server {
                 CommandNames.Occurrences,
                 CommandNames.DocumentHighlights,
                 CommandNames.DocumentHighlightsFull,
+                CommandNames.JsxClosingTag,
                 CommandNames.Open,
                 CommandNames.Quickinfo,
                 CommandNames.QuickinfoFull,

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -188,6 +188,7 @@ namespace ts.server {
 
         describe("onMessage", () => {
             const allCommandNames: CommandNames[] = [
+                CommandNames.AutoCloseTag,
                 CommandNames.Brace,
                 CommandNames.BraceFull,
                 CommandNames.BraceCompletion,

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -552,7 +552,7 @@ namespace ts.server {
             return notImplemented();
         }
 
-        getAutoCloseTagAtPosition(_fileName: string, _position: number): string | undefined {
+        getJsxClosingTagAtPosition(_fileName: string, _position: number): never {
             return notImplemented();
         }
 

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -552,6 +552,10 @@ namespace ts.server {
             return notImplemented();
         }
 
+        getAutoCloseTagAtPosition(_fileName: string, _position: number): string | undefined {
+            return notImplemented();
+        }
+
         getSpanOfEnclosingComment(_fileName: string, _position: number, _onlyMultiLine: boolean): TextSpan {
             return notImplemented();
         }

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -6,6 +6,7 @@
 namespace ts.server.protocol {
     // NOTE: If updating this, be sure to also update `allCommandNames` in `harness/unittests/session.ts`.
     export const enum CommandTypes {
+        AutoCloseTag = "autoCloseTag",
         Brace = "brace",
         /* @internal */
         BraceFull = "brace-full",
@@ -888,6 +889,17 @@ namespace ts.server.protocol {
          * Kind of opening brace
          */
         openingBrace: string;
+    }
+
+    export interface AutoCloseTagRequest extends FileLocationRequest {
+        readonly command: CommandTypes.AutoCloseTag;
+        readonly arguments: AutoCloseTagRequestArgs;
+    }
+
+    export interface AutoCloseTagRequestArgs extends FileLocationRequestArgs {}
+
+    export interface AutoCloseTagResponse extends Response {
+        readonly body: TextInsertion;
     }
 
     /**

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -6,7 +6,7 @@
 namespace ts.server.protocol {
     // NOTE: If updating this, be sure to also update `allCommandNames` in `harness/unittests/session.ts`.
     export const enum CommandTypes {
-        AutoCloseTag = "autoCloseTag",
+        JsxClosingTag = "jsxClosingTag",
         Brace = "brace",
         /* @internal */
         BraceFull = "brace-full",
@@ -891,14 +891,14 @@ namespace ts.server.protocol {
         openingBrace: string;
     }
 
-    export interface AutoCloseTagRequest extends FileLocationRequest {
-        readonly command: CommandTypes.AutoCloseTag;
-        readonly arguments: AutoCloseTagRequestArgs;
+    export interface JsxClosingTagRequest extends FileLocationRequest {
+        readonly command: CommandTypes.JsxClosingTag;
+        readonly arguments: JsxClosingTagRequestArgs;
     }
 
-    export interface AutoCloseTagRequestArgs extends FileLocationRequestArgs {}
+    export interface JsxClosingTagRequestArgs extends FileLocationRequestArgs {}
 
-    export interface AutoCloseTagResponse extends Response {
+    export interface JsxClosingTagResponse extends Response {
         readonly body: TextInsertion;
     }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -818,11 +818,11 @@ namespace ts.server {
             return this.getDiagnosticsWorker(args, /*isSemantic*/ true, (project, file) => project.getLanguageService().getSuggestionDiagnostics(file), !!args.includeLinePosition);
         }
 
-        private getAutoCloseTag(args: protocol.AutoCloseTagRequestArgs): TextInsertion | undefined {
+        private getJsxClosingTag(args: protocol.JsxClosingTagRequestArgs): TextInsertion | undefined {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
-            const tag = project.getLanguageService().getAutoCloseTagAtPosition(file, position);
-            return tag === undefined ? undefined : { newText: tag, caretOffset: 0 };
+            const tag = project.getLanguageService().getJsxClosingTagAtPosition(file, position);
+            return tag === undefined ? undefined : { newText: tag.newText, caretOffset: 0 };
         }
 
         private getDocumentHighlights(args: protocol.DocumentHighlightsRequestArgs, simplifiedResult: boolean): ReadonlyArray<protocol.DocumentHighlightsItem> | ReadonlyArray<DocumentHighlights> {
@@ -2137,8 +2137,8 @@ namespace ts.server {
                 this.projectService.reloadProjects();
                 return this.notRequired();
             },
-            [CommandNames.AutoCloseTag]: (request: protocol.AutoCloseTagRequest) => {
-                return this.requiredResponse(this.getAutoCloseTag(request.arguments));
+            [CommandNames.JsxClosingTag]: (request: protocol.JsxClosingTagRequest) => {
+                return this.requiredResponse(this.getJsxClosingTag(request.arguments));
             },
             [CommandNames.GetCodeFixes]: (request: protocol.CodeFixRequest) => {
                 return this.requiredResponse(this.getCodeFixes(request.arguments, /*simplifiedResult*/ true));

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -818,6 +818,13 @@ namespace ts.server {
             return this.getDiagnosticsWorker(args, /*isSemantic*/ true, (project, file) => project.getLanguageService().getSuggestionDiagnostics(file), !!args.includeLinePosition);
         }
 
+        private getAutoCloseTag(args: protocol.AutoCloseTagRequestArgs): TextInsertion | undefined {
+            const { file, project } = this.getFileAndProject(args);
+            const position = this.getPositionInFile(args, file);
+            const tag = project.getLanguageService().getAutoCloseTagAtPosition(file, position);
+            return tag === undefined ? undefined : { newText: tag, caretOffset: 0 };
+        }
+
         private getDocumentHighlights(args: protocol.DocumentHighlightsRequestArgs, simplifiedResult: boolean): ReadonlyArray<protocol.DocumentHighlightsItem> | ReadonlyArray<DocumentHighlights> {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
@@ -2129,6 +2136,9 @@ namespace ts.server {
             [CommandNames.ReloadProjects]: () => {
                 this.projectService.reloadProjects();
                 return this.notRequired();
+            },
+            [CommandNames.AutoCloseTag]: (request: protocol.AutoCloseTagRequest) => {
+                return this.requiredResponse(this.getAutoCloseTag(request.arguments));
             },
             [CommandNames.GetCodeFixes]: (request: protocol.CodeFixRequest) => {
                 return this.requiredResponse(this.getCodeFixes(request.arguments, /*simplifiedResult*/ true));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2051,6 +2051,18 @@ namespace ts {
             return true;
         }
 
+        function getAutoCloseTagAtPosition(fileName: string, position: number): string | undefined {
+            const sourceFile = syntaxTreeCache.getCurrentSourceFile(fileName);
+            const token = findPrecedingToken(position, sourceFile);
+            if (!token) return undefined;
+            const element = token.kind === SyntaxKind.GreaterThanToken
+                ? isJsxOpeningElement(token.parent) ? token.parent.parent : undefined
+                : isJsxText(token) ? token.parent : undefined;
+            if (element && !tagNamesAreEquivalent(element.openingElement.tagName, element.closingElement.tagName)) {
+                return `</${element.openingElement.tagName.getText(sourceFile)}>`;
+            }
+        }
+
         function getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): TextSpan | undefined {
             const sourceFile = syntaxTreeCache.getCurrentSourceFile(fileName);
             const range = formatting.getRangeOfEnclosingComment(sourceFile, position, onlyMultiLine);
@@ -2283,6 +2295,7 @@ namespace ts {
             getFormattingEditsAfterKeystroke,
             getDocCommentTemplateAtPosition,
             isValidBraceCompletionAtPosition,
+            getAutoCloseTagAtPosition,
             getSpanOfEnclosingComment,
             getCodeFixesAtPosition,
             getCombinedCodeFix,

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2051,15 +2051,14 @@ namespace ts {
             return true;
         }
 
-        function getAutoCloseTagAtPosition(fileName: string, position: number): string | undefined {
+        function getJsxClosingTagAtPosition(fileName: string, position: number): JsxClosingTagInfo | undefined {
             const sourceFile = syntaxTreeCache.getCurrentSourceFile(fileName);
             const token = findPrecedingToken(position, sourceFile);
             if (!token) return undefined;
-            const element = token.kind === SyntaxKind.GreaterThanToken
-                ? isJsxOpeningElement(token.parent) ? token.parent.parent : undefined
+            const element = token.kind === SyntaxKind.GreaterThanToken && isJsxOpeningElement(token.parent) ? token.parent.parent
                 : isJsxText(token) ? token.parent : undefined;
             if (element && !tagNamesAreEquivalent(element.openingElement.tagName, element.closingElement.tagName)) {
-                return `</${element.openingElement.tagName.getText(sourceFile)}>`;
+                return { newText: `</${element.openingElement.tagName.getText(sourceFile)}>` };
             }
         }
 
@@ -2295,7 +2294,7 @@ namespace ts {
             getFormattingEditsAfterKeystroke,
             getDocCommentTemplateAtPosition,
             isValidBraceCompletionAtPosition,
-            getAutoCloseTagAtPosition,
+            getJsxClosingTagAtPosition,
             getSpanOfEnclosingComment,
             getCodeFixesAtPosition,
             getCombinedCodeFix,

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -323,7 +323,11 @@ namespace ts {
         getDocCommentTemplateAtPosition(fileName: string, position: number): TextInsertion | undefined;
 
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
-        getAutoCloseTagAtPosition(fileName: string, position: number): string | undefined;
+        /**
+         * This will return a defined result if the position is after the `>` of the opening tag, or somewhere in the text, of a JSXElement with no closing tag.
+         * Editors should call this after `>` is typed.
+         */
+        getJsxClosingTagAtPosition(fileName: string, position: number): JsxClosingTagInfo | undefined;
 
         getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): TextSpan | undefined;
 
@@ -358,6 +362,10 @@ namespace ts {
         getSourceFile(fileName: string): SourceFile;
 
         dispose(): void;
+    }
+
+    export interface JsxClosingTagInfo {
+        readonly newText: string;
     }
 
     export interface CombinedCodeFixScope { type: "file"; fileName: string; }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -323,6 +323,7 @@ namespace ts {
         getDocCommentTemplateAtPosition(fileName: string, position: number): TextInsertion | undefined;
 
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
+        getAutoCloseTagAtPosition(fileName: string, position: number): string | undefined;
 
         getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): TextSpan | undefined;
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4556,7 +4556,11 @@ declare namespace ts {
         getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
         getDocCommentTemplateAtPosition(fileName: string, position: number): TextInsertion | undefined;
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
-        getAutoCloseTagAtPosition(fileName: string, position: number): string | undefined;
+        /**
+         * This will return a defined result if the position is after the `>` of the opening tag, or somewhere in the text, of a JSXElement with no closing tag.
+         * Editors should call this after `>` is typed.
+         */
+        getJsxClosingTagAtPosition(fileName: string, position: number): JsxClosingTagInfo | undefined;
         getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): TextSpan | undefined;
         toLineColumnOffset?(fileName: string, position: number): LineAndCharacter;
         getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: ReadonlyArray<number>, formatOptions: FormatCodeSettings, preferences: UserPreferences): ReadonlyArray<CodeFixAction>;
@@ -4577,6 +4581,9 @@ declare namespace ts {
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
         getProgram(): Program | undefined;
         dispose(): void;
+    }
+    interface JsxClosingTagInfo {
+        readonly newText: string;
     }
     interface CombinedCodeFixScope {
         type: "file";
@@ -5507,7 +5514,7 @@ declare namespace ts.server {
  */
 declare namespace ts.server.protocol {
     enum CommandTypes {
-        AutoCloseTag = "autoCloseTag",
+        JsxClosingTag = "jsxClosingTag",
         Brace = "brace",
         BraceCompletion = "braceCompletion",
         GetSpanOfEnclosingComment = "getSpanOfEnclosingComment",
@@ -6177,13 +6184,13 @@ declare namespace ts.server.protocol {
          */
         openingBrace: string;
     }
-    interface AutoCloseTagRequest extends FileLocationRequest {
-        readonly command: CommandTypes.AutoCloseTag;
-        readonly arguments: AutoCloseTagRequestArgs;
+    interface JsxClosingTagRequest extends FileLocationRequest {
+        readonly command: CommandTypes.JsxClosingTag;
+        readonly arguments: JsxClosingTagRequestArgs;
     }
-    interface AutoCloseTagRequestArgs extends FileLocationRequestArgs {
+    interface JsxClosingTagRequestArgs extends FileLocationRequestArgs {
     }
-    interface AutoCloseTagResponse extends Response {
+    interface JsxClosingTagResponse extends Response {
         readonly body: TextInsertion;
     }
     /**
@@ -8474,7 +8481,7 @@ declare namespace ts.server {
         private getSyntacticDiagnosticsSync;
         private getSemanticDiagnosticsSync;
         private getSuggestionDiagnosticsSync;
-        private getAutoCloseTag;
+        private getJsxClosingTag;
         private getDocumentHighlights;
         private setCompilerOptionsForInferredProjects;
         private getProjectInfo;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4556,6 +4556,7 @@ declare namespace ts {
         getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
         getDocCommentTemplateAtPosition(fileName: string, position: number): TextInsertion | undefined;
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
+        getAutoCloseTagAtPosition(fileName: string, position: number): string | undefined;
         getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): TextSpan | undefined;
         toLineColumnOffset?(fileName: string, position: number): LineAndCharacter;
         getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: ReadonlyArray<number>, formatOptions: FormatCodeSettings, preferences: UserPreferences): ReadonlyArray<CodeFixAction>;
@@ -5506,6 +5507,7 @@ declare namespace ts.server {
  */
 declare namespace ts.server.protocol {
     enum CommandTypes {
+        AutoCloseTag = "autoCloseTag",
         Brace = "brace",
         BraceCompletion = "braceCompletion",
         GetSpanOfEnclosingComment = "getSpanOfEnclosingComment",
@@ -6174,6 +6176,15 @@ declare namespace ts.server.protocol {
          * Kind of opening brace
          */
         openingBrace: string;
+    }
+    interface AutoCloseTagRequest extends FileLocationRequest {
+        readonly command: CommandTypes.AutoCloseTag;
+        readonly arguments: AutoCloseTagRequestArgs;
+    }
+    interface AutoCloseTagRequestArgs extends FileLocationRequestArgs {
+    }
+    interface AutoCloseTagResponse extends Response {
+        readonly body: TextInsertion;
     }
     /**
      * @deprecated
@@ -8463,6 +8474,7 @@ declare namespace ts.server {
         private getSyntacticDiagnosticsSync;
         private getSemanticDiagnosticsSync;
         private getSuggestionDiagnosticsSync;
+        private getAutoCloseTag;
         private getDocumentHighlights;
         private setCompilerOptionsForInferredProjects;
         private getProjectInfo;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4556,7 +4556,11 @@ declare namespace ts {
         getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
         getDocCommentTemplateAtPosition(fileName: string, position: number): TextInsertion | undefined;
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
-        getAutoCloseTagAtPosition(fileName: string, position: number): string | undefined;
+        /**
+         * This will return a defined result if the position is after the `>` of the opening tag, or somewhere in the text, of a JSXElement with no closing tag.
+         * Editors should call this after `>` is typed.
+         */
+        getJsxClosingTagAtPosition(fileName: string, position: number): JsxClosingTagInfo | undefined;
         getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): TextSpan | undefined;
         toLineColumnOffset?(fileName: string, position: number): LineAndCharacter;
         getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: ReadonlyArray<number>, formatOptions: FormatCodeSettings, preferences: UserPreferences): ReadonlyArray<CodeFixAction>;
@@ -4577,6 +4581,9 @@ declare namespace ts {
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
         getProgram(): Program | undefined;
         dispose(): void;
+    }
+    interface JsxClosingTagInfo {
+        readonly newText: string;
     }
     interface CombinedCodeFixScope {
         type: "file";

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4556,6 +4556,7 @@ declare namespace ts {
         getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
         getDocCommentTemplateAtPosition(fileName: string, position: number): TextInsertion | undefined;
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
+        getAutoCloseTagAtPosition(fileName: string, position: number): string | undefined;
         getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): TextSpan | undefined;
         toLineColumnOffset?(fileName: string, position: number): LineAndCharacter;
         getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: ReadonlyArray<number>, formatOptions: FormatCodeSettings, preferences: UserPreferences): ReadonlyArray<CodeFixAction>;

--- a/tests/cases/fourslash/autoCloseTag.ts
+++ b/tests/cases/fourslash/autoCloseTag.ts
@@ -11,10 +11,10 @@
 ////</p>;
 ////const x = <div> text /*5*/;
 
-verify.autoCloseTag({
-    0: "</div>",
+verify.jsxClosingTag({
+    0: { newText: "</div>" },
     1: undefined,
     2: undefined,
     3: undefined,
-    4: "</p>",
+    4: { newText: "</p>" },
 });

--- a/tests/cases/fourslash/autoCloseTag.ts
+++ b/tests/cases/fourslash/autoCloseTag.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.tsx
+////const x = <div>/*0*/;
+////const x = <div> foo/*1*/ </div>;
+////const x = <div></div>/*2*/;
+////const x = <div/>/*3*/;
+////const x = <div>
+////    <p>/*4*/
+////    </div>
+////</p>;
+////const x = <div> text /*5*/;
+
+verify.autoCloseTag({
+    0: "</div>",
+    1: undefined,
+    2: undefined,
+    3: undefined,
+    4: "</p>",
+});

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -174,6 +174,7 @@ declare namespace FourSlashInterface {
         typeDefinitionCountIs(expectedCount: number): void;
         implementationListIsEmpty(): void;
         isValidBraceCompletionAtPosition(openingBrace?: string): void;
+        autoCloseTag(map: { [markerName: string]: string | undefined }): void;
         isInCommentAtPosition(onlyMultiLineDiverges?: boolean): void;
         codeFix(options: {
             description: string,

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -174,7 +174,7 @@ declare namespace FourSlashInterface {
         typeDefinitionCountIs(expectedCount: number): void;
         implementationListIsEmpty(): void;
         isValidBraceCompletionAtPosition(openingBrace?: string): void;
-        autoCloseTag(map: { [markerName: string]: string | undefined }): void;
+        jsxClosingTag(map: { [markerName: string]: { readonly newText: string } | undefined }): void;
         isInCommentAtPosition(onlyMultiLineDiverges?: boolean): void;
         codeFix(options: {
             description: string,


### PR DESCRIPTION
Fixes #20811

The editor can call this service to get closing text for the current tag, or `undefined` if not currently in a position to close a tag (or tag already closed).