### PR TITLE
Resolve aliases before using getTypeReferenceType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9203,12 +9203,13 @@ namespace ts {
         }
 
         function resolveImportSymbolType(node: ImportTypeNode, links: NodeLinks, symbol: Symbol, meaning: SymbolFlags) {
-            links.resolvedSymbol = symbol;
+            const resolvedSymbol = resolveSymbol(symbol);
+            links.resolvedSymbol = resolvedSymbol;
             if (meaning === SymbolFlags.Value) {
-                return links.resolvedType = getTypeOfSymbol(symbol);
+                return links.resolvedType = getTypeOfSymbol(symbol); // intentionally doesn't use resolved symbol so type is cached as expected on the alias
             }
             else {
-                return links.resolvedType = getTypeReferenceType(node, symbol);
+                return links.resolvedType = getTypeReferenceType(node, resolvedSymbol); // getTypeReferenceType doesn't handle aliases - it must get the resolved symbol
             }
         }
 

--- a/tests/baselines/reference/declarationsForIndirectTypeAliasReference.js
+++ b/tests/baselines/reference/declarationsForIndirectTypeAliasReference.js
@@ -1,0 +1,66 @@
+//// [tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts] ////
+
+//// [b.ts]
+export {
+    Hash,
+    StringHash, StringHash2
+};
+
+interface Hash<T> {
+    [key: string]: T;
+}
+
+type StringHash = Hash<string>;
+
+interface StringHash2 extends Hash<string> {}
+//// [a.ts]
+import {StringHash, StringHash2} from "./b";
+
+export {
+    doSome
+}
+
+const MAP: StringHash = {
+    a: "a"
+};
+
+const MAP2: StringHash2 = {
+    a: "a"
+};
+
+function doSome(arg1: string,
+                arg2 = MAP,
+                arg3 = MAP2) {
+}
+
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+var MAP = {
+    a: "a"
+};
+var MAP2 = {
+    a: "a"
+};
+function doSome(arg1, arg2, arg3) {
+    if (arg2 === void 0) { arg2 = MAP; }
+    if (arg3 === void 0) { arg3 = MAP2; }
+}
+exports.doSome = doSome;
+
+
+//// [b.d.ts]
+export { Hash, StringHash, StringHash2 };
+interface Hash<T> {
+    [key: string]: T;
+}
+declare type StringHash = Hash<string>;
+interface StringHash2 extends Hash<string> {
+}
+//// [a.d.ts]
+import { StringHash2 } from "./b";
+export { doSome };
+declare function doSome(arg1: string, arg2?: import("./b").Hash<string>, arg3?: StringHash2): void;

--- a/tests/baselines/reference/declarationsForIndirectTypeAliasReference.symbols
+++ b/tests/baselines/reference/declarationsForIndirectTypeAliasReference.symbols
@@ -1,0 +1,68 @@
+=== tests/cases/compiler/b.ts ===
+export {
+    Hash,
+>Hash : Symbol(Hash, Decl(b.ts, 0, 8))
+
+    StringHash, StringHash2
+>StringHash : Symbol(StringHash, Decl(b.ts, 1, 9))
+>StringHash2 : Symbol(StringHash2, Decl(b.ts, 2, 15))
+
+};
+
+interface Hash<T> {
+>Hash : Symbol(Hash, Decl(b.ts, 3, 2))
+>T : Symbol(T, Decl(b.ts, 5, 15))
+
+    [key: string]: T;
+>key : Symbol(key, Decl(b.ts, 6, 5))
+>T : Symbol(T, Decl(b.ts, 5, 15))
+}
+
+type StringHash = Hash<string>;
+>StringHash : Symbol(StringHash, Decl(b.ts, 7, 1))
+>Hash : Symbol(Hash, Decl(b.ts, 3, 2))
+
+interface StringHash2 extends Hash<string> {}
+>StringHash2 : Symbol(StringHash2, Decl(b.ts, 9, 31))
+>Hash : Symbol(Hash, Decl(b.ts, 3, 2))
+
+=== tests/cases/compiler/a.ts ===
+import {StringHash, StringHash2} from "./b";
+>StringHash : Symbol(StringHash, Decl(a.ts, 0, 8))
+>StringHash2 : Symbol(StringHash2, Decl(a.ts, 0, 19))
+
+export {
+    doSome
+>doSome : Symbol(doSome, Decl(a.ts, 2, 8))
+}
+
+const MAP: StringHash = {
+>MAP : Symbol(MAP, Decl(a.ts, 6, 5))
+>StringHash : Symbol(StringHash, Decl(a.ts, 0, 8))
+
+    a: "a"
+>a : Symbol(a, Decl(a.ts, 6, 25))
+
+};
+
+const MAP2: StringHash2 = {
+>MAP2 : Symbol(MAP2, Decl(a.ts, 10, 5))
+>StringHash2 : Symbol(StringHash2, Decl(a.ts, 0, 19))
+
+    a: "a"
+>a : Symbol(a, Decl(a.ts, 10, 27))
+
+};
+
+function doSome(arg1: string,
+>doSome : Symbol(doSome, Decl(a.ts, 12, 2))
+>arg1 : Symbol(arg1, Decl(a.ts, 14, 16))
+
+                arg2 = MAP,
+>arg2 : Symbol(arg2, Decl(a.ts, 14, 29))
+>MAP : Symbol(MAP, Decl(a.ts, 6, 5))
+
+                arg3 = MAP2) {
+>arg3 : Symbol(arg3, Decl(a.ts, 15, 27))
+>MAP2 : Symbol(MAP2, Decl(a.ts, 10, 5))
+}

