### PR TITLE
[WIP] Remove unnecessary weak types when reporting errors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10616,6 +10616,7 @@ namespace ts {
                 }
 
                 let result = Ternary.False;
+                let strongIntersectionTarget: Type | undefined;
                 const saveErrorInfo = errorInfo;
                 const saveIsIntersectionConstituent = isIntersectionConstituent;
                 isIntersectionConstituent = false;
@@ -10635,6 +10636,23 @@ namespace ts {
                     else if (target.flags & TypeFlags.Intersection) {
                         isIntersectionConstituent = true;
                         result = typeRelatedToEachType(source, target as IntersectionType, reportErrors);
+
+                        // We don't report errors at first.  If the types aren't related then we'll try to see if
+                        // the intersection contains any "weak" types that aren't contributing anything to relating the two types
+                        // (but carefully in case *all* the types in the target are weak).
+                        // If so, we'll drop them and report the error on a smaller intersection which should be more readable.
+                        // If not, re-trigger the original relationship check.
+                        result = typeRelatedToEachType(source, target as IntersectionType, /*reportErrors*/ false);
+                        if (reportErrors && !result && some((target as IntersectionType).types, isWeakType) && !isWeakType(target)) {
+                            const constituents = filter((target as IntersectionType).types, t => !isWeakType(t));
+                            Debug.assert(!!constituents.length, "Should have at least one non-weak constituent result.");
+                            Debug.assert(constituents.length < (target as IntersectionType).types.length, "Should have fewer constituents");
+                            strongIntersectionTarget = getIntersectionType(constituents);
+                            if (isRelatedTo(source, strongIntersectionTarget, reportErrors)) {
+                                typeRelatedToEachType(source, target as IntersectionType, reportErrors);
+                                strongIntersectionTarget = undefined;
+                            }
+                        }
                     }
                     else if (source.flags & TypeFlags.Intersection) {
                         // Check to see if any constituents of the intersection are immediately related to the target.
@@ -10679,6 +10697,11 @@ namespace ts {
                 isIntersectionConstituent = saveIsIntersectionConstituent;
 
                 if (!result && reportErrors) {
+                    if (strongIntersectionTarget) {
+                        // Should have reported an error above.
+                        return result;
+                    }
+
                     if (source.flags & TypeFlags.Object && target.flags & TypeFlags.Primitive) {
                         tryElaborateErrorsForPrimitivesAndObjects(source, target);
                     }

--- a/tests/baselines/reference/checkJsxChildrenProperty14.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty14.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/conformance/jsx/file.tsx(42,11): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
-  Types of property 'children' are incompatible.
-    Type 'Element[]' is not assignable to type 'Element'.
-      Property 'type' is missing in type 'Element[]'.
+  Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
+    Types of property 'children' are incompatible.
+      Type 'Element[]' is not assignable to type 'Element'.
+        Property 'type' is missing in type 'Element[]'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -49,6 +50,7 @@ tests/cases/conformance/jsx/file.tsx(42,11): error TS2322: Type '{ children: Ele
     let k5 = <SingleChildComp a={10} b="hi"><></><Button /><AnotherButton /></SingleChildComp>;
               ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type 'Element[]' is not assignable to type 'Element'.
-!!! error TS2322:       Property 'type' is missing in type 'Element[]'.
+!!! error TS2322:   Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'SingleChildProp'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type 'Element[]' is not assignable to type 'Element'.
+!!! error TS2322:         Property 'type' is missing in type 'Element[]'.

--- a/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
@@ -1,26 +1,31 @@
 tests/cases/conformance/jsx/file.tsx(14,10): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
-  Property 'children' is missing in type '{ a: number; b: string; }'.
+  Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+    Property 'children' is missing in type '{ a: number; b: string; }'.
 tests/cases/conformance/jsx/file.tsx(17,11): error TS2710: 'children' are specified twice. The attribute named 'children' will be overwritten.
 tests/cases/conformance/jsx/file.tsx(31,6): error TS2322: Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
-  Types of property 'children' are incompatible.
-    Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
-      Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
-        Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
+  Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
+    Types of property 'children' are incompatible.
+      Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
+        Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
+          Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
 tests/cases/conformance/jsx/file.tsx(37,6): error TS2322: Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-  Types of property 'children' are incompatible.
-    Type '(number | Element)[]' is not assignable to type 'string | Element'.
-      Type '(number | Element)[]' is not assignable to type 'Element'.
-        Property 'type' is missing in type '(number | Element)[]'.
+  Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+    Types of property 'children' are incompatible.
+      Type '(number | Element)[]' is not assignable to type 'string | Element'.
+        Type '(number | Element)[]' is not assignable to type 'Element'.
+          Property 'type' is missing in type '(number | Element)[]'.
 tests/cases/conformance/jsx/file.tsx(43,6): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-  Types of property 'children' are incompatible.
-    Type '(string | Element)[]' is not assignable to type 'string | Element'.
-      Type '(string | Element)[]' is not assignable to type 'Element'.
-        Property 'type' is missing in type '(string | Element)[]'.
+  Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+    Types of property 'children' are incompatible.
+      Type '(string | Element)[]' is not assignable to type 'string | Element'.
+        Type '(string | Element)[]' is not assignable to type 'Element'.
+          Property 'type' is missing in type '(string | Element)[]'.
 tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
-  Types of property 'children' are incompatible.
-    Type 'Element[]' is not assignable to type 'string | Element'.
-      Type 'Element[]' is not assignable to type 'Element'.
-        Property 'type' is missing in type 'Element[]'.
+  Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
+    Types of property 'children' are incompatible.
+      Type 'Element[]' is not assignable to type 'string | Element'.
+        Type 'Element[]' is not assignable to type 'Element'.
+          Property 'type' is missing in type 'Element[]'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (6 errors) ====
@@ -40,7 +45,8 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
     let k = <Comp a={10} b="hi" />;
              ~~~~
 !!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Property 'children' is missing in type '{ a: number; b: string; }'.
+!!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Property 'children' is missing in type '{ a: number; b: string; }'.
     
     let k0 =
         <Comp a={10} b="hi" children="Random" >
@@ -62,10 +68,11 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
         <Comp a={10} b="hi">
          ~~~~
 !!! error TS2322: Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
-!!! error TS2322:       Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
-!!! error TS2322:         Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
+!!! error TS2322:   Type '{ children: (Element | ((name: string) => Element))[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type '(Element | ((name: string) => Element))[]' is not assignable to type 'string | Element'.
+!!! error TS2322:         Type '(Element | ((name: string) => Element))[]' is not assignable to type 'Element'.
+!!! error TS2322:           Property 'type' is missing in type '(Element | ((name: string) => Element))[]'.
             <div> My Div </div>
             {(name: string) => <div> My name {name} </div>}
         </Comp>;
@@ -74,10 +81,11 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
         <Comp a={10} b="hi">
          ~~~~
 !!! error TS2322: Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type '(number | Element)[]' is not assignable to type 'string | Element'.
-!!! error TS2322:       Type '(number | Element)[]' is not assignable to type 'Element'.
-!!! error TS2322:         Property 'type' is missing in type '(number | Element)[]'.
+!!! error TS2322:   Type '{ children: (number | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type '(number | Element)[]' is not assignable to type 'string | Element'.
+!!! error TS2322:         Type '(number | Element)[]' is not assignable to type 'Element'.
+!!! error TS2322:           Property 'type' is missing in type '(number | Element)[]'.
             <div> My Div </div>
             {1000000}
         </Comp>;
@@ -86,10 +94,11 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
         <Comp a={10} b="hi" >
          ~~~~
 !!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type '(string | Element)[]' is not assignable to type 'string | Element'.
-!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element'.
-!!! error TS2322:         Property 'type' is missing in type '(string | Element)[]'.
+!!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'string | Element'.
+!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element'.
+!!! error TS2322:           Property 'type' is missing in type '(string | Element)[]'.
             <div> My Div </div>
             hi hi hi!
         </Comp>;
@@ -98,10 +107,11 @@ tests/cases/conformance/jsx/file.tsx(49,6): error TS2322: Type '{ children: Elem
         <Comp a={10} b="hi" >
          ~~~~
 !!! error TS2322: Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type 'Element[]' is not assignable to type 'string | Element'.
-!!! error TS2322:       Type 'Element[]' is not assignable to type 'Element'.
-!!! error TS2322:         Property 'type' is missing in type 'Element[]'.
+!!! error TS2322:   Type '{ children: Element[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type 'Element[]' is not assignable to type 'string | Element'.
+!!! error TS2322:         Type 'Element[]' is not assignable to type 'Element'.
+!!! error TS2322:           Property 'type' is missing in type 'Element[]'.
             <div> My Div </div>
             <div> My Div </div>
         </Comp>;

--- a/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
@@ -1,8 +1,9 @@
 tests/cases/conformance/jsx/file.tsx(24,28): error TS2551: Property 'NAme' does not exist on type 'IUser'. Did you mean 'Name'?
 tests/cases/conformance/jsx/file.tsx(32,10): error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
-  Types of property 'children' are incompatible.
-    Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
-      Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
+  Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
+    Types of property 'children' are incompatible.
+      Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
+        Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -42,9 +43,10 @@ tests/cases/conformance/jsx/file.tsx(32,10): error TS2322: Type '{ children: ((u
             <FetchUser>
              ~~~~~~~~~
 !!! error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
-!!! error TS2322:       Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
+!!! error TS2322:   Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
+!!! error TS2322:         Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
     
     
                 

--- a/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
@@ -1,13 +1,16 @@
 tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
-  Property 'children' is missing in type '{ a: number; b: string; }'.
+  Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+    Property 'children' is missing in type '{ a: number; b: string; }'.
 tests/cases/conformance/jsx/file.tsx(24,6): error TS2322: Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
-  Types of property 'children' are incompatible.
-    Type 'Element' is not assignable to type 'Button'.
-      Property 'render' is missing in type 'Element'.
+  Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
+    Types of property 'children' are incompatible.
+      Type 'Element' is not assignable to type 'Button'.
+        Property 'render' is missing in type 'Element'.
 tests/cases/conformance/jsx/file.tsx(28,6): error TS2322: Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
-  Types of property 'children' are incompatible.
-    Type 'typeof Button' is not assignable to type 'Button'.
-      Property 'render' is missing in type 'typeof Button'.
+  Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
+    Types of property 'children' are incompatible.
+      Type 'typeof Button' is not assignable to type 'Button'.
+        Property 'render' is missing in type 'typeof Button'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -33,24 +36,27 @@ tests/cases/conformance/jsx/file.tsx(28,6): error TS2322: Type '{ children: type
     let k = <Comp a={10} b="hi" />;
              ~~~~
 !!! error TS2322: Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Property 'children' is missing in type '{ a: number; b: string; }'.
+!!! error TS2322:   Type '{ a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Property 'children' is missing in type '{ a: number; b: string; }'.
     
     // Error: JSX.element is not the same as JSX.ElementClass
     let k1 =
         <Comp a={10} b="hi">
          ~~~~
 !!! error TS2322: Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type 'Element' is not assignable to type 'Button'.
-!!! error TS2322:       Property 'render' is missing in type 'Element'.
+!!! error TS2322:   Type '{ children: Element; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type 'Element' is not assignable to type 'Button'.
+!!! error TS2322:         Property 'render' is missing in type 'Element'.
             <Button />
         </Comp>;
     let k2 =
         <Comp a={10} b="hi">
          ~~~~
 !!! error TS2322: Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type 'typeof Button' is not assignable to type 'Button'.
-!!! error TS2322:       Property 'render' is missing in type 'typeof Button'.
+!!! error TS2322:   Type '{ children: typeof Button; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type 'typeof Button' is not assignable to type 'Button'.
+!!! error TS2322:         Property 'render' is missing in type 'typeof Button'.
             {Button}
         </Comp>;

--- a/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty7.errors.txt
@@ -1,17 +1,20 @@
 tests/cases/conformance/jsx/file.tsx(24,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-  Types of property 'children' are incompatible.
-    Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-      Type '(string | Element)[]' is not assignable to type 'Element[]'.
-        Type 'string | Element' is not assignable to type 'Element'.
-          Type 'string' is not assignable to type 'Element'.
+  Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+    Types of property 'children' are incompatible.
+      Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+        Type '(string | Element)[]' is not assignable to type 'Element[]'.
+          Type 'string | Element' is not assignable to type 'Element'.
+            Type 'string' is not assignable to type 'Element'.
 tests/cases/conformance/jsx/file.tsx(25,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-  Types of property 'children' are incompatible.
-    Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-      Type '(string | Element)[]' is not assignable to type 'Element[]'.
+  Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+    Types of property 'children' are incompatible.
+      Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+        Type '(string | Element)[]' is not assignable to type 'Element[]'.
 tests/cases/conformance/jsx/file.tsx(27,11): error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-  Types of property 'children' are incompatible.
-    Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-      Type '(string | Element)[]' is not assignable to type 'Element[]'.
+  Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+    Types of property 'children' are incompatible.
+      Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+        Type '(string | Element)[]' is not assignable to type 'Element[]'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -41,22 +44,25 @@ tests/cases/conformance/jsx/file.tsx(27,11): error TS2322: Type '{ children: (st
     let k1 = <Comp a={10} b="hi"><Button />  <AnotherButton /></Comp>;
               ~~~~
 !!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element[]'.
-!!! error TS2322:         Type 'string | Element' is not assignable to type 'Element'.
-!!! error TS2322:           Type 'string' is not assignable to type 'Element'.
+!!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
+!!! error TS2322:           Type 'string | Element' is not assignable to type 'Element'.
+!!! error TS2322:             Type 'string' is not assignable to type 'Element'.
     let k2 = <Comp a={10} b="hi"><Button />
               ~~~~
 !!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element[]'.
+!!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
         <AnotherButton />  </Comp>;
     let k3 = <Comp a={10} b="hi">    <Button />
               ~~~~
 !!! error TS2322: Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
-!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element[]'.
+!!! error TS2322:   Type '{ children: (string | Element)[]; a: number; b: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'children' are incompatible.
+!!! error TS2322:       Type '(string | Element)[]' is not assignable to type 'Element | Element[]'.
+!!! error TS2322:         Type '(string | Element)[]' is not assignable to type 'Element[]'.
         <AnotherButton /></Comp>;

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
@@ -1,7 +1,9 @@
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,13): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
-  Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
+  Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
+    Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,13): error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
-  Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
+  Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
+    Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,43): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(30,36): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(33,65): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
@@ -38,11 +40,13 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,44): err
     const b0 = <MainButton {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type "left" | "right"
                 ~~~~~~~~~~
 !!! error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
-!!! error TS2322:   Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
+!!! error TS2322:   Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
+!!! error TS2322:     Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
     const b2 = <MainButton onClick={(k)=>{console.log(k)}} extra />;  // k has type "left" | "right"
                 ~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
-!!! error TS2322:   Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
+!!! error TS2322:   Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
+!!! error TS2322:     Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
     const b3 = <MainButton {...{goTo:"home"}} extra />;  // goTo has type"home" | "contact"
                                               ~~~~~
 !!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.

--- a/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.errors.txt
+++ b/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.errors.txt
@@ -1,0 +1,94 @@
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(10,12): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'A & B'.
+  Type '{ a: number; b: number; }' is not assignable to type 'B'.
+    Types of property 'b' are incompatible.
+      Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(16,12): error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'A & B'.
+  Type '{ a: string; b: string; }' is not assignable to type 'A'.
+    Types of property 'a' are incompatible.
+      Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(22,12): error TS2322: Type '{ a: string; }' is not assignable to type 'A & B'.
+  Type '{ a: string; }' is not assignable to type 'A'.
+    Types of property 'a' are incompatible.
+      Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(27,12): error TS2322: Type '{ a: string; b: number; }' is not assignable to type 'A & B'.
+  Type '{ a: string; b: number; }' is not assignable to type 'A'.
+    Types of property 'a' are incompatible.
+      Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(33,12): error TS2322: Type '{ b: number; }' is not assignable to type 'A & B'.
+  Type '{ b: number; }' is not assignable to type 'A'.
+    Property 'a' is missing in type '{ b: number; }'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(38,12): error TS2322: Type '{ b: string; }' is not assignable to type 'A & B'.
+  Type '{ b: string; }' is not assignable to type 'A'.
+    Property 'a' is missing in type '{ b: string; }'.
+
+
+==== tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts (6 errors) ====
+    interface A {
+        a: number;
+    }
+    
+    interface B {
+        b?: string;
+    }
+    
+    // 'b' is incompatible.
+    export let x1: A & B = {
+               ~~
+!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'A & B'.
+!!! error TS2322:   Type '{ a: number; b: number; }' is not assignable to type 'B'.
+!!! error TS2322:     Types of property 'b' are incompatible.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+        a: 0,
+        b: 12,
+    }
+    
+    // 'a' is incompatible, 'b' is present and compatible.
+    export let x2: A & B = {
+               ~~
+!!! error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'A & B'.
+!!! error TS2322:   Type '{ a: string; b: string; }' is not assignable to type 'A'.
+!!! error TS2322:     Types of property 'a' are incompatible.
+!!! error TS2322:       Type 'string' is not assignable to type 'number'.
+        a: "hello",
+        b: "hello",
+    }
+    
+    // 'a' is incompatible, 'b' is absent.
+    export let x3: A & B = {
+               ~~
+!!! error TS2322: Type '{ a: string; }' is not assignable to type 'A & B'.
+!!! error TS2322:   Type '{ a: string; }' is not assignable to type 'A'.
+!!! error TS2322:     Types of property 'a' are incompatible.
+!!! error TS2322:       Type 'string' is not assignable to type 'number'.
+        a: "hello",
+    }
+    
+    // Both 'a' and 'b' are incompatible
+    export let x4: A & B = {
+               ~~
+!!! error TS2322: Type '{ a: string; b: number; }' is not assignable to type 'A & B'.
+!!! error TS2322:   Type '{ a: string; b: number; }' is not assignable to type 'A'.
+!!! error TS2322:     Types of property 'a' are incompatible.
+!!! error TS2322:       Type 'string' is not assignable to type 'number'.
+        a: "hello",
+        b: 0,
+    }
+    
+    // 'b' is compatible, 'a' is missing
+    export let x5: A & B = {
+               ~~
+!!! error TS2322: Type '{ b: number; }' is not assignable to type 'A & B'.
+!!! error TS2322:   Type '{ b: number; }' is not assignable to type 'A'.
+!!! error TS2322:     Property 'a' is missing in type '{ b: number; }'.
+        b: 0,
+    }
+    
+    // 'b' is incompatible, 'a' is missing
+    export let x6: A & B = {
+               ~~
+!!! error TS2322: Type '{ b: string; }' is not assignable to type 'A & B'.
+!!! error TS2322:   Type '{ b: string; }' is not assignable to type 'A'.
+!!! error TS2322:     Property 'a' is missing in type '{ b: string; }'.
+        b: "",
+    }
+    

--- a/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.errors.txt
+++ b/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.errors.txt
@@ -1,23 +1,24 @@
 tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(10,12): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'A & B'.
   Type '{ a: number; b: number; }' is not assignable to type 'B'.
-    Types of property 'b' are incompatible.
-      Type 'number' is not assignable to type 'string'.
-tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(16,12): error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'A & B'.
+    Type '{ a: number; b: number; }' is not assignable to type 'B'.
+      Types of property 'b' are incompatible.
+        Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(16,12): error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'A'.
   Type '{ a: string; b: string; }' is not assignable to type 'A'.
     Types of property 'a' are incompatible.
       Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(22,12): error TS2322: Type '{ a: string; }' is not assignable to type 'A & B'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(22,12): error TS2322: Type '{ a: string; }' is not assignable to type 'A'.
   Type '{ a: string; }' is not assignable to type 'A'.
     Types of property 'a' are incompatible.
       Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(27,12): error TS2322: Type '{ a: string; b: number; }' is not assignable to type 'A & B'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(27,12): error TS2322: Type '{ a: string; b: number; }' is not assignable to type 'A'.
   Type '{ a: string; b: number; }' is not assignable to type 'A'.
     Types of property 'a' are incompatible.
       Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(33,12): error TS2322: Type '{ b: number; }' is not assignable to type 'A & B'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(33,12): error TS2322: Type '{ b: number; }' is not assignable to type 'A'.
   Type '{ b: number; }' is not assignable to type 'A'.
     Property 'a' is missing in type '{ b: number; }'.
-tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(38,12): error TS2322: Type '{ b: string; }' is not assignable to type 'A & B'.
+tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(38,12): error TS2322: Type '{ b: string; }' is not assignable to type 'A'.
   Type '{ b: string; }' is not assignable to type 'A'.
     Property 'a' is missing in type '{ b: string; }'.
 
@@ -36,8 +37,9 @@ tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(38,12): error TS23
                ~~
 !!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'A & B'.
 !!! error TS2322:   Type '{ a: number; b: number; }' is not assignable to type 'B'.
-!!! error TS2322:     Types of property 'b' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+!!! error TS2322:     Type '{ a: number; b: number; }' is not assignable to type 'B'.
+!!! error TS2322:       Types of property 'b' are incompatible.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
         a: 0,
         b: 12,
     }
@@ -45,7 +47,7 @@ tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(38,12): error TS23
     // 'a' is incompatible, 'b' is present and compatible.
     export let x2: A & B = {
                ~~
-!!! error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'A & B'.
+!!! error TS2322: Type '{ a: string; b: string; }' is not assignable to type 'A'.
 !!! error TS2322:   Type '{ a: string; b: string; }' is not assignable to type 'A'.
 !!! error TS2322:     Types of property 'a' are incompatible.
 !!! error TS2322:       Type 'string' is not assignable to type 'number'.
@@ -56,7 +58,7 @@ tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(38,12): error TS23
     // 'a' is incompatible, 'b' is absent.
     export let x3: A & B = {
                ~~
-!!! error TS2322: Type '{ a: string; }' is not assignable to type 'A & B'.
+!!! error TS2322: Type '{ a: string; }' is not assignable to type 'A'.
 !!! error TS2322:   Type '{ a: string; }' is not assignable to type 'A'.
 !!! error TS2322:     Types of property 'a' are incompatible.
 !!! error TS2322:       Type 'string' is not assignable to type 'number'.
@@ -66,7 +68,7 @@ tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(38,12): error TS23
     // Both 'a' and 'b' are incompatible
     export let x4: A & B = {
                ~~
-!!! error TS2322: Type '{ a: string; b: number; }' is not assignable to type 'A & B'.
+!!! error TS2322: Type '{ a: string; b: number; }' is not assignable to type 'A'.
 !!! error TS2322:   Type '{ a: string; b: number; }' is not assignable to type 'A'.
 !!! error TS2322:     Types of property 'a' are incompatible.
 !!! error TS2322:       Type 'string' is not assignable to type 'number'.
@@ -77,7 +79,7 @@ tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(38,12): error TS23
     // 'b' is compatible, 'a' is missing
     export let x5: A & B = {
                ~~
-!!! error TS2322: Type '{ b: number; }' is not assignable to type 'A & B'.
+!!! error TS2322: Type '{ b: number; }' is not assignable to type 'A'.
 !!! error TS2322:   Type '{ b: number; }' is not assignable to type 'A'.
 !!! error TS2322:     Property 'a' is missing in type '{ b: number; }'.
         b: 0,
@@ -86,7 +88,7 @@ tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts(38,12): error TS23
     // 'b' is incompatible, 'a' is missing
     export let x6: A & B = {
                ~~
-!!! error TS2322: Type '{ b: string; }' is not assignable to type 'A & B'.
+!!! error TS2322: Type '{ b: string; }' is not assignable to type 'A'.
 !!! error TS2322:   Type '{ b: string; }' is not assignable to type 'A'.
 !!! error TS2322:     Property 'a' is missing in type '{ b: string; }'.
         b: "",

--- a/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.js
+++ b/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.js
@@ -1,0 +1,73 @@
+//// [errorsOnWeakTypeIntersectionTargets01.ts]
+interface A {
+    a: number;
+}
+
+interface B {
+    b?: string;
+}
+
+// 'b' is incompatible.
+export let x1: A & B = {
+    a: 0,
+    b: 12,
+}
+
+// 'a' is incompatible, 'b' is present and compatible.
+export let x2: A & B = {
+    a: "hello",
+    b: "hello",
+}
+
+// 'a' is incompatible, 'b' is absent.
+export let x3: A & B = {
+    a: "hello",
+}
+
+// Both 'a' and 'b' are incompatible
+export let x4: A & B = {
+    a: "hello",
+    b: 0,
+}
+
+// 'b' is compatible, 'a' is missing
+export let x5: A & B = {
+    b: 0,
+}
+
+// 'b' is incompatible, 'a' is missing
+export let x6: A & B = {
+    b: "",
+}
+
+
+//// [errorsOnWeakTypeIntersectionTargets01.js]
+"use strict";
+exports.__esModule = true;
+// 'b' is incompatible.
+exports.x1 = {
+    a: 0,
+    b: 12
+};
+// 'a' is incompatible, 'b' is present and compatible.
+exports.x2 = {
+    a: "hello",
+    b: "hello"
+};
+// 'a' is incompatible, 'b' is absent.
+exports.x3 = {
+    a: "hello"
+};
+// Both 'a' and 'b' are incompatible
+exports.x4 = {
+    a: "hello",
+    b: 0
+};
+// 'b' is compatible, 'a' is missing
+exports.x5 = {
+    b: 0
+};
+// 'b' is incompatible, 'a' is missing
+exports.x6 = {
+    b: ""
+};

--- a/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.symbols
+++ b/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.symbols
@@ -1,0 +1,84 @@
+=== tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts ===
+interface A {
+>A : Symbol(A, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 0, 0))
+
+    a: number;
+>a : Symbol(A.a, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 0, 13))
+}
+
+interface B {
+>B : Symbol(B, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 2, 1))
+
+    b?: string;
+>b : Symbol(B.b, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 4, 13))
+}
+
+// 'b' is incompatible.
+export let x1: A & B = {
+>x1 : Symbol(x1, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 9, 10))
+>A : Symbol(A, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 0, 0))
+>B : Symbol(B, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 2, 1))
+
+    a: 0,
+>a : Symbol(a, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 9, 24))
+
+    b: 12,
+>b : Symbol(b, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 10, 9))
+}
+
+// 'a' is incompatible, 'b' is present and compatible.
+export let x2: A & B = {
+>x2 : Symbol(x2, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 15, 10))
+>A : Symbol(A, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 0, 0))
+>B : Symbol(B, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 2, 1))
+
+    a: "hello",
+>a : Symbol(a, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 15, 24))
+
+    b: "hello",
+>b : Symbol(b, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 16, 15))
+}
+
+// 'a' is incompatible, 'b' is absent.
+export let x3: A & B = {
+>x3 : Symbol(x3, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 21, 10))
+>A : Symbol(A, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 0, 0))
+>B : Symbol(B, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 2, 1))
+
+    a: "hello",
+>a : Symbol(a, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 21, 24))
+}
+
+// Both 'a' and 'b' are incompatible
+export let x4: A & B = {
+>x4 : Symbol(x4, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 26, 10))
+>A : Symbol(A, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 0, 0))
+>B : Symbol(B, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 2, 1))
+
+    a: "hello",
+>a : Symbol(a, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 26, 24))
+
+    b: 0,
+>b : Symbol(b, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 27, 15))
+}
+
+// 'b' is compatible, 'a' is missing
+export let x5: A & B = {
+>x5 : Symbol(x5, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 32, 10))
+>A : Symbol(A, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 0, 0))
+>B : Symbol(B, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 2, 1))
+
+    b: 0,
+>b : Symbol(b, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 32, 24))
+}
+
+// 'b' is incompatible, 'a' is missing
+export let x6: A & B = {
+>x6 : Symbol(x6, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 37, 10))
+>A : Symbol(A, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 0, 0))
+>B : Symbol(B, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 2, 1))
+
+    b: "",
+>b : Symbol(b, Decl(errorsOnWeakTypeIntersectionTargets01.ts, 37, 24))
+}
+

