### PR TITLE
Fix formatting at trailing comma

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2307,6 +2307,14 @@ Actual: ${stringify(fullActual)}`);
             }
         }
 
+        public verifyFormatDocumentChangesNothing(): void {
+            const { fileName } = this.activeFile;
+            const before = this.getFileContent(fileName);
+            this.formatDocument();
+            const after = this.getFileContent(fileName);
+            this.assertObjectsEqual(after, before);
+        }
+
         public verifyTextAtCaretIs(text: string) {
             const actual = this.getFileContent(this.activeFile.fileName).substring(this.currentCaretPosition, this.currentCaretPosition + text.length);
             if (actual !== text) {
@@ -4204,6 +4212,10 @@ namespace FourSlashInterface {
 
         public currentFileContentIs(text: string) {
             this.state.verifyCurrentFileContent(text);
+        }
+
+        public formatDocumentChangesNothing(): void {
+            this.state.verifyFormatDocumentChangesNothing();
         }
 
         public goToDefinitionIs(endMarkers: ArrayOrSingle<string>) {

--- a/tests/cases/fourslash/formatTrailingComma.ts
+++ b/tests/cases/fourslash/formatTrailingComma.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+////foo
+////    .bar(
+////        x,
+////    );
+
+verify.formatDocumentChangesNothing();

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -228,6 +228,7 @@ declare namespace FourSlashInterface {
         eval(expr: string, value: any): void;
         currentLineContentIs(text: string): void;
         currentFileContentIs(text: string): void;
+        formatDocumentChangesNothing(): void;
         /** Verifies that goToDefinition at the current position would take you to `endMarker`. */
         goToDefinitionIs(endMarkers: ArrayOrSingle<string>): void;
         goToDefinitionName(name: string, containerName: string): void;


### PR DESCRIPTION
Fixes #25056
Previously, we saw that `,` was not the expected end-of-list token `)` and assumed that the end-of-list token was missing. We then treated `,` and `)` as if they were children of the `ExpressionStatement` and indented them accordingly.