### PR TITLE
Add codes and categories to related information, officially

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4233,14 +4233,14 @@ namespace ts {
     }
 
     export interface Diagnostic extends DiagnosticRelatedInformation {
-        category: DiagnosticCategory;
         /** May store more in future. For now, this will simply be `true` to indicate when a diagnostic is an unused-identifier diagnostic. */
         reportsUnnecessary?: {};
-        code: number;
         source?: string;
         relatedInformation?: DiagnosticRelatedInformation[];
     }
     export interface DiagnosticRelatedInformation {
+        category: DiagnosticCategory;
+        code: number;
         file: SourceFile | undefined;
         start: number | undefined;
         length: number | undefined;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2254,11 +2254,16 @@ namespace ts.server.protocol {
 
     /**
      * Represents additional spans returned with a diagnostic which are relevant to it
-     * Like DiagnosticWithLinePosition, this is provided in two forms:
-     *   - start and length of the span
-     *   - startLocation and endLocation a pair of Location objects storing the start/end line offset of the span
      */
     export interface DiagnosticRelatedInformation {
+        /**
+         * The category of the related information message, e.g. "error", "warning", or "suggestion".
+         */
+        category: string;
+        /**
+         * The code used ot identify the related information
+         */
+        code: number;
         /**
          * Text of related or additional information.
          */

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -84,7 +84,9 @@ namespace ts.server {
     function formatRelatedInformation(info: DiagnosticRelatedInformation): protocol.DiagnosticRelatedInformation {
         if (!info.file) {
             return {
-                message: flattenDiagnosticMessageText(info.messageText, "\n")
+                message: flattenDiagnosticMessageText(info.messageText, "\n"),
+                category: diagnosticCategoryName(info),
+                code: info.code
             };
         }
         return {
@@ -93,7 +95,9 @@ namespace ts.server {
                 end: convertToLocation(getLineAndCharacterOfPosition(info.file, info.start! + info.length!)), // TODO: GH#18217
                 file: info.file.fileName
             },
-            message: flattenDiagnosticMessageText(info.messageText, "\n")
+            message: flattenDiagnosticMessageText(info.messageText, "\n"),
+            category: diagnosticCategoryName(info),
+            code: info.code
         };
     }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3595,14 +3595,14 @@ declare namespace ts {
         next?: DiagnosticMessageChain;
     }
     interface Diagnostic extends DiagnosticRelatedInformation {
-        category: DiagnosticCategory;
         /** May store more in future. For now, this will simply be `true` to indicate when a diagnostic is an unused-identifier diagnostic. */
         reportsUnnecessary?: {};
-        code: number;
         source?: string;
         relatedInformation?: DiagnosticRelatedInformation[];
     }
     interface DiagnosticRelatedInformation {
+        category: DiagnosticCategory;
+        code: number;
         file: SourceFile | undefined;
         start: number | undefined;
         length: number | undefined;
@@ -13058,6 +13058,8 @@ declare namespace ts.server.protocol {
         fileName: string;
     }
     interface DiagnosticRelatedInformation {
+        category: string;
+        code: number;
         message: string;
         span?: FileSpan;
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2397,14 +2397,14 @@ declare namespace ts {
         next?: DiagnosticMessageChain;
     }
     interface Diagnostic extends DiagnosticRelatedInformation {
-        category: DiagnosticCategory;
         /** May store more in future. For now, this will simply be `true` to indicate when a diagnostic is an unused-identifier diagnostic. */
         reportsUnnecessary?: {};
-        code: number;
         source?: string;
         relatedInformation?: DiagnosticRelatedInformation[];
     }
     interface DiagnosticRelatedInformation {
+        category: DiagnosticCategory;
+        code: number;
         file: SourceFile | undefined;
         start: number | undefined;
         length: number | undefined;


### PR DESCRIPTION
Fixes #25298

Codes per request for identification, categories to future proof allowing varrying verbosity in elaborations. (So we can choose to mark things as `Elaboration` vs `Explanation` vs `Warning` if we decide that's useful)

It's a small change because we were already reusing our diagnostic mechanisms to generate related information objects. 😉 