### PR TITLE
Add [Constructor]Parameters types to lib.d.ts

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1379,6 +1379,16 @@ type Extract<T, U> = T extends U ? T : never;
 type NonNullable<T> = T extends null | undefined ? never : T;
 
 /**
+ * Obtain the parameters of a function type in a tuple
+ */
+type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? P : never;
+
+/**
+ * Obtain the parameters of a constructor function type in a tuple
+ */
+type ConstructorParameters<T extends new (...args: any[]) => any> = T extends new (...args: infer P) => any ? P : never;
+
+/**
  * Obtain the return type of a function type
  */
 type ReturnType<T extends (...args: any[]) => any> = T extends (...args: any[]) => infer R ? R : any;

--- a/tests/baselines/reference/genericRestParameters1.errors.txt
+++ b/tests/baselines/reference/genericRestParameters1.errors.txt
@@ -1,11 +1,15 @@
 tests/cases/conformance/types/rest/genericRestParameters1.ts(22,1): error TS2556: Expected 3 arguments, but got 1 or more.
 tests/cases/conformance/types/rest/genericRestParameters1.ts(31,1): error TS2556: Expected 3 arguments, but got 1 or more.
-tests/cases/conformance/types/rest/genericRestParameters1.ts(166,1): error TS2322: Type '(a: never) => void' is not assignable to type '(...args: any[]) => void'.
+tests/cases/conformance/types/rest/genericRestParameters1.ts(133,40): error TS2344: Type '(...args: T) => void' does not satisfy the constraint '(...args: any[]) => any'.
+tests/cases/conformance/types/rest/genericRestParameters1.ts(134,51): error TS2344: Type 'new (...args: T) => void' does not satisfy the constraint 'new (...args: any[]) => any'.
+tests/cases/conformance/types/rest/genericRestParameters1.ts(135,23): error TS2344: Type 'Function' does not satisfy the constraint '(...args: any[]) => any'.
+  Type 'Function' provides no match for the signature '(...args: any[]): any'.
+tests/cases/conformance/types/rest/genericRestParameters1.ts(164,1): error TS2322: Type '(a: never) => void' is not assignable to type '(...args: any[]) => void'.
   Types of parameters 'a' and 'args' are incompatible.
     Type 'any' is not assignable to type 'never'.
 
 
-==== tests/cases/conformance/types/rest/genericRestParameters1.ts (3 errors) ====
+==== tests/cases/conformance/types/rest/genericRestParameters1.ts (6 errors) ====
     declare let f1: (...x: [number, string, boolean]) => void;
     declare let f2: (x0: number, x1: string, x2: boolean) => void;
     
@@ -136,17 +140,22 @@ tests/cases/conformance/types/rest/genericRestParameters1.ts(166,1): error TS232
     
     const c30 = f30(42, x => "" + x, x => x + 1);  // [(x: number) => string, (x: number) => number]
     
-    type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new(...args: infer U) => any) ? U : any[];
-    
     type T01 = Parameters<(x: number, y: string, z: boolean) => void>;
     type T02 = Parameters<(...args: [number, string, boolean]) => void>;
-    type T03 = Parameters<new (x: number, y: string, z: boolean) => void>;
-    type T04 = Parameters<new (...args: [number, string, boolean]) => void>;
+    type T03 = ConstructorParameters<new (x: number, y: string, z: boolean) => void>;
+    type T04 = ConstructorParameters<new (...args: [number, string, boolean]) => void>;
     type T05<T> = Parameters<(...args: T[]) => void>;
-    type T06<T> = Parameters<new (...args: []) => void>;
+    type T06<T> = ConstructorParameters<new (...args: []) => void>;
     type T07<T extends any[]> = Parameters<(...args: T) => void>;
-    type T08<T extends any[]> = Parameters<new (...args: T) => void>;
+                                           ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2344: Type '(...args: T) => void' does not satisfy the constraint '(...args: any[]) => any'.
+    type T08<T extends any[]> = ConstructorParameters<new (...args: T) => void>;
+                                                      ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2344: Type 'new (...args: T) => void' does not satisfy the constraint 'new (...args: any[]) => any'.
     type T09 = Parameters<Function>;
+                          ~~~~~~~~
+!!! error TS2344: Type 'Function' does not satisfy the constraint '(...args: any[]) => any'.
+!!! error TS2344:   Type 'Function' provides no match for the signature '(...args: any[]): any'.
     
     type Record1 = {
       move: [number, 'left' | 'right'];

--- a/tests/baselines/reference/genericRestParameters1.js
+++ b/tests/baselines/reference/genericRestParameters1.js
@@ -125,16 +125,14 @@ declare function f30<T, U extends ((x: T) => any)[]>(x: T, ...args: U): U;
 
 const c30 = f30(42, x => "" + x, x => x + 1);  // [(x: number) => string, (x: number) => number]
 
-type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new(...args: infer U) => any) ? U : any[];
-
 type T01 = Parameters<(x: number, y: string, z: boolean) => void>;
 type T02 = Parameters<(...args: [number, string, boolean]) => void>;
-type T03 = Parameters<new (x: number, y: string, z: boolean) => void>;
-type T04 = Parameters<new (...args: [number, string, boolean]) => void>;
+type T03 = ConstructorParameters<new (x: number, y: string, z: boolean) => void>;
+type T04 = ConstructorParameters<new (...args: [number, string, boolean]) => void>;
 type T05<T> = Parameters<(...args: T[]) => void>;
-type T06<T> = Parameters<new (...args: []) => void>;
+type T06<T> = ConstructorParameters<new (...args: []) => void>;
 type T07<T extends any[]> = Parameters<(...args: T) => void>;
-type T08<T extends any[]> = Parameters<new (...args: T) => void>;
+type T08<T extends any[]> = ConstructorParameters<new (...args: T) => void>;
 type T09 = Parameters<Function>;
 
 type Record1 = {
@@ -327,15 +325,14 @@ declare const g22: (z?: boolean | undefined) => string[];
 declare const g23: () => string[];
 declare function f30<T, U extends ((x: T) => any)[]>(x: T, ...args: U): U;
 declare const c30: [(x: number) => string, (x: number) => number];
-declare type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new (...args: infer U) => any) ? U : any[];
 declare type T01 = Parameters<(x: number, y: string, z: boolean) => void>;
 declare type T02 = Parameters<(...args: [number, string, boolean]) => void>;
-declare type T03 = Parameters<new (x: number, y: string, z: boolean) => void>;
-declare type T04 = Parameters<new (...args: [number, string, boolean]) => void>;
+declare type T03 = ConstructorParameters<new (x: number, y: string, z: boolean) => void>;
+declare type T04 = ConstructorParameters<new (...args: [number, string, boolean]) => void>;
 declare type T05<T> = Parameters<(...args: T[]) => void>;
-declare type T06<T> = Parameters<new (...args: []) => void>;
+declare type T06<T> = ConstructorParameters<new (...args: []) => void>;
 declare type T07<T extends any[]> = Parameters<(...args: T) => void>;
-declare type T08<T extends any[]> = Parameters<new (...args: T) => void>;
+declare type T08<T extends any[]> = ConstructorParameters<new (...args: T) => void>;
 declare type T09 = Parameters<Function>;
 declare type Record1 = {
     move: [number, 'left' | 'right'];

--- a/tests/baselines/reference/genericRestParameters1.symbols
+++ b/tests/baselines/reference/genericRestParameters1.symbols
@@ -494,160 +494,149 @@ const c30 = f30(42, x => "" + x, x => x + 1);  // [(x: number) => string, (x: nu
 >x : Symbol(x, Decl(genericRestParameters1.ts, 124, 32))
 >x : Symbol(x, Decl(genericRestParameters1.ts, 124, 32))
 
-type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new(...args: infer U) => any) ? U : any[];
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
->T : Symbol(T, Decl(genericRestParameters1.ts, 126, 16))
->Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(genericRestParameters1.ts, 126, 16))
->args : Symbol(args, Decl(genericRestParameters1.ts, 126, 50))
->U : Symbol(U, Decl(genericRestParameters1.ts, 126, 64), Decl(genericRestParameters1.ts, 126, 97))
->args : Symbol(args, Decl(genericRestParameters1.ts, 126, 83))
->U : Symbol(U, Decl(genericRestParameters1.ts, 126, 64), Decl(genericRestParameters1.ts, 126, 97))
->U : Symbol(U, Decl(genericRestParameters1.ts, 126, 64), Decl(genericRestParameters1.ts, 126, 97))
-
 type T01 = Parameters<(x: number, y: string, z: boolean) => void>;
