### PR TITLE
Actually forward sourcemaps to gulp-typescript doesnt disable sourcemaps

### DIFF
--- a/scripts/build/gulp-typescript-oop.js
+++ b/scripts/build/gulp-typescript-oop.js
@@ -31,7 +31,7 @@ function createProject(tsConfigFileName, settings, options) {
             read() {},
             /** @param {*} file */
             write(file, encoding, callback) {
-                proc.send({ method: "write", params: { path: file.path, cwd: file.cwd, base: file.base }});
+                proc.send({ method: "write", params: { path: file.path, cwd: file.cwd, base: file.base, sourceMap: file.sourceMap }});
                 callback();
             },
             final(callback) {

--- a/scripts/build/main.js
+++ b/scripts/build/main.js
@@ -72,6 +72,7 @@ process.on("message", ({ method, params }) => {
                 base: params.base
             });
             file.contents = fs.readFileSync(file.path);
+            if (params.sourceMap) file.sourceMap = params.sourceMap; 
             inputStream.push(/** @type {*} */(file));
         }
         else if (method === "final") {


### PR DESCRIPTION
`gulp` wasn't emitting any sourcemaps because the new oop compiler wasn't forwarding the initial identity map to `gulp-typescript`, so it was disabling sourcemaps even though the option was set.

