### PR TITLE
Cache specifier resolutions for speed when emitting many types from the same place

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4091,15 +4091,25 @@ namespace ts {
                         // ambient module, just use declaration/symbol name (fallthrough)
                     }
                     else {
+                        if (file.moduleName) {
+                            return `"${file.moduleName}"`;
+                        }
                         const contextFile = getSourceFileOfNode(getOriginalNode(context!.enclosingDeclaration))!;
-                        return `"${file.moduleName || moduleSpecifiers.getModuleSpecifiers(
-                            symbol,
-                            compilerOptions,
-                            contextFile,
-                            context!.tracker.moduleResolverHost!,
-                            context!.tracker.moduleResolverHost!.getSourceFiles!(),
-                            { importModuleSpecifierPreference: "non-relative" }
-                        )[0]}"`;
+                        const links = getSymbolLinks(symbol);
+                        let specifier = links.specifierCache && links.specifierCache.get(contextFile.path);
+                        if (!specifier) {
+                            specifier = flatten(moduleSpecifiers.getModuleSpecifiers(
+                                symbol,
+                                compilerOptions,
+                                contextFile,
+                                context!.tracker.moduleResolverHost!,
+                                context!.tracker.moduleResolverHost!.getSourceFiles!(),
+                                { importModuleSpecifierPreference: "non-relative" }
+                            ))[0];
+                            links.specifierCache = links.specifierCache || createMap();
+                            links.specifierCache.set(contextFile.path, specifier);
+                        }
+                        return `"${specifier}"`;
                     }
                 }
                 const declaration = symbol.declarations[0];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3492,6 +3492,7 @@ namespace ts {
         enumKind?: EnumKind;                // Enum declaration classification
         originatingImport?: ImportDeclaration | ImportCall; // Import declaration which produced the symbol, present if the symbol is marked as uncallable but had call signatures in `resolveESModuleSymbol`
         lateSymbol?: Symbol;                // Late-bound symbol for a computed property
+        specifierCache?: Map<string>;     // For symbols corresponding to external modules, a cache of incoming path -> module specifier name mappings
     }
 
     /* @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3048,6 +3048,7 @@ declare namespace ts {
         enumKind?: EnumKind;
         originatingImport?: ImportDeclaration | ImportCall;
         lateSymbol?: Symbol;
+        specifierCache?: Map<string>;
     }
     enum EnumKind {
         Numeric = 0,


### PR DESCRIPTION
Alleviates a bit of the problem in #25023, though is far from a full fix, since the real issue is with the structural decomposition; this just makes that process a little faster.

