### PR TITLE
Fix module specifier case handling for declaration emit

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -140,10 +140,11 @@ namespace ts.moduleSpecifiers {
         const result = createMap<string>();
         if (symlinks) {
             const currentDirectory = host.getCurrentDirectory ? host.getCurrentDirectory() : "";
+            const compareStrings = (!host.useCaseSensitiveFileNames || host.useCaseSensitiveFileNames()) ? compareStringsCaseSensitive : compareStringsCaseInsensitive;
             for (const [resolvedPath, originalPath] of symlinks) {
                 const resolvedParts = getPathComponents(toPath(resolvedPath, currentDirectory, getCanonicalFileName));
                 const originalParts = getPathComponents(toPath(originalPath, currentDirectory, getCanonicalFileName));
-                while (resolvedParts[resolvedParts.length - 1] === originalParts[originalParts.length - 1]) {
+                while (compareStrings(resolvedParts[resolvedParts.length - 1], originalParts[originalParts.length - 1]) === Comparison.EqualTo) {
                     resolvedParts.pop();
                     originalParts.pop();
                 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1241,6 +1241,7 @@ namespace ts {
                 readFile: f => host.readFile(f),
                 fileExists: f => host.fileExists(f),
                 ...(host.directoryExists ? { directoryExists: f => host.directoryExists!(f) } : {}),
+                useCaseSensitiveFileNames: () => host.useCaseSensitiveFileNames(),
             };
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4997,6 +4997,7 @@ namespace ts {
     /* @internal */
     export interface EmitHost extends ScriptReferenceHost, ModuleSpecifierResolutionHost {
         getSourceFiles(): ReadonlyArray<SourceFile>;
+        useCaseSensitiveFileNames(): boolean;
         getCurrentDirectory(): string;
 
         /* @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4236,6 +4236,7 @@ declare namespace ts {
     }
     interface EmitHost extends ScriptReferenceHost, ModuleSpecifierResolutionHost {
         getSourceFiles(): ReadonlyArray<SourceFile>;
+        useCaseSensitiveFileNames(): boolean;
         getCurrentDirectory(): string;
         isSourceFileFromExternalLibrary(file: SourceFile): boolean;
         getCommonSourceDirectory(): string;

--- a/tests/baselines/reference/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.js
+++ b/tests/baselines/reference/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.js
@@ -1,0 +1,66 @@
+//// [tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts] ////
+
+//// [index.ts]
+import { TypeB } from './type-b';
+
+export class Broken {
+    method () {
+        return { } as TypeB;
+    }
+}
+//// [type-b.ts]
+import { Merge } from './types';
+import { TypeA } from './type-a';
+
+export type TypeB = Merge<TypeA, {
+    b: string;
+}>;
+//// [type-a.ts]
+export type TypeA = {
+    a: string;
+}
+//// [types.ts]
+export type Merge<T, U> = T & U;
+
+
+//// [types.js]
+"use strict";
+exports.__esModule = true;
+//// [type-a.js]
+"use strict";
+exports.__esModule = true;
+//// [type-b.js]
+"use strict";
+exports.__esModule = true;
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var Broken = /** @class */ (function () {
+    function Broken() {
+    }
+    Broken.prototype.method = function () {
+        return {};
+    };
+    return Broken;
+}());
+exports.Broken = Broken;
+
+
+//// [types.d.ts]
+export declare type Merge<T, U> = T & U;
+//// [type-a.d.ts]
+export declare type TypeA = {
+    a: string;
+};
+//// [type-b.d.ts]
+import { Merge } from './types';
+import { TypeA } from './type-a';
+export declare type TypeB = Merge<TypeA, {
+    b: string;
+}>;
+//// [index.d.ts]
+export declare class Broken {
+    method(): import("./types").Merge<import("./type-a").TypeA, {
+        b: string;
+    }>;
+}

--- a/tests/baselines/reference/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.symbols
+++ b/tests/baselines/reference/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.symbols
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/Uppercased_Dir/src/index.ts ===
+import { TypeB } from './type-b';
+>TypeB : Symbol(TypeB, Decl(index.ts, 0, 8))
+
+export class Broken {
+>Broken : Symbol(Broken, Decl(index.ts, 0, 33))
+
+    method () {
+>method : Symbol(Broken.method, Decl(index.ts, 2, 21))
+
+        return { } as TypeB;
+>TypeB : Symbol(TypeB, Decl(index.ts, 0, 8))
+    }
+}
+=== tests/cases/compiler/Uppercased_Dir/src/type-b.ts ===
+import { Merge } from './types';
+>Merge : Symbol(Merge, Decl(type-b.ts, 0, 8))
+
+import { TypeA } from './type-a';
+>TypeA : Symbol(TypeA, Decl(type-b.ts, 1, 8))
+
+export type TypeB = Merge<TypeA, {
+>TypeB : Symbol(TypeB, Decl(type-b.ts, 1, 33))
+>Merge : Symbol(Merge, Decl(type-b.ts, 0, 8))
+>TypeA : Symbol(TypeA, Decl(type-b.ts, 1, 8))
+
+    b: string;
+>b : Symbol(b, Decl(type-b.ts, 3, 34))
+
+}>;
+=== tests/cases/compiler/Uppercased_Dir/src/type-a.ts ===
+export type TypeA = {
+>TypeA : Symbol(TypeA, Decl(type-a.ts, 0, 0))
+
+    a: string;
+>a : Symbol(a, Decl(type-a.ts, 0, 21))
+}
+=== tests/cases/compiler/Uppercased_Dir/src/types.ts ===
+export type Merge<T, U> = T & U;
+>Merge : Symbol(Merge, Decl(types.ts, 0, 0))
+>T : Symbol(T, Decl(types.ts, 0, 18))
+>U : Symbol(U, Decl(types.ts, 0, 20))
+>T : Symbol(T, Decl(types.ts, 0, 18))
+>U : Symbol(U, Decl(types.ts, 0, 20))
+

--- a/tests/baselines/reference/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.types
+++ b/tests/baselines/reference/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.types
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/Uppercased_Dir/src/index.ts ===
+import { TypeB } from './type-b';
+>TypeB : any
+
+export class Broken {
+>Broken : Broken
+
+    method () {
+>method : () => import("tests/cases/compiler/Uppercased_Dir/src/types").Merge<import("tests/cases/compiler/Uppercased_Dir/src/type-a").TypeA, { b: string; }>
+
+        return { } as TypeB;
+>{ } as TypeB : import("tests/cases/compiler/Uppercased_Dir/src/types").Merge<import("tests/cases/compiler/Uppercased_Dir/src/type-a").TypeA, { b: string; }>
+>{ } : {}
+>TypeB : import("tests/cases/compiler/Uppercased_Dir/src/types").Merge<import("tests/cases/compiler/Uppercased_Dir/src/type-a").TypeA, { b: string; }>
+    }
+}
+=== tests/cases/compiler/Uppercased_Dir/src/type-b.ts ===
+import { Merge } from './types';
+>Merge : any
+
+import { TypeA } from './type-a';
+>TypeA : any
+
+export type TypeB = Merge<TypeA, {
+>TypeB : Merge<TypeA, { b: string; }>
+>Merge : Merge<T, U>
+>TypeA : TypeA
+
+    b: string;
+>b : string
+
+}>;
+=== tests/cases/compiler/Uppercased_Dir/src/type-a.ts ===
+export type TypeA = {
+>TypeA : TypeA
+
+    a: string;
+>a : string
+}
+=== tests/cases/compiler/Uppercased_Dir/src/types.ts ===
+export type Merge<T, U> = T & U;
+>Merge : Merge<T, U>
+>T : T
+>U : U
+>T : T
+>U : U
+

--- a/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
+++ b/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
@@ -1,0 +1,23 @@
+// @declaration: true
+// @useCaseSensitiveFileNames: false
+// @filename: Uppercased_Dir/src/index.ts
+import { TypeB } from './type-b';
+
+export class Broken {
+    method () {
+        return { } as TypeB;
+    }
+}
+// @filename: Uppercased_Dir/src/type-b.ts
+import { Merge } from './types';
+import { TypeA } from './type-a';
+
+export type TypeB = Merge<TypeA, {
+    b: string;
+}>;
+// @filename: Uppercased_Dir/src/type-a.ts
+export type TypeA = {
+    a: string;
+}
+// @filename: Uppercased_Dir/src/types.ts
+export type Merge<T, U> = T & U;


### PR DESCRIPTION
On case-insensitive filesystems, the `EmitHost` wasn't propagating the case sensitivity from its parent compiler host, and the types weren't indicating this was a problem because the `ModuleSpecifierResolutionHost` types are loose to accommodate some odd patterns in the services layer (where some members are optional but we generally expect them to be present if we are to handle things correctly). So while we were handling case correctly in (most) cases in the algorithm itself (I found one place we were doing a `===` which needed to be a case-aware comparison, but should only have affected the ability to find symlinks), we were never indicating if it was supposed to be case-insensitive in the first place, resulting in paths canonicalized differently within the resolver vs externally to it, with an end result of paths like `../../User/foo/index`. (since externally a canonical path like `/user/foo/index` would be made, but internally we'd compare case-sensitively against the original `/User/foo/index`).

Fixes #24599
