### PR TITLE
fixUnusedIdentifier: Delete trailing comma in array binding pattern

### DIFF
--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -228,15 +228,12 @@ namespace ts.codefix {
 
             case SyntaxKind.BindingElement: {
                 const pattern = (parent as BindingElement).parent;
-                switch (pattern.kind) {
-                    case SyntaxKind.ArrayBindingPattern:
-                        changes.deleteNode(sourceFile, parent); // Don't delete ','
-                        break;
-                    case SyntaxKind.ObjectBindingPattern:
-                        changes.deleteNodeInList(sourceFile, parent);
-                        break;
-                    default:
-                        return Debug.assertNever(pattern);
+                const preserveComma = pattern.kind === SyntaxKind.ArrayBindingPattern && parent !== last(pattern.elements);
+                if (preserveComma) {
+                    changes.deleteNode(sourceFile, parent);
+                }
+                else {
+                    changes.deleteNodeInList(sourceFile, parent);
                 }
                 break;
             }

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_destructure_partlyUnused.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_destructure_partlyUnused.ts
@@ -57,7 +57,7 @@ verify.codeFixAll({
     x; z;
 }
 {
-    const [x,] = o;
+    const [x] = o;
     x;
 }
 {
@@ -65,7 +65,7 @@ verify.codeFixAll({
     y;
 }
 {
-    const [, y,] = o;
+    const [, y] = o;
     y;
 }
 {


### PR DESCRIPTION
Fixes #24788

