### PR TITLE
Improved mapped type support for arrays and tuples

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8432,6 +8432,10 @@ namespace ts {
             return createTypeFromGenericGlobalType(globalArrayType, [elementType]);
         }
 
+        function createReadonlyArrayType(elementType: Type): ObjectType {
+            return createTypeFromGenericGlobalType(globalReadonlyArrayType, [elementType]);
+        }
+
         function getTypeFromArrayTypeNode(node: ArrayTypeNode): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
@@ -10087,11 +10091,16 @@ namespace ts {
         }
 
         function instantiateMappedType(type: MappedType, mapper: TypeMapper): Type {
-            // Check if we have a homomorphic mapped type, i.e. a type of the form { [P in keyof T]: X } for some
-            // type variable T. If so, the mapped type is distributive over a union type and when T is instantiated
-            // to a union type A | B, we produce { [P in keyof A]: X } | { [P in keyof B]: X }. Furthermore, for
-            // homomorphic mapped types we leave primitive types alone. For example, when T is instantiated to a
-            // union type A | undefined, we produce { [P in keyof A]: X } | undefined.
+            // For a momomorphic mapped type { [P in keyof T]: X }, where T is some type variable, the mapping
+            // operation depends on T as follows:
+            // * If T is a primitive type no mapping is performed and the result is simply T.
+            // * If T is a union type we distribute the mapped type over the union.
+            // * If T is an array we map to an array where the element type has been transformed.
+            // * If T is a tuple we map to a tuple where the element types have been transformed.
+            // * Otherwise we map to an object type where the type of each property has been transformed.
+            // For example, when T is instantiated to a union type A | B, we produce { [P in keyof A]: X } |
+            // { [P in keyof B]: X }, and when when T is instantiated to a union type A | undefined, we produce
+            // { [P in keyof A]: X } | undefined.
             const constraintType = getConstraintTypeFromMappedType(type);
             if (constraintType.flags & TypeFlags.Index) {
                 const typeVariable = (<IndexType>constraintType).type;
@@ -10100,7 +10109,11 @@ namespace ts {
                     if (typeVariable !== mappedTypeVariable) {
                         return mapType(mappedTypeVariable, t => {
                             if (isMappableType(t)) {
-                                return instantiateAnonymousType(type, createReplacementMapper(typeVariable, t, mapper));
+                                const replacementMapper = createReplacementMapper(typeVariable, t, mapper);
+                                return isArrayType(t) ? createArrayType(instantiateMappedTypeTemplate(type, numberType, /*isOptional*/ true, replacementMapper)) :
+                                    isReadonlyArrayType(t) ? createReadonlyArrayType(instantiateMappedTypeTemplate(type, numberType, /*isOptional*/ true, replacementMapper)) :
+                                    isTupleType(t) ? instantiateMappedTupleType(t, type, replacementMapper) :
+                                    instantiateAnonymousType(type, replacementMapper);
                             }
                             return t;
                         });
@@ -10112,6 +10125,26 @@ namespace ts {
 
         function isMappableType(type: Type) {
             return type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.InstantiableNonPrimitive | TypeFlags.Object | TypeFlags.Intersection);
+        }
+
+        function instantiateMappedTupleType(tupleType: TupleTypeReference, mappedType: MappedType, mapper: TypeMapper) {
+            const minLength = tupleType.target.minLength;
+            const elementTypes = map(tupleType.typeArguments || emptyArray, (_, i) =>
+                instantiateMappedTypeTemplate(mappedType, getLiteralType("" + i), i >= minLength, mapper));
+            const modifiers = getMappedTypeModifiers(mappedType);
+            const newMinLength = modifiers & MappedTypeModifiers.IncludeOptional ? 0 :
+                modifiers & MappedTypeModifiers.ExcludeOptional ? getTypeReferenceArity(tupleType) - (tupleType.target.hasRestElement ? 1 : 0) :
+                minLength;
+            return createTupleType(elementTypes, newMinLength, tupleType.target.hasRestElement, tupleType.target.associatedNames);
+        }
+
+        function instantiateMappedTypeTemplate(type: MappedType, key: Type, isOptional: boolean, mapper: TypeMapper) {
+            const templateMapper = combineTypeMappers(mapper, createTypeMapper([getTypeParameterFromMappedType(type)], [key]));
+            const propType = instantiateType(getTemplateTypeFromMappedType(<MappedType>type.target || type), templateMapper);
+            const modifiers = getMappedTypeModifiers(type);
+            return strictNullChecks && modifiers & MappedTypeModifiers.IncludeOptional && !isTypeAssignableTo(undefinedType, propType) ? getOptionalType(propType) :
+                strictNullChecks && modifiers & MappedTypeModifiers.ExcludeOptional && isOptional ? getTypeWithFacts(propType, TypeFacts.NEUndefined) :
+                propType;
         }
 
         function instantiateAnonymousType(type: AnonymousType, mapper: TypeMapper): AnonymousType {
@@ -12441,6 +12474,10 @@ namespace ts {
             return !!(getObjectFlags(type) & ObjectFlags.Reference) && (<TypeReference>type).target === globalArrayType;
         }
 
+        function isReadonlyArrayType(type: Type): boolean {
+            return !!(getObjectFlags(type) & ObjectFlags.Reference) && (<TypeReference>type).target === globalReadonlyArrayType;
+        }
+
         function isArrayLikeType(type: Type): boolean {
             // A type is array-like if it is a reference to the global Array or global ReadonlyArray type,
             // or if it is not the undefined or null type and if it is assignable to ReadonlyArray<any>
@@ -12996,6 +13033,22 @@ namespace ts {
                     return undefined;
                 }
             }
+            // For arrays and tuples we infer new arrays and tuples where the reverse mapping has been
+            // applied to the element type(s).
+            if (isArrayType(source)) {
+                return createArrayType(inferReverseMappedType((<TypeReference>source).typeArguments![0], target));
+            }
+            if (isReadonlyArrayType(source)) {
+                return createReadonlyArrayType(inferReverseMappedType((<TypeReference>source).typeArguments![0], target));
+            }
+            if (isTupleType(source)) {
+                const elementTypes = map(source.typeArguments || emptyArray, t => inferReverseMappedType(t, target));
+                const minLength = getMappedTypeModifiers(target) & MappedTypeModifiers.IncludeOptional ?
+                    getTypeReferenceArity(source) - (source.target.hasRestElement ? 1 : 0) : source.target.minLength;
+                return createTupleType(elementTypes, minLength, source.target.hasRestElement, source.target.associatedNames);
+            }
+            // For all other object types we infer a new object type where the reverse mapping has been
+            // applied to the type of each property.
             const reversed = createObjectType(ObjectFlags.ReverseMapped | ObjectFlags.Anonymous, /*symbol*/ undefined) as ReverseMappedType;
             reversed.source = source;
             reversed.mappedType = target;

--- a/tests/baselines/reference/mappedTypes4.types
+++ b/tests/baselines/reference/mappedTypes4.types
@@ -103,7 +103,7 @@ type T01 = Readonly<A | B | C | null | undefined>;
 >null : null
 
 type T02 = Boxified<A | B[] | C | string>
->T02 : string | Boxified<A> | Boxified<C> | Boxified<B[]>
+>T02 : string | Boxified<A> | Boxified<C> | Box<B>[]
 >Boxified : Boxified<T>
 >A : A
 >B : B

--- a/tests/baselines/reference/mappedTypesArraysTuples.js
+++ b/tests/baselines/reference/mappedTypesArraysTuples.js
@@ -1,0 +1,144 @@
+//// [mappedTypesArraysTuples.ts]
+type Box<T> = { value: T };
+type Boxified<T> = { [P in keyof T]: Box<T[P]> };
+
+type T00 = Boxified<[number, string?, ...boolean[]]>;
+type T01 = Partial<[number, string?, ...boolean[]]>;
+type T02 = Required<[number, string?, ...boolean[]]>;
+
+type T10 = Boxified<string[]>;
+type T11 = Partial<string[]>;
+type T12 = Required<string[]>;
+type T13 = Boxified<ReadonlyArray<string>>;
+type T14 = Partial<ReadonlyArray<string>>;
+type T15 = Required<ReadonlyArray<string>>;
+
+type T20 = Boxified<(string | undefined)[]>;
+type T21 = Partial<(string | undefined)[]>;
+type T22 = Required<(string | undefined)[]>;
+type T23 = Boxified<ReadonlyArray<string | undefined>>;
+type T24 = Partial<ReadonlyArray<string | undefined>>;
+type T25 = Required<ReadonlyArray<string | undefined>>;
+
+type T30 = Boxified<Partial<string[]>>;
+type T31 = Partial<Boxified<string[]>>;
+
+type A = { a: string };
+type B = { b: string };
+
+type T40 = Boxified<A | A[] | ReadonlyArray<A> | [A, B] | string | string[]>;
+
+declare function unboxify<T>(x: Boxified<T>): T;
+
+declare let x10: [Box<number>, Box<string>, ...Box<boolean>[]];
+let y10 = unboxify(x10);
+
+declare let x11: Box<number>[];
+let y11 = unboxify(x11);
+
+declare let x12: { a: Box<number>, b: Box<string[]> };
+let y12 = unboxify(x12);
+
+declare function nonpartial<T>(x: Partial<T>): T;
+
+declare let x20: [number | undefined, string?, ...boolean[]];
+let y20 = nonpartial(x20);
+
+declare let x21: (number | undefined)[];
+let y21 = nonpartial(x21);
+
+declare let x22: { a: number | undefined, b?: string[] };
+let y22 = nonpartial(x22);
+
+type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+type Awaitified<T> = { [P in keyof T]: Awaited<T[P]> };
+
+declare function all<T extends any[]>(...values: T): Promise<Awaitified<T>>;
+
+function f1(a: number, b: Promise<number>, c: string[], d: Promise<string[]>) {
+    let x1 = all(a);
+    let x2 = all(a, b);
+    let x3 = all(a, b, c);
+    let x4 = all(a, b, c, d);
+}
+
+
+//// [mappedTypesArraysTuples.js]
+"use strict";
+var y10 = unboxify(x10);
+var y11 = unboxify(x11);
+var y12 = unboxify(x12);
+var y20 = nonpartial(x20);
+var y21 = nonpartial(x21);
+var y22 = nonpartial(x22);
+function f1(a, b, c, d) {
+    var x1 = all(a);
+    var x2 = all(a, b);
+    var x3 = all(a, b, c);
+    var x4 = all(a, b, c, d);
+}
+
+
+//// [mappedTypesArraysTuples.d.ts]
+declare type Box<T> = {
+    value: T;
+};
+declare type Boxified<T> = {
+    [P in keyof T]: Box<T[P]>;
+};
+declare type T00 = Boxified<[number, string?, ...boolean[]]>;
+declare type T01 = Partial<[number, string?, ...boolean[]]>;
+declare type T02 = Required<[number, string?, ...boolean[]]>;
+declare type T10 = Boxified<string[]>;
+declare type T11 = Partial<string[]>;
+declare type T12 = Required<string[]>;
+declare type T13 = Boxified<ReadonlyArray<string>>;
+declare type T14 = Partial<ReadonlyArray<string>>;
+declare type T15 = Required<ReadonlyArray<string>>;
+declare type T20 = Boxified<(string | undefined)[]>;
+declare type T21 = Partial<(string | undefined)[]>;
+declare type T22 = Required<(string | undefined)[]>;
+declare type T23 = Boxified<ReadonlyArray<string | undefined>>;
+declare type T24 = Partial<ReadonlyArray<string | undefined>>;
+declare type T25 = Required<ReadonlyArray<string | undefined>>;
+declare type T30 = Boxified<Partial<string[]>>;
+declare type T31 = Partial<Boxified<string[]>>;
+declare type A = {
+    a: string;
+};
+declare type B = {
+    b: string;
+};
+declare type T40 = Boxified<A | A[] | ReadonlyArray<A> | [A, B] | string | string[]>;
+declare function unboxify<T>(x: Boxified<T>): T;
+declare let x10: [Box<number>, Box<string>, ...Box<boolean>[]];
+declare let y10: [number, string, ...boolean[]];
+declare let x11: Box<number>[];
+declare let y11: number[];
+declare let x12: {
+    a: Box<number>;
+    b: Box<string[]>;
+};
+declare let y12: {
+    a: number;
+    b: string[];
+};
+declare function nonpartial<T>(x: Partial<T>): T;
+declare let x20: [number | undefined, string?, ...boolean[]];
+declare let y20: [number, string, ...boolean[]];
+declare let x21: (number | undefined)[];
+declare let y21: number[];
+declare let x22: {
+    a: number | undefined;
+    b?: string[];
+};
+declare let y22: {
+    a: number;
+    b: string[];
+};
+declare type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+declare type Awaitified<T> = {
+    [P in keyof T]: Awaited<T[P]>;
+};
+declare function all<T extends any[]>(...values: T): Promise<Awaitified<T>>;
+declare function f1(a: number, b: Promise<number>, c: string[], d: Promise<string[]>): void;

--- a/tests/baselines/reference/mappedTypesArraysTuples.symbols
+++ b/tests/baselines/reference/mappedTypesArraysTuples.symbols
@@ -1,0 +1,247 @@
+=== tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts ===
+type Box<T> = { value: T };
+>Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 0, 9))
+>value : Symbol(value, Decl(mappedTypesArraysTuples.ts, 0, 15))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 0, 9))
+
+type Boxified<T> = { [P in keyof T]: Box<T[P]> };
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 1, 14))
+>P : Symbol(P, Decl(mappedTypesArraysTuples.ts, 1, 22))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 1, 14))
+>Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 1, 14))
+>P : Symbol(P, Decl(mappedTypesArraysTuples.ts, 1, 22))
+
+type T00 = Boxified<[number, string?, ...boolean[]]>;
+>T00 : Symbol(T00, Decl(mappedTypesArraysTuples.ts, 1, 49))
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+
+type T01 = Partial<[number, string?, ...boolean[]]>;
+>T01 : Symbol(T01, Decl(mappedTypesArraysTuples.ts, 3, 53))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+
+type T02 = Required<[number, string?, ...boolean[]]>;
+>T02 : Symbol(T02, Decl(mappedTypesArraysTuples.ts, 4, 52))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+
+type T10 = Boxified<string[]>;
+>T10 : Symbol(T10, Decl(mappedTypesArraysTuples.ts, 5, 53))
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+
+type T11 = Partial<string[]>;
+>T11 : Symbol(T11, Decl(mappedTypesArraysTuples.ts, 7, 30))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+
+type T12 = Required<string[]>;
+>T12 : Symbol(T12, Decl(mappedTypesArraysTuples.ts, 8, 29))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+
+type T13 = Boxified<ReadonlyArray<string>>;
+>T13 : Symbol(T13, Decl(mappedTypesArraysTuples.ts, 9, 30))
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --))
+
+type T14 = Partial<ReadonlyArray<string>>;
+>T14 : Symbol(T14, Decl(mappedTypesArraysTuples.ts, 10, 43))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --))
+
+type T15 = Required<ReadonlyArray<string>>;
+>T15 : Symbol(T15, Decl(mappedTypesArraysTuples.ts, 11, 42))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --))
+
+type T20 = Boxified<(string | undefined)[]>;
+>T20 : Symbol(T20, Decl(mappedTypesArraysTuples.ts, 12, 43))
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+
+type T21 = Partial<(string | undefined)[]>;
+>T21 : Symbol(T21, Decl(mappedTypesArraysTuples.ts, 14, 44))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+
+type T22 = Required<(string | undefined)[]>;
+>T22 : Symbol(T22, Decl(mappedTypesArraysTuples.ts, 15, 43))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+
+type T23 = Boxified<ReadonlyArray<string | undefined>>;
+>T23 : Symbol(T23, Decl(mappedTypesArraysTuples.ts, 16, 44))
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --))
+
+type T24 = Partial<ReadonlyArray<string | undefined>>;
+>T24 : Symbol(T24, Decl(mappedTypesArraysTuples.ts, 17, 55))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --))
+
+type T25 = Required<ReadonlyArray<string | undefined>>;
+>T25 : Symbol(T25, Decl(mappedTypesArraysTuples.ts, 18, 54))
+>Required : Symbol(Required, Decl(lib.es5.d.ts, --, --))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --))
+
+type T30 = Boxified<Partial<string[]>>;
+>T30 : Symbol(T30, Decl(mappedTypesArraysTuples.ts, 19, 55))
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+
+type T31 = Partial<Boxified<string[]>>;
+>T31 : Symbol(T31, Decl(mappedTypesArraysTuples.ts, 21, 39))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+
+type A = { a: string };
+>A : Symbol(A, Decl(mappedTypesArraysTuples.ts, 22, 39))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 24, 10))
+
+type B = { b: string };
+>B : Symbol(B, Decl(mappedTypesArraysTuples.ts, 24, 23))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 25, 10))
+
+type T40 = Boxified<A | A[] | ReadonlyArray<A> | [A, B] | string | string[]>;
+>T40 : Symbol(T40, Decl(mappedTypesArraysTuples.ts, 25, 23))
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+>A : Symbol(A, Decl(mappedTypesArraysTuples.ts, 22, 39))
+>A : Symbol(A, Decl(mappedTypesArraysTuples.ts, 22, 39))
+>ReadonlyArray : Symbol(ReadonlyArray, Decl(lib.es5.d.ts, --, --))
+>A : Symbol(A, Decl(mappedTypesArraysTuples.ts, 22, 39))
+>A : Symbol(A, Decl(mappedTypesArraysTuples.ts, 22, 39))
+>B : Symbol(B, Decl(mappedTypesArraysTuples.ts, 24, 23))
+
+declare function unboxify<T>(x: Boxified<T>): T;
+>unboxify : Symbol(unboxify, Decl(mappedTypesArraysTuples.ts, 27, 77))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 29, 26))
+>x : Symbol(x, Decl(mappedTypesArraysTuples.ts, 29, 29))
+>Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 29, 26))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 29, 26))
+
+declare let x10: [Box<number>, Box<string>, ...Box<boolean>[]];
+>x10 : Symbol(x10, Decl(mappedTypesArraysTuples.ts, 31, 11))
+>Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
+>Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
+>Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
+
+let y10 = unboxify(x10);
+>y10 : Symbol(y10, Decl(mappedTypesArraysTuples.ts, 32, 3))
+>unboxify : Symbol(unboxify, Decl(mappedTypesArraysTuples.ts, 27, 77))
+>x10 : Symbol(x10, Decl(mappedTypesArraysTuples.ts, 31, 11))
+
+declare let x11: Box<number>[];
+>x11 : Symbol(x11, Decl(mappedTypesArraysTuples.ts, 34, 11))
+>Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
+
+let y11 = unboxify(x11);
+>y11 : Symbol(y11, Decl(mappedTypesArraysTuples.ts, 35, 3))
+>unboxify : Symbol(unboxify, Decl(mappedTypesArraysTuples.ts, 27, 77))
+>x11 : Symbol(x11, Decl(mappedTypesArraysTuples.ts, 34, 11))
+
+declare let x12: { a: Box<number>, b: Box<string[]> };
+>x12 : Symbol(x12, Decl(mappedTypesArraysTuples.ts, 37, 11))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 37, 18))
+>Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 37, 34))
+>Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
+
+let y12 = unboxify(x12);
+>y12 : Symbol(y12, Decl(mappedTypesArraysTuples.ts, 38, 3))
+>unboxify : Symbol(unboxify, Decl(mappedTypesArraysTuples.ts, 27, 77))
+>x12 : Symbol(x12, Decl(mappedTypesArraysTuples.ts, 37, 11))
+
+declare function nonpartial<T>(x: Partial<T>): T;
+>nonpartial : Symbol(nonpartial, Decl(mappedTypesArraysTuples.ts, 38, 24))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 40, 28))
+>x : Symbol(x, Decl(mappedTypesArraysTuples.ts, 40, 31))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 40, 28))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 40, 28))
+
+declare let x20: [number | undefined, string?, ...boolean[]];
+>x20 : Symbol(x20, Decl(mappedTypesArraysTuples.ts, 42, 11))
+
+let y20 = nonpartial(x20);
+>y20 : Symbol(y20, Decl(mappedTypesArraysTuples.ts, 43, 3))
+>nonpartial : Symbol(nonpartial, Decl(mappedTypesArraysTuples.ts, 38, 24))
+>x20 : Symbol(x20, Decl(mappedTypesArraysTuples.ts, 42, 11))
+
+declare let x21: (number | undefined)[];
+>x21 : Symbol(x21, Decl(mappedTypesArraysTuples.ts, 45, 11))
+
+let y21 = nonpartial(x21);
+>y21 : Symbol(y21, Decl(mappedTypesArraysTuples.ts, 46, 3))
+>nonpartial : Symbol(nonpartial, Decl(mappedTypesArraysTuples.ts, 38, 24))
+>x21 : Symbol(x21, Decl(mappedTypesArraysTuples.ts, 45, 11))
+
+declare let x22: { a: number | undefined, b?: string[] };
+>x22 : Symbol(x22, Decl(mappedTypesArraysTuples.ts, 48, 11))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 48, 18))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 48, 41))
+
+let y22 = nonpartial(x22);
+>y22 : Symbol(y22, Decl(mappedTypesArraysTuples.ts, 49, 3))
+>nonpartial : Symbol(nonpartial, Decl(mappedTypesArraysTuples.ts, 38, 24))
+>x22 : Symbol(x22, Decl(mappedTypesArraysTuples.ts, 48, 11))
+
+type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+>Awaited : Symbol(Awaited, Decl(mappedTypesArraysTuples.ts, 49, 26))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 51, 13))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 51, 13))
+>PromiseLike : Symbol(PromiseLike, Decl(lib.es5.d.ts, --, --))
+>U : Symbol(U, Decl(mappedTypesArraysTuples.ts, 51, 45))
+>U : Symbol(U, Decl(mappedTypesArraysTuples.ts, 51, 45))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 51, 13))
+
+type Awaitified<T> = { [P in keyof T]: Awaited<T[P]> };
+>Awaitified : Symbol(Awaitified, Decl(mappedTypesArraysTuples.ts, 51, 57))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 52, 16))
+>P : Symbol(P, Decl(mappedTypesArraysTuples.ts, 52, 24))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 52, 16))
+>Awaited : Symbol(Awaited, Decl(mappedTypesArraysTuples.ts, 49, 26))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 52, 16))
+>P : Symbol(P, Decl(mappedTypesArraysTuples.ts, 52, 24))
+
+declare function all<T extends any[]>(...values: T): Promise<Awaitified<T>>;
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 52, 55))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 54, 21))
+>values : Symbol(values, Decl(mappedTypesArraysTuples.ts, 54, 38))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 54, 21))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>Awaitified : Symbol(Awaitified, Decl(mappedTypesArraysTuples.ts, 51, 57))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 54, 21))
+
+function f1(a: number, b: Promise<number>, c: string[], d: Promise<string[]>) {
+>f1 : Symbol(f1, Decl(mappedTypesArraysTuples.ts, 54, 76))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 56, 12))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 56, 22))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>c : Symbol(c, Decl(mappedTypesArraysTuples.ts, 56, 42))
+>d : Symbol(d, Decl(mappedTypesArraysTuples.ts, 56, 55))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+
+    let x1 = all(a);
+>x1 : Symbol(x1, Decl(mappedTypesArraysTuples.ts, 57, 7))
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 52, 55))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 56, 12))
+
+    let x2 = all(a, b);
+>x2 : Symbol(x2, Decl(mappedTypesArraysTuples.ts, 58, 7))
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 52, 55))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 56, 12))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 56, 22))
+
+    let x3 = all(a, b, c);
+>x3 : Symbol(x3, Decl(mappedTypesArraysTuples.ts, 59, 7))
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 52, 55))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 56, 12))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 56, 22))
+>c : Symbol(c, Decl(mappedTypesArraysTuples.ts, 56, 42))
+
+    let x4 = all(a, b, c, d);
+>x4 : Symbol(x4, Decl(mappedTypesArraysTuples.ts, 60, 7))
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 52, 55))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 56, 12))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 56, 22))
+>c : Symbol(c, Decl(mappedTypesArraysTuples.ts, 56, 42))
+>d : Symbol(d, Decl(mappedTypesArraysTuples.ts, 56, 55))
+}
+

