### PR TITLE
 mapTextChangesToCodeEditsUsingScriptInfo: Handle tsconfig.json text change

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1774,6 +1774,16 @@ namespace ts.server {
             return this.getScriptInfoForNormalizedPath(toNormalizedPath(uncheckedFileName));
         }
 
+        /* @internal */
+        getScriptInfoOrConfig(uncheckedFileName: string): ScriptInfoOrConfig | undefined {
+            const path = toNormalizedPath(uncheckedFileName);
+            const info = this.getScriptInfoForNormalizedPath(path);
+            if (info) return { kind: ScriptInfoOrConfigKind.ScriptInfo, info };
+            const configProject = this.configuredProjects.get(uncheckedFileName);
+            const config = configProject && configProject.getCompilerOptions().configFile;
+            return config && { kind: ScriptInfoOrConfigKind.Config, config };
+        }
+
         /**
          * Returns the projects that contain script info through SymLink
          * Note that this does not return projects in info.containingProjects
@@ -2542,4 +2552,11 @@ namespace ts.server {
             return false;
         }
     }
+
+    /* @internal */
+    export const enum ScriptInfoOrConfigKind { ScriptInfo, Config }
+    /* @internal */
+    export type ScriptInfoOrConfig =
+        | { readonly kind: ScriptInfoOrConfigKind.ScriptInfo, readonly info: ScriptInfo }
+        | { readonly kind: ScriptInfoOrConfigKind.Config, readonly config: TsConfigSourceFile };
 }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1778,10 +1778,9 @@ namespace ts.server {
         getScriptInfoOrConfig(uncheckedFileName: string): ScriptInfoOrConfig | undefined {
             const path = toNormalizedPath(uncheckedFileName);
             const info = this.getScriptInfoForNormalizedPath(path);
-            if (info) return { kind: ScriptInfoOrConfigKind.ScriptInfo, info };
+            if (info) return info;
             const configProject = this.configuredProjects.get(uncheckedFileName);
-            const config = configProject && configProject.getCompilerOptions().configFile;
-            return config && { kind: ScriptInfoOrConfigKind.Config, config };
+            return configProject && configProject.getCompilerOptions().configFile;
         }
 
         /**
@@ -2554,9 +2553,9 @@ namespace ts.server {
     }
 
     /* @internal */
-    export const enum ScriptInfoOrConfigKind { ScriptInfo, Config }
+    export type ScriptInfoOrConfig = ScriptInfo | TsConfigSourceFile;
     /* @internal */
-    export type ScriptInfoOrConfig =
-        | { readonly kind: ScriptInfoOrConfigKind.ScriptInfo, readonly info: ScriptInfo }
-        | { readonly kind: ScriptInfoOrConfigKind.Config, readonly config: TsConfigSourceFile };
+    export function isConfigFile(config: ScriptInfoOrConfig): config is TsConfigSourceFile {
+        return (config as TsConfigSourceFile).kind !== undefined;
+    }
 }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1763,7 +1763,7 @@ namespace ts.server {
                 this.projectService,
                 project => project.getLanguageService().getEditsForFileRename(oldPath, newPath, formatOptions, preferences),
                 (a, b) => a.fileName === b.fileName);
