### PR TITLE
Improve the error message when asserting to a type that is not comparable to the original.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20041,7 +20041,8 @@ namespace ts {
             if (produceDiagnostics && targetType !== errorType) {
                 const widenedType = getWidenedType(exprType);
                 if (!isTypeComparableTo(targetType, widenedType)) {
-                    checkTypeComparableTo(exprType, targetType, errNode, Diagnostics.Type_0_cannot_be_converted_to_type_1);
+                    checkTypeComparableTo(exprType, targetType, errNode,
+                        Diagnostics.Conversion_of_type_0_to_type_1_may_be_a_mistake_because_neither_type_sufficiently_overlaps_with_the_other_If_this_was_intentional_convert_the_expression_to_unknown_first);
                 }
             }
             return targetType;
@@ -21515,7 +21516,7 @@ namespace ts {
             // in tagged templates.
             forEach(node.templateSpans, templateSpan => {
                 if (maybeTypeOfKind(checkExpression(templateSpan.expression), TypeFlags.ESSymbolLike)) {
-                    error(templateSpan.expression, Diagnostics.Type_0_cannot_be_converted_to_type_1, typeToString(esSymbolType), typeToString(stringType));
+                    error(templateSpan.expression, Diagnostics.Implicit_conversion_of_a_symbol_to_a_string_will_fail_at_runtime_Consider_wrapping_this_expression_in_String);
                 }
             });
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1196,7 +1196,7 @@
         "category": "Error",
         "code": 2351
     },
-    "Type '{0}' cannot be converted to type '{1}'.": {
+    "Conversion of type '{0}' to type '{1}' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.": {
         "category": "Error",
         "code": 2352
     },
@@ -2420,6 +2420,10 @@
     "An arrow function cannot have a 'this' parameter.": {
         "category": "Error",
         "code": 2730
+    },
+    "Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.": {
+        "category": "Error",
+        "code": 2731
     },
 
     "Import declaration '{0}' is using private name '{1}'.": {

--- a/tests/baselines/reference/arrayCast.errors.txt
+++ b/tests/baselines/reference/arrayCast.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/arrayCast.ts(3,23): error TS2352: Type '{ foo: string; }[]' cannot be converted to type '{ id: number; }[]'.
+tests/cases/compiler/arrayCast.ts(3,23): error TS2352: Conversion of type '{ foo: string; }[]' to type '{ id: number; }[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type '{ foo: string; }' is not comparable to type '{ id: number; }'.
     Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
 
@@ -8,7 +8,7 @@ tests/cases/compiler/arrayCast.ts(3,23): error TS2352: Type '{ foo: string; }[]'
     // has type { foo: string }[], which is not assignable to { id: number }[].
     <{ id: number; }[]>[{ foo: "s" }];
                           ~~~~~~~~
-!!! error TS2352: Type '{ foo: string; }[]' cannot be converted to type '{ id: number; }[]'.
+!!! error TS2352: Conversion of type '{ foo: string; }[]' to type '{ id: number; }[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type '{ foo: string; }' is not comparable to type '{ id: number; }'.
 !!! error TS2352:     Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
     

--- a/tests/baselines/reference/asOperator2.errors.txt
+++ b/tests/baselines/reference/asOperator2.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/expressions/asOperator/asOperator2.ts(1,9): error TS2352: Type 'number' cannot be converted to type 'string'.
+tests/cases/conformance/expressions/asOperator/asOperator2.ts(1,9): error TS2352: Conversion of type 'number' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 
 
 ==== tests/cases/conformance/expressions/asOperator/asOperator2.ts (1 errors) ====
     var x = 23 as string;
             ~~~~~~~~~~~~
-!!! error TS2352: Type 'number' cannot be converted to type 'string'.
+!!! error TS2352: Conversion of type 'number' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     

--- a/tests/baselines/reference/asOperatorContextualType.errors.txt
+++ b/tests/baselines/reference/asOperatorContextualType.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/expressions/asOperator/asOperatorContextualType.ts(2,9): error TS2352: Type '(v: number) => number' cannot be converted to type '(x: number) => string'.
+tests/cases/conformance/expressions/asOperator/asOperatorContextualType.ts(2,9): error TS2352: Conversion of type '(v: number) => number' to type '(x: number) => string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'number' is not comparable to type 'string'.
 
 
@@ -6,5 +6,5 @@ tests/cases/conformance/expressions/asOperator/asOperatorContextualType.ts(2,9):
     // should error
     var x = (v => v) as (x: number) => string;
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '(v: number) => number' cannot be converted to type '(x: number) => string'.
+!!! error TS2352: Conversion of type '(v: number) => number' to type '(x: number) => string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'number' is not comparable to type 'string'.

--- a/tests/baselines/reference/asOperatorNames.errors.txt
+++ b/tests/baselines/reference/asOperatorNames.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/expressions/asOperator/asOperatorNames.ts(2,9): error TS2352: Type 'number' cannot be converted to type 'string'.
+tests/cases/conformance/expressions/asOperator/asOperatorNames.ts(2,9): error TS2352: Conversion of type 'number' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 
 
 ==== tests/cases/conformance/expressions/asOperator/asOperatorNames.ts (1 errors) ====
     var a = 20;
     var b = a as string;
             ~~~~~~~~~~~
-!!! error TS2352: Type 'number' cannot be converted to type 'string'.
+!!! error TS2352: Conversion of type 'number' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     var as = "hello";
     var as1 = as as string;
     

--- a/tests/baselines/reference/castingTuple.errors.txt
+++ b/tests/baselines/reference/castingTuple.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/conformance/types/tuple/castingTuple.ts(13,23): error TS2352: Type '[number, string]' cannot be converted to type '[number, string, boolean]'.
+tests/cases/conformance/types/tuple/castingTuple.ts(13,23): error TS2352: Conversion of type '[number, string]' to type '[number, string, boolean]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property '2' is missing in type '[number, string]'.
-tests/cases/conformance/types/tuple/castingTuple.ts(14,15): error TS2352: Type '[number, string, boolean]' cannot be converted to type '[number, string]'.
+tests/cases/conformance/types/tuple/castingTuple.ts(14,15): error TS2352: Conversion of type '[number, string, boolean]' to type '[number, string]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Types of property 'length' are incompatible.
     Type '3' is not comparable to type '2'.
-tests/cases/conformance/types/tuple/castingTuple.ts(15,14): error TS2352: Type '[number, string]' cannot be converted to type '[number, string, boolean]'.
-tests/cases/conformance/types/tuple/castingTuple.ts(18,21): error TS2352: Type '[C, D]' cannot be converted to type '[C, D, A]'.
+tests/cases/conformance/types/tuple/castingTuple.ts(15,14): error TS2352: Conversion of type '[number, string]' to type '[number, string, boolean]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+tests/cases/conformance/types/tuple/castingTuple.ts(18,21): error TS2352: Conversion of type '[C, D]' to type '[C, D, A]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property '2' is missing in type '[C, D]'.
-tests/cases/conformance/types/tuple/castingTuple.ts(30,10): error TS2352: Type '[number, string]' cannot be converted to type '[number, number]'.
+tests/cases/conformance/types/tuple/castingTuple.ts(30,10): error TS2352: Conversion of type '[number, string]' to type '[number, number]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'string' is not comparable to type 'number'.
-tests/cases/conformance/types/tuple/castingTuple.ts(31,10): error TS2352: Type '[C, D]' cannot be converted to type '[A, I]'.
+tests/cases/conformance/types/tuple/castingTuple.ts(31,10): error TS2352: Conversion of type '[C, D]' to type '[A, I]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'C' is not comparable to type 'A'.
     Property 'a' is missing in type 'C'.
 tests/cases/conformance/types/tuple/castingTuple.ts(32,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'array1' must be of type '{}[]', but here has type 'number[]'.
@@ -30,21 +30,21 @@ tests/cases/conformance/types/tuple/castingTuple.ts(33,1): error TS2304: Cannot 
     var emptyObjTuple = <[{}, {}]>numStrTuple;
     var numStrBoolTuple = <[number, string, boolean]>numStrTuple;
                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '[number, string]' cannot be converted to type '[number, string, boolean]'.
+!!! error TS2352: Conversion of type '[number, string]' to type '[number, string, boolean]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property '2' is missing in type '[number, string]'.
     var shorter = numStrBoolTuple as [number, string]
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '[number, string, boolean]' cannot be converted to type '[number, string]'.
+!!! error TS2352: Conversion of type '[number, string, boolean]' to type '[number, string]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Types of property 'length' are incompatible.
 !!! error TS2352:     Type '3' is not comparable to type '2'.
     var longer = numStrTuple as [number, string, boolean]
                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '[number, string]' cannot be converted to type '[number, string, boolean]'.
+!!! error TS2352: Conversion of type '[number, string]' to type '[number, string, boolean]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     var classCDTuple: [C, D] = [new C(), new D()];
     var interfaceIITuple = <[I, I]>classCDTuple;
     var classCDATuple = <[C, D, A]>classCDTuple;
                         ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '[C, D]' cannot be converted to type '[C, D, A]'.
+!!! error TS2352: Conversion of type '[C, D]' to type '[C, D, A]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property '2' is missing in type '[C, D]'.
     var eleFromCDA1 = classCDATuple[2]; // A
     var eleFromCDA2 = classCDATuple[5]; // C | D | A
@@ -59,11 +59,11 @@ tests/cases/conformance/types/tuple/castingTuple.ts(33,1): error TS2304: Cannot 
     // error
     var t3 = <[number, number]>numStrTuple;
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '[number, string]' cannot be converted to type '[number, number]'.
+!!! error TS2352: Conversion of type '[number, string]' to type '[number, number]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'string' is not comparable to type 'number'.
     var t9 = <[A, I]>classCDTuple;
              ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '[C, D]' cannot be converted to type '[A, I]'.
+!!! error TS2352: Conversion of type '[C, D]' to type '[A, I]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'C' is not comparable to type 'A'.
 !!! error TS2352:     Property 'a' is missing in type 'C'.
     var array1 = <number[]>numStrTuple;

--- a/tests/baselines/reference/contextualTyping39.errors.txt
+++ b/tests/baselines/reference/contextualTyping39.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/contextualTyping39.ts(1,11): error TS2352: Type '() => string' cannot be converted to type '() => number'.
+tests/cases/compiler/contextualTyping39.ts(1,11): error TS2352: Conversion of type '() => string' to type '() => number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'string' is not comparable to type 'number'.
 
 
 ==== tests/cases/compiler/contextualTyping39.ts (1 errors) ====
     var foo = <{ (): number; }> function() { return "err"; };
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '() => string' cannot be converted to type '() => number'.
+!!! error TS2352: Conversion of type '() => string' to type '() => number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'string' is not comparable to type 'number'.

--- a/tests/baselines/reference/contextualTyping41.errors.txt
+++ b/tests/baselines/reference/contextualTyping41.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/contextualTyping41.ts(1,11): error TS2352: Type '() => string' cannot be converted to type '{ (): number; (i: number): number; }'.
+tests/cases/compiler/contextualTyping41.ts(1,11): error TS2352: Conversion of type '() => string' to type '{ (): number; (i: number): number; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'string' is not comparable to type 'number'.
 
 
 ==== tests/cases/compiler/contextualTyping41.ts (1 errors) ====
     var foo = <{():number; (i:number):number; }> (function(){return "err";});
               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '() => string' cannot be converted to type '{ (): number; (i: number): number; }'.
+!!! error TS2352: Conversion of type '() => string' to type '{ (): number; (i: number): number; }' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'string' is not comparable to type 'number'.

--- a/tests/baselines/reference/defaultArgsInFunctionExpressions.errors.txt
+++ b/tests/baselines/reference/defaultArgsInFunctionExpressions.errors.txt
@@ -2,9 +2,9 @@ tests/cases/compiler/defaultArgsInFunctionExpressions.ts(4,19): error TS2345: Ar
 tests/cases/compiler/defaultArgsInFunctionExpressions.ts(5,1): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/defaultArgsInFunctionExpressions.ts(8,20): error TS2322: Type '3' is not assignable to type 'string'.
 tests/cases/compiler/defaultArgsInFunctionExpressions.ts(11,1): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/defaultArgsInFunctionExpressions.ts(14,51): error TS2352: Type 'string' cannot be converted to type 'number'.
+tests/cases/compiler/defaultArgsInFunctionExpressions.ts(14,51): error TS2352: Conversion of type 'string' to type 'number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 tests/cases/compiler/defaultArgsInFunctionExpressions.ts(17,41): error TS2322: Type '""' is not assignable to type 'number'.
-tests/cases/compiler/defaultArgsInFunctionExpressions.ts(20,62): error TS2352: Type 'string' cannot be converted to type 'number'.
+tests/cases/compiler/defaultArgsInFunctionExpressions.ts(20,62): error TS2352: Conversion of type 'string' to type 'number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 tests/cases/compiler/defaultArgsInFunctionExpressions.ts(28,15): error TS2708: Cannot use namespace 'T' as a value.
 
 
@@ -32,7 +32,7 @@ tests/cases/compiler/defaultArgsInFunctionExpressions.ts(28,15): error TS2708: C
     // Contextually type the default arg with the type annotation
     var f3 = function (a: (s: string) => any = (s) => <number>s) { };
                                                       ~~~~~~~~~
-!!! error TS2352: Type 'string' cannot be converted to type 'number'.
+!!! error TS2352: Conversion of type 'string' to type 'number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     
     // Type check using the function's contextual type
     var f4: (a: number) => void = function (a = "") { };
@@ -42,7 +42,7 @@ tests/cases/compiler/defaultArgsInFunctionExpressions.ts(28,15): error TS2708: C
     // Contextually type the default arg using the function's contextual type
     var f5: (a: (s: string) => any) => void = function (a = s => <number>s) { };
                                                                  ~~~~~~~~~
-!!! error TS2352: Type 'string' cannot be converted to type 'number'.
+!!! error TS2352: Conversion of type 'string' to type 'number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     
     // Instantiated module
     module T { }

--- a/tests/baselines/reference/fuzzy.errors.txt
+++ b/tests/baselines/reference/fuzzy.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/fuzzy.ts(13,18): error TS2420: Class 'C' incorrectly implem
   Property 'alsoWorks' is missing in type 'C'.
 tests/cases/compiler/fuzzy.ts(21,34): error TS2322: Type 'this' is not assignable to type 'I'.
   Type 'C' is not assignable to type 'I'.
-tests/cases/compiler/fuzzy.ts(25,20): error TS2352: Type '{ oneI: this; }' cannot be converted to type 'R'.
+tests/cases/compiler/fuzzy.ts(25,20): error TS2352: Conversion of type '{ oneI: this; }' to type 'R' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'anything' is missing in type '{ oneI: this; }'.
 
 
@@ -40,7 +40,7 @@ tests/cases/compiler/fuzzy.ts(25,20): error TS2352: Type '{ oneI: this; }' canno
             worksToo():R {
                 return <R>({ oneI: this });
                        ~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '{ oneI: this; }' cannot be converted to type 'R'.
+!!! error TS2352: Conversion of type '{ oneI: this; }' to type 'R' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'anything' is missing in type '{ oneI: this; }'.
             }
         }

--- a/tests/baselines/reference/genericTypeAssertions1.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions1.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/genericTypeAssertions1.ts(3,5): error TS2322: Type 'A<numbe
   Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/genericTypeAssertions1.ts(4,5): error TS2322: Type 'A<A<number>>' is not assignable to type 'A<number>'.
   Type 'A<number>' is not assignable to type 'number'.
-tests/cases/compiler/genericTypeAssertions1.ts(4,21): error TS2352: Type 'A<number>' cannot be converted to type 'A<A<number>>'.
+tests/cases/compiler/genericTypeAssertions1.ts(4,21): error TS2352: Conversion of type 'A<number>' to type 'A<A<number>>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'number' is not comparable to type 'A<number>'.
 
 
@@ -18,5 +18,5 @@ tests/cases/compiler/genericTypeAssertions1.ts(4,21): error TS2352: Type 'A<numb
 !!! error TS2322: Type 'A<A<number>>' is not assignable to type 'A<number>'.
 !!! error TS2322:   Type 'A<number>' is not assignable to type 'number'.
                         ~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'A<number>' cannot be converted to type 'A<A<number>>'.
+!!! error TS2352: Conversion of type 'A<number>' to type 'A<A<number>>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'number' is not comparable to type 'A<number>'.

--- a/tests/baselines/reference/genericTypeAssertions2.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions2.errors.txt
@@ -5,7 +5,7 @@ tests/cases/compiler/genericTypeAssertions2.ts(10,5): error TS2322: Type 'B<stri
         Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/genericTypeAssertions2.ts(11,5): error TS2322: Type 'A<number>' is not assignable to type 'B<number>'.
   Property 'bar' is missing in type 'A<number>'.
-tests/cases/compiler/genericTypeAssertions2.ts(13,21): error TS2352: Type 'undefined[]' cannot be converted to type 'A<number>'.
+tests/cases/compiler/genericTypeAssertions2.ts(13,21): error TS2352: Conversion of type 'undefined[]' to type 'A<number>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'foo' is missing in type 'undefined[]'.
 
 
@@ -33,5 +33,5 @@ tests/cases/compiler/genericTypeAssertions2.ts(13,21): error TS2352: Type 'undef
     var r4: A<number> = <A<number>>new A();
     var r5: A<number> = <A<number>>[]; // error
                         ~~~~~~~~~~~~~
-!!! error TS2352: Type 'undefined[]' cannot be converted to type 'A<number>'.
+!!! error TS2352: Conversion of type 'undefined[]' to type 'A<number>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'foo' is missing in type 'undefined[]'.

--- a/tests/baselines/reference/genericTypeAssertions4.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions4.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/genericTypeAssertions4.ts(19,5): error TS2322: Type 'A' is not assignable to type 'T'.
 tests/cases/compiler/genericTypeAssertions4.ts(20,5): error TS2322: Type 'B' is not assignable to type 'T'.
 tests/cases/compiler/genericTypeAssertions4.ts(21,5): error TS2322: Type 'C' is not assignable to type 'T'.
-tests/cases/compiler/genericTypeAssertions4.ts(23,9): error TS2352: Type 'B' cannot be converted to type 'T'.
-tests/cases/compiler/genericTypeAssertions4.ts(24,9): error TS2352: Type 'C' cannot be converted to type 'T'.
+tests/cases/compiler/genericTypeAssertions4.ts(23,9): error TS2352: Conversion of type 'B' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+tests/cases/compiler/genericTypeAssertions4.ts(24,9): error TS2352: Conversion of type 'C' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 
 
 ==== tests/cases/compiler/genericTypeAssertions4.ts (5 errors) ====
@@ -36,8 +36,8 @@ tests/cases/compiler/genericTypeAssertions4.ts(24,9): error TS2352: Type 'C' can
         y = <T>a;
         y = <T>b; // error: cannot convert B to T
             ~~~~
-!!! error TS2352: Type 'B' cannot be converted to type 'T'.
+!!! error TS2352: Conversion of type 'B' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
         y = <T>c; // error: cannot convert C to T
             ~~~~
-!!! error TS2352: Type 'C' cannot be converted to type 'T'.
+!!! error TS2352: Conversion of type 'C' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     }

--- a/tests/baselines/reference/genericTypeAssertions5.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions5.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/genericTypeAssertions5.ts(19,5): error TS2322: Type 'A' is not assignable to type 'T'.
 tests/cases/compiler/genericTypeAssertions5.ts(20,5): error TS2322: Type 'B' is not assignable to type 'T'.
 tests/cases/compiler/genericTypeAssertions5.ts(21,5): error TS2322: Type 'C' is not assignable to type 'T'.
-tests/cases/compiler/genericTypeAssertions5.ts(23,9): error TS2352: Type 'B' cannot be converted to type 'T'.
-tests/cases/compiler/genericTypeAssertions5.ts(24,9): error TS2352: Type 'C' cannot be converted to type 'T'.
+tests/cases/compiler/genericTypeAssertions5.ts(23,9): error TS2352: Conversion of type 'B' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+tests/cases/compiler/genericTypeAssertions5.ts(24,9): error TS2352: Conversion of type 'C' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 
 
 ==== tests/cases/compiler/genericTypeAssertions5.ts (5 errors) ====
@@ -36,8 +36,8 @@ tests/cases/compiler/genericTypeAssertions5.ts(24,9): error TS2352: Type 'C' can
         y = <T>a;
         y = <T>b; // error: cannot convert B to T
             ~~~~
-!!! error TS2352: Type 'B' cannot be converted to type 'T'.
+!!! error TS2352: Conversion of type 'B' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
         y = <T>c; // error: cannot convert C to T
             ~~~~
-!!! error TS2352: Type 'C' cannot be converted to type 'T'.
+!!! error TS2352: Conversion of type 'C' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     }

--- a/tests/baselines/reference/genericTypeAssertions6.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions6.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/genericTypeAssertions6.ts(8,13): error TS2352: Type 'U' cannot be converted to type 'T'.
-tests/cases/compiler/genericTypeAssertions6.ts(9,13): error TS2352: Type 'T' cannot be converted to type 'U'.
-tests/cases/compiler/genericTypeAssertions6.ts(19,17): error TS2352: Type 'U' cannot be converted to type 'T'.
+tests/cases/compiler/genericTypeAssertions6.ts(8,13): error TS2352: Conversion of type 'U' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+tests/cases/compiler/genericTypeAssertions6.ts(9,13): error TS2352: Conversion of type 'T' to type 'U' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+tests/cases/compiler/genericTypeAssertions6.ts(19,17): error TS2352: Conversion of type 'U' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'Date' is not comparable to type 'T'.
 
 
@@ -14,10 +14,10 @@ tests/cases/compiler/genericTypeAssertions6.ts(19,17): error TS2352: Type 'U' ca
         f(x: T, y: U) {
             x = <T>y;
                 ~~~~
-!!! error TS2352: Type 'U' cannot be converted to type 'T'.
+!!! error TS2352: Conversion of type 'U' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
             y = <U>x;
                 ~~~~
-!!! error TS2352: Type 'T' cannot be converted to type 'U'.
+!!! error TS2352: Conversion of type 'T' to type 'U' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
         }
     }
     