->T01 : Symbol(T01, Decl(genericRestParameters1.ts, 126, 121))
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
->x : Symbol(x, Decl(genericRestParameters1.ts, 128, 23))
->y : Symbol(y, Decl(genericRestParameters1.ts, 128, 33))
->z : Symbol(z, Decl(genericRestParameters1.ts, 128, 44))
+>T01 : Symbol(T01, Decl(genericRestParameters1.ts, 124, 45))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(genericRestParameters1.ts, 126, 23))
+>y : Symbol(y, Decl(genericRestParameters1.ts, 126, 33))
+>z : Symbol(z, Decl(genericRestParameters1.ts, 126, 44))
 
 type T02 = Parameters<(...args: [number, string, boolean]) => void>;
->T02 : Symbol(T02, Decl(genericRestParameters1.ts, 128, 66))
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
->args : Symbol(args, Decl(genericRestParameters1.ts, 129, 23))
+>T02 : Symbol(T02, Decl(genericRestParameters1.ts, 126, 66))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(genericRestParameters1.ts, 127, 23))
 
-type T03 = Parameters<new (x: number, y: string, z: boolean) => void>;
->T03 : Symbol(T03, Decl(genericRestParameters1.ts, 129, 68))
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
->x : Symbol(x, Decl(genericRestParameters1.ts, 130, 27))
->y : Symbol(y, Decl(genericRestParameters1.ts, 130, 37))
->z : Symbol(z, Decl(genericRestParameters1.ts, 130, 48))
+type T03 = ConstructorParameters<new (x: number, y: string, z: boolean) => void>;
+>T03 : Symbol(T03, Decl(genericRestParameters1.ts, 127, 68))
+>ConstructorParameters : Symbol(ConstructorParameters, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(genericRestParameters1.ts, 128, 38))
+>y : Symbol(y, Decl(genericRestParameters1.ts, 128, 48))
+>z : Symbol(z, Decl(genericRestParameters1.ts, 128, 59))
 
-type T04 = Parameters<new (...args: [number, string, boolean]) => void>;
->T04 : Symbol(T04, Decl(genericRestParameters1.ts, 130, 70))
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
->args : Symbol(args, Decl(genericRestParameters1.ts, 131, 27))
+type T04 = ConstructorParameters<new (...args: [number, string, boolean]) => void>;
+>T04 : Symbol(T04, Decl(genericRestParameters1.ts, 128, 81))
+>ConstructorParameters : Symbol(ConstructorParameters, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(genericRestParameters1.ts, 129, 38))
 
 type T05<T> = Parameters<(...args: T[]) => void>;
->T05 : Symbol(T05, Decl(genericRestParameters1.ts, 131, 72))
->T : Symbol(T, Decl(genericRestParameters1.ts, 132, 9))
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
->args : Symbol(args, Decl(genericRestParameters1.ts, 132, 26))
->T : Symbol(T, Decl(genericRestParameters1.ts, 132, 9))
+>T05 : Symbol(T05, Decl(genericRestParameters1.ts, 129, 83))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 130, 9))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(genericRestParameters1.ts, 130, 26))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 130, 9))
 
-type T06<T> = Parameters<new (...args: []) => void>;
->T06 : Symbol(T06, Decl(genericRestParameters1.ts, 132, 49))
->T : Symbol(T, Decl(genericRestParameters1.ts, 133, 9))
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
->args : Symbol(args, Decl(genericRestParameters1.ts, 133, 30))
+type T06<T> = ConstructorParameters<new (...args: []) => void>;
+>T06 : Symbol(T06, Decl(genericRestParameters1.ts, 130, 49))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 131, 9))
+>ConstructorParameters : Symbol(ConstructorParameters, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(genericRestParameters1.ts, 131, 41))
 
 type T07<T extends any[]> = Parameters<(...args: T) => void>;
->T07 : Symbol(T07, Decl(genericRestParameters1.ts, 133, 52))
->T : Symbol(T, Decl(genericRestParameters1.ts, 134, 9))
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
->args : Symbol(args, Decl(genericRestParameters1.ts, 134, 40))
->T : Symbol(T, Decl(genericRestParameters1.ts, 134, 9))
+>T07 : Symbol(T07, Decl(genericRestParameters1.ts, 131, 63))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 132, 9))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(genericRestParameters1.ts, 132, 40))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 132, 9))
 
-type T08<T extends any[]> = Parameters<new (...args: T) => void>;
->T08 : Symbol(T08, Decl(genericRestParameters1.ts, 134, 61))
->T : Symbol(T, Decl(genericRestParameters1.ts, 135, 9))
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
->args : Symbol(args, Decl(genericRestParameters1.ts, 135, 44))
->T : Symbol(T, Decl(genericRestParameters1.ts, 135, 9))
+type T08<T extends any[]> = ConstructorParameters<new (...args: T) => void>;
+>T08 : Symbol(T08, Decl(genericRestParameters1.ts, 132, 61))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 133, 9))
+>ConstructorParameters : Symbol(ConstructorParameters, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(genericRestParameters1.ts, 133, 55))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 133, 9))
 
 type T09 = Parameters<Function>;
->T09 : Symbol(T09, Decl(genericRestParameters1.ts, 135, 65))
->Parameters : Symbol(Parameters, Decl(genericRestParameters1.ts, 124, 45))
+>T09 : Symbol(T09, Decl(genericRestParameters1.ts, 133, 76))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 type Record1 = {
->Record1 : Symbol(Record1, Decl(genericRestParameters1.ts, 136, 32))
+>Record1 : Symbol(Record1, Decl(genericRestParameters1.ts, 134, 32))
 
   move: [number, 'left' | 'right'];
->move : Symbol(move, Decl(genericRestParameters1.ts, 138, 16))
+>move : Symbol(move, Decl(genericRestParameters1.ts, 136, 16))
 
   jump: [number, 'up' | 'down'];
->jump : Symbol(jump, Decl(genericRestParameters1.ts, 139, 35))
+>jump : Symbol(jump, Decl(genericRestParameters1.ts, 137, 35))
 
   stop: string;
->stop : Symbol(stop, Decl(genericRestParameters1.ts, 140, 32))
+>stop : Symbol(stop, Decl(genericRestParameters1.ts, 138, 32))
 
   done: [];
->done : Symbol(done, Decl(genericRestParameters1.ts, 141, 15))
+>done : Symbol(done, Decl(genericRestParameters1.ts, 139, 15))
 }
 
 type EventType<T> = {
->EventType : Symbol(EventType, Decl(genericRestParameters1.ts, 143, 1))
->T : Symbol(T, Decl(genericRestParameters1.ts, 145, 15))
+>EventType : Symbol(EventType, Decl(genericRestParameters1.ts, 141, 1))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 143, 15))
 
   emit<K extends keyof T = keyof T>(e: K, ...payload: T[K] extends any[] ? T[K] : [T[K]]): void; 
