### PR TITLE
Do not add duplicate jsdoc for assignment used as a declaration's initializer

### DIFF
--- a/src/parser/utilities.ts
+++ b/src/parser/utilities.ts
@@ -2097,7 +2097,12 @@ namespace ts {
             if (isBinaryExpression(node) && node.operatorToken.kind === SyntaxKind.EqualsToken ||
                 isBinaryExpression(parent) && parent.operatorToken.kind === SyntaxKind.EqualsToken ||
                 node.kind === SyntaxKind.PropertyAccessExpression && node.parent && node.parent.kind === SyntaxKind.ExpressionStatement) {
-                getJSDocCommentsAndTagsWorker(parent);
+                if (isBinaryExpression(parent)) {
+                    getJSDocCommentsAndTagsWorker(parent.parent);
+                }
+                else {
+                    getJSDocCommentsAndTagsWorker(parent);
+                }
             }
 
             // Pull parameter comments from declaring function as well

--- a/tests/baselines/reference/noDuplicateJsdoc1.errors.txt
+++ b/tests/baselines/reference/noDuplicateJsdoc1.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/jsdoc/a.js(2,11): error TS2304: Cannot find name 'b'.
+
+
+==== tests/cases/conformance/jsdoc/a.js (1 errors) ====
+    /** doc */
+    const a = b = () => 0;
+              ~
+!!! error TS2304: Cannot find name 'b'.
+    

--- a/tests/baselines/reference/noDuplicateJsdoc1.symbols
+++ b/tests/baselines/reference/noDuplicateJsdoc1.symbols
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/** doc */
+const a = b = () => 0;
+>a : Symbol(a, Decl(a.js, 1, 5))
+

--- a/tests/baselines/reference/noDuplicateJsdoc1.types
+++ b/tests/baselines/reference/noDuplicateJsdoc1.types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/** doc */
+const a = b = () => 0;
+>a : () => number
+>b = () => 0 : () => number
+>b : any
+>() => 0 : () => number
+>0 : 0
+

--- a/tests/cases/conformance/jsdoc/noDuplicateJsdoc1.ts
+++ b/tests/cases/conformance/jsdoc/noDuplicateJsdoc1.ts
@@ -1,0 +1,6 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: a.js
+/** doc */
+const a = b = () => 0;


### PR DESCRIPTION
Fixes #24963

A BinaryExpression used as a declaration's initializer incorrectly gets duplicated jsdoc, which hits the assert I added to prevent such cases. The reason is that the BinaryExpression case gets hit twice: once when the node is the arrow function and the BinaryExpression is the parent, and again when the node itself is a BinaryExpression. That's because the check for assignments happens both for `node` and `node.parent`, but recurs to `node.parent` both times. The fix is to recur to `node.parent.parent` when `node.parent` is a BinaryExpression.

Unfortunately, putting the `isBinaryExpression(node.parent)` check in the logical place also ends up recurring twice, albeit with no results the second time, which causes exponential search behaviour for deeply chained assignments like `exports.x = exports.y = ... = {}`. The check was previously in the logical place, but I moved it to fix that bug (#23115).

I think getJSDocCommentsAndWorker needs a serious overhaul. For now I am just fixing the bug, but I think it might be possible to do something like a simple walk up the parent chain looking for applicable (for some definition of applicable) jsdoc, stopping at some point like ExpressionStatement.