### PR TITLE
Handle when property name turns out to be non string literal computed name because of errors in tsconfig file

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1327,9 +1327,10 @@ namespace ts {
                     errors.push(createDiagnosticForNodeInSourceFile(sourceFile, element.name, Diagnostics.String_literal_with_double_quotes_expected));
                 }
 
-                const keyText = unescapeLeadingUnderscores(getTextOfPropertyName(element.name));
-                const option = knownOptions ? knownOptions.get(keyText) : undefined;
-                if (extraKeyDiagnosticMessage && !option) {
+                const textOfKey = getTextOfPropertyName(element.name);
+                const keyText = textOfKey && unescapeLeadingUnderscores(textOfKey);
+                const option = keyText && knownOptions ? knownOptions.get(keyText) : undefined;
+                if (keyText && extraKeyDiagnosticMessage && !option) {
                     errors.push(createDiagnosticForNodeInSourceFile(sourceFile, element.name, extraKeyDiagnosticMessage, keyText));
                 }
                 const value = convertPropertyValueToJson(element.initializer, option);

--- a/src/testRunner/unittests/tsconfigParsing.ts
+++ b/src/testRunner/unittests/tsconfigParsing.ts
@@ -331,5 +331,18 @@ namespace ts {
                 Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2.code,
                 /*noLocation*/ true);
         });
+
+
+        it("generates errors for when invalid comment type present in tsconfig", () => {
+            const jsonText = `{
+              "compilerOptions": {
+                ## this comment does cause issues
+                "types" : [
+                ]
+              }
+            }`;
+            const parsed = getParsedCommandJsonNode(jsonText, "/apath/tsconfig.json", "tests/cases/unittests", ["/apath/a.ts"]);
+            assert.isTrue(parsed.errors.length >= 0);
+        });
     });
 }


### PR DESCRIPTION
Fixes #26076