### PR TITLE
Treat host as possibly undefined for base64encode/base64decode

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3674,15 +3674,15 @@ namespace ts {
         return output;
     }
 
-    export function base64encode(host: { base64encode?(input: string): string }, input: string): string {
-        if (host.base64encode) {
+    export function base64encode(host: { base64encode?(input: string): string } | undefined, input: string): string {
+        if (host && host.base64encode) {
             return host.base64encode(input);
         }
         return convertToBase64(input);
     }
 
-    export function base64decode(host: { base64decode?(input: string): string }, input: string): string {
-        if (host.base64decode) {
+    export function base64decode(host: { base64decode?(input: string): string } | undefined, input: string): string {
+        if (host && host.base64decode) {
             return host.base64decode(input);
         }
         const length = input.length;


### PR DESCRIPTION
Fixes: #24638

Does not assume that `ts.sys` (a.k.a. `host`) is always defined, because when running on non-node/ChakraCore runtimes (e.g. [deno](https://github.com/ry/deno)), `.sys` does not get defined currently.

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run ~`jake runtests`~ `gulp runtests` locally
* [X] You've signed the CLA
* [ ] There are new or updated unit tests validating the change<sup>1</sup>

Fixes: #24638 
Refs: ry/deno#117

[1]: I couldn't find any unit tests that were appropriate to update or add for this area of code.  Would be glad to if someone could point out a related unit test.
