### PR TITLE
Fix crash in elaborateElementwise when the target property is known but it doesn't have a declaration (e.g., in a mapped type).

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10367,9 +10367,9 @@ namespace ts {
                                 }
                             }
 
-                            if (!issuedElaboration && (length(targetProp && targetProp.declarations) || length(target.symbol && target.symbol.declarations))) {
+                            if (!issuedElaboration && (targetProp && length(targetProp.declarations) || target.symbol && length(target.symbol.declarations))) {
                                 addRelatedInfo(reportedDiag, createDiagnosticForNode(
-                                    targetProp ? targetProp.declarations[0] : target.symbol.declarations[0],
+                                    targetProp && length(targetProp.declarations) ? targetProp.declarations[0] : target.symbol.declarations[0],
                                     Diagnostics.The_expected_type_comes_from_property_0_which_is_declared_here_on_type_1,
                                     propertyName && !(nameType.flags & TypeFlags.UniqueESSymbol) ? unescapeLeadingUnderscores(propertyName) : typeToString(nameType),
                                     typeToString(target)

--- a/tests/baselines/reference/errorElaboration.errors.txt
+++ b/tests/baselines/reference/errorElaboration.errors.txt
@@ -2,9 +2,10 @@ tests/cases/compiler/errorElaboration.ts(12,5): error TS2345: Argument of type '
   Type 'Container<Ref<string>>' is not assignable to type 'Container<Ref<number>>'.
     Type 'Ref<string>' is not assignable to type 'Ref<number>'.
       Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/errorElaboration.ts(17,11): error TS2322: Type '"bar"' is not assignable to type '"foo"'.
 
 
-==== tests/cases/compiler/errorElaboration.ts (1 errors) ====
+==== tests/cases/compiler/errorElaboration.ts (2 errors) ====
     // Repro for #5712
     
     interface Ref<T> {
@@ -22,4 +23,13 @@ tests/cases/compiler/errorElaboration.ts(12,5): error TS2345: Argument of type '
 !!! error TS2345:   Type 'Container<Ref<string>>' is not assignable to type 'Container<Ref<number>>'.
 !!! error TS2345:     Type 'Ref<string>' is not assignable to type 'Ref<number>'.
 !!! error TS2345:       Type 'string' is not assignable to type 'number'.
+    
+    // Repro for #25498
+    
+    function test(): {[A in "foo"]: A} {
+      return {foo: "bar"};
+              ~~~
+!!! error TS2322: Type '"bar"' is not assignable to type '"foo"'.
+!!! related TS6500 tests/cases/compiler/errorElaboration.ts:16:18: The expected type comes from property 'foo' which is declared here on type '{ foo: "foo"; }'
+    }
     

--- a/tests/baselines/reference/errorElaboration.js
+++ b/tests/baselines/reference/errorElaboration.js
@@ -12,8 +12,18 @@ declare function foo(x: () => Container<Ref<number>>): void;
 let a: () => Container<Ref<string>>;
 foo(a);
 
+// Repro for #25498
+
+function test(): {[A in "foo"]: A} {
+  return {foo: "bar"};
+}
+
 
 //// [errorElaboration.js]
 // Repro for #5712
 var a;
 foo(a);
+// Repro for #25498
+function test() {
+    return { foo: "bar" };
+}

--- a/tests/baselines/reference/errorElaboration.symbols
+++ b/tests/baselines/reference/errorElaboration.symbols
@@ -38,3 +38,14 @@ foo(a);
 >foo : Symbol(foo, Decl(errorElaboration.ts, 8, 1))
 >a : Symbol(a, Decl(errorElaboration.ts, 10, 3))
 
+// Repro for #25498
+
+function test(): {[A in "foo"]: A} {
+>test : Symbol(test, Decl(errorElaboration.ts, 11, 7))
+>A : Symbol(A, Decl(errorElaboration.ts, 15, 19))
+>A : Symbol(A, Decl(errorElaboration.ts, 15, 19))
+
+  return {foo: "bar"};
+>foo : Symbol(foo, Decl(errorElaboration.ts, 16, 10))
+}
+

--- a/tests/baselines/reference/errorElaboration.types
+++ b/tests/baselines/reference/errorElaboration.types
@@ -39,3 +39,16 @@ foo(a);
 >foo : (x: () => Container<Ref<number>>) => void
 >a : () => Container<Ref<string>>
 
+// Repro for #25498
+
+function test(): {[A in "foo"]: A} {
+>test : () => { foo: "foo"; }
+>A : A
+>A : A
+
+  return {foo: "bar"};
+>{foo: "bar"} : { foo: "bar"; }
+>foo : "bar"
+>"bar" : "bar"
+}
+

--- a/tests/cases/compiler/errorElaboration.ts
+++ b/tests/cases/compiler/errorElaboration.ts
@@ -10,3 +10,9 @@ interface Container<T> {
 declare function foo(x: () => Container<Ref<number>>): void;
 let a: () => Container<Ref<string>>;
 foo(a);
+
+// Repro for #25498
+
+function test(): {[A in "foo"]: A} {
+  return {foo: "bar"};
+}


### PR DESCRIPTION
Fixes #25498.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally (Success except for some timeouts that occur even without my change)
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->