### PR TITLE
allow BindingPattern in BindingRestElement

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29188,10 +29188,6 @@ namespace ts {
                 }
                 checkGrammarForDisallowedTrailingComma(elements, Diagnostics.A_rest_parameter_or_binding_pattern_may_not_have_a_trailing_comma);
 
-                if (node.name.kind === SyntaxKind.ArrayBindingPattern || node.name.kind === SyntaxKind.ObjectBindingPattern) {
-                    return grammarErrorOnNode(node.name, Diagnostics.A_rest_element_cannot_contain_a_binding_pattern);
-                }
-
                 if (node.propertyName) {
                     return grammarErrorOnNode(node.name, Diagnostics.A_rest_element_cannot_have_a_property_name);
                 }

--- a/tests/baselines/reference/restElementWithBindingPattern.errors.txt
+++ b/tests/baselines/reference/restElementWithBindingPattern.errors.txt
@@ -1,7 +1,0 @@
-tests/cases/conformance/es6/destructuring/restElementWithBindingPattern.ts(1,9): error TS2501: A rest element cannot contain a binding pattern.
-
-
-==== tests/cases/conformance/es6/destructuring/restElementWithBindingPattern.ts (1 errors) ====
-    var [...[a, b]] = [0, 1];
-            ~~~~~~
-!!! error TS2501: A rest element cannot contain a binding pattern.

--- a/tests/baselines/reference/restElementWithBindingPattern2.errors.txt
+++ b/tests/baselines/reference/restElementWithBindingPattern2.errors.txt
@@ -1,10 +1,7 @@
-tests/cases/conformance/es6/destructuring/restElementWithBindingPattern2.ts(1,9): error TS2501: A rest element cannot contain a binding pattern.
 tests/cases/conformance/es6/destructuring/restElementWithBindingPattern2.ts(1,16): error TS2459: Type 'number[]' has no property 'b' and no string index signature.
 
 
-==== tests/cases/conformance/es6/destructuring/restElementWithBindingPattern2.ts (2 errors) ====
+==== tests/cases/conformance/es6/destructuring/restElementWithBindingPattern2.ts (1 errors) ====
     var [...{0: a, b }] = [0, 1];
-            ~~~~~~~~~~
-!!! error TS2501: A rest element cannot contain a binding pattern.
                    ~
 !!! error TS2459: Type 'number[]' has no property 'b' and no string index signature.


### PR DESCRIPTION
Part of #6275

Downlevel emit already works as expected. Those baselines were not changed.
Just to make sure, here's an example in the playground: https://agentcooper.github.io/typescript-play/?target=1#code/CYUwxgNghgTiAEEQBd7IK4AckC54G0BnZGASwDsBzAGnnPQFsAjEGWpgew6SnIF0A3ACgkqfFFoA6afiZTpAbwAMeMAF8+feAF40WJAKA 