--- a/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.types
+++ b/tests/baselines/reference/errorsOnWeakTypeIntersectionTargets01.types
@@ -1,0 +1,99 @@
+=== tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts ===
+interface A {
+>A : A
+
+    a: number;
+>a : number
+}
+
+interface B {
+>B : B
+
+    b?: string;
+>b : string
+}
+
+// 'b' is incompatible.
+export let x1: A & B = {
+>x1 : A & B
+>A : A
+>B : B
+>{    a: 0,    b: 12,} : { a: number; b: number; }
+
+    a: 0,
+>a : number
+>0 : 0
+
+    b: 12,
+>b : number
+>12 : 12
+}
+
+// 'a' is incompatible, 'b' is present and compatible.
+export let x2: A & B = {
+>x2 : A & B
+>A : A
+>B : B
+>{    a: "hello",    b: "hello",} : { a: string; b: string; }
+
+    a: "hello",
+>a : string
+>"hello" : "hello"
+
+    b: "hello",
+>b : string
+>"hello" : "hello"
+}
+
+// 'a' is incompatible, 'b' is absent.
+export let x3: A & B = {
+>x3 : A & B
+>A : A
+>B : B
+>{    a: "hello",} : { a: string; }
+
+    a: "hello",
+>a : string
+>"hello" : "hello"
+}
+
+// Both 'a' and 'b' are incompatible
+export let x4: A & B = {
+>x4 : A & B
+>A : A
+>B : B
+>{    a: "hello",    b: 0,} : { a: string; b: number; }
+
+    a: "hello",
+>a : string
+>"hello" : "hello"
+
+    b: 0,
+>b : number
+>0 : 0
+}
+
+// 'b' is compatible, 'a' is missing
+export let x5: A & B = {
+>x5 : A & B
+>A : A
+>B : B
+>{    b: 0,} : { b: number; }
+
+    b: 0,
+>b : number
+>0 : 0
+}
+
+// 'b' is incompatible, 'a' is missing
+export let x6: A & B = {
+>x6 : A & B
+>A : A
+>B : B
+>{    b: "",} : { b: string; }
+
+    b: "",
+>b : string
+>"" : ""
+}
+

