### PR TITLE
Store + use the resolved path of sourceFiles in proj. ref. scenarios

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -987,7 +987,7 @@ namespace ts {
 
             for (const oldSourceFile of oldSourceFiles) {
                 let newSourceFile = host.getSourceFileByPath
-                    ? host.getSourceFileByPath(oldSourceFile.fileName, oldSourceFile.path, options.target!, /*onError*/ undefined, shouldCreateNewSourceFile)
+                    ? host.getSourceFileByPath(oldSourceFile.fileName, oldSourceFile.resolvedPath || oldSourceFile.path, options.target!, /*onError*/ undefined, shouldCreateNewSourceFile)
                     : host.getSourceFile(oldSourceFile.fileName, options.target!, /*onError*/ undefined, shouldCreateNewSourceFile); // TODO: GH#18217
 
                 if (!newSourceFile) {
@@ -1991,6 +1991,7 @@ namespace ts {
             if (file) {
                 sourceFilesFoundSearchingNodeModules.set(path, currentNodeModulesDepth > 0);
                 file.path = path;
+                file.resolvedPath = toPath(fileName);
 
                 if (host.useCaseSensitiveFileNames()) {
                     const pathLowerCase = path.toLowerCase();

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2551,6 +2551,7 @@ namespace ts {
         fileName: string;
         /* @internal */ path: Path;
         text: string;
+        /* @internal */ resolvedPath: Path;
 
         /**
          * If two source files are for the same version of the same package, one will redirect to the other.

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -629,8 +629,8 @@ namespace ts.server {
                 return this.rootFiles;
             }
             return map(this.program.getSourceFiles(), sourceFile => {
-                const scriptInfo = this.projectService.getScriptInfoForPath(sourceFile.path);
-                Debug.assert(!!scriptInfo, "getScriptInfo", () => `scriptInfo for a file '${sourceFile.fileName}' Path: '${sourceFile.path}' is missing.`);
+                const scriptInfo = this.projectService.getScriptInfoForPath(sourceFile.resolvedPath || sourceFile.path);
+                Debug.assert(!!scriptInfo, "getScriptInfo", () => `scriptInfo for a file '${sourceFile.fileName}' Path: '${sourceFile.path}' / '${sourceFile.resolvedPath}' is missing.`);
                 return scriptInfo!;
             });
         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -540,6 +540,7 @@ namespace ts {
         public _declarationBrand: any;
         public fileName: string;
         public path: Path;
+        public resolvedPath: Path;
         public text: string;
         public scriptSnapshot: IScriptSnapshot;
         public lineMap: ReadonlyArray<number>;


### PR DESCRIPTION
Fixes an exception I observed in tsserver.log when dogfooding while editing modules spread across a project reference boundary.