### PR TITLE
Simplify and inline getPropertySymbolsFromType

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -68,11 +68,10 @@ namespace ts.GoToDefinition {
         //      bar<Test>(({pr/*goto*/op1})=>{});
         if (isPropertyName(node) && isBindingElement(parent) && isObjectBindingPattern(parent.parent) &&
             (node === (parent.propertyName || parent.name))) {
+            const name = getNameFromPropertyName(node);
             const type = typeChecker.getTypeAtLocation(parent.parent);
-            const propSymbols = getPropertySymbolsFromType(type, node);
-            if (propSymbols) {
-                return flatMap(propSymbols, propSymbol => getDefinitionFromSymbol(typeChecker, propSymbol, node));
-            }
+            const propSymbols = name === undefined ? emptyArray : mapDefined(type.isUnion() ? type.types : [type], t => t.getProperty(name));
+            return flatMap(propSymbols, propSymbol => getDefinitionFromSymbol(typeChecker, propSymbol, node));
         }
 
         // If the current location we want to find its definition is in an object literal, try to get the contextual type for the

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -70,8 +70,10 @@ namespace ts.GoToDefinition {
             (node === (parent.propertyName || parent.name))) {
             const name = getNameFromPropertyName(node);
             const type = typeChecker.getTypeAtLocation(parent.parent);
-            const propSymbols = name === undefined ? emptyArray : mapDefined(type.isUnion() ? type.types : [type], t => t.getProperty(name));
-            return flatMap(propSymbols, propSymbol => getDefinitionFromSymbol(typeChecker, propSymbol, node));
+            return name === undefined ? emptyArray : flatMap(type.isUnion() ? type.types : [type], t => {
+                const prop = t.getProperty(name);
+                return prop && getDefinitionFromSymbol(typeChecker, prop, node);
+            });
         }
 
         // If the current location we want to find its definition is in an object literal, try to get the contextual type for the

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2230,30 +2230,6 @@ namespace ts {
         return discriminatedPropertySymbols;
     }
 
-    /* @internal */
-    export function getPropertySymbolsFromType(type: Type, propName: PropertyName) {
-        const name = unescapeLeadingUnderscores(getTextOfPropertyName(propName));
-        if (name && type) {
-            const result: Symbol[] = [];
-            const symbol = type.getProperty(name);
-            if (type.flags & TypeFlags.Union) {
-                forEach((<UnionType>type).types, t => {
-                    const symbol = t.getProperty(name);
-                    if (symbol) {
-                        result.push(symbol);
-                    }
-                });
-                return result;
-            }
-
-            if (symbol) {
-                result.push(symbol);
-                return result;
-            }
-        }
-        return undefined;
-    }
-
     function isArgumentOfElementAccessExpression(node: Node) {
         return node &&
             node.parent &&


### PR DESCRIPTION
This function is only called in one place and can be simplified a lot.