### PR TITLE
completions: 'true' and 'false' are type keywords

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1187,6 +1187,7 @@ namespace ts {
     export const typeKeywords: ReadonlyArray<SyntaxKind> = [
         SyntaxKind.AnyKeyword,
         SyntaxKind.BooleanKeyword,
+        SyntaxKind.FalseKeyword,
         SyntaxKind.KeyOfKeyword,
         SyntaxKind.NeverKeyword,
         SyntaxKind.NullKeyword,
@@ -1194,6 +1195,7 @@ namespace ts {
         SyntaxKind.ObjectKeyword,
         SyntaxKind.StringKeyword,
         SyntaxKind.SymbolKeyword,
+        SyntaxKind.TrueKeyword,
         SyntaxKind.VoidKeyword,
         SyntaxKind.UndefinedKeyword,
         SyntaxKind.UniqueKeyword,

--- a/tests/cases/fourslash/completionsTypeKeywords.ts
+++ b/tests/cases/fourslash/completionsTypeKeywords.ts
@@ -6,5 +6,5 @@
 
 verify.completions({
     marker: "",
-    exact: ["T", "null", "void", "any", "boolean", "keyof", "never", "number", "object", "string", "symbol", "undefined", "unique", "unknown"],
+    exact: ["T", "false", "null", "true", "void", "any", "boolean", "keyof", "never", "number", "object", "string", "symbol", "undefined", "unique", "unknown"],
 });


### PR DESCRIPTION
Fixes #26231

