### PR TITLE
Stricter test that JSDoc @type tag matches function signature

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4021,7 +4021,7 @@
         "category": "Error",
         "code": 8029
     },
-    "The type of a function declaration must be callable.": {
+    "The type of a function declaration must match the function's signature.": {
         "category": "Error",
         "code": 8030
     },

--- a/tests/baselines/reference/checkJsdocTypeTag5.errors.txt
+++ b/tests/baselines/reference/checkJsdocTypeTag5.errors.txt
@@ -4,11 +4,12 @@ tests/cases/conformance/jsdoc/test.js(7,24): error TS2322: Type 'number' is not 
 tests/cases/conformance/jsdoc/test.js(10,17): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsdoc/test.js(12,14): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsdoc/test.js(14,24): error TS2322: Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsdoc/test.js(28,5): error TS8030: The type of a function declaration must match the function's signature.
 tests/cases/conformance/jsdoc/test.js(34,5): error TS2322: Type '1 | 2' is not assignable to type '2 | 3'.
   Type '1' is not assignable to type '2 | 3'.
 
 
-==== tests/cases/conformance/jsdoc/test.js (7 errors) ====
+==== tests/cases/conformance/jsdoc/test.js (8 errors) ====
     // all 6 should error on return statement/expression
     /** @type {(x: number) => string} */
     function h(x) { return x }
@@ -49,6 +50,8 @@ tests/cases/conformance/jsdoc/test.js(34,5): error TS2322: Type '1 | 2' is not a
     /** @typedef {{(s: string): 0 | 1; (b: boolean): 2 | 3 }} Gioconda */
     
     /** @type {Gioconda} */
+        ~~~~~~~~~~~~~~~~
+!!! error TS8030: The type of a function declaration must match the function's signature.
     function monaLisa(sb) {
         return typeof sb === 'string' ? 1 : 2;
     }

--- a/tests/baselines/reference/checkJsdocTypeTag6.errors.txt
+++ b/tests/baselines/reference/checkJsdocTypeTag6.errors.txt
@@ -1,12 +1,13 @@
-tests/cases/conformance/jsdoc/test.js(1,5): error TS8030: The type of a function declaration must be callable.
+tests/cases/conformance/jsdoc/test.js(1,5): error TS8030: The type of a function declaration must match the function's signature.
 tests/cases/conformance/jsdoc/test.js(7,5): error TS2322: Type '(prop: any) => void' is not assignable to type '{ prop: string; }'.
   Property 'prop' is missing in type '(prop: any) => void'.
+tests/cases/conformance/jsdoc/test.js(10,5): error TS8030: The type of a function declaration must match the function's signature.
 
 
-==== tests/cases/conformance/jsdoc/test.js (2 errors) ====
+==== tests/cases/conformance/jsdoc/test.js (3 errors) ====
     /** @type {number} */
         ~~~~~~~~~~~~~~
-!!! error TS8030: The type of a function declaration must be callable.
+!!! error TS8030: The type of a function declaration must match the function's signature.
     function f() {
         return 1
     }
@@ -17,4 +18,16 @@ tests/cases/conformance/jsdoc/test.js(7,5): error TS2322: Type '(prop: any) => v
 !!! error TS2322: Type '(prop: any) => void' is not assignable to type '{ prop: string; }'.
 !!! error TS2322:   Property 'prop' is missing in type '(prop: any) => void'.
     }
+    
+    /** @type {(a: number) => number} */
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS8030: The type of a function declaration must match the function's signature.
+    function add1(a, b) { return a + b; }
+    
+    /** @type {(a: number, b: number) => number} */
+    function add2(a, b) { return a + b; }
+    
+    // TODO: Should be an error since signature doesn't match.
+    /** @type {(a: number, b: number, c: number) => number} */
+    function add3(a, b) { return a + b; }
     

--- a/tests/baselines/reference/checkJsdocTypeTag6.symbols
+++ b/tests/baselines/reference/checkJsdocTypeTag6.symbols
@@ -12,3 +12,28 @@ var g = function (prop) {
 >prop : Symbol(prop, Decl(test.js, 6, 18))
 }
 
+/** @type {(a: number) => number} */
+function add1(a, b) { return a + b; }
+>add1 : Symbol(add1, Decl(test.js, 7, 1))
+>a : Symbol(a, Decl(test.js, 10, 14))
+>b : Symbol(b, Decl(test.js, 10, 16))
+>a : Symbol(a, Decl(test.js, 10, 14))
+>b : Symbol(b, Decl(test.js, 10, 16))
+
+/** @type {(a: number, b: number) => number} */
+function add2(a, b) { return a + b; }
+>add2 : Symbol(add2, Decl(test.js, 10, 37))
+>a : Symbol(a, Decl(test.js, 13, 14))
+>b : Symbol(b, Decl(test.js, 13, 16))
+>a : Symbol(a, Decl(test.js, 13, 14))
+>b : Symbol(b, Decl(test.js, 13, 16))
+
+// TODO: Should be an error since signature doesn't match.
+/** @type {(a: number, b: number, c: number) => number} */
+function add3(a, b) { return a + b; }
+>add3 : Symbol(add3, Decl(test.js, 13, 37))
+>a : Symbol(a, Decl(test.js, 17, 14))
+>b : Symbol(b, Decl(test.js, 17, 16))
+>a : Symbol(a, Decl(test.js, 17, 14))
+>b : Symbol(b, Decl(test.js, 17, 16))
+

--- a/tests/baselines/reference/checkJsdocTypeTag6.types
+++ b/tests/baselines/reference/checkJsdocTypeTag6.types
@@ -14,3 +14,31 @@ var g = function (prop) {
 >prop : any
 }
 
+/** @type {(a: number) => number} */
+function add1(a, b) { return a + b; }
+>add1 : (a: any, b: any) => number
+>a : any
+>b : any
+>a + b : any
+>a : any
+>b : any
+
+/** @type {(a: number, b: number) => number} */
+function add2(a, b) { return a + b; }
+>add2 : (a: number, b: number) => number
+>a : number
+>b : number
+>a + b : number
+>a : number
+>b : number
+
+// TODO: Should be an error since signature doesn't match.
+/** @type {(a: number, b: number, c: number) => number} */
+function add3(a, b) { return a + b; }
+>add3 : (a: number, b: number) => number
+>a : number
+>b : number
+>a + b : number
+>a : number
+>b : number
+

--- a/tests/cases/conformance/jsdoc/checkJsdocTypeTag6.ts
+++ b/tests/cases/conformance/jsdoc/checkJsdocTypeTag6.ts
@@ -11,3 +11,13 @@ function f() {
 /** @type {{ prop: string }} */
 var g = function (prop) {
 }
+
+/** @type {(a: number) => number} */
+function add1(a, b) { return a + b; }
+
+/** @type {(a: number, b: number) => number} */
+function add2(a, b) { return a + b; }
+
+// TODO: Should be an error since signature doesn't match.
+/** @type {(a: number, b: number, c: number) => number} */
+function add3(a, b) { return a + b; }


### PR DESCRIPTION
Sequel to #25580. Previously there was no error for a `@type` with the wrong arity; now there is at least an error if that arity is too small.