### PR TITLE
Ports #25908 to `release-3.0`

### DIFF
--- a/src/compiler/sourcemapDecoder.ts
+++ b/src/compiler/sourcemapDecoder.ts
@@ -98,10 +98,10 @@ namespace ts.sourcemaps {
 
         function getSourceFileLike(fileName: string, location: string): SourceFileLike | undefined {
             // Lookup file in program, if provided
-            const file = program && program.getSourceFile(fileName);
+            const path = toPath(fileName, location, host.getCanonicalFileName);
+            const file = program && program.getSourceFile(path);
             if (!file) {
                 // Otherwise check the cache (which may hit disk)
-                const path = toPath(fileName, location, host.getCanonicalFileName);
                 return fallbackCache.get(path);
             }
             return file;

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -709,7 +709,7 @@ namespace FourSlash {
 
             ts.zipWith(endMarkers, definitions, (endMarker, definition, i) => {
                 const marker = this.getMarkerByName(endMarker);
-                if (marker.fileName !== definition.fileName || marker.position !== definition.textSpan.start) {
+                if (ts.comparePaths(marker.fileName, definition.fileName, /*ignoreCase*/ true) !== ts.Comparison.EqualTo || marker.position !== definition.textSpan.start) {
                     this.raiseError(`${testName} failed for definition ${endMarker} (${i}): expected ${marker.fileName} at ${marker.position}, got ${definition.fileName} at ${definition.textSpan.start}`);
                 }
             });

--- a/tests/cases/fourslash/server/declarationMapsGoToDefinitionSameNameDifferentDirectory.ts
+++ b/tests/cases/fourslash/server/declarationMapsGoToDefinitionSameNameDifferentDirectory.ts
@@ -1,0 +1,58 @@
+/// <reference path="../fourslash.ts" />
+// @Filename: BaseClass/Source.d.ts
+////declare class Control {
+////    constructor();
+////    /** this is a super var */
+////    myVar: boolean | 'yeah';
+////}
+//////# sourceMappingURL=Source.d.ts.map
+// @Filename: BaseClass/Source.d.ts.map
+////{"version":3,"file":"Source.d.ts","sourceRoot":"","sources":["Source.ts"],"names":[],"mappings":"AAAA,cAAM,OAAO;;IAIT,0BAA0B;IACnB,KAAK,EAAE,OAAO,GAAG,MAAM,CAAQ;CACzC"}
+// @Filename: BaseClass/Source.ts
+////class /*2*/Control{
+////    constructor(){
+////        return;
+////    }
+////    /** this is a super var */
+////    public /*4*/myVar: boolean | 'yeah' = true;
+////}
+// @Filename: tsbase.json
+////{
+////    "$schema": "http://json.schemastore.org/tsconfig",
+////    "compileOnSave": true,
+////    "compilerOptions": {
+////      "sourceMap": true,
+////      "declaration": true,
+////      "declarationMap": true
+////    }
+////  }
+// @Filename: buttonClass/tsconfig.json
+////{
+////    "extends": "../tsbase.json",
+////    "compilerOptions": {
+////      "outFile": "Source.js"
+////    },
+////    "files": [
+////      "Source.ts"
+////    ],
+////    "include": [
+////      "../BaseClass/Source.d.ts"
+////    ]
+////  }
+// @Filename: buttonClass/Source.ts
+////// I cannot F12 navigate to Control
+//////                   vvvvvvv
+////class Button extends [|/*1*/Control|] {
+////    public myFunction() {
+////        // I cannot F12 navigate to myVar
+////        //              vvvvv
+////        if (typeof this.[|/*3*/myVar|] === 'boolean') {
+////            this.myVar;
+////        } else {
+////            this.myVar.toLocaleUpperCase();
+////        }
+////    }
+////}
+
+verify.goToDefinition("1", "2");
+verify.goToDefinition("3", "4");


### PR DESCRIPTION
Lookup files by resolved `Path` and not by `fileName` in sourcemapDecoder when querying program (#25908)

* Check if the file returned by the program actually refers to the same file as we intend

* Simplify

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Ports #25908 to `release-3.0`

