### PR TITLE
Fix decorator design:types emit for type variables.

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1969,7 +1969,16 @@ namespace ts {
          * @param node The type reference node.
          */
         function serializeTypeReferenceNode(node: TypeReferenceNode): SerializedTypeNode {
-            const kind = resolver.getTypeReferenceSerializationKind(node.typeName, currentScope);
+            // node might be a reference to type variable, which can be scoped to a class declaration, in addition to the regular
+            // TypeScript scopes. Walk up the AST to find the next class and use that as the lookup scope.
+            let scope: Node = node;
+            while (scope.parent && scope !== currentScope) {
+                scope = scope.parent;
+                if (isClassDeclaration(scope)) {
+                    break;
+                }
+            }
+            const kind = resolver.getTypeReferenceSerializationKind(node.typeName, scope);
             switch (kind) {
                 case TypeReferenceSerializationKind.Unknown:
                     const serialized = serializeEntityNameAsExpression(node.typeName, /*useFallback*/ true);

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -166,9 +166,6 @@ namespace ts {
 
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.FunctionDeclaration:
-                    if (isClassDeclaration(node)) {
-                        currentScope = node;
-                    }
                     if (hasModifier(node, ModifierFlags.Ambient)) {
                         break;
                     }
@@ -182,6 +179,10 @@ namespace ts {
                         // however, class declaration parsing allows for undefined names, so syntactically invalid
                         // programs may also have an undefined name.
                         Debug.assert(node.kind === SyntaxKind.ClassDeclaration || hasModifier(node, ModifierFlags.Default));
+                    }
+                    if (isClassDeclaration(node)) {
+                        // XXX: should probably also cover interfaces and type aliases that can have type variables?
+                        currentScope = node;
                     }
 
                     break;
@@ -1972,16 +1973,7 @@ namespace ts {
          * @param node The type reference node.
          */
         function serializeTypeReferenceNode(node: TypeReferenceNode): SerializedTypeNode {
-            // node might be a reference to type variable, which can be scoped to a class declaration, in addition to the regular
-            // TypeScript scopes. Walk up the AST to find the next class and use that as the lookup scope.
-            let scope: Node = currentScope;
-            // while (scope.parent && scope !== currentScope) {
-            //     scope = scope.parent;
-            //     if (isClassDeclaration(scope)) {
-            //         break;
-            //     }
-            // }
-            const kind = resolver.getTypeReferenceSerializationKind(node.typeName, scope);
+            const kind = resolver.getTypeReferenceSerializationKind(node.typeName, currentScope);
             switch (kind) {
                 case TypeReferenceSerializationKind.Unknown:
                     const serialized = serializeEntityNameAsExpression(node.typeName, /*useFallback*/ true);

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -61,7 +61,7 @@ namespace ts {
         let currentSourceFile: SourceFile;
         let currentNamespace: ModuleDeclaration;
         let currentNamespaceContainerName: Identifier;
-        let currentScope: SourceFile | Block | ModuleBlock | CaseBlock;
+        let currentScope: SourceFile | Block | ModuleBlock | CaseBlock | ClassDeclaration;
         let currentScopeFirstDeclarationsOfName: UnderscoreEscapedMap<Node> | undefined;
 
         /**
@@ -166,6 +166,9 @@ namespace ts {
 
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.FunctionDeclaration:
+                    if (isClassDeclaration(node)) {
+                        currentScope = node;
+                    }
                     if (hasModifier(node, ModifierFlags.Ambient)) {
                         break;
                     }
@@ -1971,13 +1974,13 @@ namespace ts {
         function serializeTypeReferenceNode(node: TypeReferenceNode): SerializedTypeNode {
             // node might be a reference to type variable, which can be scoped to a class declaration, in addition to the regular
             // TypeScript scopes. Walk up the AST to find the next class and use that as the lookup scope.
-            let scope: Node = node;
-            while (scope.parent && scope !== currentScope) {
-                scope = scope.parent;
-                if (isClassDeclaration(scope)) {
-                    break;
-                }
-            }
+            let scope: Node = currentScope;
+            // while (scope.parent && scope !== currentScope) {
+            //     scope = scope.parent;
+            //     if (isClassDeclaration(scope)) {
+            //         break;
+            //     }
+            // }
             const kind = resolver.getTypeReferenceSerializationKind(node.typeName, scope);
             switch (kind) {
                 case TypeReferenceSerializationKind.Unknown:

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariable.errors.txt
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariable.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts(2,4): error TS2304: Cannot find name 'Decorate'.
+
+
+==== tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts (1 errors) ====
+    export class C<TypeVariable> {
+      @Decorate
+       ~~~~~~~~
+!!! error TS2304: Cannot find name 'Decorate'.
+      member: TypeVariable;
+    }
+    

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariable.js
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariable.js
@@ -1,0 +1,29 @@
+//// [decoratorMetadataGenericTypeVariable.ts]
+export class C<TypeVariable> {
+  @Decorate
+  member: TypeVariable;
+}
+
+
+//// [decoratorMetadataGenericTypeVariable.js]
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+exports.__esModule = true;
+var C = /** @class */ (function () {
+    function C() {
+    }
+    __decorate([
+        Decorate,
+        __metadata("design:type", Object)
+    ], C.prototype, "member");
+    return C;
+}());
+exports.C = C;

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariable.symbols
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariable.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts ===
+export class C<TypeVariable> {
+>C : Symbol(C, Decl(decoratorMetadataGenericTypeVariable.ts, 0, 0))
+>TypeVariable : Symbol(TypeVariable, Decl(decoratorMetadataGenericTypeVariable.ts, 0, 15))
+
+  @Decorate
+  member: TypeVariable;
+>member : Symbol(C.member, Decl(decoratorMetadataGenericTypeVariable.ts, 0, 30))
+>TypeVariable : Symbol(TypeVariable, Decl(decoratorMetadataGenericTypeVariable.ts, 0, 15))
+}
+

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariable.types
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariable.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts ===
+export class C<TypeVariable> {
+>C : C<TypeVariable>
+>TypeVariable : TypeVariable
+
+  @Decorate
+>Decorate : any
+
+  member: TypeVariable;
+>member : TypeVariable
+>TypeVariable : TypeVariable
+}
+

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariableDefault.errors.txt
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariableDefault.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts(2,4): error TS2304: Cannot find name 'Decorate'.
+
+
+==== tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts (1 errors) ====
+    export class C<TypeVariable = string> {
+      @Decorate
+       ~~~~~~~~
+!!! error TS2304: Cannot find name 'Decorate'.
+      member: TypeVariable;
+    }
+    

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariableDefault.js
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariableDefault.js
@@ -1,0 +1,29 @@
+//// [decoratorMetadataGenericTypeVariableDefault.ts]
+export class C<TypeVariable = string> {
+  @Decorate
+  member: TypeVariable;
+}
+
+
+//// [decoratorMetadataGenericTypeVariableDefault.js]
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+exports.__esModule = true;
+var C = /** @class */ (function () {
+    function C() {
+    }
+    __decorate([
+        Decorate,
+        __metadata("design:type", Object)
+    ], C.prototype, "member");
+    return C;
+}());
+exports.C = C;

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariableDefault.symbols
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariableDefault.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts ===
+export class C<TypeVariable = string> {
+>C : Symbol(C, Decl(decoratorMetadataGenericTypeVariableDefault.ts, 0, 0))
+>TypeVariable : Symbol(TypeVariable, Decl(decoratorMetadataGenericTypeVariableDefault.ts, 0, 15))
+
+  @Decorate
+  member: TypeVariable;
+>member : Symbol(C.member, Decl(decoratorMetadataGenericTypeVariableDefault.ts, 0, 39))
+>TypeVariable : Symbol(TypeVariable, Decl(decoratorMetadataGenericTypeVariableDefault.ts, 0, 15))
+}
+

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariableDefault.types
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariableDefault.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts ===
+export class C<TypeVariable = string> {
+>C : C<TypeVariable>
+>TypeVariable : TypeVariable
+
+  @Decorate
+>Decorate : any
+
+  member: TypeVariable;
+>member : TypeVariable
+>TypeVariable : TypeVariable
+}
+

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariableInScope.errors.txt
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariableInScope.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts(5,4): error TS2304: Cannot find name 'Decorate'.
+
+
+==== tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts (1 errors) ====
+    // Unused, but could collide with the named type argument below.
+    class TypeVariable {}
+    
+    export class C<TypeVariable> {
+      @Decorate
+       ~~~~~~~~
+!!! error TS2304: Cannot find name 'Decorate'.
+      member: TypeVariable;
+    }
+    

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariableInScope.js
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariableInScope.js
@@ -1,0 +1,38 @@
+//// [decoratorMetadataGenericTypeVariableInScope.ts]
+// Unused, but could collide with the named type argument below.
+class TypeVariable {}
+
+export class C<TypeVariable> {
+  @Decorate
+  member: TypeVariable;
+}
+
+
+//// [decoratorMetadataGenericTypeVariableInScope.js]
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+exports.__esModule = true;
+// Unused, but could collide with the named type argument below.
+var TypeVariable = /** @class */ (function () {
+    function TypeVariable() {
+    }
+    return TypeVariable;
+}());
+var C = /** @class */ (function () {
+    function C() {
+    }
+    __decorate([
+        Decorate,
+        __metadata("design:type", Object)
+    ], C.prototype, "member");
+    return C;
+}());
+exports.C = C;

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariableInScope.symbols
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariableInScope.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts ===
+// Unused, but could collide with the named type argument below.
+class TypeVariable {}
+>TypeVariable : Symbol(TypeVariable, Decl(decoratorMetadataGenericTypeVariableInScope.ts, 0, 0))
+
+export class C<TypeVariable> {
+>C : Symbol(C, Decl(decoratorMetadataGenericTypeVariableInScope.ts, 1, 21))
+>TypeVariable : Symbol(TypeVariable, Decl(decoratorMetadataGenericTypeVariableInScope.ts, 3, 15))
+
+  @Decorate
+  member: TypeVariable;
+>member : Symbol(C.member, Decl(decoratorMetadataGenericTypeVariableInScope.ts, 3, 30))
+>TypeVariable : Symbol(TypeVariable, Decl(decoratorMetadataGenericTypeVariableInScope.ts, 3, 15))
+}
+

--- a/tests/baselines/reference/decoratorMetadataGenericTypeVariableInScope.types
+++ b/tests/baselines/reference/decoratorMetadataGenericTypeVariableInScope.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts ===
+// Unused, but could collide with the named type argument below.
+class TypeVariable {}
+>TypeVariable : TypeVariable
+
+export class C<TypeVariable> {
+>C : C<TypeVariable>
+>TypeVariable : TypeVariable
+
+  @Decorate
+>Decorate : any
+
+  member: TypeVariable;
+>member : TypeVariable
+>TypeVariable : TypeVariable
+}
+

--- a/tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts
+++ b/tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts
@@ -1,0 +1,7 @@
+// @experimentalDecorators: true
+// @emitDecoratorMetadata: true
+
+export class C<TypeVariable> {
+  @Decorate
+  member: TypeVariable;
+}

--- a/tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts
+++ b/tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts
@@ -1,0 +1,7 @@
+// @experimentalDecorators: true
+// @emitDecoratorMetadata: true
+
+export class C<TypeVariable = string> {
+  @Decorate
+  member: TypeVariable;
+}

--- a/tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts
+++ b/tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts
@@ -1,0 +1,10 @@
+// @experimentalDecorators: true
+// @emitDecoratorMetadata: true
+
+// Unused, but could collide with the named type argument below.
+class TypeVariable {}
+
+export class C<TypeVariable> {
+  @Decorate
+  member: TypeVariable;
+}


### PR DESCRIPTION
Fix decorator design:types emit for type variables.

Previously, TypeScript would resolve the reified types for the
`design:types` decorator emit in the regular `currentScope`. That scope
does not include class declaration bodies.

However when reifying types, class declarations do introduce a new scope
for any `TypeVariable`s declared on them. Because TS resolved the
EntityName for such types against the parent scope (e.g. the source
file), not the class scope, TypeScript would either fail to resolve the type (giving `TypeReferenceSerializationKind.Unknown`), or
incorrectly resolve to a different, accidentally matching symbol in the outer scope (giving `TypeWithConstructSignatureAndValue`).

This would result in an emit referencing an undeclared symbol, or
mis-referencing the wrong symbol.

    __metadata("design:type", typeof (_a = typeof TypeVariable !== "undefined" && TypeVariable) === "function" && _a || Object)
    __metadata("design:type", TypeVariable)

This change special cases `currentScope` for
`serializeTypeReferenceNode` to use a class scope, if present. This
changes the emit for a `TypeVariable` back to `Object`:

    __metadata("design:type", Object)
