### PR TITLE
Minor refactor in goToTypeDefinition

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -136,15 +136,8 @@ namespace ts.GoToDefinition {
 
         const symbol = typeChecker.getSymbolAtLocation(node);
         const type = symbol && typeChecker.getTypeOfSymbolAtLocation(symbol, node);
-        if (!type) {
-            return undefined;
-        }
-
-        if (type.isUnion() && !(type.flags & TypeFlags.Enum)) {
-            return flatMap(type.types, t => t.symbol && getDefinitionFromSymbol(typeChecker, t.symbol, node));
-        }
-
-        return type.symbol && getDefinitionFromSymbol(typeChecker, type.symbol, node);
+        return type && flatMap(type.isUnion() && !(type.flags & TypeFlags.Enum) ? type.types : [type], t =>
+            t.symbol && getDefinitionFromSymbol(typeChecker, t.symbol, node));
     }
 
     export function getDefinitionAndBoundSpan(program: Program, sourceFile: SourceFile, position: number): DefinitionInfoAndBoundSpan | undefined {
@@ -230,7 +223,7 @@ namespace ts.GoToDefinition {
         }
 
         function getCallSignatureDefinition(): DefinitionInfo[] | undefined {
-            return isCallExpressionTarget(node) || isNewExpressionTarget(node) || isNameOfFunctionDeclaration(node)
+            return isCallOrNewExpressionTarget(node) || isNameOfFunctionDeclaration(node)
                 ? getSignatureDefinition(symbol.declarations, /*selectConstructors*/ false)
                 : undefined;
         }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -194,16 +194,20 @@ namespace ts {
     }
 
     export function isCallExpressionTarget(node: Node): boolean {
-        return isCallOrNewExpressionTarget(node, SyntaxKind.CallExpression);
+        return isCallOrNewExpressionTargetWorker(node, isCallExpression);
     }
 
     export function isNewExpressionTarget(node: Node): boolean {
-        return isCallOrNewExpressionTarget(node, SyntaxKind.NewExpression);
+        return isCallOrNewExpressionTargetWorker(node, isNewExpression);
     }
 
-    function isCallOrNewExpressionTarget(node: Node, kind: SyntaxKind): boolean {
+    export function isCallOrNewExpressionTarget(node: Node): boolean {
+        return isCallOrNewExpressionTargetWorker(node, isCallOrNewExpression);
+    }
+
+    function isCallOrNewExpressionTargetWorker<T extends CallExpression | NewExpression>(node: Node, pred: (node: Node) => node is T): boolean {
         const target = climbPastPropertyAccess(node);
-        return !!target && !!target.parent && target.parent.kind === kind && (<CallExpression>target.parent).expression === target;
+        return !!target && !!target.parent && pred(target.parent) && target.parent.expression === target;
     }
 
     export function climbPastPropertyAccess(node: Node) {


### PR DESCRIPTION
Combine two identical cases calling `getDefinitionFromSymbol`, and combine `isCallExpressionTarget` and `isNewExpressionTarget` which both call into the same function anyway.