### PR TITLE
Remove bad import completions tests

### DIFF
--- a/tests/cases/fourslash/completionsImport_require.ts
+++ b/tests/cases/fourslash/completionsImport_require.ts
@@ -9,22 +9,6 @@
 ////import * as s from "something";
 ////fo/*b*/
 
-// @Filename: /c.js
-////const a = require("./a");
-////fo/*c*/
-
-// @Filename: /d.js
-////const x = 0;/*d*/
-
-// @Filename: /e.js
-////const a = import("./a"); // Does not make this an external module
-////fo/*e*/
-
-for (const marker of ["c", "d", "e"]) {
-    // Doesn't activate for commonjs-only module, or non-module file unless 'module' is set see also completionsImport_compilerOptionsModule)
-    verify.not.completionListContains({ name: "foo", source: "/a" });
-}
-
 goTo.marker("b");
 verify.completionListContains({ name: "foo", source: "/a" }, "const foo: 0", "", "const", /*spanIndex*/ undefined, /*hasAction*/ true, {
     includeCompletionsForModuleExports: true,


### PR DESCRIPTION
The `marker` variable is unused, so we weren't actually testing at those locations. Too bad we don't type-check tests.
The criteria for showing import completions has changed since the test was written and is better reflected in `completionsImport_compilerOptionsModule.ts`.