### PR TITLE
Always visit _all_ super arguments

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18620,7 +18620,7 @@ namespace ts {
             if (node.expression.kind === SyntaxKind.SuperKeyword) {
                 const superType = checkSuperExpression(node.expression);
                 if (isTypeAny(superType)) {
-                    forEach(node.arguments, checkExpression); // Still visit arguments so they get marked for visibility, etc
+                    forEach(node.arguments, checkExpresionNoReturn); // Still visit arguments so they get marked for visibility, etc
                     return anySignature;
                 }
                 if (superType !== errorType) {
@@ -20779,6 +20779,10 @@ namespace ts {
             const type = getTypeOfExpression(node);
             node.contextualType = saveContextualType;
             return type;
+        }
+
+        function checkExpresionNoReturn(node: Expression) {
+            checkExpression(node);
         }
 
         // Checks an expression and returns its type. The contextualMapper parameter serves two purposes: When

--- a/tests/baselines/reference/importNotElidedWhenNotFound.errors.txt
+++ b/tests/baselines/reference/importNotElidedWhenNotFound.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/compiler/importNotElidedWhenNotFound.ts(1,15): error TS2307: Cannot find module 'file'.
 tests/cases/compiler/importNotElidedWhenNotFound.ts(2,15): error TS2307: Cannot find module 'other_file'.
+tests/cases/compiler/importNotElidedWhenNotFound.ts(10,16): error TS2307: Cannot find module 'file2'.
+tests/cases/compiler/importNotElidedWhenNotFound.ts(11,16): error TS2307: Cannot find module 'file3'.
 
 
-==== tests/cases/compiler/importNotElidedWhenNotFound.ts (2 errors) ====
+==== tests/cases/compiler/importNotElidedWhenNotFound.ts (4 errors) ====
     import X from 'file';
                   ~~~~~~
 !!! error TS2307: Cannot find module 'file'.
@@ -15,3 +17,16 @@ tests/cases/compiler/importNotElidedWhenNotFound.ts(2,15): error TS2307: Cannot 
         super(X);
       }
     }
+    
+    import X2 from 'file2';
+                   ~~~~~~~
+!!! error TS2307: Cannot find module 'file2'.
+    import X3 from 'file3';
+                   ~~~~~~~
+!!! error TS2307: Cannot find module 'file3'.
+    class Q extends Z {
+      constructor() {
+        super(X2, X3);
+      }
+    }
+    

--- a/tests/baselines/reference/importNotElidedWhenNotFound.js
+++ b/tests/baselines/reference/importNotElidedWhenNotFound.js
@@ -8,6 +8,15 @@ class Y extends Z {
   }
 }
 
+import X2 from 'file2';
+import X3 from 'file3';
+class Q extends Z {
+  constructor() {
+    super(X2, X3);
+  }
+}
+
+
 //// [importNotElidedWhenNotFound.js]
 "use strict";
 var __extends = (this && this.__extends) || (function () {
@@ -29,4 +38,13 @@ var Y = /** @class */ (function (_super) {
         return _super.call(this, file_1["default"]) || this;
     }
     return Y;
+}(other_file_1["default"]));
+var file2_1 = require("file2");
+var file3_1 = require("file3");
+var Q = /** @class */ (function (_super) {
+    __extends(Q, _super);
+    function Q() {
+        return _super.call(this, file2_1["default"], file3_1["default"]) || this;
+    }
+    return Q;
 }(other_file_1["default"]));

--- a/tests/baselines/reference/importNotElidedWhenNotFound.symbols
+++ b/tests/baselines/reference/importNotElidedWhenNotFound.symbols
@@ -14,3 +14,21 @@ class Y extends Z {
 >X : Symbol(X, Decl(importNotElidedWhenNotFound.ts, 0, 6))
   }
 }
+
+import X2 from 'file2';
+>X2 : Symbol(X2, Decl(importNotElidedWhenNotFound.ts, 9, 6))
+
+import X3 from 'file3';
+>X3 : Symbol(X3, Decl(importNotElidedWhenNotFound.ts, 10, 6))
+
+class Q extends Z {
+>Q : Symbol(Q, Decl(importNotElidedWhenNotFound.ts, 10, 23))
+>Z : Symbol(Z, Decl(importNotElidedWhenNotFound.ts, 1, 6))
+
+  constructor() {
+    super(X2, X3);
+>X2 : Symbol(X2, Decl(importNotElidedWhenNotFound.ts, 9, 6))
+>X3 : Symbol(X3, Decl(importNotElidedWhenNotFound.ts, 10, 6))
+  }
+}
+

--- a/tests/baselines/reference/importNotElidedWhenNotFound.types
+++ b/tests/baselines/reference/importNotElidedWhenNotFound.types
@@ -16,3 +16,23 @@ class Y extends Z {
 >X : any
   }
 }
+
+import X2 from 'file2';
+>X2 : any
+
+import X3 from 'file3';
+>X3 : any
+
+class Q extends Z {
+>Q : Q
+>Z : any
+
+  constructor() {
+    super(X2, X3);
+>super(X2, X3) : void
+>super : any
+>X2 : any
+>X3 : any
+  }
+}
+

--- a/tests/cases/compiler/importNotElidedWhenNotFound.ts
+++ b/tests/cases/compiler/importNotElidedWhenNotFound.ts
@@ -6,3 +6,11 @@ class Y extends Z {
     super(X);
   }
 }
+
+import X2 from 'file2';
+import X3 from 'file3';
+class Q extends Z {
+  constructor() {
+    super(X2, X3);
+  }
+}


### PR DESCRIPTION
Because `forEach` bails when the function you pass returns something, eg, a type.