### PR TITLE
Reduce non-null assertions in getPropertySymbolsFromContextualType

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1417,12 +1417,14 @@ namespace ts.FindAllReferences.Core {
     }
 
     /** Gets all symbols for one property. Does not get symbols for every property. */
-    function getPropertySymbolsFromContextualType(node: ObjectLiteralElement, checker: TypeChecker): ReadonlyArray<Symbol> {
+    function getPropertySymbolsFromContextualType(node: ObjectLiteralElementWithName, checker: TypeChecker): ReadonlyArray<Symbol> {
         const contextualType = checker.getContextualType(<ObjectLiteralExpression>node.parent);
-        const name = getNameFromPropertyName(node.name!);
-        const symbol = contextualType && name && contextualType.getProperty(name);
+        if (!contextualType) return emptyArray;
+        const name = getNameFromPropertyName(node.name);
+        if (!name) return emptyArray;
+        const symbol = contextualType.getProperty(name);
         return symbol ? [symbol] :
-            contextualType && contextualType.isUnion() ? mapDefined(contextualType.types, t => t.getProperty(name!)) : emptyArray; // TODO: GH#18217
+            contextualType.isUnion() ? mapDefined(contextualType.types, t => t.getProperty(name)) : emptyArray;
     }
 
     /**

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2350,21 +2350,23 @@ namespace ts {
      * Returns the containing object literal property declaration given a possible name node, e.g. "a" in x = { "a": 1 }
      */
     /* @internal */
-    export function getContainingObjectLiteralElement(node: Node): ObjectLiteralElement | undefined {
+    export function getContainingObjectLiteralElement(node: Node): ObjectLiteralElementWithName | undefined {
         switch (node.kind) {
             case SyntaxKind.StringLiteral:
             case SyntaxKind.NumericLiteral:
                 if (node.parent.kind === SyntaxKind.ComputedPropertyName) {
-                    return isObjectLiteralElement(node.parent.parent) ? node.parent.parent : undefined;
+                    return isObjectLiteralElement(node.parent.parent) ? node.parent.parent as ObjectLiteralElementWithName : undefined;
                 }
             // falls through
             case SyntaxKind.Identifier:
                 return isObjectLiteralElement(node.parent) &&
                     (node.parent.parent.kind === SyntaxKind.ObjectLiteralExpression || node.parent.parent.kind === SyntaxKind.JsxAttributes) &&
-                    node.parent.name === node ? node.parent : undefined;
+                    node.parent.name === node ? node.parent as ObjectLiteralElementWithName : undefined;
         }
         return undefined;
     }
+    /* @internal */
+    export type ObjectLiteralElementWithName = ObjectLiteralElement & { name: PropertyName };
 
     /* @internal */
     export function getPropertySymbolsFromContextualType(typeChecker: TypeChecker, node: ObjectLiteralElement): Symbol[] {


### PR DESCRIPTION
Introduce `ObjectLiteralElementWithName` since we won't get a `SpreadAssignment` here.