### PR TITLE
Handle missing registry entries

### DIFF
--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -1340,6 +1340,27 @@ namespace ts.projectSystem {
             assert.deepEqual(result.newTypingNames, ["bar"]);
         });
 
+        it("should gracefully handle packages that have been removed from the types-registry", () => {
+            const f = {
+                path: "/a/b/app.js",
+                content: ""
+            };
+            const node = {
+                path: "/a/b/node.d.ts",
+                content: ""
+            };
+            const host = createServerHost([f, node]);
+            const cache = createMapFromTemplate<JsTyping.CachedTyping>({ node: { typingLocation: node.path, version: Semver.parse("1.3.0") } });
+            const logger = trackingLogger();
+            const result = JsTyping.discoverTypings(host, logger.log, [f.path], getDirectoryPath(<Path>f.path), emptySafeList, cache, { enable: true }, ["fs", "bar"], emptyMap);
+            assert.deepEqual(logger.finish(), [
+                'Inferred typings from unresolved imports: ["node","bar"]',
+                'Result: {"cachedTypingPaths":[],"newTypingNames":["node","bar"],"filesToWatch":["/a/b/bower_components","/a/b/node_modules"]}',
+            ]);
+            assert.deepEqual(result.cachedTypingPaths, []);
+            assert.deepEqual(result.newTypingNames, ["node", "bar"]);
+        });
+
         it("should search only 2 levels deep", () => {
             const app = {
                 path: "/app.js",

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -161,7 +161,7 @@ namespace ts.JsTyping {
         // Add the cached typing locations for inferred typings that are already installed
         packageNameToTypingLocation.forEach((typing, name) => {
             const registryEntry = typesRegistry.get(name);
-            if (inferredTypings.has(name) && inferredTypings.get(name) === undefined && registryEntry !== undefined && isTypingUpToDate(typing, typesRegistry.get(name)!)) {
+            if (inferredTypings.has(name) && inferredTypings.get(name) === undefined && registryEntry !== undefined && isTypingUpToDate(typing, registryEntry!)) {
                 inferredTypings.set(name, typing.typingLocation);
             }
         });

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -160,7 +160,7 @@ namespace ts.JsTyping {
         }
         // Add the cached typing locations for inferred typings that are already installed
         packageNameToTypingLocation.forEach((typing, name) => {
-            if (inferredTypings.has(name) && inferredTypings.get(name) === undefined && isTypingUpToDate(typing, typesRegistry.get(name)!)) {
+            if (inferredTypings.has(name) && inferredTypings.get(name) === undefined && typesRegistry.has(name) && isTypingUpToDate(typing, typesRegistry.get(name)!)) {
                 inferredTypings.set(name, typing.typingLocation);
             }
         });

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -160,7 +160,8 @@ namespace ts.JsTyping {
         }
         // Add the cached typing locations for inferred typings that are already installed
         packageNameToTypingLocation.forEach((typing, name) => {
-            if (inferredTypings.has(name) && inferredTypings.get(name) === undefined && typesRegistry.has(name) && isTypingUpToDate(typing, typesRegistry.get(name)!)) {
+            const registryEntry = typesRegistry.get(name);
+            if (inferredTypings.has(name) && inferredTypings.get(name) === undefined && registryEntry !== undefined && isTypingUpToDate(typing, typesRegistry.get(name)!)) {
                 inferredTypings.set(name, typing.typingLocation);
             }
         });

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -161,7 +161,7 @@ namespace ts.JsTyping {
         // Add the cached typing locations for inferred typings that are already installed
         packageNameToTypingLocation.forEach((typing, name) => {
             const registryEntry = typesRegistry.get(name);
-            if (inferredTypings.has(name) && inferredTypings.get(name) === undefined && registryEntry !== undefined && isTypingUpToDate(typing, registryEntry!)) {
+            if (inferredTypings.has(name) && inferredTypings.get(name) === undefined && registryEntry !== undefined && isTypingUpToDate(typing, registryEntry)) {
                 inferredTypings.set(name, typing.typingLocation);
             }
         });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Currently, if a previously installed ATA package is removed from the types-registry, we throw an exception when trying to determine whether to update it on typings install.

This PR fixes that issue by reporting the package as not cached, and then appropriately does not attempt to install it (due to it being missing from the registry).

