### PR TITLE
Fixes #26122 - erroneous "TS2350" for js constructors called with incorrect parameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19592,7 +19592,7 @@ namespace ts {
             const callSignatures = getSignaturesOfType(expressionType, SignatureKind.Call);
             if (callSignatures.length) {
                 const signature = resolveCall(node, callSignatures, candidatesOutArray, isForSignatureHelp);
-                if (!isJavaScriptConstructor(signature.declaration) && getReturnTypeOfSignature(signature) !== voidType) {
+                if (signature.declaration && !isJavaScriptConstructor(signature.declaration) && getReturnTypeOfSignature(signature) !== voidType) {
                     error(node, Diagnostics.Only_a_void_function_can_be_called_with_the_new_keyword);
                 }
                 if (getThisTypeOfSignature(signature) === voidType) {

--- a/tests/baselines/reference/callOnInstance.errors.txt
+++ b/tests/baselines/reference/callOnInstance.errors.txt
@@ -1,11 +1,10 @@
 tests/cases/compiler/callOnInstance.ts(1,18): error TS2300: Duplicate identifier 'D'.
 tests/cases/compiler/callOnInstance.ts(3,15): error TS2300: Duplicate identifier 'D'.
-tests/cases/compiler/callOnInstance.ts(7,19): error TS2350: Only a void function can be called with the 'new' keyword.
 tests/cases/compiler/callOnInstance.ts(7,19): error TS2554: Expected 0 arguments, but got 1.
 tests/cases/compiler/callOnInstance.ts(10,1): error TS2349: Cannot invoke an expression whose type lacks a call signature. Type 'C' has no compatible call signatures.
 
 
-==== tests/cases/compiler/callOnInstance.ts (5 errors) ====
+==== tests/cases/compiler/callOnInstance.ts (4 errors) ====
     declare function D(): string; // error
                      ~
 !!! error TS2300: Duplicate identifier 'D'.
@@ -17,8 +16,6 @@ tests/cases/compiler/callOnInstance.ts(10,1): error TS2349: Cannot invoke an exp
     var s1: string = D(); // OK
     
     var s2: string = (new D(1))();
-                      ~~~~~~~~
-!!! error TS2350: Only a void function can be called with the 'new' keyword.
                       ~~~~~~~~
 !!! error TS2554: Expected 0 arguments, but got 1.
     

--- a/tests/baselines/reference/callOverloads1.errors.txt
+++ b/tests/baselines/reference/callOverloads1.errors.txt
@@ -1,11 +1,10 @@
 tests/cases/compiler/callOverloads1.ts(1,7): error TS2300: Duplicate identifier 'Foo'.
 tests/cases/compiler/callOverloads1.ts(9,10): error TS2300: Duplicate identifier 'Foo'.
 tests/cases/compiler/callOverloads1.ts(9,10): error TS2391: Function implementation is missing or not immediately following the declaration.
-tests/cases/compiler/callOverloads1.ts(13,10): error TS2350: Only a void function can be called with the 'new' keyword.
 tests/cases/compiler/callOverloads1.ts(13,10): error TS2554: Expected 0 arguments, but got 1.
 
 
-==== tests/cases/compiler/callOverloads1.ts (5 errors) ====
+==== tests/cases/compiler/callOverloads1.ts (4 errors) ====
     class Foo { // error
           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
@@ -25,8 +24,6 @@ tests/cases/compiler/callOverloads1.ts(13,10): error TS2554: Expected 0 argument
     function F1(a:any) { return a;}
     
     var f1 = new Foo("hey");
-             ~~~~~~~~~~~~~~
-!!! error TS2350: Only a void function can be called with the 'new' keyword.
              ~~~~~~~~~~~~~~
 !!! error TS2554: Expected 0 arguments, but got 1.
     

--- a/tests/baselines/reference/callOverloads2.errors.txt
+++ b/tests/baselines/reference/callOverloads2.errors.txt
@@ -4,11 +4,10 @@ tests/cases/compiler/callOverloads2.ts(11,10): error TS2389: Function implementa
 tests/cases/compiler/callOverloads2.ts(11,10): error TS2393: Duplicate function implementation.
 tests/cases/compiler/callOverloads2.ts(12,10): error TS2393: Duplicate function implementation.
 tests/cases/compiler/callOverloads2.ts(14,10): error TS2391: Function implementation is missing or not immediately following the declaration.
-tests/cases/compiler/callOverloads2.ts(18,10): error TS2350: Only a void function can be called with the 'new' keyword.
 tests/cases/compiler/callOverloads2.ts(18,10): error TS2554: Expected 0 arguments, but got 1.
 
 
-==== tests/cases/compiler/callOverloads2.ts (8 errors) ====
+==== tests/cases/compiler/callOverloads2.ts (7 errors) ====
     class Foo { // error
           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
@@ -39,8 +38,6 @@ tests/cases/compiler/callOverloads2.ts(18,10): error TS2554: Expected 0 argument
     declare function Gar(s:String); // expect no error
     
     var f1 = new Foo("hey");
-             ~~~~~~~~~~~~~~
-!!! error TS2350: Only a void function can be called with the 'new' keyword.
              ~~~~~~~~~~~~~~
 !!! error TS2554: Expected 0 arguments, but got 1.
     

--- a/tests/baselines/reference/constructorFunctions.errors.txt
+++ b/tests/baselines/reference/constructorFunctions.errors.txt
@@ -1,8 +1,9 @@
 tests/cases/conformance/salsa/index.js(22,15): error TS2348: Value of type 'typeof C3' is not callable. Did you mean to include 'new'?
 tests/cases/conformance/salsa/index.js(30,15): error TS2348: Value of type 'typeof C4' is not callable. Did you mean to include 'new'?
+tests/cases/conformance/salsa/index.js(55,13): error TS2554: Expected 1 arguments, but got 0.
 
 
-==== tests/cases/conformance/salsa/index.js (2 errors) ====
+==== tests/cases/conformance/salsa/index.js (3 errors) ====
     function C1() {
         if (!(this instanceof C1)) return new C1();
         this.x = 1;
@@ -53,4 +54,15 @@ tests/cases/conformance/salsa/index.js(30,15): error TS2348: Value of type 'type
     };
     
     var c6_v1 = new C6();
+    
+    
+    /**
+     * @constructor
+     * @param {number} num
+     */
+    function C7(num) {}
+    
+    var c7_v1 = new C7();
+                ~~~~~~~~
+!!! error TS2554: Expected 1 arguments, but got 0.
     

--- a/tests/baselines/reference/constructorFunctions.symbols
+++ b/tests/baselines/reference/constructorFunctions.symbols
@@ -116,3 +116,16 @@ var c6_v1 = new C6();
 >c6_v1 : Symbol(c6_v1, Decl(index.js, 45, 3))
 >C6 : Symbol(C6, Decl(index.js, 38, 12))
 
+
+/**
+ * @constructor
+ * @param {number} num
+ */
+function C7(num) {}
+>C7 : Symbol(C7, Decl(index.js, 45, 21))
+>num : Symbol(num, Decl(index.js, 52, 12))
+
+var c7_v1 = new C7();
+>c7_v1 : Symbol(c7_v1, Decl(index.js, 54, 3))
+>C7 : Symbol(C7, Decl(index.js, 45, 21))
+

--- a/tests/baselines/reference/constructorFunctions.types
+++ b/tests/baselines/reference/constructorFunctions.types
@@ -168,3 +168,17 @@ var c6_v1 = new C6();
 >new C6() : C6
 >C6 : typeof C6
 
+
+/**
+ * @constructor
+ * @param {number} num
+ */
+function C7(num) {}
+>C7 : typeof C7
+>num : number
+
+var c7_v1 = new C7();
+>c7_v1 : any
+>new C7() : any
+>C7 : typeof C7
+

--- a/tests/baselines/reference/instantiateNonGenericTypeWithTypeArguments.errors.txt
+++ b/tests/baselines/reference/instantiateNonGenericTypeWithTypeArguments.errors.txt
@@ -1,12 +1,10 @@
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(8,15): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(11,9): error TS2350: Only a void function can be called with the 'new' keyword.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(11,17): error TS2558: Expected 0 type arguments, but got 1.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(14,10): error TS2350: Only a void function can be called with the 'new' keyword.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(14,16): error TS2558: Expected 0 type arguments, but got 1.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(18,10): error TS2347: Untyped function calls may not accept type arguments.
 
 
-==== tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts (6 errors) ====
+==== tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts (4 errors) ====
     // it is an error to provide type arguments to a non-generic call
     // all of these are errors
     
@@ -20,15 +18,11 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGen
     
     function Foo(): void { }
     var r = new Foo<number>();
-            ~~~~~~~~~~~~~~~~~
-!!! error TS2350: Only a void function can be called with the 'new' keyword.
                     ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     
     var f: { (): void };
     var r2 = new f<number>();
-             ~~~~~~~~~~~~~~~
-!!! error TS2350: Only a void function can be called with the 'new' keyword.
                    ~~~~~~
 !!! error TS2558: Expected 0 type arguments, but got 1.
     

--- a/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.errors.txt
+++ b/tests/baselines/reference/overloadsAndTypeArgumentArityErrors.errors.txt
@@ -1,10 +1,9 @@
 tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(5,11): error TS2558: Expected 0-2 type arguments, but got 3.
-tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(6,1): error TS2350: Only a void function can be called with the 'new' keyword.
 tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(6,15): error TS2558: Expected 0-2 type arguments, but got 3.
 tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(9,1): error TS2554: Expected 1 arguments, but got 0.
 
 
-==== tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts (4 errors) ====
+==== tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts (3 errors) ====
     declare function Callbacks(flags?: string): void;
     declare function Callbacks<T>(flags?: string): void;
     declare function Callbacks<T1, T2>(flags?: string): void;
@@ -13,8 +12,6 @@ tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts(9,1): error TS2554: 
               ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 0-2 type arguments, but got 3.
     new Callbacks<number, string, boolean>('s'); // wrong number of type arguments
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2350: Only a void function can be called with the 'new' keyword.
                   ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2558: Expected 0-2 type arguments, but got 3.
     

--- a/tests/cases/conformance/salsa/constructorFunctions.ts
+++ b/tests/cases/conformance/salsa/constructorFunctions.ts
@@ -49,3 +49,12 @@ function C6() {
 };
 
 var c6_v1 = new C6();
+
+
+/**
+ * @constructor
+ * @param {number} num
+ */
+function C7(num) {}
+
+var c7_v1 = new C7();


### PR DESCRIPTION
When `resolveCall` does not resolve a signature in `resolveNewExpression`, the error should only be thrown if there is a *defined* signature that is not-void.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #26122

---

Should we consider marking the call signatures of functions with `@constructor`as construct signatures (as in PR #25980). It caused a weird bug with `typeFromPropertyAssignment12` that is probably worth understanding. 