->emit : Symbol(emit, Decl(genericRestParameters1.ts, 145, 21))
->K : Symbol(K, Decl(genericRestParameters1.ts, 146, 7))
->T : Symbol(T, Decl(genericRestParameters1.ts, 145, 15))
->T : Symbol(T, Decl(genericRestParameters1.ts, 145, 15))
->e : Symbol(e, Decl(genericRestParameters1.ts, 146, 36))
->K : Symbol(K, Decl(genericRestParameters1.ts, 146, 7))
->payload : Symbol(payload, Decl(genericRestParameters1.ts, 146, 41))
->T : Symbol(T, Decl(genericRestParameters1.ts, 145, 15))
->K : Symbol(K, Decl(genericRestParameters1.ts, 146, 7))
->T : Symbol(T, Decl(genericRestParameters1.ts, 145, 15))
->K : Symbol(K, Decl(genericRestParameters1.ts, 146, 7))
->T : Symbol(T, Decl(genericRestParameters1.ts, 145, 15))
->K : Symbol(K, Decl(genericRestParameters1.ts, 146, 7))
+>emit : Symbol(emit, Decl(genericRestParameters1.ts, 143, 21))
+>K : Symbol(K, Decl(genericRestParameters1.ts, 144, 7))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 143, 15))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 143, 15))
+>e : Symbol(e, Decl(genericRestParameters1.ts, 144, 36))
+>K : Symbol(K, Decl(genericRestParameters1.ts, 144, 7))
+>payload : Symbol(payload, Decl(genericRestParameters1.ts, 144, 41))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 143, 15))
+>K : Symbol(K, Decl(genericRestParameters1.ts, 144, 7))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 143, 15))
+>K : Symbol(K, Decl(genericRestParameters1.ts, 144, 7))
+>T : Symbol(T, Decl(genericRestParameters1.ts, 143, 15))
+>K : Symbol(K, Decl(genericRestParameters1.ts, 144, 7))
 }
 
 declare var events: EventType<Record1>;
->events : Symbol(events, Decl(genericRestParameters1.ts, 149, 11))
->EventType : Symbol(EventType, Decl(genericRestParameters1.ts, 143, 1))
->Record1 : Symbol(Record1, Decl(genericRestParameters1.ts, 136, 32))
+>events : Symbol(events, Decl(genericRestParameters1.ts, 147, 11))
+>EventType : Symbol(EventType, Decl(genericRestParameters1.ts, 141, 1))
+>Record1 : Symbol(Record1, Decl(genericRestParameters1.ts, 134, 32))
 
 events.emit('move', 10, 'left');
->events.emit : Symbol(emit, Decl(genericRestParameters1.ts, 145, 21))
->events : Symbol(events, Decl(genericRestParameters1.ts, 149, 11))
->emit : Symbol(emit, Decl(genericRestParameters1.ts, 145, 21))
+>events.emit : Symbol(emit, Decl(genericRestParameters1.ts, 143, 21))
+>events : Symbol(events, Decl(genericRestParameters1.ts, 147, 11))
+>emit : Symbol(emit, Decl(genericRestParameters1.ts, 143, 21))
 
 events.emit('jump', 20, 'up');
->events.emit : Symbol(emit, Decl(genericRestParameters1.ts, 145, 21))
->events : Symbol(events, Decl(genericRestParameters1.ts, 149, 11))
->emit : Symbol(emit, Decl(genericRestParameters1.ts, 145, 21))
+>events.emit : Symbol(emit, Decl(genericRestParameters1.ts, 143, 21))
+>events : Symbol(events, Decl(genericRestParameters1.ts, 147, 11))
+>emit : Symbol(emit, Decl(genericRestParameters1.ts, 143, 21))
 
 events.emit('stop', 'Bye!');
->events.emit : Symbol(emit, Decl(genericRestParameters1.ts, 145, 21))
->events : Symbol(events, Decl(genericRestParameters1.ts, 149, 11))
->emit : Symbol(emit, Decl(genericRestParameters1.ts, 145, 21))
+>events.emit : Symbol(emit, Decl(genericRestParameters1.ts, 143, 21))
+>events : Symbol(events, Decl(genericRestParameters1.ts, 147, 11))
+>emit : Symbol(emit, Decl(genericRestParameters1.ts, 143, 21))
 
 events.emit('done');
->events.emit : Symbol(emit, Decl(genericRestParameters1.ts, 145, 21))
->events : Symbol(events, Decl(genericRestParameters1.ts, 149, 11))
->emit : Symbol(emit, Decl(genericRestParameters1.ts, 145, 21))
+>events.emit : Symbol(emit, Decl(genericRestParameters1.ts, 143, 21))
+>events : Symbol(events, Decl(genericRestParameters1.ts, 147, 11))
+>emit : Symbol(emit, Decl(genericRestParameters1.ts, 143, 21))
 
 // Repro from #25871
 
 declare var ff1: (... args: any[]) => void;
->ff1 : Symbol(ff1, Decl(genericRestParameters1.ts, 157, 11))
->args : Symbol(args, Decl(genericRestParameters1.ts, 157, 18))
+>ff1 : Symbol(ff1, Decl(genericRestParameters1.ts, 155, 11))
+>args : Symbol(args, Decl(genericRestParameters1.ts, 155, 18))
 
 declare var ff2: () => void;
->ff2 : Symbol(ff2, Decl(genericRestParameters1.ts, 159, 11))
+>ff2 : Symbol(ff2, Decl(genericRestParameters1.ts, 157, 11))
 
 declare var ff3: (...args: []) => void;
->ff3 : Symbol(ff3, Decl(genericRestParameters1.ts, 160, 11))
->args : Symbol(args, Decl(genericRestParameters1.ts, 160, 18))
+>ff3 : Symbol(ff3, Decl(genericRestParameters1.ts, 158, 11))
+>args : Symbol(args, Decl(genericRestParameters1.ts, 158, 18))
 
 declare var ff4: (a: never) => void;
->ff4 : Symbol(ff4, Decl(genericRestParameters1.ts, 161, 11))
->a : Symbol(a, Decl(genericRestParameters1.ts, 161, 18))
+>ff4 : Symbol(ff4, Decl(genericRestParameters1.ts, 159, 11))
+>a : Symbol(a, Decl(genericRestParameters1.ts, 159, 18))
 
 ff1 = ff2;
->ff1 : Symbol(ff1, Decl(genericRestParameters1.ts, 157, 11))
->ff2 : Symbol(ff2, Decl(genericRestParameters1.ts, 159, 11))
+>ff1 : Symbol(ff1, Decl(genericRestParameters1.ts, 155, 11))
+>ff2 : Symbol(ff2, Decl(genericRestParameters1.ts, 157, 11))
 
 ff1 = ff3;
->ff1 : Symbol(ff1, Decl(genericRestParameters1.ts, 157, 11))
->ff3 : Symbol(ff3, Decl(genericRestParameters1.ts, 160, 11))
+>ff1 : Symbol(ff1, Decl(genericRestParameters1.ts, 155, 11))
+>ff3 : Symbol(ff3, Decl(genericRestParameters1.ts, 158, 11))
 
 ff1 = ff4;  // Error
->ff1 : Symbol(ff1, Decl(genericRestParameters1.ts, 157, 11))
->ff4 : Symbol(ff4, Decl(genericRestParameters1.ts, 161, 11))
+>ff1 : Symbol(ff1, Decl(genericRestParameters1.ts, 155, 11))
+>ff4 : Symbol(ff4, Decl(genericRestParameters1.ts, 159, 11))
 

--- a/tests/baselines/reference/genericRestParameters1.types
+++ b/tests/baselines/reference/genericRestParameters1.types
@@ -664,11 +664,6 @@ const c30 = f30(42, x => "" + x, x => x + 1);  // [(x: number) => string, (x: nu
 >x : number
 >1 : 1
 
-type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new(...args: infer U) => any) ? U : any[];
->Parameters : Parameters<T>
->args : U
->args : U
-
 type T01 = Parameters<(x: number, y: string, z: boolean) => void>;
 >T01 : [number, string, boolean]
 >x : number
@@ -679,13 +674,13 @@ type T02 = Parameters<(...args: [number, string, boolean]) => void>;
 >T02 : [number, string, boolean]
 >args : [number, string, boolean]
 
