### PR TITLE
Add missing conditional type relationships

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4064,7 +4064,7 @@ namespace ts {
     // Thus, if Foo has a 'string' constraint on its type parameter, T will satisfy it. Substitution
     // types disappear upon instantiation (just like type parameters).
     export interface SubstitutionType extends InstantiableType {
-        typeVariable: TypeVariable;  // Target type variable
+        typeVariable: Type;          // Target type variable
         substitute: Type;            // Type to substitute for type parameter
         negatedTypes?: Type[];       // Types proven that this type variables _doesn't_ extend
     }
@@ -4153,6 +4153,7 @@ namespace ts {
         InferUnionTypes = 1 << 0,  // Infer union types for disjoint candidates (otherwise unknownType)
         NoDefault       = 1 << 1,  // Infer unknownType for no inferences (otherwise anyType or emptyObjectType)
         AnyDefault      = 1 << 2,  // Infer anyType for no inferences (otherwise emptyObjectType)
+        SkipConstraintCheck = 1 << 3, // Skip checking weather the inference is assignable to the constraint (otherwise is replaced with constraint)
     }
 
     /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4066,6 +4066,7 @@ namespace ts {
     export interface SubstitutionType extends InstantiableType {
         typeVariable: TypeVariable;  // Target type variable
         substitute: Type;            // Type to substitute for type parameter
+        negatedTypes?: Type[];       // Types proven that this type variables _doesn't_ extend
     }
 
     export const enum SignatureKind {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2302,6 +2302,7 @@ declare namespace ts {
     interface SubstitutionType extends InstantiableType {
         typeVariable: TypeVariable;
         substitute: Type;
+        negatedTypes?: Type[];
     }
     enum SignatureKind {
         Call = 0,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2300,7 +2300,7 @@ declare namespace ts {
         resolvedFalseType?: Type;
     }
     interface SubstitutionType extends InstantiableType {
-        typeVariable: TypeVariable;
+        typeVariable: Type;
         substitute: Type;
         negatedTypes?: Type[];
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2302,6 +2302,7 @@ declare namespace ts {
     interface SubstitutionType extends InstantiableType {
         typeVariable: TypeVariable;
         substitute: Type;
+        negatedTypes?: Type[];
     }
     enum SignatureKind {
         Call = 0,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2300,7 +2300,7 @@ declare namespace ts {
         resolvedFalseType?: Type;
     }
     interface SubstitutionType extends InstantiableType {
-        typeVariable: TypeVariable;
+        typeVariable: Type;
         substitute: Type;
         negatedTypes?: Type[];
     }

--- a/tests/baselines/reference/conditionalTypeGenericAssignability.errors.txt
+++ b/tests/baselines/reference/conditionalTypeGenericAssignability.errors.txt
@@ -1,8 +1,9 @@
 tests/cases/compiler/conditionalTypeGenericAssignability.ts(3,5): error TS2322: Type '0' is not assignable to type 'Extract<keyof T, string>'.
 tests/cases/compiler/conditionalTypeGenericAssignability.ts(7,5): error TS2322: Type '"foo"' is not assignable to type 'Exclude<keyof T, string>'.
+tests/cases/compiler/conditionalTypeGenericAssignability.ts(16,5): error TS2322: Type '{ y: { x: T; }; }' is not assignable to type '{ x: T; } extends { x: string; } ? { y: { x: T; }; } : never'.
 
 
-==== tests/cases/compiler/conditionalTypeGenericAssignability.ts (2 errors) ====
+==== tests/cases/compiler/conditionalTypeGenericAssignability.ts (3 errors) ====
     function f1<T extends { foo: unknown; 0: unknown }>(_a: T, b: Extract<keyof T, string>) {
         b = "foo"; // succeeds
         b = 0; // errors
@@ -15,5 +16,15 @@ tests/cases/compiler/conditionalTypeGenericAssignability.ts(7,5): error TS2322: 
         ~
 !!! error TS2322: Type '"foo"' is not assignable to type 'Exclude<keyof T, string>'.
         b = 0; // succeeds
+    }
+    
+    function f3<T extends number | string>(
+        i: T & string,
+        j: T,
+        b: { x: T } extends { x: string } ? { y: { x: T } } : never) {
+        b = { y: { x: i } }; // success
+        b = { y: { x: j } }; // failure
+        ~
+!!! error TS2322: Type '{ y: { x: T; }; }' is not assignable to type '{ x: T; } extends { x: string; } ? { y: { x: T; }; } : never'.
     }
     

--- a/tests/baselines/reference/conditionalTypeGenericAssignability.errors.txt
+++ b/tests/baselines/reference/conditionalTypeGenericAssignability.errors.txt
@@ -1,0 +1,19 @@
+tests/cases/compiler/conditionalTypeGenericAssignability.ts(3,5): error TS2322: Type '0' is not assignable to type 'Extract<keyof T, string>'.
+tests/cases/compiler/conditionalTypeGenericAssignability.ts(7,5): error TS2322: Type '"foo"' is not assignable to type 'Exclude<keyof T, string>'.
+
+
+==== tests/cases/compiler/conditionalTypeGenericAssignability.ts (2 errors) ====
+    function f1<T extends { foo: unknown; 0: unknown }>(_a: T, b: Extract<keyof T, string>) {
+        b = "foo"; // succeeds
+        b = 0; // errors
+        ~
+!!! error TS2322: Type '0' is not assignable to type 'Extract<keyof T, string>'.
+    }
+    
+    function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, string>) {
+        b = "foo"; // errors
+        ~
+!!! error TS2322: Type '"foo"' is not assignable to type 'Exclude<keyof T, string>'.
+        b = 0; // succeeds
+    }
+    

--- a/tests/baselines/reference/conditionalTypeGenericAssignability.js
+++ b/tests/baselines/reference/conditionalTypeGenericAssignability.js
@@ -9,6 +9,14 @@ function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, s
     b = 0; // succeeds
 }
 
+function f3<T extends number | string>(
+    i: T & string,
+    j: T,
+    b: { x: T } extends { x: string } ? { y: { x: T } } : never) {
+    b = { y: { x: i } }; // success
+    b = { y: { x: j } }; // failure
+}
+
 
 //// [conditionalTypeGenericAssignability.js]
 "use strict";
@@ -19,4 +27,8 @@ function f1(_a, b) {
 function f2(_a, b) {
     b = "foo"; // errors
     b = 0; // succeeds
+}
+function f3(i, j, b) {
+    b = { y: { x: i } }; // success
+    b = { y: { x: j } }; // failure
 }

--- a/tests/baselines/reference/conditionalTypeGenericAssignability.js
+++ b/tests/baselines/reference/conditionalTypeGenericAssignability.js
@@ -1,0 +1,22 @@
+//// [conditionalTypeGenericAssignability.ts]
+function f1<T extends { foo: unknown; 0: unknown }>(_a: T, b: Extract<keyof T, string>) {
+    b = "foo"; // succeeds
+    b = 0; // errors
+}
+
+function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, string>) {
+    b = "foo"; // errors
+    b = 0; // succeeds
+}
+
+
+//// [conditionalTypeGenericAssignability.js]
+"use strict";
+function f1(_a, b) {
+    b = "foo"; // succeeds
+    b = 0; // errors
+}
+function f2(_a, b) {
+    b = "foo"; // errors
+    b = 0; // succeeds
+}

--- a/tests/baselines/reference/conditionalTypeGenericAssignability.symbols
+++ b/tests/baselines/reference/conditionalTypeGenericAssignability.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/conditionalTypeGenericAssignability.ts ===
+function f1<T extends { foo: unknown; 0: unknown }>(_a: T, b: Extract<keyof T, string>) {
+>f1 : Symbol(f1, Decl(conditionalTypeGenericAssignability.ts, 0, 0))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 0, 12))
+>foo : Symbol(foo, Decl(conditionalTypeGenericAssignability.ts, 0, 23))
+>0 : Symbol(0, Decl(conditionalTypeGenericAssignability.ts, 0, 37))
+>_a : Symbol(_a, Decl(conditionalTypeGenericAssignability.ts, 0, 52))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 0, 12))
+>b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 0, 58))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 0, 12))
+
+    b = "foo"; // succeeds
+>b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 0, 58))
+
+    b = 0; // errors
+>b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 0, 58))
+}
+
+function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, string>) {
+>f2 : Symbol(f2, Decl(conditionalTypeGenericAssignability.ts, 3, 1))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 5, 12))
+>foo : Symbol(foo, Decl(conditionalTypeGenericAssignability.ts, 5, 23))
+>0 : Symbol(0, Decl(conditionalTypeGenericAssignability.ts, 5, 37))
+>_a : Symbol(_a, Decl(conditionalTypeGenericAssignability.ts, 5, 52))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 5, 12))
+>b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 5, 58))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 5, 12))
+
+    b = "foo"; // errors
+>b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 5, 58))
+
+    b = 0; // succeeds
+>b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 5, 58))
+}
+