@@ -29,7 +29,7 @@ tests/cases/compiler/genericTypeAssertions6.ts(19,17): error TS2352: Type 'U' ca
             var d = <U>new Date();
             var e = <T><U>new Date();
                     ~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'U' cannot be converted to type 'T'.
+!!! error TS2352: Conversion of type 'U' to type 'T' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'Date' is not comparable to type 'T'.
         }
     }

--- a/tests/baselines/reference/importCallExpressionCheckReturntype1.errors.txt
+++ b/tests/baselines/reference/importCallExpressionCheckReturntype1.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/dynamicImport/1.ts(4,5): error TS2322: Type 'Promise<typeof import("tests/cases/conformance/dynamicImport/defaultPath")>' is not assignable to type 'Promise<typeof import("tests/cases/conformance/dynamicImport/anotherModule")>'.
   Type 'typeof import("tests/cases/conformance/dynamicImport/defaultPath")' is not assignable to type 'typeof import("tests/cases/conformance/dynamicImport/anotherModule")'.
     Property 'D' is missing in type 'typeof import("tests/cases/conformance/dynamicImport/defaultPath")'.
-tests/cases/conformance/dynamicImport/1.ts(5,10): error TS2352: Type 'Promise<typeof import("tests/cases/conformance/dynamicImport/defaultPath")>' cannot be converted to type 'Promise<typeof import("tests/cases/conformance/dynamicImport/anotherModule")>'.
+tests/cases/conformance/dynamicImport/1.ts(5,10): error TS2352: Conversion of type 'Promise<typeof import("tests/cases/conformance/dynamicImport/defaultPath")>' to type 'Promise<typeof import("tests/cases/conformance/dynamicImport/anotherModule")>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'typeof import("tests/cases/conformance/dynamicImport/defaultPath")' is not comparable to type 'typeof import("tests/cases/conformance/dynamicImport/anotherModule")'.
     Property 'D' is missing in type 'typeof import("tests/cases/conformance/dynamicImport/defaultPath")'.
 
