### PR TITLE
When json module is not found, include enabling --resolveJsonModule might help.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2220,6 +2220,12 @@ namespace ts {
                         const diag = Diagnostics.An_import_path_cannot_end_with_a_0_extension_Consider_importing_1_instead;
                         error(errorNode, diag, tsExtension, removeExtension(moduleReference, tsExtension));
                     }
+                    else if (!compilerOptions.resolveJsonModule &&
+                        fileExtensionIs(moduleReference, Extension.Json) &&
+                        getEmitModuleResolutionKind(compilerOptions) === ModuleResolutionKind.NodeJs &&
+                        getEmitModuleKind(compilerOptions) === ModuleKind.CommonJS) {
+                        error(errorNode, Diagnostics.Cannot_find_module_0_Consider_using_resolveJsonModule_to_import_module_with_json_extension, moduleReference);
+                    }
                     else {
                         error(errorNode, moduleNotFoundError, moduleReference);
                     }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2421,6 +2421,10 @@
         "category": "Error",
         "code": 2730
     },
+    "Cannot find module '{0}'. Consider using '--resolveJsonModule' to import module with '.json' extension": {
+        "category": "Error",
+        "code": 2731
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/requireOfJsonFileWithoutResolveJsonModule.errors.txt
+++ b/tests/baselines/reference/requireOfJsonFileWithoutResolveJsonModule.errors.txt
@@ -1,15 +1,15 @@
-tests/cases/compiler/file1.ts(1,21): error TS2307: Cannot find module './b.json'.
-tests/cases/compiler/file1.ts(3,21): error TS2307: Cannot find module './b.json'.
+tests/cases/compiler/file1.ts(1,21): error TS2731: Cannot find module './b.json'. Consider using '--resolveJsonModule' to import module with '.json' extension
+tests/cases/compiler/file1.ts(3,21): error TS2731: Cannot find module './b.json'. Consider using '--resolveJsonModule' to import module with '.json' extension
 
 
 ==== tests/cases/compiler/file1.ts (2 errors) ====
     import b1 = require('./b.json'); // error
                         ~~~~~~~~~~
-!!! error TS2307: Cannot find module './b.json'.
+!!! error TS2731: Cannot find module './b.json'. Consider using '--resolveJsonModule' to import module with '.json' extension
     let x = b1.a;
     import b2 = require('./b.json'); // error
                         ~~~~~~~~~~
-!!! error TS2307: Cannot find module './b.json'.
+!!! error TS2731: Cannot find module './b.json'. Consider using '--resolveJsonModule' to import module with '.json' extension
     if (x) {
         let b = b2.b;
         x = (b1.b === b);


### PR DESCRIPTION
Fixes #25722
