### PR TITLE
Improved errors using type reference targets

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10862,15 +10862,13 @@ namespace ts {
 
             function findMatchingTypeReferenceOrTypeAliasReference(source: Type, unionTarget: UnionOrIntersectionType) {
                 if (source.flags & TypeFlags.Object && (source as ObjectType).objectFlags & (ObjectFlags.Reference | ObjectFlags.Anonymous) && unionTarget.flags & TypeFlags.Union) {
-                    return find(unionTarget.types, t => {
-                        if (t.flags & TypeFlags.Object) {
-                            if ((source as ObjectType).objectFlags & (t as ObjectType).objectFlags & ObjectFlags.Reference) {
-                                return (source as TypeReference).target === (t as TypeReference).target;
+                    return find(unionTarget.types, target => {
+                        if (target.flags & TypeFlags.Object) {
+                            if ((source as ObjectType).objectFlags & (target as ObjectType).objectFlags & ObjectFlags.Reference) {
+                                return (source as TypeReference).target === (target as TypeReference).target;
                             }
-                            if ((source as ObjectType).objectFlags & (t as ObjectType).objectFlags & ObjectFlags.Anonymous) {
-                                // TODO (drosen): Not sure why the following isn't sufficient.
-                                // return !!(source as AnonymousType).aliasSymbol && (source as AnonymousType).aliasSymbol === (target as AnonymousType).aliasSymbol;
-                                return false;
+                            if ((source as ObjectType).objectFlags & (target as ObjectType).objectFlags & ObjectFlags.Anonymous) {
+                                return !!(source as AnonymousType).aliasSymbol && (source as AnonymousType).aliasSymbol === (target as AnonymousType).aliasSymbol;
                             }
                         }
                         return false;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10851,11 +10851,33 @@ namespace ts {
                     }
                 }
                 if (reportErrors) {
-                    const discriminantType = findMatchingDiscriminantType(source, target);
-                    isRelatedTo(source, discriminantType || targetTypes[targetTypes.length - 1], /*reportErrors*/ true);
+                    const bestMatchingType =
+                        findMatchingDiscriminantType(source, target) ||
+                        findMatchingTypeReferenceOrTypeAliasReference(source, target);
+
+                    isRelatedTo(source, bestMatchingType || targetTypes[targetTypes.length - 1], /*reportErrors*/ true);
                 }
                 return Ternary.False;
             }
+
+            function findMatchingTypeReferenceOrTypeAliasReference(source: Type, unionTarget: UnionOrIntersectionType) {
+                if (source.flags & TypeFlags.Object && (source as ObjectType).objectFlags & (ObjectFlags.Reference | ObjectFlags.Anonymous) && unionTarget.flags & TypeFlags.Union) {
+                    return find(unionTarget.types, t => {
+                        if (t.flags & TypeFlags.Object) {
+                            if ((source as ObjectType).objectFlags & (t as ObjectType).objectFlags & ObjectFlags.Reference) {
+                                return (source as TypeReference).target === (t as TypeReference).target;
+                            }
+                            if ((source as ObjectType).objectFlags & (t as ObjectType).objectFlags & ObjectFlags.Anonymous) {
+                                // TODO (drosen): Not sure why the following isn't sufficient.
+                                // return !!(source as AnonymousType).aliasSymbol && (source as AnonymousType).aliasSymbol === (target as AnonymousType).aliasSymbol;
+                                return false;
+                            }
+                        }
+                        return false;
+                    });
+                }
+            }
+
 
             // Keep this up-to-date with the same logic within `getApparentTypeOfContextualType`, since they should behave similarly
             function findMatchingDiscriminantType(source: Type, target: UnionOrIntersectionType) {

--- a/tests/baselines/reference/for-of39.errors.txt
+++ b/tests/baselines/reference/for-of39.errors.txt
@@ -4,8 +4,8 @@ tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,19): error TS2345: Ar
       Types of parameters 'items' and 'items' are incompatible.
         Type 'ConcatArray<[string, boolean]>' is not assignable to type 'ConcatArray<[string, number] | [string, true]>'.
           Type '[string, boolean]' is not assignable to type '[string, number] | [string, true]'.
-            Type '[string, boolean]' is not assignable to type '[string, true]'.
-              Type 'boolean' is not assignable to type 'true'.
+            Type '[string, boolean]' is not assignable to type '[string, number]'.
+              Type 'boolean' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/es6/for-ofStatements/for-of39.ts (1 errors) ====
@@ -17,8 +17,8 @@ tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,19): error TS2345: Ar
 !!! error TS2345:       Types of parameters 'items' and 'items' are incompatible.
 !!! error TS2345:         Type 'ConcatArray<[string, boolean]>' is not assignable to type 'ConcatArray<[string, number] | [string, true]>'.
 !!! error TS2345:           Type '[string, boolean]' is not assignable to type '[string, number] | [string, true]'.
-!!! error TS2345:             Type '[string, boolean]' is not assignable to type '[string, true]'.
-!!! error TS2345:               Type 'boolean' is not assignable to type 'true'.
+!!! error TS2345:             Type '[string, boolean]' is not assignable to type '[string, number]'.
+!!! error TS2345:               Type 'boolean' is not assignable to type 'number'.
     for (var [k, v] of map) {
         k;
         v;

--- a/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.errors.txt
+++ b/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.errors.txt
@@ -1,9 +1,11 @@
 tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(25,1): error TS2322: Type 'A<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
-  Type 'A<Foo>' is not assignable to type 'C<Kwah>'.
-    Property 'cProp' is missing in type 'A<Foo>'.
+  Type 'A<Foo>' is not assignable to type 'A<Bar>'.
+    Type 'Foo' is not assignable to type 'Bar'.
+      Property 'bar' is missing in type 'Foo'.
 tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(26,1): error TS2322: Type 'B<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
-  Type 'B<Foo>' is not assignable to type 'C<Kwah>'.
-    Property 'cProp' is missing in type 'B<Foo>'.
+  Type 'B<Foo>' is not assignable to type 'B<Baz>'.
+    Type 'Foo' is not assignable to type 'Baz'.
+      Property 'baz' is missing in type 'Foo'.
 tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(27,1): error TS2322: Type 'C<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
   Type 'C<Foo>' is not assignable to type 'C<Kwah>'.
     Type 'Foo' is not assignable to type 'Kwah'.
@@ -48,13 +50,15 @@ tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(50,1): error TS2322: Typ
     thingOfInterfaces = a;
     ~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'A<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
-!!! error TS2322:   Type 'A<Foo>' is not assignable to type 'C<Kwah>'.
-!!! error TS2322:     Property 'cProp' is missing in type 'A<Foo>'.
+!!! error TS2322:   Type 'A<Foo>' is not assignable to type 'A<Bar>'.
+!!! error TS2322:     Type 'Foo' is not assignable to type 'Bar'.
+!!! error TS2322:       Property 'bar' is missing in type 'Foo'.
     thingOfInterfaces = b;
     ~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'B<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
-!!! error TS2322:   Type 'B<Foo>' is not assignable to type 'C<Kwah>'.
-!!! error TS2322:     Property 'cProp' is missing in type 'B<Foo>'.
+!!! error TS2322:   Type 'B<Foo>' is not assignable to type 'B<Baz>'.
+!!! error TS2322:     Type 'Foo' is not assignable to type 'Baz'.
+!!! error TS2322:       Property 'baz' is missing in type 'Foo'.
     thingOfInterfaces = c;
     ~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'C<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.

--- a/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.errors.txt
+++ b/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.errors.txt
@@ -11,11 +11,13 @@ tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(27,1): error TS2322: Typ
     Type 'Foo' is not assignable to type 'Kwah'.
       Property 'kwah' is missing in type 'Foo'.
 tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(48,1): error TS2322: Type 'X<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
-  Type 'X<Foo>' is not assignable to type 'Z<Kwah>'.
-    Property 'zProp' is missing in type 'X<Foo>'.
+  Type 'X<Foo>' is not assignable to type 'X<Bar>'.
+    Types of property 'xProp' are incompatible.
+      Type 'Foo' is not assignable to type 'Bar'.
 tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(49,1): error TS2322: Type 'Y<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
-  Type 'Y<Foo>' is not assignable to type 'Z<Kwah>'.
-    Property 'zProp' is missing in type 'Y<Foo>'.
+  Type 'Y<Foo>' is not assignable to type 'Y<Baz>'.
+    Types of property 'yProp' are incompatible.
+      Type 'Foo' is not assignable to type 'Baz'.
 tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(50,1): error TS2322: Type 'Z<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
   Type 'Z<Foo>' is not assignable to type 'Z<Kwah>'.
     Types of property 'zProp' are incompatible.
@@ -88,13 +90,15 @@ tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(50,1): error TS2322: Typ
     thingOfTypeAliases = x;
     ~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'X<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
-!!! error TS2322:   Type 'X<Foo>' is not assignable to type 'Z<Kwah>'.
-!!! error TS2322:     Property 'zProp' is missing in type 'X<Foo>'.
+!!! error TS2322:   Type 'X<Foo>' is not assignable to type 'X<Bar>'.
+!!! error TS2322:     Types of property 'xProp' are incompatible.
+!!! error TS2322:       Type 'Foo' is not assignable to type 'Bar'.
     thingOfTypeAliases = y;
     ~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'Y<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
-!!! error TS2322:   Type 'Y<Foo>' is not assignable to type 'Z<Kwah>'.
-!!! error TS2322:     Property 'zProp' is missing in type 'Y<Foo>'.
+!!! error TS2322:   Type 'Y<Foo>' is not assignable to type 'Y<Baz>'.
+!!! error TS2322:     Types of property 'yProp' are incompatible.
+!!! error TS2322:       Type 'Foo' is not assignable to type 'Baz'.
     thingOfTypeAliases = z;
     ~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'Z<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.

--- a/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.errors.txt
+++ b/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.errors.txt
@@ -1,0 +1,99 @@
+tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(25,1): error TS2322: Type 'A<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
+  Type 'A<Foo>' is not assignable to type 'C<Kwah>'.
+    Property 'cProp' is missing in type 'A<Foo>'.
+tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(26,1): error TS2322: Type 'B<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
+  Type 'B<Foo>' is not assignable to type 'C<Kwah>'.
+    Property 'cProp' is missing in type 'B<Foo>'.
+tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(27,1): error TS2322: Type 'C<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
+  Type 'C<Foo>' is not assignable to type 'C<Kwah>'.
+    Type 'Foo' is not assignable to type 'Kwah'.
+      Property 'kwah' is missing in type 'Foo'.
+tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(48,1): error TS2322: Type 'X<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
+  Type 'X<Foo>' is not assignable to type 'Z<Kwah>'.
+    Property 'zProp' is missing in type 'X<Foo>'.
+tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(49,1): error TS2322: Type 'Y<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
+  Type 'Y<Foo>' is not assignable to type 'Z<Kwah>'.
+    Property 'zProp' is missing in type 'Y<Foo>'.
+tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts(50,1): error TS2322: Type 'Z<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
+  Type 'Z<Foo>' is not assignable to type 'Z<Kwah>'.
+    Types of property 'zProp' are incompatible.
+      Type 'Foo' is not assignable to type 'Kwah'.
+
+
+==== tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts (6 errors) ====
+    interface Foo { foo: any }
+    interface Bar { bar: any }
+    interface Baz { baz: any }
+    interface Kwah { kwah: any }
+    
+    ////////
+    
+    interface A<T> {
+        aProp: T;
+    }
+    
+    interface B<T> {
+        bProp: T;
+    }
+    
+    interface C<T> {
+        cProp: T;
+    }
+    
+    declare const a: A<Foo>;
+    declare const b: B<Foo>;
+    declare const c: C<Foo>;
+    declare let thingOfInterfaces: A<Bar> | B<Baz> | C<Kwah>;
+    
+    thingOfInterfaces = a;
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'A<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
+!!! error TS2322:   Type 'A<Foo>' is not assignable to type 'C<Kwah>'.
+!!! error TS2322:     Property 'cProp' is missing in type 'A<Foo>'.
+    thingOfInterfaces = b;
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'B<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
+!!! error TS2322:   Type 'B<Foo>' is not assignable to type 'C<Kwah>'.
+!!! error TS2322:     Property 'cProp' is missing in type 'B<Foo>'.
+    thingOfInterfaces = c;
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'C<Foo>' is not assignable to type 'A<Bar> | B<Baz> | C<Kwah>'.
+!!! error TS2322:   Type 'C<Foo>' is not assignable to type 'C<Kwah>'.
+!!! error TS2322:     Type 'Foo' is not assignable to type 'Kwah'.
+!!! error TS2322:       Property 'kwah' is missing in type 'Foo'.
+    
+    ////////
+    
+    type X<T> = {
+        xProp: T;
+    }
+    
+    type Y<T> = {
+        yProp: T;
+    }
+    
+    type Z<T> = {
+        zProp: T;
+    }
+    
+    declare const x: X<Foo>;
+    declare const y: Y<Foo>;
+    declare const z: Z<Foo>;
+    declare let thingOfTypeAliases: X<Bar> | Y<Baz> | Z<Kwah>;
+    
+    thingOfTypeAliases = x;
+    ~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'X<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
+!!! error TS2322:   Type 'X<Foo>' is not assignable to type 'Z<Kwah>'.
+!!! error TS2322:     Property 'zProp' is missing in type 'X<Foo>'.
+    thingOfTypeAliases = y;
+    ~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Y<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
+!!! error TS2322:   Type 'Y<Foo>' is not assignable to type 'Z<Kwah>'.
+!!! error TS2322:     Property 'zProp' is missing in type 'Y<Foo>'.
+    thingOfTypeAliases = z;
+    ~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Z<Foo>' is not assignable to type 'X<Bar> | Y<Baz> | Z<Kwah>'.
+!!! error TS2322:   Type 'Z<Foo>' is not assignable to type 'Z<Kwah>'.
+!!! error TS2322:     Types of property 'zProp' are incompatible.
+!!! error TS2322:       Type 'Foo' is not assignable to type 'Kwah'.

--- a/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.js
+++ b/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.js
@@ -1,0 +1,59 @@
+//// [unionTypeErrorMessageTypeRefs01.ts]
+interface Foo { foo: any }
+interface Bar { bar: any }
+interface Baz { baz: any }
+interface Kwah { kwah: any }
+
+////////
+
+interface A<T> {
+    aProp: T;
+}
+
+interface B<T> {
+    bProp: T;
+}
+
+interface C<T> {
+    cProp: T;
+}
+
+declare const a: A<Foo>;
+declare const b: B<Foo>;
+declare const c: C<Foo>;
+declare let thingOfInterfaces: A<Bar> | B<Baz> | C<Kwah>;
+
+thingOfInterfaces = a;
+thingOfInterfaces = b;
+thingOfInterfaces = c;
+
+////////
+
+type X<T> = {
+    xProp: T;
+}
+
+type Y<T> = {
+    yProp: T;
+}
+
+type Z<T> = {
+    zProp: T;
+}
+
+declare const x: X<Foo>;
+declare const y: Y<Foo>;
+declare const z: Z<Foo>;
+declare let thingOfTypeAliases: X<Bar> | Y<Baz> | Z<Kwah>;
+
+thingOfTypeAliases = x;
+thingOfTypeAliases = y;
+thingOfTypeAliases = z;
+
+//// [unionTypeErrorMessageTypeRefs01.js]
+thingOfInterfaces = a;
+thingOfInterfaces = b;
+thingOfInterfaces = c;
+thingOfTypeAliases = x;
+thingOfTypeAliases = y;
+thingOfTypeAliases = z;

--- a/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.symbols
+++ b/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.symbols
@@ -1,0 +1,147 @@
+=== tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts ===
+interface Foo { foo: any }
+>Foo : Symbol(Foo, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 0))
+>foo : Symbol(Foo.foo, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 15))
+
+interface Bar { bar: any }
+>Bar : Symbol(Bar, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 26))
+>bar : Symbol(Bar.bar, Decl(unionTypeErrorMessageTypeRefs01.ts, 1, 15))
+
+interface Baz { baz: any }
+>Baz : Symbol(Baz, Decl(unionTypeErrorMessageTypeRefs01.ts, 1, 26))
+>baz : Symbol(Baz.baz, Decl(unionTypeErrorMessageTypeRefs01.ts, 2, 15))
+
+interface Kwah { kwah: any }
+>Kwah : Symbol(Kwah, Decl(unionTypeErrorMessageTypeRefs01.ts, 2, 26))
+>kwah : Symbol(Kwah.kwah, Decl(unionTypeErrorMessageTypeRefs01.ts, 3, 16))
+
+////////
+
+interface A<T> {
+>A : Symbol(A, Decl(unionTypeErrorMessageTypeRefs01.ts, 3, 28))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 7, 12))
+
+    aProp: T;
+>aProp : Symbol(A.aProp, Decl(unionTypeErrorMessageTypeRefs01.ts, 7, 16))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 7, 12))
+}
+
+interface B<T> {
+>B : Symbol(B, Decl(unionTypeErrorMessageTypeRefs01.ts, 9, 1))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 11, 12))
+
+    bProp: T;
+>bProp : Symbol(B.bProp, Decl(unionTypeErrorMessageTypeRefs01.ts, 11, 16))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 11, 12))
+}
+
+interface C<T> {
+>C : Symbol(C, Decl(unionTypeErrorMessageTypeRefs01.ts, 13, 1))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 15, 12))
+
+    cProp: T;
+>cProp : Symbol(C.cProp, Decl(unionTypeErrorMessageTypeRefs01.ts, 15, 16))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 15, 12))
+}
+
+declare const a: A<Foo>;
+>a : Symbol(a, Decl(unionTypeErrorMessageTypeRefs01.ts, 19, 13))
+>A : Symbol(A, Decl(unionTypeErrorMessageTypeRefs01.ts, 3, 28))
+>Foo : Symbol(Foo, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 0))
+
+declare const b: B<Foo>;
+>b : Symbol(b, Decl(unionTypeErrorMessageTypeRefs01.ts, 20, 13))
+>B : Symbol(B, Decl(unionTypeErrorMessageTypeRefs01.ts, 9, 1))
+>Foo : Symbol(Foo, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 0))
+
+declare const c: C<Foo>;
+>c : Symbol(c, Decl(unionTypeErrorMessageTypeRefs01.ts, 21, 13))
+>C : Symbol(C, Decl(unionTypeErrorMessageTypeRefs01.ts, 13, 1))
+>Foo : Symbol(Foo, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 0))
+
+declare let thingOfInterfaces: A<Bar> | B<Baz> | C<Kwah>;
+>thingOfInterfaces : Symbol(thingOfInterfaces, Decl(unionTypeErrorMessageTypeRefs01.ts, 22, 11))
+>A : Symbol(A, Decl(unionTypeErrorMessageTypeRefs01.ts, 3, 28))
+>Bar : Symbol(Bar, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 26))
+>B : Symbol(B, Decl(unionTypeErrorMessageTypeRefs01.ts, 9, 1))
+>Baz : Symbol(Baz, Decl(unionTypeErrorMessageTypeRefs01.ts, 1, 26))
+>C : Symbol(C, Decl(unionTypeErrorMessageTypeRefs01.ts, 13, 1))
+>Kwah : Symbol(Kwah, Decl(unionTypeErrorMessageTypeRefs01.ts, 2, 26))
+
+thingOfInterfaces = a;
+>thingOfInterfaces : Symbol(thingOfInterfaces, Decl(unionTypeErrorMessageTypeRefs01.ts, 22, 11))
+>a : Symbol(a, Decl(unionTypeErrorMessageTypeRefs01.ts, 19, 13))
+
+thingOfInterfaces = b;
+>thingOfInterfaces : Symbol(thingOfInterfaces, Decl(unionTypeErrorMessageTypeRefs01.ts, 22, 11))
+>b : Symbol(b, Decl(unionTypeErrorMessageTypeRefs01.ts, 20, 13))
+
+thingOfInterfaces = c;
+>thingOfInterfaces : Symbol(thingOfInterfaces, Decl(unionTypeErrorMessageTypeRefs01.ts, 22, 11))
+>c : Symbol(c, Decl(unionTypeErrorMessageTypeRefs01.ts, 21, 13))
+
+////////
+
+type X<T> = {
+>X : Symbol(X, Decl(unionTypeErrorMessageTypeRefs01.ts, 26, 22))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 30, 7))
+
+    xProp: T;
+>xProp : Symbol(xProp, Decl(unionTypeErrorMessageTypeRefs01.ts, 30, 13))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 30, 7))
+}
+
+type Y<T> = {
+>Y : Symbol(Y, Decl(unionTypeErrorMessageTypeRefs01.ts, 32, 1))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 34, 7))
+
+    yProp: T;
+>yProp : Symbol(yProp, Decl(unionTypeErrorMessageTypeRefs01.ts, 34, 13))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 34, 7))
+}
+
+type Z<T> = {
+>Z : Symbol(Z, Decl(unionTypeErrorMessageTypeRefs01.ts, 36, 1))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 38, 7))
+
+    zProp: T;
+>zProp : Symbol(zProp, Decl(unionTypeErrorMessageTypeRefs01.ts, 38, 13))
+>T : Symbol(T, Decl(unionTypeErrorMessageTypeRefs01.ts, 38, 7))
+}
+
+declare const x: X<Foo>;
+>x : Symbol(x, Decl(unionTypeErrorMessageTypeRefs01.ts, 42, 13))
+>X : Symbol(X, Decl(unionTypeErrorMessageTypeRefs01.ts, 26, 22))
+>Foo : Symbol(Foo, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 0))
+
+declare const y: Y<Foo>;
+>y : Symbol(y, Decl(unionTypeErrorMessageTypeRefs01.ts, 43, 13))
+>Y : Symbol(Y, Decl(unionTypeErrorMessageTypeRefs01.ts, 32, 1))
+>Foo : Symbol(Foo, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 0))
+
+declare const z: Z<Foo>;
+>z : Symbol(z, Decl(unionTypeErrorMessageTypeRefs01.ts, 44, 13))
+>Z : Symbol(Z, Decl(unionTypeErrorMessageTypeRefs01.ts, 36, 1))
+>Foo : Symbol(Foo, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 0))
+
+declare let thingOfTypeAliases: X<Bar> | Y<Baz> | Z<Kwah>;
+>thingOfTypeAliases : Symbol(thingOfTypeAliases, Decl(unionTypeErrorMessageTypeRefs01.ts, 45, 11))
+>X : Symbol(X, Decl(unionTypeErrorMessageTypeRefs01.ts, 26, 22))
+>Bar : Symbol(Bar, Decl(unionTypeErrorMessageTypeRefs01.ts, 0, 26))
+>Y : Symbol(Y, Decl(unionTypeErrorMessageTypeRefs01.ts, 32, 1))
+>Baz : Symbol(Baz, Decl(unionTypeErrorMessageTypeRefs01.ts, 1, 26))
+>Z : Symbol(Z, Decl(unionTypeErrorMessageTypeRefs01.ts, 36, 1))
+>Kwah : Symbol(Kwah, Decl(unionTypeErrorMessageTypeRefs01.ts, 2, 26))
+
+thingOfTypeAliases = x;
+>thingOfTypeAliases : Symbol(thingOfTypeAliases, Decl(unionTypeErrorMessageTypeRefs01.ts, 45, 11))
+>x : Symbol(x, Decl(unionTypeErrorMessageTypeRefs01.ts, 42, 13))
+
+thingOfTypeAliases = y;
+>thingOfTypeAliases : Symbol(thingOfTypeAliases, Decl(unionTypeErrorMessageTypeRefs01.ts, 45, 11))
+>y : Symbol(y, Decl(unionTypeErrorMessageTypeRefs01.ts, 43, 13))
+
+thingOfTypeAliases = z;
+>thingOfTypeAliases : Symbol(thingOfTypeAliases, Decl(unionTypeErrorMessageTypeRefs01.ts, 45, 11))
+>z : Symbol(z, Decl(unionTypeErrorMessageTypeRefs01.ts, 44, 13))
+

