### PR TITLE
Combine code-fix-all for missing class member and missing enum member

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4450,9 +4450,5 @@
     "Add missing enum member '{0}'": {
         "category": "Message",
         "code": 95063
-    },
-    "Add all missing enum members": {
-        "category": "Message",
-        "code": 95064
     }
 }

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -15,7 +15,7 @@ namespace ts.codefix {
             if (info.kind === InfoKind.enum) {
                 const { token, enumDeclaration } = info;
                 const changes = textChanges.ChangeTracker.with(context, t => addEnumMemberDeclaration(t, context.program.getTypeChecker(), token, enumDeclaration));
-                return singleElementArray(createCodeFixAction(fixName, changes, [Diagnostics.Add_missing_enum_member_0, token.text], fixId, Diagnostics.Add_all_missing_enum_members));
+                return [createCodeFixAction(fixName, changes, [Diagnostics.Add_missing_enum_member_0, token.text], fixId, Diagnostics.Add_all_missing_members)];
             }
             const { classDeclaration, classDeclarationSourceFile, inJs, makeStatic, token, call } = info;
             const methodCodeAction = call && getActionForMethodDeclaration(context, classDeclarationSourceFile, classDeclaration, token, call, makeStatic, inJs, context.preferences);

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5926,7 +5926,6 @@ declare namespace ts {
         Convert_default_export_to_named_export: DiagnosticMessage;
         Convert_named_export_to_default_export: DiagnosticMessage;
         Add_missing_enum_member_0: DiagnosticMessage;
-        Add_all_missing_enum_members: DiagnosticMessage;
     };
 }
 declare namespace ts {

--- a/tests/cases/fourslash/codeFixAddMissingMember_all.ts
+++ b/tests/cases/fourslash/codeFixAddMissingMember_all.ts
@@ -7,6 +7,9 @@
 ////        this.x = "";
 ////    }
 ////}
+////
+////enum E {}
+////E.A;
 
 verify.codeFixAll({
     fixId: "addMissingMember",
@@ -22,5 +25,10 @@ verify.codeFixAll({
     y(): any {
         throw new Error("Method not implemented.");
     }
-}`,
+}
+
+enum E {
+    A
+}
+E.A;`,
 });


### PR DESCRIPTION
Noticed in #25182 (CC @Kingwl) that the fix for a missing enum member had a different fix-all description, but the same fixId. This changes it so both add-missing-class-member and add-missing-enum-member fixes use the description "Add all missing members".