### PR TITLE
Add Parameters type to core lib

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1379,6 +1379,11 @@ type Extract<T, U> = T extends U ? T : never;
 type NonNullable<T> = T extends null | undefined ? never : T;
 
 /**
+ * Obtain the parameters type of a function type
+ */
+type Parameters<T> = T extends (... args: infer T) => any ? T : never; 
+
+/**
  * Obtain the return type of a function type
  */
 type ReturnType<T extends (...args: any[]) => any> = T extends (...args: any[]) => infer R ? R : any;


### PR DESCRIPTION
Here: https://github.com/Microsoft/TypeScript/issues/26019#issuecomment-408539886 
I was recommended by @bterlson to add Parameters type to my lib.d.ts as well as ReturnType. When doing so, I found out that ReturnType is already lives in core lib.es5.d.ts. In my case I use Parameters much more than ReturnType, and I guess some other people do as well. So I thought both said types should be in core lib.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #26019

Sorry, no new tests/docs (I am afraid I am not able for writing good ones), but the code's author is Anders Hejlsberg himself :-)