-type T03 = Parameters<new (x: number, y: string, z: boolean) => void>;
+type T03 = ConstructorParameters<new (x: number, y: string, z: boolean) => void>;
 >T03 : [number, string, boolean]
 >x : number
 >y : string
 >z : boolean
 
-type T04 = Parameters<new (...args: [number, string, boolean]) => void>;
+type T04 = ConstructorParameters<new (...args: [number, string, boolean]) => void>;
 >T04 : [number, string, boolean]
 >args : [number, string, boolean]
 
@@ -693,7 +688,7 @@ type T05<T> = Parameters<(...args: T[]) => void>;
 >T05 : T[]
 >args : T[]
 
-type T06<T> = Parameters<new (...args: []) => void>;
+type T06<T> = ConstructorParameters<new (...args: []) => void>;
 >T06 : []
 >args : []
 
@@ -701,12 +696,12 @@ type T07<T extends any[]> = Parameters<(...args: T) => void>;
 >T07 : T
 >args : T
 
-type T08<T extends any[]> = Parameters<new (...args: T) => void>;
+type T08<T extends any[]> = ConstructorParameters<new (...args: T) => void>;
 >T08 : T
 >args : T
 
 type T09 = Parameters<Function>;
->T09 : any[]
+>T09 : never
 
 type Record1 = {
 >Record1 : Record1

--- a/tests/baselines/reference/genericRestParameters2.errors.txt
+++ b/tests/baselines/reference/genericRestParameters2.errors.txt
@@ -1,0 +1,85 @@
+tests/cases/conformance/types/rest/genericRestParameters2.ts(71,40): error TS2344: Type '(x: string, ...args: T) => void' does not satisfy the constraint '(...args: any[]) => any'.
+
+
+==== tests/cases/conformance/types/rest/genericRestParameters2.ts (1 errors) ====
+    declare const t1: [number, string, ...boolean[]];
+    declare const t2: [string, ...boolean[]];
+    declare const t3: [...boolean[]];
+    declare const t4: [];
+    
+    declare let f00: (...x: [number, string, boolean]) => void;
+    declare let f01: (a: number, ...x: [string, boolean]) => void;
+    declare let f02: (a: number, b: string, ...x: [boolean]) => void;
+    declare let f03: (a: number, b: string, c: boolean) => void;
+    declare let f04: (a: number, b: string, c: boolean, ...x: []) => void;
+    
+    declare let f10: (...x: [number, string, ...boolean[]]) => void;
+    declare let f11: (a: number, ...x: [string, ...boolean[]]) => void;
+    declare let f12: (a: number, b: string, ...x: [...boolean[]]) => void;
+    declare let f13: (a: number, b: string, ...c: boolean[]) => void;
+    
+    declare const ns: [number, string];
+    declare const sn: [string, number];
+    
+    f10(42, "hello");
+    f10(42, "hello", true);
+    f10(42, "hello", true, false);
+    f10(t1[0], t1[1], t1[2], t1[3]);
+    f10(...t1);
+    f10(42, ...t2);
+    f10(42, "hello", ...t3);
+    f10(42, "hello", true, ...t4);
+    f10(42, "hello", true, ...t4, false, ...t3);
+    
+    f11(42, "hello");
+    f11(42, "hello", true);
+    f11(42, "hello", true, false);
+    f11(t1[0], t1[1], t1[2], t1[3]);
+    f11(...t1);
+    f11(42, ...t2);
+    f11(42, "hello", ...t3);
+    f11(42, "hello", true, ...t4);
+    f11(42, "hello", true, ...t4, false, ...t3);
+    
+    f12(42, "hello");
+    f12(42, "hello", true);
+    f12(42, "hello", true, false);
+    f12(t1[0], t1[1], t1[2], t1[3]);
+    f12(...t1);
+    f12(42, ...t2);
+    f12(42, "hello", ...t3);
+    f12(42, "hello", true, ...t4);
+    f12(42, "hello", true, ...t4, false, ...t3);
+    
+    f13(42, "hello");
+    f13(42, "hello", true);
+    f13(42, "hello", true, false);
+    f13(t1[0], t1[1], t1[2], t1[3]);
+    f13(...t1);
+    f13(42, ...t2);
+    f13(42, "hello", ...t3);
+    f13(42, "hello", true, ...t4);
+    f13(42, "hello", true, ...t4, false, ...t3);
+    
+    declare const f20: <T extends unknown[]>(...args: T) => T;
+    
+    f20(...t1);
+    f20(42, ...t2);
+    f20(42, "hello", ...t3);
+    f20(42, "hello", ...t2, true);
+    
+    type T01 = Parameters<(x: number, y: string, ...z: boolean[]) => void>;
+    type T02 = Parameters<(...args: [number, string, ...boolean[]]) => void>;
+    type T03 = ConstructorParameters<new (x: number, y: string, ...z: boolean[]) => void>;
+    type T04 = ConstructorParameters<new (...args: [number, string, ...boolean[]]) => void>;
+    type T05<T extends any[]> = Parameters<(x: string, ...args: T) => void>;
+                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2344: Type '(x: string, ...args: T) => void' does not satisfy the constraint '(...args: any[]) => any'.
+    type T06 = T05<[number, ...boolean[]]>;
+    
+    type P1<T extends Function> = T extends (head: infer A, ...tail: infer B) => any ? { head: A, tail: B } : any[];
+    
+    type T10 = P1<(x: number, y: string, ...z: boolean[]) => void>;
+    type T11 = P1<(...z: number[]) => void>;
+    type T12 = P1<(x: number, y: number) => void>;
+    

--- a/tests/baselines/reference/genericRestParameters2.js
+++ b/tests/baselines/reference/genericRestParameters2.js
@@ -65,12 +65,10 @@ f20(42, ...t2);
 f20(42, "hello", ...t3);
 f20(42, "hello", ...t2, true);
 
-type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new(...args: infer U) => any) ? U : any[];
-
 type T01 = Parameters<(x: number, y: string, ...z: boolean[]) => void>;
 type T02 = Parameters<(...args: [number, string, ...boolean[]]) => void>;
-type T03 = Parameters<new (x: number, y: string, ...z: boolean[]) => void>;
-type T04 = Parameters<new (...args: [number, string, ...boolean[]]) => void>;
+type T03 = ConstructorParameters<new (x: number, y: string, ...z: boolean[]) => void>;
+type T04 = ConstructorParameters<new (...args: [number, string, ...boolean[]]) => void>;
 type T05<T extends any[]> = Parameters<(x: string, ...args: T) => void>;
 type T06 = T05<[number, ...boolean[]]>;
 
@@ -142,11 +140,10 @@ declare let f13: (a: number, b: string, ...c: boolean[]) => void;
 declare const ns: [number, string];
 declare const sn: [string, number];
 declare const f20: <T extends unknown[]>(...args: T) => T;
-declare type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new (...args: infer U) => any) ? U : any[];
 declare type T01 = Parameters<(x: number, y: string, ...z: boolean[]) => void>;
 declare type T02 = Parameters<(...args: [number, string, ...boolean[]]) => void>;
