### PR TITLE
 Refresh semantic diagnostics when compiler options affecting semantic diagnostics generation changes

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -65,7 +65,8 @@ namespace ts {
         }
         state.changedFilesSet = createMap<true>();
         const useOldState = BuilderState.canReuseOldState(state.referencedMap, oldState);
-        const canCopySemanticDiagnostics = useOldState && oldState!.semanticDiagnosticsPerFile && !!state.semanticDiagnosticsPerFile;
+        const canCopySemanticDiagnostics = useOldState && oldState!.semanticDiagnosticsPerFile && !!state.semanticDiagnosticsPerFile &&
+            !compilerOptionsAffectSemanticDiagnostics(compilerOptions, oldState!.program.getCompilerOptions());
         if (useOldState) {
             // Verify the sanity of old state
             if (!oldState!.currentChangedFilePath) {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -319,13 +319,15 @@ namespace ts {
         {
             name: "noImplicitAny",
             type: "boolean",
+            strictFlag: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Strict_Type_Checking_Options,
-            description: Diagnostics.Raise_error_on_expressions_and_declarations_with_an_implied_any_type,
+            description: Diagnostics.Raise_error_on_expressions_and_declarations_with_an_implied_any_type
         },
         {
             name: "strictNullChecks",
             type: "boolean",
+            strictFlag: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Strict_Type_Checking_Options,
             description: Diagnostics.Enable_strict_null_checks
@@ -333,6 +335,7 @@ namespace ts {
         {
             name: "strictFunctionTypes",
             type: "boolean",
+            strictFlag: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Strict_Type_Checking_Options,
             description: Diagnostics.Enable_strict_checking_of_function_types
@@ -340,6 +343,7 @@ namespace ts {
         {
             name: "strictPropertyInitialization",
             type: "boolean",
+            strictFlag: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Strict_Type_Checking_Options,
             description: Diagnostics.Enable_strict_checking_of_property_initialization_in_classes
@@ -347,6 +351,7 @@ namespace ts {
         {
             name: "noImplicitThis",
             type: "boolean",
+            strictFlag: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Strict_Type_Checking_Options,
             description: Diagnostics.Raise_error_on_this_expressions_with_an_implied_any_type,
@@ -354,6 +359,7 @@ namespace ts {
         {
             name: "alwaysStrict",
             type: "boolean",
+            strictFlag: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Strict_Type_Checking_Options,
             description: Diagnostics.Parse_in_strict_mode_and_emit_use_strict_for_each_source_file
@@ -363,6 +369,7 @@ namespace ts {
         {
             name: "noUnusedLocals",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Additional_Checks,
             description: Diagnostics.Report_errors_on_unused_locals,
@@ -370,6 +377,7 @@ namespace ts {
         {
             name: "noUnusedParameters",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Additional_Checks,
             description: Diagnostics.Report_errors_on_unused_parameters,
@@ -377,6 +385,7 @@ namespace ts {
         {
             name: "noImplicitReturns",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Additional_Checks,
             description: Diagnostics.Report_error_when_not_all_code_paths_in_function_return_a_value
@@ -384,6 +393,7 @@ namespace ts {
         {
             name: "noFallthroughCasesInSwitch",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Additional_Checks,
             description: Diagnostics.Report_errors_for_fallthrough_cases_in_switch_statement
@@ -640,6 +650,7 @@ namespace ts {
         {
             name: "noImplicitUseStrict",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Do_not_emit_use_strict_directives_in_module_output
         },
@@ -678,24 +689,28 @@ namespace ts {
         {
             name: "allowUnusedLabels",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Do_not_report_errors_on_unused_labels
         },
         {
             name: "allowUnreachableCode",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Do_not_report_errors_on_unreachable_code
         },
         {
             name: "suppressExcessPropertyErrors",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Suppress_excess_property_checks_for_object_literals,
         },
         {
             name: "suppressImplicitAnyIndexErrors",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Suppress_noImplicitAny_errors_for_indexing_objects_lacking_index_signatures,
         },
@@ -714,6 +729,7 @@ namespace ts {
         {
             name: "noStrictGenericChecks",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Disable_strict_checking_of_generic_signatures_in_function_types,
         },

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -465,12 +465,14 @@ namespace ts {
         {
             name: "allowSyntheticDefaultImports",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             category: Diagnostics.Module_Resolution_Options,
             description: Diagnostics.Allow_default_imports_from_modules_with_no_default_export_This_does_not_affect_code_emit_just_typechecking
         },
         {
             name: "esModuleInterop",
             type: "boolean",
+            affectsSemanticDiagnostics: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Module_Resolution_Options,
             description: Diagnostics.Enables_emit_interoperability_between_CommonJS_and_ES_Modules_via_creation_of_namespace_objects_for_all_imports_Implies_allowSyntheticDefaultImports

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4540,6 +4540,8 @@ namespace ts {
         isCommandLineOnly?: boolean;
         showInSimplifiedHelpView?: boolean;
         category?: DiagnosticMessage;
+        strictFlag?: true;                                      // true if the option is one of the flag under strict
+        affectsSemanticDiagnostics?: true;                      // true if option affects semantic diagnostics
     }
 
     /* @internal */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6972,38 +6972,9 @@ namespace ts {
             return false;
         }
 
-        return changedCompileOptionValueOf(newOptions, oldOptions, [
-            "noImplicitReturns",
-            "strict",
-            "suppressExcessPropertyErrors",
-            "suppressImplicitAnyIndexErrors",
-            "noFallthroughCasesInSwitch",
-            "noStrictGenericChecks",
-            "noUnusedLocals",
-            "noUnusedParameters",
-            "noImplicitUseStrict"
-        ]) || changedStrictOptionValueOf(newOptions, oldOptions, [
-            "noImplicitAny",
-            "noImplicitThis",
-            "strictNullChecks",
-            "strictFunctionTypes",
-            "strictPropertyInitialization",
-            "alwaysStrict"
-        ]);
-    }
-
-    function changedStrictOptionValueOf(newOptions: CompilerOptions, oldOptions: CompilerOptions, flags: StrictOptionName[]) {
-        for (const flag of flags) {
-            if (getStrictOptionValue(newOptions, flag) !== getStrictOptionValue(oldOptions, flag)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    function changedCompileOptionValueOf(newOptions: CompilerOptions, oldOptions: CompilerOptions, optionKeys: (keyof CompilerOptions)[]) {
-        for (const optionKey of optionKeys) {
-            if (newOptions[optionKey] !== oldOptions[optionKey]) {
+        for (const option of optionDeclarations) {
+            if ((option.strictFlag && getStrictOptionValue(newOptions, option.name as StrictOptionName) !== getStrictOptionValue(oldOptions, option.name as StrictOptionName)) ||
+                (option.affectsSemanticDiagnostics && !newOptions[option.name] !== !oldOptions[option.name])) {
                 return true;
             }
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6967,6 +6967,49 @@ namespace ts {
         return compilerOptions[flag] === undefined ? !!compilerOptions.strict : !!compilerOptions[flag];
     }
 
+    export function compilerOptionsAffectSemanticDiagnostics(newOptions: CompilerOptions, oldOptions: CompilerOptions) {
+        if (oldOptions === newOptions) {
+            return false;
+        }
+
+        return changedCompileOptionValueOf(newOptions, oldOptions, [
+            "noImplicitReturns",
+            "strict",
+            "suppressExcessPropertyErrors",
+            "suppressImplicitAnyIndexErrors",
+            "noFallthroughCasesInSwitch",
+            "noStrictGenericChecks",
+            "noUnusedLocals",
+            "noUnusedParameters",
+            "noImplicitUseStrict"
+        ]) || changedStrictOptionValueOf(newOptions, oldOptions, [
+            "noImplicitAny",
+            "noImplicitThis",
+            "strictNullChecks",
+            "strictFunctionTypes",
+            "strictPropertyInitialization",
+            "alwaysStrict"
+        ]);
+    }
+
+    function changedStrictOptionValueOf(newOptions: CompilerOptions, oldOptions: CompilerOptions, flags: StrictOptionName[]) {
+        for (const flag of flags) {
+            if (getStrictOptionValue(newOptions, flag) !== getStrictOptionValue(oldOptions, flag)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    function changedCompileOptionValueOf(newOptions: CompilerOptions, oldOptions: CompilerOptions, optionKeys: (keyof CompilerOptions)[]) {
+        for (const optionKey of optionKeys) {
+            if (newOptions[optionKey] !== oldOptions[optionKey]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     export function hasZeroOrOneAsteriskCharacter(str: string): boolean {
         let seenAsterisk = false;
         for (let i = 0; i < str.length; i++) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6972,13 +6972,8 @@ namespace ts {
             return false;
         }
 
-        for (const option of optionDeclarations) {
-            if ((option.strictFlag && getStrictOptionValue(newOptions, option.name as StrictOptionName) !== getStrictOptionValue(oldOptions, option.name as StrictOptionName)) ||
-                (option.affectsSemanticDiagnostics && !newOptions[option.name] !== !oldOptions[option.name])) {
-                return true;
-            }
-        }
-        return false;
+        return optionDeclarations.some(option => (!!option.strictFlag && getStrictOptionValue(newOptions, option.name as StrictOptionName) !== getStrictOptionValue(oldOptions, option.name as StrictOptionName)) ||
+            (!!option.affectsSemanticDiagnostics && !newOptions[option.name] !== !oldOptions[option.name]));
     }
 
     export function hasZeroOrOneAsteriskCharacter(str: string): boolean {

--- a/src/testRunner/unittests/tscWatchMode.ts
+++ b/src/testRunner/unittests/tscWatchMode.ts
@@ -1141,7 +1141,6 @@ namespace ts.tscWatch {
             }
 
             it("without outDir or outFile is specified", () => {
-                debugger;
                 verifyWithOptions({ module: ModuleKind.AMD }, ["file1.js", "src/file2.js"]);
             });
 

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -9333,7 +9333,7 @@ export function Test2() {
                 textSpan: protocolTextSpanFromSubstring(userTs.content, "fnA", { index: 1 }),
                 definitions: [protocolFileSpanFromSubstring(aTs, "fnA")],
             });
-            checkNumberOfProjects(session.getProjectService(), { configuredProjects: 1 }); debugger;
+            checkNumberOfProjects(session.getProjectService(), { configuredProjects: 1 });
             verifyUserTsConfigProject(session);
 
             // Navigate to the definition


### PR DESCRIPTION
Fixes #26195