--- a/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.types
+++ b/tests/baselines/reference/unionTypeErrorMessageTypeRefs01.types
@@ -1,0 +1,153 @@
+=== tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts ===
+interface Foo { foo: any }
+>Foo : Foo
+>foo : any
+
+interface Bar { bar: any }
+>Bar : Bar
+>bar : any
+
+interface Baz { baz: any }
+>Baz : Baz
+>baz : any
+
+interface Kwah { kwah: any }
+>Kwah : Kwah
+>kwah : any
+
+////////
+
+interface A<T> {
+>A : A<T>
+>T : T
+
+    aProp: T;
+>aProp : T
+>T : T
+}
+
+interface B<T> {
+>B : B<T>
+>T : T
+
+    bProp: T;
+>bProp : T
+>T : T
+}
+
+interface C<T> {
+>C : C<T>
+>T : T
+
+    cProp: T;
+>cProp : T
+>T : T
+}
+
+declare const a: A<Foo>;
+>a : A<Foo>
+>A : A<T>
+>Foo : Foo
+
+declare const b: B<Foo>;
+>b : B<Foo>
+>B : B<T>
+>Foo : Foo
+
+declare const c: C<Foo>;
+>c : C<Foo>
+>C : C<T>
+>Foo : Foo
+
+declare let thingOfInterfaces: A<Bar> | B<Baz> | C<Kwah>;
+>thingOfInterfaces : A<Bar> | B<Baz> | C<Kwah>
+>A : A<T>
+>Bar : Bar
+>B : B<T>
+>Baz : Baz
+>C : C<T>
+>Kwah : Kwah
+
+thingOfInterfaces = a;
+>thingOfInterfaces = a : A<Foo>
+>thingOfInterfaces : A<Bar> | B<Baz> | C<Kwah>
+>a : A<Foo>
+
+thingOfInterfaces = b;
+>thingOfInterfaces = b : B<Foo>
+>thingOfInterfaces : A<Bar> | B<Baz> | C<Kwah>
+>b : B<Foo>
+
+thingOfInterfaces = c;
+>thingOfInterfaces = c : C<Foo>
+>thingOfInterfaces : A<Bar> | B<Baz> | C<Kwah>
+>c : C<Foo>
+
+////////
+
+type X<T> = {
+>X : X<T>
+>T : T
+
+    xProp: T;
+>xProp : T
+>T : T
+}
+
+type Y<T> = {
+>Y : Y<T>
+>T : T
+
+    yProp: T;
+>yProp : T
+>T : T
+}
+
+type Z<T> = {
+>Z : Z<T>
+>T : T
+
+    zProp: T;
+>zProp : T
+>T : T
+}
+
+declare const x: X<Foo>;
+>x : X<Foo>
+>X : X<T>
+>Foo : Foo
+
+declare const y: Y<Foo>;
+>y : Y<Foo>
+>Y : Y<T>
+>Foo : Foo
+
+declare const z: Z<Foo>;
+>z : Z<Foo>
+>Z : Z<T>
+>Foo : Foo
+
+declare let thingOfTypeAliases: X<Bar> | Y<Baz> | Z<Kwah>;
+>thingOfTypeAliases : X<Bar> | Y<Baz> | Z<Kwah>
+>X : X<T>
+>Bar : Bar
+>Y : Y<T>
+>Baz : Baz
+>Z : Z<T>
+>Kwah : Kwah
+
+thingOfTypeAliases = x;
+>thingOfTypeAliases = x : X<Foo>
+>thingOfTypeAliases : X<Bar> | Y<Baz> | Z<Kwah>
+>x : X<Foo>
+
+thingOfTypeAliases = y;
+>thingOfTypeAliases = y : Y<Foo>
+>thingOfTypeAliases : X<Bar> | Y<Baz> | Z<Kwah>
+>y : Y<Foo>
+
+thingOfTypeAliases = z;
+>thingOfTypeAliases = z : Z<Foo>
+>thingOfTypeAliases : X<Bar> | Y<Baz> | Z<Kwah>
+>z : Z<Foo>
+

