### PR TITLE
JSX Generic

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -206,12 +206,13 @@ namespace ts {
             type: createMapFromTemplate({
                 "preserve": JsxEmit.Preserve,
                 "react-native": JsxEmit.ReactNative,
-                "react": JsxEmit.React
+                "react": JsxEmit.React,
+                "transpile": JsxEmit.Transpile
             }),
             paramType: Diagnostics.KIND,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Basic_Options,
-            description: Diagnostics.Specify_JSX_code_generation_Colon_preserve_react_native_or_react,
+            description: Diagnostics.Specify_JSX_code_generation_Colon_preserve_react_native_react_or_transpile,
         },
         {
             name: "declaration",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2040,10 +2040,6 @@
         "category": "Error",
         "code": 2601
     },
-    "JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.": {
-        "category": "Error",
-        "code": 2602
-    },
     "Property '{0}' in type '{1}' is not assignable to type '{2}'.": {
         "category": "Error",
         "code": 2603
@@ -2072,6 +2068,14 @@
         "category": "Error",
         "code": 2609
     },
+    "JSX element '{0}' has no children.":  {
+        "category": "Error",
+        "code": 2610
+    },
+	"Failed to determine the type of JSX element.": {
+        "category": "Error",
+        "code": 2611
+	},
     "Cannot augment module '{0}' with value exports because it resolves to a non-module entity.": {
         "category": "Error",
         "code": 2649
@@ -2377,7 +2381,10 @@
         "category": "Error",
         "code": 2727
     },
-
+    "Intrinsic JSX element '{0}' does not exist in factory '{1}'.": {
+        "category": "Error",
+        "code": 2728
+    },
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",
         "code": 4000
@@ -3105,7 +3112,7 @@
         "category": "Message",
         "code": 6079
     },
-    "Specify JSX code generation: 'preserve', 'react-native', or 'react'.": {
+    "Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'.": {
         "category": "Message",
         "code": 6080
     },
@@ -4036,7 +4043,30 @@
         "category": "Error",
         "code": 17017
     },
