### PR TITLE
Don't consider `x.` a new identifier location just because x has a number index signature

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1074,7 +1074,7 @@ namespace ts.Completions {
         }
 
         function addTypeProperties(type: Type): void {
-            isNewIdentifierLocation = hasIndexSignature(type);
+            isNewIdentifierLocation = !!type.getStringIndexType();
 
             if (isUncheckedFile) {
                 // In javascript files, for union types, we don't just get the members that

--- a/tests/cases/fourslash/completionListAfterStringLiteral1.ts
+++ b/tests/cases/fourslash/completionListAfterStringLiteral1.ts
@@ -2,6 +2,10 @@
 
 ////"a"./**/
 
-goTo.marker();
-verify.not.completionListContains('alert');
-verify.completionListContains('charAt');
+verify.completions({
+    marker: "",
+    exact: [
+        "toString", "charAt", "charCodeAt", "concat", "indexOf", "lastIndexOf", "localeCompare", "match", "replace", "search", "slice",
+        "split", "substring", "toLowerCase", "toLocaleLowerCase", "toUpperCase", "toLocaleUpperCase", "trim", "length", "substr", "valueOf",
+    ],
+});

--- a/tests/cases/fourslash/getJavaScriptCompletions12.ts
+++ b/tests/cases/fourslash/getJavaScriptCompletions12.ts
@@ -24,7 +24,7 @@
 ////var test1 = function(x) { return x./*4*/ }, test2 = function(a) { return a./*5*/ };
 
 verify.completions(
-    { marker: "1", includes: { name: "charCodeAt", kind: "method" }, isNewIdentifierLocation: true },
+    { marker: "1", includes: { name: "charCodeAt", kind: "method" } },
     { marker: ["2", "3", "4"], includes: { name: "toExponential", kind: "method" } },
     { marker: "5", includes: { name: "test1", kind: "warning" } },
 );

--- a/tests/cases/fourslash/javaScriptClass1.ts
+++ b/tests/cases/fourslash/javaScriptClass1.ts
@@ -22,7 +22,7 @@ edit.insert('.');
 verify.completions({ exact: ["bar", "thing", "union", "Foo", "x"] });
 
 edit.insert('bar.');
-verify.completions({ includes: ["substr"], isNewIdentifierLocation: true });
+verify.completions({ includes: ["substr"] });
 edit.backspace('bar.'.length);
 
 edit.insert('union.');


### PR DESCRIPTION
Fixes #24690

We considered `"a".` to be a new identifier location because `"a"` has a number index signature. But typing a number after the `.` wouldn't parse, so it makes sense to consider the completions we return complete.