### PR TITLE
Fix property assignment on aliases

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2510,11 +2510,12 @@ namespace ts {
          * -                       with non-empty object literals if assigned to the prototype property
          */
         function isJavascriptContainer(symbol: Symbol): boolean {
-            const node = symbol.valueDeclaration;
             if (symbol.flags & (SymbolFlags.Function | SymbolFlags.Class | SymbolFlags.NamespaceModule)) {
                 return true;
             }
-            const init = isVariableDeclaration(node) ? node.initializer :
+            const node = symbol.valueDeclaration;
+            const init = !node ? undefined :
+                isVariableDeclaration(node) ? node.initializer :
                 isBinaryExpression(node) ? node.right :
                 isPropertyAccessExpression(node) && isBinaryExpression(node.parent) ? node.parent.right :
                 undefined;

--- a/tests/baselines/reference/propertyAssignmentOnImportedSymbol.symbols
+++ b/tests/baselines/reference/propertyAssignmentOnImportedSymbol.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/salsa/mod1.js ===
+export var hurk = {}
+>hurk : Symbol(hurk, Decl(mod1.js, 0, 10))
+
+=== tests/cases/conformance/salsa/bug24658.js ===
+import { hurk } from './mod1'
+>hurk : Symbol(hurk, Decl(bug24658.js, 0, 8))
+
+hurk.expando = 4
+>hurk : Symbol(hurk, Decl(bug24658.js, 0, 8))
+

--- a/tests/baselines/reference/propertyAssignmentOnImportedSymbol.types
+++ b/tests/baselines/reference/propertyAssignmentOnImportedSymbol.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/salsa/mod1.js ===
+export var hurk = {}
+>hurk : { [x: string]: any; }
+>{} : { [x: string]: any; }
+
+=== tests/cases/conformance/salsa/bug24658.js ===
+import { hurk } from './mod1'
+>hurk : { [x: string]: any; }
+
+hurk.expando = 4
+>hurk.expando = 4 : 4
+>hurk.expando : any
+>hurk : { [x: string]: any; }
+>expando : any
+>4 : 4
+

--- a/tests/cases/conformance/salsa/propertyAssignmentOnImportedSymbol.ts
+++ b/tests/cases/conformance/salsa/propertyAssignmentOnImportedSymbol.ts
@@ -1,0 +1,8 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: mod1.js
+export var hurk = {}
+// @Filename: bug24658.js
+import { hurk } from './mod1'
+hurk.expando = 4


### PR DESCRIPTION
Aliases don't have valueDeclarations, which caused a crash when passed to isJavascriptContainer.

Fixes #24658