### PR TITLE
Restore `NewFileContent` type

### DIFF
--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -178,7 +178,7 @@ declare namespace FourSlashInterface {
         isInCommentAtPosition(onlyMultiLineDiverges?: boolean): void;
         codeFix(options: {
             description: string,
-            newFileContent?: string | { readonly [fileName: string]: string },
+            newFileContent?: NewFileContent,
             newRangeContent?: string,
             errorCode?: number,
             index?: number,
@@ -357,7 +357,7 @@ declare namespace FourSlashInterface {
         enableFormatting(): void;
         disableFormatting(): void;
 
-        applyRefactor(options: { refactorName: string, actionName: string, actionDescription: string, newContent: string }): void;
+        applyRefactor(options: { refactorName: string, actionName: string, actionDescription: string, newContent: NewFileContent }): void;
     }
     class debug {
         printCurrentParameterHelp(): void;
@@ -626,6 +626,7 @@ declare namespace FourSlashInterface {
     }
 
     type ArrayOrSingle<T> = T | ReadonlyArray<T>;
+    type NewFileContent = string | { readonly [fileName: string]: string };
 }
 declare function verifyOperationIsCancelled(f: any): void;
 declare var test: FourSlashInterface.test_;


### PR DESCRIPTION
Was removed in #24915, which caused tests like `refactorConvertExport_defaultToNamed.ts` to show as errors. (Was not detected in tests because we don't type-check fourslash tests.)