### PR TITLE
Pass sourceFile to getChildren in getTokenAtPositionWorker (#25505)

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -679,7 +679,7 @@ namespace ts {
         let current: Node = sourceFile;
         outer: while (true) {
             // find the child that contains 'position'
-            for (const child of current.getChildren()) {
+            for (const child of current.getChildren(sourceFile)) {
                 const start = allowPositionInLeadingTrivia ? child.getFullStart() : child.getStart(sourceFile, /*includeJsDoc*/ true);
                 if (start > position) {
                     // If this child begins after position, then all subsequent children will as well.


### PR DESCRIPTION
For performance reasons, we should always pass sourceFile to getChildren, if available.

* [X] There is an associated issue that is labeled 'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [ ] There are new or updated unit tests validating the change (N/A, see note below)

Fixes #25505 

Note that per suggestion of @DanielRosenwasser and @andy-ms, this doesn't include a unit test since it's primarily a performance improvement, but if someone feels strongly otherwise, I'm happy to write one.