### PR TITLE
Support 'tsconfig.json' when converting TextChanges to CodeEdits

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1321,7 +1321,7 @@ namespace ts {
         }
 
         function getSourceFileByPath(path: Path): SourceFile | undefined {
-            return filesByName.get(path);
+            return options.configFile && toPath(options.configFile.fileName) === path ? options.configFile : filesByName.get(path);
         }
 
         function getDiagnosticsHelper<T extends Diagnostic>(

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1321,7 +1321,7 @@ namespace ts {
         }
 
         function getSourceFileByPath(path: Path): SourceFile | undefined {
-            return options.configFile && toPath(options.configFile.fileName) === path ? options.configFile : filesByName.get(path);
+            return filesByName.get(path);
         }
 
         function getDiagnosticsHelper<T extends Diagnostic>(

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -466,7 +466,7 @@ namespace ts.projectSystem {
         return newRequest;
     }
 
-    export function openFilesForSession(files: File[], session: server.Session) {
+    export function openFilesForSession(files: ReadonlyArray<File>, session: server.Session) {
         for (const file of files) {
             const request = makeSessionRequest<protocol.OpenRequestArgs>(CommandNames.Open, { file: file.path });
             session.executeCommand(request);
@@ -6190,6 +6190,69 @@ namespace ts.projectSystem {
                 ],
                 renameFilename: "/a.ts",
                 renameLocation: { line: 2, offset: 3 },
+            });
+        });
+
+        it("handles text changes in tsconfig.json", () => {
+            const aTs = {
+                path: "/a.ts",
+                content: "export const a = 0;",
+            };
+            const tsconfig = {
+                path: "/tsconfig.json",
+                content: '{ "files": ["./a.ts"] }',
+            };
+
+            const session = createSession(createServerHost([aTs, tsconfig]));
+            openFilesForSession([aTs], session);
+
+            const response1 = session.executeCommandSeq<server.protocol.GetEditsForRefactorRequest>({
+                command: server.protocol.CommandTypes.GetEditsForRefactor,
+                arguments: {
+                    refactor: "Move to a new file",
+                    action: "Move to a new file",
+                    file: "/a.ts",
+                    startLine: 1,
+                    startOffset: 1,
+                    endLine: 1,
+                    endOffset: 20,
+                },
+            }).response;
+            assert.deepEqual(response1, {
+                edits: [
+                    {
+                        fileName: "/a.ts",
+                        textChanges: [
+                            {
+                                start: { line: 1, offset: 1 },
+                                end: { line: 1, offset: 20 },
+                                newText: "",
+                            },
+                        ],
+                    },
+                    {
+                        fileName: "/tsconfig.json",
+                        textChanges: [
+                            {
+                                start: { line: 1, offset: 21 },
+                                end: { line: 1, offset: 21 },
+                                newText: ", \"./a.1.ts\"",
+                            },
+                        ],
+                    },
+                    {
+                        fileName: "/a.1.ts",
+                        textChanges: [
+                            {
+                              start: { line: 0, offset: 0 },
+                              end: { line: 0, offset: 0 },
+                              newText: "export const a = 0;",
+                            },
+                        ],
+                    }
+                ],
+                renameFilename: undefined,
+                renameLocation: undefined,
             });
         });
     });

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -550,6 +550,12 @@ namespace ts.server {
             return this.program.getSourceFileByPath(path);
         }
 
+        /* @internal */
+        getSourceFileOrConfigFile(path: Path): SourceFile | undefined {
+            const options = this.program.getCompilerOptions();
+            return path === options.configFilePath ? options.configFile : this.getSourceFile(path);
+        }
+
         close() {
             if (this.program) {
                 // if we have a program - release all files that are enlisted in program but arent root

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1772,7 +1772,7 @@ namespace ts.server {
         private mapTextChangesToCodeEdits(project: Project, textChanges: ReadonlyArray<FileTextChanges>): protocol.FileCodeEdits[] {
             return textChanges.map(change => {
                 const path = normalizedPathToPath(toNormalizedPath(change.fileName), this.host.getCurrentDirectory(), fileName => this.getCanonicalFileName(fileName));
-                return mapTextChangesToCodeEdits(change, project.getSourceFile(path));
+                return mapTextChangesToCodeEdits(change, project.getSourceFileOrConfigFile(path));
             });
         }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8556,9 +8556,7 @@ declare namespace ts.server {
         private mapCodeAction;
         private mapCodeFixAction;
         private mapTextChangesToCodeEdits;
-        private mapTextChangesToCodeEditsUsingScriptinfo;
         private convertTextChangeToCodeEdit;
-        private convertNewFileTextChangeToCodeEdit;
         private getBraceMatching;
         private getDiagnosticsForProject;
         getCanonicalFileName(fileName: string): string;


### PR DESCRIPTION
Fixes #24613

Note: the bug I'm fixing reproduces even given only one project, but I'm pretty sure that the original cause of the issue was that the extra project had `"files"` in its tsconfig, so that was updated.
