### PR TITLE
allow access protected member in this parameter context

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17107,6 +17107,8 @@ namespace ts {
             });
             // A protected property is accessible if the property is within the declaring class or classes derived from it
             if (!enclosingClass) {
+                // allow PropertyAccessibility if context is in function with this parameter
+                // static member access is disallow
                 let thisParameter: ParameterDeclaration | undefined;
                 const thisContainer = getThisContainer(node, /* includeArrowFunctions */ false);
                 if (flags & ModifierFlags.Static || !thisContainer || !isFunctionLike(thisContainer) || !(thisParameter = getThisParameter(thisContainer)) || !thisParameter.type) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17109,7 +17109,7 @@ namespace ts {
             if (!enclosingClass) {
                 let thisParameter: ParameterDeclaration | undefined;
                 const thisContainer = getThisContainer(node, /* includeArrowFunctions */ false);
-                if (!thisContainer || !isFunctionLike(thisContainer) || !(thisParameter = getThisParameter(thisContainer)) || !thisParameter.type) {
+                if (flags & ModifierFlags.Static || !thisContainer || !isFunctionLike(thisContainer) || !(thisParameter = getThisParameter(thisContainer)) || !thisParameter.type) {
                     error(errorNode, Diagnostics.Property_0_is_protected_and_only_accessible_within_class_1_and_its_subclasses, symbolToString(prop), typeToString(getDeclaringClass(prop) || type));
                     return false;
                 }
@@ -17121,7 +17121,7 @@ namespace ts {
             if (flags & ModifierFlags.Static) {
                 return true;
             }
-             if (type.flags & TypeFlags.TypeParameter) {
+            if (type.flags & TypeFlags.TypeParameter) {
                 // get the original type -- represented as the type constraint of the 'this' type
                 type = (type as TypeParameter).isThisType ? getConstraintOfTypeParameter(<TypeParameter>type)! : getBaseConstraintOfType(<TypeParameter>type)!; // TODO: GH#18217 Use a different variable that's allowed to be undefined
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17110,8 +17110,7 @@ namespace ts {
                 // allow PropertyAccessibility if context is in function with this parameter
                 // static member access is disallow
                 let thisParameter: ParameterDeclaration | undefined;
-                const thisContainer = getThisContainer(node, /* includeArrowFunctions */ false);
-                if (flags & ModifierFlags.Static || !thisContainer || !isFunctionLike(thisContainer) || !(thisParameter = getThisParameter(thisContainer)) || !thisParameter.type) {
+                if (flags & ModifierFlags.Static || !(thisParameter = getThisParameterFromNodeContext(node)) || !thisParameter.type) {
                     error(errorNode, Diagnostics.Property_0_is_protected_and_only_accessible_within_class_1_and_its_subclasses, symbolToString(prop), typeToString(getDeclaringClass(prop) || type));
                     return false;
                 }
@@ -17132,6 +17131,11 @@ namespace ts {
                 return false;
             }
             return true;
+        }
+
+        function getThisParameterFromNodeContext (node: Node) {
+            const thisContainer = getThisContainer(node, /* includeArrowFunctions */ false);
+            return thisContainer && isFunctionLike(thisContainer) ? getThisParameter(thisContainer) : undefined;
         }
 
         function symbolHasNonMethodDeclaration(symbol: Symbol) {

--- a/tests/baselines/reference/thisTypeAccessibility.errors.txt
+++ b/tests/baselines/reference/thisTypeAccessibility.errors.txt
@@ -1,13 +1,22 @@
-tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(14,10): error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
-tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(20,10): error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(17,10): error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(20,13): error TS2341: Property 'sp' is private and only accessible within class 'MyClass'.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(21,13): error TS2445: Property 'spp' is protected and only accessible within class 'MyClass' and its subclasses.
 tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(26,10): error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(29,13): error TS2341: Property 'sp' is private and only accessible within class 'MyClass'.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(30,13): error TS2445: Property 'spp' is protected and only accessible within class 'MyClass' and its subclasses.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(35,10): error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(38,13): error TS2341: Property 'sp' is private and only accessible within class 'MyClass'.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(39,13): error TS2445: Property 'spp' is protected and only accessible within class 'MyClass' and its subclasses.
 
 
-==== tests/cases/conformance/types/thisType/thisTypeAccessibility.ts (3 errors) ====
+==== tests/cases/conformance/types/thisType/thisTypeAccessibility.ts (9 errors) ====
     class MyClass {
         private p: number = 123;
         protected pp: number = 123;
         public ppp: number = 123;
+        private static sp: number = 123;
+        protected static spp: number = 123;
+        public static sppp: number = 123;
     }
     
     interface MyClass {
@@ -22,6 +31,13 @@ tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(26,10): error TS
 !!! error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
         this.pp = p;
         this.ppp = p;
+        MyClass.sp = p;
+                ~~
+!!! error TS2341: Property 'sp' is private and only accessible within class 'MyClass'.
+        MyClass.spp = p;
+                ~~~
+!!! error TS2445: Property 'spp' is protected and only accessible within class 'MyClass' and its subclasses.
+        MyClass.sppp = p;
     }
     
     MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
@@ -30,6 +46,13 @@ tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(26,10): error TS
 !!! error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
         this.pp = p;
         this.ppp = p;
+        MyClass.sp = p;
+                ~~
+!!! error TS2341: Property 'sp' is private and only accessible within class 'MyClass'.
+        MyClass.spp = p;
+                ~~~
+!!! error TS2445: Property 'spp' is protected and only accessible within class 'MyClass' and its subclasses.
+        MyClass.sppp = p;
     }
     
     function extension3<T extends MyClass> (this: T, p: number) { 
@@ -38,6 +61,13 @@ tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(26,10): error TS
 !!! error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
         this.pp = p;
         this.ppp = p;
+        MyClass.sp = p;
+                ~~
+!!! error TS2341: Property 'sp' is private and only accessible within class 'MyClass'.
+        MyClass.spp = p;
+                ~~~
+!!! error TS2445: Property 'spp' is protected and only accessible within class 'MyClass' and its subclasses.
+        MyClass.sppp = p;
     }
     
     MyClass.prototype.extension3 = extension3;

--- a/tests/baselines/reference/thisTypeAccessibility.errors.txt
+++ b/tests/baselines/reference/thisTypeAccessibility.errors.txt
@@ -1,0 +1,44 @@
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(14,10): error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(20,10): error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+tests/cases/conformance/types/thisType/thisTypeAccessibility.ts(26,10): error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+
+
+==== tests/cases/conformance/types/thisType/thisTypeAccessibility.ts (3 errors) ====
+    class MyClass {
+        private p: number = 123;
+        protected pp: number = 123;
+        public ppp: number = 123;
+    }
+    
+    interface MyClass {
+        extension1(p: number): void;
+        extension2(p: number): void;
+        extension3(p: number): void;
+    }
+    
+    MyClass.prototype.extension1 = function (this: MyClass, p: number) { 
+        this.p = p;
+             ~
+!!! error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+        this.pp = p;
+        this.ppp = p;
+    }
+    
+    MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
+        this.p = p;
+             ~
+!!! error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+        this.pp = p;
+        this.ppp = p;
+    }
+    
+    function extension3<T extends MyClass> (this: T, p: number) { 
+        this.p = p;
+             ~
+!!! error TS2341: Property 'p' is private and only accessible within class 'MyClass'.
+        this.pp = p;
+        this.ppp = p;
+    }
+    
+    MyClass.prototype.extension3 = extension3;
+    

--- a/tests/baselines/reference/thisTypeAccessibility.js
+++ b/tests/baselines/reference/thisTypeAccessibility.js
@@ -3,6 +3,9 @@ class MyClass {
     private p: number = 123;
     protected pp: number = 123;
     public ppp: number = 123;
+    private static sp: number = 123;
+    protected static spp: number = 123;
+    public static sppp: number = 123;
 }
 
 interface MyClass {
@@ -15,18 +18,27 @@ MyClass.prototype.extension1 = function (this: MyClass, p: number) {
     this.p = p;
     this.pp = p;
     this.ppp = p;
+    MyClass.sp = p;
+    MyClass.spp = p;
+    MyClass.sppp = p;
 }
 
 MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
     this.p = p;
     this.pp = p;
     this.ppp = p;
+    MyClass.sp = p;
+    MyClass.spp = p;
+    MyClass.sppp = p;
 }
 
 function extension3<T extends MyClass> (this: T, p: number) { 
     this.p = p;
     this.pp = p;
     this.ppp = p;
+    MyClass.sp = p;
+    MyClass.spp = p;
+    MyClass.sppp = p;
 }
 
 MyClass.prototype.extension3 = extension3;
@@ -39,21 +51,33 @@ var MyClass = /** @class */ (function () {
         this.pp = 123;
         this.ppp = 123;
     }
+    MyClass.sp = 123;
+    MyClass.spp = 123;
+    MyClass.sppp = 123;
     return MyClass;
 }());
 MyClass.prototype.extension1 = function (p) {
     this.p = p;
     this.pp = p;
     this.ppp = p;
+    MyClass.sp = p;
+    MyClass.spp = p;
+    MyClass.sppp = p;
 };
 MyClass.prototype.extension2 = function (p) {
     this.p = p;
     this.pp = p;
     this.ppp = p;
+    MyClass.sp = p;
+    MyClass.spp = p;
+    MyClass.sppp = p;
 };
 function extension3(p) {
     this.p = p;
     this.pp = p;
     this.ppp = p;
+    MyClass.sp = p;
+    MyClass.spp = p;
+    MyClass.sppp = p;
 }
 MyClass.prototype.extension3 = extension3;

--- a/tests/baselines/reference/thisTypeAccessibility.js
+++ b/tests/baselines/reference/thisTypeAccessibility.js
@@ -1,0 +1,59 @@
+//// [thisTypeAccessibility.ts]
+class MyClass {
+    private p: number = 123;
+    protected pp: number = 123;
+    public ppp: number = 123;
+}
+
+interface MyClass {
+    extension1(p: number): void;
+    extension2(p: number): void;
+    extension3(p: number): void;
+}
+
+MyClass.prototype.extension1 = function (this: MyClass, p: number) { 
+    this.p = p;
+    this.pp = p;
+    this.ppp = p;
+}
+
+MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
+    this.p = p;
+    this.pp = p;
+    this.ppp = p;
+}
+
+function extension3<T extends MyClass> (this: T, p: number) { 
+    this.p = p;
+    this.pp = p;
+    this.ppp = p;
+}
+
+MyClass.prototype.extension3 = extension3;
+
+
+//// [thisTypeAccessibility.js]
+var MyClass = /** @class */ (function () {
+    function MyClass() {
+        this.p = 123;
+        this.pp = 123;
+        this.ppp = 123;
+    }
+    return MyClass;
+}());
+MyClass.prototype.extension1 = function (p) {
+    this.p = p;
+    this.pp = p;
+    this.ppp = p;
+};
+MyClass.prototype.extension2 = function (p) {
+    this.p = p;
+    this.pp = p;
+    this.ppp = p;
+};
+function extension3(p) {
+    this.p = p;
+    this.pp = p;
+    this.ppp = p;
+}
+MyClass.prototype.extension3 = extension3;

--- a/tests/baselines/reference/thisTypeAccessibility.symbols
+++ b/tests/baselines/reference/thisTypeAccessibility.symbols
@@ -1,0 +1,125 @@
+=== tests/cases/conformance/types/thisType/thisTypeAccessibility.ts ===
+class MyClass {
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+
+    private p: number = 123;
+>p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
+
+    protected pp: number = 123;
+>pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
+
+    public ppp: number = 123;
+>ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
+}
+
+interface MyClass {
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+
+    extension1(p: number): void;
+>extension1 : Symbol(MyClass.extension1, Decl(thisTypeAccessibility.ts, 6, 19))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 7, 15))
+
+    extension2(p: number): void;
+>extension2 : Symbol(MyClass.extension2, Decl(thisTypeAccessibility.ts, 7, 32))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 8, 15))
+
+    extension3(p: number): void;
+>extension3 : Symbol(MyClass.extension3, Decl(thisTypeAccessibility.ts, 8, 32))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 9, 15))
+}
+
+MyClass.prototype.extension1 = function (this: MyClass, p: number) { 
+>MyClass.prototype.extension1 : Symbol(MyClass.extension1, Decl(thisTypeAccessibility.ts, 6, 19))
+>MyClass.prototype : Symbol(MyClass.prototype)
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>prototype : Symbol(MyClass.prototype)
+>extension1 : Symbol(MyClass.extension1, Decl(thisTypeAccessibility.ts, 6, 19))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 12, 41))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 12, 55))
+
+    this.p = p;
+>this.p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 12, 41))
+>p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 12, 55))
+
+    this.pp = p;
+>this.pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 12, 41))
+>pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 12, 55))
+
+    this.ppp = p;
+>this.ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 12, 41))
+>ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 12, 55))
+}
+
+MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
+>MyClass.prototype.extension2 : Symbol(MyClass.extension2, Decl(thisTypeAccessibility.ts, 7, 32))
+>MyClass.prototype : Symbol(MyClass.prototype)
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>prototype : Symbol(MyClass.prototype)
+>extension2 : Symbol(MyClass.extension2, Decl(thisTypeAccessibility.ts, 7, 32))
+>T : Symbol(T, Decl(thisTypeAccessibility.ts, 18, 40))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 18, 60))
+>T : Symbol(T, Decl(thisTypeAccessibility.ts, 18, 40))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 18, 68))
+
+    this.p = p;
+>this.p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 18, 60))
+>p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 18, 68))
+
+    this.pp = p;
+>this.pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 18, 60))
+>pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 18, 68))
+
+    this.ppp = p;
+>this.ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 18, 60))
+>ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 18, 68))
+}
+
+function extension3<T extends MyClass> (this: T, p: number) { 
+>extension3 : Symbol(extension3, Decl(thisTypeAccessibility.ts, 22, 1))
+>T : Symbol(T, Decl(thisTypeAccessibility.ts, 24, 20))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 40))
+>T : Symbol(T, Decl(thisTypeAccessibility.ts, 24, 20))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 48))
+
+    this.p = p;
+>this.p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 40))
+>p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 48))
+
+    this.pp = p;
+>this.pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 40))
+>pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 48))
+
+    this.ppp = p;
+>this.ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 40))
+>ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 48))
+}
+
+MyClass.prototype.extension3 = extension3;
+>MyClass.prototype.extension3 : Symbol(MyClass.extension3, Decl(thisTypeAccessibility.ts, 8, 32))
+>MyClass.prototype : Symbol(MyClass.prototype)
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>prototype : Symbol(MyClass.prototype)
+>extension3 : Symbol(MyClass.extension3, Decl(thisTypeAccessibility.ts, 8, 32))
+>extension3 : Symbol(extension3, Decl(thisTypeAccessibility.ts, 22, 1))
+