--- a/tests/baselines/reference/mappedTypesArraysTuples.types
+++ b/tests/baselines/reference/mappedTypesArraysTuples.types
@@ -1,0 +1,257 @@
+=== tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts ===
+type Box<T> = { value: T };
+>Box : Box<T>
+>T : T
+>value : T
+>T : T
+
+type Boxified<T> = { [P in keyof T]: Box<T[P]> };
+>Boxified : Boxified<T>
+>T : T
+>P : P
+>T : T
+>Box : Box<T>
+>T : T
+>P : P
+
+type T00 = Boxified<[number, string?, ...boolean[]]>;
+>T00 : [Box<number>, Box<string | undefined>?, ...Box<boolean>[]]
+>Boxified : Boxified<T>
+
+type T01 = Partial<[number, string?, ...boolean[]]>;
+>T01 : [(number | undefined)?, (string | undefined)?, ...(boolean | undefined)[]]
+>Partial : Partial<T>
+
+type T02 = Required<[number, string?, ...boolean[]]>;
+>T02 : [number, string, ...boolean[]]
+>Required : Required<T>
+
+type T10 = Boxified<string[]>;
+>T10 : Box<string>[]
+>Boxified : Boxified<T>
+
+type T11 = Partial<string[]>;
+>T11 : (string | undefined)[]
+>Partial : Partial<T>
+
+type T12 = Required<string[]>;
+>T12 : string[]
+>Required : Required<T>
+
+type T13 = Boxified<ReadonlyArray<string>>;
+>T13 : ReadonlyArray<Box<string>>
+>Boxified : Boxified<T>
+>ReadonlyArray : ReadonlyArray<T>
+
+type T14 = Partial<ReadonlyArray<string>>;
+>T14 : ReadonlyArray<string | undefined>
+>Partial : Partial<T>
+>ReadonlyArray : ReadonlyArray<T>
+
+type T15 = Required<ReadonlyArray<string>>;
+>T15 : ReadonlyArray<string>
+>Required : Required<T>
+>ReadonlyArray : ReadonlyArray<T>
+
+type T20 = Boxified<(string | undefined)[]>;
+>T20 : Box<string | undefined>[]
+>Boxified : Boxified<T>
+
+type T21 = Partial<(string | undefined)[]>;
+>T21 : (string | undefined)[]
+>Partial : Partial<T>
+
+type T22 = Required<(string | undefined)[]>;
+>T22 : string[]
+>Required : Required<T>
+
+type T23 = Boxified<ReadonlyArray<string | undefined>>;
+>T23 : ReadonlyArray<Box<string | undefined>>
+>Boxified : Boxified<T>
+>ReadonlyArray : ReadonlyArray<T>
+
+type T24 = Partial<ReadonlyArray<string | undefined>>;
+>T24 : ReadonlyArray<string | undefined>
+>Partial : Partial<T>
+>ReadonlyArray : ReadonlyArray<T>
+
+type T25 = Required<ReadonlyArray<string | undefined>>;
+>T25 : ReadonlyArray<string>
+>Required : Required<T>
+>ReadonlyArray : ReadonlyArray<T>
+
+type T30 = Boxified<Partial<string[]>>;
+>T30 : Box<string | undefined>[]
+>Boxified : Boxified<T>
+>Partial : Partial<T>
+
+type T31 = Partial<Boxified<string[]>>;
+>T31 : (Box<string> | undefined)[]
+>Partial : Partial<T>
+>Boxified : Boxified<T>
+
+type A = { a: string };
+>A : A
+>a : string
+
+type B = { b: string };
+>B : B
+>b : string
+
+type T40 = Boxified<A | A[] | ReadonlyArray<A> | [A, B] | string | string[]>;
+>T40 : string | Box<string>[] | Boxified<A> | Box<A>[] | ReadonlyArray<Box<A>> | [Box<A>, Box<B>]
+>Boxified : Boxified<T>
+>A : A
+>A : A
+>ReadonlyArray : ReadonlyArray<T>
+>A : A
+>A : A
+>B : B
+
+declare function unboxify<T>(x: Boxified<T>): T;
+>unboxify : <T>(x: Boxified<T>) => T
+>T : T
+>x : Boxified<T>
+>Boxified : Boxified<T>
+>T : T
+>T : T
+
+declare let x10: [Box<number>, Box<string>, ...Box<boolean>[]];
+>x10 : [Box<number>, Box<string>, ...Box<boolean>[]]
+>Box : Box<T>
+>Box : Box<T>
+>Box : Box<T>
+
+let y10 = unboxify(x10);
+>y10 : [number, string, ...boolean[]]
+>unboxify(x10) : [number, string, ...boolean[]]
+>unboxify : <T>(x: Boxified<T>) => T
+>x10 : [Box<number>, Box<string>, ...Box<boolean>[]]
+
+declare let x11: Box<number>[];
+>x11 : Box<number>[]
+>Box : Box<T>
+
+let y11 = unboxify(x11);
+>y11 : number[]
+>unboxify(x11) : number[]
+>unboxify : <T>(x: Boxified<T>) => T
+>x11 : Box<number>[]
+
+declare let x12: { a: Box<number>, b: Box<string[]> };
+>x12 : { a: Box<number>; b: Box<string[]>; }
+>a : Box<number>
+>Box : Box<T>
+>b : Box<string[]>
+>Box : Box<T>
+
+let y12 = unboxify(x12);
+>y12 : { a: number; b: string[]; }
+>unboxify(x12) : { a: number; b: string[]; }
+>unboxify : <T>(x: Boxified<T>) => T
+>x12 : { a: Box<number>; b: Box<string[]>; }
+
+declare function nonpartial<T>(x: Partial<T>): T;
+>nonpartial : <T>(x: Partial<T>) => T
+>T : T
+>x : Partial<T>
+>Partial : Partial<T>
+>T : T
+>T : T
+
+declare let x20: [number | undefined, string?, ...boolean[]];
+>x20 : [number | undefined, (string | undefined)?, ...boolean[]]
+
+let y20 = nonpartial(x20);
+>y20 : [number, string, ...boolean[]]
+>nonpartial(x20) : [number, string, ...boolean[]]
+>nonpartial : <T>(x: Partial<T>) => T
+>x20 : [number | undefined, (string | undefined)?, ...boolean[]]
+
+declare let x21: (number | undefined)[];
+>x21 : (number | undefined)[]
+
+let y21 = nonpartial(x21);
+>y21 : number[]
+>nonpartial(x21) : number[]
+>nonpartial : <T>(x: Partial<T>) => T
+>x21 : (number | undefined)[]
+
+declare let x22: { a: number | undefined, b?: string[] };
+>x22 : { a: number | undefined; b?: string[] | undefined; }
+>a : number | undefined
+>b : string[] | undefined
+
+let y22 = nonpartial(x22);
+>y22 : { a: number; b: string[]; }
+>nonpartial(x22) : { a: number; b: string[]; }
+>nonpartial : <T>(x: Partial<T>) => T
+>x22 : { a: number | undefined; b?: string[] | undefined; }
+
+type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+>Awaited : Awaited<T>
+>T : T
+>T : T
+>PromiseLike : PromiseLike<T>
+>U : U
+>U : U
+>T : T
+
+type Awaitified<T> = { [P in keyof T]: Awaited<T[P]> };
+>Awaitified : Awaitified<T>
+>T : T
+>P : P
+>T : T
+>Awaited : Awaited<T>
+>T : T
+>P : P
+
+declare function all<T extends any[]>(...values: T): Promise<Awaitified<T>>;
+>all : <T extends any[]>(...values: T) => Promise<Awaitified<T>>
+>T : T
+>values : T
+>T : T
+>Promise : Promise<T>
+>Awaitified : Awaitified<T>
+>T : T
+
+function f1(a: number, b: Promise<number>, c: string[], d: Promise<string[]>) {
+>f1 : (a: number, b: Promise<number>, c: string[], d: Promise<string[]>) => void
+>a : number
+>b : Promise<number>
+>Promise : Promise<T>
+>c : string[]
+>d : Promise<string[]>
+>Promise : Promise<T>
+
+    let x1 = all(a);
+>x1 : Promise<[number]>
+>all(a) : Promise<[number]>
+>all : <T extends any[]>(...values: T) => Promise<Awaitified<T>>
+>a : number
+
+    let x2 = all(a, b);
+>x2 : Promise<[number, number]>
+>all(a, b) : Promise<[number, number]>
+>all : <T extends any[]>(...values: T) => Promise<Awaitified<T>>
+>a : number
+>b : Promise<number>
+
+    let x3 = all(a, b, c);
+>x3 : Promise<[number, number, string[]]>
+>all(a, b, c) : Promise<[number, number, string[]]>
+>all : <T extends any[]>(...values: T) => Promise<Awaitified<T>>
+>a : number
+>b : Promise<number>
+>c : string[]
+
+    let x4 = all(a, b, c, d);
+>x4 : Promise<[number, number, string[], string[]]>
+>all(a, b, c, d) : Promise<[number, number, string[], string[]]>
+>all : <T extends any[]>(...values: T) => Promise<Awaitified<T>>
+>a : number
+>b : Promise<number>
+>c : string[]
+>d : Promise<string[]>
+}
+

