### PR TITLE
Fix prologue order in async function

### DIFF
--- a/src/harness/unittests/evaluation/asyncArrow.ts
+++ b/src/harness/unittests/evaluation/asyncArrow.ts
@@ -1,0 +1,18 @@
+describe("asyncArrowEvaluation", () => {
+    // https://github.com/Microsoft/TypeScript/issues/24722
+    it("this capture (es5)", async () => {
+        const result = evaluator.evaluateTypeScript(`
+        export class A {
+            b = async (...args: any[]) => {
+                await Promise.resolve();
+                output.push({ ["a"]: () => this }); // computed property name after 'await' triggers case
+            };
+        }
+        export const output: any[] = [];
+        export async function main() {
+            await new A().b();
+        }`);
+        await result.main();
+        assert.instanceOf(result.output[0].a(), result.A);
+    });
+});

--- a/tests/baselines/reference/asyncArrowFunction11_es5.js
+++ b/tests/baselines/reference/asyncArrowFunction11_es5.js
@@ -1,0 +1,71 @@
+//// [asyncArrowFunction11_es5.ts]
+// https://github.com/Microsoft/TypeScript/issues/24722
+class A {
+    b = async (...args: any[]) => {
+        await Promise.resolve();
+        const obj = { ["a"]: () => this }; // computed property name after `await` triggers case
+    };
+}
+
+//// [asyncArrowFunction11_es5.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+// https://github.com/Microsoft/TypeScript/issues/24722
+var A = /** @class */ (function () {
+    function A() {
+        var _this = this;
+        this.b = function () {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return __awaiter(_this, void 0, void 0, function () {
+                var _a, obj;
+                var _this = this;
+                return __generator(this, function (_b) {
+                    switch (_b.label) {
+                        case 0: return [4 /*yield*/, Promise.resolve()];
+                        case 1:
+                            _b.sent();
+                            obj = (_a = {}, _a["a"] = function () { return _this; }, _a);
+                            return [2 /*return*/];
+                    }
+                });
+            });
+        };
+    }
+    return A;
+}());

--- a/tests/baselines/reference/asyncArrowFunction11_es5.symbols
+++ b/tests/baselines/reference/asyncArrowFunction11_es5.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction11_es5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/24722
+class A {
+>A : Symbol(A, Decl(asyncArrowFunction11_es5.ts, 0, 0))
+
+    b = async (...args: any[]) => {
+>b : Symbol(A.b, Decl(asyncArrowFunction11_es5.ts, 1, 9))
+>args : Symbol(args, Decl(asyncArrowFunction11_es5.ts, 2, 15))
+
+        await Promise.resolve();
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+        const obj = { ["a"]: () => this }; // computed property name after `await` triggers case
+>obj : Symbol(obj, Decl(asyncArrowFunction11_es5.ts, 4, 13))
+>["a"] : Symbol(["a"], Decl(asyncArrowFunction11_es5.ts, 4, 21))
+>"a" : Symbol(["a"], Decl(asyncArrowFunction11_es5.ts, 4, 21))
+>this : Symbol(A, Decl(asyncArrowFunction11_es5.ts, 0, 0))
+
+    };
+}

--- a/tests/baselines/reference/asyncArrowFunction11_es5.types
+++ b/tests/baselines/reference/asyncArrowFunction11_es5.types
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction11_es5.ts ===
+// https://github.com/Microsoft/TypeScript/issues/24722
+class A {
+>A : A
+
+    b = async (...args: any[]) => {
+>b : (...args: any[]) => Promise<void>
+>async (...args: any[]) => {        await Promise.resolve();        const obj = { ["a"]: () => this }; // computed property name after `await` triggers case    } : (...args: any[]) => Promise<void>
+>args : any[]
+
+        await Promise.resolve();
+>await Promise.resolve() : void
+>Promise.resolve() : Promise<void>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+
+        const obj = { ["a"]: () => this }; // computed property name after `await` triggers case
+>obj : { ["a"]: () => this; }
+>{ ["a"]: () => this } : { ["a"]: () => this; }
+>["a"] : () => this
+>"a" : "a"
+>() => this : () => this
+>this : this
+
+    };
+}

--- a/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction11_es5.ts
+++ b/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction11_es5.ts
@@ -1,0 +1,10 @@
+// @target: es5
+// @lib: esnext, dom
+// @downlevelIteration: true
+// https://github.com/Microsoft/TypeScript/issues/24722
+class A {
+    b = async (...args: any[]) => {
+        await Promise.resolve();
+        const obj = { ["a"]: () => this }; // computed property name after `await` triggers case
+    };
+}


### PR DESCRIPTION
The recent change to insert temporary variables at the top of a statement list caused the generator transform to fail to detect the `var _this = this;` custom prologue.

Fixes #24722, #24564

