### PR TITLE
 Fix #25954 - Always retain export modifier if default modifier is present

### DIFF
--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -1164,6 +1164,17 @@ namespace ts {
             return false;
         }
 
+        function isScopeMarker(node: Node) {
+            return isExportAssignment(node) || isExportDeclaration(node);
+        }
+
+        function hasScopeMarker(node: Node) {
+            if (isModuleBlock(node)) {
+                return some(node.statements, isScopeMarker);
+            }
+            return false;
+        }
+
         function ensureModifiers(node: Node, privateDeclaration?: boolean): ReadonlyArray<Modifier> | undefined {
             const currentFlags = getModifierFlags(node);
             const newFlags = ensureModifierFlags(node, privateDeclaration);
@@ -1178,7 +1189,7 @@ namespace ts {
             let additions = (needsDeclare && !isAlwaysType(node)) ? ModifierFlags.Ambient : ModifierFlags.None;
             const parentIsFile = node.parent.kind === SyntaxKind.SourceFile;
             if (!parentIsFile || (isBundledEmit && parentIsFile && isExternalModule(node.parent as SourceFile))) {
-                mask ^= ((privateDeclaration || (isBundledEmit && parentIsFile) ? 0 : ModifierFlags.Export) | ModifierFlags.Ambient);
+                mask ^= ((privateDeclaration || (isBundledEmit && parentIsFile) || hasScopeMarker(node.parent) ? 0 : ModifierFlags.Export) | ModifierFlags.Ambient);
                 additions = ModifierFlags.None;
             }
             return maskModifierFlags(node, mask, additions);

--- a/tests/baselines/reference/declarationEmitAmdModuleDefault.js
+++ b/tests/baselines/reference/declarationEmitAmdModuleDefault.js
@@ -1,0 +1,21 @@
+//// [declarationEmitAmdModuleDefault.ts]
+export default class DefaultClass { }
+
+//// [file.js]
+define("declarationEmitAmdModuleDefault", ["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+    var DefaultClass = /** @class */ (function () {
+        function DefaultClass() {
+        }
+        return DefaultClass;
+    }());
+    exports["default"] = DefaultClass;
+});
+
+
+//// [file.d.ts]
+declare module "declarationEmitAmdModuleDefault" {
+    export default class DefaultClass {
+    }
+}

--- a/tests/baselines/reference/declarationEmitAmdModuleDefault.symbols
+++ b/tests/baselines/reference/declarationEmitAmdModuleDefault.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/declarationEmitAmdModuleDefault.ts ===
+export default class DefaultClass { }
+>DefaultClass : Symbol(DefaultClass, Decl(declarationEmitAmdModuleDefault.ts, 0, 0))
+

--- a/tests/baselines/reference/declarationEmitAmdModuleDefault.types
+++ b/tests/baselines/reference/declarationEmitAmdModuleDefault.types
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/declarationEmitAmdModuleDefault.ts ===
+export default class DefaultClass { }
+>DefaultClass : DefaultClass
+

--- a/tests/baselines/reference/declarationEmitModuleWithScopeMarker.js
+++ b/tests/baselines/reference/declarationEmitModuleWithScopeMarker.js
@@ -1,0 +1,25 @@
+//// [declarationEmitModuleWithScopeMarker.ts]
+declare module "bar" {
+    var before: typeof func;
+
+    export function normal(): void;
+
+    export default function func(): typeof func;
+
+    var after: typeof func;
+
+    export {}
+}
+
+
+//// [declarationEmitModuleWithScopeMarker.js]
+
+
+//// [declarationEmitModuleWithScopeMarker.d.ts]
+declare module "bar" {
+    var before: typeof func;
+    export function normal(): void;
+    export default function func(): typeof func;
+    var after: typeof func;
+    export {};
+}

