### PR TITLE
Do not read files greater than maxFileSize which is currently 4mb

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1,5 +1,7 @@
 namespace ts.server {
     export const maxProgramSizeForNonTsFiles = 20 * 1024 * 1024;
+    /*@internal*/
+    export const maxFileSize = 4 * 1024 * 1024;
 
     // tslint:disable variable-name
     export const ProjectsUpdatedInBackgroundEvent = "projectsUpdatedInBackground";

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -163,7 +163,10 @@ namespace ts.server {
         }
 
         private getFileText(tempFileName?: string) {
-            return this.host.readFile(tempFileName || this.fileName) || "";
+            let text: string;
+            const getText = () => text === undefined ? (text = this.host.readFile(tempFileName || this.fileName) || "") : text;
+            const size = this.host.getFileSize ? this.host.getFileSize(tempFileName || this.fileName) : getText().length;
+            return size > maxFileSize ? "" : getText();
         }
 
         private switchToScriptVersionCache(): ScriptVersionCache {


### PR DESCRIPTION
Fixes #24762

@mjbvz 
- should we be sending you event for largeFile so you can show some kind of dialog?
- Can you block sending open request to use if its a large file. Currently with this change vscode works well when i have import to "solc" module but if i click on solcjson.js file from `node_modules/solc/` folder things will go bad because we arent reading contents from file but its passed by vscode.


