### PR TITLE
Added type inference to Object.keys type definition.

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -258,7 +258,7 @@ interface ObjectConstructor {
       * Returns the names of the enumerable properties and methods of an object.
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
-    keys(o: {}): string[];
+    keys<o>(o: {}): (keyof o)[];
 }
 
 /**

--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -259,6 +259,12 @@ interface ObjectConstructor {
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
     keys<o>(o: {}): (keyof o)[];
+
+    /**
+      * Returns the names of the enumerable properties and methods of an object.
+      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+      */
+    keys(o: {}): string[];
 }
 
 /**


### PR DESCRIPTION
Reason: https://stackoverflow.com/questions/51446585/type-array-of-keys-of-a-particular-interface

In short, with the current type of Object.keys: `keys(o: {}): string[]`, typescript does not know what the values of `o` are, so if I pass Object.keys from a parent React.Component to a child and type definition of this particular child's prop is specified as `(keyof InterfaceOfO)[]`, I get a `TypeError: Type 'string[]' is not assignable to type '("whatever" | "keys" | "of" | "o" | "are")[].

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

