### PR TITLE
Slight improvement to SymbolDisplay for 'module.exports ='

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -385,11 +385,11 @@ namespace ts.SymbolDisplay {
                         const isExternalModuleDeclaration =
                             isModuleWithStringLiteralName(resolvedNode) &&
                             hasModifier(resolvedNode, ModifierFlags.Ambient);
-                        const shouldUseAliasName = symbol.name !== "default" && !isExternalModuleDeclaration;
+                        const shouldUseAliasName = symbol.name !== InternalSymbolName.Default && symbol.name !== InternalSymbolName.ExportEquals && !isExternalModuleDeclaration;
                         const resolvedInfo = getSymbolDisplayPartsDocumentationAndSymbolKind(
                             typeChecker,
                             resolvedSymbol,
-                            getSourceFileOfNode(resolvedNode),
+                            resolvedNode.getSourceFile(),
                             resolvedNode,
                             declarationName,
                             semanticMeaning,
@@ -402,16 +402,18 @@ namespace ts.SymbolDisplay {
                 }
             }
 
-            switch (symbol.declarations[0].kind) {
+            const kind = symbol.declarations[0].kind;
+            switch (kind) {
                 case SyntaxKind.NamespaceExportDeclaration:
                     displayParts.push(keywordPart(SyntaxKind.ExportKeyword));
                     displayParts.push(spacePart());
                     displayParts.push(keywordPart(SyntaxKind.NamespaceKeyword));
                     break;
+                case SyntaxKind.BinaryExpression: // For `module.exports =`
                 case SyntaxKind.ExportAssignment:
                     displayParts.push(keywordPart(SyntaxKind.ExportKeyword));
                     displayParts.push(spacePart());
-                    displayParts.push(keywordPart((symbol.declarations[0] as ExportAssignment).isExportEquals ? SyntaxKind.EqualsToken : SyntaxKind.DefaultKeyword));
+                    displayParts.push(keywordPart(kind === SyntaxKind.BinaryExpression || (symbol.declarations[0] as ExportAssignment).isExportEquals ? SyntaxKind.EqualsToken : SyntaxKind.DefaultKeyword));
                     break;
                 case SyntaxKind.ExportSpecifier:
                     displayParts.push(keywordPart(SyntaxKind.ExportKeyword));

--- a/tests/cases/fourslash/findAllRefs_importType_js.ts
+++ b/tests/cases/fourslash/findAllRefs_importType_js.ts
@@ -21,7 +21,7 @@ const [r0, r1, r2, r3, r4, r5] = test.ranges();
 verify.referenceGroups(r0, [
     { definition: "(local class) C", ranges: [r0] },
     // TODO: This definition is really ugly
-    { definition: "(alias) (local class) export=\nimport export=", ranges: [r3] },
+    { definition: "(alias) (local class) C\nexport = export=", ranges: [r3] },
 ]);
 verify.referenceGroups([r1, r5], [
     { definition: "class D\n(property) D: typeof D", ranges: [r1, r5, r5] }, // TODO: should only reference r5 once
@@ -33,5 +33,5 @@ verify.referenceGroups(r2, [
 verify.referenceGroups([r3, r4], [
     { definition: 'module "/a"', ranges: [r4] },
     { definition: "(local class) C", ranges: [r0] },
-    { definition: "(alias) (local class) export=\nimport export=", ranges: [r3] },
+    { definition: "(alias) (local class) C\nexport = export=", ranges: [r3] },
 ]);


### PR DESCRIPTION
Part of #24025

Makes us treat `module.exports =` more like `export =` in symbolDisplay. Unfortunately, `addFullSymbolName()` adds a second `export =` because that's the name we get from the checker -- ideally we could fix the checker to return the name of the exported class like it does for `export =`.