--- a/tests/baselines/reference/conditionalTypeGenericAssignability.symbols
+++ b/tests/baselines/reference/conditionalTypeGenericAssignability.symbols
@@ -35,3 +35,37 @@ function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, s
 >b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 5, 58))
 }
 
+function f3<T extends number | string>(
+>f3 : Symbol(f3, Decl(conditionalTypeGenericAssignability.ts, 8, 1))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 10, 12))
+
+    i: T & string,
+>i : Symbol(i, Decl(conditionalTypeGenericAssignability.ts, 10, 39))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 10, 12))
+
+    j: T,
+>j : Symbol(j, Decl(conditionalTypeGenericAssignability.ts, 11, 18))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 10, 12))
+
+    b: { x: T } extends { x: string } ? { y: { x: T } } : never) {
+>b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 12, 9))
+>x : Symbol(x, Decl(conditionalTypeGenericAssignability.ts, 13, 8))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 10, 12))
+>x : Symbol(x, Decl(conditionalTypeGenericAssignability.ts, 13, 25))
+>y : Symbol(y, Decl(conditionalTypeGenericAssignability.ts, 13, 41))
+>x : Symbol(x, Decl(conditionalTypeGenericAssignability.ts, 13, 46))
+>T : Symbol(T, Decl(conditionalTypeGenericAssignability.ts, 10, 12))
+
+    b = { y: { x: i } }; // success
+>b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 12, 9))
+>y : Symbol(y, Decl(conditionalTypeGenericAssignability.ts, 14, 9))
+>x : Symbol(x, Decl(conditionalTypeGenericAssignability.ts, 14, 14))
+>i : Symbol(i, Decl(conditionalTypeGenericAssignability.ts, 10, 39))
+
+    b = { y: { x: j } }; // failure
+>b : Symbol(b, Decl(conditionalTypeGenericAssignability.ts, 12, 9))
+>y : Symbol(y, Decl(conditionalTypeGenericAssignability.ts, 15, 9))
+>x : Symbol(x, Decl(conditionalTypeGenericAssignability.ts, 15, 14))
+>j : Symbol(j, Decl(conditionalTypeGenericAssignability.ts, 11, 18))
+}
+

