### PR TITLE
fixStrictClassInitialization: Support array initializer

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3047,12 +3047,12 @@ namespace ts {
         /* @internal */ getSymbolCount(): number;
         /* @internal */ getTypeCount(): number;
 
+        /* @internal */ isArrayLikeType(type: Type): boolean;
         /**
          * For a union, will include a property if it's defined in *any* of the member types.
          * So for `{ a } | { b }`, this will include both `a` and `b`.
          * Does not include properties of primitive types.
          */
-        /* @internal */ isArrayLikeType(type: Type): boolean;
         /* @internal */ getAllPossiblePropertiesOfTypes(type: ReadonlyArray<Type>): Symbol[];
         /* @internal */ resolveName(name: string, location: Node, meaning: SymbolFlags, excludeGlobals: boolean): Symbol | undefined;
         /* @internal */ getJsxNamespace(location?: Node): string;

--- a/src/services/codefixes/fixStrictClassInitialization.ts
+++ b/src/services/codefixes/fixStrictClassInitialization.ts
@@ -133,6 +133,9 @@ namespace ts.codefix {
 
             return createNew(createIdentifier(type.symbol.name), /*typeArguments*/ undefined, /*argumentsArray*/ undefined);
         }
+        else if (checker.isArrayLikeType(type)) {
+            return createArrayLiteral();
+        }
         return undefined;
     }
 }

--- a/tests/cases/fourslash/codeFixClassPropertyInitialization_all_3.ts
+++ b/tests/cases/fourslash/codeFixClassPropertyInitialization_all_3.ts
@@ -35,6 +35,8 @@
 ////     k: AT;
 ////
 ////     l: Foo;
+////
+////     m: number[];
 //// }
 
 verify.codeFixAll({
@@ -73,5 +75,7 @@ class T {
     k: AT = new AT;
 
     l: Foo = new Foo;
+
+    m: number[] = [];
 }`
 });


### PR DESCRIPTION
Supports initializing a `something[]` with `[]`.
