### PR TITLE
Allow trailing commas after non-rest elements in destructuring

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20111,7 +20111,6 @@ namespace ts {
 
         function checkObjectLiteralAssignment(node: ObjectLiteralExpression, sourceType: Type): Type {
             const properties = node.properties;
-            checkGrammarForDisallowedTrailingComma(properties, Diagnostics.A_rest_parameter_or_binding_pattern_may_not_have_a_trailing_comma);
             if (strictNullChecks && properties.length === 0) {
                 return checkNonNullType(sourceType, node);
             }
@@ -20122,7 +20121,7 @@ namespace ts {
         }
 
         /** Note: If property cannot be a SpreadAssignment, then allProperties does not need to be provided */
-        function checkObjectLiteralDestructuringPropertyAssignment(objectLiteralType: Type, property: ObjectLiteralElementLike, allProperties?: ReadonlyArray<ObjectLiteralElementLike>) {
+        function checkObjectLiteralDestructuringPropertyAssignment(objectLiteralType: Type, property: ObjectLiteralElementLike, allProperties?: NodeArray<ObjectLiteralElementLike>) {
             if (property.kind === SyntaxKind.PropertyAssignment || property.kind === SyntaxKind.ShorthandPropertyAssignment) {
                 const name = property.name;
                 if (name.kind === SyntaxKind.ComputedPropertyName) {
@@ -20162,6 +20161,7 @@ namespace ts {
                     }
                 }
                 const type = getRestType(objectLiteralType, nonRestNames, objectLiteralType.symbol);
+                checkGrammarForDisallowedTrailingComma(allProperties, Diagnostics.A_rest_parameter_or_binding_pattern_may_not_have_a_trailing_comma);
                 return checkDestructuringAssignment(property.expression, type);
             }
             else {
@@ -20171,7 +20171,6 @@ namespace ts {
 
         function checkArrayLiteralAssignment(node: ArrayLiteralExpression, sourceType: Type, checkMode?: CheckMode): Type {
             const elements = node.elements;
-            checkGrammarForDisallowedTrailingComma(elements, Diagnostics.A_rest_parameter_or_binding_pattern_may_not_have_a_trailing_comma);
             if (languageVersion < ScriptTarget.ES2015 && compilerOptions.downlevelIteration) {
                 checkExternalEmitHelpers(node, ExternalEmitHelpers.Read);
             }
@@ -20223,6 +20222,7 @@ namespace ts {
                             error((<BinaryExpression>restExpression).operatorToken, Diagnostics.A_rest_element_cannot_have_an_initializer);
                         }
                         else {
+                            checkGrammarForDisallowedTrailingComma(node.elements, Diagnostics.A_rest_parameter_or_binding_pattern_may_not_have_a_trailing_comma);
                             return checkDestructuringAssignment(restExpression, createArrayType(elementType), checkMode);
                         }
                     }

--- a/tests/baselines/reference/trailingCommasInBindingPatterns.errors.txt
+++ b/tests/baselines/reference/trailingCommasInBindingPatterns.errors.txt
@@ -19,3 +19,10 @@ tests/cases/conformance/es7/trailingCommasInBindingPatterns.ts(5,7): error TS101
           ~
 !!! error TS1013: A rest parameter or binding pattern may not have a trailing comma.
     
+    // Allowed for non-rest elements
+    const [e,] = <any>[];
+    const {f,} = <any>{};
+    let g, h;
+    ([g,] = <any>[]);
+    ({h,} = <any>{});
+    

--- a/tests/baselines/reference/trailingCommasInBindingPatterns.js
+++ b/tests/baselines/reference/trailingCommasInBindingPatterns.js
@@ -5,6 +5,13 @@ let c, d;
 ([...c,] = []);
 ({...d,} = {});
 
+// Allowed for non-rest elements
+const [e,] = <any>[];
+const {f,} = <any>{};
+let g, h;
+([g,] = <any>[]);
+({h,} = <any>{});
+
 
 //// [trailingCommasInBindingPatterns.js]
 var __rest = (this && this.__rest) || function (s, e) {
@@ -21,3 +28,9 @@ var b = __rest({}, []);
 var c, d;
 (c = [].slice(0));
 (d = __rest({}, []));
+// Allowed for non-rest elements
+var e = [][0];
+var f = {}.f;
+var g, h;
+(g = [][0]);
+(h = {}.h);

--- a/tests/baselines/reference/trailingCommasInBindingPatterns.symbols
+++ b/tests/baselines/reference/trailingCommasInBindingPatterns.symbols
@@ -15,3 +15,20 @@ let c, d;
 ({...d,} = {});
 >d : Symbol(d, Decl(trailingCommasInBindingPatterns.ts, 2, 6))
 
+// Allowed for non-rest elements
+const [e,] = <any>[];
+>e : Symbol(e, Decl(trailingCommasInBindingPatterns.ts, 7, 7))
+
+const {f,} = <any>{};
+>f : Symbol(f, Decl(trailingCommasInBindingPatterns.ts, 8, 7))
+
+let g, h;
+>g : Symbol(g, Decl(trailingCommasInBindingPatterns.ts, 9, 3))
+>h : Symbol(h, Decl(trailingCommasInBindingPatterns.ts, 9, 6))
+
+([g,] = <any>[]);
+>g : Symbol(g, Decl(trailingCommasInBindingPatterns.ts, 9, 3))
+
+({h,} = <any>{});
+>h : Symbol(h, Decl(trailingCommasInBindingPatterns.ts, 11, 2))
+

--- a/tests/baselines/reference/trailingCommasInBindingPatterns.types
+++ b/tests/baselines/reference/trailingCommasInBindingPatterns.types
@@ -26,3 +26,34 @@ let c, d;
 >d : any
 >{} : {}
 
+// Allowed for non-rest elements
+const [e,] = <any>[];
+>e : any
+><any>[] : any
+>[] : undefined[]
+
+const {f,} = <any>{};
+>f : any
+><any>{} : any
+>{} : {}
+
+let g, h;
+>g : any
+>h : any
+
+([g,] = <any>[]);
+>([g,] = <any>[]) : any
+>[g,] = <any>[] : any
+>[g,] : [any]
+>g : any
+><any>[] : any
+>[] : undefined[]
+
+({h,} = <any>{});
+>({h,} = <any>{}) : any
+>{h,} = <any>{} : any
+>{h,} : { h: any; }
+>h : any
+><any>{} : any
+>{} : {}
+

--- a/tests/cases/conformance/es7/trailingCommasInBindingPatterns.ts
+++ b/tests/cases/conformance/es7/trailingCommasInBindingPatterns.ts
@@ -3,3 +3,10 @@ const {...b,} = {};
 let c, d;
 ([...c,] = []);
 ({...d,} = {});
+
+// Allowed for non-rest elements
+const [e,] = <any>[];
+const {f,} = <any>{};
+let g, h;
+([g,] = <any>[]);
+({h,} = <any>{});


### PR DESCRIPTION
Fixes #24628.

cc @andy-ms for the original change in #22262.