--- a/tests/baselines/reference/thisTypeAccessibility.symbols
+++ b/tests/baselines/reference/thisTypeAccessibility.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/types/thisType/thisTypeAccessibility.ts ===
 class MyClass {
->MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
 
     private p: number = 123;
 >p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
@@ -10,116 +10,179 @@ class MyClass {
 
     public ppp: number = 123;
 >ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
+
+    private static sp: number = 123;
+>sp : Symbol(MyClass.sp, Decl(thisTypeAccessibility.ts, 3, 29))
+
+    protected static spp: number = 123;
+>spp : Symbol(MyClass.spp, Decl(thisTypeAccessibility.ts, 4, 36))
+
+    public static sppp: number = 123;
+>sppp : Symbol(MyClass.sppp, Decl(thisTypeAccessibility.ts, 5, 39))
 }
 
 interface MyClass {
->MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
 
     extension1(p: number): void;
->extension1 : Symbol(MyClass.extension1, Decl(thisTypeAccessibility.ts, 6, 19))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 7, 15))
+>extension1 : Symbol(MyClass.extension1, Decl(thisTypeAccessibility.ts, 9, 19))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 10, 15))
 
     extension2(p: number): void;
->extension2 : Symbol(MyClass.extension2, Decl(thisTypeAccessibility.ts, 7, 32))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 8, 15))
+>extension2 : Symbol(MyClass.extension2, Decl(thisTypeAccessibility.ts, 10, 32))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 11, 15))
 
     extension3(p: number): void;
