### PR TITLE
Don't compute suggestion diagnostics for lib files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -314,6 +314,10 @@ namespace ts {
                 return node && getTypeArgumentConstraint(node);
             },
             getSuggestionDiagnostics: (file, ct) => {
+                if (skipTypeChecking(file, compilerOptions)) {
+                    return emptyArray;
+                }
+
                 let diagnostics: DiagnosticWithLocation[] | undefined;
                 try {
                     // Record the cancellation token so it can be checked later on during checkSourceElement.
@@ -26876,10 +26880,7 @@ namespace ts {
         function checkSourceFileWorker(node: SourceFile) {
             const links = getNodeLinks(node);
             if (!(links.flags & NodeCheckFlags.TypeChecked)) {
-                // If skipLibCheck is enabled, skip type checking if file is a declaration file.
-                // If skipDefaultLibCheck is enabled, skip type checking if file contains a
-                // '/// <reference no-default-lib="true"/>' directive.
-                if (compilerOptions.skipLibCheck && node.isDeclarationFile || compilerOptions.skipDefaultLibCheck && node.hasNoDefaultLib) {
+                if (skipTypeChecking(node, compilerOptions)) {
                     return;
                 }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1476,10 +1476,7 @@ namespace ts {
 
         function getSemanticDiagnosticsForFileNoCache(sourceFile: SourceFile, cancellationToken: CancellationToken): Diagnostic[] | undefined {
             return runWithCancellationToken(() => {
-                // If skipLibCheck is enabled, skip reporting errors if file is a declaration file.
-                // If skipDefaultLibCheck is enabled, skip reporting errors if file contains a
-                // '/// <reference no-default-lib="true"/>' directive.
-                if (options.skipLibCheck && sourceFile.isDeclarationFile || options.skipDefaultLibCheck && sourceFile.hasNoDefaultLib) {
+                if (skipTypeChecking(sourceFile, options)) {
                     return emptyArray;
                 }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8212,4 +8212,11 @@ namespace ts {
         // Include the `<>`
         return { pos: typeParameters.pos - 1, end: typeParameters.end + 1 };
     }
+
+    export function skipTypeChecking(sourceFile: SourceFile, options: CompilerOptions) {
+        // If skipLibCheck is enabled, skip reporting errors if file is a declaration file.
+        // If skipDefaultLibCheck is enabled, skip reporting errors if file contains a
+        // '/// <reference no-default-lib="true"/>' directive.
+        return options.skipLibCheck && sourceFile.isDeclarationFile || options.skipDefaultLibCheck && sourceFile.hasNoDefaultLib;
+    }
 }


### PR DESCRIPTION
The check applied to semantic diagnostics (and `checkSourceFile`) should
also apply to suggestion diagnostics.  Fixes assert.