-
+    "Invalid jsx-mode pragma. Must be react or generic.": {
+        "category": "Error",
+        "code": 17018
+    },
+    "Invalid factory in jsx-intrinsic-factory pragma.": {
+        "category": "Error",
+        "code": 17019
+    },
+    "Invalid factory in jsx pragma.": {
+        "category": "Error",
+        "code": 17020
+    },
+    "No JSX intrinsic factory defined.":  {
+        "category": "Error",
+        "code": 17021
+    },
+    "Invalid JSX intrinsic factory":  {
+        "category": "Error",
+        "code": 17022
+    },
+    "Missing jsx pragma":  {
+        "category": "Error",
+        "code": 17023
+    },
     "Circularity detected while resolving configuration: {0}": {
         "category": "Error",
         "code": 18000

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -703,7 +703,7 @@ namespace ts {
 
         export function parseIsolatedEntityName(content: string, languageVersion: ScriptTarget): EntityName | undefined {
             // Choice of `isDeclarationFile` should be arbitrary
-            initializeState(content, languageVersion, /*syntaxCursor*/ undefined, ScriptKind.JS);
+            initializeState(content, languageVersion, /*syntaxCursor*/ undefined, ScriptKind.Unknown);
             // Prime the scanner.
             nextToken();
             const entityName = parseEntityName(/*allowReservedWords*/ true);
@@ -7748,7 +7748,10 @@ namespace ts {
                     });
                     break;
                 }
-                case "jsx": return; // Accessed directly
+                case "jsx":
+                case "jsx-intrinsic-factory":
+                case "jsx-mode":
+                    return; // Accessed directly
                 default: Debug.fail("Unhandled pragma kind"); // Can this be made into an assertNever in the future?
             }
         });

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -34,7 +34,7 @@ namespace ts {
 
         transformers.push(transformTypeScript);
 
-        if (jsx === JsxEmit.React) {
+        if (jsx === JsxEmit.React || jsx === JsxEmit.Transpile) {
             transformers.push(transformJsx);
         }
 

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -1,7 +1,6 @@
 /*@internal*/
 namespace ts {
     export function transformJsx(context: TransformationContext) {
-        const compilerOptions = context.getCompilerOptions();
         let currentSourceFile: SourceFile;
 
         return chainBundle(transformSourceFile);
@@ -85,7 +84,6 @@ namespace ts {
         }
 
         function visitJsxOpeningLikeElement(node: JsxOpeningLikeElement, children: ReadonlyArray<JsxChild> | undefined, isChild: boolean, location: TextRange) {
-            const tagName = getTagName(node);
             let objectProperties: Expression | undefined;
             const attrs = node.attributes.properties;
             if (attrs.length === 0) {
@@ -117,12 +115,10 @@ namespace ts {
             }
 
             const element = createExpressionForJsxElement(
-                context.getEmitResolver().getJsxFactoryEntity(currentSourceFile),
-                compilerOptions.reactNamespace!, // TODO: GH#18217
-                tagName,
+                context.getEmitResolver().getJsxDefinitions(currentSourceFile),
+                node,
                 objectProperties,
                 mapDefined(children, transformJsxChildToExpression),
-                node,
                 location
             );
 
@@ -135,8 +131,7 @@ namespace ts {
 
         function visitJsxOpeningFragment(node: JsxOpeningFragment, children: ReadonlyArray<JsxChild>, isChild: boolean, location: TextRange) {
             const element = createExpressionForJsxFragment(
-                context.getEmitResolver().getJsxFactoryEntity(currentSourceFile),
-                compilerOptions.reactNamespace!, // TODO: GH#18217
+                context.getEmitResolver().getJsxDefinitions(currentSourceFile),
                 mapDefined(children, transformJsxChildToExpression),
                 node,
                 location
@@ -270,21 +265,6 @@ namespace ts {
         function tryDecodeEntities(text: string): string | undefined {
             const decoded = decodeEntities(text);
             return decoded === text ? undefined : decoded;
-        }
-
-        function getTagName(node: JsxElement | JsxOpeningLikeElement): Expression {
-            if (node.kind === SyntaxKind.JsxElement) {
-                return getTagName(node.openingElement);
-            }
-            else {
-                const name = node.tagName;
-                if (isIdentifier(name) && isIntrinsicJsxName(name.escapedText)) {
-                    return createLiteral(idText(name));
-                }
-                else {
-                    return createExpressionFromEntityName(name);
-                }
-            }
         }
 
         /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -554,16 +554,6 @@ namespace ts {
         All = Export | Ambient | Public | Private | Protected | Static | Readonly | Abstract | Async | Default | Const
     }
 
-    export const enum JsxFlags {
-        None = 0,
-        /** An element from a named property of the JSX.IntrinsicElements interface */
-        IntrinsicNamedElement = 1 << 0,
-        /** An element inferred from the string index signature of the JSX.IntrinsicElements interface */
-        IntrinsicIndexedElement = 1 << 1,
-
-        IntrinsicElement = IntrinsicNamedElement | IntrinsicIndexedElement,
-    }
-
     /* @internal */
     export const enum RelationComparisonResult {
         Succeeded = 1, // Should be truthy
@@ -2549,6 +2539,57 @@ namespace ts {
         readonly unredirected: SourceFile;
     }
 
+    /* @internal */
+    export interface JsxDefinitions {
+        sourceFile: SourceFile | undefined;
+        checkPreconditions(node: JsxOpeningLikeElement | JsxOpeningFragment): void;
+        getMode(): JsxMode;
+        getNamespace(): string;
+        getValidateChildren(): boolean;
+        getIntrinsicElementType(intrinsicName: __String): Type;
+        getCustomElementType(tagType: Type, node: Node): Type;
+        getStatelessElementType(): Type | undefined;
+        getFragmentType(childrenTypes: { child: JsxChild, type: Type }[], node: Node): Type;
+        getIntrinsicAttributesInfo(intrinsicName: __String, errorNode?: Node): JsxIntrinsicAttributesInfo | undefined;
+        getIntrinsicChildrenType(intrinsicName: __String): Type | undefined;
+        getIntrinsicElementsType(): Type;
+        getElementClassType(): Type;
+        getElementPropertiesName(): __String | undefined;
+        getElementChildrenPropertyName(): __String | undefined;
+        getIntrinsicAttributesType(): Type;
+        getIntrinsicClassAttributesType(): Type;
+        getEmitFactoryEntity(): EntityName | undefined;
+        getEmitReactNamespace(): string;
+        getEmitFramentAsArray(): boolean;
+        getEmitElementMode(jsxElement: JsxOpeningLikeElement): JsxElementEmitMode;
+    }
+    /* @internal */
+    export const enum JsxMode {
+        Generic = 0,
+        React = 1
+    }
+    /* @internal */
+    export interface JsxGenericIntrinsicFactory {
+        factorySymbol: Symbol;
+        map: UnderscoreEscapedMap<JsxIntrinsicElement>;
+    }
+    /* @internal */
+    export interface JsxIntrinsicElement extends JsxIntrinsicAttributesInfo {
+        childrenType: Type;
+        returnedType: Type;
+    }
+    /* @internal */
+    export interface JsxIntrinsicAttributesInfo {
+        intrinsicSymbol?: Symbol;
+        attributesType: Type;
+    }
+    /* @internal */
+    export enum JsxElementEmitMode {
+        Intrinsic,
+        FactoryCall,
+        Construct,
+        FunctionCall
+    }
     // Source files are declarations when they are external modules.
     export interface SourceFile extends Declaration {
         kind: SyntaxKind.SourceFile;
@@ -2643,8 +2684,6 @@ namespace ts {
         /* @internal */ checkJsDirective?: CheckJsDirective;
         /* @internal */ version: string;
         /* @internal */ pragmas: PragmaMap;
-        /* @internal */ localJsxNamespace?: __String;
-        /* @internal */ localJsxFactory?: EntityName;
     }
 
     export interface Bundle extends Node {
@@ -3392,7 +3431,7 @@ namespace ts {
         getTypeReferenceDirectivesForEntityName(name: EntityNameOrEntityNameExpression): string[] | undefined;
         getTypeReferenceDirectivesForSymbol(symbol: Symbol, meaning?: SymbolFlags): string[] | undefined;
         isLiteralConstDeclaration(node: VariableDeclaration | PropertyDeclaration | PropertySignature | ParameterDeclaration): boolean;
-        getJsxFactoryEntity(location?: Node): EntityName | undefined;
+        getJsxDefinitions(location: Node): JsxDefinitions;
         getAllAccessorDeclarations(declaration: AccessorDeclaration): AllAccessorDeclarations;
     }
 
@@ -3671,7 +3710,6 @@ namespace ts {
         isVisible?: boolean;              // Is this node visible
         containsArgumentsReference?: boolean; // Whether a function-like declaration contains an 'arguments' reference
         hasReportedStatementInAmbientContext?: boolean;  // Cache boolean if we report statements in ambient context
-        jsxFlags: JsxFlags;              // flags for knowing what kind of element/attributes we're dealing with
         resolvedJsxElementAttributesType?: Type;  // resolved element attributes type of a JSX openinglike element
         resolvedJsxElementAllAttributesType?: Type;  // resolved all element attributes type of a JSX openinglike element
         hasSuperCall?: boolean;           // recorded result when we try to find super-call. We only try to find one if this flag is undefined, indicating that we haven't made an attempt.
@@ -4419,7 +4457,8 @@ namespace ts {
         None = 0,
         Preserve = 1,
         React = 2,
-        ReactNative = 3
+        ReactNative = 3,
+        Transpile = 4
     }
 
     export const enum NewLineKind {
@@ -5528,6 +5567,14 @@ namespace ts {
             args: [{ name: "factory" }],
             kind: PragmaKindFlags.MultiLine
         },
+        "jsx-mode": {
+            args: [{ name: "mode" }],
+            kind: PragmaKindFlags.MultiLine
+        },
+        "jsx-intrinsic-factory": {
+            args: [{ name: "factory" }],
+            kind: PragmaKindFlags.MultiLine
+        }
     });
 
     /* @internal */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2065,6 +2065,15 @@ namespace ts {
         return getAssignmentTargetKind(node) !== AssignmentKind.None;
     }
 
+    export function getFullEntityName(entityName: EntityName | undefined): string {
+        if (entityName) {
+            return (entityName.kind === SyntaxKind.QualifiedName) ? getFullEntityName(entityName.left) + "." + unescapeLeadingUnderscores(entityName.right.escapedText) : unescapeLeadingUnderscores(entityName.escapedText);
+        }
+        else {
+            return "[undefined]";
+        }
+    }
+
     export type NodeWithPossibleHoistedDeclaration =
         | Block
         | VariableStatement

--- a/src/harness/unittests/commandLineParsing.ts
+++ b/src/harness/unittests/commandLineParsing.ts
@@ -86,7 +86,7 @@ namespace ts {
                         start: undefined,
                         length: undefined,
                     }, {
-                            messageText: "Argument for '--jsx' option must be: 'preserve', 'react-native', 'react'.",
+                            messageText: "Argument for '--jsx' option must be: 'preserve', 'react-native', 'react', 'transpile'.",
                             category: Diagnostics.Argument_for_0_option_must_be_Colon_1.category,
                             code: Diagnostics.Argument_for_0_option_must_be_Colon_1.code,
 

--- a/src/harness/unittests/convertCompilerOptionsFromJson.ts
+++ b/src/harness/unittests/convertCompilerOptionsFromJson.ts
@@ -129,7 +129,7 @@ namespace ts {
                         file: undefined,
                         start: 0,
                         length: 0,
-                        messageText: "Argument for '--jsx' option must be: 'preserve', 'react-native', 'react'.",
+                        messageText: "Argument for '--jsx' option must be: 'preserve', 'react-native', 'react', 'transpile'.",
                         code: Diagnostics.Argument_for_0_option_must_be_Colon_1.code,
                         category: Diagnostics.Argument_for_0_option_must_be_Colon_1.category
                     }]

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -448,14 +448,6 @@ declare namespace ts {
         ExportDefault = 513,
         All = 3071
     }
-    enum JsxFlags {
-        None = 0,
-        /** An element from a named property of the JSX.IntrinsicElements interface */
-        IntrinsicNamedElement = 1,
-        /** An element inferred from the string index signature of the JSX.IntrinsicElements interface */
-        IntrinsicIndexedElement = 2,
-        IntrinsicElement = 3
-    }
     interface Node extends TextRange {
         kind: SyntaxKind;
         flags: NodeFlags;
@@ -2498,7 +2490,8 @@ declare namespace ts {
         None = 0,
         Preserve = 1,
         React = 2,
-        ReactNative = 3
+        ReactNative = 3,
+        Transpile = 4
     }
     enum NewLineKind {
         CarriageReturnLineFeed = 0,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -448,14 +448,6 @@ declare namespace ts {
         ExportDefault = 513,
         All = 3071
     }
-    enum JsxFlags {
-        None = 0,
-        /** An element from a named property of the JSX.IntrinsicElements interface */
-        IntrinsicNamedElement = 1,
-        /** An element inferred from the string index signature of the JSX.IntrinsicElements interface */
-        IntrinsicIndexedElement = 2,
-        IntrinsicElement = 3
-    }
     interface Node extends TextRange {
         kind: SyntaxKind;
         flags: NodeFlags;
@@ -2498,7 +2490,8 @@ declare namespace ts {
         None = 0,
         Preserve = 1,
         React = 2,
-        ReactNative = 3
+        ReactNative = 3,
+        Transpile = 4
     }
     enum NewLineKind {
         CarriageReturnLineFeed = 0,

--- a/tests/baselines/reference/jsxGenericTest1.js
+++ b/tests/baselines/reference/jsxGenericTest1.js
@@ -1,0 +1,34 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+           </div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" },
+        createElement("span", null));
+}

--- a/tests/baselines/reference/jsxGenericTest1.symbols
+++ b/tests/baselines/reference/jsxGenericTest1.symbols
@@ -1,0 +1,46 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1))
+>tagName : Symbol(tagName, Decl(file.tsx, 9, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 9, 44))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 9, 68))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 9, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 11, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 14, 15))
+
+                <span/>
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest1.types
+++ b/tests/baselines/reference/jsxGenericTest1.types
@@ -1,0 +1,53 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : (tagName: "div" | "span", attrs?: HTMLAttributes, ...children: HTMLElement[]) => HTMLElement
+>tagName : "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span"
+}
+
+function test() {
+>test : () => HTMLElement
+
+    return <div class="test">
+><div class="test">                <span/>           </div> : HTMLElement
+>div : any
+>class : string
+
+                <span/>
+><span/> : HTMLElement
+>span : any
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest10.errors.txt
+++ b/tests/baselines/reference/jsxGenericTest10.errors.txt
@@ -1,0 +1,37 @@
+tests/cases/conformance/jsxGeneric/file.tsx(26,6): error TS2322: Type 'Span' is not assignable to type 'Div'.
+  Property 'dummy' is missing in type 'Span'.
+
+
+==== tests/cases/conformance/jsxGeneric/file.tsx (1 errors) ====
+    /* @jsx-mode generic */
+    
+    interface Attributes {
+        class?:     string;
+        id?:        string;
+        onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+    }
+     
+    class Div {
+    	constructor(attrs?: Attributes, ...children:Span[]) {
+    	}
+    	
+    	public dummy() {
+    	}
+    }
+    
+    class Span {
+    	constructor(attrs?: Attributes, ...children:Div[]) {
+    	}
+    }
+    
+    function test() {
+        return <Div class="test">
+                    <Span>
+    					<Div/>
+    					<Span/>
+    					~~~~~~~
+!!! error TS2322: Type 'Span' is not assignable to type 'Div'.
+!!! error TS2322:   Property 'dummy' is missing in type 'Span'.
+    				</Span>
+               </Div>;
+    }

--- a/tests/baselines/reference/jsxGenericTest10.js
+++ b/tests/baselines/reference/jsxGenericTest10.js
@@ -1,0 +1,59 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+
+interface Attributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+class Div {
+	constructor(attrs?: Attributes, ...children:Span[]) {
+	}
+	
+	public dummy() {
+	}
+}
+
+class Span {
+	constructor(attrs?: Attributes, ...children:Div[]) {
+	}
+}
+
+function test() {
+    return <Div class="test">
+                <Span>
+					<Div/>
+					<Span/>
+				</Span>
+           </Div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+var Div = /** @class */ (function () {
+    function Div(attrs) {
+        var children = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            children[_i - 1] = arguments[_i];
+        }
+    }
+    Div.prototype.dummy = function () {
+    };
+    return Div;
+}());
+var Span = /** @class */ (function () {
+    function Span(attrs) {
+        var children = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            children[_i - 1] = arguments[_i];
+        }
+    }
+    return Span;
+}());
+function test() {
+    return new Div({ "class": "test" },
+        new Span(null,
+            new Div(null),
+            new Span(null)));
+}

--- a/tests/baselines/reference/jsxGenericTest10.symbols
+++ b/tests/baselines/reference/jsxGenericTest10.symbols
@@ -1,0 +1,68 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+
+interface Attributes {
+>Attributes : Symbol(Attributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(Attributes.class, Decl(file.tsx, 2, 22))
+
+    id?:        string;
+>id : Symbol(Attributes.id, Decl(file.tsx, 3, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(Attributes.onclick, Decl(file.tsx, 4, 23))
+>this : Symbol(this, Decl(file.tsx, 5, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 5, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+class Div {
+>Div : Symbol(Div, Decl(file.tsx, 6, 1))
+
+	constructor(attrs?: Attributes, ...children:Span[]) {
+>attrs : Symbol(attrs, Decl(file.tsx, 9, 13))
+>Attributes : Symbol(Attributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 9, 32))
+>Span : Symbol(Span, Decl(file.tsx, 14, 1))
+	}
+	
+	public dummy() {
+>dummy : Symbol(Div.dummy, Decl(file.tsx, 10, 2))
+	}
+}
+
+class Span {
+>Span : Symbol(Span, Decl(file.tsx, 14, 1))
+
+	constructor(attrs?: Attributes, ...children:Div[]) {
+>attrs : Symbol(attrs, Decl(file.tsx, 17, 13))
+>Attributes : Symbol(Attributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 17, 32))
+>Div : Symbol(Div, Decl(file.tsx, 6, 1))
+	}
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 19, 1))
+
+    return <Div class="test">
+>Div : Symbol(Div, Decl(file.tsx, 6, 1))
+>class : Symbol(class, Decl(file.tsx, 22, 15))
+
+                <Span>
+>Span : Symbol(Span, Decl(file.tsx, 14, 1))
+
+					<Div/>
+>Div : Symbol(Div, Decl(file.tsx, 6, 1))
+
+					<Span/>
+>Span : Symbol(Span, Decl(file.tsx, 14, 1))
+
+				</Span>
+>Span : Symbol(Span, Decl(file.tsx, 14, 1))
+
+           </Div>;
+>Div : Symbol(Div, Decl(file.tsx, 6, 1))
+}

--- a/tests/baselines/reference/jsxGenericTest10.types
+++ b/tests/baselines/reference/jsxGenericTest10.types
@@ -1,0 +1,72 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+
+interface Attributes {
+>Attributes : Attributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+class Div {
+>Div : Div
+
+	constructor(attrs?: Attributes, ...children:Span[]) {
+>attrs : Attributes
+>Attributes : Attributes
+>children : Span[]
+>Span : Span
+	}
+	
+	public dummy() {
+>dummy : () => void
+	}
+}
+
+class Span {
+>Span : Span
+
+	constructor(attrs?: Attributes, ...children:Div[]) {
+>attrs : Attributes
+>Attributes : Attributes
+>children : Div[]
+>Div : Div
+	}
+}
+
+function test() {
+>test : () => Div
+
+    return <Div class="test">
+><Div class="test">                <Span>					<Div/>					<Span/>				</Span>           </Div> : Div
+>Div : typeof Div
+>class : string
+
+                <Span>
+><Span>					<Div/>					<Span/>				</Span> : Span
+>Span : typeof Span
+
+					<Div/>
+><Div/> : Div
+>Div : typeof Div
+
+					<Span/>
+><Span/> : Span
+>Span : typeof Span
+
+				</Span>
+>Span : typeof Span
+
+           </Div>;
+>Div : typeof Div
+}

--- a/tests/baselines/reference/jsxGenericTest11.js
+++ b/tests/baselines/reference/jsxGenericTest11.js
@@ -1,0 +1,93 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+export interface IContainer {
+    readonly container: HTMLElement;
+}
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|IContainer|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <Simple text="test"/>
+                <FunctionContainer>
+                    <span />
+                </FunctionContainer>
+                <ClassContainer>
+                    <span />
+                    { false }
+                </ClassContainer>
+                { false }
+           </div>;
+}
+
+function Simple(attr: { text:string }) {
+    return <span>{ attr.text }</span>;
+}
+
+function FunctionContainer(attr: { }, ...children:AddNode[]) {
+    return <div>{ children }</div>;
+}
+
+class ClassContainer implements IContainer {
+    public container:HTMLElement;
+
+    constructor(attrs?: {}, ...children:AddNode[]) {
+        this.container = <div>{ children }</div>;
+	}
+}
+
+
+//// [file.js]
+"use strict";
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+exports.__esModule = true;
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" },
+        Simple({ text: "test" }),
+        FunctionContainer(null,
+            createElement("span", null)),
+        new ClassContainer(null,
+            createElement("span", null),
+            false),
+        false);
+}
+function Simple(attr) {
+    return createElement("span", null, attr.text);
+}
+function FunctionContainer(attr) {
+    var children = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        children[_i - 1] = arguments[_i];
+    }
+    return createElement("div", null, children);
+}
+var ClassContainer = /** @class */ (function () {
+    function ClassContainer(attrs) {
+        var children = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            children[_i - 1] = arguments[_i];
+        }
+        this.container = createElement("div", null, children);
+    }
+    return ClassContainer;
+}());

--- a/tests/baselines/reference/jsxGenericTest11.symbols
+++ b/tests/baselines/reference/jsxGenericTest11.symbols
@@ -1,0 +1,126 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+export interface IContainer {
+>IContainer : Symbol(IContainer, Decl(file.tsx, 7, 1))
+
+    readonly container: HTMLElement;
+>container : Symbol(IContainer.container, Decl(file.tsx, 9, 29))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+export interface AddArray extends Array<AddNode> {}
+>AddArray : Symbol(AddArray, Decl(file.tsx, 11, 1))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 12, 51))
+
+export type AddNode    = HTMLElement|string|IContainer|AddArray|false;
+>AddNode : Symbol(AddNode, Decl(file.tsx, 12, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>IContainer : Symbol(IContainer, Decl(file.tsx, 7, 1))
+>AddArray : Symbol(AddArray, Decl(file.tsx, 11, 1))
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 13, 70))
+>tagName : Symbol(tagName, Decl(file.tsx, 15, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 15, 44))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 15, 68))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 12, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 15, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 17, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 20, 15))
+
+                <Simple text="test"/>
+>Simple : Symbol(Simple, Decl(file.tsx, 31, 1))
+>text : Symbol(text, Decl(file.tsx, 21, 23))
+
+                <FunctionContainer>
+>FunctionContainer : Symbol(FunctionContainer, Decl(file.tsx, 35, 1))
+
+                    <span />
+                </FunctionContainer>
+>FunctionContainer : Symbol(FunctionContainer, Decl(file.tsx, 35, 1))
+
+                <ClassContainer>
+>ClassContainer : Symbol(ClassContainer, Decl(file.tsx, 39, 1))
+
+                    <span />
+                    { false }
+                </ClassContainer>
+>ClassContainer : Symbol(ClassContainer, Decl(file.tsx, 39, 1))
+
+                { false }
+           </div>;
+}
+
+function Simple(attr: { text:string }) {
+>Simple : Symbol(Simple, Decl(file.tsx, 31, 1))
+>attr : Symbol(attr, Decl(file.tsx, 33, 16))
+>text : Symbol(text, Decl(file.tsx, 33, 23))
+
+    return <span>{ attr.text }</span>;
+>attr.text : Symbol(text, Decl(file.tsx, 33, 23))
+>attr : Symbol(attr, Decl(file.tsx, 33, 16))
+>text : Symbol(text, Decl(file.tsx, 33, 23))
+}
+
+function FunctionContainer(attr: { }, ...children:AddNode[]) {
+>FunctionContainer : Symbol(FunctionContainer, Decl(file.tsx, 35, 1))
+>attr : Symbol(attr, Decl(file.tsx, 37, 27))
+>children : Symbol(children, Decl(file.tsx, 37, 37))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 12, 51))
+
+    return <div>{ children }</div>;
+>children : Symbol(children, Decl(file.tsx, 37, 37))
+}
+
+class ClassContainer implements IContainer {
+>ClassContainer : Symbol(ClassContainer, Decl(file.tsx, 39, 1))
+>IContainer : Symbol(IContainer, Decl(file.tsx, 7, 1))
+
+    public container:HTMLElement;
+>container : Symbol(ClassContainer.container, Decl(file.tsx, 41, 44))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    constructor(attrs?: {}, ...children:AddNode[]) {
+>attrs : Symbol(attrs, Decl(file.tsx, 44, 16))
+>children : Symbol(children, Decl(file.tsx, 44, 27))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 12, 51))
+
+        this.container = <div>{ children }</div>;
+>this.container : Symbol(ClassContainer.container, Decl(file.tsx, 41, 44))
+>this : Symbol(ClassContainer, Decl(file.tsx, 39, 1))
+>container : Symbol(ClassContainer.container, Decl(file.tsx, 41, 44))
+>children : Symbol(children, Decl(file.tsx, 44, 27))
+	}
+}
+