-declare type T03 = Parameters<new (x: number, y: string, ...z: boolean[]) => void>;
-declare type T04 = Parameters<new (...args: [number, string, ...boolean[]]) => void>;
+declare type T03 = ConstructorParameters<new (x: number, y: string, ...z: boolean[]) => void>;
+declare type T04 = ConstructorParameters<new (...args: [number, string, ...boolean[]]) => void>;
 declare type T05<T extends any[]> = Parameters<(x: string, ...args: T) => void>;
 declare type T06 = T05<[number, ...boolean[]]>;
 declare type P1<T extends Function> = T extends (head: infer A, ...tail: infer B) => any ? {

--- a/tests/baselines/reference/genericRestParameters2.symbols
+++ b/tests/baselines/reference/genericRestParameters2.symbols
@@ -245,82 +245,71 @@ f20(42, "hello", ...t2, true);
 >f20 : Symbol(f20, Decl(genericRestParameters2.ts, 59, 13))
 >t2 : Symbol(t2, Decl(genericRestParameters2.ts, 1, 13))
 
-type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new(...args: infer U) => any) ? U : any[];
->Parameters : Symbol(Parameters, Decl(genericRestParameters2.ts, 64, 30))
->T : Symbol(T, Decl(genericRestParameters2.ts, 66, 16))
->Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(genericRestParameters2.ts, 66, 16))
->args : Symbol(args, Decl(genericRestParameters2.ts, 66, 50))
->U : Symbol(U, Decl(genericRestParameters2.ts, 66, 64), Decl(genericRestParameters2.ts, 66, 97))
->args : Symbol(args, Decl(genericRestParameters2.ts, 66, 83))
->U : Symbol(U, Decl(genericRestParameters2.ts, 66, 64), Decl(genericRestParameters2.ts, 66, 97))
->U : Symbol(U, Decl(genericRestParameters2.ts, 66, 64), Decl(genericRestParameters2.ts, 66, 97))
-
 type T01 = Parameters<(x: number, y: string, ...z: boolean[]) => void>;
->T01 : Symbol(T01, Decl(genericRestParameters2.ts, 66, 121))
->Parameters : Symbol(Parameters, Decl(genericRestParameters2.ts, 64, 30))
->x : Symbol(x, Decl(genericRestParameters2.ts, 68, 23))
->y : Symbol(y, Decl(genericRestParameters2.ts, 68, 33))
->z : Symbol(z, Decl(genericRestParameters2.ts, 68, 44))
+>T01 : Symbol(T01, Decl(genericRestParameters2.ts, 64, 30))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(genericRestParameters2.ts, 66, 23))
+>y : Symbol(y, Decl(genericRestParameters2.ts, 66, 33))
+>z : Symbol(z, Decl(genericRestParameters2.ts, 66, 44))
 
 type T02 = Parameters<(...args: [number, string, ...boolean[]]) => void>;
->T02 : Symbol(T02, Decl(genericRestParameters2.ts, 68, 71))
->Parameters : Symbol(Parameters, Decl(genericRestParameters2.ts, 64, 30))
->args : Symbol(args, Decl(genericRestParameters2.ts, 69, 23))
+>T02 : Symbol(T02, Decl(genericRestParameters2.ts, 66, 71))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(genericRestParameters2.ts, 67, 23))
 
-type T03 = Parameters<new (x: number, y: string, ...z: boolean[]) => void>;
->T03 : Symbol(T03, Decl(genericRestParameters2.ts, 69, 73))
->Parameters : Symbol(Parameters, Decl(genericRestParameters2.ts, 64, 30))
->x : Symbol(x, Decl(genericRestParameters2.ts, 70, 27))
->y : Symbol(y, Decl(genericRestParameters2.ts, 70, 37))
->z : Symbol(z, Decl(genericRestParameters2.ts, 70, 48))
+type T03 = ConstructorParameters<new (x: number, y: string, ...z: boolean[]) => void>;
+>T03 : Symbol(T03, Decl(genericRestParameters2.ts, 67, 73))
+>ConstructorParameters : Symbol(ConstructorParameters, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(genericRestParameters2.ts, 68, 38))
+>y : Symbol(y, Decl(genericRestParameters2.ts, 68, 48))
+>z : Symbol(z, Decl(genericRestParameters2.ts, 68, 59))
 
-type T04 = Parameters<new (...args: [number, string, ...boolean[]]) => void>;
->T04 : Symbol(T04, Decl(genericRestParameters2.ts, 70, 75))
->Parameters : Symbol(Parameters, Decl(genericRestParameters2.ts, 64, 30))
->args : Symbol(args, Decl(genericRestParameters2.ts, 71, 27))
+type T04 = ConstructorParameters<new (...args: [number, string, ...boolean[]]) => void>;
+>T04 : Symbol(T04, Decl(genericRestParameters2.ts, 68, 86))
+>ConstructorParameters : Symbol(ConstructorParameters, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(genericRestParameters2.ts, 69, 38))
 
 type T05<T extends any[]> = Parameters<(x: string, ...args: T) => void>;
->T05 : Symbol(T05, Decl(genericRestParameters2.ts, 71, 77))
->T : Symbol(T, Decl(genericRestParameters2.ts, 72, 9))
->Parameters : Symbol(Parameters, Decl(genericRestParameters2.ts, 64, 30))
->x : Symbol(x, Decl(genericRestParameters2.ts, 72, 40))
->args : Symbol(args, Decl(genericRestParameters2.ts, 72, 50))
->T : Symbol(T, Decl(genericRestParameters2.ts, 72, 9))
+>T05 : Symbol(T05, Decl(genericRestParameters2.ts, 69, 88))
+>T : Symbol(T, Decl(genericRestParameters2.ts, 70, 9))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(genericRestParameters2.ts, 70, 40))
+>args : Symbol(args, Decl(genericRestParameters2.ts, 70, 50))
+>T : Symbol(T, Decl(genericRestParameters2.ts, 70, 9))
 
 type T06 = T05<[number, ...boolean[]]>;
->T06 : Symbol(T06, Decl(genericRestParameters2.ts, 72, 72))
->T05 : Symbol(T05, Decl(genericRestParameters2.ts, 71, 77))
+>T06 : Symbol(T06, Decl(genericRestParameters2.ts, 70, 72))
+>T05 : Symbol(T05, Decl(genericRestParameters2.ts, 69, 88))
 
 type P1<T extends Function> = T extends (head: infer A, ...tail: infer B) => any ? { head: A, tail: B } : any[];
->P1 : Symbol(P1, Decl(genericRestParameters2.ts, 73, 39))
->T : Symbol(T, Decl(genericRestParameters2.ts, 75, 8))
+>P1 : Symbol(P1, Decl(genericRestParameters2.ts, 71, 39))
+>T : Symbol(T, Decl(genericRestParameters2.ts, 73, 8))
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(genericRestParameters2.ts, 75, 8))
->head : Symbol(head, Decl(genericRestParameters2.ts, 75, 41))
->A : Symbol(A, Decl(genericRestParameters2.ts, 75, 52))
->tail : Symbol(tail, Decl(genericRestParameters2.ts, 75, 55))
->B : Symbol(B, Decl(genericRestParameters2.ts, 75, 70))
->head : Symbol(head, Decl(genericRestParameters2.ts, 75, 84))
->A : Symbol(A, Decl(genericRestParameters2.ts, 75, 52))
->tail : Symbol(tail, Decl(genericRestParameters2.ts, 75, 93))
->B : Symbol(B, Decl(genericRestParameters2.ts, 75, 70))
+>T : Symbol(T, Decl(genericRestParameters2.ts, 73, 8))
+>head : Symbol(head, Decl(genericRestParameters2.ts, 73, 41))
+>A : Symbol(A, Decl(genericRestParameters2.ts, 73, 52))
+>tail : Symbol(tail, Decl(genericRestParameters2.ts, 73, 55))
+>B : Symbol(B, Decl(genericRestParameters2.ts, 73, 70))
+>head : Symbol(head, Decl(genericRestParameters2.ts, 73, 84))
+>A : Symbol(A, Decl(genericRestParameters2.ts, 73, 52))
+>tail : Symbol(tail, Decl(genericRestParameters2.ts, 73, 93))
+>B : Symbol(B, Decl(genericRestParameters2.ts, 73, 70))
 
 type T10 = P1<(x: number, y: string, ...z: boolean[]) => void>;
