### PR TITLE
Fix control flow loop in yield expression

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19618,7 +19618,7 @@ namespace ts {
 
         function getYieldedTypeOfYieldExpression(node: YieldExpression, isAsync: boolean, checkMode?: CheckMode): Type | undefined {
             const errorNode = node.expression || node;
-            const expressionType = node.expression ? checkExpressionCached(node.expression, checkMode) : undefinedWideningType;
+            const expressionType = node.expression ? checkExpression(node.expression, checkMode) : undefinedWideningType;
             // A `yield*` expression effectively yields everything that its operand yields
             const yieldedType = node.asteriskToken ? checkIteratedTypeOrElementType(expressionType, errorNode, /*allowStringInput*/ false, isAsync) : expressionType;
             return !isAsync ? yieldedType : getAwaitedType(yieldedType, errorNode, node.asteriskToken

--- a/tests/baselines/reference/yieldExpressionInControlFlow.errors.txt
+++ b/tests/baselines/reference/yieldExpressionInControlFlow.errors.txt
@@ -1,9 +1,7 @@
-error TS2318: Cannot find global type 'IterableIterator'.
 tests/cases/conformance/es6/yieldExpressions/alsoFails.ts(3,9): error TS7034: Variable 'o' implicitly has type 'any[]' in some locations where its type cannot be determined.
 tests/cases/conformance/es6/yieldExpressions/alsoFails.ts(5,20): error TS7005: Variable 'o' implicitly has an 'any[]' type.
 
 
-!!! error TS2318: Cannot find global type 'IterableIterator'.
 ==== tests/cases/conformance/es6/yieldExpressions/bug25149.js (0 errors) ====
     function* f() {
         var o

--- a/tests/baselines/reference/yieldExpressionInControlFlow.errors.txt
+++ b/tests/baselines/reference/yieldExpressionInControlFlow.errors.txt
@@ -1,0 +1,27 @@
+error TS2318: Cannot find global type 'IterableIterator'.
+tests/cases/conformance/es6/yieldExpressions/alsoFails.ts(3,9): error TS7034: Variable 'o' implicitly has type 'any[]' in some locations where its type cannot be determined.
+tests/cases/conformance/es6/yieldExpressions/alsoFails.ts(5,20): error TS7005: Variable 'o' implicitly has an 'any[]' type.
+
+
+!!! error TS2318: Cannot find global type 'IterableIterator'.
+==== tests/cases/conformance/es6/yieldExpressions/bug25149.js (0 errors) ====
+    function* f() {
+        var o
+        while (true) {
+            o = yield o
+        }
+    }
+    
+==== tests/cases/conformance/es6/yieldExpressions/alsoFails.ts (2 errors) ====
+    // fails in Typescript too
+    function* g() {
+        var o = []
+            ~
+!!! error TS7034: Variable 'o' implicitly has type 'any[]' in some locations where its type cannot be determined.
+        while (true) {
+            o = yield* o
+                       ~
+!!! error TS7005: Variable 'o' implicitly has an 'any[]' type.
+        }
+    }
+    

--- a/tests/baselines/reference/yieldExpressionInControlFlow.symbols
+++ b/tests/baselines/reference/yieldExpressionInControlFlow.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/es6/yieldExpressions/bug25149.js ===
+function* f() {
+>f : Symbol(f, Decl(bug25149.js, 0, 0))
+
+    var o
+>o : Symbol(o, Decl(bug25149.js, 1, 7))
+
+    while (true) {
+        o = yield o
+>o : Symbol(o, Decl(bug25149.js, 1, 7))
+>o : Symbol(o, Decl(bug25149.js, 1, 7))
+    }
+}
+
+=== tests/cases/conformance/es6/yieldExpressions/alsoFails.ts ===
+// fails in Typescript too
+function* g() {
+>g : Symbol(g, Decl(alsoFails.ts, 0, 0))
+
+    var o = []
+>o : Symbol(o, Decl(alsoFails.ts, 2, 7))
+
+    while (true) {
+        o = yield* o
+>o : Symbol(o, Decl(alsoFails.ts, 2, 7))
+>o : Symbol(o, Decl(alsoFails.ts, 2, 7))
+    }
+}
+

--- a/tests/baselines/reference/yieldExpressionInControlFlow.types
+++ b/tests/baselines/reference/yieldExpressionInControlFlow.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/yieldExpressions/bug25149.js ===
 function* f() {
->f : () => {}
+>f : () => IterableIterator<any>
 
     var o
 >o : any
@@ -19,7 +19,7 @@ function* f() {
 === tests/cases/conformance/es6/yieldExpressions/alsoFails.ts ===
 // fails in Typescript too
 function* g() {
->g : () => {}
+>g : () => IterableIterator<any>
 
     var o = []
 >o : any[]

--- a/tests/baselines/reference/yieldExpressionInControlFlow.types
+++ b/tests/baselines/reference/yieldExpressionInControlFlow.types
@@ -1,0 +1,38 @@
+=== tests/cases/conformance/es6/yieldExpressions/bug25149.js ===
+function* f() {
+>f : () => {}
+
+    var o
+>o : any
+
+    while (true) {
+>true : true
+
+        o = yield o
+>o = yield o : any
+>o : any
+>yield o : any
+>o : any
+    }
+}
+
+=== tests/cases/conformance/es6/yieldExpressions/alsoFails.ts ===
+// fails in Typescript too
+function* g() {
+>g : () => {}
+
+    var o = []
+>o : any[]
+>[] : undefined[]
+
+    while (true) {
+>true : true
+
+        o = yield* o
+>o = yield* o : any
+>o : any[]
+>yield* o : any
+>o : any
+    }
+}
+

--- a/tests/cases/conformance/es6/yieldExpressions/yieldExpressionInControlFlow.ts
+++ b/tests/cases/conformance/es6/yieldExpressions/yieldExpressionInControlFlow.ts
@@ -1,0 +1,20 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @noImplicitAny: true
+// @Filename: bug25149.js
+function* f() {
+    var o
+    while (true) {
+        o = yield o
+    }
+}
+
+// @Filename: alsoFails.ts
+// fails in Typescript too
+function* g() {
+    var o = []
+    while (true) {
+        o = yield* o
+    }
+}

--- a/tests/cases/conformance/es6/yieldExpressions/yieldExpressionInControlFlow.ts
+++ b/tests/cases/conformance/es6/yieldExpressions/yieldExpressionInControlFlow.ts
@@ -2,6 +2,7 @@
 // @allowJs: true
 // @checkJs: true
 // @noImplicitAny: true
+// @lib: esnext
 // @Filename: bug25149.js
 function* f() {
     var o


### PR DESCRIPTION
Yet again, the fix is to stop using checkExpressionCached. As before, I don't know how to fix checkExpressionCached to not cause these infinite recursions.

Fixes #25149