--- a/tests/baselines/reference/declarationEmitModuleWithScopeMarker.symbols
+++ b/tests/baselines/reference/declarationEmitModuleWithScopeMarker.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/declarationEmitModuleWithScopeMarker.ts ===
+declare module "bar" {
+>"bar" : Symbol("bar", Decl(declarationEmitModuleWithScopeMarker.ts, 0, 0))
+
+    var before: typeof func;
+>before : Symbol(before, Decl(declarationEmitModuleWithScopeMarker.ts, 1, 7))
+>func : Symbol(func, Decl(declarationEmitModuleWithScopeMarker.ts, 3, 35))
+
+    export function normal(): void;
+>normal : Symbol(normal, Decl(declarationEmitModuleWithScopeMarker.ts, 1, 28))
+
+    export default function func(): typeof func;
+>func : Symbol(func, Decl(declarationEmitModuleWithScopeMarker.ts, 3, 35))
+>func : Symbol(func, Decl(declarationEmitModuleWithScopeMarker.ts, 3, 35))
+
+    var after: typeof func;
+>after : Symbol(after, Decl(declarationEmitModuleWithScopeMarker.ts, 7, 7))
+>func : Symbol(func, Decl(declarationEmitModuleWithScopeMarker.ts, 3, 35))
+
+    export {}
+}
+

--- a/tests/baselines/reference/declarationEmitModuleWithScopeMarker.types
+++ b/tests/baselines/reference/declarationEmitModuleWithScopeMarker.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/declarationEmitModuleWithScopeMarker.ts ===
+declare module "bar" {
+>"bar" : typeof import("bar")
+
+    var before: typeof func;
+>before : () => typeof func
+>func : () => typeof func
+
+    export function normal(): void;
+>normal : () => void
+
+    export default function func(): typeof func;
+>func : () => typeof func
+>func : () => typeof func
+
+    var after: typeof func;
+>after : () => typeof func
+>func : () => typeof func
+
+    export {}
+}
+

--- a/tests/baselines/reference/es5ExportDefaultClassDeclaration4.js
+++ b/tests/baselines/reference/es5ExportDefaultClassDeclaration4.js
@@ -19,7 +19,7 @@ declare module "foo" {
 //// [es5ExportDefaultClassDeclaration4.d.ts]
 declare module "foo" {
     var before: C;
-    class C {
+    export default class C {
         method(): C;
     }
     var after: C;

--- a/tests/baselines/reference/es5ExportDefaultFunctionDeclaration4.js
+++ b/tests/baselines/reference/es5ExportDefaultFunctionDeclaration4.js
@@ -13,6 +13,6 @@ declare module "bar" {
 //// [es5ExportDefaultFunctionDeclaration4.d.ts]
 declare module "bar" {
     var before: typeof func;
-    function func(): typeof func;
+    export default function func(): typeof func;
     var after: typeof func;
 }

--- a/tests/baselines/reference/exportDeclarationInInternalModule.js
+++ b/tests/baselines/reference/exportDeclarationInInternalModule.js
@@ -72,7 +72,7 @@ declare module Aaa {
     }
 }
 declare module Bbb {
-    class SomeType {
+    export class SomeType {
     }
     export * from Aaa;
 }

--- a/tests/cases/compiler/declarationEmitAmdModuleDefault.ts
+++ b/tests/cases/compiler/declarationEmitAmdModuleDefault.ts
@@ -1,0 +1,4 @@
+// @declaration: true
+// @module: amd
+// @outFile: file.js
+export default class DefaultClass { }

--- a/tests/cases/compiler/declarationEmitModuleWithScopeMarker.ts
+++ b/tests/cases/compiler/declarationEmitModuleWithScopeMarker.ts
@@ -1,0 +1,15 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+declare module "bar" {
+    var before: typeof func;
+
+    export function normal(): void;
+
+    export default function func(): typeof func;
+
+    var after: typeof func;
+
+    export {}
+}


### PR DESCRIPTION
Since a non-exported default is syntactically invalid (and simply eliding the `default` as we do now is also wrong), despite the implied export context.

Also spotted and fixed a bug where in declarations for ambient module declarations, in our zeal to trim off excess modifiers, we were ignoring the presence of a scope marker (`export {}` or `export default expr`), which could cause us to emit a declaration with the incorrect members visible. That, too, is now fixed.

Fixes #25954

