### PR TITLE
Don't crash on property access with type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4650,15 +4650,15 @@ namespace ts {
             let jsDocType: Type | undefined;
             for (const declaration of symbol.declarations) {
                 let declarationInConstructor = false;
-                const expression = declaration.kind === SyntaxKind.BinaryExpression ? <BinaryExpression>declaration :
-                    declaration.kind === SyntaxKind.PropertyAccessExpression ? cast(declaration.parent, isBinaryExpression) :
+                const expression = isBinaryExpression(declaration) ? declaration :
+                    isPropertyAccessExpression(declaration) ? isBinaryExpression(declaration.parent) ? declaration.parent : declaration :
                         undefined;
 
                 if (!expression) {
                     return errorType;
                 }
 
-                const special = getSpecialPropertyAssignmentKind(expression);
+                const special = isPropertyAccessExpression(expression) ? getSpecialPropertyAccessKind(expression) : getSpecialPropertyAssignmentKind(expression);
                 if (special === SpecialPropertyAssignmentKind.ThisProperty) {
                     const thisContainer = getThisContainer(expression, /*includeArrowFunctions*/ false);
                     // Properties defined in a constructor (or base constructor, or javascript constructor function) don't get undefined added.
@@ -4687,7 +4687,7 @@ namespace ts {
                         errorNextVariableOrPropertyDeclarationMustHaveSameType(jsDocType, declaration, declarationType);
                     }
                 }
-                else if (!jsDocType) {
+                else if (!jsDocType && isBinaryExpression(expression)) {
                     // If we don't have an explicit JSDoc type, get the type from the expression.
                     let type = getWidenedLiteralType(checkExpressionCached(expression.right));
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1887,6 +1887,14 @@ namespace ts {
             return SpecialPropertyAssignmentKind.None;
         }
         const lhs = expr.left;
+        if (isEntityNameExpression(lhs.expression) && lhs.name.escapedText === "prototype" && isObjectLiteralExpression(getInitializerOfBinaryExpression(expr))) {
+                // F.prototype = { ... }
+                return SpecialPropertyAssignmentKind.Prototype;
+        }
+        return getSpecialPropertyAccessKind(lhs);
+    }
+
+    export function getSpecialPropertyAccessKind(lhs: PropertyAccessExpression): SpecialPropertyAssignmentKind {
         if (lhs.expression.kind === SyntaxKind.ThisKeyword) {
             return SpecialPropertyAssignmentKind.ThisProperty;
         }
@@ -1895,11 +1903,7 @@ namespace ts {
             return SpecialPropertyAssignmentKind.ModuleExports;
         }
         else if (isEntityNameExpression(lhs.expression)) {
-            if (lhs.name.escapedText === "prototype" && isObjectLiteralExpression(getInitializerOfBinaryExpression(expr))) {
-                // F.prototype = { ... }
-                return SpecialPropertyAssignmentKind.Prototype;
-            }
-            else if (isPrototypeAccess(lhs.expression)) {
+            if (isPrototypeAccess(lhs.expression)) {
                 // F.G....prototype.x = expr
                 return SpecialPropertyAssignmentKind.PrototypeProperty;
             }

--- a/tests/baselines/reference/jsdocPropertyAccessWithType.errors.txt
+++ b/tests/baselines/reference/jsdocPropertyAccessWithType.errors.txt
@@ -1,0 +1,12 @@
+error TS5055: Cannot write file '/a.js' because it would overwrite input file.
+  Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
+
+
+!!! error TS5055: Cannot write file '/a.js' because it would overwrite input file.
+!!! error TS5055:   Adding a tsconfig.json file will help organize projects that contain both TypeScript and JavaScript files. Learn more at https://aka.ms/tsconfig.
+==== /a.js (0 errors) ====
+    function C() { this.x = 0; };
+    /** @type {number} */
+    C.prototype.x;
+    new C().x;
+    

--- a/tests/baselines/reference/jsdocPropertyAccessWithType.symbols
+++ b/tests/baselines/reference/jsdocPropertyAccessWithType.symbols
@@ -1,0 +1,16 @@
+=== /a.js ===
+function C() { this.x = 0; };
+>C : Symbol(C, Decl(a.js, 0, 0))
+>x : Symbol(C.x, Decl(a.js, 0, 14), Decl(a.js, 0, 29))
+
+/** @type {number} */
+C.prototype.x;
+>C.prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(a.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+
+new C().x;
+>new C().x : Symbol(C.x, Decl(a.js, 0, 14), Decl(a.js, 0, 29))
+>C : Symbol(C, Decl(a.js, 0, 0))
+>x : Symbol(C.x, Decl(a.js, 0, 14), Decl(a.js, 0, 29))
+

--- a/tests/baselines/reference/jsdocPropertyAccessWithType.types
+++ b/tests/baselines/reference/jsdocPropertyAccessWithType.types
@@ -1,0 +1,23 @@
+=== /a.js ===
+function C() { this.x = 0; };
+>C : typeof C
+>this.x = 0 : 0
+>this.x : any
+>this : any
+>x : any
+>0 : 0
+
+/** @type {number} */
+C.prototype.x;
+>C.prototype.x : any
+>C.prototype : any
+>C : typeof C
+>prototype : any
+>x : any
+
+new C().x;
+>new C().x : number
+>new C() : C
+>C : typeof C
+>x : number
+

--- a/tests/cases/compiler/jsdocPropertyAccessWithType.ts
+++ b/tests/cases/compiler/jsdocPropertyAccessWithType.ts
@@ -1,0 +1,9 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /a.js
+function C() { this.x = false; };
+/** @type {number} */
+C.prototype.x;
+new C().x;


### PR DESCRIPTION
Fixes #25154

#20198 added support for `/** @type {number} */ this.x;` syntactically, but we were crashing in the checker if that syntax was used.
This stops the crashing, but there is no error reporting yet (#25169).