### PR TITLE
Visit the children of an import type/require call/dynamic import when looking for those

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1819,11 +1819,9 @@ namespace ts {
                 else if (isLiteralImportTypeNode(node)) {
                     imports = append(imports, node.argument.literal);
                 }
-                else {
-                    collectDynamicImportOrRequireCallsForEachChild(node);
-                    if (hasJSDocNodes(node)) {
-                        forEach(node.jsDoc, collectDynamicImportOrRequireCallsForEachChild);
-                    }
+                collectDynamicImportOrRequireCallsForEachChild(node);
+                if (hasJSDocNodes(node)) {
+                    forEach(node.jsDoc, collectDynamicImportOrRequireCallsForEachChild);
                 }
             }
 

--- a/tests/baselines/reference/importUsedInGenericImportResolves.js
+++ b/tests/baselines/reference/importUsedInGenericImportResolves.js
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/importUsedInGenericImportResolves.ts] ////
+
+//// [test1.d.ts]
+export interface T<P> {
+    a: P;
+}
+
+//// [test2.d.ts]
+export declare const theme: { a: string }
+
+//// [test3.ts]
+export const a: import("./test1").T<typeof import("./test2").theme> = null as any;
+
+//// [test3.js]
+"use strict";
+exports.__esModule = true;
+exports.a = null;

--- a/tests/baselines/reference/importUsedInGenericImportResolves.symbols
+++ b/tests/baselines/reference/importUsedInGenericImportResolves.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/test1.d.ts ===
+export interface T<P> {
+>T : Symbol(T, Decl(test1.d.ts, 0, 0))
+>P : Symbol(P, Decl(test1.d.ts, 0, 19))
+
+    a: P;
+>a : Symbol(T.a, Decl(test1.d.ts, 0, 23))
+>P : Symbol(P, Decl(test1.d.ts, 0, 19))
+}
+
+=== tests/cases/compiler/test2.d.ts ===
+export declare const theme: { a: string }
+>theme : Symbol(theme, Decl(test2.d.ts, 0, 20))
+>a : Symbol(a, Decl(test2.d.ts, 0, 29))
+
+=== tests/cases/compiler/test3.ts ===
+export const a: import("./test1").T<typeof import("./test2").theme> = null as any;
+>a : Symbol(a, Decl(test3.ts, 0, 12))
+>T : Symbol(T, Decl(test1.d.ts, 0, 0))
+>theme : Symbol(theme, Decl(test2.d.ts, 0, 20))
+

--- a/tests/baselines/reference/importUsedInGenericImportResolves.types
+++ b/tests/baselines/reference/importUsedInGenericImportResolves.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/test1.d.ts ===
+export interface T<P> {
+>T : T<P>
+>P : P
+
+    a: P;
+>a : P
+>P : P
+}
+
+=== tests/cases/compiler/test2.d.ts ===
+export declare const theme: { a: string }
+>theme : { a: string; }
+>a : string
+
+=== tests/cases/compiler/test3.ts ===
+export const a: import("./test1").T<typeof import("./test2").theme> = null as any;
+>a : import("tests/cases/compiler/test1").T<{ a: string; }>
+>T : import("tests/cases/compiler/test1").T<P>
+>theme : any
+>null as any : any
+>null : null
+

--- a/tests/cases/compiler/importUsedInGenericImportResolves.ts
+++ b/tests/cases/compiler/importUsedInGenericImportResolves.ts
@@ -1,0 +1,10 @@
+// @filename: test1.d.ts
+export interface T<P> {
+    a: P;
+}
+
+// @filename: test2.d.ts
+export declare const theme: { a: string }
+
+// @filename: test3.ts
+export const a: import("./test1").T<typeof import("./test2").theme> = null as any;


### PR DESCRIPTION
Fixes #24562

This way nested import types are found, eg `import("").A<import("")>` or `require<import("")>("")`.