### PR TITLE
getEditsForFileRename: Don't update import with non-relative path if the imported file didn't move

### DIFF
--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -125,10 +125,11 @@ namespace ts {
                         // TODO:GH#18217
                         ? getSourceFileToImportFromResolved(resolveModuleName(importLiteral.text, oldImportFromPath, program.getCompilerOptions(), host as ModuleResolutionHost), oldToNew, program)
                         : getSourceFileToImport(importLiteral, sourceFile, program, host, oldToNew);
-                    // If neither the importing source file nor the imported file moved, do nothing.
-                    return toImport === undefined || !toImport.updated && !importingSourceFileMoved
-                        ? undefined
-                        : moduleSpecifiers.getModuleSpecifier(program.getCompilerOptions(), sourceFile, newImportFromPath, toImport.newFileName, host, preferences);
+
+                    // Need an update if the imported file moved, or the importing file moved and was using a relative path.
+                    return toImport !== undefined && (toImport.updated || (importingSourceFileMoved && pathIsRelative(importLiteral.text)))
+                        ? moduleSpecifiers.getModuleSpecifier(program.getCompilerOptions(), sourceFile, newImportFromPath, toImport.newFileName, host, preferences)
+                        : undefined;
                 });
         }
     }

--- a/tests/cases/fourslash/getEditsForFileRename_unaffectedNonRelativePath.ts
+++ b/tests/cases/fourslash/getEditsForFileRename_unaffectedNonRelativePath.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /sub/a.ts
+////export const a = 1;
+
+// @Filename: /sub/b.ts
+////import { a } from "sub/a";
+
+// @Filename: /tsconfig.json
+////{
+////    "compilerOptions": {
+////        "baseUrl": "."
+////    }
+////}
+
+verify.getEditsForFileRename({
+    oldPath: "/sub/b.ts",
+    newPath: "/sub/c/d.ts",
+    newFileContents: {},
+});


### PR DESCRIPTION
Fixes #25132

