### PR TITLE
Use more nodelike paths for import types when possible

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4085,7 +4085,7 @@ namespace ts {
                         // ambient module, just use declaration/symbol name (fallthrough)
                     }
                     else {
-                        return `"${getResolvedExternalModuleName(context!.tracker.moduleResolverHost!, file, getSourceFileOfNode(getOriginalNode(context!.enclosingDeclaration)))}"`;
+                        return `"${getResolvedExternalModuleNameForPossiblyExternalModule(context!.tracker.moduleResolverHost!, file, getSourceFileOfNode(getOriginalNode(context!.enclosingDeclaration)))}"`;
                     }
                 }
                 const declaration = symbol.declarations[0];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5287,6 +5287,7 @@ namespace ts {
         getCanonicalFileName(f: string): string;
         getCommonSourceDirectory(): string;
         getCurrentDirectory(): string;
+        getCompilerOptions(): CompilerOptions;
     }
 
     /** @deprecated See comment on SymbolWriter */

--- a/tests/baselines/reference/declarationEmitCommonJsModuleReferencedType.js
+++ b/tests/baselines/reference/declarationEmitCommonJsModuleReferencedType.js
@@ -1,0 +1,38 @@
+//// [tests/cases/compiler/declarationEmitCommonJsModuleReferencedType.ts] ////
+
+//// [index.d.ts]
+export interface NestedProps {}
+//// [index.d.ts]
+export interface OtherIndexProps {}
+//// [other.d.ts]
+export interface OtherProps {}
+//// [index.d.ts]
+import { OtherProps } from "./other";
+import { OtherIndexProps } from "./other/index";
+import { NestedProps } from "nested";
+export interface SomeProps {}
+
+export function foo(): [SomeProps, OtherProps, OtherIndexProps, NestedProps];
+//// [index.d.ts]
+export interface RootProps {}
+
+export function bar(): RootProps;
+//// [entry.ts]
+import { foo } from "foo";
+import { bar } from "root";
+export const x = foo();
+export const y = bar();
+
+
+//// [entry.js]
+"use strict";
+exports.__esModule = true;
+var foo_1 = require("foo");
+var root_1 = require("root");
+exports.x = foo_1.foo();
+exports.y = root_1.bar();
+
+
+//// [entry.d.ts]
+export declare const x: [import("foo/index").SomeProps, import("foo/other").OtherProps, import("foo/other/index").OtherIndexProps, import("foo/node_modules/nested/index").NestedProps];
+export declare const y: import("root/index").RootProps;

--- a/tests/baselines/reference/declarationEmitCommonJsModuleReferencedType.symbols
+++ b/tests/baselines/reference/declarationEmitCommonJsModuleReferencedType.symbols
@@ -1,0 +1,55 @@
+=== tests/cases/compiler/r/node_modules/foo/node_modules/nested/index.d.ts ===
+export interface NestedProps {}
+>NestedProps : Symbol(NestedProps, Decl(index.d.ts, 0, 0))
+
+=== tests/cases/compiler/r/node_modules/foo/other/index.d.ts ===
+export interface OtherIndexProps {}
+>OtherIndexProps : Symbol(OtherIndexProps, Decl(index.d.ts, 0, 0))
+
+=== tests/cases/compiler/r/node_modules/foo/other.d.ts ===
+export interface OtherProps {}
+>OtherProps : Symbol(OtherProps, Decl(other.d.ts, 0, 0))
+
+=== tests/cases/compiler/r/node_modules/foo/index.d.ts ===
+import { OtherProps } from "./other";
+>OtherProps : Symbol(OtherProps, Decl(index.d.ts, 0, 8))
+
+import { OtherIndexProps } from "./other/index";
+>OtherIndexProps : Symbol(OtherIndexProps, Decl(index.d.ts, 1, 8))
+
+import { NestedProps } from "nested";
+>NestedProps : Symbol(NestedProps, Decl(index.d.ts, 2, 8))
+
+export interface SomeProps {}
+>SomeProps : Symbol(SomeProps, Decl(index.d.ts, 2, 37))
+
+export function foo(): [SomeProps, OtherProps, OtherIndexProps, NestedProps];
+>foo : Symbol(foo, Decl(index.d.ts, 3, 29))
+>SomeProps : Symbol(SomeProps, Decl(index.d.ts, 2, 37))
+>OtherProps : Symbol(OtherProps, Decl(index.d.ts, 0, 8))
+>OtherIndexProps : Symbol(OtherIndexProps, Decl(index.d.ts, 1, 8))
+>NestedProps : Symbol(NestedProps, Decl(index.d.ts, 2, 8))
+
+=== tests/cases/compiler/node_modules/root/index.d.ts ===
+export interface RootProps {}
+>RootProps : Symbol(RootProps, Decl(index.d.ts, 0, 0))
+
+export function bar(): RootProps;
+>bar : Symbol(bar, Decl(index.d.ts, 0, 29))
+>RootProps : Symbol(RootProps, Decl(index.d.ts, 0, 0))
+
+=== tests/cases/compiler/r/entry.ts ===
+import { foo } from "foo";
+>foo : Symbol(foo, Decl(entry.ts, 0, 8))
+
+import { bar } from "root";
+>bar : Symbol(bar, Decl(entry.ts, 1, 8))
+
+export const x = foo();
+>x : Symbol(x, Decl(entry.ts, 2, 12))
+>foo : Symbol(foo, Decl(entry.ts, 0, 8))
+
+export const y = bar();
+>y : Symbol(y, Decl(entry.ts, 3, 12))
+>bar : Symbol(bar, Decl(entry.ts, 1, 8))
+

