### PR TITLE
Adds related spans and error grouping for duplicate identifier errors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -975,7 +975,7 @@ namespace ts {
                         : Diagnostics.Duplicate_identifier_0;
                 const sourceSymbolFile = source.declarations && getSourceFileOfNode(source.declarations[0]);
                 const targetSymbolFile = target.declarations && getSourceFileOfNode(target.declarations[0]);
-                
+
                 // Collect top-level duplicate identifier errors into one mapping, so we can then merge their diagnostics if there are a bunch
                 if (sourceSymbolFile && targetSymbolFile && amalgamatedDuplicates && !isEitherEnum && sourceSymbolFile !== targetSymbolFile) {
                     const firstFile = comparePaths(sourceSymbolFile.path, targetSymbolFile.path) === Comparison.LessThan ? sourceSymbolFile : targetSymbolFile;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3603,6 +3603,18 @@
         "code": 6199,
         "reportsUnnecessary": true
     },
+    "Definitions of the following identifiers conflict with those in another file: {0}": {
+        "category": "Error",
+        "code": 6200
+    },
+    "Conflicts are in this file.": {
+        "category": "Message",
+        "code": 6201
+    },
+    "Conflicts here.": {
+        "category": "Message",
+        "code": 6203
+    },
 
     "Projects to reference": {
         "category": "Message",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3611,9 +3611,13 @@
         "category": "Message",
         "code": 6201
     },
-    "Conflicts here.": {
+    "'{0}' was also declared here.": {
         "category": "Message",
         "code": 6203
+    },
+    "and here.": {
+        "category": "Message",
+        "code": 6204
     },
 
     "Projects to reference": {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -329,16 +329,17 @@ namespace ts {
         return context;
     }
 
-    function formatLocation(file: SourceFile, start: number, host: FormatDiagnosticsHost) {
+    /* @internal */
+    export function formatLocation(file: SourceFile, start: number, host: FormatDiagnosticsHost, color = formatColorAndReset) {
         const { line: firstLine, character: firstLineChar } = getLineAndCharacterOfPosition(file, start); // TODO: GH#18217
         const relativeFileName = host ? convertToRelativePath(file.fileName, host.getCurrentDirectory(), fileName => host.getCanonicalFileName(fileName)) : file.fileName;
 
         let output = "";
-        output += formatColorAndReset(relativeFileName, ForegroundColorEscapeSequences.Cyan);
+        output += color(relativeFileName, ForegroundColorEscapeSequences.Cyan);
         output += ":";
-        output += formatColorAndReset(`${firstLine + 1}`, ForegroundColorEscapeSequences.Yellow);
+        output += color(`${firstLine + 1}`, ForegroundColorEscapeSequences.Yellow);
         output += ":";
-        output += formatColorAndReset(`${firstLineChar + 1}`, ForegroundColorEscapeSequences.Yellow);
+        output += color(`${firstLineChar + 1}`, ForegroundColorEscapeSequences.Yellow);
         return output;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5351,6 +5351,9 @@ namespace ts {
         // Adds a diagnostic to this diagnostic collection.
         add(diagnostic: Diagnostic): void;
 
+        // Returns the first existing diagnostic that is equivalent to the given one (sans related information)
+        lookup(diagnostic: Diagnostic): Diagnostic | undefined;
+
         // Gets all the diagnostics that aren't associated with a file.
         getGlobalDiagnostics(): Diagnostic[];
 

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1348,6 +1348,12 @@ namespace Harness {
                 return "\r\n";
             }
 
+            const formatDiagnsoticHost = {
+                getCurrentDirectory: () => options && options.currentDirectory ? options.currentDirectory : "",
+                getNewLine: () => IO.newLine(),
+                getCanonicalFileName: ts.createGetCanonicalFileName(options && options.caseSensitive !== undefined ? options.caseSensitive : true),
+            };
+
             function outputErrorText(error: ts.Diagnostic) {
                 const message = ts.flattenDiagnosticMessageText(error.messageText, IO.newLine());
 
@@ -1356,6 +1362,11 @@ namespace Harness {
                     .map(s => s.length > 0 && s.charAt(s.length - 1) === "\r" ? s.substr(0, s.length - 1) : s)
                     .filter(s => s.length > 0)
                     .map(s => "!!! " + ts.diagnosticCategoryName(error) + " TS" + error.code + ": " + s);
+                if (error.relatedInformation) {
+                    for (const info of error.relatedInformation) {
+                        errLines.push(`!!! related TS${info.code}${info.file ? " " + ts.formatLocation(info.file, info.start!, formatDiagnsoticHost, ts.identity) : ""}: ${ts.flattenDiagnosticMessageText(info.messageText, IO.newLine())}`);
+                    }
+                }
                 errLines.forEach(e => outputLines += (newLine() + e));
                 errorsReported++;
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4527,6 +4527,7 @@ declare namespace ts {
     }
     interface DiagnosticCollection {
         add(diagnostic: Diagnostic): void;
+        lookup(diagnostic: Diagnostic): Diagnostic | undefined;
         getGlobalDiagnostics(): Diagnostic[];
         getDiagnostics(fileName: string): DiagnosticWithLocation[];
         getDiagnostics(): Diagnostic[];
@@ -5738,6 +5739,9 @@ declare namespace ts {
         Include_modules_imported_with_json_extension: DiagnosticMessage;
         All_destructured_elements_are_unused: DiagnosticMessage;
         All_variables_are_unused: DiagnosticMessage;
+        Definitions_of_the_following_identifiers_conflict_with_those_in_another_file_Colon_0: DiagnosticMessage;
+        Conflicts_are_in_this_file: DiagnosticMessage;
+        Conflicts_here: DiagnosticMessage;
         Projects_to_reference: DiagnosticMessage;
         Enable_project_compilation: DiagnosticMessage;
         Project_references_may_not_form_a_circular_graph_Cycle_detected_Colon_0: DiagnosticMessage;
@@ -7116,6 +7120,7 @@ declare namespace ts {
     function chainDiagnosticMessages(details: DiagnosticMessageChain | undefined, message: DiagnosticMessage, ...args: (string | undefined)[]): DiagnosticMessageChain;
     function concatenateDiagnosticMessageChains(headChain: DiagnosticMessageChain, tailChain: DiagnosticMessageChain): DiagnosticMessageChain;
     function compareDiagnostics(d1: Diagnostic, d2: Diagnostic): Comparison;
+    function compareDiagnosticsSkipRelatedInformation(d1: Diagnostic, d2: Diagnostic): Comparison;
     function getEmitScriptTarget(compilerOptions: CompilerOptions): ScriptTarget;
     function getEmitModuleKind(compilerOptions: {
         module?: CompilerOptions["module"];

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8951,6 +8951,7 @@ declare namespace ts {
     }
     /** @internal */
     function formatColorAndReset(text: string, formatStyle: string): string;
+    function formatLocation(file: SourceFile, start: number, host: FormatDiagnosticsHost, color?: typeof formatColorAndReset): string;
     function formatDiagnosticsWithColorAndContext(diagnostics: ReadonlyArray<Diagnostic>, host: FormatDiagnosticsHost): string;
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain | undefined, newLine: string): string;
     /**

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5741,7 +5741,8 @@ declare namespace ts {
         All_variables_are_unused: DiagnosticMessage;
         Definitions_of_the_following_identifiers_conflict_with_those_in_another_file_Colon_0: DiagnosticMessage;
         Conflicts_are_in_this_file: DiagnosticMessage;
-        Conflicts_here: DiagnosticMessage;
+        _0_was_also_declared_here: DiagnosticMessage;
+        and_here: DiagnosticMessage;
         Projects_to_reference: DiagnosticMessage;
         Enable_project_compilation: DiagnosticMessage;
         Project_references_may_not_form_a_circular_graph_Cycle_detected_Colon_0: DiagnosticMessage;

--- a/tests/baselines/reference/declaredClassMergedwithSelf.errors.txt
+++ b/tests/baselines/reference/declaredClassMergedwithSelf.errors.txt
@@ -32,10 +32,10 @@ tests/cases/conformance/classes/classDeclarations/file3.ts(1,15): error TS2300: 
     declare class C3 { }
                   ~~
 !!! error TS2300: Duplicate identifier 'C3'.
-!!! related TS6203 tests/cases/conformance/classes/classDeclarations/file3.ts:1:15: Conflicts here.
+!!! related TS6203 tests/cases/conformance/classes/classDeclarations/file3.ts:1:15: 'C3' was also declared here.
     
 ==== tests/cases/conformance/classes/classDeclarations/file3.ts (1 errors) ====
     declare class C3 { }
                   ~~
 !!! error TS2300: Duplicate identifier 'C3'.
-!!! related TS6203 tests/cases/conformance/classes/classDeclarations/file2.ts:1:15: Conflicts here.
+!!! related TS6203 tests/cases/conformance/classes/classDeclarations/file2.ts:1:15: 'C3' was also declared here.

--- a/tests/baselines/reference/declaredClassMergedwithSelf.errors.txt
+++ b/tests/baselines/reference/declaredClassMergedwithSelf.errors.txt
@@ -32,8 +32,10 @@ tests/cases/conformance/classes/classDeclarations/file3.ts(1,15): error TS2300: 
     declare class C3 { }
                   ~~
 !!! error TS2300: Duplicate identifier 'C3'.
+!!! related TS6203 tests/cases/conformance/classes/classDeclarations/file3.ts:1:15: Conflicts here.
     
 ==== tests/cases/conformance/classes/classDeclarations/file3.ts (1 errors) ====
     declare class C3 { }
                   ~~
 !!! error TS2300: Duplicate identifier 'C3'.
+!!! related TS6203 tests/cases/conformance/classes/classDeclarations/file2.ts:1:15: Conflicts here.

--- a/tests/baselines/reference/duplicateIdentifierEnum.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierEnum.errors.txt
@@ -48,11 +48,13 @@ tests/cases/compiler/duplicateIdentifierEnum_B.ts(4,6): error TS2567: Enum decla
     enum D {
          ~
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_B.ts:1:10: Conflicts here.
         bar
     }
     class E {
           ~
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_B.ts:4:6: Conflicts here.
         foo: number;
     }
     // also make sure the error appears when trying to merge an enum in a separate file.
@@ -60,10 +62,12 @@ tests/cases/compiler/duplicateIdentifierEnum_B.ts(4,6): error TS2567: Enum decla
     function D() {
              ~
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_A.ts:23:6: Conflicts here.
         return 0;
     }
     enum E {
          ~
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
+!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_A.ts:26:7: Conflicts here.
         bar
     }

--- a/tests/baselines/reference/duplicateIdentifierEnum.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierEnum.errors.txt
@@ -48,13 +48,13 @@ tests/cases/compiler/duplicateIdentifierEnum_B.ts(4,6): error TS2567: Enum decla
     enum D {
          ~
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
-!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_B.ts:1:10: Conflicts here.
+!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_B.ts:1:10: 'D' was also declared here.
         bar
     }
     class E {
           ~
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
-!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_B.ts:4:6: Conflicts here.
+!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_B.ts:4:6: 'E' was also declared here.
         foo: number;
     }
     // also make sure the error appears when trying to merge an enum in a separate file.
@@ -62,12 +62,12 @@ tests/cases/compiler/duplicateIdentifierEnum_B.ts(4,6): error TS2567: Enum decla
     function D() {
              ~
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
-!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_A.ts:23:6: Conflicts here.
+!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_A.ts:23:6: 'D' was also declared here.
         return 0;
     }
     enum E {
          ~
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
-!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_A.ts:26:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/duplicateIdentifierEnum_A.ts:26:7: 'E' was also declared here.
         bar
     }

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans1.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans1.errors.txt
@@ -66,21 +66,29 @@
     class Foo { }
           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:6: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file3.ts:1:6: Conflicts here.
     const Bar = 3;
           ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+!!! related TS6203 tests/cases/compiler/file2.ts:2:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file3.ts:2:5: Conflicts here.
 ==== tests/cases/compiler/file2.ts (2 errors) ====
     type Foo = number;
          ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:7: Conflicts here.
     class Bar {}
           ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+!!! related TS6203 tests/cases/compiler/file1.ts:2:7: Conflicts here.
 ==== tests/cases/compiler/file3.ts (2 errors) ====
     type Foo = 54;
          ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:7: Conflicts here.
     let Bar = 42
         ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+!!! related TS6203 tests/cases/compiler/file1.ts:2:7: Conflicts here.
     

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans1.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans1.errors.txt
@@ -1,0 +1,86 @@
+[96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'Foo'.
+
+[30;47m1[0m class Foo { }
+[30;47m [0m [91m      ~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m1[0m:[93m6[0m
+    [30;47m1[0m type Foo = number;
+    [30;47m [0m [96m     ~~~[0m
+    Conflicts here.
+  [96mtests/cases/compiler/file3.ts[0m:[93m1[0m:[93m6[0m
+    [30;47m1[0m type Foo = 54;
+    [30;47m [0m [96m     ~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file1.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
+
+[30;47m2[0m const Bar = 3;
+[30;47m [0m [91m      ~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m2[0m:[93m7[0m
+    [30;47m2[0m class Bar {}
+    [30;47m [0m [96m      ~~~[0m
+    Conflicts here.
+  [96mtests/cases/compiler/file3.ts[0m:[93m2[0m:[93m5[0m
+    [30;47m2[0m let Bar = 42
+    [30;47m [0m [96m    ~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m1[0m:[93m6[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'Foo'.
+
+[30;47m1[0m type Foo = number;
+[30;47m [0m [91m     ~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m7[0m
+    [30;47m1[0m class Foo { }
+    [30;47m [0m [96m      ~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
+
+[30;47m2[0m class Bar {}
+[30;47m [0m [91m      ~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m2[0m:[93m7[0m
+    [30;47m2[0m const Bar = 3;
+    [30;47m [0m [96m      ~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file3.ts[0m:[93m1[0m:[93m6[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'Foo'.
+
+[30;47m1[0m type Foo = 54;
+[30;47m [0m [91m     ~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m7[0m
+    [30;47m1[0m class Foo { }
+    [30;47m [0m [96m      ~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file3.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
+
+[30;47m2[0m let Bar = 42
+[30;47m [0m [91m    ~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m2[0m:[93m7[0m
+    [30;47m2[0m const Bar = 3;
+    [30;47m [0m [96m      ~~~[0m
+    Conflicts here.
+
+
+==== tests/cases/compiler/file1.ts (2 errors) ====
+    class Foo { }
+          ~~~
+!!! error TS2300: Duplicate identifier 'Foo'.
+    const Bar = 3;
+          ~~~
+!!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+==== tests/cases/compiler/file2.ts (2 errors) ====
+    type Foo = number;
+         ~~~
+!!! error TS2300: Duplicate identifier 'Foo'.
+    class Bar {}
+          ~~~
+!!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+==== tests/cases/compiler/file3.ts (2 errors) ====
+    type Foo = 54;
+         ~~~
+!!! error TS2300: Duplicate identifier 'Foo'.
+    let Bar = 42
+        ~~~
+!!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+    

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans1.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans1.errors.txt
@@ -6,11 +6,11 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m1[0m:[93m6[0m
     [30;47m1[0m type Foo = number;
     [30;47m [0m [96m     ~~~[0m
-    Conflicts here.
+    'Foo' was also declared here.
   [96mtests/cases/compiler/file3.ts[0m:[93m1[0m:[93m6[0m
     [30;47m1[0m type Foo = 54;
     [30;47m [0m [96m     ~~~[0m
-    Conflicts here.
+    and here.
 [96mtests/cases/compiler/file1.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
 
 [30;47m2[0m const Bar = 3;
@@ -19,11 +19,11 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m2[0m:[93m7[0m
     [30;47m2[0m class Bar {}
     [30;47m [0m [96m      ~~~[0m
-    Conflicts here.
+    'Bar' was also declared here.
   [96mtests/cases/compiler/file3.ts[0m:[93m2[0m:[93m5[0m
     [30;47m2[0m let Bar = 42
     [30;47m [0m [96m    ~~~[0m
-    Conflicts here.
+    and here.
 [96mtests/cases/compiler/file2.ts[0m:[93m1[0m:[93m6[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'Foo'.
 
 [30;47m1[0m type Foo = number;
@@ -32,7 +32,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m7[0m
     [30;47m1[0m class Foo { }
     [30;47m [0m [96m      ~~~[0m
-    Conflicts here.
+    'Foo' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
 
 [30;47m2[0m class Bar {}
@@ -41,7 +41,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m2[0m:[93m7[0m
     [30;47m2[0m const Bar = 3;
     [30;47m [0m [96m      ~~~[0m
-    Conflicts here.
+    'Bar' was also declared here.
 [96mtests/cases/compiler/file3.ts[0m:[93m1[0m:[93m6[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'Foo'.
 
 [30;47m1[0m type Foo = 54;
@@ -50,7 +50,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m7[0m
     [30;47m1[0m class Foo { }
     [30;47m [0m [96m      ~~~[0m
-    Conflicts here.
+    'Foo' was also declared here.
 [96mtests/cases/compiler/file3.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
 
 [30;47m2[0m let Bar = 42
@@ -59,36 +59,36 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m2[0m:[93m7[0m
     [30;47m2[0m const Bar = 3;
     [30;47m [0m [96m      ~~~[0m
-    Conflicts here.
+    'Bar' was also declared here.
 
 
 ==== tests/cases/compiler/file1.ts (2 errors) ====
     class Foo { }
           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
-!!! related TS6203 tests/cases/compiler/file2.ts:1:6: Conflicts here.
-!!! related TS6203 tests/cases/compiler/file3.ts:1:6: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:6: 'Foo' was also declared here.
+!!! related TS6204 tests/cases/compiler/file3.ts:1:6: and here.
     const Bar = 3;
           ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
-!!! related TS6203 tests/cases/compiler/file2.ts:2:7: Conflicts here.
-!!! related TS6203 tests/cases/compiler/file3.ts:2:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:2:7: 'Bar' was also declared here.
+!!! related TS6204 tests/cases/compiler/file3.ts:2:5: and here.
 ==== tests/cases/compiler/file2.ts (2 errors) ====
     type Foo = number;
          ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
-!!! related TS6203 tests/cases/compiler/file1.ts:1:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:7: 'Foo' was also declared here.
     class Bar {}
           ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
-!!! related TS6203 tests/cases/compiler/file1.ts:2:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:2:7: 'Bar' was also declared here.
 ==== tests/cases/compiler/file3.ts (2 errors) ====
     type Foo = 54;
          ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
-!!! related TS6203 tests/cases/compiler/file1.ts:1:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:7: 'Foo' was also declared here.
     let Bar = 42
         ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
-!!! related TS6203 tests/cases/compiler/file1.ts:2:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:2:7: 'Bar' was also declared here.
     

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans1.js
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans1.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/duplicateIdentifierRelatedSpans1.ts] ////
+
+//// [file1.ts]
+class Foo { }
+const Bar = 3;
+//// [file2.ts]
+type Foo = number;
+class Bar {}
+//// [file3.ts]
+type Foo = 54;
+let Bar = 42
+
+
+//// [file1.js]
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    return Foo;
+}());
+var Bar = 3;
+//// [file2.js]
+var Bar = /** @class */ (function () {
+    function Bar() {
+    }
+    return Bar;
+}());
+//// [file3.js]
+var Bar = 42;

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans1.symbols
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans1.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/file1.ts ===
+class Foo { }
+>Foo : Symbol(Foo, Decl(file1.ts, 0, 0))
+
+const Bar = 3;
+>Bar : Symbol(Bar, Decl(file1.ts, 1, 5))
+
+=== tests/cases/compiler/file2.ts ===
+type Foo = number;
+>Foo : Symbol(Foo, Decl(file2.ts, 0, 0))
+
+class Bar {}
+>Bar : Symbol(Bar, Decl(file2.ts, 0, 18))
+
+=== tests/cases/compiler/file3.ts ===
+type Foo = 54;
+>Foo : Symbol(Foo, Decl(file3.ts, 0, 0))
+
+let Bar = 42
+>Bar : Symbol(Bar, Decl(file3.ts, 1, 3))
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans1.types
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans1.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/file1.ts ===
+class Foo { }
+>Foo : Foo
+
+const Bar = 3;
+>Bar : 3
+>3 : 3
+
+=== tests/cases/compiler/file2.ts ===
+type Foo = number;
+>Foo : number
+
+class Bar {}
+>Bar : Bar
+
+=== tests/cases/compiler/file3.ts ===
+type Foo = 54;
+>Foo : 54
+
+let Bar = 42
+>Bar : number
+>42 : 42
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans2.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans2.errors.txt
@@ -1,0 +1,45 @@
+[96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS6200: [0mDefinitions of the following identifiers conflict with those in another file: A, B, C, D, E, F, G, H, I
+
+[30;47m1[0m class A { }
+[30;47m [0m [91m~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m1[0m:[93m1[0m
+    [30;47m1[0m class A { }
+    [30;47m [0m [96m~~~~~[0m
+    Conflicts are in this file.
+[96mtests/cases/compiler/file2.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS6200: [0mDefinitions of the following identifiers conflict with those in another file: A, B, C, D, E, F, G, H, I
+
+[30;47m1[0m class A { }
+[30;47m [0m [91m~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m1[0m
+    [30;47m1[0m class A { }
+    [30;47m [0m [96m~~~~~[0m
+    Conflicts are in this file.
+
+
+==== tests/cases/compiler/file1.ts (1 errors) ====
+    class A { }
+    ~~~~~
+!!! error TS6200: Definitions of the following identifiers conflict with those in another file: A, B, C, D, E, F, G, H, I
+    class B { }
+    class C { }
+    class D { }
+    class E { }
+    class F { }
+    class G { }
+    class H { }
+    class I { }
+==== tests/cases/compiler/file2.ts (1 errors) ====
+    class A { }
+    ~~~~~
+!!! error TS6200: Definitions of the following identifiers conflict with those in another file: A, B, C, D, E, F, G, H, I
+    class B { }
+    class C { }
+    class D { }
+    class E { }
+    class F { }
+    class G { }
+    class H { }
+    class I { }
+    

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans2.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans2.errors.txt
@@ -22,6 +22,7 @@
     class A { }
     ~~~~~
 !!! error TS6200: Definitions of the following identifiers conflict with those in another file: A, B, C, D, E, F, G, H, I
+!!! related TS6201 tests/cases/compiler/file2.ts:1:1: Conflicts are in this file.
     class B { }
     class C { }
     class D { }
@@ -34,6 +35,7 @@
     class A { }
     ~~~~~
 !!! error TS6200: Definitions of the following identifiers conflict with those in another file: A, B, C, D, E, F, G, H, I
+!!! related TS6201 tests/cases/compiler/file1.ts:1:1: Conflicts are in this file.
     class B { }
     class C { }
     class D { }

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans2.js
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans2.js
@@ -1,0 +1,116 @@
+//// [tests/cases/compiler/duplicateIdentifierRelatedSpans2.ts] ////
+
+//// [file1.ts]
+class A { }
+class B { }
+class C { }
+class D { }
+class E { }
+class F { }
+class G { }
+class H { }
+class I { }
+//// [file2.ts]
+class A { }
+class B { }
+class C { }
+class D { }
+class E { }
+class F { }
+class G { }
+class H { }
+class I { }
+
+
+//// [file1.js]
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+var B = /** @class */ (function () {
+    function B() {
+    }
+    return B;
+}());
+var C = /** @class */ (function () {
+    function C() {
+    }
+    return C;
+}());
+var D = /** @class */ (function () {
+    function D() {
+    }
+    return D;
+}());
+var E = /** @class */ (function () {
+    function E() {
+    }
+    return E;
+}());
+var F = /** @class */ (function () {
+    function F() {
+    }
+    return F;
+}());
+var G = /** @class */ (function () {
+    function G() {
+    }
+    return G;
+}());
+var H = /** @class */ (function () {
+    function H() {
+    }
+    return H;
+}());
+var I = /** @class */ (function () {
+    function I() {
+    }
+    return I;
+}());
+//// [file2.js]
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+var B = /** @class */ (function () {
+    function B() {
+    }
+    return B;
+}());
+var C = /** @class */ (function () {
+    function C() {
+    }
+    return C;
+}());
+var D = /** @class */ (function () {
+    function D() {
+    }
+    return D;
+}());
+var E = /** @class */ (function () {
+    function E() {
+    }
+    return E;
+}());
+var F = /** @class */ (function () {
+    function F() {
+    }
+    return F;
+}());
+var G = /** @class */ (function () {
+    function G() {
+    }
+    return G;
+}());
+var H = /** @class */ (function () {
+    function H() {
+    }
+    return H;
+}());
+var I = /** @class */ (function () {
+    function I() {
+    }
+    return I;
+}());

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans2.symbols
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans2.symbols
@@ -1,0 +1,56 @@
+=== tests/cases/compiler/file1.ts ===
+class A { }
+>A : Symbol(A, Decl(file1.ts, 0, 0))
+
+class B { }
+>B : Symbol(B, Decl(file1.ts, 0, 11))
+
+class C { }
+>C : Symbol(C, Decl(file1.ts, 1, 11))
+
+class D { }
+>D : Symbol(D, Decl(file1.ts, 2, 11))
+
+class E { }
+>E : Symbol(E, Decl(file1.ts, 3, 11))
+
+class F { }
+>F : Symbol(F, Decl(file1.ts, 4, 11))
+
+class G { }
+>G : Symbol(G, Decl(file1.ts, 5, 11))
+
+class H { }
+>H : Symbol(H, Decl(file1.ts, 6, 11))
+
+class I { }
+>I : Symbol(I, Decl(file1.ts, 7, 11))
+
+=== tests/cases/compiler/file2.ts ===
+class A { }
+>A : Symbol(A, Decl(file2.ts, 0, 0))
+
+class B { }
+>B : Symbol(B, Decl(file2.ts, 0, 11))
+
+class C { }
+>C : Symbol(C, Decl(file2.ts, 1, 11))
+
+class D { }
+>D : Symbol(D, Decl(file2.ts, 2, 11))
+
+class E { }
+>E : Symbol(E, Decl(file2.ts, 3, 11))
+
+class F { }
+>F : Symbol(F, Decl(file2.ts, 4, 11))
+
+class G { }
+>G : Symbol(G, Decl(file2.ts, 5, 11))
+
+class H { }
+>H : Symbol(H, Decl(file2.ts, 6, 11))
+
+class I { }
+>I : Symbol(I, Decl(file2.ts, 7, 11))
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans2.types
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans2.types
@@ -1,0 +1,56 @@
+=== tests/cases/compiler/file1.ts ===
+class A { }
+>A : A
+
+class B { }
+>B : B
+
+class C { }
+>C : C
+
+class D { }
+>D : D
+
+class E { }
+>E : E
+
+class F { }
+>F : F
+
+class G { }
+>G : G
+
+class H { }
+>H : H
+
+class I { }
+>I : I
+
+=== tests/cases/compiler/file2.ts ===
+class A { }
+>A : A
+
+class B { }
+>B : B
+
+class C { }
+>C : C
+
+class D { }
+>D : D
+
+class E { }
+>E : E
+
+class F { }
+>F : F
+
+class G { }
+>G : G
+
+class H { }
+>H : H
+
+class I { }
+>I : I
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans3.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans3.errors.txt
@@ -1,0 +1,81 @@
+[96mtests/cases/compiler/file1.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
+
+[30;47m2[0m     duplicate1: () => string;
+[30;47m [0m [91m    ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m2[0m:[93m5[0m
+    [30;47m2[0m     duplicate1(): number;
+    [30;47m [0m [96m    ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
+
+[30;47m3[0m     duplicate2: () => string;
+[30;47m [0m [91m    ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m3[0m:[93m5[0m
+    [30;47m3[0m     duplicate2(): number;
+    [30;47m [0m [96m    ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
+
+[30;47m4[0m     duplicate3: () => string;
+[30;47m [0m [91m    ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m4[0m:[93m5[0m
+    [30;47m4[0m     duplicate3(): number;
+    [30;47m [0m [96m    ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
+
+[30;47m2[0m     duplicate1(): number;
+[30;47m [0m [91m    ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m2[0m:[93m5[0m
+    [30;47m2[0m     duplicate1: () => string;
+    [30;47m [0m [96m    ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
+
+[30;47m3[0m     duplicate2(): number;
+[30;47m [0m [91m    ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m5[0m
+    [30;47m3[0m     duplicate2: () => string;
+    [30;47m [0m [96m    ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
+
+[30;47m4[0m     duplicate3(): number;
+[30;47m [0m [91m    ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m5[0m
+    [30;47m4[0m     duplicate3: () => string;
+    [30;47m [0m [96m    ~~~~~~~~~~[0m
+    Conflicts here.
+
+
+==== tests/cases/compiler/file1.ts (3 errors) ====
+    interface TopLevel {
+        duplicate1: () => string;
+        ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate1'.
+        duplicate2: () => string;
+        ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate2'.
+        duplicate3: () => string;
+        ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate3'.
+    }
+==== tests/cases/compiler/file2.ts (3 errors) ====
+    interface TopLevel {
+        duplicate1(): number;
+        ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate1'.
+        duplicate2(): number;
+        ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate2'.
+        duplicate3(): number;
+        ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate3'.
+    }
+    

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans3.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans3.errors.txt
@@ -59,23 +59,29 @@
         duplicate1: () => string;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
+!!! related TS6203 tests/cases/compiler/file2.ts:2:5: Conflicts here.
         duplicate2: () => string;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
+!!! related TS6203 tests/cases/compiler/file2.ts:3:5: Conflicts here.
         duplicate3: () => string;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
+!!! related TS6203 tests/cases/compiler/file2.ts:4:5: Conflicts here.
     }
 ==== tests/cases/compiler/file2.ts (3 errors) ====
     interface TopLevel {
         duplicate1(): number;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
+!!! related TS6203 tests/cases/compiler/file1.ts:2:5: Conflicts here.
         duplicate2(): number;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
+!!! related TS6203 tests/cases/compiler/file1.ts:3:5: Conflicts here.
         duplicate3(): number;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
+!!! related TS6203 tests/cases/compiler/file1.ts:4:5: Conflicts here.
     }
     

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans3.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans3.errors.txt
@@ -6,7 +6,7 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m2[0m:[93m5[0m
     [30;47m2[0m     duplicate1(): number;
     [30;47m [0m [96m    ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate1' was also declared here.
 [96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
 [30;47m3[0m     duplicate2: () => string;
@@ -15,7 +15,7 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m3[0m:[93m5[0m
     [30;47m3[0m     duplicate2(): number;
     [30;47m [0m [96m    ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate2' was also declared here.
 [96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
 [30;47m4[0m     duplicate3: () => string;
@@ -24,7 +24,7 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m4[0m:[93m5[0m
     [30;47m4[0m     duplicate3(): number;
     [30;47m [0m [96m    ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate3' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
 
 [30;47m2[0m     duplicate1(): number;
@@ -33,7 +33,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m2[0m:[93m5[0m
     [30;47m2[0m     duplicate1: () => string;
     [30;47m [0m [96m    ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate1' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m3[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
 [30;47m3[0m     duplicate2(): number;
@@ -42,7 +42,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m5[0m
     [30;47m3[0m     duplicate2: () => string;
     [30;47m [0m [96m    ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate2' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m4[0m:[93m5[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
 [30;47m4[0m     duplicate3(): number;
@@ -51,7 +51,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m5[0m
     [30;47m4[0m     duplicate3: () => string;
     [30;47m [0m [96m    ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate3' was also declared here.
 
 
 ==== tests/cases/compiler/file1.ts (3 errors) ====
@@ -59,29 +59,29 @@
         duplicate1: () => string;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
-!!! related TS6203 tests/cases/compiler/file2.ts:2:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:2:5: 'duplicate1' was also declared here.
         duplicate2: () => string;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
-!!! related TS6203 tests/cases/compiler/file2.ts:3:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:3:5: 'duplicate2' was also declared here.
         duplicate3: () => string;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
-!!! related TS6203 tests/cases/compiler/file2.ts:4:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:4:5: 'duplicate3' was also declared here.
     }
 ==== tests/cases/compiler/file2.ts (3 errors) ====
     interface TopLevel {
         duplicate1(): number;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
-!!! related TS6203 tests/cases/compiler/file1.ts:2:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:2:5: 'duplicate1' was also declared here.
         duplicate2(): number;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
-!!! related TS6203 tests/cases/compiler/file1.ts:3:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:3:5: 'duplicate2' was also declared here.
         duplicate3(): number;
         ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
-!!! related TS6203 tests/cases/compiler/file1.ts:4:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:4:5: 'duplicate3' was also declared here.
     }
     

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans3.js
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans3.js
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/duplicateIdentifierRelatedSpans3.ts] ////
+
+//// [file1.ts]
+interface TopLevel {
+    duplicate1: () => string;
+    duplicate2: () => string;
+    duplicate3: () => string;
+}
+//// [file2.ts]
+interface TopLevel {
+    duplicate1(): number;
+    duplicate2(): number;
+    duplicate3(): number;
+}
+
+
+//// [file1.js]
+//// [file2.js]

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans3.symbols
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans3.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/file1.ts ===
+interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 0), Decl(file2.ts, 0, 0))
+
+    duplicate1: () => string;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file1.ts, 0, 20))
+
+    duplicate2: () => string;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file1.ts, 1, 29))
+
+    duplicate3: () => string;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file1.ts, 2, 29))
+}
+=== tests/cases/compiler/file2.ts ===
+interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 0), Decl(file2.ts, 0, 0))
+
+    duplicate1(): number;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file2.ts, 0, 20))
+
+    duplicate2(): number;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file2.ts, 1, 25))
+
+    duplicate3(): number;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file2.ts, 2, 25))
+}
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans3.types
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans3.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/file1.ts ===
+interface TopLevel {
+>TopLevel : TopLevel
+
+    duplicate1: () => string;
+>duplicate1 : () => string
+
+    duplicate2: () => string;
+>duplicate2 : () => string
+
+    duplicate3: () => string;
+>duplicate3 : () => string
+}
+=== tests/cases/compiler/file2.ts ===
+interface TopLevel {
+>TopLevel : TopLevel
+
+    duplicate1(): number;
+>duplicate1 : () => number
+
+    duplicate2(): number;
+>duplicate2 : () => number
+
+    duplicate3(): number;
+>duplicate3 : () => number
+}
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans4.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans4.errors.txt
@@ -1,0 +1,47 @@
+[96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS6200: [0mDefinitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8
+
+[30;47m1[0m interface TopLevel {
+[30;47m [0m [91m~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m1[0m:[93m1[0m
+    [30;47m1[0m interface TopLevel {
+    [30;47m [0m [96m~~~~~~~~~[0m
+    Conflicts are in this file.
+[96mtests/cases/compiler/file2.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS6200: [0mDefinitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8
+
+[30;47m1[0m interface TopLevel {
+[30;47m [0m [91m~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m1[0m
+    [30;47m1[0m interface TopLevel {
+    [30;47m [0m [96m~~~~~~~~~[0m
+    Conflicts are in this file.
+
+
+==== tests/cases/compiler/file1.ts (1 errors) ====
+    interface TopLevel {
+    ~~~~~~~~~
+!!! error TS6200: Definitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8
+        duplicate1: () => string;
+        duplicate2: () => string;
+        duplicate3: () => string;
+        duplicate4: () => string;
+        duplicate5: () => string;
+        duplicate6: () => string;
+        duplicate7: () => string;
+        duplicate8: () => string;
+    }
+==== tests/cases/compiler/file2.ts (1 errors) ====
+    interface TopLevel {
+    ~~~~~~~~~
+!!! error TS6200: Definitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8
+        duplicate1(): number;
+        duplicate2(): number;
+        duplicate3(): number;
+        duplicate4(): number;
+        duplicate5(): number;
+        duplicate6(): number;
+        duplicate7(): number;
+        duplicate8(): number;
+    }
+    

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans4.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans4.errors.txt
@@ -22,6 +22,7 @@
     interface TopLevel {
     ~~~~~~~~~
 !!! error TS6200: Definitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8
+!!! related TS6201 tests/cases/compiler/file2.ts:1:1: Conflicts are in this file.
         duplicate1: () => string;
         duplicate2: () => string;
         duplicate3: () => string;
@@ -35,6 +36,7 @@
     interface TopLevel {
     ~~~~~~~~~
 !!! error TS6200: Definitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8
+!!! related TS6201 tests/cases/compiler/file1.ts:1:1: Conflicts are in this file.
         duplicate1(): number;
         duplicate2(): number;
         duplicate3(): number;

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans4.js
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans4.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/duplicateIdentifierRelatedSpans4.ts] ////
+
+//// [file1.ts]
+interface TopLevel {
+    duplicate1: () => string;
+    duplicate2: () => string;
+    duplicate3: () => string;
+    duplicate4: () => string;
+    duplicate5: () => string;
+    duplicate6: () => string;
+    duplicate7: () => string;
+    duplicate8: () => string;
+}
+//// [file2.ts]
+interface TopLevel {
+    duplicate1(): number;
+    duplicate2(): number;
+    duplicate3(): number;
+    duplicate4(): number;
+    duplicate5(): number;
+    duplicate6(): number;
+    duplicate7(): number;
+    duplicate8(): number;
+}
+
+
+//// [file1.js]
+//// [file2.js]

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans4.symbols
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans4.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/compiler/file1.ts ===
+interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 0), Decl(file2.ts, 0, 0))
+
+    duplicate1: () => string;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file1.ts, 0, 20))
+
+    duplicate2: () => string;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file1.ts, 1, 29))
+
+    duplicate3: () => string;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file1.ts, 2, 29))
+
+    duplicate4: () => string;
+>duplicate4 : Symbol(TopLevel.duplicate4, Decl(file1.ts, 3, 29))
+
+    duplicate5: () => string;
+>duplicate5 : Symbol(TopLevel.duplicate5, Decl(file1.ts, 4, 29))
+
+    duplicate6: () => string;
+>duplicate6 : Symbol(TopLevel.duplicate6, Decl(file1.ts, 5, 29))
+
+    duplicate7: () => string;
+>duplicate7 : Symbol(TopLevel.duplicate7, Decl(file1.ts, 6, 29))
+
+    duplicate8: () => string;
+>duplicate8 : Symbol(TopLevel.duplicate8, Decl(file1.ts, 7, 29))
+}
+=== tests/cases/compiler/file2.ts ===
+interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 0), Decl(file2.ts, 0, 0))
+
+    duplicate1(): number;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file2.ts, 0, 20))
+
+    duplicate2(): number;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file2.ts, 1, 25))
+
+    duplicate3(): number;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file2.ts, 2, 25))
+
+    duplicate4(): number;
+>duplicate4 : Symbol(TopLevel.duplicate4, Decl(file2.ts, 3, 25))
+
+    duplicate5(): number;
+>duplicate5 : Symbol(TopLevel.duplicate5, Decl(file2.ts, 4, 25))
+
+    duplicate6(): number;
+>duplicate6 : Symbol(TopLevel.duplicate6, Decl(file2.ts, 5, 25))
+
+    duplicate7(): number;
+>duplicate7 : Symbol(TopLevel.duplicate7, Decl(file2.ts, 6, 25))
+
+    duplicate8(): number;
+>duplicate8 : Symbol(TopLevel.duplicate8, Decl(file2.ts, 7, 25))
+}
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans4.types
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans4.types
@@ -1,0 +1,57 @@
+=== tests/cases/compiler/file1.ts ===
+interface TopLevel {
+>TopLevel : TopLevel
+
+    duplicate1: () => string;
+>duplicate1 : () => string
+
+    duplicate2: () => string;
+>duplicate2 : () => string
+
+    duplicate3: () => string;
+>duplicate3 : () => string
+
+    duplicate4: () => string;
+>duplicate4 : () => string
+
+    duplicate5: () => string;
+>duplicate5 : () => string
+
+    duplicate6: () => string;
+>duplicate6 : () => string
+
+    duplicate7: () => string;
+>duplicate7 : () => string
+
+    duplicate8: () => string;
+>duplicate8 : () => string
+}
+=== tests/cases/compiler/file2.ts ===
+interface TopLevel {
+>TopLevel : TopLevel
+
+    duplicate1(): number;
+>duplicate1 : () => number
+
+    duplicate2(): number;
+>duplicate2 : () => number
+
+    duplicate3(): number;
+>duplicate3 : () => number
+
+    duplicate4(): number;
+>duplicate4 : () => number
+
+    duplicate5(): number;
+>duplicate5 : () => number
+
+    duplicate6(): number;
+>duplicate6 : () => number
+
+    duplicate7(): number;
+>duplicate7 : () => number
+
+    duplicate8(): number;
+>duplicate8 : () => number
+}
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans5.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans5.errors.txt
@@ -60,12 +60,15 @@
             duplicate1: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
+!!! related TS6203 tests/cases/compiler/file2.ts:4:9: Conflicts here.
             duplicate2: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
+!!! related TS6203 tests/cases/compiler/file2.ts:5:9: Conflicts here.
             duplicate3: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
+!!! related TS6203 tests/cases/compiler/file2.ts:6:9: Conflicts here.
         }
     }
     export {}
@@ -76,12 +79,15 @@
             duplicate1(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
+!!! related TS6203 tests/cases/compiler/file1.ts:3:9: Conflicts here.
             duplicate2(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
+!!! related TS6203 tests/cases/compiler/file1.ts:4:9: Conflicts here.
             duplicate3(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
+!!! related TS6203 tests/cases/compiler/file1.ts:5:9: Conflicts here.
         }
     }
     export {}

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans5.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans5.errors.txt
@@ -6,7 +6,7 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m4[0m:[93m9[0m
     [30;47m4[0m         duplicate1(): number;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate1' was also declared here.
 [96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
 [30;47m4[0m         duplicate2: () => string;
@@ -15,7 +15,7 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m5[0m:[93m9[0m
     [30;47m5[0m         duplicate2(): number;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate2' was also declared here.
 [96mtests/cases/compiler/file1.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
 [30;47m5[0m         duplicate3: () => string;
@@ -24,7 +24,7 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m6[0m:[93m9[0m
     [30;47m6[0m         duplicate3(): number;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate3' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
 
 [30;47m4[0m         duplicate1(): number;
@@ -33,7 +33,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m9[0m
     [30;47m3[0m         duplicate1: () => string;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate1' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
 [30;47m5[0m         duplicate2(): number;
@@ -42,7 +42,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m9[0m
     [30;47m4[0m         duplicate2: () => string;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate2' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m6[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
 [30;47m6[0m         duplicate3(): number;
@@ -51,7 +51,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m5[0m:[93m9[0m
     [30;47m5[0m         duplicate3: () => string;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate3' was also declared here.
 
 
 ==== tests/cases/compiler/file1.ts (3 errors) ====
@@ -60,15 +60,15 @@
             duplicate1: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
-!!! related TS6203 tests/cases/compiler/file2.ts:4:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:4:9: 'duplicate1' was also declared here.
             duplicate2: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
-!!! related TS6203 tests/cases/compiler/file2.ts:5:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:5:9: 'duplicate2' was also declared here.
             duplicate3: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
-!!! related TS6203 tests/cases/compiler/file2.ts:6:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:6:9: 'duplicate3' was also declared here.
         }
     }
     export {}
@@ -79,15 +79,15 @@
             duplicate1(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
-!!! related TS6203 tests/cases/compiler/file1.ts:3:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:3:9: 'duplicate1' was also declared here.
             duplicate2(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
-!!! related TS6203 tests/cases/compiler/file1.ts:4:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:4:9: 'duplicate2' was also declared here.
             duplicate3(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
-!!! related TS6203 tests/cases/compiler/file1.ts:5:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:5:9: 'duplicate3' was also declared here.
         }
     }
     export {}

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans5.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans5.errors.txt
@@ -1,0 +1,88 @@
+[96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
+
+[30;47m3[0m         duplicate1: () => string;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m4[0m:[93m9[0m
+    [30;47m4[0m         duplicate1(): number;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
+
+[30;47m4[0m         duplicate2: () => string;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m5[0m:[93m9[0m
+    [30;47m5[0m         duplicate2(): number;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file1.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
+
+[30;47m5[0m         duplicate3: () => string;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m6[0m:[93m9[0m
+    [30;47m6[0m         duplicate3(): number;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
+
+[30;47m4[0m         duplicate1(): number;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m9[0m
+    [30;47m3[0m         duplicate1: () => string;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
+
+[30;47m5[0m         duplicate2(): number;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m9[0m
+    [30;47m4[0m         duplicate2: () => string;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m6[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
+
+[30;47m6[0m         duplicate3(): number;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m5[0m:[93m9[0m
+    [30;47m5[0m         duplicate3: () => string;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+
+
+==== tests/cases/compiler/file1.ts (3 errors) ====
+    declare global {
+        interface TopLevel {
+            duplicate1: () => string;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate1'.
+            duplicate2: () => string;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate2'.
+            duplicate3: () => string;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate3'.
+        }
+    }
+    export {}
+==== tests/cases/compiler/file2.ts (3 errors) ====
+    import "./file1";
+    declare global {
+        interface TopLevel {
+            duplicate1(): number;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate1'.
+            duplicate2(): number;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate2'.
+            duplicate3(): number;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate3'.
+        }
+    }
+    export {}
+    

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans5.js
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans5.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/duplicateIdentifierRelatedSpans5.ts] ////
+
+//// [file1.ts]
+declare global {
+    interface TopLevel {
+        duplicate1: () => string;
+        duplicate2: () => string;
+        duplicate3: () => string;
+    }
+}
+export {}
+//// [file2.ts]
+import "./file1";
+declare global {
+    interface TopLevel {
+        duplicate1(): number;
+        duplicate2(): number;
+        duplicate3(): number;
+    }
+}
+export {}
+
+
+//// [file1.js]
+"use strict";
+exports.__esModule = true;
+//// [file2.js]
+"use strict";
+exports.__esModule = true;
+require("./file1");

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans5.symbols
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans5.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/file1.ts ===
+declare global {
+>global : Symbol(global, Decl(file1.ts, 0, 0))
+
+    interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 16), Decl(file2.ts, 1, 16))
+
+        duplicate1: () => string;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file1.ts, 1, 24))
+
+        duplicate2: () => string;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file1.ts, 2, 33))
+
+        duplicate3: () => string;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file1.ts, 3, 33))
+    }
+}
+export {}
+=== tests/cases/compiler/file2.ts ===
+import "./file1";
+declare global {
+>global : Symbol(global, Decl(file2.ts, 0, 17))
+
+    interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 16), Decl(file2.ts, 1, 16))
+
+        duplicate1(): number;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file2.ts, 2, 24))
+
+        duplicate2(): number;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file2.ts, 3, 29))
+
+        duplicate3(): number;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file2.ts, 4, 29))
+    }
+}
+export {}
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans5.types
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans5.types
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/file1.ts ===
+declare global {
+>global : any
+
+    interface TopLevel {
+>TopLevel : TopLevel
+
+        duplicate1: () => string;
+>duplicate1 : () => string
+
+        duplicate2: () => string;
+>duplicate2 : () => string
+
+        duplicate3: () => string;
+>duplicate3 : () => string
+    }
+}
+export {}
+=== tests/cases/compiler/file2.ts ===
+import "./file1";
+declare global {
+>global : any
+
+    interface TopLevel {
+>TopLevel : TopLevel
+
+        duplicate1(): number;
+>duplicate1 : () => number
+
+        duplicate2(): number;
+>duplicate2 : () => number
+
+        duplicate3(): number;
+>duplicate3 : () => number
+    }
+}
+export {}
+

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans6.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans6.errors.txt
@@ -1,0 +1,88 @@
+[96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
+
+[30;47m3[0m         duplicate1: () => string;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m5[0m:[93m9[0m
+    [30;47m5[0m         duplicate1(): number;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
+
+[30;47m4[0m         duplicate2: () => string;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m6[0m:[93m9[0m
+    [30;47m6[0m         duplicate2(): number;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file1.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
+
+[30;47m5[0m         duplicate3: () => string;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m7[0m:[93m9[0m
+    [30;47m7[0m         duplicate3(): number;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
+
+[30;47m5[0m         duplicate1(): number;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m9[0m
+    [30;47m3[0m         duplicate1: () => string;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m6[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
+
+[30;47m6[0m         duplicate2(): number;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m9[0m
+    [30;47m4[0m         duplicate2: () => string;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+[96mtests/cases/compiler/file2.ts[0m:[93m7[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
+
+[30;47m7[0m         duplicate3(): number;
+[30;47m [0m [91m        ~~~~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m5[0m:[93m9[0m
+    [30;47m5[0m         duplicate3: () => string;
+    [30;47m [0m [96m        ~~~~~~~~~~[0m
+    Conflicts here.
+
+
+==== tests/cases/compiler/file2.ts (3 errors) ====
+    /// <reference path="./file1" />
+    
+    declare module "someMod" {
+        export interface TopLevel {
+            duplicate1(): number;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate1'.
+            duplicate2(): number;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate2'.
+            duplicate3(): number;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate3'.
+        }
+    }
+    export {};
+    
+==== tests/cases/compiler/file1.ts (3 errors) ====
+    declare module "someMod" {
+        export interface TopLevel {
+            duplicate1: () => string;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate1'.
+            duplicate2: () => string;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate2'.
+            duplicate3: () => string;
+            ~~~~~~~~~~
+!!! error TS2300: Duplicate identifier 'duplicate3'.
+        }
+    }

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans6.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans6.errors.txt
@@ -6,7 +6,7 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m5[0m:[93m9[0m
     [30;47m5[0m         duplicate1(): number;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate1' was also declared here.
 [96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
 [30;47m4[0m         duplicate2: () => string;
@@ -15,7 +15,7 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m6[0m:[93m9[0m
     [30;47m6[0m         duplicate2(): number;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate2' was also declared here.
 [96mtests/cases/compiler/file1.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
 [30;47m5[0m         duplicate3: () => string;
@@ -24,7 +24,7 @@
   [96mtests/cases/compiler/file2.ts[0m:[93m7[0m:[93m9[0m
     [30;47m7[0m         duplicate3(): number;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate3' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m5[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate1'.
 
 [30;47m5[0m         duplicate1(): number;
@@ -33,7 +33,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m3[0m:[93m9[0m
     [30;47m3[0m         duplicate1: () => string;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate1' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m6[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate2'.
 
 [30;47m6[0m         duplicate2(): number;
@@ -42,7 +42,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m4[0m:[93m9[0m
     [30;47m4[0m         duplicate2: () => string;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate2' was also declared here.
 [96mtests/cases/compiler/file2.ts[0m:[93m7[0m:[93m9[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'duplicate3'.
 
 [30;47m7[0m         duplicate3(): number;
@@ -51,7 +51,7 @@
   [96mtests/cases/compiler/file1.ts[0m:[93m5[0m:[93m9[0m
     [30;47m5[0m         duplicate3: () => string;
     [30;47m [0m [96m        ~~~~~~~~~~[0m
-    Conflicts here.
+    'duplicate3' was also declared here.
 
 
 ==== tests/cases/compiler/file2.ts (3 errors) ====
@@ -62,15 +62,15 @@
             duplicate1(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
-!!! related TS6203 tests/cases/compiler/file1.ts:3:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:3:9: 'duplicate1' was also declared here.
             duplicate2(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
-!!! related TS6203 tests/cases/compiler/file1.ts:4:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:4:9: 'duplicate2' was also declared here.
             duplicate3(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
-!!! related TS6203 tests/cases/compiler/file1.ts:5:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:5:9: 'duplicate3' was also declared here.
         }
     }
     export {};
@@ -81,14 +81,14 @@
             duplicate1: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
-!!! related TS6203 tests/cases/compiler/file2.ts:5:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:5:9: 'duplicate1' was also declared here.
             duplicate2: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
-!!! related TS6203 tests/cases/compiler/file2.ts:6:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:6:9: 'duplicate2' was also declared here.
             duplicate3: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
-!!! related TS6203 tests/cases/compiler/file2.ts:7:9: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:7:9: 'duplicate3' was also declared here.
         }
     }

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans6.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans6.errors.txt
@@ -62,12 +62,15 @@
             duplicate1(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
+!!! related TS6203 tests/cases/compiler/file1.ts:3:9: Conflicts here.
             duplicate2(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
+!!! related TS6203 tests/cases/compiler/file1.ts:4:9: Conflicts here.
             duplicate3(): number;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
+!!! related TS6203 tests/cases/compiler/file1.ts:5:9: Conflicts here.
         }
     }
     export {};
@@ -78,11 +81,14 @@
             duplicate1: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate1'.
+!!! related TS6203 tests/cases/compiler/file2.ts:5:9: Conflicts here.
             duplicate2: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate2'.
+!!! related TS6203 tests/cases/compiler/file2.ts:6:9: Conflicts here.
             duplicate3: () => string;
             ~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'duplicate3'.
+!!! related TS6203 tests/cases/compiler/file2.ts:7:9: Conflicts here.
         }
     }

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans6.js
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans6.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/duplicateIdentifierRelatedSpans6.ts] ////
+
+//// [file1.ts]
+declare module "someMod" {
+    export interface TopLevel {
+        duplicate1: () => string;
+        duplicate2: () => string;
+        duplicate3: () => string;
+    }
+}
+//// [file2.ts]
+/// <reference path="./file1" />
+
+declare module "someMod" {
+    export interface TopLevel {
+        duplicate1(): number;
+        duplicate2(): number;
+        duplicate3(): number;
+    }
+}
+export {};
+
+
+//// [file1.js]
+//// [file2.js]
+"use strict";
+/// <reference path="./file1" />
+exports.__esModule = true;

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans6.symbols
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans6.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/file2.ts ===
+/// <reference path="./file1" />
+
+declare module "someMod" {
+>"someMod" : Symbol("someMod", Decl(file1.ts, 0, 0), Decl(file2.ts, 0, 0))
+
+    export interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 26), Decl(file2.ts, 2, 26))
+
+        duplicate1(): number;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file2.ts, 3, 31))
+
+        duplicate2(): number;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file2.ts, 4, 29))
+
+        duplicate3(): number;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file2.ts, 5, 29))
+    }
+}
+export {};
+
+=== tests/cases/compiler/file1.ts ===
+declare module "someMod" {
+>"someMod" : Symbol("someMod", Decl(file1.ts, 0, 0), Decl(file2.ts, 0, 0))
+
+    export interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 26), Decl(file2.ts, 2, 26))
+
+        duplicate1: () => string;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file1.ts, 1, 31))
+
+        duplicate2: () => string;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file1.ts, 2, 33))
+
+        duplicate3: () => string;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file1.ts, 3, 33))
+    }
+}

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans6.types
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans6.types
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/file2.ts ===
+/// <reference path="./file1" />
+
+declare module "someMod" {
+>"someMod" : typeof import("someMod")
+
+    export interface TopLevel {
+>TopLevel : TopLevel
+
+        duplicate1(): number;
+>duplicate1 : () => number
+
+        duplicate2(): number;
+>duplicate2 : () => number
+
+        duplicate3(): number;
+>duplicate3 : () => number
+    }
+}
+export {};
+
+=== tests/cases/compiler/file1.ts ===
+declare module "someMod" {
+>"someMod" : typeof import("someMod")
+
+    export interface TopLevel {
+>TopLevel : TopLevel
+
+        duplicate1: () => string;
+>duplicate1 : () => string
+
+        duplicate2: () => string;
+>duplicate2 : () => string
+
+        duplicate3: () => string;
+>duplicate3 : () => string
+    }
+}

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans7.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans7.errors.txt
@@ -1,0 +1,56 @@
+[96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m1[0m - [91merror[0m[90m TS6200: [0mDefinitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8, duplicate9
+
+[30;47m1[0m declare module "someMod" {
+[30;47m [0m [91m~~~~~~~[0m
+
+  [96mtests/cases/compiler/file2.ts[0m:[93m3[0m:[93m1[0m
+    [30;47m3[0m declare module "someMod" {
+    [30;47m [0m [96m~~~~~~~[0m
+    Conflicts are in this file.
+[96mtests/cases/compiler/file2.ts[0m:[93m3[0m:[93m1[0m - [91merror[0m[90m TS6200: [0mDefinitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8, duplicate9
+
+[30;47m3[0m declare module "someMod" {
+[30;47m [0m [91m~~~~~~~[0m
+
+  [96mtests/cases/compiler/file1.ts[0m:[93m1[0m:[93m1[0m
+    [30;47m1[0m declare module "someMod" {
+    [30;47m [0m [96m~~~~~~~[0m
+    Conflicts are in this file.
+
+
+==== tests/cases/compiler/file2.ts (1 errors) ====
+    /// <reference path="./file1" />
+    
+    declare module "someMod" {
+    ~~~~~~~
+!!! error TS6200: Definitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8, duplicate9
+        export interface TopLevel {
+            duplicate1(): number;
+            duplicate2(): number;
+            duplicate3(): number;
+            duplicate4(): number;
+            duplicate5(): number;
+            duplicate6(): number;
+            duplicate7(): number;
+            duplicate8(): number;
+            duplicate9(): number;
+        }
+    }
+    export {};
+    
+==== tests/cases/compiler/file1.ts (1 errors) ====
+    declare module "someMod" {
+    ~~~~~~~
+!!! error TS6200: Definitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8, duplicate9
+        export interface TopLevel {
+            duplicate1: () => string;
+            duplicate2: () => string;
+            duplicate3: () => string;
+            duplicate4: () => string;
+            duplicate5: () => string;
+            duplicate6: () => string;
+            duplicate7: () => string;
+            duplicate8: () => string;
+            duplicate9: () => string;
+        }
+    }

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans7.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans7.errors.txt
@@ -24,6 +24,7 @@
     declare module "someMod" {
     ~~~~~~~
 !!! error TS6200: Definitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8, duplicate9
+!!! related TS6201 tests/cases/compiler/file1.ts:1:1: Conflicts are in this file.
         export interface TopLevel {
             duplicate1(): number;
             duplicate2(): number;
@@ -42,6 +43,7 @@
     declare module "someMod" {
     ~~~~~~~
 !!! error TS6200: Definitions of the following identifiers conflict with those in another file: duplicate1, duplicate2, duplicate3, duplicate4, duplicate5, duplicate6, duplicate7, duplicate8, duplicate9
+!!! related TS6201 tests/cases/compiler/file2.ts:3:1: Conflicts are in this file.
         export interface TopLevel {
             duplicate1: () => string;
             duplicate2: () => string;

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans7.js
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans7.js
@@ -1,0 +1,40 @@
+//// [tests/cases/compiler/duplicateIdentifierRelatedSpans7.ts] ////
+
+//// [file1.ts]
+declare module "someMod" {
+    export interface TopLevel {
+        duplicate1: () => string;
+        duplicate2: () => string;
+        duplicate3: () => string;
+        duplicate4: () => string;
+        duplicate5: () => string;
+        duplicate6: () => string;
+        duplicate7: () => string;
+        duplicate8: () => string;
+        duplicate9: () => string;
+    }
+}
+//// [file2.ts]
+/// <reference path="./file1" />
+
+declare module "someMod" {
+    export interface TopLevel {
+        duplicate1(): number;
+        duplicate2(): number;
+        duplicate3(): number;
+        duplicate4(): number;
+        duplicate5(): number;
+        duplicate6(): number;
+        duplicate7(): number;
+        duplicate8(): number;
+        duplicate9(): number;
+    }
+}
+export {};
+
+
+//// [file1.js]
+//// [file2.js]
+"use strict";
+/// <reference path="./file1" />
+exports.__esModule = true;

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans7.symbols
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans7.symbols
@@ -1,0 +1,74 @@
+=== tests/cases/compiler/file2.ts ===
+/// <reference path="./file1" />
+
+declare module "someMod" {
+>"someMod" : Symbol("someMod", Decl(file1.ts, 0, 0), Decl(file2.ts, 0, 0))
+
+    export interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 26), Decl(file2.ts, 2, 26))
+
+        duplicate1(): number;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file2.ts, 3, 31))
+
+        duplicate2(): number;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file2.ts, 4, 29))
+
+        duplicate3(): number;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file2.ts, 5, 29))
+
+        duplicate4(): number;
+>duplicate4 : Symbol(TopLevel.duplicate4, Decl(file2.ts, 6, 29))
+
+        duplicate5(): number;
+>duplicate5 : Symbol(TopLevel.duplicate5, Decl(file2.ts, 7, 29))
+
+        duplicate6(): number;
+>duplicate6 : Symbol(TopLevel.duplicate6, Decl(file2.ts, 8, 29))
+
+        duplicate7(): number;
+>duplicate7 : Symbol(TopLevel.duplicate7, Decl(file2.ts, 9, 29))
+
+        duplicate8(): number;
+>duplicate8 : Symbol(TopLevel.duplicate8, Decl(file2.ts, 10, 29))
+
+        duplicate9(): number;
+>duplicate9 : Symbol(TopLevel.duplicate9, Decl(file2.ts, 11, 29))
+    }
+}
+export {};
+
+=== tests/cases/compiler/file1.ts ===
+declare module "someMod" {
+>"someMod" : Symbol("someMod", Decl(file1.ts, 0, 0), Decl(file2.ts, 0, 0))
+
+    export interface TopLevel {
+>TopLevel : Symbol(TopLevel, Decl(file1.ts, 0, 26), Decl(file2.ts, 2, 26))
+
+        duplicate1: () => string;
+>duplicate1 : Symbol(TopLevel.duplicate1, Decl(file1.ts, 1, 31))
+
+        duplicate2: () => string;
+>duplicate2 : Symbol(TopLevel.duplicate2, Decl(file1.ts, 2, 33))
+
+        duplicate3: () => string;
+>duplicate3 : Symbol(TopLevel.duplicate3, Decl(file1.ts, 3, 33))
+
+        duplicate4: () => string;
+>duplicate4 : Symbol(TopLevel.duplicate4, Decl(file1.ts, 4, 33))
+
+        duplicate5: () => string;
+>duplicate5 : Symbol(TopLevel.duplicate5, Decl(file1.ts, 5, 33))
+
+        duplicate6: () => string;
+>duplicate6 : Symbol(TopLevel.duplicate6, Decl(file1.ts, 6, 33))
+
+        duplicate7: () => string;
+>duplicate7 : Symbol(TopLevel.duplicate7, Decl(file1.ts, 7, 33))
+
+        duplicate8: () => string;
+>duplicate8 : Symbol(TopLevel.duplicate8, Decl(file1.ts, 8, 33))
+
+        duplicate9: () => string;
+>duplicate9 : Symbol(TopLevel.duplicate9, Decl(file1.ts, 9, 33))
+    }
+}

--- a/tests/baselines/reference/duplicateIdentifierRelatedSpans7.types
+++ b/tests/baselines/reference/duplicateIdentifierRelatedSpans7.types
@@ -1,0 +1,74 @@
+=== tests/cases/compiler/file2.ts ===
+/// <reference path="./file1" />
+
+declare module "someMod" {
+>"someMod" : typeof import("someMod")
+
+    export interface TopLevel {
+>TopLevel : TopLevel
+
+        duplicate1(): number;
+>duplicate1 : () => number
+
+        duplicate2(): number;
+>duplicate2 : () => number
+
+        duplicate3(): number;
+>duplicate3 : () => number
+
+        duplicate4(): number;
+>duplicate4 : () => number
+
+        duplicate5(): number;
+>duplicate5 : () => number
+
+        duplicate6(): number;
+>duplicate6 : () => number
+
+        duplicate7(): number;
+>duplicate7 : () => number
+
+        duplicate8(): number;
+>duplicate8 : () => number
+
+        duplicate9(): number;
+>duplicate9 : () => number
+    }
+}
+export {};
+
+=== tests/cases/compiler/file1.ts ===
+declare module "someMod" {
+>"someMod" : typeof import("someMod")
+
+    export interface TopLevel {
+>TopLevel : TopLevel
+
+        duplicate1: () => string;
+>duplicate1 : () => string
+
+        duplicate2: () => string;
+>duplicate2 : () => string
+
+        duplicate3: () => string;
+>duplicate3 : () => string
+
+        duplicate4: () => string;
+>duplicate4 : () => string
+
+        duplicate5: () => string;
+>duplicate5 : () => string
+
+        duplicate6: () => string;
+>duplicate6 : () => string
+
+        duplicate7: () => string;
+>duplicate7 : () => string
+
+        duplicate8: () => string;
+>duplicate8 : () => string
+
+        duplicate9: () => string;
+>duplicate9 : () => string
+    }
+}

--- a/tests/baselines/reference/duplicateIdentifiersAcrossFileBoundaries.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifiersAcrossFileBoundaries.errors.txt
@@ -13,15 +13,18 @@ tests/cases/compiler/file2.ts(8,16): error TS2300: Duplicate identifier 'x'.
     class C2 { }
           ~~
 !!! error TS2300: Duplicate identifier 'C2'.
+!!! related TS6203 tests/cases/compiler/file2.ts:3:10: Conflicts here.
     function f() { }
              ~
 !!! error TS2300: Duplicate identifier 'f'.
+!!! related TS6203 tests/cases/compiler/file2.ts:4:7: Conflicts here.
     var v = 3;
     
     class Foo {
         static x: number;
                ~
 !!! error TS2300: Duplicate identifier 'x'.
+!!! related TS6203 tests/cases/compiler/file2.ts:8:16: Conflicts here.
     }
     
     module N {
@@ -36,9 +39,11 @@ tests/cases/compiler/file2.ts(8,16): error TS2300: Duplicate identifier 'x'.
     function C2() { } // error -- cannot merge function with non-ambient class
              ~~
 !!! error TS2300: Duplicate identifier 'C2'.
+!!! related TS6203 tests/cases/compiler/file1.ts:3:7: Conflicts here.
     class f { } // error -- cannot merge function with non-ambient class
           ~
 !!! error TS2300: Duplicate identifier 'f'.
+!!! related TS6203 tests/cases/compiler/file1.ts:4:10: Conflicts here.
     var v = 3;
     
     module Foo {
@@ -47,6 +52,7 @@ tests/cases/compiler/file2.ts(8,16): error TS2300: Duplicate identifier 'x'.
         export var x: number; // error for redeclaring var in a different parent
                    ~
 !!! error TS2300: Duplicate identifier 'x'.
+!!! related TS6203 tests/cases/compiler/file1.ts:8:12: Conflicts here.
     }
     
     declare module N {

--- a/tests/baselines/reference/duplicateIdentifiersAcrossFileBoundaries.errors.txt
+++ b/tests/baselines/reference/duplicateIdentifiersAcrossFileBoundaries.errors.txt
@@ -13,18 +13,18 @@ tests/cases/compiler/file2.ts(8,16): error TS2300: Duplicate identifier 'x'.
     class C2 { }
           ~~
 !!! error TS2300: Duplicate identifier 'C2'.
-!!! related TS6203 tests/cases/compiler/file2.ts:3:10: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:3:10: 'C2' was also declared here.
     function f() { }
              ~
 !!! error TS2300: Duplicate identifier 'f'.
-!!! related TS6203 tests/cases/compiler/file2.ts:4:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:4:7: 'f' was also declared here.
     var v = 3;
     
     class Foo {
         static x: number;
                ~
 !!! error TS2300: Duplicate identifier 'x'.
-!!! related TS6203 tests/cases/compiler/file2.ts:8:16: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:8:16: 'x' was also declared here.
     }
     
     module N {
@@ -39,11 +39,11 @@ tests/cases/compiler/file2.ts(8,16): error TS2300: Duplicate identifier 'x'.
     function C2() { } // error -- cannot merge function with non-ambient class
              ~~
 !!! error TS2300: Duplicate identifier 'C2'.
-!!! related TS6203 tests/cases/compiler/file1.ts:3:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:3:7: 'C2' was also declared here.
     class f { } // error -- cannot merge function with non-ambient class
           ~
 !!! error TS2300: Duplicate identifier 'f'.
-!!! related TS6203 tests/cases/compiler/file1.ts:4:10: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:4:10: 'f' was also declared here.
     var v = 3;
     
     module Foo {
@@ -52,7 +52,7 @@ tests/cases/compiler/file2.ts(8,16): error TS2300: Duplicate identifier 'x'.
         export var x: number; // error for redeclaring var in a different parent
                    ~
 !!! error TS2300: Duplicate identifier 'x'.
-!!! related TS6203 tests/cases/compiler/file1.ts:8:12: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:8:12: 'x' was also declared here.
     }
     
     declare module N {

--- a/tests/baselines/reference/esModuleInteropPrettyErrorRelatedInformation.errors.txt
+++ b/tests/baselines/reference/esModuleInteropPrettyErrorRelatedInformation.errors.txt
@@ -21,4 +21,5 @@
            ~~~
 !!! error TS2345: Argument of type '{ default: () => void; }' is not assignable to parameter of type '() => void'.
 !!! error TS2345:   Type '{ default: () => void; }' provides no match for the signature '(): void'.
+!!! related TS7038 tests/cases/compiler/index.ts:1:1: Type originates at this import. A namespace-style import cannot be called or constructed, and will cause a failure at runtime. Consider using a default import or import require here instead.
     

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates2.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates2.errors.txt
@@ -6,8 +6,10 @@ tests/cases/compiler/file2.ts(1,5): error TS2451: Cannot redeclare block-scoped 
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:5: Conflicts here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:5: Conflicts here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates2.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates2.errors.txt
@@ -6,10 +6,10 @@ tests/cases/compiler/file2.ts(1,5): error TS2451: Cannot redeclare block-scoped 
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file2.ts:1:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:5: 'var1' was also declared here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file1.ts:1:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:5: 'var1' was also declared here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates3.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates3.errors.txt
@@ -6,10 +6,10 @@ tests/cases/compiler/file2.ts(1,7): error TS2451: Cannot redeclare block-scoped 
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file2.ts:1:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:7: 'var1' was also declared here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     const var1 = 0;
           ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file1.ts:1:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:5: 'var1' was also declared here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates3.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates3.errors.txt
@@ -6,8 +6,10 @@ tests/cases/compiler/file2.ts(1,7): error TS2451: Cannot redeclare block-scoped 
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:7: Conflicts here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     const var1 = 0;
           ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:5: Conflicts here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates4.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates4.errors.txt
@@ -6,8 +6,10 @@ tests/cases/compiler/file2.ts(1,5): error TS2451: Cannot redeclare block-scoped 
     const var1 = 0;
           ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:5: Conflicts here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:7: Conflicts here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates4.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates4.errors.txt
@@ -6,10 +6,10 @@ tests/cases/compiler/file2.ts(1,5): error TS2451: Cannot redeclare block-scoped 
     const var1 = 0;
           ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file2.ts:1:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:5: 'var1' was also declared here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file1.ts:1:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:7: 'var1' was also declared here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates5.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates5.errors.txt
@@ -6,8 +6,10 @@ tests/cases/compiler/file2.ts(1,7): error TS2451: Cannot redeclare block-scoped 
     const var1 = 0;
           ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:7: Conflicts here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     const var1 = 0;
           ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:7: Conflicts here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates5.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates5.errors.txt
@@ -6,10 +6,10 @@ tests/cases/compiler/file2.ts(1,7): error TS2451: Cannot redeclare block-scoped 
     const var1 = 0;
           ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file2.ts:1:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:7: 'var1' was also declared here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     const var1 = 0;
           ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file1.ts:1:7: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:7: 'var1' was also declared here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates6.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates6.errors.txt
@@ -6,8 +6,10 @@ tests/cases/compiler/file2.ts(1,5): error TS2451: Cannot redeclare block-scoped 
     var var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:5: Conflicts here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:5: Conflicts here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates6.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates6.errors.txt
@@ -6,10 +6,10 @@ tests/cases/compiler/file2.ts(1,5): error TS2451: Cannot redeclare block-scoped 
     var var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file2.ts:1:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:5: 'var1' was also declared here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file1.ts:1:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:5: 'var1' was also declared here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates7.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates7.errors.txt
@@ -6,8 +6,10 @@ tests/cases/compiler/file2.ts(1,5): error TS2451: Cannot redeclare block-scoped 
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:5: Conflicts here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     var var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:5: Conflicts here.

--- a/tests/baselines/reference/letDeclarations-scopes-duplicates7.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes-duplicates7.errors.txt
@@ -6,10 +6,10 @@ tests/cases/compiler/file2.ts(1,5): error TS2451: Cannot redeclare block-scoped 
     let var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file2.ts:1:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file2.ts:1:5: 'var1' was also declared here.
     
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     var var1 = 0;
         ~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'var1'.
-!!! related TS6203 tests/cases/compiler/file1.ts:1:5: Conflicts here.
+!!! related TS6203 tests/cases/compiler/file1.ts:1:5: 'var1' was also declared here.

--- a/tests/baselines/reference/parser.asyncGenerators.functionExpressions.esnext.errors.txt
+++ b/tests/baselines/reference/parser.asyncGenerators.functionExpressions.esnext.errors.txt
@@ -37,6 +37,7 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingVa
 !!! error TS1005: '(' expected.
                                 ~~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'await'.
+!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts:1:30: Conflicts here.
                                      ~
 !!! error TS1005: ',' expected.
                                         ~
@@ -48,6 +49,7 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingVa
 !!! error TS1005: '(' expected.
                                 ~~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'yield'.
+!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts:1:30: Conflicts here.
                                      ~
 !!! error TS1005: ',' expected.
                                         ~
@@ -59,6 +61,7 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingVa
 !!! error TS1138: Parameter declaration expected.
                                  ~~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'await'.
+!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitNameIsError.ts:1:29: Conflicts here.
                                       ~
 !!! error TS1005: ',' expected.
     };
@@ -68,6 +71,7 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingVa
 !!! error TS1138: Parameter declaration expected.
                                  ~~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'yield'.
+!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldNameIsError.ts:1:29: Conflicts here.
                                       ~
 !!! error TS1005: ',' expected.
     };

--- a/tests/baselines/reference/parser.asyncGenerators.functionExpressions.esnext.errors.txt
+++ b/tests/baselines/reference/parser.asyncGenerators.functionExpressions.esnext.errors.txt
@@ -37,7 +37,7 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingVa
 !!! error TS1005: '(' expected.
                                 ~~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'await'.
-!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts:1:30: Conflicts here.
+!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts:1:30: 'await' was also declared here.
                                      ~
 !!! error TS1005: ',' expected.
                                         ~
@@ -49,7 +49,7 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingVa
 !!! error TS1005: '(' expected.
                                 ~~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'yield'.
-!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts:1:30: Conflicts here.
+!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts:1:30: 'yield' was also declared here.
                                      ~
 !!! error TS1005: ',' expected.
                                         ~
@@ -61,7 +61,7 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingVa
 !!! error TS1138: Parameter declaration expected.
                                  ~~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'await'.
-!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitNameIsError.ts:1:29: Conflicts here.
+!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitNameIsError.ts:1:29: 'await' was also declared here.
                                       ~
 !!! error TS1005: ',' expected.
     };
@@ -71,7 +71,7 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingVa
 !!! error TS1138: Parameter declaration expected.
                                  ~~~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'yield'.
-!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldNameIsError.ts:1:29: Conflicts here.
+!!! related TS6203 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldNameIsError.ts:1:29: 'yield' was also declared here.
                                       ~
 !!! error TS1005: ',' expected.
     };

--- a/tests/baselines/reference/project/declareVariableCollision/amd/declareVariableCollision.errors.txt
+++ b/tests/baselines/reference/project/declareVariableCollision/amd/declareVariableCollision.errors.txt
@@ -19,7 +19,9 @@ in2.d.ts(1,8): error TS2300: Duplicate identifier 'a'.
     import a = A;
            ~
 !!! error TS2300: Duplicate identifier 'a'.
+!!! related TS6203 in2.d.ts:1:8: Conflicts here.
 ==== in2.d.ts (1 errors) ====
     import a = A;
            ~
 !!! error TS2300: Duplicate identifier 'a'.
+!!! related TS6203 in1.d.ts:1:8: Conflicts here.

--- a/tests/baselines/reference/project/declareVariableCollision/amd/declareVariableCollision.errors.txt
+++ b/tests/baselines/reference/project/declareVariableCollision/amd/declareVariableCollision.errors.txt
@@ -19,9 +19,9 @@ in2.d.ts(1,8): error TS2300: Duplicate identifier 'a'.
     import a = A;
            ~
 !!! error TS2300: Duplicate identifier 'a'.
-!!! related TS6203 in2.d.ts:1:8: Conflicts here.
+!!! related TS6203 in2.d.ts:1:8: 'a' was also declared here.
 ==== in2.d.ts (1 errors) ====
     import a = A;
            ~
 !!! error TS2300: Duplicate identifier 'a'.
-!!! related TS6203 in1.d.ts:1:8: Conflicts here.
+!!! related TS6203 in1.d.ts:1:8: 'a' was also declared here.

--- a/tests/baselines/reference/project/declareVariableCollision/node/declareVariableCollision.errors.txt
+++ b/tests/baselines/reference/project/declareVariableCollision/node/declareVariableCollision.errors.txt
@@ -19,7 +19,9 @@ in2.d.ts(1,8): error TS2300: Duplicate identifier 'a'.
     import a = A;
            ~
 !!! error TS2300: Duplicate identifier 'a'.
+!!! related TS6203 in2.d.ts:1:8: Conflicts here.
 ==== in2.d.ts (1 errors) ====
     import a = A;
            ~
 !!! error TS2300: Duplicate identifier 'a'.
+!!! related TS6203 in1.d.ts:1:8: Conflicts here.

--- a/tests/baselines/reference/project/declareVariableCollision/node/declareVariableCollision.errors.txt
+++ b/tests/baselines/reference/project/declareVariableCollision/node/declareVariableCollision.errors.txt
@@ -19,9 +19,9 @@ in2.d.ts(1,8): error TS2300: Duplicate identifier 'a'.
     import a = A;
            ~
 !!! error TS2300: Duplicate identifier 'a'.
-!!! related TS6203 in2.d.ts:1:8: Conflicts here.
+!!! related TS6203 in2.d.ts:1:8: 'a' was also declared here.
 ==== in2.d.ts (1 errors) ====
     import a = A;
            ~
 !!! error TS2300: Duplicate identifier 'a'.
-!!! related TS6203 in1.d.ts:1:8: Conflicts here.
+!!! related TS6203 in1.d.ts:1:8: 'a' was also declared here.

--- a/tests/baselines/reference/typedefCrossModule5.errors.txt
+++ b/tests/baselines/reference/typedefCrossModule5.errors.txt
@@ -40,15 +40,19 @@
     /** @typedef {number} Foo */
                           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
+!!! related TS6203 tests/cases/conformance/jsdoc/mod2.js:1:7: Conflicts here.
     class Bar {}
           ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+!!! related TS6203 tests/cases/conformance/jsdoc/mod2.js:2:7: Conflicts here.
     
 ==== tests/cases/conformance/jsdoc/mod2.js (2 errors) ====
     class Foo { } // should error
           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
+!!! related TS6203 tests/cases/conformance/jsdoc/mod1.js:1:23: Conflicts here.
     const Bar = 3;
           ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+!!! related TS6203 tests/cases/conformance/jsdoc/mod1.js:2:7: Conflicts here.
     

--- a/tests/baselines/reference/typedefCrossModule5.errors.txt
+++ b/tests/baselines/reference/typedefCrossModule5.errors.txt
@@ -6,7 +6,7 @@
   [96mtests/cases/conformance/jsdoc/mod2.js[0m:[93m1[0m:[93m7[0m
     [30;47m1[0m class Foo { } // should error
     [30;47m [0m [96m      ~~~[0m
-    Conflicts here.
+    'Foo' was also declared here.
 [96mtests/cases/conformance/jsdoc/mod1.js[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
 
 [30;47m2[0m class Bar {}
@@ -15,7 +15,7 @@
   [96mtests/cases/conformance/jsdoc/mod2.js[0m:[93m2[0m:[93m7[0m
     [30;47m2[0m const Bar = 3;
     [30;47m [0m [96m      ~~~[0m
-    Conflicts here.
+    'Bar' was also declared here.
 [96mtests/cases/conformance/jsdoc/mod2.js[0m:[93m1[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'Foo'.
 
 [30;47m1[0m class Foo { } // should error
@@ -24,7 +24,7 @@
   [96mtests/cases/conformance/jsdoc/mod1.js[0m:[93m1[0m:[93m23[0m
     [30;47m1[0m /** @typedef {number} Foo */
     [30;47m [0m [96m                      ~~~[0m
-    Conflicts here.
+    'Foo' was also declared here.
 [96mtests/cases/conformance/jsdoc/mod2.js[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
 
 [30;47m2[0m const Bar = 3;
@@ -33,26 +33,26 @@
   [96mtests/cases/conformance/jsdoc/mod1.js[0m:[93m2[0m:[93m7[0m
     [30;47m2[0m class Bar {}
     [30;47m [0m [96m      ~~~[0m
-    Conflicts here.
+    'Bar' was also declared here.
 
 
 ==== tests/cases/conformance/jsdoc/mod1.js (2 errors) ====
     /** @typedef {number} Foo */
                           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
-!!! related TS6203 tests/cases/conformance/jsdoc/mod2.js:1:7: Conflicts here.
+!!! related TS6203 tests/cases/conformance/jsdoc/mod2.js:1:7: 'Foo' was also declared here.
     class Bar {}
           ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
-!!! related TS6203 tests/cases/conformance/jsdoc/mod2.js:2:7: Conflicts here.
+!!! related TS6203 tests/cases/conformance/jsdoc/mod2.js:2:7: 'Bar' was also declared here.
     
 ==== tests/cases/conformance/jsdoc/mod2.js (2 errors) ====
     class Foo { } // should error
           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
-!!! related TS6203 tests/cases/conformance/jsdoc/mod1.js:1:23: Conflicts here.
+!!! related TS6203 tests/cases/conformance/jsdoc/mod1.js:1:23: 'Foo' was also declared here.
     const Bar = 3;
           ~~~
 !!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
-!!! related TS6203 tests/cases/conformance/jsdoc/mod1.js:2:7: Conflicts here.
+!!! related TS6203 tests/cases/conformance/jsdoc/mod1.js:2:7: 'Bar' was also declared here.
     

--- a/tests/baselines/reference/typedefCrossModule5.errors.txt
+++ b/tests/baselines/reference/typedefCrossModule5.errors.txt
@@ -1,0 +1,54 @@
+[96mtests/cases/conformance/jsdoc/mod1.js[0m:[93m1[0m:[93m23[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'Foo'.
+
+[30;47m1[0m /** @typedef {number} Foo */
+[30;47m [0m [91m                      ~~~[0m
+
+  [96mtests/cases/conformance/jsdoc/mod2.js[0m:[93m1[0m:[93m7[0m
+    [30;47m1[0m class Foo { } // should error
+    [30;47m [0m [96m      ~~~[0m
+    Conflicts here.
+[96mtests/cases/conformance/jsdoc/mod1.js[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
+
+[30;47m2[0m class Bar {}
+[30;47m [0m [91m      ~~~[0m
+
+  [96mtests/cases/conformance/jsdoc/mod2.js[0m:[93m2[0m:[93m7[0m
+    [30;47m2[0m const Bar = 3;
+    [30;47m [0m [96m      ~~~[0m
+    Conflicts here.
+[96mtests/cases/conformance/jsdoc/mod2.js[0m:[93m1[0m:[93m7[0m - [91merror[0m[90m TS2300: [0mDuplicate identifier 'Foo'.
+
+[30;47m1[0m class Foo { } // should error
+[30;47m [0m [91m      ~~~[0m
+
+  [96mtests/cases/conformance/jsdoc/mod1.js[0m:[93m1[0m:[93m23[0m
+    [30;47m1[0m /** @typedef {number} Foo */
+    [30;47m [0m [96m                      ~~~[0m
+    Conflicts here.
+[96mtests/cases/conformance/jsdoc/mod2.js[0m:[93m2[0m:[93m7[0m - [91merror[0m[90m TS2451: [0mCannot redeclare block-scoped variable 'Bar'.
+
+[30;47m2[0m const Bar = 3;
+[30;47m [0m [91m      ~~~[0m
+
+  [96mtests/cases/conformance/jsdoc/mod1.js[0m:[93m2[0m:[93m7[0m
+    [30;47m2[0m class Bar {}
+    [30;47m [0m [96m      ~~~[0m
+    Conflicts here.
+
+
+==== tests/cases/conformance/jsdoc/mod1.js (2 errors) ====
+    /** @typedef {number} Foo */
+                          ~~~
+!!! error TS2300: Duplicate identifier 'Foo'.
+    class Bar {}
+          ~~~
+!!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+    
+==== tests/cases/conformance/jsdoc/mod2.js (2 errors) ====
+    class Foo { } // should error
+          ~~~
+!!! error TS2300: Duplicate identifier 'Foo'.
+    const Bar = 3;
+          ~~~
+!!! error TS2451: Cannot redeclare block-scoped variable 'Bar'.
+    

--- a/tests/baselines/reference/typedefCrossModule5.symbols
+++ b/tests/baselines/reference/typedefCrossModule5.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsdoc/mod1.js ===
+/** @typedef {number} Foo */
+class Bar {}
+>Bar : Symbol(Bar, Decl(mod1.js, 0, 0))
+
+=== tests/cases/conformance/jsdoc/mod2.js ===
+class Foo { } // should error
+>Foo : Symbol(Foo, Decl(mod2.js, 0, 0))
+
+const Bar = 3;
+>Bar : Symbol(Bar, Decl(mod2.js, 1, 5))
+

--- a/tests/baselines/reference/typedefCrossModule5.types
+++ b/tests/baselines/reference/typedefCrossModule5.types
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/jsdoc/mod1.js ===
+/** @typedef {number} Foo */
+class Bar {}
+>Bar : Bar
+
+=== tests/cases/conformance/jsdoc/mod2.js ===
+class Foo { } // should error
+>Foo : Foo
+
+const Bar = 3;
+>Bar : 3
+>3 : 3
+

--- a/tests/baselines/reference/variableDeclarationInStrictMode1.errors.txt
+++ b/tests/baselines/reference/variableDeclarationInStrictMode1.errors.txt
@@ -10,3 +10,4 @@ lib.es5.d.ts(32,18): error TS2300: Duplicate identifier 'eval'.
 !!! error TS1100: Invalid use of 'eval' in strict mode.
         ~~~~
 !!! error TS2300: Duplicate identifier 'eval'.
+!!! related TS6203 /.ts/lib.es5.d.ts:32:18: Conflicts here.

--- a/tests/baselines/reference/variableDeclarationInStrictMode1.errors.txt
+++ b/tests/baselines/reference/variableDeclarationInStrictMode1.errors.txt
@@ -10,4 +10,4 @@ lib.es5.d.ts(32,18): error TS2300: Duplicate identifier 'eval'.
 !!! error TS1100: Invalid use of 'eval' in strict mode.
         ~~~~
 !!! error TS2300: Duplicate identifier 'eval'.
-!!! related TS6203 /.ts/lib.es5.d.ts:32:18: Conflicts here.
+!!! related TS6203 /.ts/lib.es5.d.ts:32:18: 'eval' was also declared here.

--- a/tests/cases/compiler/duplicateIdentifierRelatedSpans1.ts
+++ b/tests/cases/compiler/duplicateIdentifierRelatedSpans1.ts
@@ -1,0 +1,10 @@
+// @pretty: true
+// @filename: file1.ts
+class Foo { }
+const Bar = 3;
+// @filename: file2.ts
+type Foo = number;
+class Bar {}
+// @filename: file3.ts
+type Foo = 54;
+let Bar = 42

--- a/tests/cases/compiler/duplicateIdentifierRelatedSpans2.ts
+++ b/tests/cases/compiler/duplicateIdentifierRelatedSpans2.ts
@@ -1,0 +1,21 @@
+// @pretty: true
+// @filename: file1.ts
+class A { }
+class B { }
+class C { }
+class D { }
+class E { }
+class F { }
+class G { }
+class H { }
+class I { }
+// @filename: file2.ts
+class A { }
+class B { }
+class C { }
+class D { }
+class E { }
+class F { }
+class G { }
+class H { }
+class I { }

--- a/tests/cases/compiler/duplicateIdentifierRelatedSpans3.ts
+++ b/tests/cases/compiler/duplicateIdentifierRelatedSpans3.ts
@@ -1,0 +1,13 @@
+// @pretty: true
+// @filename: file1.ts
+interface TopLevel {
+    duplicate1: () => string;
+    duplicate2: () => string;
+    duplicate3: () => string;
+}
+// @filename: file2.ts
+interface TopLevel {
+    duplicate1(): number;
+    duplicate2(): number;
+    duplicate3(): number;
+}

--- a/tests/cases/compiler/duplicateIdentifierRelatedSpans4.ts
+++ b/tests/cases/compiler/duplicateIdentifierRelatedSpans4.ts
@@ -1,0 +1,23 @@
+// @pretty: true
+// @filename: file1.ts
+interface TopLevel {
+    duplicate1: () => string;
+    duplicate2: () => string;
+    duplicate3: () => string;
+    duplicate4: () => string;
+    duplicate5: () => string;
+    duplicate6: () => string;
+    duplicate7: () => string;
+    duplicate8: () => string;
+}
+// @filename: file2.ts
+interface TopLevel {
+    duplicate1(): number;
+    duplicate2(): number;
+    duplicate3(): number;
+    duplicate4(): number;
+    duplicate5(): number;
+    duplicate6(): number;
+    duplicate7(): number;
+    duplicate8(): number;
+}

--- a/tests/cases/compiler/duplicateIdentifierRelatedSpans5.ts
+++ b/tests/cases/compiler/duplicateIdentifierRelatedSpans5.ts
@@ -1,0 +1,20 @@
+// @pretty: true
+// @filename: file1.ts
+declare global {
+    interface TopLevel {
+        duplicate1: () => string;
+        duplicate2: () => string;
+        duplicate3: () => string;
+    }
+}
+export {}
+// @filename: file2.ts
+import "./file1";
+declare global {
+    interface TopLevel {
+        duplicate1(): number;
+        duplicate2(): number;
+        duplicate3(): number;
+    }
+}
+export {}

--- a/tests/cases/compiler/duplicateIdentifierRelatedSpans6.ts
+++ b/tests/cases/compiler/duplicateIdentifierRelatedSpans6.ts
@@ -1,0 +1,20 @@
+// @pretty: true
+// @filename: file1.ts
+declare module "someMod" {
+    export interface TopLevel {
+        duplicate1: () => string;
+        duplicate2: () => string;
+        duplicate3: () => string;
+    }
+}
+// @filename: file2.ts
+/// <reference path="./file1" />
+
+declare module "someMod" {
+    export interface TopLevel {
+        duplicate1(): number;
+        duplicate2(): number;
+        duplicate3(): number;
+    }
+}
+export {};

--- a/tests/cases/compiler/duplicateIdentifierRelatedSpans7.ts
+++ b/tests/cases/compiler/duplicateIdentifierRelatedSpans7.ts
@@ -1,0 +1,32 @@
+// @pretty: true
+// @filename: file1.ts
+declare module "someMod" {
+    export interface TopLevel {
+        duplicate1: () => string;
+        duplicate2: () => string;
+        duplicate3: () => string;
+        duplicate4: () => string;
+        duplicate5: () => string;
+        duplicate6: () => string;
+        duplicate7: () => string;
+        duplicate8: () => string;
+        duplicate9: () => string;
+    }
+}
+// @filename: file2.ts
+/// <reference path="./file1" />
+
+declare module "someMod" {
+    export interface TopLevel {
+        duplicate1(): number;
+        duplicate2(): number;
+        duplicate3(): number;
+        duplicate4(): number;
+        duplicate5(): number;
+        duplicate6(): number;
+        duplicate7(): number;
+        duplicate8(): number;
+        duplicate9(): number;
+    }
+}
+export {};

--- a/tests/cases/conformance/jsdoc/typedefCrossModule5.ts
+++ b/tests/cases/conformance/jsdoc/typedefCrossModule5.ts
@@ -1,0 +1,12 @@
+// @pretty: true
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: mod1.js
+
+/** @typedef {number} Foo */
+class Bar {}
+
+// @Filename: mod2.js
+class Foo { } // should error
+const Bar = 3;


### PR DESCRIPTION
Fixes #25324

This adds related spans for cross-file "duplicate identifier" type errors (for up to the first 5 related spans, chosen by fair dice roll, as to avoid cluttering the output too much), and also compacts instances where many of such errors appear across a pair of files down to a single error message (the limit having been arbitrarily chosen as 8 instances).

Examples:
![image](https://user-images.githubusercontent.com/2932786/42119167-1fd1230e-7bbe-11e8-80ac-16272a2dc4b6.png)
![image](https://user-images.githubusercontent.com/2932786/42119181-40395a9e-7bbe-11e8-8c13-eb3d9266d475.png)

![image](https://user-images.githubusercontent.com/2932786/42119204-6a0ee91a-7bbe-11e8-8231-33c51afab17c.png)
![image](https://user-images.githubusercontent.com/2932786/42119212-7701392a-7bbe-11e8-87ad-eb62e0f31d4f.png)

