### PR TITLE
Add Variable to HasExports

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3467,7 +3467,7 @@ namespace ts {
 
         ExportHasLocal = Function | Class | Enum | ValueModule,
 
-        HasExports = Class | Enum | Module,
+        HasExports = Class | Enum | Module | Variable,
         HasMembers = Class | Interface | TypeLiteral | ObjectLiteral,
 
         BlockScoped = BlockScopedVariable | Class | Enum,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2071,7 +2071,7 @@ declare namespace ts {
         AliasExcludes = 2097152,
         ModuleMember = 2623475,
         ExportHasLocal = 944,
-        HasExports = 1952,
+        HasExports = 1955,
         HasMembers = 6240,
         BlockScoped = 418,
         PropertyOrAccessor = 98308,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2071,7 +2071,7 @@ declare namespace ts {
         AliasExcludes = 2097152,
         ModuleMember = 2623475,
         ExportHasLocal = 944,
-        HasExports = 1952,
+        HasExports = 1955,
         HasMembers = 6240,
         BlockScoped = 418,
         PropertyOrAccessor = 98308,

--- a/tests/baselines/reference/moduleExportAlias5.symbols
+++ b/tests/baselines/reference/moduleExportAlias5.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/salsa/bug24754.js ===
+// #24754
+const webpack = function (){
+>webpack : Symbol(webpack, Decl(bug24754.js, 1, 5))
+}
+exports = module.exports = webpack;
+>exports : Symbol("tests/cases/conformance/salsa/bug24754", Decl(bug24754.js, 0, 0))
+>module : Symbol(export=, Decl(bug24754.js, 3, 9))
+>exports : Symbol(export=, Decl(bug24754.js, 3, 9))
+>webpack : Symbol(webpack, Decl(bug24754.js, 1, 5))
+
+exports.version = 1001;
+>exports.version : Symbol(version, Decl(bug24754.js, 3, 35))
+>exports : Symbol(version, Decl(bug24754.js, 3, 35))
+>version : Symbol(version, Decl(bug24754.js, 3, 35))
+
+webpack.WebpackOptionsDefaulter = 1111;
+>webpack.WebpackOptionsDefaulter : Symbol(webpack.WebpackOptionsDefaulter, Decl(bug24754.js, 4, 23))
+>webpack : Symbol(webpack, Decl(bug24754.js, 1, 5))
+>WebpackOptionsDefaulter : Symbol(webpack.WebpackOptionsDefaulter, Decl(bug24754.js, 4, 23))
+

--- a/tests/baselines/reference/moduleExportAlias5.types
+++ b/tests/baselines/reference/moduleExportAlias5.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/salsa/bug24754.js ===
+// #24754
+const webpack = function (){
+>webpack : { (): void; WebpackOptionsDefaulter: number; }
+>function (){} : { (): void; WebpackOptionsDefaulter: number; }
+}
+exports = module.exports = webpack;
+>exports = module.exports = webpack : { (): void; WebpackOptionsDefaulter: number; }
+>exports : typeof import("tests/cases/conformance/salsa/bug24754")
+>module.exports = webpack : { (): void; WebpackOptionsDefaulter: number; }
+>module.exports : any
+>module : any
+>exports : any
+>webpack : { (): void; WebpackOptionsDefaulter: number; }
+
+exports.version = 1001;
+>exports.version = 1001 : 1001
+>exports.version : number
+>exports : typeof import("tests/cases/conformance/salsa/bug24754")
+>version : number
+>1001 : 1001
+
+webpack.WebpackOptionsDefaulter = 1111;
+>webpack.WebpackOptionsDefaulter = 1111 : 1111
+>webpack.WebpackOptionsDefaulter : number
+>webpack : { (): void; WebpackOptionsDefaulter: number; }
+>WebpackOptionsDefaulter : number
+>1111 : 1111
+

--- a/tests/cases/conformance/salsa/moduleExportAlias5.ts
+++ b/tests/cases/conformance/salsa/moduleExportAlias5.ts
@@ -1,0 +1,11 @@
+// @checkJs: true
+// @allowJS: true
+// @noEmit: true
+// @Filename: bug24754.js
+// #24754
+const webpack = function (){
+}
+exports = module.exports = webpack;
+exports.version = 1001;
+
+webpack.WebpackOptionsDefaulter = 1111;


### PR DESCRIPTION
JS containers are variables, but may have exports just like classes and modules.

Fixes #24754

Note that this fixes webpack's exports. Consuming webpack is still broken, which will be fixed in #24732.
