### PR TITLE
Dont use unreliable inodes for checking file identity

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -10,6 +10,15 @@ const ts = require("./lib/typescript");
 const del = require("del");
 const getDirSize = require("./scripts/build/getDirSize");
 
+// add node_modules to path so we don't need global modules, prefer the modules by adding them first
+var nodeModulesPathPrefix = path.resolve("./node_modules/.bin/") + path.delimiter;
+if (process.env.path !== undefined) {
+    process.env.path = nodeModulesPathPrefix + process.env.path;
+}
+else if (process.env.PATH !== undefined) {
+    process.env.PATH = nodeModulesPathPrefix + process.env.PATH;
+}
+
 const host = process.env.TYPESCRIPT_HOST || process.env.host || "node";
 
 const locales = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"];

--- a/scripts/build/getDirSize.js
+++ b/scripts/build/getDirSize.js
@@ -4,26 +4,19 @@ const { join } = require("path");
 
 /**
  * Find the size of a directory recursively.
- * Symbolic links are counted once (same inode).
+ * Symbolic links can cause a loop.
  * @param {string} root
- * @param {Set} seen
  * @returns {number} bytes
  */
-function getDirSize(root, seen = new Set()) {
+function getDirSize(root) {
     const stats = lstatSync(root);
-
-    if (seen.has(stats.ino)) {
-        return 0;
-    }
-
-    seen.add(stats.ino);
 
     if (!stats.isDirectory()) {
         return stats.size;
     }
 
     return readdirSync(root)
-        .map(file => getDirSize(join(root, file), seen))
+        .map(file => getDirSize(join(root, file)))
         .reduce((acc, num) => acc + num, 0);
 }
 

--- a/scripts/produceLKG.ts
+++ b/scripts/produceLKG.ts
@@ -75,7 +75,7 @@ async function writeGitAttributes() {
 
 async function copyWithCopyright(fileName: string) {
     const content = await fs.readFile(path.join(source, fileName), "utf-8");
-    await fs.writeFile(path.join(dest, fileName), copyright + "\r\n" + content);
+    await fs.writeFile(path.join(dest, fileName), copyright + "\n" + content);
 }
 
 async function copyFromBuiltLocal(fileName: string) {


### PR DESCRIPTION
Since node can report multiple files as having the same inode due to a casting bug, as just happened to me, ref https://github.com/nodejs/node/issues/12115 (and we dont need to handle symlinks anyway, tbh).

Also concatenate with just `lf`, since all the other line endings are `lf`, and we don't want mixed line endings in the lkg.