->extension3 : Symbol(MyClass.extension3, Decl(thisTypeAccessibility.ts, 8, 32))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 9, 15))
+>extension3 : Symbol(MyClass.extension3, Decl(thisTypeAccessibility.ts, 11, 32))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 12, 15))
 }
 
 MyClass.prototype.extension1 = function (this: MyClass, p: number) { 
->MyClass.prototype.extension1 : Symbol(MyClass.extension1, Decl(thisTypeAccessibility.ts, 6, 19))
+>MyClass.prototype.extension1 : Symbol(MyClass.extension1, Decl(thisTypeAccessibility.ts, 9, 19))
 >MyClass.prototype : Symbol(MyClass.prototype)
->MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
 >prototype : Symbol(MyClass.prototype)
->extension1 : Symbol(MyClass.extension1, Decl(thisTypeAccessibility.ts, 6, 19))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 12, 41))
->MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 12, 55))
+>extension1 : Symbol(MyClass.extension1, Decl(thisTypeAccessibility.ts, 9, 19))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 15, 41))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 15, 55))
 
     this.p = p;
 >this.p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 12, 41))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 15, 41))
 >p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 12, 55))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 15, 55))
 
     this.pp = p;
 >this.pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 12, 41))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 15, 41))
 >pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 12, 55))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 15, 55))
 
     this.ppp = p;
 >this.ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 12, 41))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 15, 41))
 >ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 12, 55))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 15, 55))
