### PR TITLE
Actually cache intermediate results in getBaseConstraint

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6840,11 +6840,12 @@ namespace ts {
             return type.resolvedBaseConstraint;
 
             function getBaseConstraint(t: Type): Type | undefined {
-                if (!pushTypeResolution(t, TypeSystemPropertyName.ResolvedBaseConstraint)) {
+                const simplified = getSimplifiedType(t);
+                if (!pushTypeResolution(simplified, TypeSystemPropertyName.ResolvedBaseConstraint)) {
                     circular = true;
                     return undefined;
                 }
-                const result = computeBaseConstraint(getSimplifiedType(t));
+                const result = computeBaseConstraint(simplified);
                 if (!popTypeResolution()) {
                     circular = true;
                     return undefined;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3748,6 +3748,8 @@ namespace ts {
         aliasTypeArguments?: ReadonlyArray<Type>;     // Alias type arguments (if any)
         /* @internal */
         wildcardInstantiation?: Type;    // Instantiation with type parameters mapped to wildcard type
+        /* @internal */
+        immediateBaseConstraint?: Type;  // Immediate base constraint cache
     }
 
     /* @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3253,6 +3253,7 @@ declare namespace ts {
         aliasSymbol?: Symbol;
         aliasTypeArguments?: ReadonlyArray<Type>;
         wildcardInstantiation?: Type;
+        immediateBaseConstraint?: Type;
     }
     interface IntrinsicType extends Type {
         intrinsicName: string;

--- a/tests/baselines/reference/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.js
+++ b/tests/baselines/reference/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.js
@@ -1,0 +1,27 @@
+//// [constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts]
+// https://github.com/Microsoft/TypeScript/issues/25379
+
+interface Map<K, V> {
+    // ...
+}
+
+export type ImmutableTypes = IImmutableMap<any>;
+
+export type ImmutableModel<T> = { [K in keyof T]: T[K] extends ImmutableTypes ? T[K] : never };
+
+export interface IImmutableMap<T extends ImmutableModel<T>> extends Map<string, any> {
+    set<K extends keyof T>(key: K, value: T[K]): IImmutableMap<T>;
+}
+
+export type ImmutableTypes2 = IImmutableMap2<any>;
+type isImmutableType<T> = [T] extends [ImmutableTypes2] ? T : never;
+export type ImmutableModel2<T> = { [K in keyof T]: isImmutableType<T[K]> };
+export interface IImmutableMap2<T extends ImmutableModel2<T>> extends Map<string, any> {
+    set<K extends keyof T>(key: K, value: T[K]): IImmutableMap2<T>;
+}
+
+
+//// [constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.js]
+"use strict";
+// https://github.com/Microsoft/TypeScript/issues/25379
+exports.__esModule = true;

--- a/tests/baselines/reference/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.symbols
+++ b/tests/baselines/reference/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.symbols
@@ -1,0 +1,86 @@
+=== tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts ===
+// https://github.com/Microsoft/TypeScript/issues/25379
+
+interface Map<K, V> {
+>Map : Symbol(Map, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 0, 0))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 2, 14))
+>V : Symbol(V, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 2, 16))
+
+    // ...
+}
+
+export type ImmutableTypes = IImmutableMap<any>;
+>ImmutableTypes : Symbol(ImmutableTypes, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 4, 1))
+>IImmutableMap : Symbol(IImmutableMap, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 95))
+
+export type ImmutableModel<T> = { [K in keyof T]: T[K] extends ImmutableTypes ? T[K] : never };
+>ImmutableModel : Symbol(ImmutableModel, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 6, 48))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 27))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 35))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 27))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 27))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 35))
+>ImmutableTypes : Symbol(ImmutableTypes, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 4, 1))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 27))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 35))
+
+export interface IImmutableMap<T extends ImmutableModel<T>> extends Map<string, any> {
+>IImmutableMap : Symbol(IImmutableMap, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 95))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 10, 31))
+>ImmutableModel : Symbol(ImmutableModel, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 6, 48))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 10, 31))
+>Map : Symbol(Map, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 0, 0))
+
+    set<K extends keyof T>(key: K, value: T[K]): IImmutableMap<T>;
+>set : Symbol(IImmutableMap.set, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 10, 86))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 11, 8))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 10, 31))
+>key : Symbol(key, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 11, 27))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 11, 8))
+>value : Symbol(value, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 11, 34))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 10, 31))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 11, 8))
+>IImmutableMap : Symbol(IImmutableMap, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 8, 95))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 10, 31))
+}
+
+export type ImmutableTypes2 = IImmutableMap2<any>;
+>ImmutableTypes2 : Symbol(ImmutableTypes2, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 12, 1))
+>IImmutableMap2 : Symbol(IImmutableMap2, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 16, 75))
+
+type isImmutableType<T> = [T] extends [ImmutableTypes2] ? T : never;
+>isImmutableType : Symbol(isImmutableType, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 14, 50))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 15, 21))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 15, 21))
+>ImmutableTypes2 : Symbol(ImmutableTypes2, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 12, 1))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 15, 21))
+
+export type ImmutableModel2<T> = { [K in keyof T]: isImmutableType<T[K]> };
+>ImmutableModel2 : Symbol(ImmutableModel2, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 15, 68))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 16, 28))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 16, 36))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 16, 28))
+>isImmutableType : Symbol(isImmutableType, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 14, 50))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 16, 28))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 16, 36))
+
+export interface IImmutableMap2<T extends ImmutableModel2<T>> extends Map<string, any> {
+>IImmutableMap2 : Symbol(IImmutableMap2, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 16, 75))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 17, 32))
+>ImmutableModel2 : Symbol(ImmutableModel2, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 15, 68))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 17, 32))
+>Map : Symbol(Map, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 0, 0))
+
+    set<K extends keyof T>(key: K, value: T[K]): IImmutableMap2<T>;
+>set : Symbol(IImmutableMap2.set, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 17, 88))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 18, 8))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 17, 32))
+>key : Symbol(key, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 18, 27))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 18, 8))
+>value : Symbol(value, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 18, 34))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 17, 32))
+>K : Symbol(K, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 18, 8))
+>IImmutableMap2 : Symbol(IImmutableMap2, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 16, 75))
+>T : Symbol(T, Decl(constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts, 17, 32))
+}
+

--- a/tests/baselines/reference/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.types
+++ b/tests/baselines/reference/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.types
@@ -1,0 +1,86 @@
+=== tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts ===
+// https://github.com/Microsoft/TypeScript/issues/25379
+
+interface Map<K, V> {
+>Map : Map<K, V>
+>K : K
+>V : V
+
+    // ...
+}
+
+export type ImmutableTypes = IImmutableMap<any>;
+>ImmutableTypes : IImmutableMap<any>
+>IImmutableMap : IImmutableMap<T>
+
+export type ImmutableModel<T> = { [K in keyof T]: T[K] extends ImmutableTypes ? T[K] : never };
+>ImmutableModel : ImmutableModel<T>
+>T : T
+>K : K
+>T : T
+>T : T
+>K : K
+>ImmutableTypes : IImmutableMap<any>
+>T : T
+>K : K
+
+export interface IImmutableMap<T extends ImmutableModel<T>> extends Map<string, any> {
+>IImmutableMap : IImmutableMap<T>
+>T : T
+>ImmutableModel : ImmutableModel<T>
+>T : T
+>Map : Map<K, V>
+
+    set<K extends keyof T>(key: K, value: T[K]): IImmutableMap<T>;
+>set : <K extends keyof T>(key: K, value: T[K]) => IImmutableMap<T>
+>K : K
+>T : T
+>key : K
+>K : K
+>value : T[K]
+>T : T
+>K : K
+>IImmutableMap : IImmutableMap<T>
+>T : T
+}
+
+export type ImmutableTypes2 = IImmutableMap2<any>;
+>ImmutableTypes2 : IImmutableMap2<any>
+>IImmutableMap2 : IImmutableMap2<T>
+
+type isImmutableType<T> = [T] extends [ImmutableTypes2] ? T : never;
+>isImmutableType : isImmutableType<T>
+>T : T
+>T : T
+>ImmutableTypes2 : IImmutableMap2<any>
+>T : T
+
+export type ImmutableModel2<T> = { [K in keyof T]: isImmutableType<T[K]> };
+>ImmutableModel2 : ImmutableModel2<T>
+>T : T
+>K : K
+>T : T
+>isImmutableType : isImmutableType<T>
+>T : T
+>K : K
+
+export interface IImmutableMap2<T extends ImmutableModel2<T>> extends Map<string, any> {
+>IImmutableMap2 : IImmutableMap2<T>
+>T : T
+>ImmutableModel2 : ImmutableModel2<T>
+>T : T
+>Map : Map<K, V>
+
+    set<K extends keyof T>(key: K, value: T[K]): IImmutableMap2<T>;
+>set : <K extends keyof T>(key: K, value: T[K]) => IImmutableMap2<T>
+>K : K
+>T : T
+>key : K
+>K : K
+>value : T[K]
+>T : T
+>K : K
+>IImmutableMap2 : IImmutableMap2<T>
+>T : T
+}
+

--- a/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.errors.txt
+++ b/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.errors.txt
@@ -1,11 +1,17 @@
+tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts(2,24): error TS2313: Type parameter 'T' has a circular constraint.
 tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts(2,32): error TS2313: Type parameter 'P' has a circular constraint.
+tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts(3,5): error TS2365: Operator '+=' cannot be applied to types 'number' and 'T[K]'.
 
 
-==== tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts (1 errors) ====
+==== tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts (3 errors) ====
     // #17847
     function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T, k: K) {
+                           ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2313: Type parameter 'T' has a circular constraint.
                                    ~
 !!! error TS2313: Type parameter 'P' has a circular constraint.
         n += v[k];
+        ~~~~~~~~~
+!!! error TS2365: Operator '+=' cannot be applied to types 'number' and 'T[K]'.
     }
     

--- a/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.types
+++ b/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.types
@@ -14,7 +14,7 @@ function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T,
 >K : K
 
     n += v[k];
->n += v[k] : number
+>n += v[k] : any
 >n : number
 >v[k] : T[K]
 >v : T

--- a/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts
+++ b/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts
@@ -1,0 +1,20 @@
+// https://github.com/Microsoft/TypeScript/issues/25379
+
+interface Map<K, V> {
+    // ...
+}
+
+export type ImmutableTypes = IImmutableMap<any>;
+
+export type ImmutableModel<T> = { [K in keyof T]: T[K] extends ImmutableTypes ? T[K] : never };
+
+export interface IImmutableMap<T extends ImmutableModel<T>> extends Map<string, any> {
+    set<K extends keyof T>(key: K, value: T[K]): IImmutableMap<T>;
+}
+
+export type ImmutableTypes2 = IImmutableMap2<any>;
+type isImmutableType<T> = [T] extends [ImmutableTypes2] ? T : never;
+export type ImmutableModel2<T> = { [K in keyof T]: isImmutableType<T[K]> };
+export interface IImmutableMap2<T extends ImmutableModel2<T>> extends Map<string, any> {
+    set<K extends keyof T>(key: K, value: T[K]): IImmutableMap2<T>;
+}


### PR DESCRIPTION
`pushTypeResolution` returns `-1` (no cycle) when it finds a valid cached value for the desired property. In `getBaseConstraint`, we push a type resolution.... but never actually check that cache for a value to terminate recursion, so we recur forever. In the example given in the associated issue, `T[K]` acquires a cached resolved constraint during this process, triggering the issue. We can't and don't want to check on `resolvedBaseConstraint` within `getBaseConstraint`, as it is this-instantiated, therefore not safe to propagate; so in this PR I swap the checks on `resolvedBaseConstraint` with a new field, `immediateBaseConstraint` which, unlike `resolvedBaseConstraint` should be transitive (as it is not this-instantiated yet) and safe to propagate.

Fixes #25379

