### PR TITLE
remove redundant assertions in fourslash tests

### DIFF
--- a/tests/cases/fourslash/getOccurrencesAsyncAwait.ts
+++ b/tests/cases/fourslash/getOccurrencesAsyncAwait.ts
@@ -20,8 +20,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesAsyncAwait2.ts
+++ b/tests/cases/fourslash/getOccurrencesAsyncAwait2.ts
@@ -9,8 +9,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesConstructor.ts
+++ b/tests/cases/fourslash/getOccurrencesConstructor.ts
@@ -19,8 +19,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesConstructor2.ts
+++ b/tests/cases/fourslash/getOccurrencesConstructor2.ts
@@ -19,8 +19,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesIfElse.ts
+++ b/tests/cases/fourslash/getOccurrencesIfElse.ts
@@ -23,8 +23,3 @@
 ////[|else|] { }
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesLoopBreakContinue.ts
+++ b/tests/cases/fourslash/getOccurrencesLoopBreakContinue.ts
@@ -64,9 +64,3 @@
 ////label7: while (true) continue label5;
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-verify.occurrencesAtPositionCount(test.ranges().length);
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesLoopBreakContinue2.ts
+++ b/tests/cases/fourslash/getOccurrencesLoopBreakContinue2.ts
@@ -64,9 +64,3 @@
 ////label7: while (true) continue label5;
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-verify.occurrencesAtPositionCount(test.ranges().length);
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesLoopBreakContinue3.ts
+++ b/tests/cases/fourslash/getOccurrencesLoopBreakContinue3.ts
@@ -64,8 +64,3 @@
 ////label7: while (true) continue label5;
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesLoopBreakContinue4.ts
+++ b/tests/cases/fourslash/getOccurrencesLoopBreakContinue4.ts
@@ -64,9 +64,3 @@
 ////label7: while (true) continue label5;
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-verify.occurrencesAtPositionCount(test.ranges().length);
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesLoopBreakContinue5.ts
+++ b/tests/cases/fourslash/getOccurrencesLoopBreakContinue5.ts
@@ -64,9 +64,3 @@
 ////label7: while (true) continue label5;
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-verify.occurrencesAtPositionCount(test.ranges().length);
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesReturn.ts
+++ b/tests/cases/fourslash/getOccurrencesReturn.ts
@@ -20,8 +20,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesReturn2.ts
+++ b/tests/cases/fourslash/getOccurrencesReturn2.ts
@@ -20,8 +20,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesSuper.ts
+++ b/tests/cases/fourslash/getOccurrencesSuper.ts
@@ -51,8 +51,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesSuper2.ts
+++ b/tests/cases/fourslash/getOccurrencesSuper2.ts
@@ -51,8 +51,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThis.ts
+++ b/tests/cases/fourslash/getOccurrencesThis.ts
@@ -141,8 +141,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThis2.ts
+++ b/tests/cases/fourslash/getOccurrencesThis2.ts
@@ -141,8 +141,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThis3.ts
+++ b/tests/cases/fourslash/getOccurrencesThis3.ts
@@ -141,8 +141,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThis4.ts
+++ b/tests/cases/fourslash/getOccurrencesThis4.ts
@@ -141,8 +141,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThis5.ts
+++ b/tests/cases/fourslash/getOccurrencesThis5.ts
@@ -141,8 +141,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThrow.ts
+++ b/tests/cases/fourslash/getOccurrencesThrow.ts
@@ -43,8 +43,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThrow2.ts
+++ b/tests/cases/fourslash/getOccurrencesThrow2.ts
@@ -43,8 +43,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThrow3.ts
+++ b/tests/cases/fourslash/getOccurrencesThrow3.ts
@@ -43,8 +43,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThrow4.ts
+++ b/tests/cases/fourslash/getOccurrencesThrow4.ts
@@ -43,8 +43,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesThrow5.ts
+++ b/tests/cases/fourslash/getOccurrencesThrow5.ts
@@ -43,8 +43,3 @@
 ////}
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}

--- a/tests/cases/fourslash/getOccurrencesYield.ts
+++ b/tests/cases/fourslash/getOccurrencesYield.ts
@@ -15,8 +15,3 @@
 
 
 verify.rangesAreOccurrences(false);
-
-goTo.marker();
-for (const range of test.ranges()) {
-    verify.occurrencesAtPositionContains(range, false);
-}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Basically, this PR removes all
```javascript
goTo.marker();
for (const range of test.ranges()) {
    verify.occurrencesAtPositionContains(range, false);
}
```
after
```javascript
verify.rangesAreOccurrences(false);
```
