### PR TITLE
Ensure upToDate also handles referenced project outputs

### DIFF
--- a/scripts/build/project.js
+++ b/scripts/build/project.js
@@ -402,6 +402,21 @@ function getOrCreateProjectGraph(projectSpec, paths) {
 }
 
 /**
+ * @param {ResolvedPathOptions} paths
+ */
+function createParseProject(paths) {
+    /**
+     * @param {string} configFilePath
+     */
+    function getProject(configFilePath) {
+        const projectSpec = resolveProjectSpec(configFilePath, paths, /*referrer*/ undefined);
+        const projectGraph = getOrCreateProjectGraph(projectSpec, defaultPaths);
+        return projectGraph && projectGraph.project;
+    }
+    return getProject;
+}
+
+/**
  * @param {ProjectGraph} projectGraph
  * @param {ResolvedProjectOptions} resolvedOptions
  * @returns {ProjectGraphConfiguration}
@@ -473,7 +488,7 @@ function ensureCompileTask(projectGraph, options) {
                 ? tsc.createProject(configFilePath, { typescript: require(options.typescript.typescript) })
                 : tsc_oop.createProject(configFilePath, {}, { typescript: options.typescript.typescript });
             const stream = project.src()
-                .pipe(gulpif(!options.force, upToDate(projectGraph.project, { verbose: options.verbose })))
+                .pipe(gulpif(!options.force, upToDate(projectGraph.project, { verbose: options.verbose, parseProject: createParseProject(options.paths) })))
                 .pipe(gulpif(sourceMap || inlineSourceMap, sourcemaps.init()))
                 .pipe(project());
             const js = (options.js ? options.js(stream.js) : stream.js)

--- a/scripts/build/upToDate.js
+++ b/scripts/build/upToDate.js
@@ -15,6 +15,7 @@ const Vinyl = require("vinyl");
  * 
  * @typedef UpToDateOptions
  * @property {boolean} [verbose]
+ * @property {(configFilePath: string) => ParsedCommandLine | undefined} [parseProject]
  */
 function upToDate(parsedProject, options) {
     /** @type {File[]} */
@@ -31,7 +32,8 @@ function upToDate(parsedProject, options) {
         },
         getModifiedTime(fileName) {
             return getStat(fileName).mtime;
-        }
+        },
+        parseConfigFile: options && options.parseProject
     };
     const duplex = new Duplex({
         objectMode: true,
@@ -77,7 +79,6 @@ function upToDate(parsedProject, options) {
 module.exports = exports = upToDate;
 
 /**
- * 
  * @param {DiagnosticMessage} message 
  * @param {...string} args 
  */


### PR DESCRIPTION
Updates _scripts/build/upToDate.js_ to support project reference outputs.