### PR TITLE
Add 'fileToRename' property to RenameInfo

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1544,7 +1544,7 @@ Actual: ${stringify(fullActual)}`);
             }
         }
 
-        public verifyRenameInfoSucceeded(displayName?: string, fullDisplayName?: string, kind?: string, kindModifiers?: string) {
+        public verifyRenameInfoSucceeded(displayName?: string, fullDisplayName?: string, kind?: string, kindModifiers?: string, fileToRename?: string): void {
             const renameInfo = this.languageService.getRenameInfo(this.activeFile.fileName, this.currentCaretPosition);
             if (!renameInfo.canRename) {
                 this.raiseError("Rename did not succeed");
@@ -1554,6 +1554,7 @@ Actual: ${stringify(fullActual)}`);
             this.validate("fullDisplayName", fullDisplayName, renameInfo.fullDisplayName);
             this.validate("kind", kind, renameInfo.kind);
             this.validate("kindModifiers", kindModifiers, renameInfo.kindModifiers);
+            this.validate("fileToRename", fileToRename, renameInfo.fileToRename);
 
             if (this.getRanges().length !== 1) {
                 this.raiseError("Expected a single range to be selected in the test file.");
@@ -4404,8 +4405,8 @@ namespace FourSlashInterface {
             this.state.verifySemanticClassifications(classifications);
         }
 
-        public renameInfoSucceeded(displayName?: string, fullDisplayName?: string, kind?: string, kindModifiers?: string) {
-            this.state.verifyRenameInfoSucceeded(displayName, fullDisplayName, kind, kindModifiers);
+        public renameInfoSucceeded(displayName?: string, fullDisplayName?: string, kind?: string, kindModifiers?: string, fileToRename?: string) {
+            this.state.verifyRenameInfoSucceeded(displayName, fullDisplayName, kind, kindModifiers, fileToRename);
         }
 
         public renameInfoFailed(message?: string) {

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -394,6 +394,7 @@ namespace ts.server {
 
             return this.lastRenameEntry = {
                 canRename: body.info.canRename,
+                fileToRename: body.info.fileToRename,
                 displayName: body.info.displayName,
                 fullDisplayName: body.info.fullDisplayName,
                 kind: body.info.kind,

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1064,6 +1064,12 @@ namespace ts.server.protocol {
         canRename: boolean;
 
         /**
+         * fileName to rename.
+         * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
+         */
+        fileToRename?: string;
+
+        /**
          * Error message if item can not be renamed.
          */
         localizedErrorMessage?: string;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -878,7 +878,7 @@ namespace ts.server {
             return projectInfo;
         }
 
-        private getRenameInfo(args: protocol.FileLocationRequestArgs) {
+        private getRenameInfo(args: protocol.FileLocationRequestArgs): RenameInfo {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
             return project.getLanguageService().getRenameInfo(file, position);

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -737,6 +737,11 @@ namespace ts {
 
     export interface RenameInfo {
         canRename: boolean;
+        /**
+         * fileName to rename.
+         * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
+         */
+        fileToRename?: string;
         localizedErrorMessage?: string;
         displayName: string;
         fullDisplayName: string;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4919,6 +4919,11 @@ declare namespace ts {
     }
     interface RenameInfo {
         canRename: boolean;
+        /**
+         * fileName to rename.
+         * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
+         */
+        fileToRename?: string;
         localizedErrorMessage?: string;
         displayName: string;
         fullDisplayName: string;
@@ -6343,6 +6348,11 @@ declare namespace ts.server.protocol {
          * True if item can be renamed.
          */
         canRename: boolean;
+        /**
+         * fileName to rename.
+         * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
+         */
+        fileToRename?: string;
         /**
          * Error message if item can not be renamed.
          */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4919,6 +4919,11 @@ declare namespace ts {
     }
     interface RenameInfo {
         canRename: boolean;
+        /**
+         * fileName to rename.
+         * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
+         */
+        fileToRename?: string;
         localizedErrorMessage?: string;
         displayName: string;
         fullDisplayName: string;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -310,7 +310,7 @@ declare namespace FourSlashInterface {
             text: string;
             textSpan?: TextSpan;
         }[]): void;
-        renameInfoSucceeded(displayName?: string, fullDisplayName?: string, kind?: string, kindModifiers?: string): void;
+        renameInfoSucceeded(displayName?: string, fullDisplayName?: string, kind?: string, kindModifiers?: string, fileToRename?: string): void;
         renameInfoFailed(message?: string): void;
         renameLocations(startRanges: ArrayOrSingle<Range>, options: Range[] | { findInStrings?: boolean, findInComments?: boolean, ranges: Range[] }): void;
 

--- a/tests/cases/fourslash/renameFile.ts
+++ b/tests/cases/fourslash/renameFile.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: /a.ts
+////export const a = 0;
+
+// @Filename: /b.ts
+////import { a } from "[|/**/./a|]";
+
+goTo.marker();
+verify.renameInfoSucceeded(/*displayName*/ "/a.ts", /*fullDisplayName*/ "/a.ts", /*kind*/ "module", /*kindModifiers*/ "", /*fileToRename*/ "/a.ts");


### PR DESCRIPTION
Fixes #24501

Adds a `fileToRename` property to `RenameInfo` so that the editor can rename the file instead.