### PR TITLE
Fix circular constraint check

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4372,7 +4372,7 @@ namespace ts {
                 case TypeSystemPropertyName.ImmediateBaseConstraint:
                     return !!(<Type>target).immediateBaseConstraint;
             }
-            return Debug.fail("Unhandled TypeSystemPropertyName " + propertyName);
+            return Debug.assertNever(propertyName);
         }
 
         // Pop an entry from the type resolution stack and return its associated result value. The result value will
@@ -7879,6 +7879,7 @@ namespace ts {
             return inferences && getIntersectionType(inferences);
         }
 
+        /** This is a worker function. Use getConstraintOfTypeParameter which guards against circular constraints. */
         function getConstraintFromTypeParameter(typeParameter: TypeParameter): Type | undefined {
             if (!typeParameter.constraint) {
                 if (typeParameter.target) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -249,7 +249,7 @@ namespace ts {
                 getTypeOfSymbol,
                 getResolvedSymbol,
                 getIndexTypeOfStructuredType,
-                getConstraintFromTypeParameter,
+                getConstraintOfTypeParameter,
                 getFirstIdentifier,
             ),
             getAmbientModules,
@@ -6951,21 +6951,12 @@ namespace ts {
             return undefined;
         }
 
-        function getBaseConstraintOfInstantiableNonPrimitiveUnionOrIntersection(type: Type) {
+        function getBaseConstraintOfType(type: Type): Type | undefined {
             if (type.flags & (TypeFlags.InstantiableNonPrimitive | TypeFlags.UnionOrIntersection)) {
                 const constraint = getResolvedBaseConstraint(<InstantiableType | UnionOrIntersectionType>type);
-                if (constraint !== noConstraintType && constraint !== circularConstraintType) {
-                    return constraint;
-                }
+                return constraint !== noConstraintType && constraint !== circularConstraintType ? constraint : undefined;
             }
-        }
-
-        function getBaseConstraintOfType(type: Type): Type | undefined {
-            const constraint = getBaseConstraintOfInstantiableNonPrimitiveUnionOrIntersection(type);
-            if (!constraint && type.flags & TypeFlags.Index) {
-                return keyofConstraintType;
-            }
-            return constraint;
+            return type.flags & TypeFlags.Index ? keyofConstraintType : undefined;
         }
 
         /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4370,8 +4370,7 @@ namespace ts {
                 case TypeSystemPropertyName.ResolvedReturnType:
                     return !!(<Signature>target).resolvedReturnType;
                 case TypeSystemPropertyName.ImmediateBaseConstraint:
-                    const bc = (<Type>target).immediateBaseConstraint;
-                    return !!bc && bc !== circularConstraintType;
+                    return !!(<Type>target).immediateBaseConstraint;
             }
             return Debug.fail("Unhandled TypeSystemPropertyName " + propertyName);
         }
@@ -6987,30 +6986,26 @@ namespace ts {
          * circularly references the type variable.
          */
         function getResolvedBaseConstraint(type: InstantiableType | UnionOrIntersectionType): Type {
-            let circular: boolean | undefined;
-            if (!type.resolvedBaseConstraint) {
-                const constraint = getBaseConstraint(type);
-                type.resolvedBaseConstraint = circular ? circularConstraintType : getTypeWithThisArgument(constraint || noConstraintType, type);
+            return type.resolvedBaseConstraint ||
+                (type.resolvedBaseConstraint = getTypeWithThisArgument(getImmediateBaseConstraint(type), type));
+
+            function getImmediateBaseConstraint(t: Type): Type {
+                if (!t.immediateBaseConstraint) {
+                    if (!pushTypeResolution(t, TypeSystemPropertyName.ImmediateBaseConstraint)) {
+                        return circularConstraintType;
+                    }
+                    let result = computeBaseConstraint(getSimplifiedType(t));
+                    if (!popTypeResolution()) {
+                        result = circularConstraintType;
+                    }
+                    t.immediateBaseConstraint = result || noConstraintType;
+                }
+                return t.immediateBaseConstraint;
             }
-            return type.resolvedBaseConstraint;
 
             function getBaseConstraint(t: Type): Type | undefined {
-                if (t.immediateBaseConstraint) {
-                    return t.immediateBaseConstraint === noConstraintType ? undefined : t.immediateBaseConstraint;
-                }
-                if (!pushTypeResolution(t, TypeSystemPropertyName.ImmediateBaseConstraint)) {
-                    circular = true;
-                    t.immediateBaseConstraint = circularConstraintType;
-                    return undefined;
-                }
-                const result = computeBaseConstraint(getSimplifiedType(t));
-                if (!popTypeResolution()) {
-                    circular = true;
-                    t.immediateBaseConstraint = circularConstraintType;
-                    return undefined;
-                }
-                t.immediateBaseConstraint = !result ? noConstraintType : result;
-                return result;
+                const c = getImmediateBaseConstraint(t);
+                return c !== noConstraintType && c !== circularConstraintType ? c : undefined;
             }
 
             function computeBaseConstraint(t: Type): Type | undefined {

--- a/src/compiler/symbolWalker.ts
+++ b/src/compiler/symbolWalker.ts
@@ -9,7 +9,7 @@ namespace ts {
         getTypeOfSymbol: (sym: Symbol) => Type,
         getResolvedSymbol: (node: Node) => Symbol,
         getIndexTypeOfStructuredType: (type: Type, kind: IndexKind) => Type | undefined,
-        getConstraintFromTypeParameter: (typeParameter: TypeParameter) => Type | undefined,
+        getConstraintOfTypeParameter: (typeParameter: TypeParameter) => Type | undefined,
         getFirstIdentifier: (node: EntityNameOrEntityNameExpression) => Identifier) {
 
         return getSymbolWalker;
@@ -93,7 +93,7 @@ namespace ts {
             }
 
             function visitTypeParameter(type: TypeParameter): void {
-                visitType(getConstraintFromTypeParameter(type));
+                visitType(getConstraintOfTypeParameter(type));
             }
 
             function visitUnionOrIntersectionType(type: UnionOrIntersectionType): void {

--- a/tests/baselines/reference/circularIndexedAccessErrors.types
+++ b/tests/baselines/reference/circularIndexedAccessErrors.types
@@ -86,7 +86,7 @@ interface Foo {
 }
 
 function foo<T extends Foo | T["hello"]>() {
->foo : <T extends Foo | T["hello"]>() => void
+>foo : <T>() => void
 >T : T
 >Foo : Foo
 >T : T

--- a/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.types
+++ b/tests/baselines/reference/incorrectRecursiveMappedTypeConstraint.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts ===
 // #17847
 function sum<T extends { [P in T]: number }, K extends keyof T>(n: number, v: T, k: K) {
->sum : <T extends { [x: string]: number; }, K extends keyof T>(n: number, v: T, k: K) => void
+>sum : <T, K extends keyof T>(n: number, v: T, k: K) => void
 >T : T
 >P : P
 >T : T

--- a/tests/baselines/reference/typeParameterDirectlyConstrainedToItself.types
+++ b/tests/baselines/reference/typeParameterDirectlyConstrainedToItself.types
@@ -24,18 +24,18 @@ interface I2<T, U extends U> { }
 >U : U
 
 function f<T extends T>() { }
->f : <T extends T>() => void
+>f : <T>() => void
 >T : T
 >T : T
 
 function f2<T, U extends U>() { }
->f2 : <T, U extends U>() => void
+>f2 : <T, U>() => void
 >T : T
 >U : U
 >U : U
 
 var a: {
->a : { <T extends T>(): void; <T, U extends U>(): void; }
+>a : { <T>(): void; <T, U>(): void; }
 
     <T extends T>(): void;
 >T : T
@@ -48,14 +48,14 @@ var a: {
 }
 
 var b = <T extends T>() => { }
->b : <T extends T>() => void
-><T extends T>() => { } : <T extends T>() => void
+>b : <T>() => void
+><T extends T>() => { } : <T>() => void
 >T : T
 >T : T
 
 var b2 = <T, U extends U>() => { }
->b2 : <T, U extends U>() => void
-><T, U extends U>() => { } : <T, U extends U>() => void
+>b2 : <T, U>() => void
+><T, U extends U>() => { } : <T, U>() => void
 >T : T
 >U : U
 >U : U

--- a/tests/baselines/reference/typeParameterHasSelfAsConstraint.types
+++ b/tests/baselines/reference/typeParameterHasSelfAsConstraint.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/typeParameterHasSelfAsConstraint.ts ===
 function foo<T extends T>(x: T): number {
->foo : <T extends T>(x: T) => number
+>foo : <T>(x: T) => number
 >T : T
 >T : T
 >x : T

--- a/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.errors.txt
+++ b/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.errors.txt
@@ -25,9 +25,10 @@ tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterInd
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(16,47): error TS2313: Type parameter 'V' has a circular constraint.
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(18,32): error TS2313: Type parameter 'T' has a circular constraint.
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(18,45): error TS2313: Type parameter 'V' has a circular constraint.
+tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(23,24): error TS2313: Type parameter 'S' has a circular constraint.
 
 
-==== tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts (27 errors) ====
+==== tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts (28 errors) ====
     class C<U extends T, T extends U> { }
                       ~
 !!! error TS2313: Type parameter 'U' has a circular constraint.
@@ -100,3 +101,11 @@ tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterInd
 !!! error TS2313: Type parameter 'T' has a circular constraint.
                                                 ~
 !!! error TS2313: Type parameter 'V' has a circular constraint.
+    
+    // Repro from #25740
+    
+    type Foo<T> = [T] extends [number] ? {} : {};
+    function foo<S extends Foo<S>>() {}
+                           ~~~~~~
+!!! error TS2313: Type parameter 'S' has a circular constraint.
+    

--- a/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.errors.txt
+++ b/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.errors.txt
@@ -23,12 +23,11 @@ tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterInd
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(16,21): error TS2313: Type parameter 'T' has a circular constraint.
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(16,34): error TS2313: Type parameter 'U' has a circular constraint.
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(16,47): error TS2313: Type parameter 'V' has a circular constraint.
-tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(18,19): error TS2313: Type parameter 'U' has a circular constraint.
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(18,32): error TS2313: Type parameter 'T' has a circular constraint.
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(18,45): error TS2313: Type parameter 'V' has a circular constraint.
 
 
-==== tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts (28 errors) ====
+==== tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts (27 errors) ====
     class C<U extends T, T extends U> { }
                       ~
 !!! error TS2313: Type parameter 'U' has a circular constraint.
@@ -97,8 +96,6 @@ tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterInd
 !!! error TS2313: Type parameter 'V' has a circular constraint.
     
     class D<U extends T, T extends V, V extends T> { }
-                      ~
-!!! error TS2313: Type parameter 'U' has a circular constraint.
                                    ~
 !!! error TS2313: Type parameter 'T' has a circular constraint.
                                                 ~

--- a/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.js
+++ b/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.js
@@ -18,6 +18,12 @@ var b2 = <T extends U, U extends V, V extends T>() => { }
 
 class D<U extends T, T extends V, V extends T> { }
 
+// Repro from #25740
+
+type Foo<T> = [T] extends [number] ? {} : {};
+function foo<S extends Foo<S>>() {}
+
+
 //// [typeParameterIndirectlyConstrainedToItself.js]
 var C = /** @class */ (function () {
     function C() {
@@ -39,3 +45,4 @@ var D = /** @class */ (function () {
     }
     return D;
 }());
+function foo() { }

--- a/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.symbols
+++ b/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.symbols
@@ -90,3 +90,16 @@ class D<U extends T, T extends V, V extends T> { }
 >V : Symbol(V, Decl(typeParameterIndirectlyConstrainedToItself.ts, 17, 33))
 >T : Symbol(T, Decl(typeParameterIndirectlyConstrainedToItself.ts, 17, 20))
 
+// Repro from #25740
+
+type Foo<T> = [T] extends [number] ? {} : {};
+>Foo : Symbol(Foo, Decl(typeParameterIndirectlyConstrainedToItself.ts, 17, 50))
+>T : Symbol(T, Decl(typeParameterIndirectlyConstrainedToItself.ts, 21, 9))
+>T : Symbol(T, Decl(typeParameterIndirectlyConstrainedToItself.ts, 21, 9))
+
+function foo<S extends Foo<S>>() {}
+>foo : Symbol(foo, Decl(typeParameterIndirectlyConstrainedToItself.ts, 21, 45))
+>S : Symbol(S, Decl(typeParameterIndirectlyConstrainedToItself.ts, 22, 13))
+>Foo : Symbol(Foo, Decl(typeParameterIndirectlyConstrainedToItself.ts, 17, 50))
+>S : Symbol(S, Decl(typeParameterIndirectlyConstrainedToItself.ts, 22, 13))
+

--- a/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.types
+++ b/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.types
@@ -92,3 +92,16 @@ class D<U extends T, T extends V, V extends T> { }
 >V : V
 >T : T
 
+// Repro from #25740
+
+type Foo<T> = [T] extends [number] ? {} : {};
+>Foo : Foo<T>
+>T : T
+>T : T
+
+function foo<S extends Foo<S>>() {}
+>foo : <S>() => void
+>S : S
+>Foo : Foo<T>
+>S : S
+

--- a/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.types
+++ b/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.types
@@ -32,14 +32,14 @@ interface I2<T extends U, U extends V, V extends T> { }
 >T : T
 
 function f<U extends T, T extends U>() { }
->f : <U extends T, T extends U>() => void
+>f : <U, T>() => void
 >U : U
 >T : T
 >T : T
 >U : U
 
 function f2<T extends U, U extends V, V extends T>() { }
->f2 : <T extends U, U extends V, V extends T>() => void
+>f2 : <T, U, V>() => void
 >T : T
 >U : U
 >U : U
@@ -48,7 +48,7 @@ function f2<T extends U, U extends V, V extends T>() { }
 >T : T
 
 var a: {
->a : { <U extends T, T extends U>(): void; <T extends U, U extends V, V extends T>(): void; }
+>a : { <U, T>(): void; <T, U, V>(): void; }
 
     <U extends T, T extends U>(): void;
 >U : U
@@ -66,16 +66,16 @@ var a: {
 }
 
 var b = <U extends T, T extends U>() => { }
->b : <U extends T, T extends U>() => void
-><U extends T, T extends U>() => { } : <U extends T, T extends U>() => void
+>b : <U, T>() => void
+><U extends T, T extends U>() => { } : <U, T>() => void
 >U : U
 >T : T
 >T : T
 >U : U
 
 var b2 = <T extends U, U extends V, V extends T>() => { }
->b2 : <T extends U, U extends V, V extends T>() => void
-><T extends U, U extends V, V extends T>() => { } : <T extends U, U extends V, V extends T>() => void
+>b2 : <T, U, V>() => void
+><T extends U, U extends V, V extends T>() => { } : <T, U, V>() => void
 >T : T
 >U : U
 >U : U

--- a/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts
+++ b/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts
@@ -16,3 +16,8 @@ var b = <U extends T, T extends U>() => { }
 var b2 = <T extends U, U extends V, V extends T>() => { }
 
 class D<U extends T, T extends V, V extends T> { }
+
+// Repro from #25740
+
+type Foo<T> = [T] extends [number] ? {} : {};
+function foo<S extends Foo<S>>() {}


### PR DESCRIPTION
This PR ensures that we consistently call `getConstraintOfTypeParameter` to obtain type parameter constraints. The `getConstraintOfTypeParameter` method protects against circular constraints, unlike the lower level `getConstraintFromTypeParameter` helper function.

Fixes #25740.