--- a/tests/baselines/reference/jsxGenericTest11.types
+++ b/tests/baselines/reference/jsxGenericTest11.types
@@ -1,0 +1,154 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+export interface IContainer {
+>IContainer : IContainer
+
+    readonly container: HTMLElement;
+>container : HTMLElement
+>HTMLElement : HTMLElement
+}
+export interface AddArray extends Array<AddNode> {}
+>AddArray : AddArray
+>Array : T[]
+>AddNode : AddNode
+
+export type AddNode    = HTMLElement|string|IContainer|AddArray|false;
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+>IContainer : IContainer
+>AddArray : AddArray
+>false : false
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : (tagName: "div" | "span", attrs?: HTMLAttributes, ...children: AddNode[]) => HTMLElement
+>tagName : "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : AddNode[]
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span"
+}
+
+function test() {
+>test : () => HTMLElement
+
+    return <div class="test">
+><div class="test">                <Simple text="test"/>                <FunctionContainer>                    <span />                </FunctionContainer>                <ClassContainer>                    <span />                    { false }                </ClassContainer>                { false }           </div> : HTMLElement
+>div : any
+>class : string
+
+                <Simple text="test"/>
+><Simple text="test"/> : HTMLElement
+>Simple : (attr: { text: string; }) => HTMLElement
+>text : string
+
+                <FunctionContainer>
+><FunctionContainer>                    <span />                </FunctionContainer> : HTMLElement
+>FunctionContainer : (attr: {}, ...children: AddNode[]) => HTMLElement
+
+                    <span />
+><span /> : HTMLElement
+>span : any
+
+                </FunctionContainer>
+>FunctionContainer : (attr: {}, ...children: AddNode[]) => HTMLElement
+
+                <ClassContainer>
+><ClassContainer>                    <span />                    { false }                </ClassContainer> : ClassContainer
+>ClassContainer : typeof ClassContainer
+
+                    <span />
+><span /> : HTMLElement
+>span : any
+
+                    { false }
+>false : false
+
+                </ClassContainer>
+>ClassContainer : typeof ClassContainer
+
+                { false }
+>false : false
+
+           </div>;
+>div : any
+}
+
+function Simple(attr: { text:string }) {
+>Simple : (attr: { text: string; }) => HTMLElement
+>attr : { text: string; }
+>text : string
+
+    return <span>{ attr.text }</span>;
+><span>{ attr.text }</span> : HTMLElement
+>span : any
+>attr.text : string
+>attr : { text: string; }
+>text : string
+>span : any
+}
+
+function FunctionContainer(attr: { }, ...children:AddNode[]) {
+>FunctionContainer : (attr: {}, ...children: AddNode[]) => HTMLElement
+>attr : {}
+>children : AddNode[]
+>AddNode : AddNode
+
+    return <div>{ children }</div>;
+><div>{ children }</div> : HTMLElement
+>div : any
+>children : AddNode[]
+>div : any
+}
+
+class ClassContainer implements IContainer {
+>ClassContainer : ClassContainer
+>IContainer : IContainer
+
+    public container:HTMLElement;
+>container : HTMLElement
+>HTMLElement : HTMLElement
+
+    constructor(attrs?: {}, ...children:AddNode[]) {
+>attrs : {}
+>children : AddNode[]
+>AddNode : AddNode
+
+        this.container = <div>{ children }</div>;
+>this.container = <div>{ children }</div> : HTMLElement
+>this.container : HTMLElement
+>this : this
+>container : HTMLElement
+><div>{ children }</div> : HTMLElement
+>div : any
+>children : AddNode[]
+>div : any
+	}
+}
+

