### PR TITLE
moduleNameResolver: fix getCommonPrefix

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -407,11 +407,8 @@ namespace ts {
                 // directory: /a/b/c/d/e
                 // resolvedFileName: /a/b/foo.d.ts
                 // commonPrefix: /a/b
-                // for failed lookups use the root directory as commonPrefix
-                const commonPrefix = resolvedFileName ? getCommonPrefix(path, resolvedFileName) : path.substr(0, getRootLength(path));
-                if (!commonPrefix) {
-                    return;
-                }
+                // for failed lookups cache the result for every directory up to root
+                const commonPrefix = resolvedFileName && getCommonPrefix(path, resolvedFileName);
                 let current = path;
                 while (current !== commonPrefix) {
                     const parent = getDirectoryPath(current);

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -407,18 +407,17 @@ namespace ts {
                 // directory: /a/b/c/d/e
                 // resolvedFileName: /a/b/foo.d.ts
                 const commonPrefix = getCommonPrefix(path, resolvedFileName);
+                if (commonPrefix === undefined) {
+                    return;
+                }
                 let current = path;
-                while (true) {
+                while (current !== commonPrefix) {
                     const parent = getDirectoryPath(current);
                     if (parent === current || directoryPathMap.has(parent)) {
                         break;
                     }
                     directoryPathMap.set(parent, result);
                     current = parent;
-
-                    if (current === commonPrefix) {
-                        break;
-                    }
                 }
             }
 
@@ -432,6 +431,10 @@ namespace ts {
                 let i = 0;
                 while (i < Math.min(directory.length, resolutionDirectory.length) && directory.charCodeAt(i) === resolutionDirectory.charCodeAt(i)) {
                     i++;
+                }
+
+                if (i === directory.length && resolutionDirectory.length > i && resolutionDirectory[i] === directorySeparator) {
+                    return directory;
                 }
 
                 // find last directory separator before position i

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -403,10 +403,12 @@ namespace ts {
 
                 const resolvedFileName = result.resolvedModule && result.resolvedModule.resolvedFileName;
                 // find common prefix between directory and resolved file name
-                // this common prefix should be the shorted path that has the same resolution
+                // this common prefix should be the shortest path that has the same resolution
                 // directory: /a/b/c/d/e
                 // resolvedFileName: /a/b/foo.d.ts
-                const commonPrefix = getCommonPrefix(path, resolvedFileName);
+                // commonPrefix: /a/b
+                // for failed lookups use the root directory as commonPrefix
+                const commonPrefix = resolvedFileName ? getCommonPrefix(path, resolvedFileName) : path.substr(0, getRootLength(path));
                 if (!commonPrefix) {
                     return;
                 }
@@ -421,10 +423,7 @@ namespace ts {
                 }
             }
 
-            function getCommonPrefix(directory: Path, resolution: string | undefined) {
-                if (resolution === undefined) {
-                    return undefined;
-                }
+            function getCommonPrefix(directory: Path, resolution: string) {
                 const resolutionDirectory = toPath(getDirectoryPath(resolution), currentDirectory, getCanonicalFileName);
 
                 let current = directory;

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -423,21 +423,24 @@ namespace ts {
             function getCommonPrefix(directory: Path, resolution: string) {
                 const resolutionDirectory = toPath(getDirectoryPath(resolution), currentDirectory, getCanonicalFileName);
 
-                let current = directory;
-                let parent = getDirectoryPath(current);
-                while (
-                    // keep going until we find a matching prefix
-                    !startsWith(resolutionDirectory, current) ||
-                    // keep going if the prefix is not a complete directory segment, e.g. '/dir' as prefix of '/directory'
-                    resolutionDirectory.length > current.length && resolutionDirectory[current.length] !== directorySeparator && current !== parent
-                ) {
-                    if (current === parent) {
-                        return undefined;
-                    }
-                    current = parent;
-                    parent = getDirectoryPath(current);
+                // find first position where directory and resolution differs
+                let i = 0;
+                const limit = Math.min(directory.length, resolutionDirectory.length);
+                while (i < limit && directory.charCodeAt(i) === resolutionDirectory.charCodeAt(i)) {
+                    i++;
                 }
-                return current;
+                if (i === directory.length && (resolutionDirectory.length === i || resolutionDirectory[i] === directorySeparator)) {
+                    return directory;
+                }
+                const rootLength = getRootLength(directory);
+                if (i < rootLength) {
+                    return undefined;
+                }
+                const sep = directory.lastIndexOf(directorySeparator, i - 1);
+                if (sep === -1) {
+                    return undefined;
+                }
+                return directory.substr(0, Math.max(sep, rootLength));
             }
         }
     }

--- a/src/testRunner/unittests/moduleResolution.ts
+++ b/src/testRunner/unittests/moduleResolution.ts
@@ -262,7 +262,7 @@ namespace ts {
                 failedLookupLocations: [],
             });
             assert.isDefined(cache.get("c:/foo"));
-            assert.isUndefined(cache.get("c:/"));
+            assert.isDefined(cache.get("c:/"));
             assert.isUndefined(cache.get("d:/"));
 
             cache = resolutionCache.getOrCreateCacheForModuleName("f");

--- a/src/testRunner/unittests/moduleResolution.ts
+++ b/src/testRunner/unittests/moduleResolution.ts
@@ -264,6 +264,16 @@ namespace ts {
             assert.isDefined(cache.get("c:/foo"));
             assert.isUndefined(cache.get("c:/"));
             assert.isUndefined(cache.get("d:/"));
+
+            cache = resolutionCache.getOrCreateCacheForModuleName("f");
+            cache.set("/foo/bar/baz", {
+                resolvedModule: undefined,
+                failedLookupLocations: [],
+            });
+            assert.isDefined(cache.get("/foo/bar/baz"));
+            assert.isDefined(cache.get("/foo/bar"));
+            assert.isDefined(cache.get("/foo"));
+            assert.isDefined(cache.get("/"));
         });
 
         it("load module as file - ts files not loaded", () => {

--- a/src/testRunner/unittests/moduleResolution.ts
+++ b/src/testRunner/unittests/moduleResolution.ts
@@ -195,7 +195,8 @@ namespace ts {
 
     describe("Node module resolution - non-relative paths", () => {
         it("computes correct commonPrefix for moduleName cache", () => {
-            const cache = createModuleResolutionCache("/", (f) => f).getOrCreateCacheForModuleName("a");
+            const resolutionCache = createModuleResolutionCache("/", (f) => f);
+            let cache = resolutionCache.getOrCreateCacheForModuleName("a");
             cache.set("/sub", {
                 resolvedModule: {
                     originalPath: undefined,
@@ -207,6 +208,62 @@ namespace ts {
             });
             assert.isDefined(cache.get("/sub"));
             assert.isUndefined(cache.get("/"));
+
+            cache = resolutionCache.getOrCreateCacheForModuleName("b");
+            cache.set("/sub/dir/foo", {
+                resolvedModule: {
+                    originalPath: undefined,
+                    resolvedFileName: "/sub/directory/node_modules/b/index.ts",
+                    isExternalLibraryImport: true,
+                    extension: Extension.Ts,
+                },
+                failedLookupLocations: [],
+            });
+            assert.isDefined(cache.get("/sub/dir/foo"));
+            assert.isDefined(cache.get("/sub/dir"));
+            assert.isDefined(cache.get("/sub"));
+            assert.isUndefined(cache.get("/"));
+
+            cache = resolutionCache.getOrCreateCacheForModuleName("c");
+            cache.set("/foo/bar", {
+                resolvedModule: {
+                    originalPath: undefined,
+                    resolvedFileName: "/bar/node_modules/c/index.ts",
+                    isExternalLibraryImport: true,
+                    extension: Extension.Ts,
+                },
+                failedLookupLocations: [],
+            });
+            assert.isDefined(cache.get("/foo/bar"));
+            assert.isDefined(cache.get("/foo"));
+            assert.isDefined(cache.get("/"));
+
+            cache = resolutionCache.getOrCreateCacheForModuleName("d");
+            cache.set("/foo", {
+                resolvedModule: {
+                    originalPath: undefined,
+                    resolvedFileName: "/foo/index.ts",
+                    isExternalLibraryImport: true,
+                    extension: Extension.Ts,
+                },
+                failedLookupLocations: [],
+            });
+            assert.isDefined(cache.get("/foo"));
+            assert.isUndefined(cache.get("/"));
+
+            cache = resolutionCache.getOrCreateCacheForModuleName("e");
+            cache.set("c:/foo", {
+                resolvedModule: {
+                    originalPath: undefined,
+                    resolvedFileName: "d:/bar/node_modules/e/index.ts",
+                    isExternalLibraryImport: true,
+                    extension: Extension.Ts,
+                },
+                failedLookupLocations: [],
+            });
+            assert.isDefined(cache.get("c:/foo"));
+            assert.isUndefined(cache.get("c:/"));
+            assert.isUndefined(cache.get("d:/"));
         });
 
         it("load module as file - ts files not loaded", () => {

--- a/src/testRunner/unittests/moduleResolution.ts
+++ b/src/testRunner/unittests/moduleResolution.ts
@@ -194,6 +194,21 @@ namespace ts {
     });
 
     describe("Node module resolution - non-relative paths", () => {
+        it("computes correct commonPrefix for moduleName cache", () => {
+            const cache = createModuleResolutionCache("/", (f) => f).getOrCreateCacheForModuleName("a");
+            cache.set("/sub", {
+                resolvedModule: {
+                    originalPath: undefined,
+                    resolvedFileName: "/sub/node_modules/a/index.ts",
+                    isExternalLibraryImport: true,
+                    extension: Extension.Ts,
+                },
+                failedLookupLocations: [],
+            });
+            assert.isDefined(cache.get("/sub"));
+            assert.isUndefined(cache.get("/"));
+        });
+
         it("load module as file - ts files not loaded", () => {
             test(/*hasDirectoryExists*/ false);
             test(/*hasDirectoryExists*/ true);


### PR DESCRIPTION
Fixes: #26301 

* Fixes the case where `directory` is a parent directory of `resolution`.
* Also correctly handle root directory if that is the common prefix.
* Added tests for all the different cases