### PR TITLE
No merge for redirected source files in initializeTypeChecker

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27700,6 +27700,9 @@ namespace ts {
             // Initialize global symbol table
             let augmentations: ReadonlyArray<StringLiteral | Identifier>[] | undefined;
             for (const file of host.getSourceFiles()) {
+                if (file.redirectInfo) {
+                    continue;
+                }
                 if (!isExternalOrCommonJsModule(file)) {
                     mergeSymbolTable(globals, file.locals!);
                 }

--- a/tests/baselines/reference/duplicatePackage_globalMerge.errors.txt
+++ b/tests/baselines/reference/duplicatePackage_globalMerge.errors.txt
@@ -1,0 +1,31 @@
+/node_modules/@types/react/index.d.ts(1,9): error TS2669: Augmentations for the global scope can only be directly nested in external modules or ambient module declarations.
+/src/index.ts(1,24): error TS2306: File '/node_modules/@types/react/index.d.ts' is not a module.
+/tests/index.ts(1,24): error TS2306: File '/tests/node_modules/@types/react/index.d.ts' is not a module.
+
+
+==== /src/bug25410.ts (0 errors) ====
+    import { x } from './index'
+    import { y } from '../tests/index'
+    
+==== /src/index.ts (1 errors) ====
+    import * as React from 'react';
+                           ~~~~~~~
+!!! error TS2306: File '/node_modules/@types/react/index.d.ts' is not a module.
+    export var x = 1
+==== /tests/index.ts (1 errors) ====
+    import * as React from 'react';
+                           ~~~~~~~
+!!! error TS2306: File '/tests/node_modules/@types/react/index.d.ts' is not a module.
+    export var y = 2
+    
+==== /tests/node_modules/@types/react/package.json (0 errors) ====
+    { "name": "@types/react", "version": "16.4.6" }
+==== /tests/node_modules/@types/react/index.d.ts (0 errors) ====
+    
+==== /node_modules/@types/react/package.json (0 errors) ====
+    { "name": "@types/react", "version": "16.4.6" }
+==== /node_modules/@types/react/index.d.ts (1 errors) ====
+    declare global { }
+            ~~~~~~
+!!! error TS2669: Augmentations for the global scope can only be directly nested in external modules or ambient module declarations.
+    

--- a/tests/baselines/reference/duplicatePackage_globalMerge.js
+++ b/tests/baselines/reference/duplicatePackage_globalMerge.js
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/duplicatePackage_globalMerge.ts] ////
+
+//// [index.ts]
+import * as React from 'react';
+export var x = 1
+//// [index.ts]
+import * as React from 'react';
+export var y = 2
+
+//// [package.json]
+{ "name": "@types/react", "version": "16.4.6" }
+//// [index.d.ts]
+
+//// [package.json]
+{ "name": "@types/react", "version": "16.4.6" }
+//// [index.d.ts]
+declare global { }
+
+//// [bug25410.ts]
+import { x } from './index'
+import { y } from '../tests/index'
+
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+exports.x = 1;
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+exports.y = 2;
+//// [bug25410.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/duplicatePackage_globalMerge.symbols
+++ b/tests/baselines/reference/duplicatePackage_globalMerge.symbols
@@ -1,0 +1,29 @@
+=== /src/bug25410.ts ===
+import { x } from './index'
+>x : Symbol(x, Decl(bug25410.ts, 0, 8))
+
+import { y } from '../tests/index'
+>y : Symbol(y, Decl(bug25410.ts, 1, 8))
+
+=== /src/index.ts ===
+import * as React from 'react';
+>React : Symbol(React, Decl(index.ts, 0, 6))
+
+export var x = 1
+>x : Symbol(x, Decl(index.ts, 1, 10))
+
+=== /tests/index.ts ===
+import * as React from 'react';
+>React : Symbol(React, Decl(index.ts, 0, 6))
+
+export var y = 2
+>y : Symbol(y, Decl(index.ts, 1, 10))
+
+=== /tests/node_modules/@types/react/index.d.ts ===
+
+>global : Symbol(global, Decl(index.d.ts, 0, 0))
+
+=== /node_modules/@types/react/index.d.ts ===
+declare global { }
+>global : Symbol(global, Decl(index.d.ts, 0, 0))
+

--- a/tests/baselines/reference/duplicatePackage_globalMerge.types
+++ b/tests/baselines/reference/duplicatePackage_globalMerge.types
@@ -1,0 +1,31 @@
+=== /src/bug25410.ts ===
+import { x } from './index'
+>x : number
+
+import { y } from '../tests/index'
+>y : number
+
+=== /src/index.ts ===
+import * as React from 'react';
+>React : any
+
+export var x = 1
+>x : number
+>1 : 1
+
+=== /tests/index.ts ===
+import * as React from 'react';
+>React : any
+
+export var y = 2
+>y : number
+>2 : 2
+
+=== /tests/node_modules/@types/react/index.d.ts ===
+
+>global : typeof global
+
+=== /node_modules/@types/react/index.d.ts ===
+declare global { }
+>global : typeof global
+

--- a/tests/cases/compiler/duplicatePackage_globalMerge.ts
+++ b/tests/cases/compiler/duplicatePackage_globalMerge.ts
@@ -1,0 +1,21 @@
+// @noImplicitReferences: true
+
+// @Filename: /src/index.ts
+import * as React from 'react';
+export var x = 1
+// @Filename: /tests/index.ts
+import * as React from 'react';
+export var y = 2
+
+// @Filename: /tests/node_modules/@types/react/package.json
+{ "name": "@types/react", "version": "16.4.6" }
+// @Filename: /tests/node_modules/@types/react/index.d.ts
+
+// @Filename: /node_modules/@types/react/package.json
+{ "name": "@types/react", "version": "16.4.6" }
+// @Filename: /node_modules/@types/react/index.d.ts
+declare global { }
+
+// @Filename: /src/bug25410.ts
+import { x } from './index'
+import { y } from '../tests/index'


### PR DESCRIPTION
Previously, redirected source files merged the same way as other source files, effectively causing the target of the redirection to be merged twice. mergeSymbol now has an assert (`source===target`) that disallows this double merge, so this PR makes sure not to merge redirected source files.

This change doesn't apply to the preceding binding loop, since the binder handles already-bound source files correctly.

Fixes #25410 
Fixes #25339