+
+    MyClass.sp = p;
+>MyClass.sp : Symbol(MyClass.sp, Decl(thisTypeAccessibility.ts, 3, 29))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>sp : Symbol(MyClass.sp, Decl(thisTypeAccessibility.ts, 3, 29))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 15, 55))
+
+    MyClass.spp = p;
+>MyClass.spp : Symbol(MyClass.spp, Decl(thisTypeAccessibility.ts, 4, 36))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>spp : Symbol(MyClass.spp, Decl(thisTypeAccessibility.ts, 4, 36))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 15, 55))
+
+    MyClass.sppp = p;
+>MyClass.sppp : Symbol(MyClass.sppp, Decl(thisTypeAccessibility.ts, 5, 39))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>sppp : Symbol(MyClass.sppp, Decl(thisTypeAccessibility.ts, 5, 39))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 15, 55))
 }
 
 MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
->MyClass.prototype.extension2 : Symbol(MyClass.extension2, Decl(thisTypeAccessibility.ts, 7, 32))
+>MyClass.prototype.extension2 : Symbol(MyClass.extension2, Decl(thisTypeAccessibility.ts, 10, 32))
 >MyClass.prototype : Symbol(MyClass.prototype)
->MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
 >prototype : Symbol(MyClass.prototype)
->extension2 : Symbol(MyClass.extension2, Decl(thisTypeAccessibility.ts, 7, 32))
->T : Symbol(T, Decl(thisTypeAccessibility.ts, 18, 40))
->MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 18, 60))
->T : Symbol(T, Decl(thisTypeAccessibility.ts, 18, 40))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 18, 68))
+>extension2 : Symbol(MyClass.extension2, Decl(thisTypeAccessibility.ts, 10, 32))
+>T : Symbol(T, Decl(thisTypeAccessibility.ts, 24, 40))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 60))
+>T : Symbol(T, Decl(thisTypeAccessibility.ts, 24, 40))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 68))
 
     this.p = p;
 >this.p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 18, 60))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 60))
 >p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 18, 68))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 68))
 
     this.pp = p;
 >this.pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 18, 60))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 60))
 >pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 18, 68))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 68))
 
     this.ppp = p;
 >this.ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 18, 60))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 60))
 >ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 18, 68))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 68))
