### PR TITLE
Canonicalize path before calling `startsWith`

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -290,7 +290,7 @@ namespace ts.moduleSpecifiers {
         const moduleSpecifier = getDirectoryOrExtensionlessFileName(moduleFileName);
         // Get a path that's relative to node_modules or the importing file's path
         // if node_modules folder is in this folder or any of its parent folders, no need to keep it.
-        if (!startsWith(sourceDirectory, moduleSpecifier.substring(0, parts.topLevelNodeModulesIndex))) return undefined;
+        if (!startsWith(sourceDirectory, getCanonicalFileName(moduleSpecifier.substring(0, parts.topLevelNodeModulesIndex)))) return undefined;
         // If the module was found in @types, get the actual Node package name
         return getPackageNameFromAtTypesDirectory(moduleSpecifier.substring(parts.topLevelPackageNameIndex + 1));
 

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -9,7 +9,7 @@ namespace ts.moduleSpecifiers {
     export function getModuleSpecifier(
         compilerOptions: CompilerOptions,
         importingSourceFile: SourceFile,
-        importingSourceFileName: string,
+        importingSourceFileName: Path,
         toFileName: string,
         host: ModuleSpecifierResolutionHost,
         files: ReadonlyArray<SourceFile>,
@@ -49,10 +49,10 @@ namespace ts.moduleSpecifiers {
         readonly moduleResolutionKind: ModuleResolutionKind;
         readonly addJsExtension: boolean;
         readonly getCanonicalFileName: GetCanonicalFileName;
-        readonly sourceDirectory: string;
+        readonly sourceDirectory: Path;
     }
     // importingSourceFileName is separate because getEditsForFileRename may need to specify an updated path
-    function getInfo(compilerOptions: CompilerOptions, importingSourceFile: SourceFile, importingSourceFileName: string, host: ModuleSpecifierResolutionHost): Info {
+    function getInfo(compilerOptions: CompilerOptions, importingSourceFile: SourceFile, importingSourceFileName: Path, host: ModuleSpecifierResolutionHost): Info {
         const moduleResolutionKind = getEmitModuleResolutionKind(compilerOptions);
         const addJsExtension = usesJsExtensionOnImports(importingSourceFile);
         const getCanonicalFileName = createGetCanonicalFileName(host.useCaseSensitiveFileNames ? host.useCaseSensitiveFileNames() : true);
@@ -271,7 +271,7 @@ namespace ts.moduleSpecifiers {
         moduleFileName: string,
         host: ModuleSpecifierResolutionHost,
         getCanonicalFileName: (file: string) => string,
-        sourceDirectory: string,
+        sourceDirectory: Path,
     ): string | undefined {
         if (getEmitModuleResolutionKind(options) !== ModuleResolutionKind.NodeJs) {
             // nothing to do here

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -155,7 +155,7 @@ namespace Harness.LanguageService {
             this.vfs.mkdirpSync(ts.getDirectoryPath(newPath));
             this.vfs.renameSync(oldPath, newPath);
 
-            const updater = ts.getPathUpdater(oldPath, newPath, ts.createGetCanonicalFileName(/*useCaseSensitiveFileNames*/ false));
+            const updater = ts.getPathUpdater(oldPath, newPath, ts.createGetCanonicalFileName(this.useCaseSensitiveFileNames()));
             this.scriptInfos.forEach((scriptInfo, key) => {
                 const newFileName = updater(key);
                 if (newFileName !== undefined) {
@@ -188,6 +188,10 @@ namespace Harness.LanguageService {
             const script: ScriptInfo = this.getScriptInfo(fileName)!;
             assert.isOk(script);
             return ts.computeLineAndCharacterOfPosition(script.getLineMap(), position);
+        }
+
+        useCaseSensitiveFileNames() {
+            return !this.vfs.ignoreCase;
         }
     }
 
@@ -250,7 +254,6 @@ namespace Harness.LanguageService {
         getTypeRootsVersion() {
             return 0;
         }
-
 
         log = ts.noop;
         trace = ts.noop;

--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -104,8 +104,8 @@ namespace ts {
     ): void {
         const allFiles = program.getSourceFiles();
         for (const sourceFile of allFiles) {
-            const newFromOld = oldToNew(sourceFile.fileName);
-            const newImportFromPath = newFromOld !== undefined ? newFromOld : sourceFile.fileName;
+            const newFromOld = oldToNew(sourceFile.path) as Path;
+            const newImportFromPath = newFromOld !== undefined ? newFromOld : sourceFile.path;
             const newImportFromDirectory = getDirectoryPath(newImportFromPath);
 
             const oldFromNew: string | undefined = newToOld(sourceFile.fileName);

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9290,7 +9290,7 @@ declare namespace ts.moduleSpecifiers {
     interface ModuleSpecifierPreferences {
         readonly importModuleSpecifierPreference?: "relative" | "non-relative";
     }
-    function getModuleSpecifier(compilerOptions: CompilerOptions, importingSourceFile: SourceFile, importingSourceFileName: string, toFileName: string, host: ModuleSpecifierResolutionHost, files: ReadonlyArray<SourceFile>, preferences?: ModuleSpecifierPreferences): string;
+    function getModuleSpecifier(compilerOptions: CompilerOptions, importingSourceFile: SourceFile, importingSourceFileName: Path, toFileName: string, host: ModuleSpecifierResolutionHost, files: ReadonlyArray<SourceFile>, preferences?: ModuleSpecifierPreferences): string;
     function getModuleSpecifiers(moduleSymbol: Symbol, compilerOptions: CompilerOptions, importingSourceFile: SourceFile, host: ModuleSpecifierResolutionHost, files: ReadonlyArray<SourceFile>, preferences: ModuleSpecifierPreferences): ReadonlyArray<ReadonlyArray<string>>;
 }
 declare namespace ts {

--- a/tests/cases/fourslash/importNameCodeFix_getCanonicalFileName.ts
+++ b/tests/cases/fourslash/importNameCodeFix_getCanonicalFileName.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /howNow/node_modules/brownCow/index.d.ts
+////export const foo: number;
+
+// @Filename: /howNow/a.ts
+////foo;
+
+// Before fixing this bug, we compared a canonicalized `hownow` to a non-canonicalized `howNow`.
+
+goTo.file("/howNow/a.ts");
+verify.importFixAtPosition([
+`import { foo } from "brownCow";
+
+foo;`,
+]);


### PR DESCRIPTION
Fixes Microsoft/vscode#52089 and #25279