### PR TITLE
Report errors correctly by invalidating super set of affected files

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -35,6 +35,10 @@ namespace ts {
          */
         seenAffectedFiles: Map<true> | undefined;
         /**
+         * Files which have semantic diagnostics from old state
+         */
+        semanticDiagnosticsFromOldState: Map<true> | undefined;
+        /**
          * program corresponding to this state
          */
         program: Program;
@@ -96,6 +100,10 @@ namespace ts {
                 const diagnostics = oldState!.semanticDiagnosticsPerFile!.get(sourceFilePath);
                 if (diagnostics) {
                     state.semanticDiagnosticsPerFile!.set(sourceFilePath, diagnostics);
+                    if (!state.semanticDiagnosticsFromOldState) {
+                        state.semanticDiagnosticsFromOldState = createMap<true>();
+                    }
+                    state.semanticDiagnosticsFromOldState.set(sourceFilePath, true);
                 }
             }
         });
@@ -120,17 +128,16 @@ namespace ts {
         while (true) {
             const { affectedFiles } = state;
             if (affectedFiles) {
-                const { seenAffectedFiles, semanticDiagnosticsPerFile } = state;
-                let affectedFilesIndex = state.affectedFilesIndex!; // TODO: GH#18217
+                const seenAffectedFiles = state.seenAffectedFiles!;
+                let affectedFilesIndex = state.affectedFilesIndex!;
                 while (affectedFilesIndex < affectedFiles.length) {
                     const affectedFile = affectedFiles[affectedFilesIndex];
-                    if (!seenAffectedFiles!.has(affectedFile.path)) {
+                    if (!seenAffectedFiles.has(affectedFile.path)) {
                         // Set the next affected file as seen and remove the cached semantic diagnostics
                         state.affectedFilesIndex = affectedFilesIndex;
-                        semanticDiagnosticsPerFile!.delete(affectedFile.path);
                         return affectedFile;
                     }
-                    seenAffectedFiles!.set(affectedFile.path, true);
+                    seenAffectedFiles.set(affectedFile.path, true);
                     affectedFilesIndex++;
                 }
 
@@ -162,10 +169,58 @@ namespace ts {
             state.currentAffectedFilesSignatures = state.currentAffectedFilesSignatures || createMap();
             state.affectedFiles = BuilderState.getFilesAffectedBy(state, state.program, nextKey.value as Path, cancellationToken, computeHash, state.currentAffectedFilesSignatures);
             state.currentChangedFilePath = nextKey.value as Path;
-            state.semanticDiagnosticsPerFile!.delete(nextKey.value as Path);
+            cleanSemanticDiagnosticsCacheWithChangedFile(state);
             state.affectedFilesIndex = 0;
             state.seenAffectedFiles = state.seenAffectedFiles || createMap<true>();
         }
+    }
+
+    /**
+     * Remove the cached semantic diagnostics from old state for changed file, affected files and files referencing affected file(directly or indirectly)
+     */
+    function cleanSemanticDiagnosticsCacheWithChangedFile(state: BuilderProgramState) {
+        // If everything is clean then this map will not be present and we dont need to do anything
+        if (!state.semanticDiagnosticsFromOldState || !state.semanticDiagnosticsFromOldState.size) {
+            return;
+        }
+
+        removeSemanticDiagnosticsCachedFromOldState(state, state.currentChangedFilePath!);
+        // If the change to the file was internal no need to go through affected files super set
+        if (state.affectedFiles!.length === 1) {
+            Debug.assert(state.affectedFiles![0].path === state.currentChangedFilePath!);
+            return;
+        }
+
+        // At this point the change was not internal to file, discard errors from super set of affected files
+        if (!state.referencedMap || // non module emit
+            find(state.affectedFiles!, affectedFile => !isExternalModule(affectedFile) && !BuilderState.containsOnlyAmbientModules(affectedFile))) { // global file
+            clearMap(state.semanticDiagnosticsFromOldState, (_value, path) => state.semanticDiagnosticsPerFile!.delete(path));
+            return;
+        }
+
+        // Start with the paths this file was referenced by affected files
+        const queue = mapDefined(state.affectedFiles, f => removeSemanticDiagnosticsCachedFromOldState(state, f.path) ? f.path : undefined);
+        while (queue.length > 0) {
+            const currentPath = queue.pop()!;
+            // Add referenced by paths if semantic diagnostics from old cache are present
+            state.referencedMap.forEach((referencesInFile, filePath) => {
+                if (referencesInFile.has(currentPath) && removeSemanticDiagnosticsCachedFromOldState(state, filePath as Path)) {
+                    queue.push(filePath as Path);
+                }
+            });
+        }
+    }
+
+    /**
+     * Remove old cached semantic diagnostics from state
+     */
+    function removeSemanticDiagnosticsCachedFromOldState(state: BuilderProgramState, path: Path) {
+        if (state.semanticDiagnosticsFromOldState!.has(path)) {
+            state.semanticDiagnosticsFromOldState!.delete(path);
+            state.semanticDiagnosticsPerFile!.delete(path);
+            return true;
+        }
+        return false;
     }
 
     /**
@@ -205,6 +260,7 @@ namespace ts {
         // Diagnostics werent cached, get them from program, and cache the result
         const diagnostics = state.program.getSemanticDiagnostics(sourceFile, cancellationToken);
         state.semanticDiagnosticsPerFile!.set(path, diagnostics);
+        if (state.semanticDiagnosticsFromOldState) state.semanticDiagnosticsFromOldState.delete(path);
         return diagnostics;
     }
 

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -296,7 +296,7 @@ namespace ts.BuilderState {
      * there are no point to rebuild all script files if these special files have changed. However, if any statement
      * in the file is not ambient external module, we treat it as a regular script file.
      */
-    function containsOnlyAmbientModules(sourceFile: SourceFile) {
+    export function containsOnlyAmbientModules(sourceFile: SourceFile) {
         for (const statement of sourceFile.statements) {
             if (!isModuleWithStringLiteralName(statement)) {
                 return false;
@@ -308,7 +308,7 @@ namespace ts.BuilderState {
     /**
      * Gets all files of the program excluding the default library file
      */
-    function getAllFilesExcludingDefaultLibraryFile(state: BuilderState, programOfThisState: Program, firstSourceFile: SourceFile): ReadonlyArray<SourceFile> {
+    export function getAllFilesExcludingDefaultLibraryFile(state: BuilderState, programOfThisState: Program, firstSourceFile: SourceFile): ReadonlyArray<SourceFile> {
         // Use cached result
         if (state.allFilesExcludingDefaultLibraryFile) {
             return state.allFilesExcludingDefaultLibraryFile;
@@ -376,7 +376,6 @@ namespace ts.BuilderState {
             }
         }
 
-        // Return array of values that needs emit
         // Return array of values that needs emit
         return arrayFrom(mapDefinedIterator(seenFileNamesMap.values(), value => value));
     }

--- a/src/testRunner/unittests/tscWatchMode.ts
+++ b/src/testRunner/unittests/tscWatchMode.ts
@@ -1270,6 +1270,46 @@ export default test;`;
                 checkOutputErrorsIncremental(host, expectedErrors);
             }
         });
+
+        it("updates errors when deep import file changes", () => {
+            const currentDirectory = "/user/username/projects/myproject";
+            const aFile: File = {
+                path: `${currentDirectory}/a.ts`,
+                content: `import {B} from './b';
+declare var console: any;
+let b = new B();
+console.log(b.c.d);`
+            };
+            const bFile: File = {
+                path: `${currentDirectory}/b.ts`,
+                content: `import {C} from './c';
+export class B
+{
+    c = new C();
+}`
+            };
+            const cFile: File = {
+                path: `${currentDirectory}/c.ts`,
+                content: `export class C
+{
+    d = 1;
+}`
+            };
+            const config: File = {
+                path: `${currentDirectory}/tsconfig.json`,
+                content: `{}`
+            };
+            const files = [aFile, bFile, cFile, config, libFile];
+            const host = createWatchedSystem(files, { currentDirectory });
+            const watch = createWatchOfConfigFile("tsconfig.json", host);
+            checkProgramActualFiles(watch(), [aFile.path, bFile.path, cFile.path, libFile.path]);
+            checkOutputErrorsInitial(host, emptyArray);
+            host.writeFile(cFile.path, cFile.content.replace("d", "d2"));
+            host.runQueuedTimeoutCallbacks();
+            checkOutputErrorsIncremental(host, [
+                getDiagnosticOfFileFromProgram(watch(), aFile.path, aFile.content.lastIndexOf("d"), 1, Diagnostics.Property_0_does_not_exist_on_type_1, "d", "C")
+            ]);
+        });
     });
 
     describe("tsc-watch emit with outFile or out setting", () => {


### PR DESCRIPTION
Fixes #24986
The issue reported was with the graph a -> b -> c
When change was made c, the declaration file for b doesnt change (it still remains ```import {C}from "./c" export class B{ c: C}```). From emit persepctive file a.ts doesnt need to be emitted (since its not part of affected files by that change) and without deleting errors for a.ts we wont see new error.
With this change, whenever change in declaration file for c happens, we not only delete errors for b.ts, we will delete errors for a.ts (since it references b.ts) and any file that will reference a.ts as well. This will hamper the performance in scenarios where errors didnt change (eg if a.ts never referenced b.c.d property) but finding out such dependencies would be costlier than re-generating errors.