--- a/tests/baselines/reference/conditionalTypeGenericAssignability.types
+++ b/tests/baselines/reference/conditionalTypeGenericAssignability.types
@@ -43,3 +43,43 @@ function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, s
 >0 : 0
 }
 
+function f3<T extends number | string>(
+>f3 : <T extends string | number>(i: T & string, j: T, b: { x: T; } extends { x: string; } ? { y: { x: T; }; } : never) => void
+>T : T
+
+    i: T & string,
+>i : T & string
+>T : T
+
+    j: T,
+>j : T
+>T : T
+
+    b: { x: T } extends { x: string } ? { y: { x: T } } : never) {
+>b : { x: T; } extends { x: string; } ? { y: { x: T; }; } : never
+>x : T
+>T : T
+>x : string
+>y : { x: T; }
+>x : T
+>T : T
+
+    b = { y: { x: i } }; // success
+>b = { y: { x: i } } : { y: { x: T & string; }; }
+>b : { x: T; } extends { x: string; } ? { y: { x: T; }; } : never
+>{ y: { x: i } } : { y: { x: T & string; }; }
+>y : { x: T & string; }
+>{ x: i } : { x: T & string; }
+>x : T & string
+>i : T & string
+
+    b = { y: { x: j } }; // failure
+>b = { y: { x: j } } : { y: { x: T; }; }
+>b : { x: T; } extends { x: string; } ? { y: { x: T; }; } : never
+>{ y: { x: j } } : { y: { x: T; }; }
+>y : { x: T; }
+>{ x: j } : { x: T; }
+>x : T
+>j : T
+}
+

--- a/tests/baselines/reference/conditionalTypeGenericAssignability.types
+++ b/tests/baselines/reference/conditionalTypeGenericAssignability.types
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/conditionalTypeGenericAssignability.ts ===
+function f1<T extends { foo: unknown; 0: unknown }>(_a: T, b: Extract<keyof T, string>) {
+>f1 : <T extends { foo: unknown; 0: unknown; }>(_a: T, b: Extract<keyof T, string>) => void
+>T : T
+>foo : unknown
+>0 : unknown
+>_a : T
+>T : T
+>b : Extract<keyof T, string>
+>Extract : Extract<T, U>
+>T : T
+
+    b = "foo"; // succeeds
+>b = "foo" : "foo"
+>b : Extract<keyof T, string>
+>"foo" : "foo"
+
+    b = 0; // errors
+>b = 0 : 0
+>b : Extract<keyof T, string>
+>0 : 0
+}
+
+function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, string>) {
+>f2 : <T extends { foo: unknown; 0: unknown; }>(_a: T, b: Exclude<keyof T, string>) => void
+>T : T
+>foo : unknown
+>0 : unknown
+>_a : T
+>T : T
+>b : Exclude<keyof T, string>
+>Exclude : Exclude<T, U>
+>T : T
+
+    b = "foo"; // errors
+>b = "foo" : "foo"
+>b : Exclude<keyof T, string>
+>"foo" : "foo"
+
+    b = 0; // succeeds
+>b = 0 : 0
+>b : Exclude<keyof T, string>
+>0 : 0
+}
+

