### PR TITLE
Split isConst into isVarConst and isEnumConst

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -26,7 +26,7 @@ namespace ts {
                 return ModuleInstanceState.NonInstantiated;
             // 2. const enum declarations
             case SyntaxKind.EnumDeclaration:
-                if (isConst(node)) {
+                if (isEnumConst(node as EnumDeclaration)) {
                     return ModuleInstanceState.ConstEnumOnly;
                 }
                 break;
@@ -2611,7 +2611,7 @@ namespace ts {
         }
 
         function bindEnumDeclaration(node: EnumDeclaration) {
-            return isConst(node)
+            return isEnumConst(node)
                 ? bindBlockScopedDeclaration(node, SymbolFlags.ConstEnum, SymbolFlags.ConstEnumExcludes)
                 : bindBlockScopedDeclaration(node, SymbolFlags.RegularEnum, SymbolFlags.RegularEnumExcludes);
         }
@@ -2768,7 +2768,7 @@ namespace ts {
                     // report error on instantiated modules or const-enums only modules if preserveConstEnums is set
                     (node.kind === SyntaxKind.ModuleDeclaration && shouldReportErrorOnModuleDeclaration(<ModuleDeclaration>node)) ||
                     // report error on regular enums and const enums if preserveConstEnums is set
-                    (node.kind === SyntaxKind.EnumDeclaration && (!isConstEnumDeclaration(node) || options.preserveConstEnums));
+                    (isEnumDeclaration(node) && (!isEnumConst(node) || options.preserveConstEnums));
 
                 if (reportError) {
                     currentFlow = reportedUnreachableFlow;

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1983,7 +1983,7 @@ namespace ts {
         }
 
         function emitVariableDeclarationList(node: VariableDeclarationList) {
-            writeKeyword(isLet(node) ? "let" : isConst(node) ? "const" : "var");
+            writeKeyword(isLet(node) ? "let" : isVarConst(node) ? "const" : "var");
             writeSpace();
             emitList(node, node.declarations, ListFormat.VariableDeclarationList);
         }

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2602,7 +2602,7 @@ namespace ts {
          * @param node The enum declaration node.
          */
         function shouldEmitEnumDeclaration(node: EnumDeclaration) {
-            return !isConst(node)
+            return !isEnumConst(node)
                 || compilerOptions.preserveConstEnums
                 || compilerOptions.isolatedModules;
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -897,13 +897,12 @@ namespace ts {
         return file.scriptKind === ScriptKind.JSON;
     }
 
-    export function isConstEnumDeclaration(node: Node): boolean {
-        return node.kind === SyntaxKind.EnumDeclaration && isConst(node);
+    export function isEnumConst(node: EnumDeclaration): boolean {
+        return !!(getCombinedModifierFlags(node) & ModifierFlags.Const);
     }
 
-    export function isConst(node: Node): boolean {
-        return !!(getCombinedNodeFlags(node) & NodeFlags.Const)
-            || !!(isDeclaration(node) && getCombinedModifierFlags(node) & ModifierFlags.Const);
+    export function isVarConst(node: VariableDeclaration | VariableDeclarationList): boolean {
+        return !!(getCombinedNodeFlags(node) & NodeFlags.Const);
     }
 
     export function isLet(node: Node): boolean {
@@ -1184,7 +1183,7 @@ namespace ts {
     }
 
     export function isValidESSymbolDeclaration(node: Node): node is VariableDeclaration | PropertyDeclaration | SignatureDeclaration {
-        return isVariableDeclaration(node) ? isConst(node) && isIdentifier(node.name) && isVariableDeclarationInVariableStatement(node) :
+        return isVariableDeclaration(node) ? isVarConst(node) && isIdentifier(node.name) && isVariableDeclarationInVariableStatement(node) :
             isPropertyDeclaration(node) ? hasReadonlyModifier(node) && hasStaticModifier(node) :
                 isPropertySignature(node) && hasReadonlyModifier(node);
     }

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -49,7 +49,7 @@ namespace ts.SymbolDisplay {
             if (isFirstDeclarationOfSymbolParameter(symbol)) {
                 return ScriptElementKind.parameterElement;
             }
-            else if (symbol.valueDeclaration && isConst(symbol.valueDeclaration)) {
+            else if (symbol.valueDeclaration && isVarConst(symbol.valueDeclaration as VariableDeclaration)) {
                 return ScriptElementKind.constElement;
             }
             else if (forEach(symbol.declarations, isLet)) {
@@ -298,7 +298,7 @@ namespace ts.SymbolDisplay {
         }
         if (symbolFlags & SymbolFlags.Enum) {
             prefixNextMeaning();
-            if (forEach(symbol.declarations, isConstEnumDeclaration)) {
+            if (some(symbol.declarations, d => isEnumDeclaration(d) && isEnumConst(d))) {
                 displayParts.push(keywordPart(SyntaxKind.ConstKeyword));
                 displayParts.push(spacePart());
             }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -380,7 +380,7 @@ namespace ts {
         }
 
         function getKindOfVariableDeclaration(v: VariableDeclaration): ScriptElementKind {
-            return isConst(v)
+            return isVarConst(v)
                 ? ScriptElementKind.constElement
                 : isLet(v)
                     ? ScriptElementKind.letElement

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6168,8 +6168,8 @@ declare namespace ts {
     function getErrorSpanForNode(sourceFile: SourceFile, node: Node): TextSpan;
     function isExternalOrCommonJsModule(file: SourceFile): boolean;
     function isJsonSourceFile(file: SourceFile): file is JsonSourceFile;
-    function isConstEnumDeclaration(node: Node): boolean;
-    function isConst(node: Node): boolean;
+    function isEnumConst(node: EnumDeclaration): boolean;
+    function isVarConst(node: VariableDeclaration | VariableDeclarationList): boolean;
     function isLet(node: Node): boolean;
     function isSuperCall(n: Node): n is SuperCall;
     function isImportCall(n: Node): n is ImportCall;


### PR DESCRIPTION
Noticed while looking at #25282 -- this function covers two different cases which we never need to cover both of at once.