### PR TITLE
Fix bogus use before def in jsdoc

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1059,6 +1059,7 @@ namespace ts {
             // 5. inside a TS export= declaration (since we will move the export statement during emit to avoid TDZ)
             // or if usage is in a type context:
             // 1. inside a type query (typeof in type position)
+            // 2. inside a jsdoc comment
             if (usage.parent.kind === SyntaxKind.ExportSpecifier || (usage.parent.kind === SyntaxKind.ExportAssignment && (usage.parent as ExportAssignment).isExportEquals)) {
                 // export specifiers do not use the variable, they only make it available for use
                 return true;
@@ -1069,7 +1070,7 @@ namespace ts {
             }
 
             const container = getEnclosingBlockScopeContainer(declaration);
-            return isInTypeQuery(usage) || isUsedInFunctionOrInstanceProperty(usage, declaration, container);
+            return !!(usage.flags & NodeFlags.JSDoc) || isInTypeQuery(usage) || isUsedInFunctionOrInstanceProperty(usage, declaration, container);
 
             function isImmediatelyUsedInInitializerOfBlockScopedVariable(declaration: VariableDeclaration, usage: Node): boolean {
                 const container = getEnclosingBlockScopeContainer(declaration);

--- a/tests/baselines/reference/jsdocTypeReferenceUseBeforeDef.symbols
+++ b/tests/baselines/reference/jsdocTypeReferenceUseBeforeDef.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsdoc/bug25097.js ===
+/** @type {C | null} */
+const c = null
+>c : Symbol(c, Decl(bug25097.js, 1, 5))
+
+class C {
+>C : Symbol(C, Decl(bug25097.js, 1, 14))
+}
+

--- a/tests/baselines/reference/jsdocTypeReferenceUseBeforeDef.types
+++ b/tests/baselines/reference/jsdocTypeReferenceUseBeforeDef.types
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/jsdoc/bug25097.js ===
+/** @type {C | null} */
+const c = null
+>c : C
+>null : null
+
+class C {
+>C : C
+}
+

--- a/tests/cases/conformance/jsdoc/jsdocTypeReferenceUseBeforeDef.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeReferenceUseBeforeDef.ts
@@ -1,0 +1,8 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: bug25097.js
+/** @type {C | null} */
+const c = null
+class C {
+}


### PR DESCRIPTION
Block scoped variables, classes and enums would issue a bogus use-before-def error in jsdoc because name resolution always adds Value, even when resolving a type.

Fixes #25097