--- a/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
@@ -1,0 +1,65 @@
+// @strict: true
+// @declaration: true
+
+type Box<T> = { value: T };
+type Boxified<T> = { [P in keyof T]: Box<T[P]> };
+
+type T00 = Boxified<[number, string?, ...boolean[]]>;
+type T01 = Partial<[number, string?, ...boolean[]]>;
+type T02 = Required<[number, string?, ...boolean[]]>;
+
+type T10 = Boxified<string[]>;
+type T11 = Partial<string[]>;
+type T12 = Required<string[]>;
+type T13 = Boxified<ReadonlyArray<string>>;
+type T14 = Partial<ReadonlyArray<string>>;
+type T15 = Required<ReadonlyArray<string>>;
+
+type T20 = Boxified<(string | undefined)[]>;
+type T21 = Partial<(string | undefined)[]>;
+type T22 = Required<(string | undefined)[]>;
+type T23 = Boxified<ReadonlyArray<string | undefined>>;
+type T24 = Partial<ReadonlyArray<string | undefined>>;
+type T25 = Required<ReadonlyArray<string | undefined>>;
+
+type T30 = Boxified<Partial<string[]>>;
+type T31 = Partial<Boxified<string[]>>;
+
+type A = { a: string };
+type B = { b: string };
+
+type T40 = Boxified<A | A[] | ReadonlyArray<A> | [A, B] | string | string[]>;
+
+declare function unboxify<T>(x: Boxified<T>): T;
+
+declare let x10: [Box<number>, Box<string>, ...Box<boolean>[]];
+let y10 = unboxify(x10);
+
+declare let x11: Box<number>[];
+let y11 = unboxify(x11);
+
+declare let x12: { a: Box<number>, b: Box<string[]> };
+let y12 = unboxify(x12);
+
+declare function nonpartial<T>(x: Partial<T>): T;
+
+declare let x20: [number | undefined, string?, ...boolean[]];
+let y20 = nonpartial(x20);
+
+declare let x21: (number | undefined)[];
+let y21 = nonpartial(x21);
+
+declare let x22: { a: number | undefined, b?: string[] };
+let y22 = nonpartial(x22);
+
+type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
+type Awaitified<T> = { [P in keyof T]: Awaited<T[P]> };
+
+declare function all<T extends any[]>(...values: T): Promise<Awaitified<T>>;
+
+function f1(a: number, b: Promise<number>, c: string[], d: Promise<string[]>) {
+    let x1 = all(a);
+    let x2 = all(a, b);
+    let x3 = all(a, b, c);
+    let x4 = all(a, b, c, d);
+}


