### PR TITLE
Refactor and improve caching in getTypeOfSymbol callees

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5232,16 +5232,17 @@ namespace ts {
                 return getWidenedTypeFromJSSpecialPropertyDeclarations(symbol);
             }
             else if (symbol.flags & SymbolFlags.ValueModule && declaration && isSourceFile(declaration) && declaration.commonJsModuleIndicator) {
-                if (!pushTypeResolution(symbol, TypeSystemPropertyName.Type)) {
-                    return errorType;
-                }
                 const resolvedModule = resolveExternalModuleSymbol(symbol);
                 if (resolvedModule !== symbol) {
+                    if (!pushTypeResolution(symbol, TypeSystemPropertyName.Type)) {
+                        return errorType;
+                    }
                     const exportEquals = getMergedSymbol(symbol.exports!.get(InternalSymbolName.ExportEquals)!);
-                    return getWidenedTypeFromJSSpecialPropertyDeclarations(exportEquals, exportEquals === resolvedModule ? undefined : resolvedModule);
-                }
-                if (!popTypeResolution()) {
-                    return reportCircularityError(symbol);
+                    const type = getWidenedTypeFromJSSpecialPropertyDeclarations(exportEquals, exportEquals === resolvedModule ? undefined : resolvedModule);
+                    if (!popTypeResolution()) {
+                        return reportCircularityError(symbol);
+                    }
+                    return type;
                 }
             }
             const type = createObjectType(ObjectFlags.Anonymous, symbol);


### PR DESCRIPTION
1. Always cache calls to getTypeOfSymbol, even in the error case.
2. JS expando types are now cached on the original symbol as well as the cloned symbol. Previously they were only cached on the cloned symbol.
3. Large callees of getTypeOfSymbol (variable/param/property, func/class/enum/module, and accessors) now handle only caching and delegate to -Worker functions whose return values are cached
unconditionally (unlike previously). This makes the code in the -Worker functions easier to write and reason about.
4. Previously, successfully obtaining a type from a js special property declaration would forget to pop the circularity detection stack and check its value.