### PR TITLE
tryGetModuleNameAsNodeModule: Ignore file extension

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -248,7 +248,7 @@ namespace ts.moduleSpecifiers {
                     const mainFileRelative = packageJsonContent.typings || packageJsonContent.types || packageJsonContent.main;
                     if (mainFileRelative) {
                         const mainExportFile = toPath(mainFileRelative, packageRootPath, getCanonicalFileName);
-                        if (mainExportFile === getCanonicalFileName(path)) {
+                        if (removeFileExtension(mainExportFile) === removeFileExtension(getCanonicalFileName(path))) {
                             return packageRootPath;
                         }
                     }

--- a/tests/cases/fourslash/importNameCodeFixNewImportNodeModules7.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportNodeModules7.ts
@@ -15,15 +15,8 @@
 // @Filename: node_modules/package-name/package.json
 //// { "main": "bin/lib/libfile.js" }
 
-
-// In this case, importing the module by its package name:
-// import { f1 } from 'package-name'
-// could in theory work, however the resulting code compiles with a module resolution error
-// since bin/lib/libfile.d.ts isn't declared under "typings" in package.json
-// Therefore just import the module by its qualified path
-
 verify.importFixAtPosition([
-`import { f1 } from "package-name/bin/lib/libfile";
+`import { f1 } from "package-name";
 
 f1('');`
 ]);


### PR DESCRIPTION
Fixes #24742

The old behavior is no longer necessary thanks to #24112