-            return simplifiedResult ? changes.map(c => this.mapTextChangeToCodeEditUsingScriptInfo(c)) : changes;
+            return simplifiedResult ? changes.map(c => this.mapTextChangeToCodeEditUsingScriptInfoOrConfigFile(c)) : changes;
         }
 
         private getCodeFixes(args: protocol.CodeFixRequestArgs, simplifiedResult: boolean): ReadonlyArray<protocol.CodeFixAction> | ReadonlyArray<CodeFixAction> | undefined {
@@ -1840,8 +1840,8 @@ namespace ts.server {
             return mapTextChangesToCodeEditsForFile(change, project.getSourceFileOrConfigFile(this.normalizePath(change.fileName)));
         }
 
-        private mapTextChangeToCodeEditUsingScriptInfo(change: FileTextChanges): protocol.FileCodeEdits {
-            return mapTextChangesToCodeEditsUsingScriptInfo(change, this.projectService.getScriptInfo(this.normalizePath(change.fileName)));
+        private mapTextChangeToCodeEditUsingScriptInfoOrConfigFile(change: FileTextChanges): protocol.FileCodeEdits {
+            return mapTextChangesToCodeEditsUsingScriptInfoOrConfig(change, this.projectService.getScriptInfoOrConfig(this.normalizePath(change.fileName)));
         }
 
         private normalizePath(fileName: string) {
@@ -2358,7 +2358,7 @@ namespace ts.server {
     }
 
     function mapTextChangesToCodeEditsForFile(textChanges: FileTextChanges, sourceFile: SourceFile | undefined): protocol.FileCodeEdits {
-        Debug.assert(!!textChanges.isNewFile === !sourceFile, "Expected isNewFile for (only) new files", () => JSON.stringify({ isNewFile: textChanges.isNewFile, hasSourceFile: !!sourceFile }));
+        Debug.assert(!!textChanges.isNewFile === !sourceFile, "Expected isNewFile for (only) new files", () => JSON.stringify({ isNewFile: !!textChanges.isNewFile, hasSourceFile: !!sourceFile }));
         if (sourceFile) {
             return {
                 fileName: textChanges.fileName,
@@ -2370,10 +2370,10 @@ namespace ts.server {
         }
     }
 
-    function mapTextChangesToCodeEditsUsingScriptInfo(textChanges: FileTextChanges, scriptInfo: ScriptInfo | undefined): protocol.FileCodeEdits {
-        Debug.assert(!!textChanges.isNewFile === !scriptInfo);
+    function mapTextChangesToCodeEditsUsingScriptInfoOrConfig(textChanges: FileTextChanges, scriptInfo: ScriptInfoOrConfig | undefined): protocol.FileCodeEdits {
+        Debug.assert(!!textChanges.isNewFile === !scriptInfo, "Expected isNewFile for (only) new files", () => JSON.stringify({ isNewFile: !!textChanges.isNewFile, hasScriptInfo: !!scriptInfo }));
         return scriptInfo
-            ? { fileName: textChanges.fileName, textChanges: textChanges.textChanges.map(textChange => convertTextChangeToCodeEditUsingScriptInfo(textChange, scriptInfo)) }
+            ? { fileName: textChanges.fileName, textChanges: textChanges.textChanges.map(textChange => convertTextChangeToCodeEditUsingScriptInfoOrConfig(textChange, scriptInfo)) }
             : convertNewFileTextChangeToCodeEdit(textChanges);
     }
 
@@ -2385,8 +2385,16 @@ namespace ts.server {
         };
     }
 
-    function convertTextChangeToCodeEditUsingScriptInfo(change: TextChange, scriptInfo: ScriptInfo) {
-        return { start: scriptInfo.positionToLineOffset(change.span.start), end: scriptInfo.positionToLineOffset(textSpanEnd(change.span)), newText: change.newText };
+    function convertTextChangeToCodeEditUsingScriptInfoOrConfig(change: TextChange, scriptInfo: ScriptInfoOrConfig): protocol.CodeEdit {
+        return { start: positionToLineOffset(scriptInfo, change.span.start), end: positionToLineOffset(scriptInfo, textSpanEnd(change.span)), newText: change.newText };
+    }
+
+    function positionToLineOffset(info: ScriptInfoOrConfig, position: number): protocol.Location {
+        return info.kind === ScriptInfoOrConfigKind.ScriptInfo ? info.info.positionToLineOffset(position) : locationFromLineAndCharacter(info.config.getLineAndCharacterOfPosition(position));
+    }
+
+    function locationFromLineAndCharacter(lc: LineAndCharacter): protocol.Location {
+        return { line: lc.line + 1, offset: lc.character + 1 };
     }
 
     function convertNewFileTextChangeToCodeEdit(textChanges: FileTextChanges): protocol.FileCodeEdits {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -2390,7 +2390,7 @@ namespace ts.server {
     }
 
     function positionToLineOffset(info: ScriptInfoOrConfig, position: number): protocol.Location {
-        return info.kind === ScriptInfoOrConfigKind.ScriptInfo ? info.info.positionToLineOffset(position) : locationFromLineAndCharacter(info.config.getLineAndCharacterOfPosition(position));
+        return isConfigFile(info) ? locationFromLineAndCharacter(info.getLineAndCharacterOfPosition(position)) : info.positionToLineOffset(position);
     }
 
     function locationFromLineAndCharacter(lc: LineAndCharacter): protocol.Location {

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -8739,7 +8739,7 @@ export const x = 10;`
             assert.deepEqual<ReadonlyArray<protocol.FileCodeEdits>>(response, [
                 {
                     fileName: "/tsconfig.json",
-                    textChanges: [{ ...protocolTextSpanFromSubstring(tsconfig.content, "./b.ts"), "newText": "c.ts" }],
+                    textChanges: [{ ...protocolTextSpanFromSubstring(tsconfig.content, "./b.ts"), newText: "c.ts" }],
                 },
                 {
                     fileName: "/a.ts",

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8893,7 +8893,7 @@ declare namespace ts.server {
         private mapCodeFixAction;
         private mapTextChangesToCodeEdits;
         private mapTextChangeToCodeEdit;
-        private mapTextChangeToCodeEditUsingScriptInfo;
+        private mapTextChangeToCodeEditUsingScriptInfoOrConfigFile;
         private normalizePath;
         private convertTextChangeToCodeEdit;
         private getBraceMatching;


### PR DESCRIPTION
Noticed while looking at #24857 -- there's no `ScriptInfo` for a `tsconfig.json` file so we have to use a union.