+
+    MyClass.sp = p;
+>MyClass.sp : Symbol(MyClass.sp, Decl(thisTypeAccessibility.ts, 3, 29))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>sp : Symbol(MyClass.sp, Decl(thisTypeAccessibility.ts, 3, 29))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 68))
+
+    MyClass.spp = p;
+>MyClass.spp : Symbol(MyClass.spp, Decl(thisTypeAccessibility.ts, 4, 36))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>spp : Symbol(MyClass.spp, Decl(thisTypeAccessibility.ts, 4, 36))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 68))
+
+    MyClass.sppp = p;
+>MyClass.sppp : Symbol(MyClass.sppp, Decl(thisTypeAccessibility.ts, 5, 39))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>sppp : Symbol(MyClass.sppp, Decl(thisTypeAccessibility.ts, 5, 39))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 68))
 }
 
 function extension3<T extends MyClass> (this: T, p: number) { 
->extension3 : Symbol(extension3, Decl(thisTypeAccessibility.ts, 22, 1))
->T : Symbol(T, Decl(thisTypeAccessibility.ts, 24, 20))
->MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 40))
->T : Symbol(T, Decl(thisTypeAccessibility.ts, 24, 20))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 48))
+>extension3 : Symbol(extension3, Decl(thisTypeAccessibility.ts, 31, 1))
+>T : Symbol(T, Decl(thisTypeAccessibility.ts, 33, 20))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 33, 40))
+>T : Symbol(T, Decl(thisTypeAccessibility.ts, 33, 20))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 33, 48))
 
     this.p = p;
 >this.p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 40))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 33, 40))
 >p : Symbol(MyClass.p, Decl(thisTypeAccessibility.ts, 0, 15))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 48))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 33, 48))
 
     this.pp = p;
 >this.pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 40))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 33, 40))
 >pp : Symbol(MyClass.pp, Decl(thisTypeAccessibility.ts, 1, 28))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 48))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 33, 48))
 
     this.ppp = p;
 >this.ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
