### PR TITLE
Fix crash in JS when checking destructuring shorthand assignment

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21102,7 +21102,7 @@ namespace ts {
                         getUnionType([removeDefinitelyFalsyTypes(leftType), rightType], UnionReduction.Subtype) :
                         leftType;
                 case SyntaxKind.EqualsToken:
-                    const special = getSpecialPropertyAssignmentKind(left.parent as BinaryExpression);
+                    const special = isBinaryExpression(left.parent) ? getSpecialPropertyAssignmentKind(left.parent) : SpecialPropertyAssignmentKind.None;
                     checkSpecialAssignment(special, right);
                     if (isJSSpecialPropertyAssignment(special)) {
                         return leftType;

--- a/tests/baselines/reference/checkDestructuringShorthandAssigment.errors.txt
+++ b/tests/baselines/reference/checkDestructuringShorthandAssigment.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/bug25434.js(4,9): error TS2304: Cannot find name 'b'.
+
+
+==== tests/cases/compiler/bug25434.js (1 errors) ====
+    // should not crash while checking
+    function Test({ b = '' } = {}) {}
+    
+    Test(({ b = '5' } = {}));
+            ~
+!!! error TS2304: Cannot find name 'b'.
+    

--- a/tests/baselines/reference/checkDestructuringShorthandAssigment.symbols
+++ b/tests/baselines/reference/checkDestructuringShorthandAssigment.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/bug25434.js ===
+// should not crash while checking
+function Test({ b = '' } = {}) {}
+>Test : Symbol(Test, Decl(bug25434.js, 0, 0))
+>b : Symbol(b, Decl(bug25434.js, 1, 15))
+
+Test(({ b = '5' } = {}));
+>Test : Symbol(Test, Decl(bug25434.js, 0, 0))
+>b : Symbol(b, Decl(bug25434.js, 3, 7))
+

--- a/tests/baselines/reference/checkDestructuringShorthandAssigment.types
+++ b/tests/baselines/reference/checkDestructuringShorthandAssigment.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/bug25434.js ===
+// should not crash while checking
+function Test({ b = '' } = {}) {}
+>Test : ({ b }?: { [x: string]: any; }) => void
+>b : string
+>'' : ""
+>{} : { b?: string; }
+
+Test(({ b = '5' } = {}));
+>Test(({ b = '5' } = {})) : void
+>Test : ({ b }?: { [x: string]: any; }) => void
+>({ b = '5' } = {}) : { b?: any; }
+>{ b = '5' } = {} : { b?: any; }
+>{ b = '5' } : { [x: string]: any; b?: any; }
+>b : any
+>{} : { b?: any; }
+

--- a/tests/cases/compiler/checkDestructuringShorthandAssigment.ts
+++ b/tests/cases/compiler/checkDestructuringShorthandAssigment.ts
@@ -1,0 +1,8 @@
+// @allowjs: true
+// @checkjs: true
+// @noEmit: true
+// @Filename: bug25434.js
+// should not crash while checking
+function Test({ b = '' } = {}) {}
+
+Test(({ b = '5' } = {}));


### PR DESCRIPTION
Fixes #25434

Special property assignment kind only applies to BinaryExpressions, but checkBinaryLikeExpression also operates on ShorthandPropertyAssignments (among others?).