### PR TITLE
Do not watch parent folders recursively if not needed

### DIFF
--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -8506,6 +8506,66 @@ new C();`
                 }
             });
         });
+
+        it("when watching directories for failed lookup locations in amd resolution", () => {
+            const projectRoot = "/user/username/projects/project";
+            const nodeFile: File = {
+                path: `${projectRoot}/src/typings/node.d.ts`,
+                content: `
+declare module "fs" {
+    export interface something {
+    }
+}`
+            };
+            const electronFile: File = {
+                path: `${projectRoot}/src/typings/electron.d.ts`,
+                content: `
+declare module 'original-fs' {
+    import * as fs from 'fs';
+    export = fs;
+}`
+            };
+            const srcFile: File = {
+                path: `${projectRoot}/src/somefolder/srcfile.ts`,
+                content: `
+import { x } from "somefolder/module1";
+import { x } from "somefolder/module2";
+const y = x;`
+            };
+            const moduleFile: File = {
+                path: `${projectRoot}/src/somefolder/module1.ts`,
+                content: `
+export const x = 10;`
+            };
+            const configFile: File = {
+                path: `${projectRoot}/src/tsconfig.json`,
+                content: JSON.stringify({
+                    compilerOptions: {
+                        module: "amd",
+                        moduleResolution: "classic",
+                        target: "es5",
+                        outDir: "../out",
+                        baseUrl: "./",
+                        typeRoots: ["typings"]
+
+                    }
+                })
+            };
+            const files = [nodeFile, electronFile, srcFile, moduleFile, configFile, libFile];
+            const host = createServerHost(files);
+            const service = createProjectService(host);
+            service.openClientFile(srcFile.path, srcFile.content, ScriptKind.TS, projectRoot);
+            checkProjectActualFiles(service.configuredProjects.get(configFile.path)!, files.map(f => f.path));
+            checkWatchedFilesDetailed(host, mapDefined(files, f => f === srcFile ? undefined : f.path), 1);
+            checkWatchedDirectories(host, emptyArray, /*recursive*/ false);
+            const expectedWatchedDirectories = createMap<number>();
+            expectedWatchedDirectories.set(`${projectRoot}/src`, 2); // Wild card and failed lookup
+            expectedWatchedDirectories.set(`${projectRoot}/somefolder`, 1); // failed lookup for somefolder/module2
+            expectedWatchedDirectories.set(`${projectRoot}`, 1); // failed lookup for fs
+            expectedWatchedDirectories.set(`${projectRoot}/node_modules`, 1); // failed lookup for with node_modules/@types/fs
+            expectedWatchedDirectories.set(`${projectRoot}/src/typings`, 1); // typeroot directory
+            checkWatchedDirectoriesDetailed(host, expectedWatchedDirectories, /*recursive*/ true);
+        });
     });
 
     describe("tsserverProjectSystem watchDirectories implementation", () => {


### PR DESCRIPTION
Fixes Microsoft/vscode#51139 further to avoid the unnecessary directory watch triggers

In case of AMD resolution, say we are trying to resolve module "fs" we would go looking for file fs.ts/fs.tsx/etc in each of the ancestor folder. At this point we use to create directory watch in the ancestor folder but to watch it recursively. This lead to the watch being triggered frequently. This fixes that issue since ancestor folders will be watched only for something directly in it. (eg. ancestor/fs.ts) In rest of the scenarios we will watch subdirectory of ancestor folder as shown in #24471
