### PR TITLE
Avoid using old node in import fix to use namespace import

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -482,7 +482,7 @@ namespace ts.codefix {
     }
 
     function addNamespaceQualifier(changes: textChanges.ChangeTracker, sourceFile: SourceFile, { namespacePrefix, symbolToken }: FixUseNamespaceImport): void {
-        changes.replaceNode(sourceFile, symbolToken, createPropertyAccess(createIdentifier(namespacePrefix), symbolToken));
+        changes.replaceNode(sourceFile, symbolToken, createPropertyAccess(createIdentifier(namespacePrefix), createIdentifier(symbolToken.text)));
     }
 
     interface ImportsCollection {

--- a/tests/cases/fourslash/importNameCodeFixExistingImport2.ts
+++ b/tests/cases/fourslash/importNameCodeFixExistingImport2.ts
@@ -1,7 +1,8 @@
 /// <reference path="fourslash.ts" />
 
-//// [|import * as ns from "./module";
-//// f1/*0*/();|]
+////import * as ns from "./module";
+////// Comment
+////f1/*0*/();
 
 // @Filename: module.ts
 //// export function f1() {}
@@ -9,8 +10,10 @@
 
 verify.importFixAtPosition([
 `import * as ns from "./module";
+// Comment
 ns.f1();`,
 `import * as ns from "./module";
 import { f1 } from "./module";
+// Comment
 f1();`,
 ]);


### PR DESCRIPTION
Fixes #25707