### PR TITLE
Multifaceted approach to performantly enabling fileExists outside of the synchronize step in the emit host

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1239,7 +1239,14 @@ namespace ts {
                     (fileName, data, writeByteOrderMark, onError, sourceFiles) => host.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles)),
                 isEmitBlocked,
                 readFile: f => host.readFile(f),
-                fileExists: f => host.fileExists(f),
+                fileExists: f => {
+                    // Use local caches
+                    const path = toPath(f);
+                    if (getSourceFileByPath(path)) return true;
+                    if (contains(missingFilePaths, path)) return false;
+                    // Before falling back to the host
+                    return host.fileExists(f);
+                },
                 ...(host.directoryExists ? { directoryExists: f => host.directoryExists!(f) } : {}),
             };
         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1278,6 +1278,7 @@ namespace ts {
             }
 
             function getOrCreateSourceFileByPath(fileName: string, path: Path, _languageVersion: ScriptTarget, _onError?: (message: string) => void, shouldCreateNewSourceFile?: boolean): SourceFile | undefined {
+                Debug.assert(hostCache !== undefined);
                 // The program is asking for this file, check first if the host can locate it.
                 // If the host can not locate the file, then it does not exist. return undefined
                 // to the program to allow reporting of errors for missing files.

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1278,7 +1278,7 @@ namespace ts {
             }
 
             function getOrCreateSourceFileByPath(fileName: string, path: Path, _languageVersion: ScriptTarget, _onError?: (message: string) => void, shouldCreateNewSourceFile?: boolean): SourceFile | undefined {
-                Debug.assert(hostCache !== undefined);
+                Debug.assert(hostCache !== undefined, "getOrCreateSourceFileByPath called after typical CompilerHost lifetime, check the callstack something with a reference to an old host.");
                 // The program is asking for this file, check first if the host can locate it.
                 // If the host can not locate the file, then it does not exist. return undefined
                 // to the program to allow reporting of errors for missing files.

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1246,7 +1246,7 @@ namespace ts {
 
             // hostCache is captured in the closure for 'getOrCreateSourceFile' but it should not be used past this point.
             // It needs to be cleared to allow all collected snapshots to be released
-            hostCache = undefined!;
+            hostCache = undefined;
 
             // We reset this cache on structure invalidation so we don't hold on to outdated files for long; however we can't use the `compilerHost` above,
             // Because it only functions until `hostCache` is cleared, while we'll potentially need the functionality to lazily read sourcemap files during

--- a/tests/cases/fourslash/importTypesDeclarationDiagnosticsNoServerError.ts
+++ b/tests/cases/fourslash/importTypesDeclarationDiagnosticsNoServerError.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @declaration: true
+// @Filename: node_modules/foo/index.d.ts
+////export function f(): I;
+////export interface I {
+////  x: number;
+////}
+// @Filename: a.ts
+////import { f } from "foo";
+////export const x = f();
+
+goTo.file(1);
+verify.getSemanticDiagnostics([]);


### PR DESCRIPTION
First, in `program`, as @sheetalkamat suggested, we use the local caches if they have a result for the desired path. Since they still may not (ie, because the file isn't in the program, which is possibly the case when attempting to check paths for module specifiers), we also keep around a "thin" version of the host cache - effectively a host cache that doesn't contain any file contents, just metadata. (This way if the file is looked up for other reasons, that data is still there.) Finally, if both of those fail, we should hit disk (via the language server host).

Fixes #25047

Deleting the host cache was a performance optimization so we didn't hold on to file contents for files we weren't actively using - this should retain that invariant, since we're replacing the cache with one with no content.

