### PR TITLE
goToDefinition: Don't add duplicate definitions for PropertyAssignment and ArrowFunction at `m: () => {}`

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -99,7 +99,7 @@ namespace ts.GoToDefinition {
      */
     function symbolMatchesSignature(s: Symbol, calledDeclaration: SignatureDeclaration) {
         return s === calledDeclaration.symbol || s === calledDeclaration.symbol.parent ||
-            isVariableDeclaration(calledDeclaration.parent) && s === calledDeclaration.parent.symbol;
+            (isVariableDeclaration(calledDeclaration.parent) || isPropertyAssignment(calledDeclaration.parent)) && s === calledDeclaration.parent.symbol;
     }
 
     export function getReferenceAtPosition(sourceFile: SourceFile, position: number, program: Program): { fileName: string, file: SourceFile } | undefined {

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -99,7 +99,7 @@ namespace ts.GoToDefinition {
      */
     function symbolMatchesSignature(s: Symbol, calledDeclaration: SignatureDeclaration) {
         return s === calledDeclaration.symbol || s === calledDeclaration.symbol.parent ||
-            (isVariableDeclaration(calledDeclaration.parent) || isPropertyAssignment(calledDeclaration.parent)) && s === calledDeclaration.parent.symbol;
+            !isCallLikeExpression(calledDeclaration.parent) && s === calledDeclaration.parent.symbol;
     }
 
     export function getReferenceAtPosition(sourceFile: SourceFile, position: number, program: Program): { fileName: string, file: SourceFile } | undefined {

--- a/tests/cases/fourslash/goToDefinitionSignatureAlias.ts
+++ b/tests/cases/fourslash/goToDefinitionSignatureAlias.ts
@@ -14,6 +14,9 @@
 ////[|/*useI*/i|]();
 ////[|/*useJ*/j|]();
 
+////const o = { m: /*m*/() => 0 };
+////o.[|/*useM*/m|]();
+
 verify.goToDefinition({
     useF: "f",
     useG: ["g", "f"],
@@ -21,4 +24,5 @@ verify.goToDefinition({
 
     useI: "i",
     useJ: ["j", "i"],
+    useM: "m",
 });


### PR DESCRIPTION
Sequel to #24863
Fixes an issue identified in #24809
