### PR TITLE
Treat NoSubstitutionTemplateLiteral like StringLiteral in more places

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -259,7 +259,7 @@ namespace ts {
                 if (name.kind === SyntaxKind.ComputedPropertyName) {
                     const nameExpression = name.expression;
                     // treat computed property names where expression is string/numeric literal as just string/numeric literal
-                    if (isStringOrNumericLiteral(nameExpression)) {
+                    if (isStringOrNumericLiteralLike(nameExpression)) {
                         return escapeLeadingUnderscores(nameExpression.text);
                     }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4442,7 +4442,7 @@ namespace ts {
         }
 
         function isComputedNonLiteralName(name: PropertyName): boolean {
-            return name.kind === SyntaxKind.ComputedPropertyName && !isStringOrNumericLiteral(name.expression);
+            return name.kind === SyntaxKind.ComputedPropertyName && !isStringOrNumericLiteralLike(name.expression);
         }
 
         function getRestType(source: Type, properties: PropertyName[], symbol: Symbol | undefined): Type {
@@ -13715,7 +13715,7 @@ namespace ts {
                     case SyntaxKind.Identifier:
                         return idText(name);
                     case SyntaxKind.ComputedPropertyName:
-                        return isStringOrNumericLiteral(name.expression) ? name.expression.text : undefined;
+                        return isStringOrNumericLiteralLike(name.expression) ? name.expression.text : undefined;
                     case SyntaxKind.StringLiteral:
                     case SyntaxKind.NumericLiteral:
                         return name.text;

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -4709,7 +4709,7 @@ namespace ts {
     /**
      * Gets the property name of a BindingOrAssignmentElement
      */
-    export function getPropertyNameOfBindingOrAssignmentElement(bindingElement: BindingOrAssignmentElement) {
+    export function getPropertyNameOfBindingOrAssignmentElement(bindingElement: BindingOrAssignmentElement): PropertyName | undefined {
         switch (bindingElement.kind) {
             case SyntaxKind.BindingElement:
                 // `a` in `let { a: b } = ...`
@@ -4752,6 +4752,12 @@ namespace ts {
         }
 
         Debug.fail("Invalid property name for binding element.");
+    }
+
+    function isStringOrNumericLiteral(node: Node): node is StringLiteral | NumericLiteral {
+        const kind = node.kind;
+        return kind === SyntaxKind.StringLiteral
+            || kind === SyntaxKind.NumericLiteral;
     }
 
     /**

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4465,7 +4465,7 @@ namespace ts {
                     }
                     else {
                         const argument = allowInAnd(parseExpression);
-                        if (isStringOrNumericLiteral(argument)) {
+                        if (isStringOrNumericLiteralLike(argument)) {
                             argument.text = internIdentifier(argument.text);
                         }
                         indexedAccess.argumentExpression = argument;

--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -447,7 +447,7 @@ namespace ts {
             const argumentExpression = ensureIdentifier(flattenContext, visitNode(propertyName.expression, flattenContext.visitor), /*reuseIdentifierExpressions*/ false, /*location*/ propertyName);
             return createElementAccess(value, argumentExpression);
         }
-        else if (isStringOrNumericLiteral(propertyName)) {
+        else if (isStringOrNumericLiteralLike(propertyName)) {
             const argumentExpression = getSynthesizedClone(propertyName);
             argumentExpression.text = argumentExpression.text;
             return createElementAccess(value, argumentExpression);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2560,14 +2560,8 @@ namespace ts {
         return false;
     }
 
-    export function isStringOrNumericLiteral(node: Node): node is StringLiteral | NumericLiteral {
-        const kind = node.kind;
-        return kind === SyntaxKind.StringLiteral
-            || kind === SyntaxKind.NumericLiteral;
-    }
-
     export function isStringOrNumericLiteralLike(node: Node): node is StringLiteralLike | NumericLiteral {
-        return isStringOrNumericLiteral(node) || isNoSubstitutionTemplateLiteral(node);
+        return isStringLiteralLike(node) || isNumericLiteral(node);
     }
 
     /**

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -416,7 +416,7 @@ namespace ts.NavigationBar {
         }
 
         const declName = getNameOfDeclaration(<Declaration>node);
-        if (declName) {
+        if (declName && isPropertyName(declName)) {
             return unescapeLeadingUnderscores(getPropertyNameForPropertyNameNode(declName)!); // TODO: GH#18217
         }
         switch (node.kind) {

--- a/src/services/rename.ts
+++ b/src/services/rename.ts
@@ -29,7 +29,7 @@ namespace ts.Rename {
         if (isStringLiteralLike(node) && tryGetImportFromModuleSpecifier(node)) return undefined;
 
         const kind = SymbolDisplay.getSymbolKind(typeChecker, symbol, node);
-        const specifierName = (isImportOrExportSpecifierName(node) || isStringOrNumericLiteral(node) && node.parent.kind === SyntaxKind.ComputedPropertyName)
+        const specifierName = (isImportOrExportSpecifierName(node) || isStringOrNumericLiteralLike(node) && node.parent.kind === SyntaxKind.ComputedPropertyName)
             ? stripQuotes(getTextOfIdentifierOrLiteral(node))
             : undefined;
         const displayName = specifierName || typeChecker.symbolToString(symbol);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2142,7 +2142,7 @@ namespace ts {
     function initializeNameTable(sourceFile: SourceFile): void {
         const nameTable = sourceFile.nameTable = createUnderscoreEscapedMap<number>();
         sourceFile.forEachChild(function walk(node) {
-            if (isIdentifier(node) && node.escapedText || isStringOrNumericLiteral(node) && literalIsName(node)) {
+            if (isIdentifier(node) && node.escapedText || isStringOrNumericLiteralLike(node) && literalIsName(node)) {
                 const text = getEscapedTextOfIdentifierOrLiteral(node);
                 nameTable.set(text, nameTable.get(text) === undefined ? node.pos : -1);
             }
@@ -2162,7 +2162,7 @@ namespace ts {
      * then we want 'something' to be in the name table.  Similarly, if we have
      * "a['propname']" then we want to store "propname" in the name table.
      */
-    function literalIsName(node: StringLiteral | NumericLiteral): boolean {
+    function literalIsName(node: StringLiteralLike | NumericLiteral): boolean {
         return isDeclarationName(node) ||
             node.parent.kind === SyntaxKind.ExternalModuleReference ||
             isArgumentOfElementAccessExpression(node) ||

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1240,7 +1240,7 @@ namespace ts {
     export function getNameFromPropertyName(name: PropertyName): string | undefined {
         return name.kind === SyntaxKind.ComputedPropertyName
             // treat computed property names where expression is string/numeric literal as just string/numeric literal
-            ? isStringOrNumericLiteral(name.expression) ? name.expression.text : undefined
+            ? isStringOrNumericLiteralLike(name.expression) ? name.expression.text : undefined
             : getTextOfIdentifierOrLiteral(name);
     }
 

--- a/tests/baselines/reference/computedPropertyNames11_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames11_ES5.types
@@ -9,8 +9,8 @@ var a: any;
 >a : any
 
 var v = {
->v : { [x: string]: any; [x: number]: any; [""]: any; readonly [0]: number; }
->{    get [s]() { return 0; },    set [n](v) { },    get [s + s]() { return 0; },    set [s + n](v) { },    get [+s]() { return 0; },    set [""](v) { },    get [0]() { return 0; },    set [a](v) { },    get [<any>true]() { return 0; },    set [`hello bye`](v) { },    get [`hello ${a} bye`]() { return 0; }} : { [x: string]: any; [x: number]: any; [""]: any; readonly [0]: number; }
+>v : { [x: string]: any; [x: number]: any; [""]: any; readonly [0]: number; [`hello bye`]: any; }
+>{    get [s]() { return 0; },    set [n](v) { },    get [s + s]() { return 0; },    set [s + n](v) { },    get [+s]() { return 0; },    set [""](v) { },    get [0]() { return 0; },    set [a](v) { },    get [<any>true]() { return 0; },    set [`hello bye`](v) { },    get [`hello ${a} bye`]() { return 0; }} : { [x: string]: any; [x: number]: any; [""]: any; readonly [0]: number; [`hello bye`]: any; }
 
     get [s]() { return 0; },
 >[s] : number

--- a/tests/baselines/reference/computedPropertyNames11_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames11_ES6.types
@@ -9,8 +9,8 @@ var a: any;
 >a : any
 
 var v = {
->v : { [x: string]: any; [x: number]: any; [""]: any; readonly [0]: number; }
->{    get [s]() { return 0; },    set [n](v) { },    get [s + s]() { return 0; },    set [s + n](v) { },    get [+s]() { return 0; },    set [""](v) { },    get [0]() { return 0; },    set [a](v) { },    get [<any>true]() { return 0; },    set [`hello bye`](v) { },    get [`hello ${a} bye`]() { return 0; }} : { [x: string]: any; [x: number]: any; [""]: any; readonly [0]: number; }
+>v : { [x: string]: any; [x: number]: any; [""]: any; readonly [0]: number; [`hello bye`]: any; }
+>{    get [s]() { return 0; },    set [n](v) { },    get [s + s]() { return 0; },    set [s + n](v) { },    get [+s]() { return 0; },    set [""](v) { },    get [0]() { return 0; },    set [a](v) { },    get [<any>true]() { return 0; },    set [`hello bye`](v) { },    get [`hello ${a} bye`]() { return 0; }} : { [x: string]: any; [x: number]: any; [""]: any; readonly [0]: number; [`hello bye`]: any; }
 
     get [s]() { return 0; },
 >[s] : number

--- a/tests/baselines/reference/computedPropertyNames12_ES5.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames12_ES5.errors.txt
@@ -5,11 +5,10 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(8,
 tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(9,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(12,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(13,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(14,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(15,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
 
 
-==== tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts (9 errors) ====
+==== tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts (8 errors) ====
     var s: string;
     var n: number;
     var a: any;
@@ -38,8 +37,6 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES5.ts(15
                ~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
         [`hello bye`] = 0;
-        ~~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
         static [`hello ${a} bye`] = 0
                ~~~~~~~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.

--- a/tests/baselines/reference/computedPropertyNames12_ES6.errors.txt
+++ b/tests/baselines/reference/computedPropertyNames12_ES6.errors.txt
@@ -5,11 +5,10 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(8,
 tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(9,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(12,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(13,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
-tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(14,5): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
 tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(15,12): error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
 
 
-==== tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts (9 errors) ====
+==== tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts (8 errors) ====
     var s: string;
     var n: number;
     var a: any;
@@ -38,8 +37,6 @@ tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts(15
                ~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
         [`hello bye`] = 0;
-        ~~~~~~~~~~~~~
-!!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.
         static [`hello ${a} bye`] = 0
                ~~~~~~~~~~~~~~~~~~
 !!! error TS1166: A computed property name in a class property declaration must refer to an expression whose type is a literal type or a 'unique symbol' type.

--- a/tests/baselines/reference/computerPropertiesInES5ShouldBeTransformed.types
+++ b/tests/baselines/reference/computerPropertiesInES5ShouldBeTransformed.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/computerPropertiesInES5ShouldBeTransformed.ts ===
 const b = ({ [`key`]: renamed }) => renamed;
->b : ({ [`key`]: renamed }: {}) => any
->({ [`key`]: renamed }) => renamed : ({ [`key`]: renamed }: {}) => any
+>b : ({ [`key`]: renamed }: { key: any; }) => any
+>({ [`key`]: renamed }) => renamed : ({ [`key`]: renamed }: { key: any; }) => any
 >`key` : "key"
 >renamed : any
 >renamed : any


### PR DESCRIPTION
This is an immediate fix to the particular repro from #26321 but doesn't solve the general case. Still, don't see any reason not to treat these the same.