@@ -23,7 +23,7 @@ tests/cases/conformance/dynamicImport/1.ts(5,10): error TS2352: Type 'Promise<ty
 !!! error TS2322:     Property 'D' is missing in type 'typeof import("tests/cases/conformance/dynamicImport/defaultPath")'.
     let p2 = import("./defaultPath") as Promise<typeof anotherModule>;
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'Promise<typeof import("tests/cases/conformance/dynamicImport/defaultPath")>' cannot be converted to type 'Promise<typeof import("tests/cases/conformance/dynamicImport/anotherModule")>'.
+!!! error TS2352: Conversion of type 'Promise<typeof import("tests/cases/conformance/dynamicImport/defaultPath")>' to type 'Promise<typeof import("tests/cases/conformance/dynamicImport/anotherModule")>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'typeof import("tests/cases/conformance/dynamicImport/defaultPath")' is not comparable to type 'typeof import("tests/cases/conformance/dynamicImport/anotherModule")'.
 !!! error TS2352:     Property 'D' is missing in type 'typeof import("tests/cases/conformance/dynamicImport/defaultPath")'.
     let p3: Promise<any> = import("./defaultPath");

--- a/tests/baselines/reference/intTypeCheck.errors.txt
+++ b/tests/baselines/reference/intTypeCheck.errors.txt
@@ -76,7 +76,7 @@ tests/cases/compiler/intTypeCheck.ts(182,5): error TS2322: Type '{}' is not assi
 tests/cases/compiler/intTypeCheck.ts(183,5): error TS2322: Type 'Object' is not assignable to type 'i7'.
   The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
     Type 'Object' provides no match for the signature 'new (): any'.