--- a/tests/baselines/reference/tsxAttributeResolution12.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution12.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/jsx/file.tsx(25,11): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
+tests/cases/conformance/jsx/file.tsx(25,11): error TS2322: Type '{}' is not assignable to type '{ reqd: any; }'.
   Type '{}' is not assignable to type '{ reqd: any; }'.
     Property 'reqd' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
+tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{}' is not assignable to type '{ reqd: any; }'.
   Type '{}' is not assignable to type '{ reqd: any; }'.
     Property 'reqd' is missing in type '{}'.
 
@@ -46,14 +46,14 @@ tests/cases/conformance/jsx/file.tsx(28,11): error TS2322: Type '{}' is not assi
     const T = TestMod.Test;
     var t1 = <T />;
               ~
-!!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
+!!! error TS2322: Type '{}' is not assignable to type '{ reqd: any; }'.
 !!! error TS2322:   Type '{}' is not assignable to type '{ reqd: any; }'.
 !!! error TS2322:     Property 'reqd' is missing in type '{}'.
     
     // Should error
     var t2 = <TestMod.Test />;
               ~~~~~~~~~~~~
-!!! error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { reqd: any; }'.
+!!! error TS2322: Type '{}' is not assignable to type '{ reqd: any; }'.
 !!! error TS2322:   Type '{}' is not assignable to type '{ reqd: any; }'.
 !!! error TS2322:     Property 'reqd' is missing in type '{}'.
     

