### PR TITLE
Fix merge lexical environment to *always* respect prologue statements

### DIFF
--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -1468,7 +1468,7 @@ namespace ts {
         }
 
         return isNodeArray(statements)
-            ? setTextRange(createNodeArray(concatenate(declarations, statements)), statements)
+            ? setTextRange(createNodeArray(prependStatements(statements.slice(), declarations)), statements)
             : prependStatements(statements, declarations);
     }
 

--- a/tests/baselines/reference/destructuringTempOccursAfterPrologue.js
+++ b/tests/baselines/reference/destructuringTempOccursAfterPrologue.js
@@ -1,0 +1,12 @@
+//// [destructuringTempOccursAfterPrologue.ts]
+function test(p: any) {
+    'use strict';
+    p = { prop: p } = p;
+}
+
+//// [destructuringTempOccursAfterPrologue.js]
+function test(p) {
+    'use strict';
+    var _a;
+    p = (_a = p, p = _a.prop, _a);
+}

--- a/tests/baselines/reference/destructuringTempOccursAfterPrologue.symbols
+++ b/tests/baselines/reference/destructuringTempOccursAfterPrologue.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/destructuringTempOccursAfterPrologue.ts ===
+function test(p: any) {
+>test : Symbol(test, Decl(destructuringTempOccursAfterPrologue.ts, 0, 0))
+>p : Symbol(p, Decl(destructuringTempOccursAfterPrologue.ts, 0, 14))
+
+    'use strict';
+    p = { prop: p } = p;
+>p : Symbol(p, Decl(destructuringTempOccursAfterPrologue.ts, 0, 14))
+>prop : Symbol(prop, Decl(destructuringTempOccursAfterPrologue.ts, 2, 9))
+>p : Symbol(p, Decl(destructuringTempOccursAfterPrologue.ts, 0, 14))
+>p : Symbol(p, Decl(destructuringTempOccursAfterPrologue.ts, 0, 14))
+}

--- a/tests/baselines/reference/destructuringTempOccursAfterPrologue.types
+++ b/tests/baselines/reference/destructuringTempOccursAfterPrologue.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/destructuringTempOccursAfterPrologue.ts ===
+function test(p: any) {
+>test : (p: any) => void
+>p : any
+
+    'use strict';
+>'use strict' : "use strict"
+
+    p = { prop: p } = p;
+>p = { prop: p } = p : any
+>p : any
+>{ prop: p } = p : any
+>{ prop: p } : { prop: any; }
+>prop : any
+>p : any
+>p : any
+}

--- a/tests/cases/compiler/destructuringTempOccursAfterPrologue.ts
+++ b/tests/cases/compiler/destructuringTempOccursAfterPrologue.ts
@@ -1,0 +1,4 @@
+function test(p: any) {
+    'use strict';
+    p = { prop: p } = p;
+}


### PR DESCRIPTION
Fixes #24582

`mergeLexicalEnvironment` only called `prependStatements` when `statements` wasn't a node array. Specifically in the case of destructuring assignments, it seems like it was an array instead of a node array, causing the difference. Now `mergeLexicalEnvironment` uses `prependStatements` in both cases.