### PR TITLE
Error on 'const' in class expression

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27347,7 +27347,7 @@ namespace ts {
                 }
                 switch (modifier.kind) {
                     case SyntaxKind.ConstKeyword:
-                        if (node.kind !== SyntaxKind.EnumDeclaration && node.parent.kind === SyntaxKind.ClassDeclaration) {
+                        if (node.kind !== SyntaxKind.EnumDeclaration) {
                             return grammarErrorOnNode(node, Diagnostics.A_class_member_cannot_have_the_0_keyword, tokenToString(SyntaxKind.ConstKeyword));
                         }
                         break;

--- a/tests/baselines/reference/constInClassExpression.errors.txt
+++ b/tests/baselines/reference/constInClassExpression.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/constInClassExpression.ts(2,11): error TS1248: A class member cannot have the 'const' keyword.
+
+
+==== tests/cases/compiler/constInClassExpression.ts (1 errors) ====
+    let C = class {
+        const a = 4;
+              ~
+!!! error TS1248: A class member cannot have the 'const' keyword.
+    };
+    

--- a/tests/baselines/reference/constInClassExpression.js
+++ b/tests/baselines/reference/constInClassExpression.js
@@ -1,0 +1,13 @@
+//// [constInClassExpression.ts]
+let C = class {
+    const a = 4;
+};
+
+
+//// [constInClassExpression.js]
+var C = /** @class */ (function () {
+    function class_1() {
+        this.a = 4;
+    }
+    return class_1;
+}());

--- a/tests/baselines/reference/constInClassExpression.symbols
+++ b/tests/baselines/reference/constInClassExpression.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/constInClassExpression.ts ===
+let C = class {
+>C : Symbol(C, Decl(constInClassExpression.ts, 0, 3))
+
+    const a = 4;
+>a : Symbol(C.a, Decl(constInClassExpression.ts, 0, 15))
+
+};
+

--- a/tests/baselines/reference/constInClassExpression.types
+++ b/tests/baselines/reference/constInClassExpression.types
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/constInClassExpression.ts ===
+let C = class {
+>C : typeof C
+>class {    const a = 4;} : typeof C
+
+    const a = 4;
+>a : number
+>4 : 4
+
+};
+

--- a/tests/cases/compiler/constInClassExpression.ts
+++ b/tests/cases/compiler/constInClassExpression.ts
@@ -1,0 +1,3 @@
+let C = class {
+    const a = 4;
+};


### PR DESCRIPTION
Fixes #25123

The extra condition doesn't make sense since we want to error on *all* extra modifiers, not just those that happen to appear in `ClassDeclaration`s.