### PR TITLE
Clean up browserify task, remove unused 'debugMode.js' script

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -10,13 +10,8 @@ const insert = require("gulp-insert");
 const { append } = require("gulp-insert");
 const sourcemaps = require("gulp-sourcemaps");
 const del = require("del");
-const browserify = require("browserify");
-const through2 = require("through2");
 const fold = require("travis-fold");
 const rename = require("gulp-rename");
-const convertMap = require("convert-source-map");
-const sorcery = require("sorcery");
-const Vinyl = require("vinyl");
 const mkdirp = require("./scripts/build/mkdirp");
 const gulp = require("./scripts/build/gulp");
 const getDirSize = require("./scripts/build/getDirSize");
@@ -28,7 +23,7 @@ const getDiffTool = require("./scripts/build/getDiffTool");
 const baselineAccept = require("./scripts/build/baselineAccept");
 const cmdLineOptions = require("./scripts/build/options");
 const exec = require("./scripts/build/exec");
-const _debugMode = require("./scripts/build/debugMode");
+const browserify = require("./scripts/build/browserify");
 const { libraryTargets, generateLibs } = require("./scripts/build/lib");
 const { runConsoleTests, cleanTestDirs, writeTestConfigFile, refBaseline, localBaseline, refRwcBaseline, localRwcBaseline } = require("./scripts/build/tests");
 