--- a/tests/baselines/reference/jsxGenericTest12.js
+++ b/tests/baselines/reference/jsxGenericTest12.js
@@ -1,0 +1,50 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    const f = <>
+                <span>1</span>
+                <span>2</span>
+              </>;
+
+    return <div class="test">
+                <span/>
+                { f }
+           </div>;
+}
+
+//// [file.js]
+"use strict";
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+exports.__esModule = true;
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    var f = [
+        createElement("span", null, "1"),
+        createElement("span", null, "2")
+    ];
+    return createElement("div", { "class": "test" },
+        createElement("span", null),
+        f);
+}

--- a/tests/baselines/reference/jsxGenericTest12.symbols
+++ b/tests/baselines/reference/jsxGenericTest12.symbols
@@ -1,0 +1,66 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+
+export interface AddArray extends Array<AddNode> {}
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 10, 59))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 12, 44))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 12, 68))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 14, 1))
+
+    const f = <>
+>f : Symbol(f, Decl(file.tsx, 17, 9))
+
+                <span>1</span>
+                <span>2</span>
+              </>;
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 22, 15))
+
+                <span/>
+                { f }
+>f : Symbol(f, Decl(file.tsx, 17, 9))
+
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest12.types
+++ b/tests/baselines/reference/jsxGenericTest12.types
@@ -1,0 +1,83 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+
+export interface AddArray extends Array<AddNode> {}
+>AddArray : AddArray
+>Array : T[]
+>AddNode : AddNode
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+>AddArray : AddArray
+>false : false
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : (tagName: "div" | "span", attrs?: HTMLAttributes, ...children: AddNode[]) => HTMLElement
+>tagName : "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : AddNode[]
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span"
+}
+
+function test() {
+>test : () => HTMLElement
+
+    const f = <>
+>f : HTMLElement[]
+><>                <span>1</span>                <span>2</span>              </> : HTMLElement[]
+
+                <span>1</span>
+><span>1</span> : HTMLElement
+>span : any
+>span : any
+
+                <span>2</span>
+><span>2</span> : HTMLElement
+>span : any
+>span : any
+
+              </>;
+
+    return <div class="test">
+><div class="test">                <span/>                { f }           </div> : HTMLElement
+>div : any
+>class : string
+
+                <span/>
+><span/> : HTMLElement
+>span : any
+
+                { f }
+>f : HTMLElement[]
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest13.errors.txt
+++ b/tests/baselines/reference/jsxGenericTest13.errors.txt
@@ -1,0 +1,45 @@
+tests/cases/conformance/jsxGeneric/file.tsx(25,17): error TS2322: Type '(HTMLElement | 10)[]' is not assignable to type 'AddNode'.
+  Type '(HTMLElement | 10)[]' is not assignable to type 'AddArray'.
+    Types of property 'push' are incompatible.
+      Type '(...items: (HTMLElement | 10)[]) => number' is not assignable to type '(...items: AddNode[]) => number'.
+        Types of parameters 'items' and 'items' are incompatible.
+          Type 'AddNode' is not assignable to type 'HTMLElement | 10'.
+            Type 'string' is not assignable to type 'HTMLElement | 10'.
+
+
+==== tests/cases/conformance/jsxGeneric/file.tsx (1 errors) ====
+    /* @jsx-mode generic */
+    /* @jsx-intrinsic-factory createElement */
+    
+    interface HTMLAttributes {
+        class?:     string;
+        id?:        string;
+        onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+    }
+    
+    export interface AddArray extends Array<AddNode> {}
+    export type AddNode    = HTMLElement|string|AddArray|false;
+    
+    function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+        return document.createElement(tagName);
+    }
+    
+    function test() {
+        const f = <>
+                    <span>1</span>
+                    { 10 }
+                  </>;
+    
+        return <div class="test">
+                    <span/>
+                    { f }
+                    ~~~~~
+!!! error TS2322: Type '(HTMLElement | 10)[]' is not assignable to type 'AddNode'.
+!!! error TS2322:   Type '(HTMLElement | 10)[]' is not assignable to type 'AddArray'.
+!!! error TS2322:     Types of property 'push' are incompatible.
+!!! error TS2322:       Type '(...items: (HTMLElement | 10)[]) => number' is not assignable to type '(...items: AddNode[]) => number'.
+!!! error TS2322:         Types of parameters 'items' and 'items' are incompatible.
+!!! error TS2322:           Type 'AddNode' is not assignable to type 'HTMLElement | 10'.
+!!! error TS2322:             Type 'string' is not assignable to type 'HTMLElement | 10'.
+               </div>;
+    }

--- a/tests/baselines/reference/jsxGenericTest13.js
+++ b/tests/baselines/reference/jsxGenericTest13.js
@@ -1,0 +1,50 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    const f = <>
+                <span>1</span>
+                { 10 }
+              </>;
+
+    return <div class="test">
+                <span/>
+                { f }
+           </div>;
+}
+
+//// [file.js]
+"use strict";
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+exports.__esModule = true;
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    var f = [
+        createElement("span", null, "1"),
+        10
+    ];
+    return createElement("div", { "class": "test" },
+        createElement("span", null),
+        f);
+}

--- a/tests/baselines/reference/jsxGenericTest13.symbols
+++ b/tests/baselines/reference/jsxGenericTest13.symbols
@@ -1,0 +1,66 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+
+export interface AddArray extends Array<AddNode> {}
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 10, 59))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 12, 44))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 12, 68))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 14, 1))
+
+    const f = <>
+>f : Symbol(f, Decl(file.tsx, 17, 9))
+
+                <span>1</span>
+                { 10 }
+              </>;
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 22, 15))
+
+                <span/>
+                { f }
+>f : Symbol(f, Decl(file.tsx, 17, 9))
+
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest13.types
+++ b/tests/baselines/reference/jsxGenericTest13.types
@@ -1,0 +1,81 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+
+export interface AddArray extends Array<AddNode> {}
+>AddArray : AddArray
+>Array : T[]
+>AddNode : AddNode
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+>AddArray : AddArray
+>false : false
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : (tagName: "div" | "span", attrs?: HTMLAttributes, ...children: AddNode[]) => HTMLElement
+>tagName : "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : AddNode[]
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span"
+}
+
+function test() {
+>test : () => HTMLElement
+
+    const f = <>
+>f : (HTMLElement | 10)[]
+><>                <span>1</span>                { 10 }              </> : (HTMLElement | 10)[]
+
+                <span>1</span>
+><span>1</span> : HTMLElement
+>span : any
+>span : any
+
+                { 10 }
+>10 : 10
+
+              </>;
+
+    return <div class="test">
+><div class="test">                <span/>                { f }           </div> : HTMLElement
+>div : any
+>class : string
+
+                <span/>
+><span/> : HTMLElement
+>span : any
+
+                { f }
+>f : (HTMLElement | 10)[]
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest14.js
+++ b/tests/baselines/reference/jsxGenericTest14.js
@@ -1,0 +1,39 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+function createElement(tagName:"br"): HTMLBRElement;
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+                <br/>
+           </div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" },
+        createElement("span", null),
+        createElement("br", null));
+}

