### PR TITLE
Don't crash on computed property in destructure

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24363,10 +24363,13 @@ namespace ts {
                 const parentType = getTypeForBindingElementParent(parent);
                 const name = node.propertyName || node.name;
                 if (!isBindingPattern(name)) {
-                    const property = getPropertyOfType(parentType!, getTextOfPropertyName(name))!; // TODO: GH#18217
-                    markPropertyAsReferenced(property, /*nodeForCheckWriteOnly*/ undefined, /*isThisAccess*/ false); // A destructuring is never a write-only reference.
-                    if (parent.initializer && property) {
-                        checkPropertyAccessibility(parent, parent.initializer, parentType!, property);
+                    const nameText = getTextOfPropertyName(name);
+                    if (nameText) {
+                        const property = getPropertyOfType(parentType!, nameText)!; // TODO: GH#18217
+                        markPropertyAsReferenced(property, /*nodeForCheckWriteOnly*/ undefined, /*isThisAccess*/ false); // A destructuring is never a write-only reference.
+                        if (parent.initializer && property) {
+                            checkPropertyAccessibility(parent, parent.initializer, parentType!, property);
+                        }
                     }
                 }
             }

--- a/tests/baselines/reference/destructureComputedProperty.errors.txt
+++ b/tests/baselines/reference/destructureComputedProperty.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/destructureComputedProperty.ts(8,7): error TS2341: Property 'p' is private and only accessible within class 'C'.
+
+
+==== tests/cases/compiler/destructureComputedProperty.ts (1 errors) ====
+    declare const ab: { n: number } | { n: string };
+    const nameN = "n";
+    const { [nameN]: n } = ab;
+    
+    class C { private p: number; }
+    const nameP = "p";
+    const { [nameP]: p } = new C();
+    const { p: p2 } = new C();
+          ~~~~~~~~~
+!!! error TS2341: Property 'p' is private and only accessible within class 'C'.
+    

--- a/tests/baselines/reference/destructureComputedProperty.js
+++ b/tests/baselines/reference/destructureComputedProperty.js
@@ -1,0 +1,22 @@
+//// [destructureComputedProperty.ts]
+declare const ab: { n: number } | { n: string };
+const nameN = "n";
+const { [nameN]: n } = ab;
+
+class C { private p: number; }
+const nameP = "p";
+const { [nameP]: p } = new C();
+const { p: p2 } = new C();
+
+
+//// [destructureComputedProperty.js]
+var nameN = "n";
+var _a = nameN, n = ab[_a];
+var C = /** @class */ (function () {
+    function C() {
+    }
+    return C;
+}());
+var nameP = "p";
+var _b = nameP, p = new C()[_b];
+var p2 = new C().p;

--- a/tests/baselines/reference/destructureComputedProperty.symbols
+++ b/tests/baselines/reference/destructureComputedProperty.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/destructureComputedProperty.ts ===
+declare const ab: { n: number } | { n: string };
+>ab : Symbol(ab, Decl(destructureComputedProperty.ts, 0, 13))
+>n : Symbol(n, Decl(destructureComputedProperty.ts, 0, 19))
+>n : Symbol(n, Decl(destructureComputedProperty.ts, 0, 35))
+
+const nameN = "n";
+>nameN : Symbol(nameN, Decl(destructureComputedProperty.ts, 1, 5))
+
+const { [nameN]: n } = ab;
+>nameN : Symbol(nameN, Decl(destructureComputedProperty.ts, 1, 5))
+>n : Symbol(n, Decl(destructureComputedProperty.ts, 2, 7))
+>ab : Symbol(ab, Decl(destructureComputedProperty.ts, 0, 13))
+
+class C { private p: number; }
+>C : Symbol(C, Decl(destructureComputedProperty.ts, 2, 26))
+>p : Symbol(C.p, Decl(destructureComputedProperty.ts, 4, 9))
+
+const nameP = "p";
+>nameP : Symbol(nameP, Decl(destructureComputedProperty.ts, 5, 5))
+
+const { [nameP]: p } = new C();
+>nameP : Symbol(nameP, Decl(destructureComputedProperty.ts, 5, 5))
+>p : Symbol(p, Decl(destructureComputedProperty.ts, 6, 7))
+>C : Symbol(C, Decl(destructureComputedProperty.ts, 2, 26))
+
+const { p: p2 } = new C();
+>p : Symbol(C.p, Decl(destructureComputedProperty.ts, 4, 9))
+>p2 : Symbol(p2, Decl(destructureComputedProperty.ts, 7, 7))
+>C : Symbol(C, Decl(destructureComputedProperty.ts, 2, 26))
+

--- a/tests/baselines/reference/destructureComputedProperty.types
+++ b/tests/baselines/reference/destructureComputedProperty.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/destructureComputedProperty.ts ===
+declare const ab: { n: number } | { n: string };
+>ab : { n: number; } | { n: string; }
+>n : number
+>n : string
+
+const nameN = "n";
+>nameN : "n"
+>"n" : "n"
+
+const { [nameN]: n } = ab;
+>nameN : "n"
+>n : string | number
+>ab : { n: number; } | { n: string; }
+
+class C { private p: number; }
+>C : C
+>p : number
+
+const nameP = "p";
+>nameP : "p"
+>"p" : "p"
+
+const { [nameP]: p } = new C();
+>nameP : "p"
+>p : number
+>new C() : C
+>C : typeof C
+
+const { p: p2 } = new C();
+>p : any
+>p2 : number
+>new C() : C
+>C : typeof C
+

--- a/tests/cases/compiler/destructureComputedProperty.ts
+++ b/tests/cases/compiler/destructureComputedProperty.ts
@@ -1,0 +1,8 @@
+declare const ab: { n: number } | { n: string };
+const nameN = "n";
+const { [nameN]: n } = ab;
+
+class C { private p: number; }
+const nameP = "p";
+const { [nameP]: p } = new C();
+const { p: p2 } = new C();


### PR DESCRIPTION
Fixes #26321
Per #26328, we won't warn on a private property access that happens through a computed property.