->T10 : Symbol(T10, Decl(genericRestParameters2.ts, 75, 112))
->P1 : Symbol(P1, Decl(genericRestParameters2.ts, 73, 39))
->x : Symbol(x, Decl(genericRestParameters2.ts, 77, 15))
->y : Symbol(y, Decl(genericRestParameters2.ts, 77, 25))
->z : Symbol(z, Decl(genericRestParameters2.ts, 77, 36))
+>T10 : Symbol(T10, Decl(genericRestParameters2.ts, 73, 112))
+>P1 : Symbol(P1, Decl(genericRestParameters2.ts, 71, 39))
+>x : Symbol(x, Decl(genericRestParameters2.ts, 75, 15))
+>y : Symbol(y, Decl(genericRestParameters2.ts, 75, 25))
+>z : Symbol(z, Decl(genericRestParameters2.ts, 75, 36))
 
 type T11 = P1<(...z: number[]) => void>;
->T11 : Symbol(T11, Decl(genericRestParameters2.ts, 77, 63))
->P1 : Symbol(P1, Decl(genericRestParameters2.ts, 73, 39))
->z : Symbol(z, Decl(genericRestParameters2.ts, 78, 15))
+>T11 : Symbol(T11, Decl(genericRestParameters2.ts, 75, 63))
+>P1 : Symbol(P1, Decl(genericRestParameters2.ts, 71, 39))
+>z : Symbol(z, Decl(genericRestParameters2.ts, 76, 15))
 
 type T12 = P1<(x: number, y: number) => void>;
->T12 : Symbol(T12, Decl(genericRestParameters2.ts, 78, 40))
->P1 : Symbol(P1, Decl(genericRestParameters2.ts, 73, 39))
->x : Symbol(x, Decl(genericRestParameters2.ts, 79, 15))
->y : Symbol(y, Decl(genericRestParameters2.ts, 79, 25))
+>T12 : Symbol(T12, Decl(genericRestParameters2.ts, 76, 40))
+>P1 : Symbol(P1, Decl(genericRestParameters2.ts, 71, 39))
+>x : Symbol(x, Decl(genericRestParameters2.ts, 77, 15))
+>y : Symbol(y, Decl(genericRestParameters2.ts, 77, 25))
 

--- a/tests/baselines/reference/genericRestParameters2.types
+++ b/tests/baselines/reference/genericRestParameters2.types
@@ -416,11 +416,6 @@ f20(42, "hello", ...t2, true);
 >t2 : [string, ...boolean[]]
 >true : true
 
-type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new(...args: infer U) => any) ? U : any[];
->Parameters : Parameters<T>
->args : U
->args : U
-
 type T01 = Parameters<(x: number, y: string, ...z: boolean[]) => void>;
 >T01 : [number, string, ...boolean[]]
 >x : number
@@ -431,13 +426,13 @@ type T02 = Parameters<(...args: [number, string, ...boolean[]]) => void>;
 >T02 : [number, string, ...boolean[]]
 >args : [number, string, ...boolean[]]
 
-type T03 = Parameters<new (x: number, y: string, ...z: boolean[]) => void>;
+type T03 = ConstructorParameters<new (x: number, y: string, ...z: boolean[]) => void>;
 >T03 : [number, string, ...boolean[]]
 >x : number
 >y : string
 >z : boolean[]
 
-type T04 = Parameters<new (...args: [number, string, ...boolean[]]) => void>;
+type T04 = ConstructorParameters<new (...args: [number, string, ...boolean[]]) => void>;
 >T04 : [number, string, ...boolean[]]
 >args : [number, string, ...boolean[]]
 

--- a/tests/baselines/reference/genericRestTypes.js
+++ b/tests/baselines/reference/genericRestTypes.js
@@ -2,7 +2,6 @@
 // Repro from #25793
 
 // Gets the parameters of a function type as a tuple
-type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer U) => any ? U : never;
 // Removes the first element from a tuple
 type Tail<T extends any[]> = ((...args: T) => any) extends ((head: any, ...tail: infer U) => any) ? U : never;
 

--- a/tests/baselines/reference/genericRestTypes.symbols
+++ b/tests/baselines/reference/genericRestTypes.symbols
@@ -2,54 +2,45 @@
 // Repro from #25793
 
 // Gets the parameters of a function type as a tuple
-type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer U) => any ? U : never;
->Parameters : Symbol(Parameters, Decl(genericRestTypes.ts, 0, 0))
->T : Symbol(T, Decl(genericRestTypes.ts, 3, 16))
->args : Symbol(args, Decl(genericRestTypes.ts, 3, 27))
->T : Symbol(T, Decl(genericRestTypes.ts, 3, 16))
->args : Symbol(args, Decl(genericRestTypes.ts, 3, 64))
->U : Symbol(U, Decl(genericRestTypes.ts, 3, 78))
->U : Symbol(U, Decl(genericRestTypes.ts, 3, 78))
-
 // Removes the first element from a tuple
 type Tail<T extends any[]> = ((...args: T) => any) extends ((head: any, ...tail: infer U) => any) ? U : never;
->Tail : Symbol(Tail, Decl(genericRestTypes.ts, 3, 101))
->T : Symbol(T, Decl(genericRestTypes.ts, 5, 10))
->args : Symbol(args, Decl(genericRestTypes.ts, 5, 31))
->T : Symbol(T, Decl(genericRestTypes.ts, 5, 10))
->head : Symbol(head, Decl(genericRestTypes.ts, 5, 61))
->tail : Symbol(tail, Decl(genericRestTypes.ts, 5, 71))
->U : Symbol(U, Decl(genericRestTypes.ts, 5, 86))
->U : Symbol(U, Decl(genericRestTypes.ts, 5, 86))
+>Tail : Symbol(Tail, Decl(genericRestTypes.ts, 0, 0))
+>T : Symbol(T, Decl(genericRestTypes.ts, 4, 10))
+>args : Symbol(args, Decl(genericRestTypes.ts, 4, 31))
+>T : Symbol(T, Decl(genericRestTypes.ts, 4, 10))
+>head : Symbol(head, Decl(genericRestTypes.ts, 4, 61))
+>tail : Symbol(tail, Decl(genericRestTypes.ts, 4, 71))
+>U : Symbol(U, Decl(genericRestTypes.ts, 4, 86))
+>U : Symbol(U, Decl(genericRestTypes.ts, 4, 86))
 
 type MyFunctionType = (foo: number, bar: string) => boolean;
->MyFunctionType : Symbol(MyFunctionType, Decl(genericRestTypes.ts, 5, 110))
->foo : Symbol(foo, Decl(genericRestTypes.ts, 7, 23))
->bar : Symbol(bar, Decl(genericRestTypes.ts, 7, 35))
+>MyFunctionType : Symbol(MyFunctionType, Decl(genericRestTypes.ts, 4, 110))
+>foo : Symbol(foo, Decl(genericRestTypes.ts, 6, 23))
+>bar : Symbol(bar, Decl(genericRestTypes.ts, 6, 35))
 
 type Explicit = (...args: Tail<Parameters<MyFunctionType>>) => ReturnType<MyFunctionType>; // (bar: string) => boolean
->Explicit : Symbol(Explicit, Decl(genericRestTypes.ts, 7, 60))
->args : Symbol(args, Decl(genericRestTypes.ts, 9, 17))
->Tail : Symbol(Tail, Decl(genericRestTypes.ts, 3, 101))
->Parameters : Symbol(Parameters, Decl(genericRestTypes.ts, 0, 0))
->MyFunctionType : Symbol(MyFunctionType, Decl(genericRestTypes.ts, 5, 110))
+>Explicit : Symbol(Explicit, Decl(genericRestTypes.ts, 6, 60))
+>args : Symbol(args, Decl(genericRestTypes.ts, 8, 17))
+>Tail : Symbol(Tail, Decl(genericRestTypes.ts, 0, 0))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>MyFunctionType : Symbol(MyFunctionType, Decl(genericRestTypes.ts, 4, 110))
 >ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
->MyFunctionType : Symbol(MyFunctionType, Decl(genericRestTypes.ts, 5, 110))
+>MyFunctionType : Symbol(MyFunctionType, Decl(genericRestTypes.ts, 4, 110))
 
 type Bind1<T extends (head: any, ...tail: any[]) => any> = (...args: Tail<Parameters<T>>) => ReturnType<T>;