--- a/tests/baselines/reference/jsxGenericTest14.symbols
+++ b/tests/baselines/reference/jsxGenericTest14.symbols
@@ -1,0 +1,70 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 9, 105), Decl(file.tsx, 10, 107), Decl(file.tsx, 11, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 9, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 9, 37))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 9, 61))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLDivElement : Symbol(HTMLDivElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 9, 105), Decl(file.tsx, 10, 107), Decl(file.tsx, 11, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 10, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 10, 38))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 10, 62))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLSpanElement : Symbol(HTMLSpanElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+function createElement(tagName:"br"): HTMLBRElement;
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 9, 105), Decl(file.tsx, 10, 107), Decl(file.tsx, 11, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 11, 23))
+>HTMLBRElement : Symbol(HTMLBRElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 9, 105), Decl(file.tsx, 10, 107), Decl(file.tsx, 11, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 12, 49))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 12, 73))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 14, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 17, 15))
+
+                <span/>
+                <br/>
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest14.types
+++ b/tests/baselines/reference/jsxGenericTest14.types
@@ -1,0 +1,80 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "div"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLDivElement : HTMLDivElement
+
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLSpanElement : HTMLSpanElement
+
+function createElement(tagName:"br"): HTMLBRElement;
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "br"
+>HTMLBRElement : HTMLBRElement
+
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "div" | "span" | "br"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement | HTMLBRElement
+>document.createElement : { <K extends "object" | "div" | "span" | "br" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "br" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span" | "br"
+}
+
+function test() {
+>test : () => HTMLDivElement
+
+    return <div class="test">
+><div class="test">                <span/>                <br/>           </div> : HTMLDivElement
+>div : any
+>class : string
+
+                <span/>
+><span/> : HTMLSpanElement
+>span : any
+
+                <br/>
+><br/> : HTMLBRElement
+>br : any
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest15.errors.txt
+++ b/tests/baselines/reference/jsxGenericTest15.errors.txt
@@ -1,0 +1,32 @@
+tests/cases/conformance/jsxGeneric/file.tsx(23,21): error TS2610: JSX element 'br' has no children.
+
+
+==== tests/cases/conformance/jsxGeneric/file.tsx (1 errors) ====
+    /* @jsx-mode generic */
+    /* @jsx-intrinsic-factory createElement */
+    
+    interface HTMLAttributes {
+        class?:     string;
+        id?:        string;
+        onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+    }
+    
+    
+    
+    function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+    function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+    function createElement(tagName:"br"): HTMLBRElement;
+    function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+        return document.createElement(tagName);
+    }
+    
+    function test() {
+        return <div class="test">
+                    <span/>
+                    <br>
+                        <span class=""/>
+                        ~~~~~~~~~~~~~~~~
+!!! error TS2610: JSX element 'br' has no children.
+                    </br>
+               </div>;
+    }

--- a/tests/baselines/reference/jsxGenericTest15.js
+++ b/tests/baselines/reference/jsxGenericTest15.js
@@ -1,0 +1,44 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+function createElement(tagName:"br"): HTMLBRElement;
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+                <br>
+                    <span class=""/>
+                </br>
+           </div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" },
+        createElement("span", null),
+        createElement("br", null,
+            createElement("span", { "class": "" })));
+}

--- a/tests/baselines/reference/jsxGenericTest15.symbols
+++ b/tests/baselines/reference/jsxGenericTest15.symbols
@@ -1,0 +1,76 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+
+
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 11, 105), Decl(file.tsx, 12, 107), Decl(file.tsx, 13, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 11, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 11, 37))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 11, 61))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLDivElement : Symbol(HTMLDivElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 11, 105), Decl(file.tsx, 12, 107), Decl(file.tsx, 13, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 12, 38))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 12, 62))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLSpanElement : Symbol(HTMLSpanElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+function createElement(tagName:"br"): HTMLBRElement;
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 11, 105), Decl(file.tsx, 12, 107), Decl(file.tsx, 13, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 13, 23))
+>HTMLBRElement : Symbol(HTMLBRElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 11, 105), Decl(file.tsx, 12, 107), Decl(file.tsx, 13, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 14, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 14, 49))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 14, 73))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 14, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 16, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 19, 15))
+
+                <span/>
+                <br>
+                    <span class=""/>
+>class : Symbol(class, Decl(file.tsx, 22, 25))
+
+                </br>
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest15.types
+++ b/tests/baselines/reference/jsxGenericTest15.types
@@ -1,0 +1,90 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+
+
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "div"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLDivElement : HTMLDivElement
+
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLSpanElement : HTMLSpanElement
+
+function createElement(tagName:"br"): HTMLBRElement;
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "br"
+>HTMLBRElement : HTMLBRElement
+
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "div" | "span" | "br"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement | HTMLBRElement
+>document.createElement : { <K extends "object" | "div" | "span" | "br" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "br" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span" | "br"
+}
+
+function test() {
+>test : () => HTMLDivElement
+
+    return <div class="test">
+><div class="test">                <span/>                <br>                    <span class=""/>                </br>           </div> : HTMLDivElement
+>div : any
+>class : string
+
+                <span/>
+><span/> : HTMLSpanElement
+>span : any
+
+                <br>
+><br>                    <span class=""/>                </br> : HTMLBRElement
+>br : any
+
+                    <span class=""/>
+><span class=""/> : HTMLSpanElement
+>span : any
+>class : string
+
+                </br>
+>br : any
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest16.errors.txt
+++ b/tests/baselines/reference/jsxGenericTest16.errors.txt
@@ -1,0 +1,30 @@
+tests/cases/conformance/jsxGeneric/file.tsx(22,21): error TS2339: Property 'class' does not exist on type '{}'.
+
+
+==== tests/cases/conformance/jsxGeneric/file.tsx (1 errors) ====
+    /* @jsx-mode generic */
+    /* @jsx-intrinsic-factory createElement */
+    
+    interface HTMLAttributes {
+        class?:     string;
+        id?:        string;
+        onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+    }
+    
+    
+    
+    function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+    function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+    function createElement(tagName:"br"): HTMLBRElement;
+    function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+        return document.createElement(tagName);
+    }
+    
+    function test() {
+        return <div class="test">
+                    <span/>
+                    <br class=""/>
+                        ~~~~~~~~
+!!! error TS2339: Property 'class' does not exist on type '{}'.
+               </div>;
+    }

--- a/tests/baselines/reference/jsxGenericTest16.js
+++ b/tests/baselines/reference/jsxGenericTest16.js
@@ -1,0 +1,41 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+function createElement(tagName:"br"): HTMLBRElement;
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+                <br class=""/>
+           </div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" },
+        createElement("span", null),
+        createElement("br", { "class": "" }));
+}

--- a/tests/baselines/reference/jsxGenericTest16.symbols
+++ b/tests/baselines/reference/jsxGenericTest16.symbols
@@ -1,0 +1,74 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+
+
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 11, 105), Decl(file.tsx, 12, 107), Decl(file.tsx, 13, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 11, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 11, 37))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 11, 61))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLDivElement : Symbol(HTMLDivElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 11, 105), Decl(file.tsx, 12, 107), Decl(file.tsx, 13, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 12, 38))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 12, 62))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLSpanElement : Symbol(HTMLSpanElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+function createElement(tagName:"br"): HTMLBRElement;
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 11, 105), Decl(file.tsx, 12, 107), Decl(file.tsx, 13, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 13, 23))
+>HTMLBRElement : Symbol(HTMLBRElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1), Decl(file.tsx, 11, 105), Decl(file.tsx, 12, 107), Decl(file.tsx, 13, 52))
+>tagName : Symbol(tagName, Decl(file.tsx, 14, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 14, 49))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 14, 73))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 14, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 16, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 19, 15))
+
+                <span/>
+                <br class=""/>
+>class : Symbol(class, Decl(file.tsx, 21, 19))
+
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest16.types
+++ b/tests/baselines/reference/jsxGenericTest16.types
@@ -1,0 +1,83 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+
+
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "div"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLDivElement : HTMLDivElement
+
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLSpanElement : HTMLSpanElement
+
+function createElement(tagName:"br"): HTMLBRElement;
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "br"
+>HTMLBRElement : HTMLBRElement
+
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : { (tagName: "div", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLDivElement; (tagName: "span", attrs?: HTMLAttributes, ...children: HTMLElement[]): HTMLSpanElement; (tagName: "br"): HTMLBRElement; }
+>tagName : "div" | "span" | "br"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement | HTMLBRElement
+>document.createElement : { <K extends "object" | "div" | "span" | "br" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "br" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span" | "br"
+}
+
+function test() {
+>test : () => HTMLDivElement
+
+    return <div class="test">
+><div class="test">                <span/>                <br class=""/>           </div> : HTMLDivElement
+>div : any
+>class : string
+
+                <span/>
+><span/> : HTMLSpanElement
+>span : any
+
+                <br class=""/>
+><br class=""/> : HTMLBRElement
+>br : any
+>class : string
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest2.errors.txt
+++ b/tests/baselines/reference/jsxGenericTest2.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/conformance/jsxGeneric/file.tsx(16,17): error TS2728: Intrinsic JSX element 'br' does not exist in factory 'createElement'.
+
+
+==== tests/cases/conformance/jsxGeneric/file.tsx (1 errors) ====
+    /* @jsx-mode generic */
+    /* @jsx-intrinsic-factory createElement */
+    
+    interface HTMLAttributes {
+        class?:     string;
+        id?:        string;
+        onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+    }
+     
+    function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+        return document.createElement(tagName);
+    }
+    
+    function test() {
+        return <div class="test">
+                    <br/>
+                    ~~~~~
+!!! error TS2728: Intrinsic JSX element 'br' does not exist in factory 'createElement'.
+               </div>;
+    }

--- a/tests/baselines/reference/jsxGenericTest2.js
+++ b/tests/baselines/reference/jsxGenericTest2.js
@@ -1,0 +1,34 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <br/>
+           </div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" },
+        createElement("br", null));
+}

