### PR TITLE
Handle PropertyAssignment in getCommentOwnerInfo

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -142,6 +142,16 @@ namespace ts {
         return undefined;
     }
 
+    export function forEachAncestor<T>(node: Node, callback: (n: Node) => T | undefined | "quit"): T | undefined {
+        while (true) {
+            const res = callback(node);
+            if (res === "quit") return undefined;
+            if (res !== undefined) return res;
+            if (isSourceFile(node)) return undefined;
+            node = node.parent;
+        }
+    }
+
     /**
      * Calls `callback` for each entry in the map, returning the first truthy result.
      * Use `map.forEach` instead for normal iteration.

--- a/tests/cases/fourslash/docCommentTemplateObjectLiteralMethods01.ts
+++ b/tests/cases/fourslash/docCommentTemplateObjectLiteralMethods01.ts
@@ -10,6 +10,8 @@ const multiLineOffset = 12;
 ////    }
 ////    /*1*/
 ////    [1 + 2 + 3 + Math.rand()](x: number, y: string, z = true) { }
+////    /*2*/
+////    m: function(a) {}
 ////}
 
 verify.docCommentTemplateAt("0", singleLineOffset, "/** */");
@@ -20,4 +22,10 @@ verify.docCommentTemplateAt("1", multiLineOffset,
      * @param x
      * @param y
      * @param z
+     */`);
+    
+verify.docCommentTemplateAt("2", multiLineOffset,
+   `/**
+     * 
+     * @param a
      */`);


### PR DESCRIPTION
Fixes #25783

View diff with https://github.com/Microsoft/TypeScript/pull/25911/files?w=1 -- needed to move the loop body to a function so it could call itself once (rather than recursing to the loop, which would infinitely recurse since the initializer's parent is the `PropertyAssignment`)