### PR TITLE
Parse nested prop and param tags the same way

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6922,9 +6922,9 @@ namespace ts {
                             case SyntaxKind.AtToken:
                                 if (canParseTag) {
                                     const child = tryParseChildTag(target);
-                                    if (child && child.kind === SyntaxKind.JSDocParameterTag &&
+                                    if (child && (child.kind === SyntaxKind.JSDocParameterTag || child.kind === SyntaxKind.JSDocPropertyTag) &&
                                         target !== PropertyLikeParse.CallbackParameter &&
-                                        (ts.isIdentifier(child.name) || !escapedTextsEqual(name!, child.name.left))) { // TODO: GH#18217
+                                        name && (ts.isIdentifier(child.name) || !escapedTextsEqual(name, child.name.left))) {
                                         return false;
                                     }
                                     return child;

--- a/tests/baselines/reference/typedefTagNested.symbols
+++ b/tests/baselines/reference/typedefTagNested.symbols
@@ -32,8 +32,38 @@ const app = {
  * @property {string} horrible
  * @type {string} idea
  */
+var intercessor = 1
+>intercessor : Symbol(intercessor, Decl(a.js, 23, 3))
 
 /** @type {Opp} */
 var mistake;
->mistake : Symbol(mistake, Decl(a.js, 25, 3))
+>mistake : Symbol(mistake, Decl(a.js, 26, 3))
+
+/** @typedef {Object} Upp
+ * @property {string} name
+ * @property {Object} not
+ * @property {string} nested
+ */
+
+/** @type {Upp} */
+var sala = { name: 'uppsala', not: 0, nested: "ok" };
+>sala : Symbol(sala, Decl(a.js, 35, 3))
+>name : Symbol(name, Decl(a.js, 35, 12))
+>not : Symbol(not, Decl(a.js, 35, 29))
+>nested : Symbol(nested, Decl(a.js, 35, 37))
+
+sala.name
+>sala.name : Symbol(name, Decl(a.js, 29, 3))
+>sala : Symbol(sala, Decl(a.js, 35, 3))
+>name : Symbol(name, Decl(a.js, 29, 3))
+
+sala.not
+>sala.not : Symbol(not, Decl(a.js, 30, 3))
+>sala : Symbol(sala, Decl(a.js, 35, 3))
+>not : Symbol(not, Decl(a.js, 30, 3))
+
+sala.nested
+>sala.nested : Symbol(nested, Decl(a.js, 31, 3))
+>sala : Symbol(sala, Decl(a.js, 35, 3))
+>nested : Symbol(nested, Decl(a.js, 31, 3))
 

--- a/tests/baselines/reference/typedefTagNested.types
+++ b/tests/baselines/reference/typedefTagNested.types
@@ -37,8 +37,43 @@ const app = {
  * @property {string} horrible
  * @type {string} idea
  */
+var intercessor = 1
+>intercessor : number
+>1 : 1
 
 /** @type {Opp} */
 var mistake;
->mistake : Opp
+>mistake : string
+
+/** @typedef {Object} Upp
+ * @property {string} name
+ * @property {Object} not
+ * @property {string} nested
+ */
+
+/** @type {Upp} */
+var sala = { name: 'uppsala', not: 0, nested: "ok" };
+>sala : Upp
+>{ name: 'uppsala', not: 0, nested: "ok" } : { name: string; not: number; nested: string; }
+>name : string
+>'uppsala' : "uppsala"
+>not : number
+>0 : 0
+>nested : string
+>"ok" : "ok"
+
+sala.name
+>sala.name : string
+>sala : Upp
+>name : string
+
+sala.not
+>sala.not : any
+>sala : Upp
+>not : any
+
+sala.nested
+>sala.nested : string
+>sala : Upp
+>nested : string
 

--- a/tests/cases/conformance/jsdoc/typedefTagNested.ts
+++ b/tests/cases/conformance/jsdoc/typedefTagNested.ts
@@ -27,6 +27,19 @@ const app = {
  * @property {string} horrible
  * @type {string} idea
  */
+var intercessor = 1
 
 /** @type {Opp} */
 var mistake;
+
+/** @typedef {Object} Upp
+ * @property {string} name
+ * @property {Object} not
+ * @property {string} nested
+ */
+
+/** @type {Upp} */
+var sala = { name: 'uppsala', not: 0, nested: "ok" };
+sala.name
+sala.not
+sala.nested


### PR DESCRIPTION
That is, only nest them if their name matches the provided parent name.  Otherwise do not nest them. Now this code creates a type with three properties `a,b,c` instead of two `a,b`:

```js
/**
 * @typedef {Object} T
 * @param {string} a
 * @param {object} b
 * @param {string} c
 */
```

Note that this commit changes the behaviour of an incorrect typedef that contains both an `@type` child tag and `@property` child tags.

Previously, the `@type` would be incorrectly nested under a `@property` tag with type `object`, just like `@property` tags would be. Now, the `@type` tag causes the entire typedef to ignore the `@property` tags and treat the typedef as if it were an instance of the typedef-and-nested-type pattern:

```js
/**
 * @typedef {Object} name
 * @type {{ the, actual, type }}
 */
```

Fixes #25072
Fixes #25118