--- a/tests/baselines/reference/inferTypes1.types
+++ b/tests/baselines/reference/inferTypes1.types
@@ -320,7 +320,7 @@ type T61<T> = infer A extends infer B ? infer C : infer D;  // Error
 >D : D
 
 type T62<T> = U extends (infer U)[] ? U : U;  // Error
->T62 : any
+>T62 : {} | any
 >T : T
 >U : No type information available!
 >U : U

--- a/tests/baselines/reference/keyofExtractConstrainsAsExpected.js
+++ b/tests/baselines/reference/keyofExtractConstrainsAsExpected.js
@@ -1,0 +1,12 @@
+//// [keyofExtractConstrainsAsExpected.ts]
+type StringKeyof<T> = Extract<keyof T, string>;
+
+type Whatever<T, K extends StringKeyof<T>> = any;
+
+type WithoutFoo = Whatever<{ foo: string }, "foo">; // ok
+
+// no error on the following
+type WithoutFooGeneric<P extends { foo: string }> = Whatever<P, "foo">;
+
+
+//// [keyofExtractConstrainsAsExpected.js]

--- a/tests/baselines/reference/keyofExtractConstrainsAsExpected.symbols
+++ b/tests/baselines/reference/keyofExtractConstrainsAsExpected.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/keyofExtractConstrainsAsExpected.ts ===
+type StringKeyof<T> = Extract<keyof T, string>;
+>StringKeyof : Symbol(StringKeyof, Decl(keyofExtractConstrainsAsExpected.ts, 0, 0))
+>T : Symbol(T, Decl(keyofExtractConstrainsAsExpected.ts, 0, 17))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofExtractConstrainsAsExpected.ts, 0, 17))
+
+type Whatever<T, K extends StringKeyof<T>> = any;
+>Whatever : Symbol(Whatever, Decl(keyofExtractConstrainsAsExpected.ts, 0, 47))
+>T : Symbol(T, Decl(keyofExtractConstrainsAsExpected.ts, 2, 14))
+>K : Symbol(K, Decl(keyofExtractConstrainsAsExpected.ts, 2, 16))
+>StringKeyof : Symbol(StringKeyof, Decl(keyofExtractConstrainsAsExpected.ts, 0, 0))
+>T : Symbol(T, Decl(keyofExtractConstrainsAsExpected.ts, 2, 14))
+
+type WithoutFoo = Whatever<{ foo: string }, "foo">; // ok
+>WithoutFoo : Symbol(WithoutFoo, Decl(keyofExtractConstrainsAsExpected.ts, 2, 49))
+>Whatever : Symbol(Whatever, Decl(keyofExtractConstrainsAsExpected.ts, 0, 47))
+>foo : Symbol(foo, Decl(keyofExtractConstrainsAsExpected.ts, 4, 28))
+
+// no error on the following
+type WithoutFooGeneric<P extends { foo: string }> = Whatever<P, "foo">;
+>WithoutFooGeneric : Symbol(WithoutFooGeneric, Decl(keyofExtractConstrainsAsExpected.ts, 4, 51))
+>P : Symbol(P, Decl(keyofExtractConstrainsAsExpected.ts, 7, 23))
+>foo : Symbol(foo, Decl(keyofExtractConstrainsAsExpected.ts, 7, 34))
+>Whatever : Symbol(Whatever, Decl(keyofExtractConstrainsAsExpected.ts, 0, 47))
+>P : Symbol(P, Decl(keyofExtractConstrainsAsExpected.ts, 7, 23))
+

