### PR TITLE
When `import("foo")` has module resolution error, error span should be "foo"

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9377,11 +9377,9 @@ namespace ts {
                     links.resolvedSymbol = unknownSymbol;
                     return links.resolvedType = errorType;
                 }
-                const argumentType = getTypeFromTypeNode(node.argument);
                 const targetMeaning = node.isTypeOf ? SymbolFlags.Value : SymbolFlags.Type;
                 // TODO: Future work: support unions/generics/whatever via a deferred import-type
-                const moduleName = (argumentType as StringLiteralType).value;
-                const innerModuleSymbol = resolveExternalModule(node, moduleName, Diagnostics.Cannot_find_module_0, node, /*isForAugmentation*/ false);
+                const innerModuleSymbol = resolveExternalModuleName(node, node.argument.literal);
                 if (!innerModuleSymbol) {
                     links.resolvedSymbol = unknownSymbol;
                     return links.resolvedType = errorType;
@@ -9413,7 +9411,7 @@ namespace ts {
                             ? Diagnostics.Module_0_does_not_refer_to_a_value_but_is_used_as_a_value_here
                             : Diagnostics.Module_0_does_not_refer_to_a_type_but_is_used_as_a_type_here_Did_you_mean_typeof_import_0;
 
-                        error(node, errorMessage, moduleName);
+                        error(node, errorMessage, node.argument.literal.text);
 
                         links.resolvedSymbol = unknownSymbol;
                         links.resolvedType = errorType;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -912,9 +912,7 @@ namespace ts {
     }
 
     export function isLiteralImportTypeNode(n: Node): n is LiteralImportTypeNode {
-        return n.kind === SyntaxKind.ImportType &&
-            (n as ImportTypeNode).argument.kind === SyntaxKind.LiteralType &&
-            isStringLiteral(((n as ImportTypeNode).argument as LiteralTypeNode).literal);
+        return isImportTypeNode(n) && isLiteralTypeNode(n.argument) && isStringLiteral(n.argument.literal);
     }
 
     export function isPrologueDirective(node: Node): node is PrologueDirective {

--- a/tests/baselines/reference/importTypeAmbientMissing.errors.txt
+++ b/tests/baselines/reference/importTypeAmbientMissing.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/import/importTypeAmbientMissing.ts(8,10): error TS2307: Cannot find module 'fo'.
+tests/cases/conformance/types/import/importTypeAmbientMissing.ts(8,17): error TS2307: Cannot find module 'fo'.
 
 
 ==== tests/cases/conformance/types/import/importTypeAmbientMissing.ts (1 errors) ====
@@ -10,7 +10,7 @@ tests/cases/conformance/types/import/importTypeAmbientMissing.ts(8,10): error TS
         export = Point;
     }
     const x: import("fo") = { x: 0, y: 0 }; // typo, error
-             ~~~~~~~~~~~~
+                    ~~~~
 !!! error TS2307: Cannot find module 'fo'.
     
     

--- a/tests/baselines/reference/importTypeLocalMissing.errors.txt
+++ b/tests/baselines/reference/importTypeLocalMissing.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/types/import/usage.ts(1,17): error TS2307: Cannot find module './fo'.
-tests/cases/conformance/types/import/usage.ts(2,15): error TS2307: Cannot find module './fo2'.
+tests/cases/conformance/types/import/usage.ts(1,24): error TS2307: Cannot find module './fo'.
+tests/cases/conformance/types/import/usage.ts(2,22): error TS2307: Cannot find module './fo2'.
 tests/cases/conformance/types/import/usage.ts(3,36): error TS2694: Namespace '"tests/cases/conformance/types/import/foo2".Bar' has no exported member 'Q'.
-tests/cases/conformance/types/import/usage.ts(10,18): error TS2307: Cannot find module './fo2'.
+tests/cases/conformance/types/import/usage.ts(10,32): error TS2307: Cannot find module './fo2'.
 
 
 ==== tests/cases/conformance/types/import/foo.ts (0 errors) ====
@@ -34,10 +34,10 @@ tests/cases/conformance/types/import/usage.ts(10,18): error TS2307: Cannot find 
     
 ==== tests/cases/conformance/types/import/usage.ts (4 errors) ====
     export const x: import("./fo") = { x: 0, y: 0 };
-                    ~~~~~~~~~~~~~~
+                           ~~~~~~
 !!! error TS2307: Cannot find module './fo'.
     export let y: import("./fo2").Bar.I = { a: "", b: 0 };
-                  ~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~
 !!! error TS2307: Cannot find module './fo2'.
     export let z: import("./foo2").Bar.Q = { a: "", b: 0 };
                                        ~
@@ -49,7 +49,7 @@ tests/cases/conformance/types/import/usage.ts(10,18): error TS2307: Cannot find 
     }
     
     export let shim: typeof import("./fo2") = {
-                     ~~~~~~~~~~~~~~~~~~~~~~
+                                   ~~~~~~~
 !!! error TS2307: Cannot find module './fo2'.
         Bar: Bar2
     };

--- a/tests/baselines/reference/metadataImportType.errors.txt
+++ b/tests/baselines/reference/metadataImportType.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/metadataImportType.ts(2,6): error TS2304: Cannot find name 'test'.
-tests/cases/compiler/metadataImportType.ts(3,8): error TS2307: Cannot find module './b'.
+tests/cases/compiler/metadataImportType.ts(3,15): error TS2307: Cannot find module './b'.
 
 
 ==== tests/cases/compiler/metadataImportType.ts (2 errors) ====
@@ -8,6 +8,6 @@ tests/cases/compiler/metadataImportType.ts(3,8): error TS2307: Cannot find modul
          ~~~~
 !!! error TS2304: Cannot find name 'test'.
         b: import('./b').B
-           ~~~~~~~~~~~~~~~
+                  ~~~~~
 !!! error TS2307: Cannot find module './b'.
     }