--- a/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
+++ b/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/conformance/jsx/file.tsx(13,11): error TS2322: Type '{}' is not assignable to type 'Prop'.
-  Property 'a' is missing in type '{}'.
+  Type '{}' is not assignable to type 'Prop'.
+    Property 'a' is missing in type '{}'.
 tests/cases/conformance/jsx/file.tsx(19,18): error TS2326: Types of property 'a' are incompatible.
   Type 'string' is not assignable to type 'number'.
 
@@ -20,7 +21,8 @@ tests/cases/conformance/jsx/file.tsx(19,18): error TS2326: Types of property 'a'
     let x1 = <MyComp />
               ~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'Prop'.
-!!! error TS2322:   Property 'a' is missing in type '{}'.
+!!! error TS2322:   Type '{}' is not assignable to type 'Prop'.
+!!! error TS2322:     Property 'a' is missing in type '{}'.
     
     // OK
     let x = <MyComp a={10} b="hi" />

--- a/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
@@ -3,8 +3,9 @@ tests/cases/conformance/jsx/file.tsx(27,33): error TS2326: Types of property 'y'
 tests/cases/conformance/jsx/file.tsx(28,50): error TS2326: Types of property 'x' are incompatible.
   Type '3' is not assignable to type '2'.
 tests/cases/conformance/jsx/file.tsx(30,11): error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