--- a/tests/baselines/reference/declarationEmitCommonJsModuleReferencedType.types
+++ b/tests/baselines/reference/declarationEmitCommonJsModuleReferencedType.types
@@ -1,0 +1,57 @@
+=== tests/cases/compiler/r/node_modules/foo/node_modules/nested/index.d.ts ===
+export interface NestedProps {}
+>NestedProps : NestedProps
+
+=== tests/cases/compiler/r/node_modules/foo/other/index.d.ts ===
+export interface OtherIndexProps {}
+>OtherIndexProps : OtherIndexProps
+
+=== tests/cases/compiler/r/node_modules/foo/other.d.ts ===
+export interface OtherProps {}
+>OtherProps : OtherProps
+
+=== tests/cases/compiler/r/node_modules/foo/index.d.ts ===
+import { OtherProps } from "./other";
+>OtherProps : any
+
+import { OtherIndexProps } from "./other/index";
+>OtherIndexProps : any
+
+import { NestedProps } from "nested";
+>NestedProps : any
+
+export interface SomeProps {}
+>SomeProps : SomeProps
+
+export function foo(): [SomeProps, OtherProps, OtherIndexProps, NestedProps];
+>foo : () => [SomeProps, OtherProps, OtherIndexProps, NestedProps]
+>SomeProps : SomeProps
+>OtherProps : OtherProps
+>OtherIndexProps : OtherIndexProps
+>NestedProps : NestedProps
+
+=== tests/cases/compiler/node_modules/root/index.d.ts ===
+export interface RootProps {}
+>RootProps : RootProps
+
+export function bar(): RootProps;
+>bar : () => RootProps
+>RootProps : RootProps
+
+=== tests/cases/compiler/r/entry.ts ===
+import { foo } from "foo";
+>foo : () => [import("tests/cases/compiler/r/node_modules/foo/index").SomeProps, import("tests/cases/compiler/r/node_modules/foo/other").OtherProps, import("tests/cases/compiler/r/node_modules/foo/other/index").OtherIndexProps, import("tests/cases/compiler/r/node_modules/foo/node_modules/nested/index").NestedProps]
+
+import { bar } from "root";
+>bar : () => import("tests/cases/compiler/node_modules/root/index").RootProps
+
+export const x = foo();
+>x : [import("tests/cases/compiler/r/node_modules/foo/index").SomeProps, import("tests/cases/compiler/r/node_modules/foo/other").OtherProps, import("tests/cases/compiler/r/node_modules/foo/other/index").OtherIndexProps, import("tests/cases/compiler/r/node_modules/foo/node_modules/nested/index").NestedProps]
+>foo() : [import("tests/cases/compiler/r/node_modules/foo/index").SomeProps, import("tests/cases/compiler/r/node_modules/foo/other").OtherProps, import("tests/cases/compiler/r/node_modules/foo/other/index").OtherIndexProps, import("tests/cases/compiler/r/node_modules/foo/node_modules/nested/index").NestedProps]
+>foo : () => [import("tests/cases/compiler/r/node_modules/foo/index").SomeProps, import("tests/cases/compiler/r/node_modules/foo/other").OtherProps, import("tests/cases/compiler/r/node_modules/foo/other/index").OtherIndexProps, import("tests/cases/compiler/r/node_modules/foo/node_modules/nested/index").NestedProps]
+
+export const y = bar();
+>y : import("tests/cases/compiler/node_modules/root/index").RootProps
+>bar() : import("tests/cases/compiler/node_modules/root/index").RootProps
+>bar : () => import("tests/cases/compiler/node_modules/root/index").RootProps
+

--- a/tests/baselines/reference/importShouldNotBeElidedInDeclarationEmit.js
+++ b/tests/baselines/reference/importShouldNotBeElidedInDeclarationEmit.js
@@ -21,4 +21,4 @@ exports.thing = umd_1.makeThing();
 
 
 //// [index.d.ts]
-export declare const thing: import("./node_modules/umd").Thing;
+export declare const thing: import("umd").Thing;

--- a/tests/cases/compiler/declarationEmitCommonJsModuleReferencedType.ts
+++ b/tests/cases/compiler/declarationEmitCommonJsModuleReferencedType.ts
@@ -1,0 +1,23 @@
+// @declaration: true
+// @filename: r/node_modules/foo/node_modules/nested/index.d.ts
+export interface NestedProps {}
+// @filename: r/node_modules/foo/other/index.d.ts
+export interface OtherIndexProps {}
+// @filename: r/node_modules/foo/other.d.ts
+export interface OtherProps {}
+// @filename: r/node_modules/foo/index.d.ts
+import { OtherProps } from "./other";
+import { OtherIndexProps } from "./other/index";
+import { NestedProps } from "nested";
+export interface SomeProps {}
+
+export function foo(): [SomeProps, OtherProps, OtherIndexProps, NestedProps];
+// @filename: node_modules/root/index.d.ts
+export interface RootProps {}
+
+export function bar(): RootProps;
+// @filename: r/entry.ts
+import { foo } from "foo";
+import { bar } from "root";
+export const x = foo();
+export const y = bar();


### PR DESCRIPTION
Partial fix for #24599

A complete fix (ie, one where `/index` is also removed and maybe where `package.json`'s get walked backward) requires a much more complex reverse resolver to check there's no directory/file conflicts (in the case of `/index`) and for file contents (in the case of reversing a `package.json`). If we think that's worth doing, we can; but this simple change makes the output as portable as is usually expected.

