### PR TITLE
expose createExpressionStatement and updateExpressionStatement

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -1531,13 +1531,6 @@ namespace ts {
         return block;
     }
 
-    /* @internal */
-    export function createExpressionStatement(expression: Expression): ExpressionStatement {
-        const node = <ExpressionStatement>createSynthesizedNode(SyntaxKind.ExpressionStatement);
-        node.expression = expression;
-        return node;
-    }
-
     export function updateBlock(node: Block, statements: ReadonlyArray<Statement>) {
         return node.statements !== statements
             ? updateNode(createBlock(statements, node.multiLine), node)
@@ -1563,15 +1556,22 @@ namespace ts {
         return <EmptyStatement>createSynthesizedNode(SyntaxKind.EmptyStatement);
     }
 
-    export function createStatement(expression: Expression) {
-        return createExpressionStatement(parenthesizeExpressionForExpressionStatement(expression));
+    export function createExpressionStatement(expression: Expression): ExpressionStatement {
+        const node = <ExpressionStatement>createSynthesizedNode(SyntaxKind.ExpressionStatement);
+        node.expression = parenthesizeExpressionForExpressionStatement(expression);
+        return node;
     }
 
-    export function updateStatement(node: ExpressionStatement, expression: Expression) {
+    export function updateExpressionStatement(node: ExpressionStatement, expression: Expression) {
         return node.expression !== expression
-            ? updateNode(createStatement(expression), node)
+            ? updateNode(createExpressionStatement(expression), node)
             : node;
     }
+
+    /** @deprecated Use `createExpressionStatement` instead.  */
+    export const createStatement = createExpressionStatement;
+    /** @deprecated Use `updateExpressionStatement` instead.  */
+    export const updateStatement = updateExpressionStatement;
 
     export function createIf(expression: Expression, thenStatement: Statement, elseStatement?: Statement) {
         const node = <IfStatement>createSynthesizedNode(SyntaxKind.IfStatement);

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -855,7 +855,7 @@ namespace ts {
             if (extendsClauseElement) {
                 statements.push(
                     setTextRange(
-                        createStatement(
+                        createExpressionStatement(
                             createExtendsHelper(context, getInternalName(node))
                         ),
                         /*location*/ extendsClauseElement
@@ -1280,7 +1280,7 @@ namespace ts {
             else if (initializer) {
                 statements.push(
                     setEmitFlags(
-                        createStatement(
+                        createExpressionStatement(
                             createAssignment(
                                 temp,
                                 visitNode(initializer, visitor, isExpression)
@@ -1307,7 +1307,7 @@ namespace ts {
                 setEmitFlags(
                     setTextRange(
                         createBlock([
-                            createStatement(
+                            createExpressionStatement(
                                 setEmitFlags(
                                     setTextRange(
                                         createAssignment(
@@ -1409,7 +1409,7 @@ namespace ts {
                 createBlock([
                     startOnNewLine(
                         setTextRange(
-                            createStatement(
+                            createExpressionStatement(
                                 createAssignment(
                                     createElementAccess(
                                         expressionName,
@@ -1594,7 +1594,7 @@ namespace ts {
             setSourceMapRange(memberFunction, sourceMapRange);
 
             const statement = setTextRange(
-                createStatement(
+                createExpressionStatement(
                     createAssignment(memberName, memberFunction)
                 ),
                 /*location*/ member
@@ -1619,7 +1619,7 @@ namespace ts {
          * @param accessors The set of related get/set accessors.
          */
         function transformAccessorsToStatement(receiver: LeftHandSideExpression, accessors: AllAccessorDeclarations, container: Node): Statement {
-            const statement = createStatement(transformAccessorsToExpression(receiver, accessors, container, /*startsOnNewLine*/ false));
+            const statement = createExpressionStatement(transformAccessorsToExpression(receiver, accessors, container, /*startsOnNewLine*/ false));
             // The location for the statement is used to emit source maps only.
             // No comments should be emitted for this statement to align with the
             // old emitter.
@@ -1949,9 +1949,9 @@ namespace ts {
             // If we are here it is most likely because our expression is a destructuring assignment.
             switch (node.expression.kind) {
                 case SyntaxKind.ParenthesizedExpression:
-                    return updateStatement(node, visitParenthesizedExpression(<ParenthesizedExpression>node.expression, /*needsDestructuringValue*/ false));
+                    return updateExpressionStatement(node, visitParenthesizedExpression(<ParenthesizedExpression>node.expression, /*needsDestructuringValue*/ false));
                 case SyntaxKind.BinaryExpression:
-                    return updateStatement(node, visitBinaryExpression(<BinaryExpression>node.expression, /*needsDestructuringValue*/ false));
+                    return updateExpressionStatement(node, visitBinaryExpression(<BinaryExpression>node.expression, /*needsDestructuringValue*/ false));
             }
             return visitEachChild(node, visitor, context);
         }
@@ -2026,7 +2026,7 @@ namespace ts {
                     }
                 }
                 if (assignments) {
-                    updated = setTextRange(createStatement(inlineExpressions(assignments)), node);
+                    updated = setTextRange(createExpressionStatement(inlineExpressions(assignments)), node);
                 }
                 else {
                     // none of declarations has initializer - the entire variable statement can be deleted
@@ -2330,11 +2330,11 @@ namespace ts {
                 const assignment = createAssignment(initializer, boundValue);
                 if (isDestructuringAssignment(assignment)) {
                     aggregateTransformFlags(assignment);
-                    statements.push(createStatement(visitBinaryExpression(assignment, /*needsDestructuringValue*/ false)));
+                    statements.push(createExpressionStatement(visitBinaryExpression(assignment, /*needsDestructuringValue*/ false)));
                 }
                 else {
                     assignment.end = initializer.end;
-                    statements.push(setTextRange(createStatement(visitNode(assignment, visitor, isExpression)), moveRangeEnd(initializer, -1)));
+                    statements.push(setTextRange(createExpressionStatement(visitNode(assignment, visitor, isExpression)), moveRangeEnd(initializer, -1)));
                 }
             }
 
@@ -2483,7 +2483,7 @@ namespace ts {
                 createCatchClause(createVariableDeclaration(catchVariable),
                     setEmitFlags(
                         createBlock([
-                            createStatement(
+                            createExpressionStatement(
                                 createAssignment(
                                     errorRecord,
                                     createObjectLiteral([
@@ -2512,7 +2512,7 @@ namespace ts {
                                             createPropertyAccess(iterator, "return")
                                         )
                                     ),
-                                    createStatement(
+                                    createExpressionStatement(
                                         createFunctionCall(returnMethod, iterator, [])
                                     )
                                 ),
@@ -2868,7 +2868,7 @@ namespace ts {
 
         function copyOutParameters(outParams: LoopOutParameter[], copyDirection: CopyDirection, statements: Statement[]): void {
             for (const outParam of outParams) {
-                statements.push(createStatement(copyOutParameter(outParam, copyDirection)));
+                statements.push(createExpressionStatement(copyOutParameter(outParam, copyDirection)));
             }
         }
 
@@ -2892,7 +2892,7 @@ namespace ts {
                 )
                 : call;
             if (isSimpleLoop) {
-                statements.push(createStatement(callResult));
+                statements.push(createExpressionStatement(callResult));
                 copyOutParameters(state.loopOutParameters!, CopyDirection.ToOriginal, statements);
             }
             else {
@@ -3358,7 +3358,7 @@ namespace ts {
 
                 // Add the class alias following the declaration.
                 statements.push(
-                    createStatement(
+                    createExpressionStatement(
                         createAssignment(
                             aliasAssignment.left,
                             cast(variable.name, isIdentifier)

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -144,7 +144,7 @@ namespace ts {
         function visitVariableStatementInAsyncBody(node: VariableStatement) {
             if (isVariableDeclarationListWithCollidingName(node.declarationList)) {
                 const expression = visitVariableDeclarationListWithCollidingNames(node.declarationList, /*hasReceiver*/ false);
-                return expression ? createStatement(expression) : undefined;
+                return expression ? createExpressionStatement(expression) : undefined;
             }
             return visitEachChild(node, visitor, context);
         }

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -446,7 +446,7 @@ namespace ts {
                     createVariableDeclaration(catchVariable),
                     setEmitFlags(
                         createBlock([
-                            createStatement(
+                            createExpressionStatement(
                                 createAssignment(
                                     errorRecord,
                                     createObjectLiteral([
@@ -473,7 +473,7 @@ namespace ts {
                                             createPropertyAccess(iterator, "return")
                                         )
                                     ),
-                                    createStatement(createDownlevelAwait(callReturn))
+                                    createExpressionStatement(createDownlevelAwait(callReturn))
                                 ),
                                 EmitFlags.SingleLine
                             )

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -637,7 +637,7 @@ namespace ts {
                 }
 
                 return setSourceMapRange(
-                    createStatement(
+                    createExpressionStatement(
                         inlineExpressions(
                             map(variables, transformInitializedVariable)
                         )
@@ -872,7 +872,7 @@ namespace ts {
                 }
                 else {
                     if (containsYield(node) && pendingExpressions.length > 0) {
-                        emitWorker(OpCode.Statement, [createStatement(inlineExpressions(pendingExpressions))]);
+                        emitWorker(OpCode.Statement, [createExpressionStatement(inlineExpressions(pendingExpressions))]);
                         pendingExpressions = [];
                     }
 
@@ -1067,7 +1067,7 @@ namespace ts {
 
             function reduceProperty(expressions: Expression[], property: ObjectLiteralElementLike) {
                 if (containsYield(property) && expressions.length > 0) {
-                    emitStatement(createStatement(inlineExpressions(expressions)));
+                    emitStatement(createExpressionStatement(inlineExpressions(expressions)));
                     expressions = [];
                 }
 
@@ -1270,7 +1270,7 @@ namespace ts {
                 }
 
                 if (pendingExpressions.length) {
-                    emitStatement(createStatement(inlineExpressions(pendingExpressions)));
+                    emitStatement(createExpressionStatement(inlineExpressions(pendingExpressions)));
                     variablesWritten += pendingExpressions.length;
                     pendingExpressions = [];
                 }
@@ -1441,7 +1441,7 @@ namespace ts {
                     else {
                         emitStatement(
                             setTextRange(
-                                createStatement(
+                                createExpressionStatement(
                                     visitNode(initializer, visitor, isExpression)
                                 ),
                                 initializer
@@ -1461,7 +1461,7 @@ namespace ts {
                 if (node.incrementor) {
                     emitStatement(
                         setTextRange(
-                            createStatement(
+                            createExpressionStatement(
                                 visitNode(node.incrementor, visitor, isExpression)
                             ),
                             node.incrementor
@@ -1543,7 +1543,7 @@ namespace ts {
                     createForIn(
                         key,
                         visitNode(node.expression, visitor, isExpression),
-                        createStatement(
+                        createExpressionStatement(
                             createCall(
                                 createPropertyAccess(keysArray, "push"),
                                 /*typeArguments*/ undefined,
@@ -1579,7 +1579,7 @@ namespace ts {
                 transformAndEmitEmbeddedStatement(node.statement);
 
                 markLabel(incrementLabel);
-                emitStatement(createStatement(createPostfixIncrement(keysIndex)));
+                emitStatement(createExpressionStatement(createPostfixIncrement(keysIndex)));
 
                 emitBreak(conditionLabel);
                 endLoopBlock();
@@ -2778,7 +2778,7 @@ namespace ts {
                     // for each block in the protected region.
                     const { startLabel, catchLabel, finallyLabel, endLabel } = currentExceptionBlock;
                     statements.unshift(
-                        createStatement(
+                        createExpressionStatement(
                             createCall(
                                 createPropertyAccess(createPropertyAccess(state, "trys"), "push"),
                                 /*typeArguments*/ undefined,
@@ -2801,7 +2801,7 @@ namespace ts {
                     // The case clause for the last label falls through to this label, so we
                     // add an assignment statement to reflect the change in labels.
                     statements.push(
-                        createStatement(
+                        createExpressionStatement(
                             createAssignment(
                                 createPropertyAccess(state, "label"),
                                 createLiteral(labelNumber + 1)
@@ -2985,7 +2985,7 @@ namespace ts {
          * @param operationLocation The source map location for the operation.
          */
         function writeAssign(left: Expression, right: Expression, operationLocation: TextRange | undefined): void {
-            writeStatement(setTextRange(createStatement(createAssignment(left, right)), operationLocation));
+            writeStatement(setTextRange(createExpressionStatement(createAssignment(left, right)), operationLocation));
         }
 
         /**

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -147,7 +147,7 @@ namespace ts {
             const updated = updateSourceFileNode(node,
                 setTextRange(
                     createNodeArray([
-                        createStatement(
+                        createExpressionStatement(
                             createCall(
                                 define,
                                 /*typeArguments*/ undefined,
@@ -240,7 +240,7 @@ namespace ts {
                                                 createIdentifier("v"),
                                                 createIdentifier("undefined")
                                             ),
-                                            createStatement(
+                                            createExpressionStatement(
                                                 createAssignment(
                                                     createPropertyAccess(createIdentifier("module"), "exports"),
                                                     createIdentifier("v")
@@ -256,7 +256,7 @@ namespace ts {
                                         createPropertyAccess(createIdentifier("define"), "amd")
                                     ),
                                     createBlock([
-                                        createStatement(
+                                        createExpressionStatement(
                                             createCall(
                                                 createIdentifier("define"),
                                                 /*typeArguments*/ undefined,
@@ -299,7 +299,7 @@ namespace ts {
                 node,
                 setTextRange(
                     createNodeArray([
-                        createStatement(
+                        createExpressionStatement(
                             createCall(
                                 umdHeader,
                                 /*typeArguments*/ undefined,
@@ -396,7 +396,7 @@ namespace ts {
             if (expr === name) {
                 return undefined;
             }
-            return createStatement(createAssignment(name, expr));
+            return createExpressionStatement(createAssignment(name, expr));
         }
 
         /**
@@ -460,7 +460,7 @@ namespace ts {
                         statements.push(statement);
                     }
                     else {
-                        const statement = createStatement(
+                        const statement = createExpressionStatement(
                             createAssignment(
                                 createPropertyAccess(
                                     createIdentifier("module"),
@@ -652,7 +652,7 @@ namespace ts {
                 createParameter(/*decorator*/ undefined, /*modifiers*/ undefined, /*dotDotDotToken*/ undefined, /*name*/ reject)
             ];
             const body = createBlock([
-                createStatement(
+                createExpressionStatement(
                     createCall(
                         createIdentifier("require"),
                         /*typeArguments*/ undefined,
@@ -767,7 +767,7 @@ namespace ts {
             if (moduleKind !== ModuleKind.AMD) {
                 if (!node.importClause) {
                     // import "mod";
-                    return setTextRange(createStatement(createRequireCall(node)), node);
+                    return setTextRange(createExpressionStatement(createRequireCall(node)), node);
                 }
                 else {
                     const variables: VariableDeclaration[] = [];
@@ -881,7 +881,7 @@ namespace ts {
                 if (hasModifier(node, ModifierFlags.Export)) {
                     statements = append(statements,
                         setTextRange(
-                            createStatement(
+                            createExpressionStatement(
                                 createExportExpression(
                                     node.name,
                                     createRequireCall(node)
@@ -916,7 +916,7 @@ namespace ts {
                 if (hasModifier(node, ModifierFlags.Export)) {
                     statements = append(statements,
                         setTextRange(
-                            createStatement(
+                            createExpressionStatement(
                                 createExportExpression(getExportName(node), getLocalName(node))
                             ),
                             node
@@ -978,7 +978,7 @@ namespace ts {
                     );
                     statements.push(
                         setTextRange(
-                            createStatement(
+                            createExpressionStatement(
                                 createExportExpression(getExportName(specifier), exportedValue)
                             ),
                             specifier
@@ -991,7 +991,7 @@ namespace ts {
             else {
                 // export * from "mod";
                 return setTextRange(
-                    createStatement(
+                    createExpressionStatement(
                         createExportStarHelper(context, moduleKind !== ModuleKind.AMD ? createRequireCall(node) : generatedName)
                     ),
                     node
@@ -1140,7 +1140,7 @@ namespace ts {
                 }
 
                 if (expressions) {
-                    statements = append(statements, setTextRange(createStatement(inlineExpressions(expressions)), node));
+                    statements = append(statements, setTextRange(createExpressionStatement(inlineExpressions(expressions)), node));
                 }
             }
             else {
@@ -1429,7 +1429,7 @@ namespace ts {
         function createUnderscoreUnderscoreESModule() {
             let statement: Statement;
             if (languageVersion === ScriptTarget.ES3) {
-                statement = createStatement(
+                statement = createExpressionStatement(
                     createExportExpression(
                         createIdentifier("__esModule"),
                         createLiteral(/*value*/ true)
@@ -1437,7 +1437,7 @@ namespace ts {
                 );
             }
             else {
-                statement = createStatement(
+                statement = createExpressionStatement(
                     createCall(
                         createPropertyAccess(createIdentifier("Object"), "defineProperty"),
                         /*typeArguments*/ undefined,
@@ -1464,7 +1464,7 @@ namespace ts {
          * @param allowComments An optional value indicating whether to emit comments for the statement.
          */
         function createExportStatement(name: Identifier, value: Expression, location?: TextRange, allowComments?: boolean) {
-            const statement = setTextRange(createStatement(createExportExpression(name, value)), location);
+            const statement = setTextRange(createExpressionStatement(createExportExpression(name, value)), location);
             startOnNewLine(statement);
             if (!allowComments) {
                 setEmitFlags(statement, EmitFlags.NoComments);

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -103,7 +103,7 @@ namespace ts {
                     node,
                     setTextRange(
                         createNodeArray([
-                            createStatement(
+                            createExpressionStatement(
                                 createCall(
                                     createPropertyAccess(createIdentifier("System"), "register"),
                                 /*typeArguments*/ undefined,
@@ -428,7 +428,7 @@ namespace ts {
                             setEmitFlags(
                                 createIf(
                                     condition,
-                                    createStatement(
+                                    createExpressionStatement(
                                         createAssignment(
                                             createElementAccess(exports, n),
                                             createElementAccess(m, n)
@@ -439,7 +439,7 @@ namespace ts {
                             )
                         ])
                     ),
-                    createStatement(
+                    createExpressionStatement(
                         createCall(
                             exportFunction,
                             /*typeArguments*/ undefined,
@@ -478,7 +478,7 @@ namespace ts {
                             Debug.assert(importVariableName !== undefined);
                             // save import into the local
                             statements.push(
-                                createStatement(
+                                createExpressionStatement(
                                     createAssignment(importVariableName, parameterName)
                                 )
                             );
@@ -509,7 +509,7 @@ namespace ts {
                                 }
 
                                 statements.push(
-                                    createStatement(
+                                    createExpressionStatement(
                                         createCall(
                                             exportFunction,
                                             /*typeArguments*/ undefined,
@@ -525,7 +525,7 @@ namespace ts {
                                 //
                                 //  exportStar(foo_1_1);
                                 statements.push(
-                                    createStatement(
+                                    createExpressionStatement(
                                         createCall(
                                             exportStarFunction,
                                             /*typeArguments*/ undefined,
@@ -703,7 +703,7 @@ namespace ts {
             // Rewrite the class declaration into an assignment of a class expression.
             statements = append(statements,
                 setTextRange(
-                    createStatement(
+                    createExpressionStatement(
                         createAssignment(
                             name,
                             setTextRange(
@@ -759,7 +759,7 @@ namespace ts {
 
             let statements: Statement[] | undefined;
             if (expressions) {
-                statements = append(statements, setTextRange(createStatement(inlineExpressions(expressions)), node));
+                statements = append(statements, setTextRange(createExpressionStatement(inlineExpressions(expressions)), node));
             }
 
             if (isMarkedDeclaration) {
@@ -1116,7 +1116,7 @@ namespace ts {
          * @param allowComments An optional value indicating whether to emit comments for the statement.
          */
         function createExportStatement(name: Identifier | StringLiteral, value: Expression, allowComments?: boolean) {
-            const statement = createStatement(createExportExpression(name, value));
+            const statement = createExpressionStatement(createExportExpression(name, value));
             startOnNewLine(statement);
             if (!allowComments) {
                 setEmitFlags(statement, EmitFlags.NoComments);

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -638,7 +638,7 @@ namespace ts {
 
             // Write any pending expressions from elided or moved computed property names
             if (some(pendingExpressions)) {
-                statements.push(createStatement(inlineExpressions(pendingExpressions!)));
+                statements.push(createExpressionStatement(inlineExpressions(pendingExpressions!)));
             }
             pendingExpressions = savedPendingExpressions;
 
@@ -1069,7 +1069,7 @@ namespace ts {
                 //  super(...arguments);
                 //
                 statements.push(
-                    createStatement(
+                    createExpressionStatement(
                         createCall(
                             createSuper(),
                             /*typeArguments*/ undefined,
@@ -1175,7 +1175,7 @@ namespace ts {
             return startOnNewLine(
                 setEmitFlags(
                     setTextRange(
-                        createStatement(
+                        createExpressionStatement(
                             createAssignment(
                                 setTextRange(
                                     createPropertyAccess(
@@ -1242,7 +1242,7 @@ namespace ts {
          */
         function addInitializedPropertyStatements(statements: Statement[], properties: ReadonlyArray<PropertyDeclaration>, receiver: LeftHandSideExpression) {
             for (const property of properties) {
-                const statement = createStatement(transformInitializedProperty(property, receiver));
+                const statement = createExpressionStatement(transformInitializedProperty(property, receiver));
                 setSourceMapRange(statement, moveRangePastModifiers(property));
                 setCommentRange(statement, property);
                 statements.push(statement);
@@ -1596,7 +1596,7 @@ namespace ts {
         function addConstructorDecorationStatement(statements: Statement[], node: ClassDeclaration) {
             const expression = generateConstructorDecorationExpression(node);
             if (expression) {
-                statements.push(setOriginalNode(createStatement(expression), node));
+                statements.push(setOriginalNode(createExpressionStatement(expression), node));
             }
         }
 
@@ -2481,7 +2481,7 @@ namespace ts {
                 }
 
                 return setTextRange(
-                    createStatement(
+                    createExpressionStatement(
                         inlineExpressions(
                             map(variables, transformInitializedVariable)
                         )
@@ -2669,7 +2669,7 @@ namespace ts {
             //      x[x["y"] = 0] = "y";
             //      ...
             //  })(x || (x = {}));
-            const enumStatement = createStatement(
+            const enumStatement = createExpressionStatement(
                 createCall(
                     createFunctionExpression(
                         /*modifiers*/ undefined,
@@ -2746,7 +2746,7 @@ namespace ts {
                     name
                 );
             return setTextRange(
-                createStatement(
+                createExpressionStatement(
                     setTextRange(
                         outerAssignment,
                         member
@@ -2957,7 +2957,7 @@ namespace ts {
             //  (function (x_1) {
             //      x_1.y = ...;
             //  })(x || (x = {}));
-            const moduleStatement = createStatement(
+            const moduleStatement = createExpressionStatement(
                 createCall(
                     createFunctionExpression(
                         /*modifiers*/ undefined,
@@ -3309,7 +3309,7 @@ namespace ts {
          * Creates a statement for the provided expression. This is used in calls to `map`.
          */
         function expressionToStatement(expression: Expression) {
-            return createStatement(expression);
+            return createExpressionStatement(expression);
         }
 
         function addExportMemberAssignment(statements: Statement[], node: ClassDeclaration | FunctionDeclaration) {
@@ -3319,14 +3319,14 @@ namespace ts {
             );
             setSourceMapRange(expression, createRange(node.name ? node.name.pos : node.pos, node.end));
 
-            const statement = createStatement(expression);
+            const statement = createExpressionStatement(expression);
             setSourceMapRange(statement, createRange(-1, node.end));
             statements.push(statement);
         }
 
         function createNamespaceExport(exportName: Identifier, exportValue: Expression, location?: TextRange) {
             return setTextRange(
-                createStatement(
+                createExpressionStatement(
                     createAssignment(
                         getNamespaceMemberName(currentNamespaceContainerName, exportName, /*allowComments*/ false, /*allowSourceMaps*/ true),
                         exportValue

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -142,7 +142,7 @@ namespace ts {
         context.startLexicalEnvironment();
         statements = visitNodes(statements, visitor, isStatement, start);
         if (ensureUseStrict && !startsWithUseStrict(statements)) {
-            statements = setTextRange(createNodeArray([createStatement(createLiteral("use strict")), ...statements]), statements);
+            statements = setTextRange(createNodeArray([createExpressionStatement(createLiteral("use strict")), ...statements]), statements);
         }
         const declarations = context.endLexicalEnvironment();
         return setTextRange(createNodeArray(concatenate(declarations, statements)), statements);
@@ -614,7 +614,7 @@ namespace ts {
                     visitNode((<VariableStatement>node).declarationList, visitor, isVariableDeclarationList));
 
             case SyntaxKind.ExpressionStatement:
-                return updateStatement(<ExpressionStatement>node,
+                return updateExpressionStatement(<ExpressionStatement>node,
                     visitNode((<ExpressionStatement>node).expression, visitor, isExpression));
 
             case SyntaxKind.IfStatement:

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -7898,13 +7898,16 @@ declare namespace ts {
     function updateTemplateSpan(node: TemplateSpan, expression: Expression, literal: TemplateMiddle | TemplateTail): TemplateSpan;
     function createSemicolonClassElement(): SemicolonClassElement;
     function createBlock(statements: ReadonlyArray<Statement>, multiLine?: boolean): Block;
-    function createExpressionStatement(expression: Expression): ExpressionStatement;
     function updateBlock(node: Block, statements: ReadonlyArray<Statement>): Block;
     function createVariableStatement(modifiers: ReadonlyArray<Modifier> | undefined, declarationList: VariableDeclarationList | ReadonlyArray<VariableDeclaration>): VariableStatement;
     function updateVariableStatement(node: VariableStatement, modifiers: ReadonlyArray<Modifier> | undefined, declarationList: VariableDeclarationList): VariableStatement;
     function createEmptyStatement(): EmptyStatement;
-    function createStatement(expression: Expression): ExpressionStatement;
-    function updateStatement(node: ExpressionStatement, expression: Expression): ExpressionStatement;
+    function createExpressionStatement(expression: Expression): ExpressionStatement;
+    function updateExpressionStatement(node: ExpressionStatement, expression: Expression): ExpressionStatement;
+    /** @deprecated Use `createExpressionStatement` instead.  */
+    const createStatement: typeof createExpressionStatement;
+    /** @deprecated Use `updateExpressionStatement` instead.  */
+    const updateStatement: typeof updateExpressionStatement;
     function createIf(expression: Expression, thenStatement: Statement, elseStatement?: Statement): IfStatement;
     function updateIf(node: IfStatement, expression: Expression, thenStatement: Statement, elseStatement: Statement | undefined): IfStatement;
     function createDo(statement: Statement, expression: Expression): DoStatement;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3785,8 +3785,12 @@ declare namespace ts {
     function createVariableStatement(modifiers: ReadonlyArray<Modifier> | undefined, declarationList: VariableDeclarationList | ReadonlyArray<VariableDeclaration>): VariableStatement;
     function updateVariableStatement(node: VariableStatement, modifiers: ReadonlyArray<Modifier> | undefined, declarationList: VariableDeclarationList): VariableStatement;
     function createEmptyStatement(): EmptyStatement;
-    function createStatement(expression: Expression): ExpressionStatement;
-    function updateStatement(node: ExpressionStatement, expression: Expression): ExpressionStatement;
+    function createExpressionStatement(expression: Expression): ExpressionStatement;
+    function updateExpressionStatement(node: ExpressionStatement, expression: Expression): ExpressionStatement;
+    /** @deprecated Use `createExpressionStatement` instead.  */
+    const createStatement: typeof createExpressionStatement;
+    /** @deprecated Use `updateExpressionStatement` instead.  */
+    const updateStatement: typeof updateExpressionStatement;
     function createIf(expression: Expression, thenStatement: Statement, elseStatement?: Statement): IfStatement;
     function updateIf(node: IfStatement, expression: Expression, thenStatement: Statement, elseStatement: Statement | undefined): IfStatement;
     function createDo(statement: Statement, expression: Expression): DoStatement;


### PR DESCRIPTION
keep a deprecated alias for back-compat

Fixes: #25220