### PR TITLE
Fix bug when name resolution fails in a @typedef: Don't set `lastLocation`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1458,9 +1458,8 @@ namespace ts {
                     case SyntaxKind.JSDocTypedefTag:
                     case SyntaxKind.JSDocCallbackTag:
                         // js type aliases do not resolve names from their host, so skip past it
-                        lastLocation = location;
-                        location = getJSDocHost(location).parent;
-                        continue;
+                        location = getJSDocHost(location);
+                        break;
                 }
                 if (isSelfReferenceLocation(location)) {
                     lastSelfReferenceLocation = location;

--- a/tests/baselines/reference/jsdocResolveNameFailureInTypedef.errors.txt
+++ b/tests/baselines/reference/jsdocResolveNameFailureInTypedef.errors.txt
@@ -1,0 +1,19 @@
+error TS5055: Cannot write file '/a.js' because it would overwrite input file.
+  Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
+/a.js(7,14): error TS2304: Cannot find name 'CantResolveThis'.
+
+
+!!! error TS5055: Cannot write file '/a.js' because it would overwrite input file.
+!!! error TS5055:   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
+==== /a.js (1 errors) ====
+    /**
+     * @param {Ty} x
+     */
+    function f(x) {}
+    
+    /**
+     * @typedef {CantResolveThis} Ty
+                 ~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'CantResolveThis'.
+     */
+    

--- a/tests/baselines/reference/jsdocResolveNameFailureInTypedef.errors.txt
+++ b/tests/baselines/reference/jsdocResolveNameFailureInTypedef.errors.txt
@@ -1,10 +1,6 @@
-error TS5055: Cannot write file '/a.js' because it would overwrite input file.
-  Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
 /a.js(7,14): error TS2304: Cannot find name 'CantResolveThis'.
 
 
-!!! error TS5055: Cannot write file '/a.js' because it would overwrite input file.
-!!! error TS5055:   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
 ==== /a.js (1 errors) ====
     /**
      * @param {Ty} x

--- a/tests/baselines/reference/jsdocResolveNameFailureInTypedef.symbols
+++ b/tests/baselines/reference/jsdocResolveNameFailureInTypedef.symbols
@@ -1,0 +1,12 @@
+=== /a.js ===
+/**
+ * @param {Ty} x
+ */
+function f(x) {}
+>f : Symbol(f, Decl(a.js, 0, 0))
+>x : Symbol(x, Decl(a.js, 3, 11))
+
+/**
+ * @typedef {CantResolveThis} Ty
+ */
+

--- a/tests/baselines/reference/jsdocResolveNameFailureInTypedef.types
+++ b/tests/baselines/reference/jsdocResolveNameFailureInTypedef.types
@@ -1,0 +1,12 @@
+=== /a.js ===
+/**
+ * @param {Ty} x
+ */
+function f(x) {}
+>f : (x: any) => void
+>x : any
+
+/**
+ * @typedef {CantResolveThis} Ty
+ */
+

--- a/tests/cases/compiler/jsdocResolveNameFailureInTypedef.ts
+++ b/tests/cases/compiler/jsdocResolveNameFailureInTypedef.ts
@@ -1,0 +1,12 @@
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: /a.js
+/**
+ * @param {Ty} x
+ */
+function f(x) {}
+
+/**
+ * @typedef {CantResolveThis} Ty
+ */

--- a/tests/cases/compiler/jsdocResolveNameFailureInTypedef.ts
+++ b/tests/cases/compiler/jsdocResolveNameFailureInTypedef.ts
@@ -1,5 +1,6 @@
 // @allowJs: true
 // @checkJs: true
+// @noEmit: true
 
 // @Filename: /a.js
 /**


### PR DESCRIPTION
Fixes #24577

