### PR TITLE
[release-2.9] Do not watch folders like "c:/users/username", "c:/users/username/folderAtRoot"

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -7566,8 +7566,8 @@ namespace ts.projectSystem {
     });
 
     describe("tsserverProjectSystem Watched recursive directories with windows style file system", () => {
-        function verifyWatchedDirectories(useProjectAtRoot: boolean) {
-            const root = useProjectAtRoot ? "c:/" : "c:/myfolder/allproject/";
+        function verifyWatchedDirectories(rootedPath: string, useProjectAtRoot: boolean) {
+            const root = useProjectAtRoot ? rootedPath : `${rootedPath}myfolder/allproject/`;
             const configFile: File = {
                 path: root + "project/tsconfig.json",
                 content: "{}"
@@ -7596,12 +7596,22 @@ namespace ts.projectSystem {
             ].concat(useProjectAtRoot ? [] : [root + nodeModulesAtTypes]), /*recursive*/ true);
         }
 
-        it("When project is in rootFolder", () => {
-            verifyWatchedDirectories(/*useProjectAtRoot*/ true);
+        function verifyRootedDirectoryWatch(rootedPath: string) {
+            it("When project is in rootFolder of style c:/", () => {
+                verifyWatchedDirectories(rootedPath, /*useProjectAtRoot*/ true);
+            });
+
+            it("When files at some folder other than root", () => {
+                verifyWatchedDirectories(rootedPath, /*useProjectAtRoot*/ false);
+            });
+        }
+
+        describe("for rootFolder of style c:/", () => {
+            verifyRootedDirectoryWatch("c:/");
         });
 
-        it("When files at some folder other than root", () => {
-            verifyWatchedDirectories(/*useProjectAtRoot*/ false);
+        describe("for rootFolder of style c:/users/username", () => {
+            verifyRootedDirectoryWatch("c:/users/username/");
         });
     });
 


### PR DESCRIPTION
Fixes Microsoft/vscode#51139
Port of  #24769 to release-2.9