-tests/cases/compiler/intTypeCheck.ts(185,17): error TS2352: Type 'Base' cannot be converted to type 'i7'.
+tests/cases/compiler/intTypeCheck.ts(185,17): error TS2352: Conversion of type 'Base' to type 'i7' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'Base' provides no match for the signature 'new (): any'.
 tests/cases/compiler/intTypeCheck.ts(187,5): error TS2322: Type '() => void' is not assignable to type 'i7'.
   Type '() => void' provides no match for the signature 'new (): any'.
@@ -408,7 +408,7 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj69: i7 = new obj66;
     var obj70: i7 = <i7>new Base;
                     ~~~~~~~~~~~~
-!!! error TS2352: Type 'Base' cannot be converted to type 'i7'.
+!!! error TS2352: Conversion of type 'Base' to type 'i7' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'Base' provides no match for the signature 'new (): any'.
     var obj71: i7 = null;
     var obj72: i7 = function () { };

--- a/tests/baselines/reference/jsdocTypeTagCast.errors.txt
+++ b/tests/baselines/reference/jsdocTypeTagCast.errors.txt
@@ -1,17 +1,17 @@
-tests/cases/conformance/jsdoc/b.js(4,13): error TS2352: Type 'number' cannot be converted to type 'string'.
-tests/cases/conformance/jsdoc/b.js(45,16): error TS2352: Type 'SomeOther' cannot be converted to type 'SomeBase'.
+tests/cases/conformance/jsdoc/b.js(4,13): error TS2352: Conversion of type 'number' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+tests/cases/conformance/jsdoc/b.js(45,16): error TS2352: Conversion of type 'SomeOther' to type 'SomeBase' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'p' is missing in type 'SomeOther'.
-tests/cases/conformance/jsdoc/b.js(49,19): error TS2352: Type 'SomeOther' cannot be converted to type 'SomeDerived'.
+tests/cases/conformance/jsdoc/b.js(49,19): error TS2352: Conversion of type 'SomeOther' to type 'SomeDerived' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'x' is missing in type 'SomeOther'.
-tests/cases/conformance/jsdoc/b.js(51,17): error TS2352: Type 'SomeDerived' cannot be converted to type 'SomeOther'.
+tests/cases/conformance/jsdoc/b.js(51,17): error TS2352: Conversion of type 'SomeDerived' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'q' is missing in type 'SomeDerived'.
-tests/cases/conformance/jsdoc/b.js(52,17): error TS2352: Type 'SomeBase' cannot be converted to type 'SomeOther'.
+tests/cases/conformance/jsdoc/b.js(52,17): error TS2352: Conversion of type 'SomeBase' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'q' is missing in type 'SomeBase'.
 tests/cases/conformance/jsdoc/b.js(58,1): error TS2322: Type 'SomeFakeClass' is not assignable to type 'SomeBase'.
   Types of property 'p' are incompatible.
     Type 'string | number' is not assignable to type 'number'.
       Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsdoc/b.js(66,8): error TS2352: Type 'boolean' cannot be converted to type 'string | number'.
