### PR TITLE
goToDefinition: Don't add duplicate definitions for VariableDeclaration and ArrowFunction at `f = () => {}`

### DIFF
--- a/tests/cases/fourslash/goToDefinitionSignatureAlias.ts
+++ b/tests/cases/fourslash/goToDefinitionSignatureAlias.ts
@@ -8,8 +8,17 @@
 ////[|/*useG*/g|]();
 ////[|/*useH*/h|]();
 
+////const i = /*i*/() => 0;
+////const /*j*/j = i;
+
+////[|/*useI*/i|]();
+////[|/*useJ*/j|]();
+
 verify.goToDefinition({
     useF: "f",
     useG: ["g", "f"],
     useH: ["h", "f"],
+
+    useI: "i",
+    useJ: ["j", "i"],
 });


### PR DESCRIPTION
Fixes #24861

