### PR TITLE
fixUnusedIdentifier: Don't needlessly exclude jsdoc

### DIFF
--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -173,8 +173,8 @@ namespace ts.codefix {
                 const typeParameters = getEffectiveTypeParameterDeclarations(<DeclarationWithTypeParameters>parent.parent);
                 if (typeParameters.length === 1) {
                     const { pos, end } = cast(typeParameters, isNodeArray);
-                    const previousToken = getTokenAtPosition(sourceFile, pos - 1, /*includeJsDocComment*/ false);
-                    const nextToken = getTokenAtPosition(sourceFile, end, /*includeJsDocComment*/ false);
+                    const previousToken = getTokenAtPosition(sourceFile, pos - 1, /*includeJsDocComment*/ true);
+                    const nextToken = getTokenAtPosition(sourceFile, end, /*includeJsDocComment*/ true);
                     Debug.assert(previousToken.kind === SyntaxKind.LessThanToken);
                     Debug.assert(nextToken.kind === SyntaxKind.GreaterThanToken);
 

--- a/tests/cases/fourslash/fixUnusedIdentifier_jsdocTypeParameter.ts
+++ b/tests/cases/fourslash/fixUnusedIdentifier_jsdocTypeParameter.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+
+// @Filename: /a.js
+/////**
+//// * @type {<T>() => void}
+//// */
+////export const x = 0;
+
+verify.codeFix({
+    description: "Remove declaration for: 'T'",
+    newFileContent:
+`/**
+ * @type {() => void}
+ */
+export const x = 0;`,
+});


### PR DESCRIPTION
Fixes #24913

