### PR TITLE
getJsxClosingTagAtPosition: Return a result if parent has same name and is unclosed

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1884,9 +1884,14 @@ namespace ts {
             if (!token) return undefined;
             const element = token.kind === SyntaxKind.GreaterThanToken && isJsxOpeningElement(token.parent) ? token.parent.parent
                 : isJsxText(token) ? token.parent : undefined;
-            if (element && !tagNamesAreEquivalent(element.openingElement.tagName, element.closingElement.tagName)) {
+            if (element && isUnclosedTag(element)) {
                 return { newText: `</${element.openingElement.tagName.getText(sourceFile)}>` };
             }
+        }
+
+        function isUnclosedTag({ openingElement, closingElement, parent }: JsxElement): boolean {
+            return !tagNamesAreEquivalent(openingElement.tagName, closingElement.tagName) ||
+                isJsxElement(parent) && tagNamesAreEquivalent(openingElement.tagName, parent.openingElement.tagName) && isUnclosedTag(parent);
         }
 
         function getSpanOfEnclosingComment(fileName: string, position: number, onlyMultiLine: boolean): TextSpan | undefined {

--- a/tests/cases/fourslash/autoCloseTag.ts
+++ b/tests/cases/fourslash/autoCloseTag.ts
@@ -1,15 +1,42 @@
 /// <reference path='fourslash.ts' />
 
-// @Filename: /a.tsx
+// Using separate files for each example to avoid unclosed JSX tags affecting other tests.
+
+// @Filename: /0.tsx
 ////const x = <div>/*0*/;
+
+// @Filename: /1.tsx
 ////const x = <div> foo/*1*/ </div>;
+
+// @Filename: /2.tsx
 ////const x = <div></div>/*2*/;
+
+// @Filename: /3.tsx
 ////const x = <div/>/*3*/;
+
+// @Filename: /4.tsx
 ////const x = <div>
 ////    <p>/*4*/
 ////    </div>
 ////</p>;
+
+// @Filename: /5.tsx
 ////const x = <div> text /*5*/;
+
+// @Filename: /6.tsx
+////const x = <div>
+////    <div>/*6*/
+////</div>;
+
+// @Filename: /7.tsx
+////const x = <div>
+////    <p>/*7*/
+////</div>;
+
+// @Filename: /8.tsx
+////const x = <div>
+////    <div>/*8*/</div>
+////</div>;
 
 verify.jsxClosingTag({
     0: { newText: "</div>" },
@@ -17,4 +44,8 @@ verify.jsxClosingTag({
     2: undefined,
     3: undefined,
     4: { newText: "</p>" },
+    5: { newText: "</div>" },
+    6: { newText: "</div>" },
+    7: { newText: "</p>" },
+    8: undefined,
 });


### PR DESCRIPTION
Fixes #25552