->this : Symbol(this, Decl(thisTypeAccessibility.ts, 24, 40))
+>this : Symbol(this, Decl(thisTypeAccessibility.ts, 33, 40))
 >ppp : Symbol(MyClass.ppp, Decl(thisTypeAccessibility.ts, 2, 31))
->p : Symbol(p, Decl(thisTypeAccessibility.ts, 24, 48))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 33, 48))
+
+    MyClass.sp = p;
+>MyClass.sp : Symbol(MyClass.sp, Decl(thisTypeAccessibility.ts, 3, 29))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>sp : Symbol(MyClass.sp, Decl(thisTypeAccessibility.ts, 3, 29))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 33, 48))
+
+    MyClass.spp = p;
+>MyClass.spp : Symbol(MyClass.spp, Decl(thisTypeAccessibility.ts, 4, 36))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>spp : Symbol(MyClass.spp, Decl(thisTypeAccessibility.ts, 4, 36))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 33, 48))
+
+    MyClass.sppp = p;
+>MyClass.sppp : Symbol(MyClass.sppp, Decl(thisTypeAccessibility.ts, 5, 39))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
+>sppp : Symbol(MyClass.sppp, Decl(thisTypeAccessibility.ts, 5, 39))
+>p : Symbol(p, Decl(thisTypeAccessibility.ts, 33, 48))
 }
 
 MyClass.prototype.extension3 = extension3;
->MyClass.prototype.extension3 : Symbol(MyClass.extension3, Decl(thisTypeAccessibility.ts, 8, 32))
+>MyClass.prototype.extension3 : Symbol(MyClass.extension3, Decl(thisTypeAccessibility.ts, 11, 32))
 >MyClass.prototype : Symbol(MyClass.prototype)
->MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 4, 1))
+>MyClass : Symbol(MyClass, Decl(thisTypeAccessibility.ts, 0, 0), Decl(thisTypeAccessibility.ts, 7, 1))
 >prototype : Symbol(MyClass.prototype)
->extension3 : Symbol(MyClass.extension3, Decl(thisTypeAccessibility.ts, 8, 32))
->extension3 : Symbol(extension3, Decl(thisTypeAccessibility.ts, 22, 1))
+>extension3 : Symbol(MyClass.extension3, Decl(thisTypeAccessibility.ts, 11, 32))
+>extension3 : Symbol(extension3, Decl(thisTypeAccessibility.ts, 31, 1))
 

