### PR TITLE
Fixes to ensure getDefinitionAndBoundSpan works correctly when using composite projects

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2358,7 +2358,7 @@ namespace ts {
             if (sourceFile === undefined) {
                 return undefined;
             }
-
+            sourceFile.path = toPath(refPath);
             const commandLine = parseJsonSourceFileConfigFileContent(sourceFile, configParsingHost, basePath, /*existingOptions*/ undefined, refPath);
             return { commandLine, sourceFile };
         }

--- a/src/compiler/sourcemapDecoder.ts
+++ b/src/compiler/sourcemapDecoder.ts
@@ -100,7 +100,8 @@ namespace ts.sourcemaps {
             // Lookup file in program, if provided
             const path = toPath(fileName, location, host.getCanonicalFileName);
             const file = program && program.getSourceFile(path);
-            if (!file) {
+            // file returned here could be .d.ts when asked for .ts file if projectReferences and module resolution created this source file
+            if (!file || file.resolvedPath !== path) {
                 // Otherwise check the cache (which may hit disk)
                 return fallbackCache.get(path);
             }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2243,6 +2243,20 @@ namespace ts.server {
                     toRemoveConfiguredProjects.delete(project.canonicalConfigFilePath);
                     markOriginalProjectsAsUsed(project);
                 }
+                else {
+                    // If the configured project for project reference has more than zero references, keep it alive
+                    const resolvedProjectReferences = project.getResolvedProjectReferences();
+                    if (resolvedProjectReferences) {
+                        for (const ref of resolvedProjectReferences) {
+                            if (ref) {
+                                const refProject = this.configuredProjects.get(ref.sourceFile.path);
+                                if (refProject && refProject.hasOpenRef()) {
+                                    toRemoveConfiguredProjects.delete(project.canonicalConfigFilePath);
+                                }
+                            }
+                        }
+                    }
+                }
             });
 
             // Remove all the non marked projects

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -572,6 +572,14 @@ namespace ts.server {
                 for (const f of this.program.getSourceFiles()) {
                     this.detachScriptInfoIfNotRoot(f.fileName);
                 }
+                const projectReferences = this.program.getProjectReferences();
+                if (projectReferences) {
+                    for (const ref of projectReferences) {
+                        if (ref) {
+                            this.detachScriptInfoFromProject(ref.sourceFile.fileName);
+                        }
+                    }
+                }
             }
             // Release external files
             forEach(this.externalFiles, externalFile => this.detachScriptInfoIfNotRoot(externalFile));
@@ -1365,6 +1373,12 @@ namespace ts.server {
 
         updateReferences(refs: ReadonlyArray<ProjectReference> | undefined) {
             this.projectReferences = refs;
+        }
+
+        /*@internal*/
+        getResolvedProjectReferences() {
+            const program = this.getCurrentProgram();
+            return program && program.getProjectReferences();
         }
 
         enablePlugins() {


### PR DESCRIPTION
Project references need to be detached from the project when closing project
In SourceMapDecoder handle when the redirected file to project reference is set as the output of the project
Keep configured project alive if project it references has open ref
Fixes #26164