### PR TITLE
Include export specifiers in the list of syntactic defaults

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1784,7 +1784,7 @@ namespace ts {
         }
 
         function isSyntacticDefault(node: Node) {
-            return ((isExportAssignment(node) && !node.isExportEquals) || hasModifier(node, ModifierFlags.Default));
+            return ((isExportAssignment(node) && !node.isExportEquals) || hasModifier(node, ModifierFlags.Default) || isExportSpecifier(node));
         }
 
         function canHaveSyntheticDefault(file: SourceFile | undefined, moduleSymbol: Symbol, dontResolveAlias: boolean) {

--- a/tests/baselines/reference/reexportDefaultIsCallable.js
+++ b/tests/baselines/reference/reexportDefaultIsCallable.js
@@ -1,0 +1,36 @@
+//// [tests/cases/compiler/reexportDefaultIsCallable.ts] ////
+
+//// [schema.d.ts]
+export default class Schema {}
+//// [reexporter.d.ts]
+export { default } from "./schema";
+//// [usage.ts]
+import Base from "./reexporter";
+export default class Mine extends Base {}
+
+
+//// [usage.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+exports.__esModule = true;
+var reexporter_1 = __importDefault(require("./reexporter"));
+var Mine = /** @class */ (function (_super) {
+    __extends(Mine, _super);
+    function Mine() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return Mine;
+}(reexporter_1["default"]));
+exports["default"] = Mine;

--- a/tests/baselines/reference/reexportDefaultIsCallable.symbols
+++ b/tests/baselines/reference/reexportDefaultIsCallable.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/schema.d.ts ===
+export default class Schema {}
+>Schema : Symbol(Schema, Decl(schema.d.ts, 0, 0))
+
+=== tests/cases/compiler/reexporter.d.ts ===
+export { default } from "./schema";
+>default : Symbol(default, Decl(reexporter.d.ts, 0, 8))
+
+=== tests/cases/compiler/usage.ts ===
+import Base from "./reexporter";
+>Base : Symbol(Base, Decl(usage.ts, 0, 6))
+
+export default class Mine extends Base {}
+>Mine : Symbol(Mine, Decl(usage.ts, 0, 32))
+>Base : Symbol(Base, Decl(usage.ts, 0, 6))
+

--- a/tests/baselines/reference/reexportDefaultIsCallable.types
+++ b/tests/baselines/reference/reexportDefaultIsCallable.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/schema.d.ts ===
+export default class Schema {}
+>Schema : Schema
+
+=== tests/cases/compiler/reexporter.d.ts ===
+export { default } from "./schema";
+>default : typeof import("tests/cases/compiler/schema").default
+
+=== tests/cases/compiler/usage.ts ===
+import Base from "./reexporter";
+>Base : typeof Base
+
+export default class Mine extends Base {}
+>Mine : Mine
+>Base : Base
+

--- a/tests/cases/compiler/reexportDefaultIsCallable.ts
+++ b/tests/cases/compiler/reexportDefaultIsCallable.ts
@@ -1,0 +1,8 @@
+// @esModuleInterop: true
+// @filename: schema.d.ts
+export default class Schema {}
+// @filename: reexporter.d.ts
+export { default } from "./schema";
+// @filename: usage.ts
+import Base from "./reexporter";
+export default class Mine extends Base {}


### PR DESCRIPTION
It was omitted in the original list of possible syntactic default declarations (things that indicate a declaration file definitely refers to a module). I can't imagine why it'd only break in 2.9 though, and not 2.8 - perhaps `resolveExportByName` was mistakenly resolving the alias before, or the symbol was otherwise mismanaged and masked the issue? I kinda wanna bisect just to see what triggered the change.

Fixes #24528