### PR TITLE
Give better error message for using import as type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9251,7 +9251,7 @@ namespace ts {
                         resolveImportSymbolType(node, links, moduleSymbol, targetMeaning);
                     }
                     else {
-                        error(node, targetMeaning === SymbolFlags.Value ? Diagnostics.Module_0_does_not_refer_to_a_value_but_is_used_as_a_value_here : Diagnostics.Module_0_does_not_refer_to_a_type_but_is_used_as_a_type_here, moduleName);
+                        error(node, targetMeaning === SymbolFlags.Value ? Diagnostics.Module_0_does_not_refer_to_a_value_but_is_used_as_a_value_here : Diagnostics.Did_you_mean_typeof_import_0, moduleName);
                         links.resolvedSymbol = unknownSymbol;
                         links.resolvedType = errorType;
                     }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -967,7 +967,7 @@
         "category": "Error",
         "code": 1339
     },
-    "Module '{0}' does not refer to a type, but is used as a type here.": {
+    "Did you mean \"typeof import('{0}')\"?": {
         "category": "Error",
         "code": 1340
     },
@@ -3636,7 +3636,7 @@
         "category": "Message",
         "code": 6353
     },
-    
+
     "Project '{0}' is up to date with .d.ts files from its dependencies": {
         "category": "Message",
         "code": 6354

--- a/src/services/codefixes/fixAddModuleReferTypeMissingTypeof.ts
+++ b/src/services/codefixes/fixAddModuleReferTypeMissingTypeof.ts
@@ -2,7 +2,7 @@
 namespace ts.codefix {
     const fixIdAddMissingTypeof = "fixAddModuleReferTypeMissingTypeof";
     const fixId = fixIdAddMissingTypeof;
-    const errorCodes = [Diagnostics.Module_0_does_not_refer_to_a_type_but_is_used_as_a_type_here.code];
+    const errorCodes = [Diagnostics.Did_you_mean_typeof_import_0.code];
     registerCodeFix({
         errorCodes,
         getCodeActions: context => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #24839

Changes:
- Updates message for using import() as type to `Did you mean "typeof import('@my_import')"?` in DiagnosticMessages
- Updated usages of message
- ~Separate commit - found a missing semicolon while figuring out what I was doing wrong from a build perspective (or, VS Code found it - woo!). Kept as a separate commit to be left out/included at reviewers discretion~ Looks like this was fixed between opening this PR and now

This is the first PR I have for TS, so if there's anything I can improve on (in this PR or otherwise), please feel free to let me know 🙂 

