### PR TITLE
Fix runtests-parallel, tsserverlibrary, up-to-date checks in gulp builds

### DIFF
--- a/scripts/build/gulp-typescript-oop.js
+++ b/scripts/build/gulp-typescript-oop.js
@@ -24,7 +24,10 @@ function createProject(tsConfigFileName, settings, options) {
 
     const project = tsConfigFileName === undefined ? tsc.createProject(localSettings) : tsc.createProject(tsConfigFileName, localSettings);
     const wrappedProject = /** @type {tsc.Project} */(() => {
-        const proc = child_process.fork(require.resolve("./main.js"));
+        const proc = child_process.fork(require.resolve("./main.js"), [], { 
+            // Prevent errors when debugging gulpfile due to the same debug port being passed to forked children.
+            execArgv: [] 
+        });
         /** @type {Duplex & { js?: Readable, dts?: Readable }} */
         const compileStream = new Duplex({
             objectMode: true,


### PR DESCRIPTION
This fixes a few issues @weswigham and I have found in the gulpfile:

- Up-to-date checks weren't working for typescriptServices.js
- Now builds tsserverlibrary.js in the same way typescriptServices.js is built (to support stripInternal)
- "runtests-parallel" wasn't working because Gulp _really_ doesn't like it when you call `gulp.start` inside of multiple tasks, causing the orchestration to end prematurely. Resolved this in _scripts/build/project.js_ by copying the tasks from `compilationGulp` to a separate gulp instance for execution. This still ensures projects are only built once (as each task maintains its own completion state).