@@ -72,7 +67,7 @@ gulp.task(
     "publish-nightly",
     "Runs `npm publish --tag next` to create a new nightly build on npm",
     ["LKG"],
-    () => runSequence("clean", "useDebugMode", "runtests-parallel",
+    () => runSequence("clean", "runtests-parallel",
         () => exec("npm", ["publish", "--tag", "next"])));
 
 const importDefinitelyTypedTestsProject = "scripts/importDefinitelyTypedTests/tsconfig.json";
@@ -187,6 +182,10 @@ const tscProject = "src/tsc/tsconfig.json";
 const tscJs = "built/local/tsc.js";
 gulp.task(tscJs, /*help*/ false, [typescriptServicesJs], () => project.compile(tscProject, { typescript: "built" }));
 
+const tscReleaseProject = "src/tsc/tsconfig.release.json";
+const tscReleaseJs = "built/local/tsc.release.js";
+gulp.task(tscReleaseJs, /*help*/ false, () => project.compile(tscReleaseProject));
+
 const cancellationTokenProject = "src/cancellationToken/tsconfig.json";
 const cancellationTokenJs = "built/local/cancellationToken.js";
 gulp.task(cancellationTokenJs, /*help*/ false, [typescriptServicesJs], () => project.compile(cancellationTokenProject, { typescript: "built" }));
@@ -258,9 +257,9 @@ gulp.task(
     "Generates a Markdown version of the Language Specification", 
     [specMd]);
 
-gulp.task("produce-LKG", /*help*/ false, ["scripts", "local", cancellationTokenJs, typingsInstallerJs, watchGuardJs], () => {
+gulp.task("produce-LKG", /*help*/ false, ["scripts", "local", cancellationTokenJs, typingsInstallerJs, watchGuardJs, tscReleaseJs], () => {
     const expectedFiles = [
-        tscJs, 
+        tscReleaseJs, 
         typescriptServicesJs, 
         tsserverJs, 
         typescriptJs, 
@@ -289,7 +288,7 @@ gulp.task("produce-LKG", /*help*/ false, ["scripts", "local", cancellationTokenJ
 gulp.task(
     "LKG", 
     "Makes a new LKG out of the built js files", 
-    () => runSequence("clean-built", "dontUseDebugMode", "produce-LKG"));
+    () => runSequence("clean-built", "produce-LKG"));
 
 // Task to build the tests infrastructure using the built compiler
 const testRunnerProject = "src/testRunner/tsconfig.json";
@@ -300,11 +299,6 @@ gulp.task(
     "tests",
     "Builds the test infrastructure using the built compiler",
     [runJs]);
-
-gulp.task(
-    "tests-debug",
-    "Builds the test sources and automation in debug mode",
-    () => runSequence("useDebugMode", "tests"));
 
 gulp.task(
     "runtests-parallel",
@@ -325,77 +319,17 @@ gulp.task("clean:" + webTestServerJs, /*help*/ false, () => project.clean(webTes
 
 const bundlePath = path.resolve("built/local/bundle.js");
 
-// TODO(rbuckton): Clean up browserify logic
 gulp.task(
     "browserify",
     "Runs browserify on run.js to produce a file suitable for running tests in the browser",
     [runJs],
-    (done) => {
-        /** @type {*} */
-        let originalMap;
-        /** @type {string} */
-        let prebundledContent;
-        browserify(gulp.src([runJs])
-            .pipe(newer(bundlePath))
-            .pipe(sourcemaps.init({ loadMaps: true }))
-            .pipe(through2.obj((file, enc, next) => {
-                if (originalMap) {
-                    throw new Error("Should only recieve one file!");
-                }
-                log(`Saving sourcemaps for ${file.path}`);
-                originalMap = file.sourceMap;
-                prebundledContent = file.contents.toString();
-                // Make paths absolute to help sorcery deal with all the terrible paths being thrown around
-                originalMap.sources = originalMap.sources.map(s => path.resolve(path.join("src/harness", s)));
-                // browserify names input files this when they are streamed in, so this is what it puts in the sourcemap
-                originalMap.file = "built/local/_stream_0.js";
-
-                next(/*err*/ undefined, file.contents);
-            }))
-            .on("error", err => {
-                return done(err);
-            }), { debug: true, basedir: __dirname }) // Attach error handler to inner stream
-            .bundle((err, contents) => {
-                if (err) {
-                    if (err.message.match(/Cannot find module '.*_stream_0.js'/)) {
-                        return done(); // Browserify errors when we pass in no files when `newer` filters the input, we should count that as a success, though
-                    }
-                    return done(err);
-                }
-                const stringContent = contents.toString();
-                const file = new Vinyl({ contents, path: bundlePath });
-                log(`Fixing sourcemaps for ${file.path}`);
-                // assumes contents is a Buffer, since that's what browserify yields
-                const maps = convertMap.fromSource(stringContent).toObject();
-                delete maps.sourceRoot;
-                maps.sources = maps.sources.map(s => path.resolve(s === "_stream_0.js" ? "built/local/_stream_0.js" : s));
-                // Strip browserify's inline comments away (could probably just let sorcery do this, but then we couldn't fix the paths)
-                file.contents = new Buffer(convertMap.removeComments(stringContent));
-                const chain = sorcery.loadSync(bundlePath, {
-                    content: {
-                        "built/local/_stream_0.js": prebundledContent,
-                        [bundlePath]: stringContent
-                    },
-                    sourcemaps: {
-                        "built/local/_stream_0.js": originalMap,
-                        [bundlePath]: maps,
-                        "node_modules/source-map-support/source-map-support.js": undefined,
-                    }
-                });
-                const finalMap = chain.apply();
-                file.sourceMap = finalMap;
-
-                const stream = through2.obj((file, enc, callback) => {
-                    return callback(/*err*/ undefined, file);
-                });
-                stream.pipe(sourcemaps.write(".", { includeContent: false }))
-                    .pipe(gulp.dest("."))
-                    .on("end", done)
-                    .on("error", done);
-                stream.write(file);
-                stream.end();
-            });
-    });
+    () => gulp.src([runJs], { base: "built/local" })
+        .pipe(newer(bundlePath))
+        .pipe(sourcemaps.init({ loadMaps: true }))
+        .pipe(browserify())
+        .pipe(rename("bundle.js"))
+        .pipe(sourcemaps.write(".", /**@type {*}*/({ includeContent: false, destPath: "built/local" })))
+        .pipe(gulp.dest("built/local")));
 
 gulp.task(
     "runtests-browser",

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -59,6 +59,7 @@ Paths.builtLocal = "built/local";
 Paths.builtLocalCompiler = "built/local/tsc.js";
 Paths.builtLocalTSServer = "built/local/tsserver.js";
 Paths.builtLocalRun = "built/local/run.js";
+Paths.releaseCompiler = "built/local/tsc.release.js";
 Paths.typesMapOutput = "built/local/typesMap.json";
 Paths.typescriptFile = "built/local/typescript.js";
 Paths.servicesFile = "built/local/typescriptServices.js";
@@ -95,6 +96,7 @@ Paths.versionFile = "src/compiler/core.ts";
 
 const ConfigFileFor = {
     tsc: "src/tsc",
+    tscRelease: "src/tsc/tsconfig.release.json",
     tsserver: "src/tsserver",
     runjs: "src/testRunner",
     lint: "scripts/tslint",
@@ -157,6 +159,12 @@ task(TaskNames.scripts, [TaskNames.coreBuild], function() {
     });
 }, { async: true });
 
+task(Paths.releaseCompiler, function () {
+    tsbuild([ConfigFileFor.tscRelease], true, () => {
+        complete();
+    });
+}, { async: true });
+
 // Makes a new LKG. This target does not build anything, but errors if not all the outputs are present in the built/local directory
 desc("Makes a new LKG out of the built js files");
 task(TaskNames.lkg, [
@@ -165,6 +173,7 @@ task(TaskNames.lkg, [
     TaskNames.local,
     Paths.servicesDefinitionFile,
     Paths.tsserverLibraryDefinitionFile,
+    Paths.releaseCompiler,
     ...libraryTargets
 ], () => {
     const sizeBefore = getDirSize(Paths.lkg);

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,9 +36,9 @@
             }
         },
         "@octokit/rest": {
-            "version": "15.8.2",
-            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.8.2.tgz",
-            "integrity": "sha512-hMUDI6NveJE49rGYfNfXT2CiHODhQMfbqFAa2h8TjR3GrfI1wnfSlsYeGZe4D/Qu+Svqlg9eUisoeIvYWz1yZw==",
+            "version": "15.9.2",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.9.2.tgz",
+            "integrity": "sha512-UpV9ZTI9ok73E0iFK+LH//c2/WIm6w/FGQ9LFF5GZFANsXut7z75LE0TCcgMZYdCS4eFm525qa3s+0INkPXigA==",
             "dev": true,
             "requires": {
                 "before-after-hook": "1.1.0",
@@ -233,9 +233,9 @@
             }
         },
         "@types/mocha": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.2.tgz",
-            "integrity": "sha512-tfg9rh2qQhBW6SBqpvfqTgU6lHWGhQURoTrn7NeDF+CEkO9JGYbkzU23EXu6p3bnvDxLeeSX8ohAA23urvWeNw==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.3.tgz",
+            "integrity": "sha512-C1wVVr7xhKu6c3Mb27dFzNYR05qvHwgtpN+JOYTGc1pKA7dCEDDYpscn7kul+bCUwa3NoGDbzI1pdznSOa397w==",
             "dev": true
         },
         "@types/node": {
@@ -310,16 +310,6 @@
             "dev": true,
             "requires": {
                 "@types/node": "8.5.5"
-            }
-        },
-        "JSONStream": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
-            "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
-            "dev": true,
-            "requires": {
-                "jsonparse": "1.3.1",
-                "through": "2.3.8"
             }
         },
         "abbrev": {
@@ -786,9 +776,9 @@
             "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.3",
                 "combine-source-map": "0.8.0",
                 "defined": "1.0.0",
+                "JSONStream": "1.3.3",
                 "safe-buffer": "5.1.2",
                 "through2": "2.0.3",
                 "umd": "3.0.3"
@@ -815,7 +805,6 @@
             "integrity": "sha512-fMES05wq1Oukts6ksGUU2TMVHHp06LyQt0SIwbXIHm7waSrQmNBZePsU0iM/4f94zbvb/wHma+D1YrdzWYnF/A==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.3",
                 "assert": "1.4.1",
                 "browser-pack": "6.1.0",
                 "browser-resolve": "1.11.2",
@@ -837,6 +826,7 @@
                 "https-browserify": "1.0.0",
                 "inherits": "2.0.3",
                 "insert-module-globals": "7.1.0",
+                "JSONStream": "1.3.3",
                 "labeled-stream-splicer": "2.0.1",
                 "mkdirp": "0.5.1",
                 "module-deps": "6.1.0",
@@ -950,12 +940,6 @@
                 "base64-js": "1.3.0",
                 "ieee754": "1.1.12"
             }
-        },
-        "buffer-crc32": {
-            "version": "0.2.13",
-            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-            "dev": true
         },
         "buffer-equal": {
             "version": "1.0.0",
@@ -1702,12 +1686,6 @@
                 "es5-ext": "0.10.45",
                 "es6-symbol": "3.1.1"
             }
-        },
-        "es6-promise": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
-            "dev": true
         },
         "es6-promisify": {
             "version": "5.0.0",
@@ -3189,10 +3167,10 @@
             "integrity": "sha512-LbYZdybvKjbbcKLp03lB323Cgc8f0iL0Rjh8U6JZ7K1gZSf7MxQH191iCNUcLX4qIQ6/yWe4Q4ZsQ+opcReNFg==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.3",
                 "combine-source-map": "0.8.0",
                 "concat-stream": "1.6.2",
                 "is-buffer": "1.1.6",
+                "JSONStream": "1.3.3",
                 "lexical-scope": "1.2.0",
                 "path-is-absolute": "1.0.1",
                 "process": "0.11.10",
@@ -3614,6 +3592,16 @@
             "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
             "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
             "dev": true
+        },
+        "JSONStream": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+            "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
+            "dev": true,
+            "requires": {
+                "jsonparse": "1.3.1",
+                "through": "2.3.8"
+            }
         },
         "kew": {
             "version": "0.7.0",
@@ -4095,7 +4083,6 @@
             "integrity": "sha512-NPs5N511VD1rrVJihSso/LiBShRbJALYBKzDW91uZYy7BpjnO4bGnZL3HjZ9yKcFdZUWwaYjDz9zxbuP7vKMuQ==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.3",
                 "browser-resolve": "1.11.2",
                 "cached-path-relative": "1.0.1",
                 "concat-stream": "1.6.2",
@@ -4103,6 +4090,7 @@
                 "detective": "5.1.0",
                 "duplexer2": "0.1.4",
                 "inherits": "2.0.3",
+                "JSONStream": "1.3.3",
                 "parents": "1.0.1",
                 "readable-stream": "2.3.6",
                 "resolve": "1.7.1",
@@ -5106,26 +5094,6 @@
                 "ret": "0.1.15"
             }
         },
-        "sander": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
-            "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
-            "dev": true,
-            "requires": {
-                "es6-promise": "3.3.1",
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
-            },
-            "dependencies": {
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-                    "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-                    "dev": true
-                }
-            }
-        },
         "sax": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
@@ -5339,18 +5307,6 @@
                 }
             }
         },
