### PR TITLE
Simplify getWidenedTypeFromJSSpecialPropertyDeclarations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4713,6 +4713,18 @@ namespace ts {
                 }
                 return getWidenedLiteralType(checkExpressionCached(specialDeclaration));
             }
+            const declaredType = getJSDocTypeFromSpecialDeclarations(symbol) || getInitializerTypeFromSpecialDeclarations(symbol, resolvedSymbol);
+            const type = getWidenedType(declaredType);
+            if (filterType(type, t => !!(t.flags & ~TypeFlags.Nullable)) === neverType) {
+                if (noImplicitAny) {
+                    reportImplicitAnyError(symbol.valueDeclaration, anyType);
+                }
+                return anyType;
+            }
+            return type;
+        }
+
+        function getJSDocTypeFromSpecialDeclarations(symbol: Symbol) {
             let declaredType: Type | undefined;
             for (const declaration of symbol.declarations) {
                 const expression = isBinaryExpression(declaration) ? declaration :
@@ -4734,68 +4746,60 @@ namespace ts {
                     }
                 }
             }
-            if (!declaredType) {
-                const types: Type[] = [];
-                for (const declaration of symbol.declarations) {
-                    const expression = isBinaryExpression(declaration) ? declaration :
-                         isBinaryExpression(declaration.parent) ? declaration.parent : declaration;
-                    // TODO: Maybe we should try harder in the case that expression is not a binary expression.
-                    if (isBinaryExpression(expression)) {
-                        // If we don't have an explicit JSDoc type, get the type from the expression.
-                        let type = resolvedSymbol ? getTypeOfSymbol(resolvedSymbol) : getWidenedLiteralType(checkExpressionCached(expression.right));
-                        const special = isPropertyAccessExpression(expression) ? getSpecialPropertyAccessKind(expression) : getSpecialPropertyAssignmentKind(expression);
-
-                        if (type.flags & TypeFlags.Object &&
-                            special === SpecialPropertyAssignmentKind.ModuleExports &&
-                            symbol.escapedName === InternalSymbolName.ExportEquals) {
-                            const exportedType = resolveStructuredTypeMembers(type as ObjectType);
-                            const members = createSymbolTable();
-                            copyEntries(exportedType.members, members);
-                            if (resolvedSymbol && !resolvedSymbol.exports) {
-                                resolvedSymbol.exports = createSymbolTable();
-                            }
-                            (resolvedSymbol || symbol).exports!.forEach((s, name) => {
-                                if (members.has(name)) {
-                                    const exportedMember = exportedType.members.get(name)!;
-                                    const union = createSymbol(s.flags | exportedMember.flags, name);
-                                    union.type = getUnionType([getTypeOfSymbol(s), getTypeOfSymbol(exportedMember)]);
-                                    members.set(name, union);
-                                }
-                                else {
-                                    members.set(name, s);
-                                }
-                            });
-                            type = createAnonymousType(
-                                exportedType.symbol,
-                                members,
-                                exportedType.callSignatures,
-                                exportedType.constructSignatures,
-                                exportedType.stringIndexInfo,
-                                exportedType.numberIndexInfo);
-                        }
-                        let anyedType = type;
-                        if (isEmptyArrayLiteralType(type)) {
-                            anyedType = anyArrayType;
-                            if (noImplicitAny) {
-                                reportImplicitAnyError(expression, anyArrayType);
-                            }
-                        }
-                        types.push(anyedType);
-                    }
-                }
-                declaredType = getUnionType(types, UnionReduction.Subtype);
-            }
-
-            const type = getWidenedType(declaredType);
-            if (filterType(type, t => !!(t.flags & ~TypeFlags.Nullable)) === neverType) {
-                if (noImplicitAny) {
-                    reportImplicitAnyError(symbol.valueDeclaration, anyType);
-                }
-                return anyType;
-            }
-            return type;
+            return declaredType;
         }
 
+        /** If we don't have an explicit JSDoc type, get the type from the expression. */
+        function getInitializerTypeFromSpecialDeclarations(symbol: Symbol, resolvedSymbol: Symbol | undefined) {
+            const types: Type[] = [];
+            for (const declaration of symbol.declarations) {
+                const expression = isBinaryExpression(declaration) ? declaration :
+                    isBinaryExpression(declaration.parent) ? declaration.parent : declaration;
+                // TODO: Maybe we should try harder in the case that expression is not a binary expression.
+                if (isBinaryExpression(expression)) {
+                    let type = resolvedSymbol ? getTypeOfSymbol(resolvedSymbol) : getWidenedLiteralType(checkExpressionCached(expression.right));
+                    const special = isPropertyAccessExpression(expression) ? getSpecialPropertyAccessKind(expression) : getSpecialPropertyAssignmentKind(expression);
+
+                    if (type.flags & TypeFlags.Object &&
+                        special === SpecialPropertyAssignmentKind.ModuleExports &&
+                        symbol.escapedName === InternalSymbolName.ExportEquals) {
+                        const exportedType = resolveStructuredTypeMembers(type as ObjectType);
+                        const members = createSymbolTable();
+                        copyEntries(exportedType.members, members);
+                        if (resolvedSymbol && !resolvedSymbol.exports) {
+                            resolvedSymbol.exports = createSymbolTable();
+                        }
+                        (resolvedSymbol || symbol).exports!.forEach((s, name) => {
+                            if (members.has(name)) {
+                                const exportedMember = exportedType.members.get(name)!;
+                                const union = createSymbol(s.flags | exportedMember.flags, name);
+                                union.type = getUnionType([getTypeOfSymbol(s), getTypeOfSymbol(exportedMember)]);
+                                members.set(name, union);
+                            }
+                            else {
+                                members.set(name, s);
+                            }
+                        });
+                        type = createAnonymousType(
+                            exportedType.symbol,
+                            members,
+                            exportedType.callSignatures,
+                            exportedType.constructSignatures,
+                            exportedType.stringIndexInfo,
+                            exportedType.numberIndexInfo);
+                    }
+                    let anyedType = type;
+                    if (isEmptyArrayLiteralType(type)) {
+                        anyedType = anyArrayType;
+                        if (noImplicitAny) {
+                            reportImplicitAnyError(expression, anyArrayType);
+                        }
+                    }
+                    types.push(anyedType);
+                }
+            }
+            return getUnionType(types, UnionReduction.Subtype);
+        }
         function getSpecial(declaration: Declaration) {
             const expression = isBinaryExpression(declaration) ? declaration :
                 isPropertyAccessExpression(declaration) ? isBinaryExpression(declaration.parent) ? declaration.parent : declaration :


### PR DESCRIPTION
1. Extract reduce-style [1] functions for two of the major components (jsdoc type checking and initializer type checking)
2. Switch this-assignment location checking to the same style. Also introduce an enum to aid readability.
3. Filter initializer types down to constructor-defined initializer types after the main loop.

[1] That is, functions that manually take a state parameter and return the updated state.
