### PR TITLE
Fix completions trigger character on JSX opening tag

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -850,7 +850,7 @@ namespace FourSlash {
         private verifyCompletionsWorker(options: FourSlashInterface.VerifyCompletionsOptions): void {
             const actualCompletions = this.getCompletionListAtCaret({ ...options.preferences, triggerCharacter: options.triggerCharacter })!;
             if (!actualCompletions) {
-                if (options.exact === undefined) return;
+                if ("exact" in options && options.exact === undefined) return;
                 this.raiseError(`No completions at position '${this.currentCaretPosition}'.`);
             }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -961,8 +961,7 @@ namespace ts.Completions {
                         break;
 
                     case SyntaxKind.BinaryExpression:
-                        if (!((parent as BinaryExpression).left.flags & NodeFlags.ThisNodeHasError)) {
-                            // It has a left-hand side, so we're not in an opening JSX tag.
+                        if (!binaryExpressionMayBeOpenTag(parent as BinaryExpression)) {
                             break;
                         }
                     // falls through
@@ -2256,7 +2255,7 @@ namespace ts.Completions {
                 return isStringLiteralOrTemplate(contextToken) && position === contextToken.getStart(sourceFile) + 1;
             case "<":
                 // Opening JSX tag
-                return contextToken.kind === SyntaxKind.LessThanToken && contextToken.parent.kind !== SyntaxKind.BinaryExpression;
+                return contextToken.kind === SyntaxKind.LessThanToken && (!isBinaryExpression(contextToken.parent) || binaryExpressionMayBeOpenTag(contextToken.parent));
             case "/":
                 return isStringLiteralLike(contextToken)
                     ? !!tryGetImportFromModuleSpecifier(contextToken)
@@ -2264,6 +2263,10 @@ namespace ts.Completions {
             default:
                 return Debug.assertNever(triggerCharacter);
         }
+    }
+
+    function binaryExpressionMayBeOpenTag({ left }: BinaryExpression): boolean {
+        return nodeIsMissing(left);
     }
 
     function isStringLiteralOrTemplate(node: Node): node is StringLiteralLike | TemplateExpression | TaggedTemplateExpression {

--- a/tests/cases/fourslash/completionsTriggerCharacter.ts
+++ b/tests/cases/fourslash/completionsTriggerCharacter.ts
@@ -13,10 +13,12 @@
 ////whatever
 
 // @Filename: /a.tsx
-////declare namespace JSX {
-////    interface Element {}
-////    interface IntrinsicElements {
-////        div: {};
+////declare global {
+////    namespace JSX {
+////        interface Element {}
+////        interface IntrinsicElements {
+////            div: {};
+////        }
 ////    }
 ////}
 ////const ctr = </*openTag*/;


### PR DESCRIPTION
Fixes completion trigger at `const x = <`, which is probably the start of a JSX opening tag but parses as a `BinaryExpression`.
