### PR TITLE
Reproduce a crash in TypeScript 2.9 JS support.

### DIFF
--- a/tests/cases/compiler/checkJsFiles8.ts
+++ b/tests/cases/compiler/checkJsFiles8.ts
@@ -1,0 +1,15 @@
+// @allowJs: true
+// @checkJs: false
+// @noEmit: true
+
+// @fileName: a.js
+// @ts-check
+
+var CtorFunction = function() {
+  this.myField = 'a';
+};
+/** @type {string} */
+CtorFunction.prototype.myField;
+
+var x = new CtorFunction();
+x.myField = 'b';


### PR DESCRIPTION
If JavaScript code has both a `valueDeclaration` that is a binary
expression (e.g. property assignment), and additional declarations that are not, TypeScript gets confused and crashes in an attempted cast:

```js
var CtorFunction = function() {
  this.myField = 'a';
};
/** @type {string} */
CtorFunction.prototype.myField;

var x = new CtorFunction();
x.myField = 'b';
```

Leading to:

```
Error: Debug Failure. Invalid cast. The supplied value [object Object] did not pass the test 'isBinaryExpression'.
  at Object.cast (src/compiler/core.ts:1445:22)
  at _loop_4 (src/compiler/checker.ts:4644:80)
  at getWidenedTypeFromJSSpecialPropertyDeclarations (built/local/run.js:33366:31)
  at getJSSpecialType (src/compiler/checker.ts:4982:21)
  at getTypeOfVariableOrParameterOrProperty (src/compiler/checker.ts:4920:28)
  at getTypeOfSymbol (src/compiler/checker.ts:5219:24)
  at checkPropertyAccessExpressionOrQualifiedName (src/compiler/checker.ts:17285:53)
  at checkPropertyAccessExpression (src/compiler/checker.ts:17238:20)
  at checkExpressionWorker (src/compiler/checker.ts:20937:28)
  at checkExpression (src/compiler/checker.ts:20878:44)
  at checkBinaryLikeExpression (src/compiler/checker.ts:20350:28)
  at checkBinaryExpression (src/compiler/checker.ts:20342:20)
  at checkExpressionWorker (src/compiler/checker.ts:20976:28)
```

`getWidenedTypeFromJSSpecialPropertyDeclarations` iterates all declarations and then runs into the non-binary one.
