### PR TITLE
Fix lint race when not running tests in parallel

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -486,7 +486,6 @@ function runConsoleTests(defaultReporter, runInParallel) {
             process.env.NODE_ENV = savedNodeEnv;
             Travis.measure(startTime);
             runLinterAndComplete();
-            finish();
         }, function (e, status) {
             process.env.NODE_ENV = savedNodeEnv;
             Travis.measure(startTime);
@@ -523,11 +522,11 @@ function runConsoleTests(defaultReporter, runInParallel) {
 
     function runLinterAndComplete() {
         if (!lintFlag || dirty) {
-            return;
+            return finish();
         }
         var lint = jake.Task['lint'];
-        lint.addListener('complete', function () {
-            complete();
+        lint.once('complete', function () {
+            finish();
         });
         lint.invoke();
     }


### PR DESCRIPTION
Both `runLinterAndComplete` and `finish` were invoking `complete` (the first when linting was actually done, the second immediately), causing `complete` to be called for the lint's prerequisite build before the task was actually done (and more times and required), leading to `lint` running before is prerequisite `tsbuild` task was complete, resulting in an error if lint rules were not already built.

The `jake` API isn't exactly forgiving when it comes to ensuring your tasks only complete once when used in the way we've authored; as it turns out, [`jake` supports async tasks returning promises](https://github.com/jakejs/jake/blob/master/lib/task/task.js#L264) (and if you do so, you no longer have to configure the async flag) - it would be much safer to be using them.