--- a/tests/baselines/reference/keyofExtractConstrainsAsExpected.types
+++ b/tests/baselines/reference/keyofExtractConstrainsAsExpected.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/keyofExtractConstrainsAsExpected.ts ===
+type StringKeyof<T> = Extract<keyof T, string>;
+>StringKeyof : Extract<keyof T, string>
+>T : T
+>Extract : Extract<T, U>
+>T : T
+
+type Whatever<T, K extends StringKeyof<T>> = any;
+>Whatever : any
+>T : T
+>K : K
+>StringKeyof : Extract<keyof T, string>
+>T : T
+
+type WithoutFoo = Whatever<{ foo: string }, "foo">; // ok
+>WithoutFoo : any
+>Whatever : any
+>foo : string
+
+// no error on the following
+type WithoutFooGeneric<P extends { foo: string }> = Whatever<P, "foo">;
+>WithoutFooGeneric : any
+>P : P
+>foo : string
+>Whatever : any
+>P : P
+

--- a/tests/cases/compiler/conditionalTypeGenericAssignability.ts
+++ b/tests/cases/compiler/conditionalTypeGenericAssignability.ts
@@ -8,3 +8,11 @@ function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, s
     b = "foo"; // errors
     b = 0; // succeeds
 }
+
+function f3<T extends number | string>(
+    i: T & string,
+    j: T,
+    b: { x: T } extends { x: string } ? { y: { x: T } } : never) {
+    b = { y: { x: i } }; // success
+    b = { y: { x: j } }; // failure
+}

--- a/tests/cases/compiler/conditionalTypeGenericAssignability.ts
+++ b/tests/cases/compiler/conditionalTypeGenericAssignability.ts
@@ -1,0 +1,10 @@
+// @strict: true
+function f1<T extends { foo: unknown; 0: unknown }>(_a: T, b: Extract<keyof T, string>) {
+    b = "foo"; // succeeds
+    b = 0; // errors
+}
+
+function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, string>) {
+    b = "foo"; // errors
+    b = 0; // succeeds
+}

--- a/tests/cases/compiler/keyofExtractConstrainsAsExpected.ts
+++ b/tests/cases/compiler/keyofExtractConstrainsAsExpected.ts
@@ -1,0 +1,8 @@
+type StringKeyof<T> = Extract<keyof T, string>;
+
+type Whatever<T, K extends StringKeyof<T>> = any;
+
+type WithoutFoo = Whatever<{ foo: string }, "foo">; // ok
+
+// no error on the following
+type WithoutFooGeneric<P extends { foo: string }> = Whatever<P, "foo">;


### PR DESCRIPTION
Also:
* Improve `keyof` reverse inference for non-string literal types (so an inference from `0` to `keyof T` produces a nonempty object for `T`).
* Track substitution types for both `true` and `false` conditional branches, and for a greater variety of references (more than simply a bare reference or index - now substitutions for `keyof`, for example, would be allowed) This has two implications:
    * `keyof T extends string ? keyof T : never`  now has the additional constraint on `keyof T` in the true branch correctly tracked.
    * `keyof T extends string ? never : keyof T` has the _negation_ of its constraint in the _false_ branch tracked (yes, that means conditional types now function as _real_ negated types)

An example:
```ts
// @strict: true
function f1<T extends { foo: unknown; 0: unknown }>(_a: T, b: Extract<keyof T, string>) {
    b = "foo"; // succeeds
    b = 0; // errors
}

function f2<T extends { foo: unknown; 0: unknown }>(_a: T, b: Exclude<keyof T, string>) {
    b = "foo"; // errors
    b = 0; // succeeds
}
```
Note that the above are the critical usecases, since they're how we're telling people to workaround the keyof changes in 2.9 (hence the bundled keyof inference fix).

Fixes #24560

@ahejlsberg This is what I was talking about with you earlier. 590e4d59f9f6ebea7b942cd2f012f9261dfcc36e has just the new relationships and the true-branch-only (as without the following two commits, the false branch would produce false positives) conditional-reverse inference checking implementation (less some bugfixes in the third commit), while 88623add3ca4ddf4cc57136e2d101f6a72bfe37c and aa2709f15d9d9fa5500d14072fb2651c515c27a1 are about improving substitution types to be able to track the negation of a constraint in addition to the constraint itself, then enabling the `false` branch relation.

As an aside, I still don't create substitution types _everywhere_ (though I certainly applied them to more locations) - generally, the usage of any generic type (or thing which can contain one) should potentially be a substitution type (which can then be removed by instantiation until it gets potentially reapplied later by relationship checking), so it can be matched on. Eg, `{ x: T } extends { x: string } ? { y: { x: T } } : never` should be able to find `{ y: { x: (T & string) } }` assignable to it when `T extends number | string`. This really brings home how substitution types are really just emulating flow control in the typespace.