--- a/tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts
+++ b/tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts
@@ -1,0 +1,51 @@
+
+interface Foo { foo: any }
+interface Bar { bar: any }
+interface Baz { baz: any }
+interface Kwah { kwah: any }
+
+////////
+
+interface A<T> {
+    aProp: T;
+}
+
+interface B<T> {
+    bProp: T;
+}
+
+interface C<T> {
+    cProp: T;
+}
+
+declare const a: A<Foo>;
+declare const b: B<Foo>;
+declare const c: C<Foo>;
+declare let thingOfInterfaces: A<Bar> | B<Baz> | C<Kwah>;
+
+thingOfInterfaces = a;
+thingOfInterfaces = b;
+thingOfInterfaces = c;
+
+////////
+
+type X<T> = {
+    xProp: T;
+}
+
+type Y<T> = {
+    yProp: T;
+}
+
+type Z<T> = {
+    zProp: T;
+}
+
+declare const x: X<Foo>;
+declare const y: Y<Foo>;
+declare const z: Z<Foo>;
+declare let thingOfTypeAliases: X<Bar> | Y<Baz> | Z<Kwah>;
+
+thingOfTypeAliases = x;
+thingOfTypeAliases = y;
+thingOfTypeAliases = z;


### PR DESCRIPTION

