### PR TITLE
Lookup files by resolved `Path` and not by `fileName` in sourcemapDecoder when querying program

### DIFF
--- a/src/compiler/sourcemapDecoder.ts
+++ b/src/compiler/sourcemapDecoder.ts
@@ -99,10 +99,10 @@ namespace ts.sourcemaps {
         function getSourceFileLike(fileName: string, location: string): SourceFileLike | undefined {
             // Lookup file in program, if provided
             const file = program && program.getSourceFile(fileName);
-            if (!file) {
+            const path = toPath(fileName, location, host.getCanonicalFileName);
+            if (!file || file.path !== path) {
                 // Otherwise check the cache (which may hit disk)
-                const path = toPath(fileName, location, host.getCanonicalFileName);
-                return fallbackCache.get(path);
+                return program && program.getSourceFile(path) || fallbackCache.get(path);
             }
             return file;
         }

--- a/src/compiler/sourcemapDecoder.ts
+++ b/src/compiler/sourcemapDecoder.ts
@@ -98,11 +98,11 @@ namespace ts.sourcemaps {
 
         function getSourceFileLike(fileName: string, location: string): SourceFileLike | undefined {
             // Lookup file in program, if provided
-            const file = program && program.getSourceFile(fileName);
             const path = toPath(fileName, location, host.getCanonicalFileName);
-            if (!file || file.path !== path) {
+            const file = program && program.getSourceFile(path);
+            if (!file) {
                 // Otherwise check the cache (which may hit disk)
-                return program && program.getSourceFile(path) || fallbackCache.get(path);
+                return fallbackCache.get(path);
             }
             return file;
         }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -709,7 +709,7 @@ namespace FourSlash {
 
             ts.zipWith(endMarkers, definitions, (endMarker, definition, i) => {
                 const marker = this.getMarkerByName(endMarker);
-                if (marker.fileName !== definition.fileName || marker.position !== definition.textSpan.start) {
+                if (ts.comparePaths(marker.fileName, definition.fileName, /*ignoreCase*/ true) !== ts.Comparison.EqualTo || marker.position !== definition.textSpan.start) {
                     this.raiseError(`${testName} failed for definition ${endMarker} (${i}): expected ${marker.fileName} at ${marker.position}, got ${definition.fileName} at ${definition.textSpan.start}`);
                 }
             });

--- a/tests/cases/fourslash/server/declarationMapsGoToDefinitionSameNameDifferentDirectory.ts
+++ b/tests/cases/fourslash/server/declarationMapsGoToDefinitionSameNameDifferentDirectory.ts
@@ -1,0 +1,58 @@
+/// <reference path="../fourslash.ts" />
+// @Filename: BaseClass/Source.d.ts
+////declare class Control {
+////    constructor();
+////    /** this is a super var */
+////    myVar: boolean | 'yeah';
+////}
+//////# sourceMappingURL=Source.d.ts.map
+// @Filename: BaseClass/Source.d.ts.map
+////{"version":3,"file":"Source.d.ts","sourceRoot":"","sources":["Source.ts"],"names":[],"mappings":"AAAA,cAAM,OAAO;;IAIT,0BAA0B;IACnB,KAAK,EAAE,OAAO,GAAG,MAAM,CAAQ;CACzC"}
+// @Filename: BaseClass/Source.ts
+////class /*2*/Control{
+////    constructor(){
+////        return;
+////    }
+////    /** this is a super var */
+////    public /*4*/myVar: boolean | 'yeah' = true;
+////}
+// @Filename: tsbase.json
+////{
+////    "$schema": "http://json.schemastore.org/tsconfig",
+////    "compileOnSave": true,
+////    "compilerOptions": {
+////      "sourceMap": true,
+////      "declaration": true,
+////      "declarationMap": true
+////    }
+////  }
+// @Filename: buttonClass/tsconfig.json
+////{
+////    "extends": "../tsbase.json",
+////    "compilerOptions": {
+////      "outFile": "Source.js"
+////    },
+////    "files": [
+////      "Source.ts"
+////    ],
+////    "include": [
+////      "../BaseClass/Source.d.ts"
+////    ]
+////  }
+// @Filename: buttonClass/Source.ts
+////// I cannot F12 navigate to Control
+//////                   vvvvvvv
+////class Button extends [|/*1*/Control|] {
+////    public myFunction() {
+////        // I cannot F12 navigate to myVar
+////        //              vvvvv
+////        if (typeof this.[|/*3*/myVar|] === 'boolean') {
+////            this.myVar;
+////        } else {
+////            this.myVar.toLocaleUpperCase();
+////        }
+////    }
+////}
+
+verify.goToDefinition("1", "2");
+verify.goToDefinition("3", "4");


### PR DESCRIPTION
Since each project has a different program, we were looking for a `Source.ts` which _just so happened_ to _also_ exist in the current program (different file, same name - ah, the folly of using a relative path as an identifier). Now we lookup using the full `path` instead of the shorthand `fileName`.

Fixes #25792 and I believe #25662

