### PR TITLE
Simplify rules for `isControlFlowEndingStatement`

### DIFF
--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -579,17 +579,10 @@ namespace ts.formatting {
         function isControlFlowEndingStatement(kind: SyntaxKind, parent: TextRangeWithKind): boolean {
             switch (kind) {
                 case SyntaxKind.ReturnStatement:
-                case SyntaxKind.ThrowStatement: {
-                    if (parent.kind !== SyntaxKind.Block) {
-                        return true;
-                    }
-                    const grandParent = (parent as Node).parent;
-                    // In a function, we may want to write inner functions after this.
-                    return !(grandParent && grandParent.kind === SyntaxKind.FunctionExpression || grandParent.kind === SyntaxKind.FunctionDeclaration);
-                }
+                case SyntaxKind.ThrowStatement:
                 case SyntaxKind.ContinueStatement:
                 case SyntaxKind.BreakStatement:
-                    return true;
+                    return parent.kind !== SyntaxKind.Block;
                 default:
                     return false;
             }

--- a/tests/cases/fourslash/smartIndentReturn.ts
+++ b/tests/cases/fourslash/smartIndentReturn.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts'/>
+
+//// function foo() {
+////     if (true) {
+////         {| "indentation": 8|}
+////         return;
+////         {| "indentation": 8|}
+////     }
+//// }
+
+for (const marker of test.markers()) {
+    verify.indentationAtPositionIs(marker.fileName, marker.position, marker.data.indentation);
+}


### PR DESCRIPTION
Fixes #25582
We will now always stay indented within a block.