Fixes #24776

This pull request should improve error messages when assigning type references to union types when a target type contains a type reference whose target type matches the source's.

As an example,

```ts
interface A<T> {
    aProp: T;
}

interface B<T> {
    bProp: T;
}

interface C<T> {
    cProp: T;
}

declare const a: A<Foo>;
declare let thing: A<Bar> | B<Baz> | C<Kwah>;

thing = a;
```

Previously we would report

```
Type 'A<Foo>' is not assignable to type 'A<Bar> | B<Baz>'.
  Type 'A<Foo>' is not assignable to type 'B<Baz>'.
    Property 'bProp' is missing in type 'A<Foo>'.
```

Notice that we try to use `B<Baz>` to explain the incompatibility. Intuitively, we'd assume that `A<Bar>` is probably what the user wanted to assign to.

With this change, we report a more relevant error:

```
Type 'A<Foo>' is not assignable to type 'A<Bar> | B<Baz>'.
  Type 'A<Foo>' is not assignable to type 'A<Bar>'.
    Property 'bar' is missing in type 'Foo'.
```

~~Currently I'm trying to get this to also work for anonymous types which have a well-associated alias type, however, I might need help there (@weswigham @sandersn).~~

As future work, we can

* use inheritance chains of each type's target, since there may be cases when users relate a `Derived` to a `Base<Foo>`
* make this work when the source is an intersection types as well
* make this work on other type operators