### PR TITLE
Create sectional sourcemaps when unparsed sources are found in the emit

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1026,7 +1026,7 @@ namespace ts {
 
         // SyntaxKind.UnparsedSource
         function emitUnparsedSource(unparsed: UnparsedSource) {
-            write(unparsed.text);
+            writer.rawWrite(unparsed.text);
         }
 
         //

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2585,16 +2585,19 @@ namespace ts {
         return node;
     }
 
-    export function createUnparsedSourceFile(text: string): UnparsedSource {
+    export function createUnparsedSourceFile(text: string, map?: string): UnparsedSource {
         const node = <UnparsedSource>createNode(SyntaxKind.UnparsedSource);
         node.text = text;
+        node.sourceMapText = map;
         return node;
     }
 
-    export function createInputFiles(javascript: string, declaration: string): InputFiles {
+    export function createInputFiles(javascript: string, declaration: string, javascriptMapText?: string, declarationMapText?: string): InputFiles {
         const node = <InputFiles>createNode(SyntaxKind.InputFiles);
         node.javascriptText = javascript;
+        node.javascriptMapText = javascriptMapText;
         node.declarationText = declaration;
+        node.declarationMapText = declarationMapText;
         return node;
     }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1192,8 +1192,10 @@ namespace ts {
 
                     const dtsFilename = changeExtension(resolvedRefOpts.options.outFile, ".d.ts");
                     const js = host.readFile(resolvedRefOpts.options.outFile) || `/* Input file ${resolvedRefOpts.options.outFile} was missing */\r\n`;
+                    const jsMap = host.readFile(resolvedRefOpts.options.outFile + ".map"); // TODO: try to read sourceMappingUrl comment from the js file
                     const dts = host.readFile(dtsFilename) || `/* Input file ${dtsFilename} was missing */\r\n`;
-                    const node = createInputFiles(js, dts);
+                    const dtsMap = host.readFile(dtsFilename + ".map");
+                    const node = createInputFiles(js, dts, jsMap, dtsMap);
                     nodes.push(node);
                 }
             }

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -180,7 +180,7 @@ namespace ts {
                     }
                 ), mapDefined(node.prepends, prepend => {
                     if (prepend.kind === SyntaxKind.InputFiles) {
-                        return createUnparsedSourceFile(prepend.declarationText);
+                        return createUnparsedSourceFile(prepend.declarationText, prepend.declarationMapText);
                     }
                 }));
                 bundle.syntheticFileReferences = [];

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -100,7 +100,7 @@ namespace ts {
         function transformBundle(node: Bundle) {
             return createBundle(node.sourceFiles.map(transformSourceFile), mapDefined(node.prepends, prepend => {
                 if (prepend.kind === SyntaxKind.InputFiles) {
-                    return createUnparsedSourceFile(prepend.javascriptText);
+                    return createUnparsedSourceFile(prepend.javascriptText, prepend.javascriptMapText);
                 }
                 return prepend;
             }));

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2652,12 +2652,15 @@ namespace ts {
     export interface InputFiles extends Node {
         kind: SyntaxKind.InputFiles;
         javascriptText: string;
+        javascriptMapText?: string;
         declarationText: string;
+        declarationMapText?: string;
     }
 
     export interface UnparsedSource extends Node {
         kind: SyntaxKind.UnparsedSource;
         text: string;
+        sourceMapText?: string;
     }
 
     export interface JsonSourceFile extends SourceFile {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2825,13 +2825,26 @@ namespace ts {
         let lineCount: number;
         let linePos: number;
 
+        function updateLineCountAndPosFor(s: string) {
+            const lineStartsOfS = computeLineStarts(s);
+            if (lineStartsOfS.length > 1) {
+                lineCount = lineCount + lineStartsOfS.length - 1;
+                linePos = output.length - s.length + last(lineStartsOfS);
+                lineStart = (linePos - output.length) === 0;
+            }
+            else {
+                lineStart = false;
+            }
+        }
+
         function write(s: string) {
             if (s && s.length) {
                 if (lineStart) {
-                    output += getIndentString(indent);
+                    s = getIndentString(indent) + s;
                     lineStart = false;
                 }
                 output += s;
+                updateLineCountAndPosFor(s);
             }
         }
 
@@ -2845,21 +2858,14 @@ namespace ts {
 
         function rawWrite(s: string) {
             if (s !== undefined) {
-                if (lineStart) {
-                    lineStart = false;
-                }
                 output += s;
+                updateLineCountAndPosFor(s);
             }
         }
 
         function writeLiteral(s: string) {
             if (s && s.length) {
                 write(s);
-                const lineStartsOfS = computeLineStarts(s);
-                if (lineStartsOfS.length > 1) {
-                    lineCount = lineCount + lineStartsOfS.length - 1;
-                    linePos = output.length - s.length + last(lineStartsOfS);
-                }
             }
         }
 
@@ -2873,7 +2879,9 @@ namespace ts {
         }
 
         function writeTextOfNode(text: string, node: Node) {
-            write(getTextOfNodeFromSourceText(text, node));
+            const s = getTextOfNodeFromSourceText(text, node);
+            write(s);
+            updateLineCountAndPosFor(s);
         }
 
         reset();

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5454,6 +5454,10 @@ namespace ts {
         return node.kind === SyntaxKind.Bundle;
     }
 
+    export function isUnparsedSource(node: Node): node is UnparsedSource {
+        return node.kind === SyntaxKind.UnparsedSource;
+    }
+
     // JSDoc
 
     export function isJSDocTypeExpression(node: Node): node is JSDocTypeExpression {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1669,11 +1669,14 @@ declare namespace ts {
     interface InputFiles extends Node {
         kind: SyntaxKind.InputFiles;
         javascriptText: string;
+        javascriptMapText?: string;
         declarationText: string;
+        declarationMapText?: string;
     }
     interface UnparsedSource extends Node {
         kind: SyntaxKind.UnparsedSource;
         text: string;
+        sourceMapText?: string;
     }
     interface JsonSourceFile extends SourceFile {
         statements: NodeArray<JsonObjectExpressionStatement>;
@@ -3371,6 +3374,7 @@ declare namespace ts {
     function isEnumMember(node: Node): node is EnumMember;
     function isSourceFile(node: Node): node is SourceFile;
     function isBundle(node: Node): node is Bundle;
+    function isUnparsedSource(node: Node): node is UnparsedSource;
     function isJSDocTypeExpression(node: Node): node is JSDocTypeExpression;
     function isJSDocAllType(node: JSDocAllType): node is JSDocAllType;
     function isJSDocUnknownType(node: Node): node is JSDocUnknownType;
@@ -3826,8 +3830,8 @@ declare namespace ts {
     function createCommaList(elements: ReadonlyArray<Expression>): CommaListExpression;
     function updateCommaList(node: CommaListExpression, elements: ReadonlyArray<Expression>): CommaListExpression;
     function createBundle(sourceFiles: ReadonlyArray<SourceFile>, prepends?: ReadonlyArray<UnparsedSource | InputFiles>): Bundle;
-    function createUnparsedSourceFile(text: string): UnparsedSource;
-    function createInputFiles(javascript: string, declaration: string): InputFiles;
+    function createUnparsedSourceFile(text: string, map?: string): UnparsedSource;
+    function createInputFiles(javascript: string, declaration: string, javascriptMapText?: string, declarationMapText?: string): InputFiles;
     function updateBundle(node: Bundle, sourceFiles: ReadonlyArray<SourceFile>, prepends?: ReadonlyArray<UnparsedSource>): Bundle;
     function createImmediatelyInvokedFunctionExpression(statements: ReadonlyArray<Statement>): CallExpression;
     function createImmediatelyInvokedFunctionExpression(statements: ReadonlyArray<Statement>, param: ParameterDeclaration, paramValue: Expression): CallExpression;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1669,11 +1669,14 @@ declare namespace ts {
     interface InputFiles extends Node {
         kind: SyntaxKind.InputFiles;
         javascriptText: string;
+        javascriptMapText?: string;
         declarationText: string;
+        declarationMapText?: string;
     }
     interface UnparsedSource extends Node {
         kind: SyntaxKind.UnparsedSource;
         text: string;
+        sourceMapText?: string;
     }
     interface JsonSourceFile extends SourceFile {
         statements: NodeArray<JsonObjectExpressionStatement>;
@@ -3371,6 +3374,7 @@ declare namespace ts {
     function isEnumMember(node: Node): node is EnumMember;
     function isSourceFile(node: Node): node is SourceFile;
     function isBundle(node: Node): node is Bundle;
+    function isUnparsedSource(node: Node): node is UnparsedSource;
     function isJSDocTypeExpression(node: Node): node is JSDocTypeExpression;
     function isJSDocAllType(node: JSDocAllType): node is JSDocAllType;
     function isJSDocUnknownType(node: Node): node is JSDocUnknownType;
@@ -3826,8 +3830,8 @@ declare namespace ts {
     function createCommaList(elements: ReadonlyArray<Expression>): CommaListExpression;
     function updateCommaList(node: CommaListExpression, elements: ReadonlyArray<Expression>): CommaListExpression;
     function createBundle(sourceFiles: ReadonlyArray<SourceFile>, prepends?: ReadonlyArray<UnparsedSource | InputFiles>): Bundle;
-    function createUnparsedSourceFile(text: string): UnparsedSource;
-    function createInputFiles(javascript: string, declaration: string): InputFiles;
+    function createUnparsedSourceFile(text: string, map?: string): UnparsedSource;
+    function createInputFiles(javascript: string, declaration: string, javascriptMapText?: string, declarationMapText?: string): InputFiles;
     function updateBundle(node: Bundle, sourceFiles: ReadonlyArray<SourceFile>, prepends?: ReadonlyArray<UnparsedSource>): Bundle;
     function createImmediatelyInvokedFunctionExpression(statements: ReadonlyArray<Statement>): CallExpression;
     function createImmediatelyInvokedFunctionExpression(statements: ReadonlyArray<Statement>, param: ParameterDeclaration, paramValue: Expression): CallExpression;

--- a/tests/baselines/reference/tsxErrorRecovery1.js
+++ b/tests/baselines/reference/tsxErrorRecovery1.js
@@ -14,5 +14,5 @@ function foo() {
 }
 // Shouldn't see any errors down here
 var y = {a} 1 };
-</>;
+    </>;
 }

--- a/tests/baselines/reference/tsxStatelessFunctionComponents3.js
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents3.js
@@ -27,7 +27,7 @@ define(["require", "exports", "react"], function (require, exports, React) {
     // Should be OK
     var MainMenu = function (props) { return (<div>
     <h3>Main Menu</h3>
-</div>); };
+    </div>); };
     var App = function (_a) {
         var children = _a.children;
         return (<div>


### PR DESCRIPTION
So their sourcemaps can be retained and concatenated. @RyanCavanaugh said he'll have a project references test harness up so it can actually be tested soon.

The `EmitTextWriter` I also had to fix a bug in - it wasn't tracking line and column updates correctly (and therefore sourcemaps or indentation) when you wrote multiple lines in a single write call via any call other than `writeLiteral` - which did happen (for example, JSX text) and now happens for `UnparsedSource`.