-  Types of property 'y' are incompatible.
-    Type 'true' is not assignable to type 'false'.
+  Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
+    Types of property 'y' are incompatible.
+      Type 'true' is not assignable to type 'false'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -46,7 +47,8 @@ tests/cases/conformance/jsx/file.tsx(30,11): error TS2322: Type '{ y: true; x: 2
     let x3 = <OverWriteAttr overwrite="hi" {...obj1} {...{y: true}} />
               ~~~~~~~~~~~~~
 !!! error TS2322: Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
-!!! error TS2322:   Types of property 'y' are incompatible.
-!!! error TS2322:     Type 'true' is not assignable to type 'false'.
+!!! error TS2322:   Type '{ y: true; x: 2; overwrite: string; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'y' are incompatible.
+!!! error TS2322:       Type 'true' is not assignable to type 'false'.
     
     

--- a/tests/baselines/reference/tsxSpreadAttributesResolution16.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution16.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
-  Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
+  Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
+    Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -16,7 +17,8 @@ tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ property1: st
             <AnotherComponent {...props} />
              ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
-!!! error TS2322:   Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
+!!! error TS2322:   Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
+!!! error TS2322:     Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
         );
     }
     

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
@@ -1,17 +1,21 @@
 tests/cases/conformance/jsx/file.tsx(17,10): error TS2322: Type '{}' is not assignable to type 'PoisonedProp'.
