### PR TITLE
Fix duplicate "this" completion

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4676,7 +4676,7 @@ namespace ts {
                     }
                 }
                 // Use contextual parameter type if one is available
-                const type = declaration.symbol.escapedName === "this" ? getContextualThisParameterType(func) : getContextuallyTypedParameterType(declaration);
+                const type = declaration.symbol.escapedName === InternalSymbolName.This ? getContextualThisParameterType(func) : getContextuallyTypedParameterType(declaration);
                 if (type) {
                     return addOptionality(type, isOptional);
                 }
@@ -7507,7 +7507,7 @@ namespace ts {
                         const resolvedSymbol = resolveName(param, paramSymbol.escapedName, SymbolFlags.Value, undefined, undefined, /*isUse*/ false);
                         paramSymbol = resolvedSymbol!;
                     }
-                    if (i === 0 && paramSymbol.escapedName === "this") {
+                    if (i === 0 && paramSymbol.escapedName === InternalSymbolName.This) {
                         hasThisParameter = true;
                         thisParameter = param.symbol;
                     }
@@ -15345,7 +15345,7 @@ namespace ts {
                 const jsDocFunctionType = <JSDocFunctionType>jsdocType;
                 if (jsDocFunctionType.parameters.length > 0 &&
                     jsDocFunctionType.parameters[0].name &&
-                    (jsDocFunctionType.parameters[0].name as Identifier).escapedText === "this") {
+                    (jsDocFunctionType.parameters[0].name as Identifier).escapedText === InternalSymbolName.This) {
                     return getTypeFromTypeNode(jsDocFunctionType.parameters[0].type!);
                 }
             }
@@ -26766,6 +26766,7 @@ namespace ts {
 
             populateSymbols();
 
+            symbols.delete(InternalSymbolName.This); // Not a symbol, a keyword
             return symbolsToArray(symbols);
 
             function populateSymbols() {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3559,6 +3559,7 @@ namespace ts {
         Resolving = "__resolving__", // Indicator symbol used to mark partially resolved type aliases
         ExportEquals = "export=", // Export assignment symbol
         Default = "default", // Default export symbol (technically not wholly internal, but included here for usability)
+        This = "this",
     }
 
     /**

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2106,7 +2106,8 @@ declare namespace ts {
         Computed = "__computed",
         Resolving = "__resolving__",
         ExportEquals = "export=",
-        Default = "default"
+        Default = "default",
+        This = "this"
     }
     /**
      * This represents a string whose leading underscore have been escaped by adding extra leading underscores.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2106,7 +2106,8 @@ declare namespace ts {
         Computed = "__computed",
         Resolving = "__resolving__",
         ExportEquals = "export=",
-        Default = "default"
+        Default = "default",
+        This = "this"
     }
     /**
      * This represents a string whose leading underscore have been escaped by adding extra leading underscores.

--- a/tests/cases/fourslash/completionsThisType.ts
+++ b/tests/cases/fourslash/completionsThisType.ts
@@ -9,21 +9,20 @@
 ////
 ////function f(this: { x: number }) { /*f*/ }
 
-goTo.marker("");
-
-verify.completionListContains("xyz", "(method) C.xyz(): any", "", "method", undefined, undefined, {
-    includeInsertTextCompletions: true,
-    insertText: "this.xyz",
-});
-
-verify.completionListContains("foo bar", '(property) C["foo bar"]: number', "", "property", undefined, undefined, {
-    includeInsertTextCompletions: true,
-    insertText: 'this["foo bar"]',
-});
-
-goTo.marker("f");
-
-verify.completionListContains("x", "(property) x: number", "", "property", undefined, undefined, {
-    includeInsertTextCompletions: true,
-    insertText: "this.x",
-});
+const preferences: FourSlashInterface.UserPreferences = { includeInsertTextCompletions: true };
+verify.completions(
+    {
+        marker: "",
+        includes: [
+            { name: "xyz", text: "(method) C.xyz(): any", kind: "method", insertText: "this.xyz" },
+            { name: "foo bar", text: '(property) C["foo bar"]: number', kind: "property", insertText: 'this["foo bar"]' },
+        ],
+        isNewIdentifierLocation: true,
+        preferences,
+    },
+    {
+        marker: "f",
+        includes: { name: "x", text: "(property) x: number", kind: "property", insertText: "this.x" },
+        preferences,
+    },
+);


### PR DESCRIPTION
Without the `checker.ts` change, the updated test will fail because there are 2 "this" completions, one a keyword and one a parameter.