### PR TITLE
Fix typo to fix logging when built with --watch --diagnostics

### DIFF
--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -490,7 +490,7 @@ namespace ts {
 
         const trace = host.trace && ((s: string) => { host.trace!(s + newLine); });
         const watchLogLevel = trace ? compilerOptions.extendedDiagnostics ? WatchLogLevel.Verbose :
-            compilerOptions.diagnostis ? WatchLogLevel.TriggerOnly : WatchLogLevel.None : WatchLogLevel.None;
+            compilerOptions.diagnostics ? WatchLogLevel.TriggerOnly : WatchLogLevel.None : WatchLogLevel.None;
         const writeLog: (s: string) => void = watchLogLevel !== WatchLogLevel.None ? trace! : noop; // TODO: GH#18217
         const { watchFile, watchFilePath, watchDirectory } = getWatchFactory<string>(watchLogLevel, writeLog);
 


### PR DESCRIPTION
Investigated from as part of https://github.com/Microsoft/TypeScript/issues/7211#issuecomment-402261106 and fixes this.