-        "sorcery": {
-            "version": "0.10.0",
-            "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
-            "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
-            "dev": true,
-            "requires": {
-                "buffer-crc32": "0.2.13",
-                "minimist": "1.2.0",
-                "sander": "0.5.1",
-                "sourcemap-codec": "1.4.1"
-            }
-        },
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -5392,12 +5348,6 @@
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-            "dev": true
-        },
-        "sourcemap-codec": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz",
-            "integrity": "sha512-hX1eNBNuilj8yfFnECh0DzLgwKpBLMIvmhgEhixXNui8lMLBInTI8Kyxt++RwJnMNu7cAUo635L2+N1TxMJCzA==",
             "dev": true
         },
         "sparkles": {
@@ -5532,6 +5482,15 @@
                 }
             }
         },
+        "string_decoder": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
+        },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -5557,15 +5516,6 @@
                         "ansi-regex": "3.0.0"
                     }
                 }
-            }
-        },
-        "string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dev": true,
-            "requires": {
-                "safe-buffer": "5.1.2"
             }
         },
         "strip-ansi": {
@@ -6178,6 +6128,15 @@
                     "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
                     "dev": true
                 }
+            }
+        },
+        "vinyl-sourcemaps-apply": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemaps-apply/-/vinyl-sourcemaps-apply-0.2.1.tgz",
+            "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
+            "dev": true,
+            "requires": {
+                "source-map": "0.5.7"
             }
         },
         "vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -84,13 +84,13 @@
         "q": "latest",
         "remove-internal": "^2.9.2",
         "run-sequence": "latest",