+tests/cases/conformance/jsdoc/b.js(66,8): error TS2352: Conversion of type 'boolean' to type 'string | number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 tests/cases/conformance/jsdoc/b.js(66,15): error TS2304: Cannot find name 'numOrStr'.
 tests/cases/conformance/jsdoc/b.js(66,24): error TS1005: '}' expected.
 tests/cases/conformance/jsdoc/b.js(66,38): error TS2454: Variable 'numOrStr' is used before being assigned.
@@ -29,7 +29,7 @@ tests/cases/conformance/jsdoc/b.js(67,8): error TS2454: Variable 'numOrStr' is u
     
     var W = /** @type {string} */(4); // Error
                 ~~~~~~~~~~~~~~
-!!! error TS2352: Type 'number' cannot be converted to type 'string'.
+!!! error TS2352: Conversion of type 'number' to type 'string' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     
     /** @type {*} */
     var a;
@@ -72,23 +72,23 @@ tests/cases/conformance/jsdoc/b.js(67,8): error TS2454: Variable 'numOrStr' is u
     someBase = /** @type {SomeBase} */(someBase);
     someBase = /** @type {SomeBase} */(someOther); // Error
                    ~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'SomeOther' cannot be converted to type 'SomeBase'.
+!!! error TS2352: Conversion of type 'SomeOther' to type 'SomeBase' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'p' is missing in type 'SomeOther'.
     
     someDerived = /** @type {SomeDerived} */(someDerived);
     someDerived = /** @type {SomeDerived} */(someBase);
     someDerived = /** @type {SomeDerived} */(someOther); // Error
                       ~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'SomeOther' cannot be converted to type 'SomeDerived'.