### PR DESCRIPTION
This PR improves our support for arrays and tuples in homomorphic mapped types (i.e. structure preserving mapped types of the form `{ [P in keyof T]: X }`). When a homomorphic mapped type is applied to an array or tuple type, we now produce a corresponding array or tuple type where the element type(s) have been transformed.

```ts
type Box<T> = { value: T };
type Boxified<T> = { [P in keyof T]: Box<T[P]> };

type T1 = Boxified<string[]>;  // Box<string>[]
type T2 = Boxified<ReadonlyArray<string>>;  // ReadonlyArray<Box<string>>
type T3 = Boxified<[number, string?]>;  // [Box<number>, Box<string>?]
type T4 = Boxified<[number, ...string[]]>;  // [Box<number>, ...Box<string>[]]
type T5 = Boxified<string[] | undefined>;  // Box<string>[] | undefined
type T6 = Boxified<(string | undefined)[]>;  // Box<string | undefined>[]
```

Previously, we would treat array and tuple types like regular object types and transform *all* properties (including methods) of the arrays and tuples. This behavior is rarely if ever desired.

Given a homomorphic mapped type `{ [P in keyof T]: X }`, where `T` is some type variable, the mapping operation depends on `T` as follows (the first two rules are existing behavior and the remaining are introduced by this PR):

