### PR TITLE
Fix circularity error when extending a class in same JSContainer

### DIFF
--- a/tests/baselines/reference/typeFromPropertyAssignment25.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment25.symbols
@@ -1,0 +1,62 @@
+=== tests/cases/conformance/salsa/bug24703.js ===
+var Common = {};
+>Common : Symbol(Common, Decl(bug24703.js, 0, 3), Decl(bug24703.js, 0, 16))
+
+Common.I = class {
+>Common.I : Symbol(Common.I, Decl(bug24703.js, 0, 16))
+>Common : Symbol(Common, Decl(bug24703.js, 0, 3), Decl(bug24703.js, 0, 16))
+>I : Symbol(Common.I, Decl(bug24703.js, 0, 16))
+
+    constructor() {
+        this.i = 1
+>this.i : Symbol(I.i, Decl(bug24703.js, 2, 19))
+>this : Symbol(I, Decl(bug24703.js, 1, 10))
+>i : Symbol(I.i, Decl(bug24703.js, 2, 19))
+    }
+}
+Common.O = class extends Common.I {
+>Common.O : Symbol(Common.O, Decl(bug24703.js, 5, 1))
+>Common : Symbol(Common, Decl(bug24703.js, 0, 3), Decl(bug24703.js, 0, 16))
+>O : Symbol(Common.O, Decl(bug24703.js, 5, 1))
+>Common.I : Symbol(Common.I, Decl(bug24703.js, 0, 16))
+>Common : Symbol(Common, Decl(bug24703.js, 0, 3), Decl(bug24703.js, 0, 16))
+>I : Symbol(Common.I, Decl(bug24703.js, 0, 16))
+
+    constructor() {
+        super()
+>super : Symbol(I, Decl(bug24703.js, 1, 10))
+
+        this.o = 2
+>this.o : Symbol(O.o, Decl(bug24703.js, 8, 15))
+>this : Symbol(O, Decl(bug24703.js, 6, 10))
+>o : Symbol(O.o, Decl(bug24703.js, 8, 15))
+    }
+}
+var o = new Common.O()
+>o : Symbol(o, Decl(bug24703.js, 12, 3))
+>Common.O : Symbol(Common.O, Decl(bug24703.js, 5, 1))
+>Common : Symbol(Common, Decl(bug24703.js, 0, 3), Decl(bug24703.js, 0, 16))
+>O : Symbol(Common.O, Decl(bug24703.js, 5, 1))
+
+var i = new Common.I()
+>i : Symbol(i, Decl(bug24703.js, 13, 3))
+>Common.I : Symbol(Common.I, Decl(bug24703.js, 0, 16))
+>Common : Symbol(Common, Decl(bug24703.js, 0, 3), Decl(bug24703.js, 0, 16))
+>I : Symbol(Common.I, Decl(bug24703.js, 0, 16))
+
+o.i
+>o.i : Symbol(I.i, Decl(bug24703.js, 2, 19))
+>o : Symbol(o, Decl(bug24703.js, 12, 3))
+>i : Symbol(I.i, Decl(bug24703.js, 2, 19))
+
+o.o
+>o.o : Symbol(O.o, Decl(bug24703.js, 8, 15))
+>o : Symbol(o, Decl(bug24703.js, 12, 3))
+>o : Symbol(O.o, Decl(bug24703.js, 8, 15))
+
+i.i
+>i.i : Symbol(I.i, Decl(bug24703.js, 2, 19))
+>i : Symbol(i, Decl(bug24703.js, 13, 3))
+>i : Symbol(I.i, Decl(bug24703.js, 2, 19))
+
+

--- a/tests/baselines/reference/typeFromPropertyAssignment25.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment25.types
@@ -1,0 +1,74 @@
+=== tests/cases/conformance/salsa/bug24703.js ===
+var Common = {};
+>Common : { [x: string]: any; I: typeof I; O: typeof O; }
+>{} : { [x: string]: any; I: typeof I; O: typeof O; }
+
+Common.I = class {
+>Common.I = class {    constructor() {        this.i = 1    }} : typeof I
+>Common.I : typeof I
+>Common : { [x: string]: any; I: typeof I; O: typeof O; }
+>I : typeof I
+>class {    constructor() {        this.i = 1    }} : typeof I
+
+    constructor() {
+        this.i = 1
+>this.i = 1 : 1
+>this.i : number
+>this : this
+>i : number
+>1 : 1
+    }
+}
+Common.O = class extends Common.I {
+>Common.O = class extends Common.I {    constructor() {        super()        this.o = 2    }} : typeof O
+>Common.O : typeof O
+>Common : { [x: string]: any; I: typeof I; O: typeof O; }
+>O : typeof O
+>class extends Common.I {    constructor() {        super()        this.o = 2    }} : typeof O
+>Common.I : I
+>Common : { [x: string]: any; I: typeof I; O: typeof O; }
+>I : typeof I
+
+    constructor() {
+        super()
+>super() : void
+>super : typeof I
+
+        this.o = 2
+>this.o = 2 : 2
+>this.o : number
+>this : this
+>o : number
+>2 : 2
+    }
+}
+var o = new Common.O()
+>o : O
+>new Common.O() : O
+>Common.O : typeof O
+>Common : { [x: string]: any; I: typeof I; O: typeof O; }
+>O : typeof O
+
+var i = new Common.I()
+>i : I
+>new Common.I() : I
+>Common.I : typeof I
+>Common : { [x: string]: any; I: typeof I; O: typeof O; }
+>I : typeof I
+
+o.i
+>o.i : number
+>o : O
+>i : number
+
+o.o
+>o.o : number
+>o : O
+>o : number
+
+i.i
+>i.i : number
+>i : I
+>i : number
+
+

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment25.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment25.ts
@@ -1,0 +1,22 @@
+// @noEmit: true
+// @checkJs: true
+// @allowJs: true
+// @Filename: bug24703.js
+var Common = {};
+Common.I = class {
+    constructor() {
+        this.i = 1
+    }
+}
+Common.O = class extends Common.I {
+    constructor() {
+        super()
+        this.o = 2
+    }
+}
+var o = new Common.O()
+var i = new Common.I()
+o.i
+o.o
+i.i
+


### PR DESCRIPTION
Do this by not widening properties of an object literal that are

1. JS initialisers
2. and not an object literal

These properties have types that will never widen, so the compiler shouldn't ask for the types earlier than it strictly needs to. This avoids the bogus circularity error.

Fixes #24703 

This reverses the chrome-devtools-frontend errors that #24707 introduces with its improved valueDeclaration location. Together, they provide a substantial improvement to the number of errors we get when compiling that project.