+!!! error TS2352: Conversion of type 'SomeOther' to type 'SomeDerived' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'x' is missing in type 'SomeOther'.
     
     someOther = /** @type {SomeOther} */(someDerived); // Error
                     ~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'SomeDerived' cannot be converted to type 'SomeOther'.
+!!! error TS2352: Conversion of type 'SomeDerived' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'q' is missing in type 'SomeDerived'.
     someOther = /** @type {SomeOther} */(someBase); // Error
                     ~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'SomeBase' cannot be converted to type 'SomeOther'.
+!!! error TS2352: Conversion of type 'SomeBase' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'q' is missing in type 'SomeBase'.
     someOther = /** @type {SomeOther} */(someOther);
     
@@ -110,7 +110,7 @@ tests/cases/conformance/jsdoc/b.js(67,8): error TS2454: Variable 'numOrStr' is u
     var str;
     if(/** @type {numOrStr is string} */(numOrStr === undefined)) { // Error
            ~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'boolean' cannot be converted to type 'string | number'.
+!!! error TS2352: Conversion of type 'boolean' to type 'string | number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
                   ~~~~~~~~
 !!! error TS2304: Cannot find name 'numOrStr'.
                            ~~

--- a/tests/baselines/reference/literals-negative.errors.txt
+++ b/tests/baselines/reference/literals-negative.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/literals-negative.ts(5,9): error TS2352: Type 'number' cannot be converted to type 'boolean'.
+tests/cases/compiler/literals-negative.ts(5,9): error TS2352: Conversion of type 'number' to type 'boolean' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 
 
 ==== tests/cases/compiler/literals-negative.ts (1 errors) ====
@@ -8,7 +8,7 @@ tests/cases/compiler/literals-negative.ts(5,9): error TS2352: Type 'number' cann
     var s = <string>(null);
     var b = <boolean>(n);
             ~~~~~~~~~~~~
-!!! error TS2352: Type 'number' cannot be converted to type 'boolean'.
+!!! error TS2352: Conversion of type 'number' to type 'boolean' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     
     function isVoid() : void { }
     

--- a/tests/baselines/reference/noImplicitAnyInCastExpression.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyInCastExpression.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/noImplicitAnyInCastExpression.ts(15,2): error TS2352: Type '{ c: null; }' cannot be converted to type 'IFoo'.
+tests/cases/compiler/noImplicitAnyInCastExpression.ts(15,2): error TS2352: Conversion of type '{ c: null; }' to type 'IFoo' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'a' is missing in type '{ c: null; }'.
 
 
@@ -19,5 +19,5 @@ tests/cases/compiler/noImplicitAnyInCastExpression.ts(15,2): error TS2352: Type 
     // Neither types is assignable to each other
     (<IFoo>{ c: null });
      ~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type '{ c: null; }' cannot be converted to type 'IFoo'.
+!!! error TS2352: Conversion of type '{ c: null; }' to type 'IFoo' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'a' is missing in type '{ c: null; }'.

--- a/tests/baselines/reference/noImplicitSymbolToString.errors.txt
+++ b/tests/baselines/reference/noImplicitSymbolToString.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/noImplicitSymbolToString.ts(6,30): error TS2352: Type 'symbol' cannot be converted to type 'string'.
+tests/cases/compiler/noImplicitSymbolToString.ts(6,30): error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
 tests/cases/compiler/noImplicitSymbolToString.ts(7,30): error TS2469: The '+' operator cannot be applied to type 'symbol'.
 tests/cases/compiler/noImplicitSymbolToString.ts(8,8): error TS2469: The '+=' operator cannot be applied to type 'symbol'.
-tests/cases/compiler/noImplicitSymbolToString.ts(13,47): error TS2352: Type 'symbol' cannot be converted to type 'string'.
-tests/cases/compiler/noImplicitSymbolToString.ts(13,90): error TS2352: Type 'symbol' cannot be converted to type 'string'.
+tests/cases/compiler/noImplicitSymbolToString.ts(13,47): error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
+tests/cases/compiler/noImplicitSymbolToString.ts(13,90): error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
 
 
 ==== tests/cases/compiler/noImplicitSymbolToString.ts (5 errors) ====
@@ -13,7 +13,7 @@ tests/cases/compiler/noImplicitSymbolToString.ts(13,90): error TS2352: Type 'sym
     
     const templateStr = `hello ${symbol}`;
                                  ~~~~~~
-!!! error TS2352: Type 'symbol' cannot be converted to type 'string'.
+!!! error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
     const appendStr = "hello " + symbol;
                                  ~~~~~~
 !!! error TS2469: The '+' operator cannot be applied to type 'symbol'.
@@ -26,7 +26,7 @@ tests/cases/compiler/noImplicitSymbolToString.ts(13,90): error TS2352: Type 'sym
     
     const templateStrUnion = `union with number ${symbolUnionNumber} and union with string ${symbolUnionString}`;
                                                   ~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'symbol' cannot be converted to type 'string'.
+!!! error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
                                                                                              ~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'symbol' cannot be converted to type 'string'.
+!!! error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
     

--- a/tests/baselines/reference/objectTypesIdentityWithPrivates3.errors.txt
+++ b/tests/baselines/reference/objectTypesIdentityWithPrivates3.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates3.ts(25,1): error TS2352: Type 'C3<T2>' cannot be converted to type 'C4'.
+tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithPrivates3.ts(25,1): error TS2352: Conversion of type 'C3<T2>' to type 'C4' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'y' is missing in type 'C3<T2>'.
 
 
@@ -29,5 +29,5 @@ tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectType
     var c3: C3<T2>;
     <C4>c3; // Should fail (private x originates in the same declaration, but different types)
     ~~~~~~
-!!! error TS2352: Type 'C3<T2>' cannot be converted to type 'C4'.
+!!! error TS2352: Conversion of type 'C3<T2>' to type 'C4' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'y' is missing in type 'C3<T2>'.

--- a/tests/baselines/reference/stringLiteralsAssertionsInEqualityComparisons02.errors.txt
+++ b/tests/baselines/reference/stringLiteralsAssertionsInEqualityComparisons02.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts(3,9): error TS2367: This condition will always return 'false' since the types '"foo"' and '"baz"' have no overlap.
 tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts(5,9): error TS2367: This condition will always return 'false' since the types 'string' and 'number' have no overlap.
-tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts(5,19): error TS2352: Type 'string' cannot be converted to type 'number'.
+tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts(5,19): error TS2352: Conversion of type 'string' to type 'number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 
 
 ==== tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts (3 errors) ====
@@ -14,5 +14,5 @@ tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparis
             ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2367: This condition will always return 'false' since the types 'string' and 'number' have no overlap.
                       ~~~~~~~~~~~~~
-!!! error TS2352: Type 'string' cannot be converted to type 'number'.
+!!! error TS2352: Conversion of type 'string' to type 'number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     var d = "foo" === ("bar" as EnhancedString);

--- a/tests/baselines/reference/typeAssertions.errors.txt
+++ b/tests/baselines/reference/typeAssertions.errors.txt
@@ -1,11 +1,11 @@
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(5,9): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(31,12): error TS2352: Type 'SomeOther' cannot be converted to type 'SomeBase'.
+tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(31,12): error TS2352: Conversion of type 'SomeOther' to type 'SomeBase' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'p' is missing in type 'SomeOther'.
-tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(35,15): error TS2352: Type 'SomeOther' cannot be converted to type 'SomeDerived'.
+tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(35,15): error TS2352: Conversion of type 'SomeOther' to type 'SomeDerived' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'x' is missing in type 'SomeOther'.
-tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(37,13): error TS2352: Type 'SomeDerived' cannot be converted to type 'SomeOther'.
+tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(37,13): error TS2352: Conversion of type 'SomeDerived' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'q' is missing in type 'SomeDerived'.
-tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(38,13): error TS2352: Type 'SomeBase' cannot be converted to type 'SomeOther'.
+tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(38,13): error TS2352: Conversion of type 'SomeBase' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'q' is missing in type 'SomeBase'.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,5): error TS2304: Cannot find name 'numOrStr'.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,14): error TS1005: '>' expected.
@@ -58,23 +58,23 @@ tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,50): err
     someBase = <SomeBase>someBase;
     someBase = <SomeBase>someOther; // Error
                ~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'SomeOther' cannot be converted to type 'SomeBase'.
