### PR TITLE
Call toPath on sourceRoot to ensure it is always absolute (#25838)

### DIFF
--- a/src/compiler/sourcemapDecoder.ts
+++ b/src/compiler/sourcemapDecoder.ts
@@ -61,7 +61,7 @@ namespace ts.sourcemaps {
 
     export function decode(host: SourceMapDecodeHost, mapPath: string, map: SourceMapData, program?: Program, fallbackCache = createSourceFileLikeCache(host)): SourceMapper {
         const currentDirectory = getDirectoryPath(mapPath);
-        const sourceRoot = map.sourceRoot || currentDirectory;
+        const sourceRoot = map.sourceRoot ? getNormalizedAbsolutePath(map.sourceRoot, currentDirectory) : currentDirectory;
         let decodedMappings: ProcessedSourceMapPosition[];
         let generatedOrderedMappings: ProcessedSourceMapPosition[];
         let sourceOrderedMappings: ProcessedSourceMapPosition[];

--- a/tests/cases/fourslash/server/declarationMapsGoToDefinitionRelativeSourceRoot.ts
+++ b/tests/cases/fourslash/server/declarationMapsGoToDefinitionRelativeSourceRoot.ts
@@ -1,0 +1,40 @@
+/// <reference path="../fourslash.ts" />
+// @Filename: index.ts
+////export class Foo {
+////    member: string;
+////    /*2*/methodName(propName: SomeType): void {}
+////    otherMethod() {
+////        if (Math.random() > 0.5) {
+////            return {x: 42};
+////        }
+////        return {y: "yes"};
+////    }
+////}
+////
+////export interface SomeType {
+////    member: number;
+////}
+// @Filename: out/indexdef.d.ts.map
+////{"version":3,"file":"indexdef.d.ts","sourceRoot":"../","sources":["index.ts"],"names":[],"mappings":"AAAA;IACI,MAAM,EAAE,MAAM,CAAC;IACf,UAAU,CAAC,QAAQ,EAAE,QAAQ,GAAG,IAAI;IACpC,WAAW;;;;;;;CAMd;AAED,MAAM,WAAW,QAAQ;IACrB,MAAM,EAAE,MAAM,CAAC;CAClB"}
+// @Filename: out/indexdef.d.ts
+////export declare class Foo {
+////    member: string;
+////    methodName(propName: SomeType): void;
+////    otherMethod(): {
+////        x: number;
+////        y?: undefined;
+////    } | {
+////        y: string;
+////        x?: undefined;
+////    };
+////}
+////export interface SomeType {
+////    member: number;
+////}
+//////# sourceMappingURL=out/indexdef.d.ts.map
+// @Filename: mymodule.ts
+////import * as mod from "./out/indexdef";
+////const instance = new mod.Foo();
+////instance.[|/*1*/methodName|]({member: 12});
+
+verify.goToDefinition("1", "2");


### PR DESCRIPTION
* Call toPath on sourceRoot to ensure it is always absolute

* Leave canonicalization to avoid a Path/string union

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Ports #25838 to `release-3.0`.