--- a/tests/baselines/reference/thisTypeAccessibility.types
+++ b/tests/baselines/reference/thisTypeAccessibility.types
@@ -1,0 +1,142 @@
+=== tests/cases/conformance/types/thisType/thisTypeAccessibility.ts ===
+class MyClass {
+>MyClass : MyClass
+
+    private p: number = 123;
+>p : number
+>123 : 123
+
+    protected pp: number = 123;
+>pp : number
+>123 : 123
+
+    public ppp: number = 123;
+>ppp : number
+>123 : 123
+}
+
+interface MyClass {
+>MyClass : MyClass
+
+    extension1(p: number): void;
+>extension1 : (p: number) => void
+>p : number
+
+    extension2(p: number): void;
+>extension2 : (p: number) => void
+>p : number
+
+    extension3(p: number): void;
+>extension3 : (p: number) => void
+>p : number
+}
+
+MyClass.prototype.extension1 = function (this: MyClass, p: number) { 
+>MyClass.prototype.extension1 = function (this: MyClass, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;} : (this: MyClass, p: number) => void
+>MyClass.prototype.extension1 : (p: number) => void
+>MyClass.prototype : MyClass
+>MyClass : typeof MyClass
+>prototype : MyClass
+>extension1 : (p: number) => void
+>function (this: MyClass, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;} : (this: MyClass, p: number) => void
+>this : MyClass
+>MyClass : MyClass
+>p : number
+
+    this.p = p;
+>this.p = p : number
+>this.p : number
+>this : MyClass
+>p : number
+>p : number
+
+    this.pp = p;
+>this.pp = p : number
+>this.pp : number
+>this : MyClass
+>pp : number
+>p : number
+
+    this.ppp = p;
+>this.ppp = p : number
+>this.ppp : number
+>this : MyClass
+>ppp : number
+>p : number
+}
+
+MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
+>MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;} : <T extends MyClass>(this: T, p: number) => void
+>MyClass.prototype.extension2 : (p: number) => void
+>MyClass.prototype : MyClass
+>MyClass : typeof MyClass
+>prototype : MyClass
+>extension2 : (p: number) => void
+>function<T extends MyClass> (this: T, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;} : <T extends MyClass>(this: T, p: number) => void
+>T : T
+>MyClass : MyClass
+>this : T
+>T : T
+>p : number
+
+    this.p = p;
+>this.p = p : number
+>this.p : number
+>this : T
+>p : number
+>p : number
+
+    this.pp = p;
+>this.pp = p : number
+>this.pp : number
+>this : T
+>pp : number
+>p : number
+
+    this.ppp = p;
+>this.ppp = p : number
+>this.ppp : number
+>this : T
+>ppp : number
+>p : number
+}
+
+function extension3<T extends MyClass> (this: T, p: number) { 
+>extension3 : <T extends MyClass>(this: T, p: number) => void
+>T : T
+>MyClass : MyClass
+>this : T
+>T : T
+>p : number
+
+    this.p = p;
+>this.p = p : number
+>this.p : number
+>this : T
+>p : number
+>p : number
+
+    this.pp = p;
+>this.pp = p : number
+>this.pp : number
+>this : T
+>pp : number
+>p : number
+
+    this.ppp = p;
+>this.ppp = p : number
+>this.ppp : number
+>this : T
+>ppp : number
+>p : number
+}
+
+MyClass.prototype.extension3 = extension3;
+>MyClass.prototype.extension3 = extension3 : <T extends MyClass>(this: T, p: number) => void
+>MyClass.prototype.extension3 : (p: number) => void
+>MyClass.prototype : MyClass
+>MyClass : typeof MyClass
+>prototype : MyClass
+>extension3 : (p: number) => void
+>extension3 : <T extends MyClass>(this: T, p: number) => void
+

--- a/tests/baselines/reference/thisTypeAccessibility.types
+++ b/tests/baselines/reference/thisTypeAccessibility.types
@@ -13,6 +13,18 @@ class MyClass {
     public ppp: number = 123;
 >ppp : number
 >123 : 123
+
+    private static sp: number = 123;
+>sp : number
+>123 : 123
+
+    protected static spp: number = 123;
+>spp : number
+>123 : 123
+
+    public static sppp: number = 123;
+>sppp : number
+>123 : 123
 }
 
 interface MyClass {
@@ -32,13 +44,13 @@ interface MyClass {
 }
 
 MyClass.prototype.extension1 = function (this: MyClass, p: number) { 
->MyClass.prototype.extension1 = function (this: MyClass, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;} : (this: MyClass, p: number) => void
+>MyClass.prototype.extension1 = function (this: MyClass, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;    MyClass.sp = p;    MyClass.spp = p;    MyClass.sppp = p;} : (this: MyClass, p: number) => void
 >MyClass.prototype.extension1 : (p: number) => void
 >MyClass.prototype : MyClass
 >MyClass : typeof MyClass
 >prototype : MyClass
 >extension1 : (p: number) => void
->function (this: MyClass, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;} : (this: MyClass, p: number) => void
+>function (this: MyClass, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;    MyClass.sp = p;    MyClass.spp = p;    MyClass.sppp = p;} : (this: MyClass, p: number) => void
 >this : MyClass
 >MyClass : MyClass
 >p : number
@@ -63,16 +75,37 @@ MyClass.prototype.extension1 = function (this: MyClass, p: number) {
 >this : MyClass
 >ppp : number
 >p : number
+
+    MyClass.sp = p;
+>MyClass.sp = p : number
+>MyClass.sp : number
+>MyClass : typeof MyClass
+>sp : number
+>p : number
+
+    MyClass.spp = p;
+>MyClass.spp = p : number
+>MyClass.spp : number
+>MyClass : typeof MyClass
+>spp : number
+>p : number
+
+    MyClass.sppp = p;
+>MyClass.sppp = p : number
+>MyClass.sppp : number
+>MyClass : typeof MyClass
+>sppp : number
+>p : number
 }
 
 MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
->MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;} : <T extends MyClass>(this: T, p: number) => void
+>MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;    MyClass.sp = p;    MyClass.spp = p;    MyClass.sppp = p;} : <T extends MyClass>(this: T, p: number) => void
 >MyClass.prototype.extension2 : (p: number) => void
 >MyClass.prototype : MyClass
 >MyClass : typeof MyClass
 >prototype : MyClass
 >extension2 : (p: number) => void
