### PR TITLE
--noEmit doesn't indicate an intent to use ES6 modules

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1242,7 +1242,7 @@ namespace ts {
         return program.getSourceFiles().some(s => !s.isDeclarationFile && !program.isSourceFileFromExternalLibrary(s) && !!s.externalModuleIndicator);
     }
     export function compilerOptionsIndicateEs6Modules(compilerOptions: CompilerOptions): boolean {
-        return !!compilerOptions.module || compilerOptions.target! >= ScriptTarget.ES2015 || !!compilerOptions.noEmit;
+        return !!compilerOptions.module || compilerOptions.target! >= ScriptTarget.ES2015;
     }
 
     export function hostUsesCaseSensitiveFileNames(host: LanguageServiceHost): boolean {


### PR DESCRIPTION
Sequel to #23576.
I don't think it makes sense to view `--noEmit` as permission to suggest ES6 modules, because any JS project is likely to have `--noEmit` set.