--- a/tests/baselines/reference/jsxGenericTest2.symbols
+++ b/tests/baselines/reference/jsxGenericTest2.symbols
@@ -1,0 +1,46 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1))
+>tagName : Symbol(tagName, Decl(file.tsx, 9, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 9, 44))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 9, 68))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 9, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 11, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 14, 15))
+
+                <br/>
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest2.types
+++ b/tests/baselines/reference/jsxGenericTest2.types
@@ -1,0 +1,53 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : (tagName: "div" | "span", attrs?: HTMLAttributes, ...children: HTMLElement[]) => HTMLElement
+>tagName : "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span"
+}
+
+function test() {
+>test : () => HTMLElement
+
+    return <div class="test">
+><div class="test">                <br/>           </div> : HTMLElement
+>div : any
+>class : string
+
+                <br/>
+><br/> : any
+>br : any
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest3.errors.txt
+++ b/tests/baselines/reference/jsxGenericTest3.errors.txt
@@ -1,0 +1,38 @@
+tests/cases/conformance/jsxGeneric/file.tsx(10,10): error TS17022: Invalid JSX intrinsic factory
+tests/cases/conformance/jsxGeneric/file.tsx(11,35): error TS2345: Argument of type 'number | "div" | "span"' is not assignable to parameter of type 'string'.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsxGeneric/file.tsx(15,12): error TS2728: Intrinsic JSX element 'div' does not exist in factory 'createElement'.
+tests/cases/conformance/jsxGeneric/file.tsx(16,17): error TS2728: Intrinsic JSX element 'span' does not exist in factory 'createElement'.
+tests/cases/conformance/jsxGeneric/file.tsx(17,12): error TS2728: Intrinsic JSX element 'div' does not exist in factory 'createElement'.
+
+
+==== tests/cases/conformance/jsxGeneric/file.tsx (5 errors) ====
+    /* @jsx-mode generic */
+    /* @jsx-intrinsic-factory createElement */
+    
+    interface HTMLAttributes {
+        class?:     string;
+        id?:        string;
+        onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+    }
+     
+    function createElement(tagName:"div"|"span"|number, attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+             ~~~~~~~~~~~~~
+!!! error TS17022: Invalid JSX intrinsic factory
+        return document.createElement(tagName);
+                                      ~~~~~~~
+!!! error TS2345: Argument of type 'number | "div" | "span"' is not assignable to parameter of type 'string'.
+!!! error TS2345:   Type 'number' is not assignable to type 'string'.
+    }
+    
+    function test() {
+        return <div class="test">
+               ~~~~~~~~~~~~~~~~~~
+!!! error TS2728: Intrinsic JSX element 'div' does not exist in factory 'createElement'.
+                    <span/>
+                    ~~~~~~~
+!!! error TS2728: Intrinsic JSX element 'span' does not exist in factory 'createElement'.
+               </div>;
+               ~~~~~~
+!!! error TS2728: Intrinsic JSX element 'div' does not exist in factory 'createElement'.
+    }

--- a/tests/baselines/reference/jsxGenericTest3.js
+++ b/tests/baselines/reference/jsxGenericTest3.js
@@ -1,0 +1,34 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+function createElement(tagName:"div"|"span"|number, attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+           </div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" },
+        createElement("span", null));
+}

--- a/tests/baselines/reference/jsxGenericTest3.symbols
+++ b/tests/baselines/reference/jsxGenericTest3.symbols
@@ -1,0 +1,46 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+function createElement(tagName:"div"|"span"|number, attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1))
+>tagName : Symbol(tagName, Decl(file.tsx, 9, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 9, 51))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 9, 75))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 9, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 11, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 14, 15))
+
+                <span/>
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest3.types
+++ b/tests/baselines/reference/jsxGenericTest3.types
@@ -1,0 +1,53 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+function createElement(tagName:"div"|"span"|number, attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : (tagName: number | "div" | "span", attrs?: HTMLAttributes, ...children: HTMLElement[]) => HTMLElement
+>tagName : number | "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : any
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : number | "div" | "span"
+}
+
+function test() {
+>test : () => any
+
+    return <div class="test">
+><div class="test">                <span/>           </div> : any
+>div : any
+>class : string
+
+                <span/>
+><span/> : any
+>span : any
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest4.errors.txt
+++ b/tests/baselines/reference/jsxGenericTest4.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/conformance/jsxGeneric/file.tsx(15,30): error TS2339: Property 'pipo' does not exist on type 'HTMLAttributes'.
+
+
+==== tests/cases/conformance/jsxGeneric/file.tsx (1 errors) ====
+    /* @jsx-mode generic */
+    /* @jsx-intrinsic-factory createElement */
+    
+    interface HTMLAttributes {
+        class?:     string;
+        id?:        string;
+        onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+    }
+     
+    function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+        return document.createElement(tagName);
+    }
+    
+    function test() {
+        return <div class="test" pipo="1">
+                                 ~~~~~~~~
+!!! error TS2339: Property 'pipo' does not exist on type 'HTMLAttributes'.
+                    <span/>
+               </div>;
+    }

--- a/tests/baselines/reference/jsxGenericTest4.js
+++ b/tests/baselines/reference/jsxGenericTest4.js
@@ -1,0 +1,34 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test" pipo="1">
+                <span/>
+           </div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test", pipo: "1" },
+        createElement("span", null));
+}

--- a/tests/baselines/reference/jsxGenericTest4.symbols
+++ b/tests/baselines/reference/jsxGenericTest4.symbols
@@ -1,0 +1,47 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 7, 1))
+>tagName : Symbol(tagName, Decl(file.tsx, 9, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 9, 44))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 9, 68))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 9, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 11, 1))
+
+    return <div class="test" pipo="1">
+>class : Symbol(class, Decl(file.tsx, 14, 15))
+>pipo : Symbol(pipo, Decl(file.tsx, 14, 28))
+
+                <span/>
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest4.types
+++ b/tests/baselines/reference/jsxGenericTest4.types
@@ -1,0 +1,54 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+>createElement : (tagName: "div" | "span", attrs?: HTMLAttributes, ...children: HTMLElement[]) => HTMLElement
+>tagName : "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : HTMLElement[]
+>HTMLElement : HTMLElement
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span"
+}
+
+function test() {
+>test : () => HTMLElement
+
+    return <div class="test" pipo="1">
+><div class="test" pipo="1">                <span/>           </div> : HTMLElement
+>div : any
+>class : string
+>pipo : string
+
+                <span/>
+><span/> : HTMLElement
+>span : any
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest5.errors.txt
+++ b/tests/baselines/reference/jsxGenericTest5.errors.txt
@@ -1,0 +1,19 @@
+tests/cases/conformance/jsxGeneric/file.tsx(4,12): error TS17021: No JSX intrinsic factory defined.
+tests/cases/conformance/jsxGeneric/file.tsx(5,17): error TS17021: No JSX intrinsic factory defined.
+tests/cases/conformance/jsxGeneric/file.tsx(6,12): error TS17021: No JSX intrinsic factory defined.
+
+
+==== tests/cases/conformance/jsxGeneric/file.tsx (3 errors) ====
+    /* @jsx-mode generic */
+    
+    function test() {
+        return <div class="test">
+               ~~~~~~~~~~~~~~~~~~
+!!! error TS17021: No JSX intrinsic factory defined.
+                    <span/>
+                    ~~~~~~~
+!!! error TS17021: No JSX intrinsic factory defined.
+               </div>;
+               ~~~~~~
+!!! error TS17021: No JSX intrinsic factory defined.
+    }

--- a/tests/baselines/reference/jsxGenericTest5.js
+++ b/tests/baselines/reference/jsxGenericTest5.js
@@ -1,0 +1,15 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+
+function test() {
+    return <div class="test">
+                <span/>
+           </div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+function test() {
+    return ERROR_UNKNOWN_INTRINSIC_FACTORY("div", { "class": "test" },
+        ERROR_UNKNOWN_INTRINSIC_FACTORY("span", null));
+}

--- a/tests/baselines/reference/jsxGenericTest5.symbols
+++ b/tests/baselines/reference/jsxGenericTest5.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 0, 0))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 3, 15))
+
+                <span/>
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest5.types
+++ b/tests/baselines/reference/jsxGenericTest5.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+
+function test() {
+>test : () => any
+
+    return <div class="test">
+><div class="test">                <span/>           </div> : any
+>div : any
+>class : string
+
+                <span/>
+><span/> : any
+>span : any
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest6.js
+++ b/tests/baselines/reference/jsxGenericTest6.js
@@ -1,0 +1,39 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+           </div>;
+}
+
+//// [file.js]
+"use strict";
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+exports.__esModule = true;
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" },
+        createElement("span", null));
+}

