### PR TITLE
Add outlining spans for JSX elements

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -191,8 +191,8 @@ namespace ts.OutliningElementsCollector {
         }
 
         function spanForJSXElement(node: JsxElement): OutliningSpan | undefined {
-            const textSpan = createTextSpanFromBounds(node.openingElement.getStart(), node.closingElement.getEnd());
-            const tagName = node.openingElement.tagName.getText();
+            const textSpan = createTextSpanFromBounds(node.openingElement.getStart(sourceFile), node.closingElement.getEnd());
+            const tagName = node.openingElement.tagName.getText(sourceFile);
             const bannerText = "<" + tagName + ">...</" + tagName + ">";
             return createOutliningSpan(textSpan, OutliningSpanKind.Code, textSpan, /*autoCollapse*/ false, bannerText);
         }
@@ -202,7 +202,7 @@ namespace ts.OutliningElementsCollector {
                 return undefined;
             }
 
-            return createOutliningSpanFromBounds(node.getStart(), node.getEnd(), OutliningSpanKind.Code);
+            return createOutliningSpanFromBounds(node.getStart(sourceFile), node.getEnd(), OutliningSpanKind.Code);
         }
 
         function spanForObjectOrArrayLiteral(node: Node, open: SyntaxKind.OpenBraceToken | SyntaxKind.OpenBracketToken = SyntaxKind.OpenBraceToken): OutliningSpan | undefined {

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -198,6 +198,10 @@ namespace ts.OutliningElementsCollector {
         }
 
         function spanForJSXAttributes(node: JsxAttributes): OutliningSpan | undefined {
+            if (node.properties.length === 0) {
+                return undefined;
+            }
+
             return createOutliningSpanFromBounds(node.getStart(), node.getEnd(), OutliningSpanKind.Code);
         }
 

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -183,6 +183,22 @@ namespace ts.OutliningElementsCollector {
                 return spanForObjectOrArrayLiteral(n);
             case SyntaxKind.ArrayLiteralExpression:
                 return spanForObjectOrArrayLiteral(n, SyntaxKind.OpenBracketToken);
+            case SyntaxKind.JsxElement:
+                return spanForJSXElement(<JsxElement>n);
+            case SyntaxKind.JsxSelfClosingElement:
+            case SyntaxKind.JsxOpeningElement:
+                return spanForJSXAttributes((<JsxOpeningLikeElement>n).attributes);
+        }
+
+        function spanForJSXElement(node: JsxElement): OutliningSpan | undefined {
+            const textSpan = createTextSpanFromBounds(node.openingElement.getStart(), node.closingElement.getEnd());
+            const tagName = node.openingElement.tagName.getText();
+            const bannerText = "<" + tagName + ">...</" + tagName + ">";
+            return createOutliningSpan(textSpan, OutliningSpanKind.Code, textSpan, /*autoCollapse*/ false, bannerText);
+        }
+
+        function spanForJSXAttributes(node: JsxAttributes): OutliningSpan | undefined {
+            return createOutliningSpanFromBounds(node.getStart(), node.getEnd(), OutliningSpanKind.Code);
         }
 
         function spanForObjectOrArrayLiteral(node: Node, open: SyntaxKind.OpenBraceToken | SyntaxKind.OpenBracketToken = SyntaxKind.OpenBraceToken): OutliningSpan | undefined {

--- a/tests/cases/fourslash/getJSXOutliningSpans.tsx
+++ b/tests/cases/fourslash/getJSXOutliningSpans.tsx
@@ -1,0 +1,33 @@
+////import React, { Component } from 'react';
+////
+////export class Home extends Component[| {
+////  render()[| {
+////    return (
+////    [|<div>
+////      [|<h1>Hello, world!</h1>|]
+////      [|<ul>
+////        [|<li>
+////          [|<a [|href='https://get.asp.net/'|]>
+////            ASP.NET Core
+////          </a>|]
+////        </li>|]
+////        [|<li>[|<a [|href='https://facebook.github.io/react/'|]>React</a>|] for client-side code</li>|]
+////        [|<li>[|<a [|href='http://getbootstrap.com/'|]>Bootstrap</a>|] for layout and styling</li>|]
+////      </ul>|]
+////      <div
+////        [|accesskey="test"
+////        class="active"
+////        dir="auto"|] />
+////      <PageHeader [|title="Log in"
+////        {...[|{
+////          item: true,
+////          xs: 9,
+////          md: 5
+////        }|]}|]
+////      />
+////    </div>|]
+////    );
+////  }|]
+////}|]
+
+verify.outliningSpansInCurrentFile(test.ranges(), "code");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #23273 .

This PR adds outlining regions for JSX elements in two ways:

- For JSX elements (with an opening tag and a closing tag), we provide an outlining region that spans the whole element. This matches the behavior in Visual Studio for HTML files. When collapsed, the text `<tagname>…</tagname>` is shown, regardless of attributes.

- For JSX opening elements (including self-closing elements), we provide an outlining region that spans the attributes. This allows tags with multiple lines of attributes to be collapsed.

