### PR TITLE
Check for optional type parameters before issuing a "wrong number of type arguments" error on a function call.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19083,7 +19083,7 @@ namespace ts {
             else if (candidateForTypeArgumentError) {
                 checkTypeArguments(candidateForTypeArgumentError, (node as CallExpression | TaggedTemplateExpression).typeArguments!, /*reportErrors*/ true, fallbackError);
             }
-            else if (typeArguments && every(signatures, sig => length(sig.typeParameters) !== typeArguments!.length)) {
+            else if (typeArguments && every(signatures, sig => typeArguments!.length < getMinTypeArgumentCount(sig.typeParameters) || typeArguments!.length > length(sig.typeParameters))) {
                 diagnostics.add(getTypeArgumentArityError(node, signatures, typeArguments));
             }
             else if (args) {

--- a/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.errors.txt
+++ b/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.errors.txt
@@ -1,9 +1,10 @@
 tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(5,11): error TS2558: Expected 0-2 type arguments, but got 3.
 tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(6,1): error TS2350: Only a void function can be called with the 'new' keyword.
 tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(6,15): error TS2558: Expected 0-2 type arguments, but got 3.
+tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(9,1): error TS2554: Expected 1 arguments, but got 0.
 
 
-==== tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts (3 errors) ====
+==== tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts (4 errors) ====
     declare function Callbacks(flags?: string): void;
     declare function Callbacks<T>(flags?: string): void;
     declare function Callbacks<T1, T2>(flags?: string): void;
@@ -16,3 +17,9 @@ tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(6,15): error TS2558:
 !!! error TS2350: Only a void function can be called with the 'new' keyword.
                   ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 0-2 type arguments, but got 3.
+    
+    declare function f<A, B = {}>(arg: number): void;
+    f<number>(); // wrong number of arguments (#25683)
+    ~~~~~~~~~~~
+!!! error TS2554: Expected 1 arguments, but got 0.
+    

--- a/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.js
+++ b/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.js
@@ -6,6 +6,11 @@ declare function Callbacks<T1, T2>(flags?: string): void;
 Callbacks<number, string, boolean>('s'); // wrong number of type arguments
 new Callbacks<number, string, boolean>('s'); // wrong number of type arguments
 
+declare function f<A, B = {}>(arg: number): void;
+f<number>(); // wrong number of arguments (#25683)
+
+
 //// [overloadsAndTypeArgumentArityErrors.js]
 Callbacks('s'); // wrong number of type arguments
 new Callbacks('s'); // wrong number of type arguments
+f(); // wrong number of arguments (#25683)

--- a/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.symbols
+++ b/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.symbols
@@ -20,3 +20,12 @@ Callbacks<number, string, boolean>('s'); // wrong number of type arguments
 new Callbacks<number, string, boolean>('s'); // wrong number of type arguments
 >Callbacks : Symbol(Callbacks, Decl(overloadsAndTypeArgumentArityErrors.ts, 0, 0), Decl(overloadsAndTypeArgumentArityErrors.ts, 0, 49), Decl(overloadsAndTypeArgumentArityErrors.ts, 1, 52))
 
+declare function f<A, B = {}>(arg: number): void;
+>f : Symbol(f, Decl(overloadsAndTypeArgumentArityErrors.ts, 5, 44))
+>A : Symbol(A, Decl(overloadsAndTypeArgumentArityErrors.ts, 7, 19))
+>B : Symbol(B, Decl(overloadsAndTypeArgumentArityErrors.ts, 7, 21))
+>arg : Symbol(arg, Decl(overloadsAndTypeArgumentArityErrors.ts, 7, 30))
+
+f<number>(); // wrong number of arguments (#25683)
+>f : Symbol(f, Decl(overloadsAndTypeArgumentArityErrors.ts, 5, 44))
+

--- a/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.types
+++ b/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.types
@@ -24,3 +24,13 @@ new Callbacks<number, string, boolean>('s'); // wrong number of type arguments
 >Callbacks : { (flags?: string): void; <T>(flags?: string): void; <T1, T2>(flags?: string): void; }
 >'s' : "s"
 
+declare function f<A, B = {}>(arg: number): void;
+>f : <A, B = {}>(arg: number) => void
+>A : A
+>B : B
+>arg : number
+
+f<number>(); // wrong number of arguments (#25683)
+>f<number>() : any
+>f : <A, B = {}>(arg: number) => void
+

--- a/tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts
+++ b/tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts
@@ -4,3 +4,6 @@ declare function Callbacks<T1, T2>(flags?: string): void;
 
 Callbacks<number, string, boolean>('s'); // wrong number of type arguments
 new Callbacks<number, string, boolean>('s'); // wrong number of type arguments
+
+declare function f<A, B = {}>(arg: number): void;
+f<number>(); // wrong number of arguments (#25683)


### PR DESCRIPTION
Fixes #25683.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->