--- a/tests/baselines/reference/symbolLinkDeclarationEmitModuleNames.js
+++ b/tests/baselines/reference/symbolLinkDeclarationEmitModuleNames.js
@@ -81,7 +81,7 @@ export declare const CONTROLLER_CLASS: BindingKey<import("@loopback/context/src/
 tests/cases/compiler/monorepo/context/src/bindingkey.d.ts(1,29): error TS2307: Cannot find module '@loopback/context'.
 tests/cases/compiler/monorepo/core/src/application.d.ts(1,29): error TS2307: Cannot find module '@loopback/context'.
 tests/cases/compiler/monorepo/core/src/usage.d.ts(1,28): error TS2307: Cannot find module '@loopback/context'.
-tests/cases/compiler/monorepo/core/src/usage.d.ts(2,51): error TS2307: Cannot find module '@loopback/context/src/value-promise'.
+tests/cases/compiler/monorepo/core/src/usage.d.ts(2,58): error TS2307: Cannot find module '@loopback/context/src/value-promise'.
 
 
 ==== tests/cases/compiler/monorepo/core/src/application.d.ts (1 errors) ====
@@ -95,7 +95,7 @@ tests/cases/compiler/monorepo/core/src/usage.d.ts(2,51): error TS2307: Cannot fi
                                ~~~~~~~~~~~~~~~~~~~
 !!! error TS2307: Cannot find module '@loopback/context'.
     export declare const CONTROLLER_CLASS: BindingKey<import("@loopback/context/src/value-promise").Constructor<any>>;
-                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2307: Cannot find module '@loopback/context/src/value-promise'.
     
 ==== /.src/tests/cases/compiler/monorepo/context/src/value-promise.d.ts (0 errors) ====

--- a/tests/baselines/reference/symbolLinkDeclarationEmitModuleNamesRootDir.js
+++ b/tests/baselines/reference/symbolLinkDeclarationEmitModuleNamesRootDir.js
@@ -47,7 +47,7 @@ export declare const CONTROLLER_CLASS: BindingKey<import("@loopback/context/src/
 
 tests/cases/compiler/monorepo/core/dist/src/application.d.ts(1,29): error TS2307: Cannot find module '@loopback/context'.
 tests/cases/compiler/monorepo/core/dist/src/usage.d.ts(1,28): error TS2307: Cannot find module '@loopback/context'.
-tests/cases/compiler/monorepo/core/dist/src/usage.d.ts(2,51): error TS2307: Cannot find module '@loopback/context/src/value-promise'.
+tests/cases/compiler/monorepo/core/dist/src/usage.d.ts(2,58): error TS2307: Cannot find module '@loopback/context/src/value-promise'.
 
 
 ==== tests/cases/compiler/monorepo/core/tsconfig.json (0 errors) ====
@@ -82,6 +82,6 @@ tests/cases/compiler/monorepo/core/dist/src/usage.d.ts(2,51): error TS2307: Cann
                                ~~~~~~~~~~~~~~~~~~~
 !!! error TS2307: Cannot find module '@loopback/context'.
     export declare const CONTROLLER_CLASS: BindingKey<import("@loopback/context/src/value-promise").Constructor<any>>;
-                                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2307: Cannot find module '@loopback/context/src/value-promise'.
     

--- a/tests/cases/fourslash/codeFixCannotFindModule.ts
+++ b/tests/cases/fourslash/codeFixCannotFindModule.ts
@@ -10,17 +10,21 @@
 ////import * as abs from "abs";
 ////abs;
 
+// @Filename: /b.ts
+////const x: import("abs").T = 0;
+
 test.setTypesRegistry({
     "abs": undefined,
 });
 
-goTo.file("/a.ts");
-
-verify.codeFixAvailable([{
-    description: "Install '@types/abs'",
-    commands: [{
-        type: "install package",
-        file: "/a.ts",
-        packageName: "@types/abs",
-    }],
-}]);
+for (const file of ["/a.ts", "/b.ts"]) {
+    goTo.file(file);
+    verify.codeFixAvailable([{
+        description: "Install '@types/abs'",
+        commands: [{
+            type: "install package",
+            file,
+            packageName: "@types/abs",
+        }],
+    }]);
+}

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -184,7 +184,7 @@ declare namespace FourSlashInterface {
             index?: number,
             preferences?: UserPreferences,
         });
-        codeFixAvailable(options?: Array<{ description: string, actions?: Array<{ type: string, data: {} }>, commands?: {}[] }>): void;
+        codeFixAvailable(options?: ReadonlyArray<VerifyCodeFixAvailableOptions>): void;
         applicableRefactorAvailableAtMarker(markerName: string): void;
         codeFixDiagnosticsAvailableAtMarkers(markerNames: string[], diagnosticCode?: number): void;
         applicableRefactorAvailableForRange(): void;
@@ -602,6 +602,12 @@ declare namespace FourSlashInterface {
          * Character that was responsible for triggering signature help.
          */
         triggerCharacter?: string,
+    }
+
+    export interface VerifyCodeFixAvailableOptions {
+        readonly description: string;
+        readonly actions?: ReadonlyArray<{ readonly type: string, readonly data: {} }>;
+        readonly commands?: ReadonlyArray<{}?;
     }
 
     interface VerifyNavigateToOptions {


### PR DESCRIPTION
Before this change, the codefix would crash because it expected the error span to be a string.

