### PR TITLE
Remove extraneous `const`, fixing #25714

### DIFF
--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -154,7 +154,7 @@ namespace ts {
 
             if (node.kind === SyntaxKind.Bundle) {
                 isBundledEmit = true;
-                const refs = createMap<SourceFile>();
+                refs = createMap<SourceFile>();
                 let hasNoDefaultLib = false;
                 const bundle = createBundle(map(node.sourceFiles,
                     sourceFile => {

--- a/tests/baselines/reference/declarationEmitBundleWithAmbientReferences.js
+++ b/tests/baselines/reference/declarationEmitBundleWithAmbientReferences.js
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/declarationEmitBundleWithAmbientReferences.ts] ////
+
+//// [lib.d.ts]
+declare module "lib/result" {
+    export type Result<E extends Error, T> = (E & Failure<E>) | (T & Success<T>);
+    export interface Failure<E extends Error> { }
+    export interface Success<T> { }
+}
+
+//// [datastore_result.ts]
+import { Result } from "lib/result";
+
+export type T<T> = Result<Error, T>;
+
+//// [conditional_directive_field.ts]
+import * as DatastoreResult from "src/datastore_result";
+
+export const build = (): DatastoreResult.T<string> => {
+	return null;
+};
+
+
+//// [datastore.bundle.js]
+define("datastore_result", ["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+});
+define("conditional_directive_field", ["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+    exports.build = function () {
+        return null;
+    };
+});
+
+
+//// [datastore.bundle.d.ts]
+/// <reference path="../lib/lib.d.ts" />
+declare module "datastore_result" {
+    import { Result } from "lib/result";
+    export type T<T> = Result<Error, T>;
+}
+declare module "conditional_directive_field" {
+    export const build: () => import("lib/result").Result<Error, string>;
+}

--- a/tests/baselines/reference/declarationEmitBundleWithAmbientReferences.symbols
+++ b/tests/baselines/reference/declarationEmitBundleWithAmbientReferences.symbols
@@ -1,0 +1,49 @@
+=== tests/cases/compiler/lib/lib.d.ts ===
+declare module "lib/result" {
+>"lib/result" : Symbol("lib/result", Decl(lib.d.ts, --, --))
+
+    export type Result<E extends Error, T> = (E & Failure<E>) | (T & Success<T>);
+>Result : Symbol(Result, Decl(lib.d.ts, --, --))
+>E : Symbol(E, Decl(lib.d.ts, --, --))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(lib.d.ts, --, --))
+>E : Symbol(E, Decl(lib.d.ts, --, --))
+>Failure : Symbol(Failure, Decl(lib.d.ts, --, --))
+>E : Symbol(E, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(lib.d.ts, --, --))
+>Success : Symbol(Success, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(lib.d.ts, --, --))
+
+    export interface Failure<E extends Error> { }
+>Failure : Symbol(Failure, Decl(lib.d.ts, --, --))
+>E : Symbol(E, Decl(lib.d.ts, --, --))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    export interface Success<T> { }
+>Success : Symbol(Success, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(lib.d.ts, --, --))
+}
+
+=== tests/cases/compiler/src/datastore_result.ts ===
+import { Result } from "lib/result";
+>Result : Symbol(Result, Decl(datastore_result.ts, 0, 8))
+
+export type T<T> = Result<Error, T>;
+>T : Symbol(T, Decl(datastore_result.ts, 0, 36))
+>T : Symbol(T, Decl(datastore_result.ts, 2, 14))
+>Result : Symbol(Result, Decl(datastore_result.ts, 0, 8))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(datastore_result.ts, 2, 14))
+
+=== tests/cases/compiler/src/conditional_directive_field.ts ===
+import * as DatastoreResult from "src/datastore_result";
+>DatastoreResult : Symbol(DatastoreResult, Decl(conditional_directive_field.ts, 0, 6))
+
+export const build = (): DatastoreResult.T<string> => {
+>build : Symbol(build, Decl(conditional_directive_field.ts, 2, 12))
+>DatastoreResult : Symbol(DatastoreResult, Decl(conditional_directive_field.ts, 0, 6))
+>T : Symbol(DatastoreResult.T, Decl(datastore_result.ts, 0, 36))
+
+	return null;
+};
+

--- a/tests/baselines/reference/declarationEmitBundleWithAmbientReferences.types
+++ b/tests/baselines/reference/declarationEmitBundleWithAmbientReferences.types
@@ -1,0 +1,52 @@
+=== tests/cases/compiler/lib/lib.d.ts ===
+declare module "lib/result" {
+>"lib/result" : typeof import("lib/result")
+
+    export type Result<E extends Error, T> = (E & Failure<E>) | (T & Success<T>);
+>Result : Result<E, T>
+>E : E
+>Error : Error
+>T : T
+>E : E
+>Failure : Failure<E>
+>E : E
+>T : T
+>Success : Success<T>
+>T : T
+
+    export interface Failure<E extends Error> { }
+>Failure : Failure<E>
+>E : E
+>Error : Error
+
+    export interface Success<T> { }
+>Success : Success<T>
+>T : T
+}
+
+=== tests/cases/compiler/src/datastore_result.ts ===
+import { Result } from "lib/result";
+>Result : any
+
+export type T<T> = Result<Error, T>;
+>T : Result<Error, T>
+>T : T
+>Result : Result<E, T>
+>Error : Error
+>T : T
+
+=== tests/cases/compiler/src/conditional_directive_field.ts ===
+import * as DatastoreResult from "src/datastore_result";
+>DatastoreResult : typeof DatastoreResult
+
+export const build = (): DatastoreResult.T<string> => {
+>build : () => import("lib/result").Result<Error, string>
+>(): DatastoreResult.T<string> => {	return null;} : () => import("lib/result").Result<Error, string>
+>DatastoreResult : any
+>T : import("lib/result").Result<Error, T>
+
+	return null;
+>null : null
+
+};
+

--- a/tests/cases/compiler/declarationEmitBundleWithAmbientReferences.ts
+++ b/tests/cases/compiler/declarationEmitBundleWithAmbientReferences.ts
@@ -1,0 +1,22 @@
+// @noResolve: true
+// @declaration: true
+// @module: amd
+// @outFile: tests/cases/compiler/out/datastore.bundle.js
+// @filename: lib/lib.d.ts
+declare module "lib/result" {
+    export type Result<E extends Error, T> = (E & Failure<E>) | (T & Success<T>);
+    export interface Failure<E extends Error> { }
+    export interface Success<T> { }
+}
+
+// @filename: src/datastore_result.ts
+import { Result } from "lib/result";
+
+export type T<T> = Result<Error, T>;
+
+// @filename: src/conditional_directive_field.ts
+import * as DatastoreResult from "src/datastore_result";
+
+export const build = (): DatastoreResult.T<string> => {
+	return null;
+};


### PR DESCRIPTION
A `const` redeclaration of the refs collection in a child scope in the declaration transformer was shadowing the (transformation-wide scoped) declaration it was actually supposed to assign to in the case of bundled emit.

Fixes #25714