-  Property 'x' is missing in type '{}'.
+  Type '{}' is not assignable to type 'PoisonedProp'.
+    Property 'x' is missing in type '{}'.
 tests/cases/conformance/jsx/file.tsx(18,10): error TS2322: Type '{}' is not assignable to type 'PoisonedProp'.
-  Property 'x' is missing in type '{}'.
+  Type '{}' is not assignable to type 'PoisonedProp'.
+    Property 'x' is missing in type '{}'.
 tests/cases/conformance/jsx/file.tsx(19,19): error TS2326: Types of property 'x' are incompatible.
   Type 'true' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(19,21): error TS2326: Types of property 'y' are incompatible.
   Type 'true' is not assignable to type '"2"'.
 tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
-  Types of property 'x' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+  Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+    Types of property 'x' are incompatible.
+      Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(21,11): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
-  Types of property 'x' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+  Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+    Types of property 'x' are incompatible.
+      Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (6 errors) ====
@@ -34,11 +38,13 @@ tests/cases/conformance/jsx/file.tsx(21,11): error TS2322: Type '{ X: string; x:
     let p = <Poisoned {...obj} />;
              ~~~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:   Property 'x' is missing in type '{}'.
+!!! error TS2322:   Type '{}' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:     Property 'x' is missing in type '{}'.
     let y = <Poisoned />;
              ~~~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:   Property 'x' is missing in type '{}'.
+!!! error TS2322:   Type '{}' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:     Property 'x' is missing in type '{}'.
     let z = <Poisoned x y/>;
                       ~
 !!! error TS2326: Types of property 'x' are incompatible.
@@ -49,10 +55,12 @@ tests/cases/conformance/jsx/file.tsx(21,11): error TS2322: Type '{ X: string; x:
     let w = <Poisoned {...{x: 5, y: "2"}}/>;
              ~~~~~~~~
 !!! error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:   Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:     Types of property 'x' are incompatible.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.
     let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
               ~~~~~~~~
 !!! error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:   Types of property 'x' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:   Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:     Types of property 'x' are incompatible.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution5.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution5.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
-  Types of property 'y' are incompatible.
-    Type 'number' is not assignable to type '2'.
+  Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
+    Types of property 'y' are incompatible.
+      Type 'number' is not assignable to type '2'.
 tests/cases/conformance/jsx/file.tsx(33,10): error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes & IntrinsicClassAttributes<EmptyProp> & { children?: ReactNode; }'.
 
 
@@ -27,8 +28,9 @@ tests/cases/conformance/jsx/file.tsx(33,10): error TS2559: Type '{ prop1: boolea
     let p = <Poisoned {...obj} />;
              ~~~~~~~~
 !!! error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
