### PR TITLE
In JSDoc, resolve import types as values too

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9458,7 +9458,7 @@ namespace ts {
                     links.resolvedSymbol = unknownSymbol;
                     return links.resolvedType = errorType;
                 }
-                const targetMeaning = node.isTypeOf ? SymbolFlags.Value : node.flags & NodeFlags.JSDoc ? SymbolFlags.Value | SymbolFlags.Type :SymbolFlags.Type;
+                const targetMeaning = node.isTypeOf ? SymbolFlags.Value : node.flags & NodeFlags.JSDoc ? SymbolFlags.Value | SymbolFlags.Type : SymbolFlags.Type;
                 // TODO: Future work: support unions/generics/whatever via a deferred import-type
                 const innerModuleSymbol = resolveExternalModuleName(node, node.argument.literal);
                 if (!innerModuleSymbol) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8189,7 +8189,7 @@ namespace ts {
         }
 
         function isJSDocTypeReference(node: Node): node is TypeReferenceNode {
-            return !!(node.flags & NodeFlags.JSDoc) && node.kind === SyntaxKind.TypeReference;
+            return !!(node.flags & NodeFlags.JSDoc) && (node.kind === SyntaxKind.TypeReference || node.kind === SyntaxKind.ImportType);
         }
 
         function checkNoTypeArguments(node: NodeWithTypeArguments, symbol?: Symbol) {
@@ -9458,7 +9458,7 @@ namespace ts {
                     links.resolvedSymbol = unknownSymbol;
                     return links.resolvedType = errorType;
                 }
-                const targetMeaning = node.isTypeOf ? SymbolFlags.Value : SymbolFlags.Type;
+                const targetMeaning = node.isTypeOf ? SymbolFlags.Value : node.flags & NodeFlags.JSDoc ? SymbolFlags.Value | SymbolFlags.Type :SymbolFlags.Type;
                 // TODO: Future work: support unions/generics/whatever via a deferred import-type
                 const innerModuleSymbol = resolveExternalModuleName(node, node.argument.literal);
                 if (!innerModuleSymbol) {

--- a/tests/baselines/reference/enumTagImported.symbols
+++ b/tests/baselines/reference/enumTagImported.symbols
@@ -1,0 +1,34 @@
+=== tests/cases/conformance/jsdoc/type.js ===
+/** @typedef {import("./mod1").TestEnum} TE */
+/** @type {TE} */
+const test = 'add'
+>test : Symbol(test, Decl(type.js, 2, 5))
+
+/** @type {import("./mod1").TestEnum} */
+const tost = 'remove'
+>tost : Symbol(tost, Decl(type.js, 4, 5))
+
+=== tests/cases/conformance/jsdoc/value.js ===
+import { TestEnum } from "./mod1"
+>TestEnum : Symbol(TestEnum, Decl(value.js, 0, 8))
+
+/** @type {TestEnum} */
+const tist = TestEnum.ADD
+>tist : Symbol(tist, Decl(value.js, 2, 5))
+>TestEnum.ADD : Symbol(ADD, Decl(mod1.js, 1, 25))
+>TestEnum : Symbol(TestEnum, Decl(value.js, 0, 8))
+>ADD : Symbol(ADD, Decl(mod1.js, 1, 25))
+
+
+=== tests/cases/conformance/jsdoc/mod1.js ===
+/** @enum {string} */
+export const TestEnum = {
+>TestEnum : Symbol(TestEnum, Decl(mod1.js, 1, 12))
+
+    ADD: 'add',
+>ADD : Symbol(ADD, Decl(mod1.js, 1, 25))
+
+    REMOVE: 'remove'
+>REMOVE : Symbol(REMOVE, Decl(mod1.js, 2, 15))
+}
+

--- a/tests/baselines/reference/enumTagImported.types
+++ b/tests/baselines/reference/enumTagImported.types
@@ -1,0 +1,39 @@
+=== tests/cases/conformance/jsdoc/type.js ===
+/** @typedef {import("./mod1").TestEnum} TE */
+/** @type {TE} */
+const test = 'add'
+>test : string
+>'add' : "add"
+
+/** @type {import("./mod1").TestEnum} */
+const tost = 'remove'
+>tost : string
+>'remove' : "remove"
+
+=== tests/cases/conformance/jsdoc/value.js ===
+import { TestEnum } from "./mod1"
+>TestEnum : { ADD: string; REMOVE: string; }
+
+/** @type {TestEnum} */
+const tist = TestEnum.ADD
+>tist : string
+>TestEnum.ADD : string
+>TestEnum : { ADD: string; REMOVE: string; }
+>ADD : string
+
+
+=== tests/cases/conformance/jsdoc/mod1.js ===
+/** @enum {string} */
+export const TestEnum = {
+>TestEnum : { ADD: string; REMOVE: string; }
+>{    ADD: 'add',    REMOVE: 'remove'} : { ADD: string; REMOVE: string; }
+
+    ADD: 'add',
+>ADD : string
+>'add' : "add"
+
+    REMOVE: 'remove'
+>REMOVE : string
+>'remove' : "remove"
+}
+

--- a/tests/cases/conformance/jsdoc/enumTagImported.ts
+++ b/tests/cases/conformance/jsdoc/enumTagImported.ts
@@ -1,0 +1,23 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: type.js
+/** @typedef {import("./mod1").TestEnum} TE */
+/** @type {TE} */
+const test = 'add'
+/** @type {import("./mod1").TestEnum} */
+const tost = 'remove'
+
+// @Filename: value.js
+import { TestEnum } from "./mod1"
+/** @type {TestEnum} */
+const tist = TestEnum.ADD
+
+
+// @Filename: mod1.js
+
+/** @enum {string} */
+export const TestEnum = {
+    ADD: 'add',
+    REMOVE: 'remove'
+}


### PR DESCRIPTION
This is something that we probably should have been doing for some time.
Fixes #26049