->function<T extends MyClass> (this: T, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;} : <T extends MyClass>(this: T, p: number) => void
+>function<T extends MyClass> (this: T, p: number) {     this.p = p;    this.pp = p;    this.ppp = p;    MyClass.sp = p;    MyClass.spp = p;    MyClass.sppp = p;} : <T extends MyClass>(this: T, p: number) => void
 >T : T
 >MyClass : MyClass
 >this : T
@@ -98,6 +131,27 @@ MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) 
 >this.ppp : number
 >this : T
 >ppp : number
+>p : number
+
+    MyClass.sp = p;
+>MyClass.sp = p : number
+>MyClass.sp : number
+>MyClass : typeof MyClass
+>sp : number
+>p : number
+
+    MyClass.spp = p;
+>MyClass.spp = p : number
+>MyClass.spp : number
+>MyClass : typeof MyClass
+>spp : number
+>p : number
+
+    MyClass.sppp = p;
+>MyClass.sppp = p : number
+>MyClass.sppp : number
+>MyClass : typeof MyClass
+>sppp : number
 >p : number
 }
 
@@ -128,6 +182,27 @@ function extension3<T extends MyClass> (this: T, p: number) {
 >this.ppp : number
 >this : T
 >ppp : number
+>p : number
+
+    MyClass.sp = p;
+>MyClass.sp = p : number
+>MyClass.sp : number
+>MyClass : typeof MyClass
+>sp : number
+>p : number
+
+    MyClass.spp = p;
+>MyClass.spp = p : number
+>MyClass.spp : number
+>MyClass : typeof MyClass
+>spp : number
+>p : number
+
+    MyClass.sppp = p;
+>MyClass.sppp = p : number
+>MyClass.sppp : number
+>MyClass : typeof MyClass
+>sppp : number
 >p : number
 }
 

--- a/tests/cases/conformance/types/thisType/thisTypeAccessibility.ts
+++ b/tests/cases/conformance/types/thisType/thisTypeAccessibility.ts
@@ -2,6 +2,9 @@ class MyClass {
     private p: number = 123;
     protected pp: number = 123;
     public ppp: number = 123;
+    private static sp: number = 123;
+    protected static spp: number = 123;
+    public static sppp: number = 123;
 }
 
 interface MyClass {
@@ -14,18 +17,27 @@ MyClass.prototype.extension1 = function (this: MyClass, p: number) {
     this.p = p;
     this.pp = p;
     this.ppp = p;
+    MyClass.sp = p;
+    MyClass.spp = p;
+    MyClass.sppp = p;
 }
 
 MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
     this.p = p;
     this.pp = p;
     this.ppp = p;
+    MyClass.sp = p;
+    MyClass.spp = p;
+    MyClass.sppp = p;
 }
 
 function extension3<T extends MyClass> (this: T, p: number) { 
     this.p = p;
     this.pp = p;
     this.ppp = p;
+    MyClass.sp = p;
+    MyClass.spp = p;
+    MyClass.sppp = p;
 }
 
 MyClass.prototype.extension3 = extension3;

--- a/tests/cases/conformance/types/thisType/thisTypeAccessibility.ts
+++ b/tests/cases/conformance/types/thisType/thisTypeAccessibility.ts
@@ -1,0 +1,31 @@
+class MyClass {
+    private p: number = 123;
+    protected pp: number = 123;
+    public ppp: number = 123;
+}
+
+interface MyClass {
+    extension1(p: number): void;
+    extension2(p: number): void;
+    extension3(p: number): void;
+}
+
+MyClass.prototype.extension1 = function (this: MyClass, p: number) { 
+    this.p = p;
+    this.pp = p;
+    this.ppp = p;
+}
+
+MyClass.prototype.extension2 = function<T extends MyClass> (this: T, p: number) { 
+    this.p = p;
+    this.pp = p;
+    this.ppp = p;
+}
+
+function extension3<T extends MyClass> (this: T, p: number) { 
+    this.p = p;
+    this.pp = p;
+    this.ppp = p;
+}
+
+MyClass.prototype.extension3 = extension3;


### PR DESCRIPTION
this PR take a simple implement 
- lookup `ThisParameter` when cannot find `enclosingClass` in protected accessibility check
- get `Constraint` if typeof this is generic parameter

Fixes #10302 

