### PR TITLE
Fix parsing of parenthesized JSDoc parameters

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2967,6 +2967,8 @@ namespace ts {
                 case SyntaxKind.InferKeyword:
                 case SyntaxKind.ImportKeyword:
                     return true;
+                case SyntaxKind.FunctionKeyword:
+                    return !inStartOfParameter;
                 case SyntaxKind.MinusToken:
                     return !inStartOfParameter && lookAhead(nextTokenIsNumericLiteral);
                 case SyntaxKind.OpenParenToken:

--- a/tests/baselines/reference/jsdocParseHigherOrderFunction.symbols
+++ b/tests/baselines/reference/jsdocParseHigherOrderFunction.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsdoc/paren.js ===
+/** @type {function((string), function((string)): string): string} */
+var x = s => s.toString()
+>x : Symbol(x, Decl(paren.js, 1, 3))
+>s : Symbol(s, Decl(paren.js, 1, 7))
+>s.toString : Symbol(String.toString, Decl(lib.es5.d.ts, --, --))
+>s : Symbol(s, Decl(paren.js, 1, 7))
+>toString : Symbol(String.toString, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/jsdocParseHigherOrderFunction.symbols
+++ b/tests/baselines/reference/jsdocParseHigherOrderFunction.symbols
@@ -1,9 +1,9 @@
 === tests/cases/conformance/jsdoc/paren.js ===
 /** @type {function((string), function((string)): string): string} */
-var x = s => s.toString()
+var x = (s, id) => id(s)
 >x : Symbol(x, Decl(paren.js, 1, 3))
->s : Symbol(s, Decl(paren.js, 1, 7))
->s.toString : Symbol(String.toString, Decl(lib.es5.d.ts, --, --))
->s : Symbol(s, Decl(paren.js, 1, 7))
->toString : Symbol(String.toString, Decl(lib.es5.d.ts, --, --))
+>s : Symbol(s, Decl(paren.js, 1, 9))
+>id : Symbol(id, Decl(paren.js, 1, 11))
+>id : Symbol(id, Decl(paren.js, 1, 11))
+>s : Symbol(s, Decl(paren.js, 1, 9))
 

--- a/tests/baselines/reference/jsdocParseHigherOrderFunction.types
+++ b/tests/baselines/reference/jsdocParseHigherOrderFunction.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/jsdoc/paren.js ===
+/** @type {function((string), function((string)): string): string} */
+var x = s => s.toString()
+>x : (arg0: string, arg1: (arg0: string) => string) => string
+>s => s.toString() : (s: string) => string
+>s : string
+>s.toString() : string
+>s.toString : () => string
+>s : string
+>toString : () => string
+

--- a/tests/baselines/reference/jsdocParseHigherOrderFunction.types
+++ b/tests/baselines/reference/jsdocParseHigherOrderFunction.types
@@ -1,11 +1,11 @@
 === tests/cases/conformance/jsdoc/paren.js ===
 /** @type {function((string), function((string)): string): string} */
-var x = s => s.toString()
+var x = (s, id) => id(s)
 >x : (arg0: string, arg1: (arg0: string) => string) => string
->s => s.toString() : (s: string) => string
+>(s, id) => id(s) : (s: string, id: (arg0: string) => string) => string
 >s : string
->s.toString() : string
->s.toString : () => string
+>id : (arg0: string) => string
+>id(s) : string
+>id : (arg0: string) => string
 >s : string
->toString : () => string
 

--- a/tests/baselines/reference/jsdocParseParenthesizedJSDocParameter.symbols
+++ b/tests/baselines/reference/jsdocParseParenthesizedJSDocParameter.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsdoc/paren.js ===
+/** @type {function((string)): string} */
+var x = s => s.toString()
+>x : Symbol(x, Decl(paren.js, 1, 3))
+>s : Symbol(s, Decl(paren.js, 1, 7))
+>s.toString : Symbol(String.toString, Decl(lib.es5.d.ts, --, --))
+>s : Symbol(s, Decl(paren.js, 1, 7))
+>toString : Symbol(String.toString, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/jsdocParseParenthesizedJSDocParameter.types
+++ b/tests/baselines/reference/jsdocParseParenthesizedJSDocParameter.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/jsdoc/paren.js ===
+/** @type {function((string)): string} */
+var x = s => s.toString()
+>x : (arg0: string) => string
+>s => s.toString() : (s: string) => string
+>s : string
+>s.toString() : string
+>s.toString : () => string
+>s : string
+>toString : () => string
+

--- a/tests/cases/conformance/jsdoc/jsdocParseHigherOrderFunction.ts
+++ b/tests/cases/conformance/jsdoc/jsdocParseHigherOrderFunction.ts
@@ -1,0 +1,7 @@
+// @noemit: true
+// @allowjs: true
+// @checkjs: true
+// @strict: true
+// @Filename: paren.js
+/** @type {function((string), function((string)): string): string} */
+var x = s => s.toString()

--- a/tests/cases/conformance/jsdoc/jsdocParseHigherOrderFunction.ts
+++ b/tests/cases/conformance/jsdoc/jsdocParseHigherOrderFunction.ts
@@ -4,4 +4,4 @@
 // @strict: true
 // @Filename: paren.js
 /** @type {function((string), function((string)): string): string} */
-var x = s => s.toString()
+var x = (s, id) => id(s)

--- a/tests/cases/conformance/jsdoc/jsdocParseParenthesizedJSDocParameter.ts
+++ b/tests/cases/conformance/jsdoc/jsdocParseParenthesizedJSDocParameter.ts
@@ -1,0 +1,7 @@
+// @noemit: true
+// @allowjs: true
+// @checkjs: true
+// @strict: true
+// @Filename: paren.js
+/** @type {function((string)): string} */
+var x = s => s.toString()


### PR DESCRIPTION
Parenthesis can start a jsdoc function parameter since it is just a type, and parenthesis can start a type:

```js
/** @type {function(((string))): void} */
```

However, this is not legal in other parameter lists:

```ts
function x((((a))): string) { }
```

This change makes jsdoc function parameter lists parse differently than normal parameter lists by allowing parenthesis as a start character of jsdoc parameters.

Fixes #25779 
Fixes #25800 