->Bind1 : Symbol(Bind1, Decl(genericRestTypes.ts, 9, 90))
->T : Symbol(T, Decl(genericRestTypes.ts, 11, 11))
->head : Symbol(head, Decl(genericRestTypes.ts, 11, 22))
->tail : Symbol(tail, Decl(genericRestTypes.ts, 11, 32))
->args : Symbol(args, Decl(genericRestTypes.ts, 11, 60))
->Tail : Symbol(Tail, Decl(genericRestTypes.ts, 3, 101))
->Parameters : Symbol(Parameters, Decl(genericRestTypes.ts, 0, 0))
->T : Symbol(T, Decl(genericRestTypes.ts, 11, 11))
+>Bind1 : Symbol(Bind1, Decl(genericRestTypes.ts, 8, 90))
+>T : Symbol(T, Decl(genericRestTypes.ts, 10, 11))
+>head : Symbol(head, Decl(genericRestTypes.ts, 10, 22))
+>tail : Symbol(tail, Decl(genericRestTypes.ts, 10, 32))
+>args : Symbol(args, Decl(genericRestTypes.ts, 10, 60))
+>Tail : Symbol(Tail, Decl(genericRestTypes.ts, 0, 0))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(genericRestTypes.ts, 10, 11))
 >ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(genericRestTypes.ts, 11, 11))
+>T : Symbol(T, Decl(genericRestTypes.ts, 10, 11))
 
 type Generic = Bind1<MyFunctionType>; // (bar: string) => boolean
->Generic : Symbol(Generic, Decl(genericRestTypes.ts, 11, 107))
->Bind1 : Symbol(Bind1, Decl(genericRestTypes.ts, 9, 90))
->MyFunctionType : Symbol(MyFunctionType, Decl(genericRestTypes.ts, 5, 110))
+>Generic : Symbol(Generic, Decl(genericRestTypes.ts, 10, 107))
+>Bind1 : Symbol(Bind1, Decl(genericRestTypes.ts, 8, 90))
+>MyFunctionType : Symbol(MyFunctionType, Decl(genericRestTypes.ts, 4, 110))
 

--- a/tests/baselines/reference/genericRestTypes.types
+++ b/tests/baselines/reference/genericRestTypes.types
@@ -2,11 +2,6 @@
 // Repro from #25793
 
 // Gets the parameters of a function type as a tuple
-type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer U) => any ? U : never;
->Parameters : Parameters<T>
->args : any[]
->args : U
-
 // Removes the first element from a tuple
 type Tail<T extends any[]> = ((...args: T) => any) extends ((head: any, ...tail: infer U) => any) ? U : never;
 >Tail : Tail<T>

--- a/tests/baselines/reference/parameterListAsTupleType.errors.txt
+++ b/tests/baselines/reference/parameterListAsTupleType.errors.txt
@@ -1,0 +1,35 @@
+tests/cases/compiler/parameterListAsTupleType.ts(8,17): error TS2322: Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/parameterListAsTupleType.ts(16,23): error TS2344: Type 'typeof C' does not satisfy the constraint '(...args: any[]) => any'.
+  Type 'typeof C' provides no match for the signature '(...args: any[]): any'.
+
+
+==== tests/cases/compiler/parameterListAsTupleType.ts (2 errors) ====
+    function foo(a: number, b: string) {
+      return true;
+    }
+    type Foops = Parameters<typeof foo>;
+    
+    const x = (a: number) => 5;
+    type Xps = Parameters<typeof x>;
+    const a: Xps = ['should-not-work']; // works, but shouldn't
+                    ~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'string' is not assignable to type 'number'.
+    function t(...args: Xps) {} // should work
+    
+    class C {
+        constructor(a: number, b: string) {
+        }
+    }
+    
+    type Cps = Parameters<typeof C>; // should not work
+                          ~~~~~~~~
+!!! error TS2344: Type 'typeof C' does not satisfy the constraint '(...args: any[]) => any'.
+!!! error TS2344:   Type 'typeof C' provides no match for the signature '(...args: any[]): any'.
+    type Ccps = ConstructorParameters<typeof C>; // should be [number, string]
+    
+    class D {
+        constructor(a: number, ...rest: string[]) {
+        }
+    }
+    type Dcps = ConstructorParameters<typeof D>; // should be [number, ...string[]]
+    

--- a/tests/baselines/reference/parameterListAsTupleType.js
+++ b/tests/baselines/reference/parameterListAsTupleType.js
@@ -1,0 +1,52 @@
+//// [parameterListAsTupleType.ts]
+function foo(a: number, b: string) {
+  return true;
+}
+type Foops = Parameters<typeof foo>;
+
+const x = (a: number) => 5;
+type Xps = Parameters<typeof x>;
+const a: Xps = ['should-not-work']; // works, but shouldn't
+function t(...args: Xps) {} // should work
+
+class C {
+    constructor(a: number, b: string) {
+    }
+}
+
+type Cps = Parameters<typeof C>; // should not work
+type Ccps = ConstructorParameters<typeof C>; // should be [number, string]
+
+class D {
+    constructor(a: number, ...rest: string[]) {
+    }
+}
+type Dcps = ConstructorParameters<typeof D>; // should be [number, ...string[]]
+
+
+//// [parameterListAsTupleType.js]
+function foo(a, b) {
+    return true;
+}
+var x = function (a) { return 5; };
+var a = ['should-not-work']; // works, but shouldn't
+function t() {
+    var args = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        args[_i] = arguments[_i];
+    }
+} // should work
+var C = /** @class */ (function () {
+    function C(a, b) {
+    }
+    return C;
+}());
+var D = /** @class */ (function () {
+    function D(a) {
+        var rest = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            rest[_i - 1] = arguments[_i];
+        }
+    }
+    return D;
+}());

--- a/tests/baselines/reference/parameterListAsTupleType.symbols
+++ b/tests/baselines/reference/parameterListAsTupleType.symbols
@@ -1,0 +1,63 @@
+=== tests/cases/compiler/parameterListAsTupleType.ts ===
+function foo(a: number, b: string) {
+>foo : Symbol(foo, Decl(parameterListAsTupleType.ts, 0, 0))
+>a : Symbol(a, Decl(parameterListAsTupleType.ts, 0, 13))
+>b : Symbol(b, Decl(parameterListAsTupleType.ts, 0, 23))
+
+  return true;
+}
+type Foops = Parameters<typeof foo>;
+>Foops : Symbol(Foops, Decl(parameterListAsTupleType.ts, 2, 1))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>foo : Symbol(foo, Decl(parameterListAsTupleType.ts, 0, 0))
+
+const x = (a: number) => 5;
+>x : Symbol(x, Decl(parameterListAsTupleType.ts, 5, 5))
+>a : Symbol(a, Decl(parameterListAsTupleType.ts, 5, 11))
+
+type Xps = Parameters<typeof x>;
+>Xps : Symbol(Xps, Decl(parameterListAsTupleType.ts, 5, 27))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(parameterListAsTupleType.ts, 5, 5))
+
+const a: Xps = ['should-not-work']; // works, but shouldn't
+>a : Symbol(a, Decl(parameterListAsTupleType.ts, 7, 5))
+>Xps : Symbol(Xps, Decl(parameterListAsTupleType.ts, 5, 27))
+
+function t(...args: Xps) {} // should work
+>t : Symbol(t, Decl(parameterListAsTupleType.ts, 7, 35))
+>args : Symbol(args, Decl(parameterListAsTupleType.ts, 8, 11))
+>Xps : Symbol(Xps, Decl(parameterListAsTupleType.ts, 5, 27))
+
+class C {
+>C : Symbol(C, Decl(parameterListAsTupleType.ts, 8, 27))
+
+    constructor(a: number, b: string) {
+>a : Symbol(a, Decl(parameterListAsTupleType.ts, 11, 16))
+>b : Symbol(b, Decl(parameterListAsTupleType.ts, 11, 26))
+    }
+}
+
+type Cps = Parameters<typeof C>; // should not work
+>Cps : Symbol(Cps, Decl(parameterListAsTupleType.ts, 13, 1))
+>Parameters : Symbol(Parameters, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(parameterListAsTupleType.ts, 8, 27))
+
+type Ccps = ConstructorParameters<typeof C>; // should be [number, string]
+>Ccps : Symbol(Ccps, Decl(parameterListAsTupleType.ts, 15, 32))
+>ConstructorParameters : Symbol(ConstructorParameters, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(parameterListAsTupleType.ts, 8, 27))
+
+class D {
+>D : Symbol(D, Decl(parameterListAsTupleType.ts, 16, 44))
+
+    constructor(a: number, ...rest: string[]) {
+>a : Symbol(a, Decl(parameterListAsTupleType.ts, 19, 16))
+>rest : Symbol(rest, Decl(parameterListAsTupleType.ts, 19, 26))
+    }
+}
+type Dcps = ConstructorParameters<typeof D>; // should be [number, ...string[]]
+>Dcps : Symbol(Dcps, Decl(parameterListAsTupleType.ts, 21, 1))
+>ConstructorParameters : Symbol(ConstructorParameters, Decl(lib.es5.d.ts, --, --))
+>D : Symbol(D, Decl(parameterListAsTupleType.ts, 16, 44))
+

