### PR TITLE
Add exists check before unlink

### DIFF
--- a/scripts/failed-tests.js
+++ b/scripts/failed-tests.js
@@ -80,7 +80,7 @@ class FailedTestsReporter extends Mocha.reporters.Base {
             const failed = Array.from(failingTests).join(os.EOL);
             fs.writeFile(file, failed, "utf8", done);
         }
-        else if (!keepFailed) {
+        else if (!keepFailed && fs.existsSync(file)) {
             fs.unlink(file, done);
         }
         else {


### PR DESCRIPTION
Adds a check for an existing `.failed-tests` file before calling `fs.unlink`.