--- a/tests/baselines/reference/declarationsForIndirectTypeAliasReference.types
+++ b/tests/baselines/reference/declarationsForIndirectTypeAliasReference.types
@@ -1,0 +1,72 @@
+=== tests/cases/compiler/b.ts ===
+export {
+    Hash,
+>Hash : any
+
+    StringHash, StringHash2
+>StringHash : any
+>StringHash2 : any
+
+};
+
+interface Hash<T> {
+>Hash : Hash<T>
+>T : T
+
+    [key: string]: T;
+>key : string
+>T : T
+}
+
+type StringHash = Hash<string>;
+>StringHash : Hash<string>
+>Hash : Hash<T>
+
+interface StringHash2 extends Hash<string> {}
+>StringHash2 : StringHash2
+>Hash : Hash<T>
+
+=== tests/cases/compiler/a.ts ===
+import {StringHash, StringHash2} from "./b";
+>StringHash : any
+>StringHash2 : any
+
+export {
+    doSome
+>doSome : (arg1: string, arg2?: import("tests/cases/compiler/b").Hash<string>, arg3?: StringHash2) => void
+}
+
+const MAP: StringHash = {
+>MAP : import("tests/cases/compiler/b").Hash<string>
+>StringHash : import("tests/cases/compiler/b").Hash<string>
+>{    a: "a"} : { a: string; }
+
+    a: "a"
+>a : string
+>"a" : "a"
+
+};
+
+const MAP2: StringHash2 = {
+>MAP2 : StringHash2
+>StringHash2 : StringHash2
+>{    a: "a"} : { a: string; }
+
+    a: "a"
+>a : string
+>"a" : "a"
+
+};
+
+function doSome(arg1: string,
+>doSome : (arg1: string, arg2?: import("tests/cases/compiler/b").Hash<string>, arg3?: StringHash2) => void
+>arg1 : string
+
+                arg2 = MAP,
+>arg2 : import("tests/cases/compiler/b").Hash<string>
+>MAP : import("tests/cases/compiler/b").Hash<string>
+
+                arg3 = MAP2) {
+>arg3 : StringHash2
+>MAP2 : StringHash2
+}

--- a/tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts
+++ b/tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts
@@ -1,0 +1,33 @@
+// @declaration: true
+// @filename: b.ts
+export {
+    Hash,
+    StringHash, StringHash2
+};
+
+interface Hash<T> {
+    [key: string]: T;
+}
+
+type StringHash = Hash<string>;
+
+interface StringHash2 extends Hash<string> {}
+// @filename: a.ts
+import {StringHash, StringHash2} from "./b";
+
+export {
+    doSome
+}
+
+const MAP: StringHash = {
+    a: "a"
+};
+
+const MAP2: StringHash2 = {
+    a: "a"
+};
+
+function doSome(arg1: string,
+                arg2 = MAP,
+                arg3 = MAP2) {
+}


### PR DESCRIPTION
While looking at [this comment](https://github.com/Microsoft/TypeScript/issues/24287#issuecomment-393927214), I couldn't repro the reported issue (a visibility error); but I _could_ witness another problem with the generated file:
![image](https://user-images.githubusercontent.com/2932786/40863440-aeef9b9a-65a4-11e8-8c81-90c810261afe.png)

As it happens, `getTypeReferenceType` silently returns `undefined` on `Alias`es (resolveEntityName never returns an alias and is the only other place symbols come from when they are passed into it). So externally aliased types (aka those looked up via export specifiers) couldn't be found.