### PR TITLE
Support doc comment template at function expression

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -263,11 +263,7 @@ namespace ts.JsDoc {
             return { newText: singleLineResult, caretOffset: 3 };
         }
 
-        const posLineAndChar = sourceFile.getLineAndCharacterOfPosition(position);
-        const lineStart = sourceFile.getLineStarts()[posLineAndChar.line];
-
-        // replace non-whitespace characters in prefix with spaces.
-        const indentationStr = sourceFile.text.substr(lineStart, posLineAndChar.character).replace(/\S/i, () => " ");
+        const indentationStr = getIndentationStringAtPosition(sourceFile, position);
 
         // A doc comment consists of the following
         // * The opening comment line
@@ -276,8 +272,7 @@ namespace ts.JsDoc {
         // * TODO: other tags.
         // * the closing comment line
         // * if the caret was directly in front of the object, then we add an extra line and indentation.
-        const preamble = "/**" + newLine +
-            indentationStr + " * ";
+        const preamble = "/**" + newLine + indentationStr + " * ";
         const result =
             preamble + newLine +
             parameterDocComments(parameters, hasJavaScriptFileExtension(sourceFile.fileName), indentationStr, newLine) +
@@ -285,6 +280,14 @@ namespace ts.JsDoc {
             (tokenStart === position ? newLine + indentationStr : "");
 
         return { newText: result, caretOffset: preamble.length };
+    }
+
+    function getIndentationStringAtPosition(sourceFile: SourceFile, position: number): string {
+        const { text } = sourceFile;
+        const lineStart = getLineStartPositionForPosition(position, sourceFile);
+        let pos = lineStart;
+        for (; pos <= position && isWhiteSpaceSingleLine(text.charCodeAt(pos)); pos++);
+        return text.slice(lineStart, pos);
     }
 
     function parameterDocComments(parameters: ReadonlyArray<ParameterDeclaration>, isJavaScriptFile: boolean, indentationStr: string, newLine: string): string {
@@ -303,6 +306,7 @@ namespace ts.JsDoc {
         for (let commentOwner = tokenAtPos; commentOwner; commentOwner = commentOwner.parent) {
             switch (commentOwner.kind) {
                 case SyntaxKind.FunctionDeclaration:
+                case SyntaxKind.FunctionExpression:
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.Constructor:
                 case SyntaxKind.MethodSignature:

--- a/tests/cases/fourslash/docCommentTemplateClassDeclMethods01.ts
+++ b/tests/cases/fourslash/docCommentTemplateClassDeclMethods01.ts
@@ -9,7 +9,7 @@ const multiLineOffset = 12;
 ////    foo();
 ////    /*2*/foo(a);
 ////    /*3*/foo(a, b);
-////    /*4*/ foo(a, {x: string}, [c]);
+////    /*4*/foo(a, {x: string}, [c]);
 ////    /*5*/foo(a?, b?, ...args) {
 ////    }
 ////}
@@ -43,7 +43,8 @@ verify.docCommentTemplateAt("4", multiLineOffset,
      * @param a
      * @param param1
      * @param param2
-     */`);
+     */
+    `);
 
 verify.docCommentTemplateAt("5", multiLineOffset,
     `/**

--- a/tests/cases/fourslash/docCommentTemplateFunctionExpression.ts
+++ b/tests/cases/fourslash/docCommentTemplateFunctionExpression.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts' />
+
+/////*above*/
+////const x = /*next*/ function f(p) {}
+
+for (const marker of test.markerNames()) {
+    verify.docCommentTemplateAt(marker, 8,
+`/**
+ * 
+ * @param p
+ */`);
+}

--- a/tests/cases/fourslash/docCommentTemplateObjectLiteralMethods01.ts
+++ b/tests/cases/fourslash/docCommentTemplateObjectLiteralMethods01.ts
@@ -12,8 +12,7 @@ const multiLineOffset = 12;
 ////    [1 + 2 + 3 + Math.rand()](x: number, y: string, z = true) { }
 ////}
 
-verify.docCommentTemplateAt("0", singleLineOffset,
-  "/** */");
+verify.docCommentTemplateAt("0", singleLineOffset, "/** */");
 
 verify.docCommentTemplateAt("1", multiLineOffset,
    `/**

--- a/tests/cases/fourslash/docCommentTemplateRegex.ts
+++ b/tests/cases/fourslash/docCommentTemplateRegex.ts
@@ -1,6 +1,5 @@
 /// <reference path='fourslash.ts' />
 
-// @Filename: regex.ts
 ////var regex = /*0*///*1*/asdf/*2*/ /*3*///*4*/;
 
 for (const marker of test.markers()) {


### PR DESCRIPTION
Fixes #14280

Also needed to fix getting the indentation string. Previously it just copied whatever text was before the marker, but this wasn't guaranteed to be whitespace. There was an attempt to convert to spaces, but it only worked for the first character (due to forgetting the `g` regexp flag), and would generate too much whitespace anyway. Instead, we walk from the beginning of the line to the first non-whitespace character and make everything preceding that the indentation.