### PR TITLE
If parsing a function type fails, parseTypeReference() to ensure something is returned

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2342,7 +2342,7 @@ namespace ts {
             return finishNode(parameter);
         }
 
-        function parseJSDocType() {
+        function parseJSDocType(): TypeNode {
             const dotdotdot = parseOptionalToken(SyntaxKind.DotDotDotToken);
             let type = parseType();
             if (dotdotdot) {
@@ -3133,11 +3133,9 @@ namespace ts {
         }
 
         function parseTypeWorker(noConditionalTypes?: boolean): TypeNode {
-            if (isStartOfFunctionType()) {
-                return parseFunctionOrConstructorType(SyntaxKind.FunctionType)!; // TODO: GH#18217
-            }
-            if (token() === SyntaxKind.NewKeyword) {
-                return parseFunctionOrConstructorType(SyntaxKind.ConstructorType)!;
+            if (isStartOfFunctionType() || token() === SyntaxKind.NewKeyword) {
+                const fn = tryParse(() => parseFunctionOrConstructorType(token() === SyntaxKind.NewKeyword ? SyntaxKind.ConstructorType : SyntaxKind.FunctionType));
+                return fn || parseTypeReference(); // If function parsing failed, parseTypeReference() will fail with a diagnostic
             }
             const type = parseUnionTypeOrHigher();
             if (!noConditionalTypes && !scanner.hasPrecedingLineBreak() && parseOptional(SyntaxKind.ExtendsKeyword)) {

--- a/tests/baselines/reference/jsdocFunctionTypeFalsePositive.errors.txt
+++ b/tests/baselines/reference/jsdocFunctionTypeFalsePositive.errors.txt
@@ -1,0 +1,15 @@
+/a.js(1,13): error TS1110: Type expected.
+/a.js(1,13): error TS1099: Type argument list cannot be empty.
+/a.js(1,14): error TS1005: '>' expected.
+
+
+==== /a.js (3 errors) ====
+    /** @param {<} x */
+                ~
+!!! error TS1110: Type expected.
+                ~~
+!!! error TS1099: Type argument list cannot be empty.
+                 ~
+!!! error TS1005: '>' expected.
+    function f(x) {}
+    

--- a/tests/baselines/reference/jsdocFunctionTypeFalsePositive.symbols
+++ b/tests/baselines/reference/jsdocFunctionTypeFalsePositive.symbols
@@ -1,0 +1,6 @@
+=== /a.js ===
+/** @param {<} x */
+function f(x) {}
+>f : Symbol(f, Decl(a.js, 0, 0))
+>x : Symbol(x, Decl(a.js, 1, 11))
+

--- a/tests/baselines/reference/jsdocFunctionTypeFalsePositive.types
+++ b/tests/baselines/reference/jsdocFunctionTypeFalsePositive.types
@@ -1,0 +1,6 @@
+=== /a.js ===
+/** @param {<} x */
+function f(x) {}
+>f : (x: any) => void
+>x : any
+

--- a/tests/cases/compiler/jsdocFunctionTypeFalsePositive.ts
+++ b/tests/cases/compiler/jsdocFunctionTypeFalsePositive.ts
@@ -1,0 +1,7 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /a.js
+/** @param {<} x */
+function f(x) {}


### PR DESCRIPTION
Fixes #24565