+!!! error TS2352: Conversion of type 'SomeOther' to type 'SomeBase' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'p' is missing in type 'SomeOther'.
     
     someDerived = <SomeDerived>someDerived;
     someDerived = <SomeDerived>someBase;
     someDerived = <SomeDerived>someOther; // Error
                   ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'SomeOther' cannot be converted to type 'SomeDerived'.
+!!! error TS2352: Conversion of type 'SomeOther' to type 'SomeDerived' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'x' is missing in type 'SomeOther'.
     
     someOther = <SomeOther>someDerived; // Error
                 ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'SomeDerived' cannot be converted to type 'SomeOther'.
+!!! error TS2352: Conversion of type 'SomeDerived' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'q' is missing in type 'SomeDerived'.
     someOther = <SomeOther>someBase; // Error
                 ~~~~~~~~~~~~~~~~~~~
-!!! error TS2352: Type 'SomeBase' cannot be converted to type 'SomeOther'.
+!!! error TS2352: Conversion of type 'SomeBase' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Property 'q' is missing in type 'SomeBase'.
     someOther = <SomeOther>someOther;
     

--- a/tests/baselines/reference/typeAssertionsWithIntersectionTypes01.errors.txt
+++ b/tests/baselines/reference/typeAssertionsWithIntersectionTypes01.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithIntersectionTypes01.ts(17,9): error TS2352: Type 'I2' cannot be converted to type 'I1 & I3'.
+tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithIntersectionTypes01.ts(17,9): error TS2352: Conversion of type 'I2' to type 'I1 & I3' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Type 'I2' is not comparable to type 'I3'.
     Property 'p3' is missing in type 'I2'.
-tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithIntersectionTypes01.ts(18,9): error TS2352: Type 'I2' cannot be converted to type 'I3'.
+tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithIntersectionTypes01.ts(18,9): error TS2352: Conversion of type 'I2' to type 'I3' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 
 
 ==== tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithIntersectionTypes01.ts (2 errors) ====
@@ -23,12 +23,12 @@ tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithInt
     
     var a = <I1 & I3>z;
             ~~~~~~~~~~
-!!! error TS2352: Type 'I2' cannot be converted to type 'I1 & I3'.
+!!! error TS2352: Conversion of type 'I2' to type 'I1 & I3' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 !!! error TS2352:   Type 'I2' is not comparable to type 'I3'.
 !!! error TS2352:     Property 'p3' is missing in type 'I2'.
     var b = <I3>z;
             ~~~~~
-!!! error TS2352: Type 'I2' cannot be converted to type 'I3'.
+!!! error TS2352: Conversion of type 'I2' to type 'I3' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     var c = <I2>z;
     var d = <I1>y;
     

--- a/tests/baselines/reference/typeAssertionsWithUnionTypes01.errors.txt
+++ b/tests/baselines/reference/typeAssertionsWithUnionTypes01.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithUnionTypes01.ts(14,9): error TS2352: Type 'I1' cannot be converted to type 'number'.
+tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithUnionTypes01.ts(14,9): error TS2352: Conversion of type 'I1' to type 'number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 
 
 ==== tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithUnionTypes01.ts (1 errors) ====
@@ -17,7 +17,7 @@ tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithUni
     var a = <number | I2>z;
     var b = <number>z;
             ~~~~~~~~~
-!!! error TS2352: Type 'I1' cannot be converted to type 'number'.
+!!! error TS2352: Conversion of type 'I1' to type 'number' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
     var c = <I2>z;
     var d = <I1>y;
     


### PR DESCRIPTION
Also improve the error message for implicit conversion of a symbol to a string in a template literal, which previously shared the error message with type assertions.

Fixes #25539.  Addresses #25870.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone: No, but the PR was trivial enough to write that I won't be upset if it is rejected.
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->