--- a/tests/baselines/reference/jsxGenericTest6.symbols
+++ b/tests/baselines/reference/jsxGenericTest6.symbols
@@ -1,0 +1,56 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 10, 59))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 12, 44))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 12, 68))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 14, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 17, 15))
+
+                <span/>
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest6.types
+++ b/tests/baselines/reference/jsxGenericTest6.types
@@ -1,0 +1,64 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+>AddArray : AddArray
+>Array : T[]
+>AddNode : AddNode
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+>AddArray : AddArray
+>false : false
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : (tagName: "div" | "span", attrs?: HTMLAttributes, ...children: AddNode[]) => HTMLElement
+>tagName : "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : AddNode[]
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span"
+}
+
+function test() {
+>test : () => HTMLElement
+
+    return <div class="test">
+><div class="test">                <span/>           </div> : HTMLElement
+>div : any
+>class : string
+
+                <span/>
+><span/> : HTMLElement
+>span : any
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest7.js
+++ b/tests/baselines/reference/jsxGenericTest7.js
@@ -1,0 +1,38 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                { false }
+           </div>;
+}
+
+//// [file.js]
+"use strict";
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+exports.__esModule = true;
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" }, false);
+}

--- a/tests/baselines/reference/jsxGenericTest7.symbols
+++ b/tests/baselines/reference/jsxGenericTest7.symbols
@@ -1,0 +1,56 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 10, 59))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 12, 44))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 12, 68))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 14, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 17, 15))
+
+                { false }
+           </div>;
+}

--- a/tests/baselines/reference/jsxGenericTest7.types
+++ b/tests/baselines/reference/jsxGenericTest7.types
@@ -1,0 +1,63 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+>AddArray : AddArray
+>Array : T[]
+>AddNode : AddNode
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+>AddArray : AddArray
+>false : false
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : (tagName: "div" | "span", attrs?: HTMLAttributes, ...children: AddNode[]) => HTMLElement
+>tagName : "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : AddNode[]
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span"
+}
+
+function test() {
+>test : () => HTMLElement
+
+    return <div class="test">
+><div class="test">                { false }           </div> : HTMLElement
+>div : any
+>class : string
+
+                { false }
+>false : false
+
+           </div>;
+>div : any
+}

--- a/tests/baselines/reference/jsxGenericTest8.js
+++ b/tests/baselines/reference/jsxGenericTest8.js
@@ -1,0 +1,45 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                { x() }
+           </div>;
+}
+
+function x(): AddNode {
+    return <span/>;
+}
+
+//// [file.js]
+"use strict";
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+exports.__esModule = true;
+function createElement(tagName, attrs) {
+    var children = [];
+    for (var _i = 2; _i < arguments.length; _i++) {
+        children[_i - 2] = arguments[_i];
+    }
+    return document.createElement(tagName);
+}
+function test() {
+    return createElement("div", { "class": "test" }, x());
+}
+function x() {
+    return createElement("span", null);
+}

--- a/tests/baselines/reference/jsxGenericTest8.symbols
+++ b/tests/baselines/reference/jsxGenericTest8.symbols
@@ -1,0 +1,65 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(HTMLAttributes.class, Decl(file.tsx, 3, 26))
+
+    id?:        string;
+>id : Symbol(HTMLAttributes.id, Decl(file.tsx, 4, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(HTMLAttributes.onclick, Decl(file.tsx, 5, 23))
+>this : Symbol(this, Decl(file.tsx, 6, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 6, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>AddArray : Symbol(AddArray, Decl(file.tsx, 7, 1))
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : Symbol(createElement, Decl(file.tsx, 10, 59))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+>attrs : Symbol(attrs, Decl(file.tsx, 12, 44))
+>HTMLAttributes : Symbol(HTMLAttributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 12, 68))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+
+    return document.createElement(tagName);
+>document.createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>document : Symbol(document, Decl(lib.dom.d.ts, --, --))
+>createElement : Symbol(Document.createElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>tagName : Symbol(tagName, Decl(file.tsx, 12, 23))
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 14, 1))
+
+    return <div class="test">
+>class : Symbol(class, Decl(file.tsx, 17, 15))
+
+                { x() }
+>x : Symbol(x, Decl(file.tsx, 20, 1))
+
+           </div>;
+}
+
+function x(): AddNode {
+>x : Symbol(x, Decl(file.tsx, 20, 1))
+>AddNode : Symbol(AddNode, Decl(file.tsx, 9, 51))
+
+    return <span/>;
+}

--- a/tests/baselines/reference/jsxGenericTest8.types
+++ b/tests/baselines/reference/jsxGenericTest8.types
@@ -1,0 +1,73 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+>HTMLAttributes : HTMLAttributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+>AddArray : AddArray
+>Array : T[]
+>AddNode : AddNode
+
+export type AddNode    = HTMLElement|string|AddArray|false;
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+>AddArray : AddArray
+>false : false
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+>createElement : (tagName: "div" | "span", attrs?: HTMLAttributes, ...children: AddNode[]) => HTMLElement
+>tagName : "div" | "span"
+>attrs : HTMLAttributes
+>HTMLAttributes : HTMLAttributes
+>children : AddNode[]
+>AddNode : AddNode
+>HTMLElement : HTMLElement
+
+    return document.createElement(tagName);
+>document.createElement(tagName) : HTMLDivElement | HTMLSpanElement
+>document.createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>document : Document
+>createElement : { <K extends "object" | "div" | "span" | "a" | "abbr" | "acronym" | "address" | "applet" | "area" | "article" | "aside" | "audio" | "b" | "base" | "basefont" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | "canvas" | "caption" | "center" | "cite" | "code" | "col" | "colgroup" | "data" | "datalist" | "dd" | "del" | "dfn" | "dir" | "dl" | "dt" | "em" | "embed" | "fieldset" | "figcaption" | "figure" | "font" | "footer" | "form" | "frame" | "frameset" | "h1" | "h2" | "h3" | "h4" | "h5" | "h6" | "head" | "header" | "hgroup" | "hr" | "html" | "i" | "iframe" | "img" | "input" | "ins" | "isindex" | "kbd" | "keygen" | "label" | "legend" | "li" | "link" | "listing" | "map" | "mark" | "marquee" | "menu" | "meta" | "meter" | "nav" | "nextid" | "nobr" | "noframes" | "noscript" | "ol" | "optgroup" | "option" | "output" | "p" | "param" | "picture" | "plaintext" | "pre" | "progress" | "q" | "rt" | "ruby" | "s" | "samp" | "script" | "section" | "select" | "slot" | "small" | "source" | "strike" | "strong" | "style" | "sub" | "sup" | "table" | "tbody" | "td" | "template" | "textarea" | "tfoot" | "th" | "thead" | "time" | "title" | "tr" | "track" | "tt" | "u" | "ul" | "var" | "video" | "wbr" | "xmp">(tagName: K, options?: ElementCreationOptions): HTMLElementTagNameMap[K]; (tagName: string, options?: ElementCreationOptions): HTMLElement; }
+>tagName : "div" | "span"
+}
+
+function test() {
+>test : () => HTMLElement
+
+    return <div class="test">
+><div class="test">                { x() }           </div> : HTMLElement
+>div : any
+>class : string
+
+                { x() }
+>x() : AddNode
+>x : () => AddNode
+
+           </div>;
+>div : any
+}
+
+function x(): AddNode {
+>x : () => AddNode
+>AddNode : AddNode
+
+    return <span/>;
+><span/> : HTMLElement
+>span : any
+}

--- a/tests/baselines/reference/jsxGenericTest9.js
+++ b/tests/baselines/reference/jsxGenericTest9.js
@@ -1,0 +1,54 @@
+//// [file.tsx]
+/* @jsx-mode generic */
+
+interface Attributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+class Div {
+	constructor(attrs?: Attributes, ...children:Span[]) {
+	}
+	
+	public dummy() {
+	}
+}
+
+class Span {
+	constructor(attrs?: Attributes, ...children:Div[]) {
+	}
+}
+
+function test() {
+    return <Div class="test">
+                <Span/>
+           </Div>;
+}
+
+//// [file.js]
+/* @jsx-mode generic */
+var Div = /** @class */ (function () {
+    function Div(attrs) {
+        var children = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            children[_i - 1] = arguments[_i];
+        }
+    }
+    Div.prototype.dummy = function () {
+    };
+    return Div;
+}());
+var Span = /** @class */ (function () {
+    function Span(attrs) {
+        var children = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            children[_i - 1] = arguments[_i];
+        }
+    }
+    return Span;
+}());
+function test() {
+    return new Div({ "class": "test" },
+        new Span(null));
+}