-        "sorcery": "latest",
         "source-map-support": "latest",
         "through2": "latest",
         "travis-fold": "latest",
         "tslint": "latest",
         "typescript": "next",
         "vinyl": "latest",
+        "vinyl-sourcemaps-apply": "latest",
         "xml2js": "^0.4.19"
     },
     "scripts": {

--- a/scripts/build/browserify.js
+++ b/scripts/build/browserify.js
@@ -1,0 +1,120 @@
+// @ts-check
+const Browserify = require("browserify");
+const Vinyl = require("vinyl");
+const fs = require("fs");
+const path = require("path");
+const convertMap = require("convert-source-map");
+const applySourceMap = require("vinyl-sourcemaps-apply");
+const { Transform, Readable } = require("stream");
+
+module.exports = browserify;
+
+/**
+ * @param {import("browserify").Options} [opts]
+ */
+function browserify(opts) {
+    return new Transform({
+        objectMode: true,
+        /**
+         * @param {string | Buffer | File} input
+         */
+        transform(input, _, cb) {
+            if (typeof input === "string" || Buffer.isBuffer(input)) return cb(new Error("Only Vinyl files are supported."));
+            try {
+                const sourceMap = input.sourceMap;
+                const cwd = input.cwd || process.cwd();
+                const base = input.base || cwd;
+                const output = /**@type {File}*/(new Vinyl({ path: input.path, base: input.base }));
+                const stream = streamFromFile(input);
+                const b = new Browserify(Object.assign({}, opts, { debug: !!sourceMap, basedir: input.base }));
+                b.add(stream, { file: input.path, basedir: input.base });
+                b.bundle((err, contents) => {
+                    if (err) return cb(err);
+                    output.contents = contents;
+                    if (sourceMap) {
+                        output.sourceMap = typeof sourceMap === "string" ? JSON.parse(sourceMap) : sourceMap;
+                        const sourceRoot = output.sourceMap.sourceRoot;
+                        makeAbsoluteSourceMap(cwd, base, output.sourceMap);
+                        const stringContents = contents.toString("utf8");
+                        const newSourceMapConverter = convertMap.fromSource(stringContents);
+                        if (newSourceMapConverter) {
+                            const newSourceMap = newSourceMapConverter.toObject();
+                            makeAbsoluteSourceMap(cwd, base, newSourceMap);
+                            applySourceMap(output, newSourceMap);
+                            makeRelativeSourceMap(cwd, base, sourceRoot, output.sourceMap);
+                            output.contents = new Buffer(convertMap.removeComments(stringContents), "utf8");
+                        }
+                    }
+                    cb(null, output);
+                });
+            }
+            catch (e) {
+                cb(e);
+            }
+        }
+    });
+}
+
+/**
+ * @param {string | undefined} cwd
+ * @param {string | undefined} base
+ * @param {RawSourceMap} sourceMap
+ *
+ * @typedef RawSourceMap
+ * @property {string} version
+ * @property {string} file
+ * @property {string} [sourceRoot]
+ * @property {string[]} sources
+ * @property {string[]} [sourcesContents]
+ * @property {string} mappings
+ * @property {string[]} [names]
+ */
+function makeAbsoluteSourceMap(cwd = process.cwd(), base = "", sourceMap) {
+    const sourceRoot = sourceMap.sourceRoot || "";
+    const resolvedBase = path.resolve(cwd, base);
+    const resolvedSourceRoot = path.resolve(resolvedBase, sourceRoot);
+    sourceMap.file = path.resolve(resolvedBase, sourceMap.file).replace(/\\/g, "/");
+    sourceMap.sources = sourceMap.sources.map(source => path.resolve(resolvedSourceRoot, source).replace(/\\/g, "/"));
+    sourceMap.sourceRoot = "";
+}
+
+/**
+ * @param {string | undefined} cwd
+ * @param {string | undefined} base
+ * @param {string} sourceRoot
+ * @param {RawSourceMap} sourceMap
+ */
+function makeRelativeSourceMap(cwd = process.cwd(), base = "", sourceRoot, sourceMap) {
+    makeAbsoluteSourceMap(cwd, base, sourceMap);
+    const resolvedBase = path.resolve(cwd, base);
+    const resolvedSourceRoot = path.resolve(resolvedBase, sourceRoot);
+    sourceMap.file = path.relative(resolvedBase, sourceMap.file).replace(/\\/g, "/");
+    sourceMap.sources = sourceMap.sources.map(source => path.relative(resolvedSourceRoot, source).replace(/\\/g, "/"));
+    sourceMap.sourceRoot = sourceRoot;
+}
+
+/**
+ * @param {File} file
+ */
+function streamFromFile(file) {
+    return file.isBuffer() ? streamFromBuffer(file.contents) :
+        file.isStream() ? file.contents :
+        fs.createReadStream(file.path, { autoClose: true });
+}
+
+/**
+ * @param {Buffer} buffer
+ */
+function streamFromBuffer(buffer) {
+    return new Readable({
+        read() {
+            this.push(buffer);
+            this.push(null);
+        }
+    });
+}
+
+/**
+ * @typedef {import("vinyl") & { sourceMap?: any }} File
+ */
+void 0;

--- a/scripts/build/debugMode.js
+++ b/scripts/build/debugMode.js
@@ -1,7 +1,0 @@
-// @ts-check
-const gulp = require("./gulp");
-
-exports.useDebugMode = true;
-
-gulp.task("useDebugMode", /*help*/ false, [], (done) => { exports["useDebugMode"] = true; done(); });
-gulp.task("dontUseDebugMode", /*help*/ false, [], (done) => { exports["useDebugMode"] = false; done(); });

--- a/scripts/build/rm.js
+++ b/scripts/build/rm.js
@@ -35,32 +35,28 @@ function rm(dest, opts) {
          */
         write(file, _, cb) {
             if (failed) return;
-            if (Vinyl.isVinyl(file)) {
-                const basePath = typeof dest === "string" ? path.resolve(cwd, dest) :
-                    typeof dest === "function" ? path.resolve(cwd, dest(file)) :
-                    file.base;
-                const filePath = path.resolve(basePath, file.relative);
-                file.cwd = cwd;
-                file.base = basePath;
-                file.path = filePath;
-                const entry = { 
-                    file, 
-                    deleted: false, 
-                    cb,
-                    promise: del(file.path).then(() => {
-                        entry.deleted = true;
-                        processDeleted();
-                    }, err => {
-                        failed = true;
-                        pending.length = 0;
-                        cb(err);
-                    }) 
-                };
-                pending.push(entry);
-            }
-            else {
-                cb(new Error("Only Vinyl files are supported."));
-            }
+            if (typeof file === "string" || Buffer.isBuffer(file)) return cb(new Error("Only Vinyl files are supported."));
+            const basePath = typeof dest === "string" ? path.resolve(cwd, dest) :
+                typeof dest === "function" ? path.resolve(cwd, dest(file)) :
+                file.base;
+            const filePath = path.resolve(basePath, file.relative);
+            file.cwd = cwd;
+            file.base = basePath;
+            file.path = filePath;
+            const entry = { 
+                file, 
+                deleted: false, 
+                cb,
+                promise: del(file.path).then(() => {
+                    entry.deleted = true;
+                    processDeleted();
+                }, err => {
+                    failed = true;
+                    pending.length = 0;
+                    cb(err);
+                }) 
+            };
+            pending.push(entry);
         },
         final(cb) {
             processDeleted();

--- a/scripts/build/upToDate.js
+++ b/scripts/build/upToDate.js
@@ -39,10 +39,9 @@ function upToDate(parsedProject, options) {
          * @param {string|Buffer|File} file 
          */
         write(file, _, cb) {
-            if (Vinyl.isVinyl(file)) {
-                inputs.push(file);
-                inputMap.set(path.resolve(file.path), file);
-            }
+            if (typeof file === "string" || Buffer.isBuffer(file)) return cb(new Error("Only Vinyl files are supported."));
+            inputs.push(file);
+            inputMap.set(path.resolve(file.path), file);
             cb();
         },
         final(cb) {

--- a/scripts/produceLKG.ts
+++ b/scripts/produceLKG.ts
@@ -17,7 +17,6 @@ async function produceLKG() {
     await copyLocalizedDiagnostics();
     await buildProtocol();
     await copyScriptOutputs();
-    await buildTsc();
     await copyDeclarationOutputs();
     await writeGitAttributes();
 }
@@ -53,16 +52,12 @@ async function buildProtocol() {
 
 async function copyScriptOutputs() {
     await copyWithCopyright("cancellationToken.js");
-    await copyWithCopyright("tsc.js");
+    await copyWithCopyright("tsc.release.js", "tsc.js");
     await copyWithCopyright("tsserver.js");
     await copyWithCopyright("typescript.js");
     await copyWithCopyright("typescriptServices.js");
     await copyWithCopyright("typingsInstaller.js");
     await copyWithCopyright("watchGuard.js");
-}
-
-async function buildTsc() {
-    await exec(path.join(source, "tsc.js"), [`-b -f ${path.join(root, "src/tsc/tsconfig.release.json")}`]);
 }
 
 async function copyDeclarationOutputs() {
@@ -75,9 +70,9 @@ async function writeGitAttributes() {
     await fs.writeFile(path.join(dest, ".gitattributes"), `* text eol=lf`, "utf-8");
 }
 
-async function copyWithCopyright(fileName: string) {
+async function copyWithCopyright(fileName: string, destName = fileName) {
     const content = await fs.readFile(path.join(source, fileName), "utf-8");
-    await fs.writeFile(path.join(dest, fileName), copyright + "\n" + content);
+    await fs.writeFile(path.join(dest, destName), copyright + "\n" + content);
 }
 
 async function copyFromBuiltLocal(fileName: string) {

--- a/src/tsc/tsconfig.release.json
+++ b/src/tsc/tsconfig.release.json
@@ -1,7 +1,7 @@
 {
     "extends": "../tsconfig-base",
     "compilerOptions": {
-        "outFile": "../../lib/tsc.js",
+        "outFile": "../../built/local/tsc.release.js",
         "stripInternal": true,
         "preserveConstEnums": false,
         "declaration": false,


### PR DESCRIPTION
This cleans up our `"browserify"` build task in gulp and removes the dependency for the `sorcery` package. This also removes the now unused _debugMode.js_ script and builds `src/tsc/tsconfig.release.json` in a build task in both the gulpfile and the jakefile.