### PR TITLE
Stop folding region delimiters

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -83,8 +83,9 @@ namespace ts.OutliningElementsCollector {
         }
     }
 
+    const regionDelimiterRegExp = /^\s*\/\/\s*#(end)?region(?:\s+(.*))?(?:\r)?$/;
     function isRegionDelimiter(lineText: string) {
-        return lineText.match(/^\s*\/\/\s*#(end)?region(?:\s+(.*))?(?:\r)?$/);
+        return regionDelimiterRegExp.exec(lineText);
     }
 
     function addOutliningForLeadingCommentsForNode(n: Node, sourceFile: SourceFile, cancellationToken: CancellationToken, out: Push<OutliningSpan>): void {

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -63,7 +63,7 @@ namespace ts.OutliningElementsCollector {
             const currentLineStart = lineStarts[i];
             const lineEnd = i + 1 === lineStarts.length ? sourceFile.getEnd() : lineStarts[i + 1] - 1;
             const lineText = sourceFile.text.substring(currentLineStart, lineEnd);
-            const result = lineText.match(/^\s*\/\/\s*#(end)?region(?:\s+(.*))?(?:\r)?$/);
+            const result = isRegionDelimiter(lineText);
             if (!result || isInComment(sourceFile, currentLineStart)) {
                 continue;
             }
@@ -83,16 +83,29 @@ namespace ts.OutliningElementsCollector {
         }
     }
 
+    function isRegionDelimiter(lineText: string) {
+        return lineText.match(/^\s*\/\/\s*#(end)?region(?:\s+(.*))?(?:\r)?$/);
+    }
+
     function addOutliningForLeadingCommentsForNode(n: Node, sourceFile: SourceFile, cancellationToken: CancellationToken, out: Push<OutliningSpan>): void {
         const comments = getLeadingCommentRangesOfNode(n, sourceFile);
         if (!comments) return;
         let firstSingleLineCommentStart = -1;
         let lastSingleLineCommentEnd = -1;
         let singleLineCommentCount = 0;
+        const sourceText = sourceFile.getFullText();
         for (const { kind, pos, end } of comments) {
             cancellationToken.throwIfCancellationRequested();
             switch (kind) {
                 case SyntaxKind.SingleLineCommentTrivia:
+                    // never fold region delimiters into single-line comment regions
+                    const commentText = sourceText.slice(pos, end);
+                    if (isRegionDelimiter(commentText)) {
+                        combineAndAddMultipleSingleLineComments();
+                        singleLineCommentCount = 0;
+                        break;
+                    }
+
                     // For single line comments, combine consecutive ones (2 or more) into
                     // a single span from the start of the first till the end of the last
                     if (singleLineCommentCount === 0) {

--- a/tests/cases/fourslash/server/getOutliningSpansForRegionsNoSingleLineFolds.ts
+++ b/tests/cases/fourslash/server/getOutliningSpansForRegionsNoSingleLineFolds.ts
@@ -1,0 +1,17 @@
+////[|//#region
+////function foo()[| {
+////
+////}|]
+////[|//these
+//////should|]
+//////#endregion not you|]
+////[|// be
+////// together|]
+////
+////[|//#region bla bla bla
+////
+////function bar()[| { }|]
+////
+//////#endregion|]
+
+verify.outliningSpansInCurrentFile(test.ranges());


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #23270.
Fixes #24152.

Previously, consecutive region delimiters are grouped into a folding region of their own.
This change excludes region delimiters from such folding regions.