--- a/tests/baselines/reference/jsxGenericTest9.symbols
+++ b/tests/baselines/reference/jsxGenericTest9.symbols
@@ -1,0 +1,59 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+
+interface Attributes {
+>Attributes : Symbol(Attributes, Decl(file.tsx, 0, 0))
+
+    class?:     string;
+>class : Symbol(Attributes.class, Decl(file.tsx, 2, 22))
+
+    id?:        string;
+>id : Symbol(Attributes.id, Decl(file.tsx, 3, 23))
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : Symbol(Attributes.onclick, Decl(file.tsx, 4, 23))
+>this : Symbol(this, Decl(file.tsx, 5, 17))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+>ev : Symbol(ev, Decl(file.tsx, 5, 35))
+>MouseEvent : Symbol(MouseEvent, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+}
+ 
+class Div {
+>Div : Symbol(Div, Decl(file.tsx, 6, 1))
+
+	constructor(attrs?: Attributes, ...children:Span[]) {
+>attrs : Symbol(attrs, Decl(file.tsx, 9, 13))
+>Attributes : Symbol(Attributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 9, 32))
+>Span : Symbol(Span, Decl(file.tsx, 14, 1))
+	}
+	
+	public dummy() {
+>dummy : Symbol(Div.dummy, Decl(file.tsx, 10, 2))
+	}
+}
+
+class Span {
+>Span : Symbol(Span, Decl(file.tsx, 14, 1))
+
+	constructor(attrs?: Attributes, ...children:Div[]) {
+>attrs : Symbol(attrs, Decl(file.tsx, 17, 13))
+>Attributes : Symbol(Attributes, Decl(file.tsx, 0, 0))
+>children : Symbol(children, Decl(file.tsx, 17, 32))
+>Div : Symbol(Div, Decl(file.tsx, 6, 1))
+	}
+}
+
+function test() {
+>test : Symbol(test, Decl(file.tsx, 19, 1))
+
+    return <Div class="test">
+>Div : Symbol(Div, Decl(file.tsx, 6, 1))
+>class : Symbol(class, Decl(file.tsx, 22, 15))
+
+                <Span/>
+>Span : Symbol(Span, Decl(file.tsx, 14, 1))
+
+           </Div>;
+>Div : Symbol(Div, Decl(file.tsx, 6, 1))
+}

--- a/tests/baselines/reference/jsxGenericTest9.types
+++ b/tests/baselines/reference/jsxGenericTest9.types
@@ -1,0 +1,61 @@
+=== tests/cases/conformance/jsxGeneric/file.tsx ===
+/* @jsx-mode generic */
+
+interface Attributes {
+>Attributes : Attributes
+
+    class?:     string;
+>class : string
+
+    id?:        string;
+>id : string
+
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+>onclick : (this: HTMLElement, ev: MouseEvent) => void
+>this : HTMLElement
+>HTMLElement : HTMLElement
+>ev : MouseEvent
+>MouseEvent : MouseEvent
+}
+ 
+class Div {
+>Div : Div
+
+	constructor(attrs?: Attributes, ...children:Span[]) {
+>attrs : Attributes
+>Attributes : Attributes
+>children : Span[]
+>Span : Span
+	}
+	
+	public dummy() {
+>dummy : () => void
+	}
+}
+
+class Span {
+>Span : Span
+
+	constructor(attrs?: Attributes, ...children:Div[]) {
+>attrs : Attributes
+>Attributes : Attributes
+>children : Div[]
+>Div : Div
+	}
+}
+
+function test() {
+>test : () => Div
+
+    return <Div class="test">
+><Div class="test">                <Span/>           </Div> : Div
+>Div : typeof Div
+>class : string
+
+                <Span/>
+><Span/> : Span
+>Span : typeof Span
+
+           </Div>;
+>Div : typeof Div
+}

--- a/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
@@ -6,7 +6,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
@@ -6,7 +6,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'. */
     "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -6,7 +6,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -6,7 +6,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "jsx": "react",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
@@ -6,7 +6,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["es5","es2015.promise"],          /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -6,7 +6,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -6,7 +6,7 @@
     "lib": ["es5","es2015.core"],             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -6,7 +6,7 @@
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', 'react' or 'transpile'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest1.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest1.tsx
@@ -1,0 +1,20 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest10.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest10.tsx
@@ -1,0 +1,31 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+
+interface Attributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+class Div {
+	constructor(attrs?: Attributes, ...children:Span[]) {
+	}
+	
+	public dummy() {
+	}
+}
+
+class Span {
+	constructor(attrs?: Attributes, ...children:Div[]) {
+	}
+}
+
+function test() {
+    return <Div class="test">
+                <Span>
+					<Div/>
+					<Span/>
+				</Span>
+           </Div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest11.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest11.tsx
@@ -1,0 +1,50 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+export interface IContainer {
+    readonly container: HTMLElement;
+}
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|IContainer|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <Simple text="test"/>
+                <FunctionContainer>
+                    <span />
+                </FunctionContainer>
+                <ClassContainer>
+                    <span />
+                    { false }
+                </ClassContainer>
+                { false }
+           </div>;
+}
+
+function Simple(attr: { text:string }) {
+    return <span>{ attr.text }</span>;
+}
+
+function FunctionContainer(attr: { }, ...children:AddNode[]) {
+    return <div>{ children }</div>;
+}
+
+class ClassContainer implements IContainer {
+    public container:HTMLElement;
+
+    constructor(attrs?: {}, ...children:AddNode[]) {
+        this.container = <div>{ children }</div>;
+	}
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest12.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest12.tsx
@@ -1,0 +1,29 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    const f = <>
+                <span>1</span>
+                <span>2</span>
+              </>;
+
+    return <div class="test">
+                <span/>
+                { f }
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest13.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest13.tsx
@@ -1,0 +1,29 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    const f = <>
+                <span>1</span>
+                { 10 }
+              </>;
+
+    return <div class="test">
+                <span/>
+                { f }
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest14.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest14.tsx
@@ -1,0 +1,24 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+function createElement(tagName:"br"): HTMLBRElement;
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+                <br/>
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest15.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest15.tsx
@@ -1,0 +1,28 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+function createElement(tagName:"br"): HTMLBRElement;
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+                <br>
+                    <span class=""/>
+                </br>
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest16.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest16.tsx
@@ -1,0 +1,26 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+
+
+
+function createElement(tagName:"div", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLDivElement;
+function createElement(tagName:"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLSpanElement;
+function createElement(tagName:"br"): HTMLBRElement;
+function createElement(tagName:"div"|"span"|"br", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+                <br class=""/>
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest2.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest2.tsx
@@ -1,0 +1,20 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <br/>
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest3.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest3.tsx
@@ -1,0 +1,20 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+function createElement(tagName:"div"|"span"|number, attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest4.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest4.tsx
@@ -1,0 +1,20 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:HTMLElement[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test" pipo="1">
+                <span/>
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest5.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest5.tsx
@@ -1,0 +1,9 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+
+function test() {
+    return <div class="test">
+                <span/>
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest6.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest6.tsx
@@ -1,0 +1,23 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                <span/>
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest7.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest7.tsx
@@ -1,0 +1,23 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                { false }
+           </div>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest8.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest8.tsx
@@ -1,0 +1,27 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+/* @jsx-intrinsic-factory createElement */
+
+interface HTMLAttributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+export interface AddArray extends Array<AddNode> {}
+export type AddNode    = HTMLElement|string|AddArray|false;
+
+function createElement(tagName:"div"|"span", attrs?: HTMLAttributes, ...children:AddNode[]): HTMLElement {
+    return document.createElement(tagName);
+}
+
+function test() {
+    return <div class="test">
+                { x() }
+           </div>;
+}
+
+function x(): AddNode {
+    return <span/>;
+}

--- a/tests/cases/conformance/jsxGeneric/jsxGenericTest9.tsx
+++ b/tests/cases/conformance/jsxGeneric/jsxGenericTest9.tsx
@@ -1,0 +1,28 @@
+// @filename: file.tsx
+// @jsx: transpile
+/* @jsx-mode generic */
+
+interface Attributes {
+    class?:     string;
+    id?:        string;
+    onclick?:   (this: HTMLElement, ev: MouseEvent) => void;
+}
+ 
+class Div {
+	constructor(attrs?: Attributes, ...children:Span[]) {
+	}
+	
+	public dummy() {
+	}
+}
+
+class Span {
+	constructor(attrs?: Attributes, ...children:Div[]) {
+	}
+}
+
+function test() {
+    return <Div class="test">
+                <Span/>
+           </Div>;
+}


### PR DESCRIPTION
Since typescript 1.6 we patch typescript so that we can use JSX with our projects. Originally, we had problems with JSX not working together with require (and requirejs). require is no longer required (import also works with AMD). However, we ran into the fact that JSX was written with React in mind.

Although we use typescript with the patch, it is not directly written for our environment.
This patch translates JSX element to standard typescript / javascript. And has no knowledge of any library/framework 

* Intrinsic elements use a factory defined by / * @ jsx-intrinsic-factory * /
* Custom elements can be functions or classes. And transpiles to function calls or class constructs
* Fragments are translated to arrays.
* No JSX namespace is required.
* Everything with complete typing :)

All tests run unchanged and 16 tests were added. There are no braking changes.

See https://github.com/pjannesen/TypeScript-jsx-generic for examples.

It is a large patch, but please give it a look and say what you think about it.