### PR TITLE
Fix bug: In findAllReferences, don't crash on static method missing body

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1035,14 +1035,16 @@ namespace ts.FindAllReferences.Core {
             if (!(isMethodOrAccessor(member) && hasModifier(member, ModifierFlags.Static))) {
                 continue;
             }
-            member.body!.forEachChild(function cb(node) {
-                if (node.kind === SyntaxKind.ThisKeyword) {
-                    addRef(node);
-                }
-                else if (!isFunctionLike(node)) {
-                    node.forEachChild(cb);
-                }
-            });
+            if (member.body) {
+                member.body.forEachChild(function cb(node) {
+                    if (node.kind === SyntaxKind.ThisKeyword) {
+                        addRef(node);
+                    }
+                    else if (!isFunctionLike(node)) {
+                        node.forEachChild(cb);
+                    }
+                });
+            }
         }
     }
 

--- a/tests/cases/fourslash/findAllRefsDeclareClass.ts
+++ b/tests/cases/fourslash/findAllRefsDeclareClass.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts" />
+
+////declare class [|{| "isWriteAccess": true, "isDefinition": true |}C|] {
+////    static m(): void;
+////}
+
+verify.singleReferenceGroup("class C");


### PR DESCRIPTION
Previously we would crash if any body-less static method existed.
