### PR TITLE
"Could not find a declaration file for module" error needs to use the unmangled package name where appropriate.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2244,8 +2244,9 @@ namespace ts {
                 ? chainDiagnosticMessages(
                     /*details*/ undefined,
                     typesPackageExists(packageId.name)
-                        ? Diagnostics.If_the_0_package_actually_exposes_this_module_consider_sending_a_pull_request_to_amend_https_Colon_Slash_Slashgithub_com_SlashDefinitelyTyped_SlashDefinitelyTyped_Slashtree_Slashmaster_Slashtypes_Slash_0
-                        : Diagnostics.Try_npm_install_types_Slash_0_if_it_exists_or_add_a_new_declaration_d_ts_file_containing_declare_module_0,
+                        ? Diagnostics.If_the_0_package_actually_exposes_this_module_consider_sending_a_pull_request_to_amend_https_Colon_Slash_Slashgithub_com_SlashDefinitelyTyped_SlashDefinitelyTyped_Slashtree_Slashmaster_Slashtypes_Slash_1
+                        : Diagnostics.Try_npm_install_types_Slash_1_if_it_exists_or_add_a_new_declaration_d_ts_file_containing_declare_module_0,
+                    packageId.name,
                     getMangledNameForScopedPackage(packageId.name))
                 : undefined;
             errorOrSuggestion(isError, errorNode, chainDiagnosticMessages(

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3901,7 +3901,7 @@
         "category": "Error",
         "code": 7034
     },
-    "Try `npm install @types/{0}` if it exists or add a new declaration (.d.ts) file containing `declare module '{0}';`": {
+    "Try `npm install @types/{1}` if it exists or add a new declaration (.d.ts) file containing `declare module '{0}';`": {
         "category": "Error",
         "code": 7035
     },
@@ -3921,7 +3921,7 @@
         "category": "Error",
         "code": 7039
     },
-    "If the '{0}' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/{0}`": {
+    "If the '{0}' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/{1}`": {
         "category": "Error",
         "code": 7040
     },

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_scoped.errors.txt
@@ -1,12 +1,12 @@
 /a.ts(1,22): error TS7016: Could not find a declaration file for module '@foo/bar'. '/node_modules/@foo/bar/index.js' implicitly has an 'any' type.
-  Try `npm install @types/foo__bar` if it exists or add a new declaration (.d.ts) file containing `declare module 'foo__bar';`
+  Try `npm install @types/foo__bar` if it exists or add a new declaration (.d.ts) file containing `declare module '@foo/bar';`
 
 
 ==== /a.ts (1 errors) ====
     import * as foo from "@foo/bar";
                          ~~~~~~~~~~
 !!! error TS7016: Could not find a declaration file for module '@foo/bar'. '/node_modules/@foo/bar/index.js' implicitly has an 'any' type.
-!!! error TS7016:   Try `npm install @types/foo__bar` if it exists or add a new declaration (.d.ts) file containing `declare module 'foo__bar';`
+!!! error TS7016:   Try `npm install @types/foo__bar` if it exists or add a new declaration (.d.ts) file containing `declare module '@foo/bar';`
     
 ==== /node_modules/@foo/bar/package.json (0 errors) ====
     { "name": "@foo/bar", "version": "1.2.3" }

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.errors.txt
@@ -2,9 +2,13 @@
   If the 'foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/foo`
 /a.ts(3,25): error TS7016: Could not find a declaration file for module 'bar/sub'. '/node_modules/bar/sub.js' implicitly has an 'any' type.
   Try `npm install @types/bar` if it exists or add a new declaration (.d.ts) file containing `declare module 'bar';`
+/a.ts(5,30): error TS7016: Could not find a declaration file for module '@scope/foo/sub'. '/node_modules/@scope/foo/sub.js' implicitly has an 'any' type.
+  If the '@scope/foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scope__foo`
+/a.ts(6,30): error TS7016: Could not find a declaration file for module '@scope/bar/sub'. '/node_modules/@scope/bar/sub.js' implicitly has an 'any' type.
+  Try `npm install @types/scope__bar` if it exists or add a new declaration (.d.ts) file containing `declare module '@scope/bar';`
 
 
-==== /a.ts (2 errors) ====
+==== /a.ts (4 errors) ====
     import * as foo from "foo";
     import * as fooSub from "foo/sub";
                             ~~~~~~~~~
@@ -14,6 +18,15 @@
                             ~~~~~~~~~
 !!! error TS7016: Could not find a declaration file for module 'bar/sub'. '/node_modules/bar/sub.js' implicitly has an 'any' type.
 !!! error TS7016:   Try `npm install @types/bar` if it exists or add a new declaration (.d.ts) file containing `declare module 'bar';`
+    import * as scopeFoo from "@scope/foo";
+    import * as scopeFooSub from "@scope/foo/sub";
+                                 ~~~~~~~~~~~~~~~~
+!!! error TS7016: Could not find a declaration file for module '@scope/foo/sub'. '/node_modules/@scope/foo/sub.js' implicitly has an 'any' type.
+!!! error TS7016:   If the '@scope/foo' package actually exposes this module, consider sending a pull request to amend 'https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/scope__foo`
+    import * as scopeBarSub from "@scope/bar/sub";
+                                 ~~~~~~~~~~~~~~~~
+!!! error TS7016: Could not find a declaration file for module '@scope/bar/sub'. '/node_modules/@scope/bar/sub.js' implicitly has an 'any' type.
+!!! error TS7016:   Try `npm install @types/scope__bar` if it exists or add a new declaration (.d.ts) file containing `declare module '@scope/bar';`
     
 ==== /node_modules/@types/foo/index.d.ts (0 errors) ====
     export const foo: number;
@@ -32,4 +45,22 @@
     
 ==== /node_modules/bar/package.json (0 errors) ====
     { "name": "bar", "version": "1.2.3" }
+    
+==== /node_modules/@types/scope__foo/index.d.ts (0 errors) ====
+    export const foo: number;
+    
+==== /node_modules/@types/scope__foo/package.json (0 errors) ====
+    { "name": "@types/scope__foo", "version": "1.2.3" }
+    
+==== /node_modules/@scope/foo/sub.js (0 errors) ====
+    const x = 0;
+    
+==== /node_modules/@scope/foo/package.json (0 errors) ====
+    { "name": "@scope/foo", "version": "1.2.3" }
+    
+==== /node_modules/@scope/bar/sub.js (0 errors) ====
+    const x = 0;
+    
+==== /node_modules/@scope/bar/package.json (0 errors) ====
+    { "name": "@scope/bar", "version": "1.2.3" }
     

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.js
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.js
@@ -18,10 +18,31 @@ const x = 0;
 //// [package.json]
 { "name": "bar", "version": "1.2.3" }
 
+//// [index.d.ts]
+export const foo: number;
+
+//// [package.json]
+{ "name": "@types/scope__foo", "version": "1.2.3" }
+
+//// [sub.js]
+const x = 0;
+
+//// [package.json]
+{ "name": "@scope/foo", "version": "1.2.3" }
+
+//// [sub.js]
+const x = 0;
+
+//// [package.json]
+{ "name": "@scope/bar", "version": "1.2.3" }
+
 //// [a.ts]
 import * as foo from "foo";
 import * as fooSub from "foo/sub";
 import * as barSub from "bar/sub";
+import * as scopeFoo from "@scope/foo";
+import * as scopeFooSub from "@scope/foo/sub";
+import * as scopeBarSub from "@scope/bar/sub";
 
 
 //// [a.js]

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.symbols
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.symbols
@@ -8,7 +8,20 @@ import * as fooSub from "foo/sub";
 import * as barSub from "bar/sub";
 >barSub : Symbol(barSub, Decl(a.ts, 2, 6))
 
+import * as scopeFoo from "@scope/foo";
+>scopeFoo : Symbol(scopeFoo, Decl(a.ts, 3, 6))
+
+import * as scopeFooSub from "@scope/foo/sub";
+>scopeFooSub : Symbol(scopeFooSub, Decl(a.ts, 4, 6))
+
+import * as scopeBarSub from "@scope/bar/sub";
+>scopeBarSub : Symbol(scopeBarSub, Decl(a.ts, 5, 6))
+
 === /node_modules/@types/foo/index.d.ts ===
+export const foo: number;
+>foo : Symbol(foo, Decl(index.d.ts, 0, 12))
+
+=== /node_modules/@types/scope__foo/index.d.ts ===
 export const foo: number;
 >foo : Symbol(foo, Decl(index.d.ts, 0, 12))
 

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.types
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny_typesForPackageExist.types
@@ -8,7 +8,20 @@ import * as fooSub from "foo/sub";
 import * as barSub from "bar/sub";
 >barSub : any
 
+import * as scopeFoo from "@scope/foo";
+>scopeFoo : typeof scopeFoo
+
+import * as scopeFooSub from "@scope/foo/sub";
+>scopeFooSub : any
+
+import * as scopeBarSub from "@scope/bar/sub";
+>scopeBarSub : any
+
 === /node_modules/@types/foo/index.d.ts ===
+export const foo: number;
+>foo : number
+
+=== /node_modules/@types/scope__foo/index.d.ts ===
 export const foo: number;
 >foo : number
 

--- a/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_typesForPackageExist.ts
+++ b/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny_typesForPackageExist.ts
@@ -19,7 +19,28 @@ const x = 0;
 // @Filename: /node_modules/bar/package.json
 { "name": "bar", "version": "1.2.3" }
 
+// @Filename: /node_modules/@types/scope__foo/index.d.ts
+export const foo: number;
+
+// @Filename: /node_modules/@types/scope__foo/package.json
+{ "name": "@types/scope__foo", "version": "1.2.3" }
+
+// @Filename: /node_modules/@scope/foo/sub.js
+const x = 0;
+
+// @Filename: /node_modules/@scope/foo/package.json
+{ "name": "@scope/foo", "version": "1.2.3" }
+
+// @Filename: /node_modules/@scope/bar/sub.js
+const x = 0;
+
+// @Filename: /node_modules/@scope/bar/package.json
+{ "name": "@scope/bar", "version": "1.2.3" }
+
 // @Filename: /a.ts
 import * as foo from "foo";
 import * as fooSub from "foo/sub";
 import * as barSub from "bar/sub";
+import * as scopeFoo from "@scope/foo";
+import * as scopeFooSub from "@scope/foo/sub";
+import * as scopeBarSub from "@scope/bar/sub";


### PR DESCRIPTION
Add a test case for an untyped sub-module of a scoped package with
typings.  The other diagnostic message is covered by existing tests; I
guess no one looked at the baselines closely enough.

Fixes #23999.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