* If T is a primitive type no mapping is performed and the result is simply T.
* If T is a union type we distribute the mapped type over the union.
* If T is an array type `S[]` we map to an array type `R[]`, where `R` is an instantiation of `X` with `S` substituted for `T[P]`.
* If T is an array type `ReadonlyArray<S>` we map to an array type `ReadonlyArray<R>`, where `R` is an instantiation of `X` with `S` substituted for `T[P]`.
* If T is a tuple `[S0, S1, ..., Sn]` we map to a tuple type `[R0, R1, ..., Rn]`, where each `Rx` is an instantiation of `X` with the corresponding `Sx` substituted for `T[P]`.

Homomorphic mapped types can use `?`, `-?`, or `+?` annotations to modify the optional-ness of tuple element types. For example, the predefined `Partial<T>` and `Required<T>` types have the expected effects on tuple element types:

```ts
type T10 = Partial<[number, string]>;  // [number?, string?]
type T11 = Required<[number?, string?]>;  // [number, string]
```

In `--strictNullChecks` mode the `?`, `-?`, or `+?` annotations also add or remove `undefined` from the element type(s) of arrays and tuples:

```ts
type T20 = Partial<string[]>;  // (string | undefined)[]
type T21 = Required<(string | undefined)[]>;  // string[]
```

A `readonly`, `-readonly`, or `+readonly` annotation in a homomorphic mapped type currently has no effect on array or tuple elements (we might consider mapping from `Array` to `ReadonlyArray` and vice versa, although that technically isn't structure preserving because it adds or removes methods).

Homomorphic mapped type support for tuples makes it possible to transform variable length parameter lists, eliminating the need for repetitive patterns overloads in several scenarios. For example:

```ts
type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
type Awaitified<T> = { [P in keyof T]: Awaited<T[P]> };

declare function all<T extends any[]>(...values: T): Promise<Awaitified<T>>;

function f1(a: number, b: Promise<number>, c: string[], d: Promise<string[]>) {
    let x1 = all(a);  // Promise<[number]>
    let x2 = all(a, b);  // Promise<[number, number]>
    let x3 = all(a, b, c);  // Promise<[number, number, string[]]>
    let x4 = all(a, b, c, d);  // Promise<[number, number, string[], string[]]>
}
```

This PR implements much of what is suggested in #25947, but without introducing new syntax.
