### PR TITLE
navigationBar: Avoid double recursion on special property assignment

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -277,7 +277,7 @@ namespace ts.NavigationBar {
                     case SpecialPropertyAssignmentKind.PrototypeProperty:
                     case SpecialPropertyAssignmentKind.Prototype:
                         addNodeWithRecursiveChild(node, (node as BinaryExpression).right);
-                        break;
+                        return;
                     case SpecialPropertyAssignmentKind.ThisProperty:
                     case SpecialPropertyAssignmentKind.Property:
                     case SpecialPropertyAssignmentKind.None:

--- a/tests/cases/fourslash/navbarNestedCommonJsExports.ts
+++ b/tests/cases/fourslash/navbarNestedCommonJsExports.ts
@@ -1,0 +1,35 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+
+// @Filename: /a.js
+////exports.a = exports.b = exports.c = 0;
+
+verify.navigationTree({
+    text: "<global>",
+    kind: "script",
+    childItems: [
+        {
+            text: "a",
+            kind: "const",
+            childItems: [
+                {
+                    text: "b",
+                    kind: "const",
+                    childItems: [{ text: "c", kind: "const" }],
+                },
+            ],
+        },
+    ],
+});
+
+verify.navigationBar([
+    {
+        text: "<global>",
+        kind: "script",
+        childItems: [
+            { text: "a", kind: "const" },
+        ],
+    },
+]);
+


### PR DESCRIPTION
Fixes the navtree issue from #24999.

Without this change, `b` would appear as both a top-level export and as a child of `a`, and then `c` would appear as a top-level export, a child of `a`, and a child of both `b`s, meaning an exponential blowup.