### PR TITLE
Remove unused function

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1029,23 +1029,6 @@ namespace ts {
         return array.slice().sort(comparer);
     }
 
-    export function best<T>(iter: Iterator<T>, isBetter: (a: T, b: T) => boolean): T | undefined {
-        const x = iter.next();
-        if (x.done) {
-            return undefined;
-        }
-        let best = x.value;
-        while (true) {
-            const { value, done } = iter.next();
-            if (done) {
-                return best;
-            }
-            if (isBetter(value, best)) {
-                best = value;
-            }
-        }
-    }
-
     export function arrayIterator<T>(array: ReadonlyArray<T>): Iterator<T> {
         let i = 0;
         return { next: () => {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -225,7 +225,6 @@ declare namespace ts {
      * Returns a new sorted array.
      */
     function sort<T>(array: ReadonlyArray<T>, comparer: Comparer<T>): T[];
-    function best<T>(iter: Iterator<T>, isBetter: (a: T, b: T) => boolean): T | undefined;
     function arrayIterator<T>(array: ReadonlyArray<T>): Iterator<T>;
     /**
      * Stable sort of an array. Elements equal to each other maintain their relative position in the array.


### PR DESCRIPTION
This function isn't used anywhere, but we don't have a way of automatically knowing that since it's marked `export`.