--- a/tests/baselines/reference/parameterListAsTupleType.types
+++ b/tests/baselines/reference/parameterListAsTupleType.types
@@ -1,0 +1,61 @@
+=== tests/cases/compiler/parameterListAsTupleType.ts ===
+function foo(a: number, b: string) {
+>foo : (a: number, b: string) => boolean
+>a : number
+>b : string
+
+  return true;
+>true : true
+}
+type Foops = Parameters<typeof foo>;
+>Foops : [number, string]
+>foo : (a: number, b: string) => boolean
+
+const x = (a: number) => 5;
+>x : (a: number) => number
+>(a: number) => 5 : (a: number) => number
+>a : number
+>5 : 5
+
+type Xps = Parameters<typeof x>;
+>Xps : [number]
+>x : (a: number) => number
+
+const a: Xps = ['should-not-work']; // works, but shouldn't
+>a : [number]
+>['should-not-work'] : [string]
+>'should-not-work' : "should-not-work"
+
+function t(...args: Xps) {} // should work
+>t : (a: number) => void
+>args : [number]
+
+class C {
+>C : C
+
+    constructor(a: number, b: string) {
+>a : number
+>b : string
+    }
+}
+
+type Cps = Parameters<typeof C>; // should not work
+>Cps : never
+>C : typeof C
+
+type Ccps = ConstructorParameters<typeof C>; // should be [number, string]
+>Ccps : [number, string]
+>C : typeof C
+
+class D {
+>D : D
+
+    constructor(a: number, ...rest: string[]) {
+>a : number
+>rest : string[]
+    }
+}
+type Dcps = ConstructorParameters<typeof D>; // should be [number, ...string[]]
+>Dcps : [number, ...string[]]
+>D : typeof D
+

--- a/tests/cases/compiler/genericRestTypes.ts
+++ b/tests/cases/compiler/genericRestTypes.ts
@@ -3,7 +3,6 @@
 // Repro from #25793
 
 // Gets the parameters of a function type as a tuple
-type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer U) => any ? U : never;
 // Removes the first element from a tuple
 type Tail<T extends any[]> = ((...args: T) => any) extends ((head: any, ...tail: infer U) => any) ? U : never;
 

--- a/tests/cases/compiler/parameterListAsTupleType.ts
+++ b/tests/cases/compiler/parameterListAsTupleType.ts
@@ -1,0 +1,23 @@
+function foo(a: number, b: string) {
+  return true;
+}
+type Foops = Parameters<typeof foo>;
+
+const x = (a: number) => 5;
+type Xps = Parameters<typeof x>;
+const a: Xps = ['should-not-work']; // works, but shouldn't
+function t(...args: Xps) {} // should work
+
+class C {
+    constructor(a: number, b: string) {
+    }
+}
+
+type Cps = Parameters<typeof C>; // should not work
+type Ccps = ConstructorParameters<typeof C>; // should be [number, string]
+
+class D {
+    constructor(a: number, ...rest: string[]) {
+    }
+}
+type Dcps = ConstructorParameters<typeof D>; // should be [number, ...string[]]

--- a/tests/cases/conformance/types/rest/genericRestParameters1.ts
+++ b/tests/cases/conformance/types/rest/genericRestParameters1.ts
@@ -127,16 +127,14 @@ declare function f30<T, U extends ((x: T) => any)[]>(x: T, ...args: U): U;
 
 const c30 = f30(42, x => "" + x, x => x + 1);  // [(x: number) => string, (x: number) => number]
 
-type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new(...args: infer U) => any) ? U : any[];
-
 type T01 = Parameters<(x: number, y: string, z: boolean) => void>;
 type T02 = Parameters<(...args: [number, string, boolean]) => void>;
-type T03 = Parameters<new (x: number, y: string, z: boolean) => void>;
-type T04 = Parameters<new (...args: [number, string, boolean]) => void>;
+type T03 = ConstructorParameters<new (x: number, y: string, z: boolean) => void>;
+type T04 = ConstructorParameters<new (...args: [number, string, boolean]) => void>;
 type T05<T> = Parameters<(...args: T[]) => void>;
-type T06<T> = Parameters<new (...args: []) => void>;
+type T06<T> = ConstructorParameters<new (...args: []) => void>;
 type T07<T extends any[]> = Parameters<(...args: T) => void>;
-type T08<T extends any[]> = Parameters<new (...args: T) => void>;
+type T08<T extends any[]> = ConstructorParameters<new (...args: T) => void>;
 type T09 = Parameters<Function>;
 
 type Record1 = {

--- a/tests/cases/conformance/types/rest/genericRestParameters2.ts
+++ b/tests/cases/conformance/types/rest/genericRestParameters2.ts
@@ -67,12 +67,10 @@ f20(42, ...t2);
 f20(42, "hello", ...t3);
 f20(42, "hello", ...t2, true);
 
-type Parameters<T extends Function> = T extends ((...args: infer U) => any) | (new(...args: infer U) => any) ? U : any[];
-
 type T01 = Parameters<(x: number, y: string, ...z: boolean[]) => void>;
 type T02 = Parameters<(...args: [number, string, ...boolean[]]) => void>;
-type T03 = Parameters<new (x: number, y: string, ...z: boolean[]) => void>;
-type T04 = Parameters<new (...args: [number, string, ...boolean[]]) => void>;
+type T03 = ConstructorParameters<new (x: number, y: string, ...z: boolean[]) => void>;
+type T04 = ConstructorParameters<new (...args: [number, string, ...boolean[]]) => void>;
 type T05<T extends any[]> = Parameters<(x: string, ...args: T) => void>;
 type T06 = T05<[number, ...boolean[]]>;
 


### PR DESCRIPTION
Based on #26042 and discussion from the most recent design meeting. Thanks @anurbol for creating the initial PR.

It turns out that our tests have a couple of examples of looser definitions of `Parameters`. The differences are instructive:

```ts
type Parameters<T extends Function> = ((...args: infer U) => any) | (new (...args: infer U) => any) ? U : any[];
```

This looser definition allows:
1. `Function` to create an array of parameters `any[]`. 
2. Either constructors or functions to be passed in.
3. Tuple-constrained type parameters, for example `T extends any[]` to be used as the type of rest parameters.

(1) is pretty questionable and is fine to disallow, I think. (2) is now handled by `Parameters` vs `ConstructorParameters`. (3) is unsound, as pointed out in #26013, since it is equivalent to allowing the assignability of `T extends any[]` to `any[]`. So I think all 3 differences are improvements. I preserved them in the test baselines.

Fixes #26019

