### PR TITLE
addClassStaticThisReferences: Don't cross class boundary

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1040,7 +1040,7 @@ namespace ts.FindAllReferences.Core {
                     if (node.kind === SyntaxKind.ThisKeyword) {
                         addRef(node);
                     }
-                    else if (!isFunctionLike(node)) {
+                    else if (!isFunctionLike(node) && !isClassLike(node)) {
                         node.forEachChild(cb);
                     }
                 });

--- a/tests/cases/fourslash/findAllRefsClassWithStaticThisAccess.ts
+++ b/tests/cases/fourslash/findAllRefsClassWithStaticThisAccess.ts
@@ -4,7 +4,12 @@
 ////    static s() {
 ////        [|this|];
 ////    }
-////    static get f() { return [|this|]; }
+////    static get f() {
+////        return [|this|];
+////
+////        function inner() { this; }
+////        class Inner { x = this; }
+////    }
 ////}
 
 const [r0, r1, r2] = test.ranges();


### PR DESCRIPTION
Fixes #24818

