### PR TITLE
Updates the graph before checking if file is present in project for error checking

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -511,6 +511,8 @@ namespace ts.server {
 
                 const { fileName, project } = checkList[index];
                 index++;
+                // Ensure the project is upto date before checking if this file is present in the project
+                project.updateGraph();
                 if (!project.containsFile(fileName, requireOpen)) {
                     return;
                 }


### PR DESCRIPTION
When file is moved using getEditsForFileRename, the watch notification could be delayed
This could result in project updates in background that could be delayed and result in file not present in the project after its synchronised
Fixes #24547