### PR TITLE
Remove dead code testing result of `resolveProjectReferencePath`

### DIFF
--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -494,10 +494,6 @@ namespace ts {
         function addProject(projectSpecification: string) {
             const fileName = resolvePath(compilerHost.getCurrentDirectory(), projectSpecification);
             const refPath = resolveProjectReferencePath(compilerHost, { path: fileName });
-            if (!refPath) {
-                return buildHost.error(Diagnostics.File_0_does_not_exist, projectSpecification);
-            }
-
             if (!compilerHost.fileExists(refPath)) {
                 return buildHost.error(Diagnostics.File_0_does_not_exist, fileName);
             }


### PR DESCRIPTION
This function should always return a defined result.