-!!! error TS2322:   Types of property 'y' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type '2'.
+!!! error TS2322:   Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:     Types of property 'y' are incompatible.
+!!! error TS2322:       Type 'number' is not assignable to type '2'.
     
     class EmptyProp extends React.Component<{}, {}> {
         render() {

--- a/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution6.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/conformance/jsx/file.tsx(13,10): error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
   Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
-    Property 'onEdit' is missing in type '{ editable: true; }'.
+    Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
+      Property 'onEdit' is missing in type '{ editable: true; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -20,7 +21,8 @@ tests/cases/conformance/jsx/file.tsx(13,10): error TS2322: Type '{ editable: tru
              ~~~~~~~~~~~~~
 !!! error TS2322: Type '{ editable: true; }' is not assignable to type '(IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: false; } & { children?: ReactNode; }) | (IntrinsicAttributes & IntrinsicClassAttributes<TextComponent> & { editable: true; onEdit: (newText: string) => void; } & { children?: ReactNode; })'.
 !!! error TS2322:   Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
-!!! error TS2322:     Property 'onEdit' is missing in type '{ editable: true; }'.
+!!! error TS2322:     Type '{ editable: true; }' is not assignable to type '{ editable: true; onEdit: (newText: string) => void; }'.
+!!! error TS2322:       Property 'onEdit' is missing in type '{ editable: true; }'.
     
     const textProps: TextProps = {
         editable: false

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -1,15 +1,19 @@
 tests/cases/conformance/jsx/file.tsx(12,13): error TS2322: Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
-  Property 'yy' is missing in type '{ extraProp: true; }'.
+  Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
+    Property 'yy' is missing in type '{ extraProp: true; }'.
 tests/cases/conformance/jsx/file.tsx(13,13): error TS2322: Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
-  Property 'yy1' is missing in type '{ yy: number; }'.
+  Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
+    Property 'yy1' is missing in type '{ yy: number; }'.
 tests/cases/conformance/jsx/file.tsx(14,31): error TS2326: Types of property 'yy1' are incompatible.
   Type 'true' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(16,31): error TS2339: Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 tests/cases/conformance/jsx/file.tsx(17,13): error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
-  Types of property 'yy' are incompatible.
-    Type 'boolean' is not assignable to type 'number'.
+  Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
+    Types of property 'yy' are incompatible.
+      Type 'boolean' is not assignable to type 'number'.
 tests/cases/conformance/jsx/file.tsx(25,13): error TS2322: Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
-  Property 'yy' is missing in type '{ extra-data: true; }'.
+  Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
+    Property 'yy' is missing in type '{ extra-data: true; }'.
 tests/cases/conformance/jsx/file.tsx(26,40): error TS2326: Types of property 'direction' are incompatible.
   Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/jsx/file.tsx(33,32): error TS2326: Types of property 'y3' are incompatible.
@@ -37,11 +41,13 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2326: Types of property 'y1
     const c0 = <OneThing extraProp />;  // extra property;
                 ~~~~~~~~
 !!! error TS2322: Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
-!!! error TS2322:   Property 'yy' is missing in type '{ extraProp: true; }'.
+!!! error TS2322:   Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
+!!! error TS2322:     Property 'yy' is missing in type '{ extraProp: true; }'.
     const c1 = <OneThing yy={10}/>;  // missing property;
                 ~~~~~~~~
 !!! error TS2322: Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
-!!! error TS2322:   Property 'yy1' is missing in type '{ yy: number; }'.
+!!! error TS2322:   Type '{ yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
+!!! error TS2322:     Property 'yy1' is missing in type '{ yy: number; }'.
     const c2 = <OneThing {...obj} yy1 />; // type incompatible;
                                   ~~~
 !!! error TS2326: Types of property 'yy1' are incompatible.
@@ -53,8 +59,9 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2326: Types of property 'y1
     const c5 = <OneThing {...obj} {...{yy: true}} />;  // type incompatible;
                 ~~~~~~~~
 !!! error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
-!!! error TS2322:   Types of property 'yy' are incompatible.
-!!! error TS2322:     Type 'boolean' is not assignable to type 'number'.
+!!! error TS2322:   Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
+!!! error TS2322:     Types of property 'yy' are incompatible.
+!!! error TS2322:       Type 'boolean' is not assignable to type 'number'.
     const c6 = <OneThing {...obj2} {...{extra: "extra attr"}} />;  // Should error as there is extra attribute that doesn't match any. Current it is not
     const c7 = <OneThing {...obj2} yy />;  // Should error as there is extra attribute that doesn't match any. Current it is not
     
@@ -65,7 +72,8 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2326: Types of property 'y1
     const d1 = <TestingOneThing extra-data />
                 ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
-!!! error TS2322:   Property 'yy' is missing in type '{ extra-data: true; }'.
+!!! error TS2322:   Type '{ extra-data: true; }' is not assignable to type '{ yy: string; direction?: number; }'.
+!!! error TS2322:     Property 'yy' is missing in type '{ extra-data: true; }'.
     const d2 = <TestingOneThing yy="hello" direction="left" />
                                            ~~~~~~~~~~~~~~~~
 !!! error TS2326: Types of property 'direction' are incompatible.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,13 +1,18 @@
 tests/cases/conformance/jsx/file.tsx(48,13): error TS2322: Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
-  Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
+  Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
 tests/cases/conformance/jsx/file.tsx(49,13): error TS2322: Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
-  Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
+  Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
 tests/cases/conformance/jsx/file.tsx(50,13): error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
-  Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
+  Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
 tests/cases/conformance/jsx/file.tsx(51,13): error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
-  Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
+  Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
 tests/cases/conformance/jsx/file.tsx(53,13): error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-  Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
+  Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
 tests/cases/conformance/jsx/file.tsx(54,51): error TS2326: Types of property 'children' are incompatible.
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(55,68): error TS2326: Types of property 'className' are incompatible.
@@ -67,24 +72,29 @@ tests/cases/conformance/jsx/file.tsx(56,24): error TS2326: Types of property 'da
     const b0 = <MainButton to='/some/path' onClick={(e)=>{}}>GO</MainButton>;  // extra property;
                 ~~~~~~~~~~
 !!! error TS2322: Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:   Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
+!!! error TS2322:   Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }'.
     const b1 = <MainButton onClick={(e: any)=> {}} {...obj0}>Hello world</MainButton>;  // extra property;
                 ~~~~~~~~~~
 !!! error TS2322: Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:   Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
+!!! error TS2322:   Type '{ children: string; to: string; onClick: (e: any) => void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ children: string; to: string; onClick: (e: any) => void; }'.
     const b2 = <MainButton {...{to: "10000"}} {...obj2} />;  // extra property
                 ~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:   Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
+!!! error TS2322:   Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
     const b3 = <MainButton {...{to: "10000"}} {...{onClick: (k) => {}}} />;  // extra property
                 ~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:   Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
+!!! error TS2322:   Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
     const b4 = <MainButton {...obj3} to />;  // Should error because Incorrect type; but attributes are any so everything is allowed
     const b5 = <MainButton {...{ onClick(e: any) { } }} {...obj0} />;  // Spread retain method declaration (see GitHub #13365), so now there is an extra attributes
                 ~~~~~~~~~~
 !!! error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
-!!! error TS2322:   Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
+!!! error TS2322:   Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
     const b6 = <MainButton {...{ onClick(e: any){} }} children={10} />;  // incorrect type for optional attribute
                                                       ~~~~~~~~~~~~~
 !!! error TS2326: Types of property 'children' are incompatible.

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
@@ -1,10 +1,12 @@
 tests/cases/conformance/jsx/file.tsx(19,10): error TS2322: Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
-  Property 'name' is missing in type '{ naaame: string; }'.
+  Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
+    Property 'name' is missing in type '{ naaame: string; }'.
 tests/cases/conformance/jsx/file.tsx(27,15): error TS2326: Types of property 'name' are incompatible.
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(29,10): error TS2559: Type '{ naaaaaaame: string; }' has no properties in common with type 'IntrinsicAttributes & { name?: string; }'.
 tests/cases/conformance/jsx/file.tsx(34,10): error TS2322: Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
-  Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
+  Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
+    Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
 tests/cases/conformance/jsx/file.tsx(37,10): error TS2559: Type '{ prop1: true; }' has no properties in common with type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(38,11): error TS2559: Type '{ ref: (x: any) => any; }' has no properties in common with type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(41,16): error TS1005: ',' expected.
@@ -33,7 +35,8 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
     let b = <Greet naaame='world' />;
              ~~~~~
 !!! error TS2322: Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
-!!! error TS2322:   Property 'name' is missing in type '{ naaame: string; }'.
+!!! error TS2322:   Type '{ naaame: string; }' is not assignable to type '{ name: string; }'.
+!!! error TS2322:     Property 'name' is missing in type '{ naaame: string; }'.
     
     // OK
     let c = <Meet />;
@@ -56,7 +59,8 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
     let h = <MeetAndGreet extra-prop-name="World" />;
              ~~~~~~~~~~~~
 !!! error TS2322: Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
-!!! error TS2322:   Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
+!!! error TS2322:   Type '{ extra-prop-name: string; }' is not assignable to type '{ "prop-name": string; }'.
+!!! error TS2322:     Property '"prop-name"' is missing in type '{ extra-prop-name: string; }'.
     
     // Error
     let i = <EmptyPropSFC prop1 />

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments2.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/jsx/file.tsx(8,43): error TS2326: Types of property 'ignore-prop' are incompatible.
   Type '(T & { ignore-prop: number; })["ignore-prop"]' is not assignable to type 'string'.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(13,15): error TS2322: Type 'T' is not assignable to type 'IntrinsicAttributes & { prop: {}; "ignore-prop": string; }'.
+tests/cases/conformance/jsx/file.tsx(13,15): error TS2322: Type 'T' is not assignable to type '{ prop: {}; "ignore-prop": string; }'.
   Type 'T' is not assignable to type '{ prop: {}; "ignore-prop": string; }'.
 tests/cases/conformance/jsx/file.tsx(20,19): error TS2326: Types of property 'func' are incompatible.
   Type '(a: number, b: string) => void' is not assignable to type '(arg: number) => void'.
@@ -30,7 +30,7 @@ tests/cases/conformance/jsx/file.tsx(31,52): error TS2326: Types of property 'se
     function Baz<T>(arg: T) {
         let a0 = <ComponentSpecific1 {...arg} />
                   ~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type 'T' is not assignable to type 'IntrinsicAttributes & { prop: {}; "ignore-prop": string; }'.
+!!! error TS2322: Type 'T' is not assignable to type '{ prop: {}; "ignore-prop": string; }'.
 !!! error TS2322:   Type 'T' is not assignable to type '{ prop: {}; "ignore-prop": string; }'.
     }
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/conformance/jsx/file.tsx(9,15): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
-  Property 'b' is missing in type '{ a: number; }'.
-tests/cases/conformance/jsx/file.tsx(10,15): error TS2322: Type 'T & { ignore-prop: true; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: {}; }'.
+  Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
+    Property 'b' is missing in type '{ a: number; }'.
+tests/cases/conformance/jsx/file.tsx(10,15): error TS2322: Type 'T & { ignore-prop: true; }' is not assignable to type '{ b: {}; a: {}; }'.
   Type 'T & { ignore-prop: true; }' is not assignable to type '{ b: {}; a: {}; }'.
     Property 'a' is missing in type '{ b: number; } & { ignore-prop: true; }'.
 
@@ -17,10 +18,11 @@ tests/cases/conformance/jsx/file.tsx(10,15): error TS2322: Type 'T & { ignore-pr
         let a0 = <OverloadComponent a={arg1.b}/>
                   ~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
-!!! error TS2322:   Property 'b' is missing in type '{ a: number; }'.
+!!! error TS2322:   Type '{ a: number; }' is not assignable to type '{ b: {}; a: number; }'.
+!!! error TS2322:     Property 'b' is missing in type '{ a: number; }'.
         let a2 = <OverloadComponent {...arg1} ignore-prop />  // missing a
                   ~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type 'T & { ignore-prop: true; }' is not assignable to type 'IntrinsicAttributes & { b: {}; a: {}; }'.
+!!! error TS2322: Type 'T & { ignore-prop: true; }' is not assignable to type '{ b: {}; a: {}; }'.
 !!! error TS2322:   Type 'T & { ignore-prop: true; }' is not assignable to type '{ b: {}; a: {}; }'.
 !!! error TS2322:     Property 'a' is missing in type '{ b: number; } & { ignore-prop: true; }'.
     }

--- a/tests/baselines/reference/tsxUnionElementType6.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType6.errors.txt
@@ -2,9 +2,11 @@ tests/cases/conformance/jsx/file.tsx(18,10): error TS2559: Type '{ x: true; }' h
 tests/cases/conformance/jsx/file.tsx(19,27): error TS2326: Types of property 'x' are incompatible.
   Type 'string' is not assignable to type 'boolean'.
 tests/cases/conformance/jsx/file.tsx(20,10): error TS2322: Type '{}' is not assignable to type '{ x: boolean; }'.
-  Property 'x' is missing in type '{}'.
+  Type '{}' is not assignable to type '{ x: boolean; }'.
+    Property 'x' is missing in type '{}'.
 tests/cases/conformance/jsx/file.tsx(21,10): error TS2322: Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
-  Property 'x' is missing in type '{ data-prop: true; }'.
+  Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
+    Property 'x' is missing in type '{ data-prop: true; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (4 errors) ====
@@ -35,10 +37,12 @@ tests/cases/conformance/jsx/file.tsx(21,10): error TS2322: Type '{ data-prop: tr
     let c = <SFC2AndEmptyComp />;
              ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{}' is not assignable to type '{ x: boolean; }'.
-!!! error TS2322:   Property 'x' is missing in type '{}'.
+!!! error TS2322:   Type '{}' is not assignable to type '{ x: boolean; }'.
+!!! error TS2322:     Property 'x' is missing in type '{}'.
     let d = <SFC2AndEmptyComp data-prop />;
              ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
-!!! error TS2322:   Property 'x' is missing in type '{ data-prop: true; }'.
+!!! error TS2322:   Type '{ data-prop: true; }' is not assignable to type '{ x: boolean; }'.
+!!! error TS2322:     Property 'x' is missing in type '{ data-prop: true; }'.
     
     

--- a/tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts
+++ b/tests/cases/compiler/errorsOnWeakTypeIntersectionTargets01.ts
@@ -1,0 +1,40 @@
+interface A {
+    a: number;
+}
+
+interface B {
+    b?: string;
+}
+
+// 'b' is incompatible.
+export let x1: A & B = {
+    a: 0,
+    b: 12,
+}
+
+// 'a' is incompatible, 'b' is present and compatible.
+export let x2: A & B = {
+    a: "hello",
+    b: "hello",
+}
+
+// 'a' is incompatible, 'b' is absent.
+export let x3: A & B = {
+    a: "hello",
+}
+
+// Both 'a' and 'b' are incompatible
+export let x4: A & B = {
+    a: "hello",
+    b: 0,
+}
+
+// 'b' is compatible, 'a' is missing
+export let x5: A & B = {
+    b: 0,
+}
+
+// 'b' is incompatible, 'a' is missing
+export let x6: A & B = {
+    b: "",
+}


### PR DESCRIPTION
Ignore for now - I've made some changes that actually make errors worse.

~~Fixes #24146.~~

~~When a source type still isn't assignable to an intersection with all the weak types removed, we can generally assume that the "strong" types are the ones that are more interesting to report on. As an improvement, we try to keep them around and remove weak types which we believe will cause noise.~~

~~While this sometimes has undesirable effects when there are incompatibilities among strong types *and* weak types, this by and large gives better behavior when dealing with types like JSX's `IntrinsicAttributes`.~~