### PR TITLE
Mark error type in type baselines if the baselines otherwise seem clean

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1493,7 +1493,7 @@ namespace Harness {
             });
         }
 
-        export function doTypeAndSymbolBaseline(baselinePath: string, program: ts.Program, allFiles: {unitName: string, content: string}[], opts?: Baseline.BaselineOptions, multifile?: boolean, skipTypeBaselines?: boolean, skipSymbolBaselines?: boolean) {
+        export function doTypeAndSymbolBaseline(baselinePath: string, program: ts.Program, allFiles: {unitName: string, content: string}[], opts?: Baseline.BaselineOptions, multifile?: boolean, skipTypeBaselines?: boolean, skipSymbolBaselines?: boolean, hasErrorBaseline?: boolean) {
             // The full walker simulates the types that you would get from doing a full
             // compile.  The pull walker simulates the types you get when you just do
             // a type query for a random node (like how the LS would do it).  Most of the
@@ -1509,7 +1509,7 @@ namespace Harness {
             // These types are equivalent, but depend on what order the compiler observed
             // certain parts of the program.
 
-            const fullWalker = new TypeWriterWalker(program, /*fullTypeCheck*/ true);
+            const fullWalker = new TypeWriterWalker(program, /*fullTypeCheck*/ true, !!hasErrorBaseline);
 
             // Produce baselines.  The first gives the types for all expressions.
             // The second gives symbols for all identifiers.

--- a/src/testRunner/compilerRunner.ts
+++ b/src/testRunner/compilerRunner.ts
@@ -258,7 +258,13 @@ class CompilerTest {
         Harness.Compiler.doTypeAndSymbolBaseline(
             this.justName,
             this.result.program!,
-            this.toBeCompiled.concat(this.otherFiles).filter(file => !!this.result.program!.getSourceFile(file.unitName)));
+            this.toBeCompiled.concat(this.otherFiles).filter(file => !!this.result.program!.getSourceFile(file.unitName)),
+            /*opts*/ undefined,
+            /*multifile*/ undefined,
+            /*skipTypeBaselines*/ undefined,
+            /*skipSymbolBaselines*/ undefined,
+            !!ts.length(this.result.diagnostics)
+        );
     }
 
     private makeUnitName(name: string, root: string) {

--- a/tests/baselines/reference/acceptableAlias1.types
+++ b/tests/baselines/reference/acceptableAlias1.types
@@ -6,7 +6,7 @@ module M {
     }
     export import X = N;
 >X : any
->N : any
+>N : error
 }
 
 import r = M.X;

--- a/tests/baselines/reference/aliasInaccessibleModule.types
+++ b/tests/baselines/reference/aliasInaccessibleModule.types
@@ -6,5 +6,5 @@ module M {
     }
     export import X = N;
 >X : any
->N : any
+>N : error
 }

--- a/tests/baselines/reference/checkJsFiles_skipDiagnostics.types
+++ b/tests/baselines/reference/checkJsFiles_skipDiagnostics.types
@@ -6,17 +6,17 @@ var x = 0;
 
 /// @ts-ignore
 x();
->x() : any
+>x() : error
 >x : number
 
 /// @ts-ignore
 x();
->x() : any
+>x() : error
 >x : number
 
 /// @ts-ignore
 x(
->x(    2,    3) : any
+>x(    2,    3) : error
 >x : number
 
     2,
@@ -34,13 +34,13 @@ x(
 // @another
 
 x();
->x() : any
+>x() : error
 >x : number
 
 
 
 // @ts-ignore: no call signature
 x();
->x() : any
+>x() : error
 >x : number
 

--- a/tests/baselines/reference/declarationEmitNameConflictsWithAlias.types
+++ b/tests/baselines/reference/declarationEmitNameConflictsWithAlias.types
@@ -2,7 +2,7 @@
 export module C { export interface I { } }
 export import v = C;
 >v : any
->C : any
+>C : error
 
 export module M {
 >M : typeof M

--- a/tests/baselines/reference/doubleUnderscoreReactNamespace.types
+++ b/tests/baselines/reference/doubleUnderscoreReactNamespace.types
@@ -11,8 +11,8 @@ declare var __foot: any;
 >__foot : any
 
 const thing = <__foot />;
->thing : any
-><__foot /> : any
+>thing : error
+><__foot /> : error
 >__foot : any
 
 export {}

--- a/tests/baselines/reference/duplicateVarAndImport.types
+++ b/tests/baselines/reference/duplicateVarAndImport.types
@@ -7,5 +7,5 @@ var a;
 module M { }
 import a = M;
 >a : any
->M : any
+>M : error
 

--- a/tests/baselines/reference/es3-jsx-preserve.types
+++ b/tests/baselines/reference/es3-jsx-preserve.types
@@ -4,8 +4,8 @@ const React: any = null;
 >null : null
 
 const elem = <div></div>;
->elem : any
-><div></div> : any
+>elem : error
+><div></div> : error
 >div : any
 >div : any
 

--- a/tests/baselines/reference/es3-jsx-react-native.types
+++ b/tests/baselines/reference/es3-jsx-react-native.types
@@ -4,8 +4,8 @@ const React: any = null;
 >null : null
 
 const elem = <div></div>;
->elem : any
-><div></div> : any
+>elem : error
+><div></div> : error
 >div : any
 >div : any
 

--- a/tests/baselines/reference/es3-jsx-react.types
+++ b/tests/baselines/reference/es3-jsx-react.types
@@ -4,8 +4,8 @@ const React: any = null;
 >null : null
 
 const elem = <div></div>;
->elem : any
-><div></div> : any
+>elem : error
+><div></div> : error
 >div : any
 >div : any
 

--- a/tests/baselines/reference/exportImportNonInstantiatedModule.types
+++ b/tests/baselines/reference/exportImportNonInstantiatedModule.types
@@ -9,7 +9,7 @@ module B {
 
     export import A1 = A
 >A1 : any
->A : any
+>A : error
     
 }
 

--- a/tests/baselines/reference/importHelpersInTsx.types
+++ b/tests/baselines/reference/importHelpersInTsx.types
@@ -6,8 +6,8 @@ declare var o: any;
 >o : any
 
 export const x = <span {...o} />
->x : any
-><span {...o} /> : any
+>x : error
+><span {...o} /> : error
 >span : any
 >o : any
 
@@ -19,8 +19,8 @@ declare var o: any;
 >o : any
 
 const x = <span {...o} />
->x : any
-><span {...o} /> : any
+>x : error
+><span {...o} /> : error
 >span : any
 >o : any
 

--- a/tests/baselines/reference/importUsedInGenericImportResolves.types
+++ b/tests/baselines/reference/importUsedInGenericImportResolves.types
@@ -12,7 +12,7 @@ export declare const theme: { a: string }
 === tests/cases/compiler/test3.ts ===
 export const a: import("./test1").T<typeof import("./test2").theme> = null as any;
 >a : import("tests/cases/compiler/test1").T<{ a: string; }>
->theme : any
+>theme : error
 >null as any : any
 >null : null
 

--- a/tests/baselines/reference/importedModuleClassNameClash.types
+++ b/tests/baselines/reference/importedModuleClassNameClash.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/importedModuleClassNameClash.ts ===
 import foo = m1;
 >foo : typeof foo
->m1 : any
+>m1 : error
  
 export module m1 { }
  

--- a/tests/baselines/reference/indexingTypesWithNever.types
+++ b/tests/baselines/reference/indexingTypesWithNever.types
@@ -69,8 +69,8 @@ declare function genericFn3<
 
 // Should be never
 const result5 = genericFn3({ g: "gtest", h: "htest" }, "g", "h"); // 'g' & 'h' will reduce to never
->result5 : any
->genericFn3({ g: "gtest", h: "htest" }, "g", "h") : any
+>result5 : error
+>genericFn3({ g: "gtest", h: "htest" }, "g", "h") : error
 >genericFn3 : <T extends { [K in keyof T]: T[K]; }, U extends keyof T, V extends keyof T>(obj: T, u: U, v: V) => T[U & V]
 >{ g: "gtest", h: "htest" } : { g: string; h: string; }
 >g : string

--- a/tests/baselines/reference/inlineJsxFactoryDeclarations.types
+++ b/tests/baselines/reference/inlineJsxFactoryDeclarations.types
@@ -28,7 +28,7 @@ import * as React from "./renderer";
 >React : typeof React
 
 <h></h>
-><h></h> : any
+><h></h> : error
 >h : any
 >h : any
 
@@ -39,8 +39,8 @@ import { dom as h } from "./renderer"
 >h : () => void
 
 export const prerendered = <h></h>;
->prerendered : any
-><h></h> : any
+>prerendered : error
+><h></h> : error
 >h : () => void
 >h : () => void
 
@@ -50,8 +50,8 @@ import { otherdom } from "./renderer"
 >otherdom : () => void
 
 export const prerendered2 = <h></h>;
->prerendered2 : any
-><h></h> : any
+>prerendered2 : error
+><h></h> : error
 >h : any
 >h : any
 
@@ -60,8 +60,8 @@ import React from "./renderer"
 >React : () => void
 
 export const prerendered3 = <h></h>;
->prerendered3 : any
-><h></h> : any
+>prerendered3 : error
+><h></h> : error
 >h : any
 >h : any
 
@@ -71,7 +71,7 @@ import { dom } from "./renderer"
 >dom : () => void
 
 <h></h>
-><h></h> : any
+><h></h> : error
 >h : any
 >h : any
 

--- a/tests/baselines/reference/inlineJsxFactoryOverridesCompilerOption.types
+++ b/tests/baselines/reference/inlineJsxFactoryOverridesCompilerOption.types
@@ -22,7 +22,7 @@ import {dom} from "./renderer";
 >dom : () => void
 
 <h></h>
-><h></h> : any
+><h></h> : error
 >h : any
 >h : any
 
@@ -31,7 +31,7 @@ import { p } from "./renderer";
 >p : () => void
 
 <h></h>
-><h></h> : any
+><h></h> : error
 >h : any
 >h : any
 

--- a/tests/baselines/reference/internalImportUnInstantiatedModuleNotReferencingInstanceNoConflict.types
+++ b/tests/baselines/reference/internalImportUnInstantiatedModuleNotReferencingInstanceNoConflict.types
@@ -13,6 +13,6 @@ module B {
 
     import Y = A;
 >Y : any
->A : any
+>A : error
 }
 

--- a/tests/baselines/reference/jsFileClassPropertyInitalizationInObjectLiteral.types
+++ b/tests/baselines/reference/jsFileClassPropertyInitalizationInObjectLiteral.types
@@ -15,7 +15,7 @@ module.exports = function () {
     c: A.b = 1,
 >c : number
 >A.b = 1 : 1
->A.b : any
+>A.b : error
 >A : typeof A
 >b : any
 >1 : 1

--- a/tests/baselines/reference/jsFileClassSelfReferencedProperty.types
+++ b/tests/baselines/reference/jsFileClassSelfReferencedProperty.types
@@ -4,11 +4,11 @@ export class StackOverflowTest {
 
   constructor () {
     this.testStackOverflow = this.testStackOverflow.bind(this)
->this.testStackOverflow = this.testStackOverflow.bind(this) : any
+>this.testStackOverflow = this.testStackOverflow.bind(this) : error
 >this.testStackOverflow : any
 >this : this
 >testStackOverflow : any
->this.testStackOverflow.bind(this) : any
+>this.testStackOverflow.bind(this) : error
 >this.testStackOverflow.bind : any
 >this.testStackOverflow : any
 >this : this

--- a/tests/baselines/reference/jsFileCompilationDecoratorSyntax.types
+++ b/tests/baselines/reference/jsFileCompilationDecoratorSyntax.types
@@ -1,5 +1,5 @@
 === tests/cases/compiler/a.js ===
 @internal class C { }
->internal : any
+>internal : error
 >C : C
 

--- a/tests/baselines/reference/jsFileCompilationExternalPackageError.types
+++ b/tests/baselines/reference/jsFileCompilationExternalPackageError.types
@@ -4,14 +4,14 @@ import {a} from "b";
 
 a++;
 >a++ : number
->a : any
+>a : error
 
 import {c} from "c";
 >c : any
 
 c++;
 >c++ : number
->c : any
+>c : error
 
 === tests/cases/compiler/node_modules/b.ts ===
 var a = 10;
@@ -28,6 +28,6 @@ exports.a = 10;
 
 c = 10;
 >c = 10 : 10
->c : any
+>c : error
 >10 : 10
 

--- a/tests/baselines/reference/jsxEmitAttributeWithPreserve.types
+++ b/tests/baselines/reference/jsxEmitAttributeWithPreserve.types
@@ -3,7 +3,7 @@ declare var React: any;
 >React : any
 
 <foo data/>
-><foo data/> : any
+><foo data/> : error
 >foo : any
 >data : true
 

--- a/tests/baselines/reference/jsxEmitWithAttributes.types
+++ b/tests/baselines/reference/jsxEmitWithAttributes.types
@@ -105,13 +105,13 @@ class A {
 >[			<meta content="helloworld"></meta>,			<meta content={c.a!.b}></meta>		] : any[]
 
 			<meta content="helloworld"></meta>,
-><meta content="helloworld"></meta> : any
+><meta content="helloworld"></meta> : error
 >meta : any
 >content : string
 >meta : any
 
 			<meta content={c.a!.b}></meta>
-><meta content={c.a!.b}></meta> : any
+><meta content={c.a!.b}></meta> : error
 >meta : any
 >content : string
 >c.a!.b : string

--- a/tests/baselines/reference/jsxFactoryIdentifier.types
+++ b/tests/baselines/reference/jsxFactoryIdentifier.types
@@ -111,13 +111,13 @@ class A {
 >[			<meta content="helloworld"></meta>,			<meta content={c.a!.b}></meta>		] : any[]
 
 			<meta content="helloworld"></meta>,
-><meta content="helloworld"></meta> : any
+><meta content="helloworld"></meta> : error
 >meta : any
 >content : string
 >meta : any
 
 			<meta content={c.a!.b}></meta>
-><meta content={c.a!.b}></meta> : any
+><meta content={c.a!.b}></meta> : error
 >meta : any
 >content : string
 >c.a!.b : string

--- a/tests/baselines/reference/jsxFactoryIdentifierAsParameter.types
+++ b/tests/baselines/reference/jsxFactoryIdentifierAsParameter.types
@@ -14,7 +14,7 @@ export class AppComponent {
 >createElement : any
 
         return <div />;
-><div /> : any
+><div /> : error
 >div : any
     }
 }

--- a/tests/baselines/reference/jsxFactoryQualifiedName.types
+++ b/tests/baselines/reference/jsxFactoryQualifiedName.types
@@ -105,13 +105,13 @@ class A {
 >[			<meta content="helloworld"></meta>,			<meta content={c.a!.b}></meta>		] : any[]
 
 			<meta content="helloworld"></meta>,
-><meta content="helloworld"></meta> : any
+><meta content="helloworld"></meta> : error
 >meta : any
 >content : string
 >meta : any
 
 			<meta content={c.a!.b}></meta>
-><meta content={c.a!.b}></meta> : any
+><meta content={c.a!.b}></meta> : error
 >meta : any
 >content : string
 >c.a!.b : string

--- a/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.types
+++ b/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.types
@@ -19,7 +19,7 @@ class Component {
 >renderCallback : () => any
 
         return <div>test</div>;
-><div>test</div> : any
+><div>test</div> : error
 >div : any
 >div : any
     }

--- a/tests/baselines/reference/jsxHash.types
+++ b/tests/baselines/reference/jsxHash.types
@@ -1,89 +1,89 @@
 === tests/cases/compiler/jsxHash.tsx ===
 var t02 = <a>{0}#</a>;
->t02 : any
-><a>{0}#</a> : any
+>t02 : error
+><a>{0}#</a> : error
 >a : any
 >0 : 0
 >a : any
 
 var t03 = <a>#{0}</a>;
->t03 : any
-><a>#{0}</a> : any
+>t03 : error
+><a>#{0}</a> : error
 >a : any
 >0 : 0
 >a : any
 
 var t04 = <a>#{0}#</a>;
->t04 : any
-><a>#{0}#</a> : any
+>t04 : error
+><a>#{0}#</a> : error
 >a : any
 >0 : 0
 >a : any
 
 var t05 = <a>#<i></i></a>;
->t05 : any
-><a>#<i></i></a> : any
+>t05 : error
+><a>#<i></i></a> : error
 >a : any
-><i></i> : any
+><i></i> : error
 >i : any
 >i : any
 >a : any
 
 var t06 = <a>#<i></i></a>;
->t06 : any
-><a>#<i></i></a> : any
+>t06 : error
+><a>#<i></i></a> : error
 >a : any
-><i></i> : any
+><i></i> : error
 >i : any
 >i : any
 >a : any
 
 var t07 = <a>#<i>#</i></a>;
->t07 : any
-><a>#<i>#</i></a> : any
+>t07 : error
+><a>#<i>#</i></a> : error
 >a : any
-><i>#</i> : any
+><i>#</i> : error
 >i : any
 >i : any
 >a : any
 
 var t08 = <a><i></i>#</a>;
->t08 : any
-><a><i></i>#</a> : any
+>t08 : error
+><a><i></i>#</a> : error
 >a : any
-><i></i> : any
+><i></i> : error
 >i : any
 >i : any
 >a : any
 
 var t09 = <a>#<i></i>#</a>;
->t09 : any
-><a>#<i></i>#</a> : any
+>t09 : error
+><a>#<i></i>#</a> : error
 >a : any
-><i></i> : any
+><i></i> : error
 >i : any
 >i : any
 >a : any
 
 var t10 = <a><i/>#</a>;
->t10 : any
-><a><i/>#</a> : any
+>t10 : error
+><a><i/>#</a> : error
 >a : any
-><i/> : any
+><i/> : error
 >i : any
 >a : any
 
 var t11 = <a>#<i/></a>;
->t11 : any
-><a>#<i/></a> : any
+>t11 : error
+><a>#<i/></a> : error
 >a : any
-><i/> : any
+><i/> : error
 >i : any
 >a : any
 
 var t12 = <a>#</a>;
->t12 : any
-><a>#</a> : any
+>t12 : error
+><a>#</a> : error
 >a : any
 >a : any
 

--- a/tests/baselines/reference/jsxImportInAttribute.types
+++ b/tests/baselines/reference/jsxImportInAttribute.types
@@ -8,7 +8,7 @@ let x = Test; // emit test_1.default
 >Test : typeof Test
 
 <anything attr={Test} />; // ?
-><anything attr={Test} /> : any
+><anything attr={Test} /> : error
 >anything : any
 >attr : typeof Test
 >Test : typeof Test

--- a/tests/baselines/reference/jsxInExtendsClause.types
+++ b/tests/baselines/reference/jsxInExtendsClause.types
@@ -27,7 +27,7 @@ class Foo extends createComponentClass(() => class extends React.Component<{}, {
 >render : () => any
 
     return <span>Hello, world!</span>;
-><span>Hello, world!</span> : any
+><span>Hello, world!</span> : error
 >span : any
 >span : any
   }

--- a/tests/baselines/reference/jsxMultilineAttributeStringValues.types
+++ b/tests/baselines/reference/jsxMultilineAttributeStringValues.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/jsxMultilineAttributeStringValues.tsx ===
 const a = <input value="
->a : any
-><input value="  foo: 23"></input> : any
+>a : error
+><input value="  foo: 23"></input> : error
 >input : any
 >value : string
 
@@ -10,8 +10,8 @@ const a = <input value="
 >input : any
 
 const b = <input value='
->b : any
-><input value='foo: 23'></input> : any
+>b : error
+><input value='foo: 23'></input> : error
 >input : any
 >value : string
 

--- a/tests/baselines/reference/jsxMultilineAttributeValuesReact.types
+++ b/tests/baselines/reference/jsxMultilineAttributeValuesReact.types
@@ -3,8 +3,8 @@ declare var React: any;
 >React : any
 
 const a = <input value="
->a : any
-><input value="foo: 23"></input> : any
+>a : error
+><input value="foo: 23"></input> : error
 >input : any
 >value : string
 
@@ -13,8 +13,8 @@ foo: 23
 >input : any
 
 const b = <input value='
->b : any
-><input value='foo: 23'></input> : any
+>b : error
+><input value='foo: 23'></input> : error
 >input : any
 >value : string
 
@@ -23,8 +23,8 @@ foo: 23
 >input : any
 
 const c = <input value='
->c : any
-><input value='foo: 23\n'></input> : any
+>c : error
+><input value='foo: 23\n'></input> : error
 >input : any
 >value : string
 

--- a/tests/baselines/reference/jsxNestedWithinTernaryParsesCorrectly.types
+++ b/tests/baselines/reference/jsxNestedWithinTernaryParsesCorrectly.types
@@ -5,11 +5,11 @@ const emptyMessage = null as any;
 >null : null
 
 const a = (
->a : any
->(    <div>      {0 ? (        emptyMessage // must be identifier?      ) : (          // must be exactly two expression holes        <span>          {0}{0}        </span>      )}    </div>) : any
+>a : error
+>(    <div>      {0 ? (        emptyMessage // must be identifier?      ) : (          // must be exactly two expression holes        <span>          {0}{0}        </span>      )}    </div>) : error
 
     <div>
-><div>      {0 ? (        emptyMessage // must be identifier?      ) : (          // must be exactly two expression holes        <span>          {0}{0}        </span>      )}    </div> : any
+><div>      {0 ? (        emptyMessage // must be identifier?      ) : (          // must be exactly two expression holes        <span>          {0}{0}        </span>      )}    </div> : error
 >div : any
 
       {0 ? (
@@ -21,11 +21,11 @@ const a = (
 >emptyMessage : any
 
       ) : (
->(          // must be exactly two expression holes        <span>          {0}{0}        </span>      ) : any
+>(          // must be exactly two expression holes        <span>          {0}{0}        </span>      ) : error
 
           // must be exactly two expression holes
         <span>
-><span>          {0}{0}        </span> : any
+><span>          {0}{0}        </span> : error
 >span : any
 
           {0}{0}

--- a/tests/baselines/reference/jsxPreserveWithJsInput.types
+++ b/tests/baselines/reference/jsxPreserveWithJsInput.types
@@ -5,16 +5,16 @@ var elemA = 42;
 
 === tests/cases/compiler/b.jsx ===
 var elemB = <b>{"test"}</b>;
->elemB : any
-><b>{"test"}</b> : any
+>elemB : error
+><b>{"test"}</b> : error
 >b : any
 >"test" : "test"
 >b : any
 
 === tests/cases/compiler/c.js ===
 var elemC = <c>{42}</c>;
->elemC : any
-><c>{42}</c> : any
+>elemC : error
+><c>{42}</c> : error
 >c : any
 >42 : 42
 >c : any
@@ -26,8 +26,8 @@ var elemD = 42;
 
 === tests/cases/compiler/e.tsx ===
 var elemE = <e>{true}</e>;
->elemE : any
-><e>{true}</e> : any
+>elemE : error
+><e>{true}</e> : error
 >e : any
 >true : true
 >e : any

--- a/tests/baselines/reference/jsxReactTestSuite.types
+++ b/tests/baselines/reference/jsxReactTestSuite.types
@@ -36,12 +36,12 @@ declare var hasOwnProperty:any;
 >hasOwnProperty : any
 
 <div>text</div>;
-><div>text</div> : any
+><div>text</div> : error
 >div : any
 >div : any
 
 <div>
-><div>  {this.props.children}</div> : any
+><div>  {this.props.children}</div> : error
 >div : any
 
   {this.props.children}
@@ -55,27 +55,27 @@ declare var hasOwnProperty:any;
 >div : any
 
 <div>
-><div>  <div><br /></div>  <Component>{foo}<br />{bar}</Component>  <br /></div> : any
+><div>  <div><br /></div>  <Component>{foo}<br />{bar}</Component>  <br /></div> : error
 >div : any
 
   <div><br /></div>
-><div><br /></div> : any
+><div><br /></div> : error
 >div : any
-><br /> : any
+><br /> : error
 >br : any
 >div : any
 
   <Component>{foo}<br />{bar}</Component>
-><Component>{foo}<br />{bar}</Component> : any
+><Component>{foo}<br />{bar}</Component> : error
 >Component : any
 >foo : any
-><br /> : any
+><br /> : error
 >br : any
 >bar : any
 >Component : any
 
   <br />
-><br /> : any
+><br /> : error
 >br : any
 
 </div>;
@@ -83,7 +83,7 @@ declare var hasOwnProperty:any;
 
 
 <Composite>
-><Composite>    {this.props.children}</Composite> : any
+><Composite>    {this.props.children}</Composite> : error
 >Composite : any
 
     {this.props.children}
@@ -97,11 +97,11 @@ declare var hasOwnProperty:any;
 >Composite : any
 
 <Composite>
-><Composite>    <Composite2 /></Composite> : any
+><Composite>    <Composite2 /></Composite> : error
 >Composite : any
 
     <Composite2 />
-><Composite2 /> : any
+><Composite2 /> : error
 >Composite2 : any
 
 </Composite>;
@@ -111,7 +111,7 @@ var x =
 >x : any
 
   <div
-><div    attr1={      "foo" + "bar"    }    attr2={      "foo" + "bar" +            "baz" + "bug"    }    attr3={      "foo" + "bar" +      "baz" + "bug"      // Extra line here.    }    attr4="baz">  </div> : any
+><div    attr1={      "foo" + "bar"    }    attr2={      "foo" + "bar" +            "baz" + "bug"    }    attr3={      "foo" + "bar" +      "baz" + "bug"      // Extra line here.    }    attr4="baz">  </div> : error
 >div : any
 
     attr1={
@@ -159,16 +159,16 @@ var x =
 >div : any
 
 (
->(  <div>    {/* A comment at the beginning */}    {/* A second comment at the beginning */}    <span>      {/* A nested comment */}    </span>    {/* A sandwiched comment */}    <br />    {/* A comment at the end */}    {/* A second comment at the end */}  </div>) : any
+>(  <div>    {/* A comment at the beginning */}    {/* A second comment at the beginning */}    <span>      {/* A nested comment */}    </span>    {/* A sandwiched comment */}    <br />    {/* A comment at the end */}    {/* A second comment at the end */}  </div>) : error
 
   <div>
-><div>    {/* A comment at the beginning */}    {/* A second comment at the beginning */}    <span>      {/* A nested comment */}    </span>    {/* A sandwiched comment */}    <br />    {/* A comment at the end */}    {/* A second comment at the end */}  </div> : any
+><div>    {/* A comment at the beginning */}    {/* A second comment at the beginning */}    <span>      {/* A nested comment */}    </span>    {/* A sandwiched comment */}    <br />    {/* A comment at the end */}    {/* A second comment at the end */}  </div> : error
 >div : any
 
     {/* A comment at the beginning */}
     {/* A second comment at the beginning */}
     <span>
-><span>      {/* A nested comment */}    </span> : any
+><span>      {/* A nested comment */}    </span> : error
 >span : any
 
       {/* A nested comment */}
@@ -177,7 +177,7 @@ var x =
 
     {/* A sandwiched comment */}
     <br />
-><br /> : any
+><br /> : error
 >br : any
 
     {/* A comment at the end */}
@@ -188,10 +188,10 @@ var x =
 );
 
 (
->(  <div    /* a multi-line       comment */    attr1="foo">    <span // a double-slash comment      attr2="bar"    />  </div>) : any
+>(  <div    /* a multi-line       comment */    attr1="foo">    <span // a double-slash comment      attr2="bar"    />  </div>) : error
 
   <div
-><div    /* a multi-line       comment */    attr1="foo">    <span // a double-slash comment      attr2="bar"    />  </div> : any
+><div    /* a multi-line       comment */    attr1="foo">    <span // a double-slash comment      attr2="bar"    />  </div> : error
 >div : any
 
     /* a multi-line
@@ -200,7 +200,7 @@ var x =
 >attr1 : string
 
     <span // a double-slash comment
-><span // a double-slash comment      attr2="bar"    /> : any
+><span // a double-slash comment      attr2="bar"    /> : error
 >span : any
 
       attr2="bar"
@@ -213,33 +213,33 @@ var x =
 );
 
 <div>&nbsp;</div>;
-><div>&nbsp;</div> : any
+><div>&nbsp;</div> : error
 >div : any
 >div : any
 
 <div>&nbsp; </div>;
-><div>&nbsp; </div> : any
+><div>&nbsp; </div> : error
 >div : any
 >div : any
 
 <hasOwnProperty>testing</hasOwnProperty>;
-><hasOwnProperty>testing</hasOwnProperty> : any
+><hasOwnProperty>testing</hasOwnProperty> : error
 >hasOwnProperty : any
 >hasOwnProperty : any
 
 <Component constructor="foo" />;
-><Component constructor="foo" /> : any
+><Component constructor="foo" /> : error
 >Component : any
 >constructor : string
 
 <Namespace.Component />;
-><Namespace.Component /> : any
+><Namespace.Component /> : error
 >Namespace.Component : any
 >Namespace : any
 >Component : any
 
 <Namespace.DeepNamespace.Component />;
-><Namespace.DeepNamespace.Component /> : any
+><Namespace.DeepNamespace.Component /> : error
 >Namespace.DeepNamespace.Component : any
 >Namespace.DeepNamespace : any
 >Namespace : any
@@ -247,7 +247,7 @@ var x =
 >Component : any
 
 <Component { ... x } y
-><Component { ... x } y={2 } z /> : any
+><Component { ... x } y={2 } z /> : error
 >Component : any
 >x : any
 >y : number
@@ -257,7 +257,7 @@ var x =
 >z : true
 
 <Component
-><Component    {...this.props} sound="moo" /> : any
+><Component    {...this.props} sound="moo" /> : error
 >Component : any
 
     {...this.props} sound="moo" />;
@@ -267,33 +267,33 @@ var x =
 >sound : string
 
 <font-face />;
-><font-face /> : any
+><font-face /> : error
 >font-face : any
 
 <Component x={y} />;
-><Component x={y} /> : any
+><Component x={y} /> : error
 >Component : any
 >x : any
 >y : any
 
 <x-component />;
-><x-component /> : any
+><x-component /> : error
 >x-component : any
 
 <Component {...x} />;
-><Component {...x} /> : any
+><Component {...x} /> : error
 >Component : any
 >x : any
 
 <Component { ...x } y={2} />;
-><Component { ...x } y={2} /> : any
+><Component { ...x } y={2} /> : error
 >Component : any
 >x : any
 >y : number
 >2 : 2
 
 <Component { ... x } y={2} z />;
-><Component { ... x } y={2} z /> : any
+><Component { ... x } y={2} z /> : error
 >Component : any
 >x : any
 >y : number
@@ -301,7 +301,7 @@ var x =
 >z : true
 
 <Component x={1} {...y} />;
-><Component x={1} {...y} /> : any
+><Component x={1} {...y} /> : error
 >Component : any
 >x : number
 >1 : 1
@@ -309,19 +309,19 @@ var x =
 
 
 <Component x={1} y="2" {...z} {...z}><Child /></Component>;
-><Component x={1} y="2" {...z} {...z}><Child /></Component> : any
+><Component x={1} y="2" {...z} {...z}><Child /></Component> : error
 >Component : any
 >x : number
 >1 : 1
 >y : string
 >z : any
 >z : any
-><Child /> : any
+><Child /> : error
 >Child : any
 >Component : any
 
 <Component x="1" {...(z = { y: 2 }, z)} z={3}>Text</Component>;
-><Component x="1" {...(z = { y: 2 }, z)} z={3}>Text</Component> : any
+><Component x="1" {...(z = { y: 2 }, z)} z={3}>Text</Component> : error
 >Component : any
 >x : string
 >(z = { y: 2 }, z) : any

--- a/tests/baselines/reference/jsxViaImport.2.types
+++ b/tests/baselines/reference/jsxViaImport.2.types
@@ -13,7 +13,7 @@ class TestComponent extends React.Component<any, {}> {
 >render : () => any
 
         return <BaseComponent />;
-><BaseComponent /> : any
+><BaseComponent /> : error
 >BaseComponent : typeof BaseComponent
     }
 }

--- a/tests/baselines/reference/keywordInJsxIdentifier.types
+++ b/tests/baselines/reference/keywordInJsxIdentifier.types
@@ -3,22 +3,22 @@ declare var React: any;
 >React : any
 
 <foo class-id/>;
-><foo class-id/> : any
+><foo class-id/> : error
 >foo : any
 >class-id : true
 
 <foo class/>;
-><foo class/> : any
+><foo class/> : error
 >foo : any
 >class : true
 
 <foo class-id="1"/>;
-><foo class-id="1"/> : any
+><foo class-id="1"/> : error
 >foo : any
 >class-id : string
 
 <foo class="1"/>;
-><foo class="1"/> : any
+><foo class="1"/> : error
 >foo : any
 >class : string
 

--- a/tests/baselines/reference/methodsReturningThis.types
+++ b/tests/baselines/reference/methodsReturningThis.types
@@ -13,7 +13,7 @@ Class.prototype.containsError = function () { return this.notPresent; };
 >prototype : any
 >containsError : any
 >function () { return this.notPresent; } : () => any
->this.notPresent : any
+>this.notPresent : error
 >this : Class
 >notPresent : any
 

--- a/tests/baselines/reference/misspelledJsDocTypedefTags.types
+++ b/tests/baselines/reference/misspelledJsDocTypedefTags.types
@@ -1,7 +1,7 @@
 === tests/cases/compiler/a.js ===
 /** @typedef {{ endTime: number, screenshots: number}} A.<b>*/
 Animation.AnimationModel.ScreenshotCapture.Request;
->Animation.AnimationModel.ScreenshotCapture.Request : any
+>Animation.AnimationModel.ScreenshotCapture.Request : error
 >Animation.AnimationModel.ScreenshotCapture : any
 >Animation.AnimationModel : any
 >Animation : { new (effect?: AnimationEffect, timeline?: AnimationTimeline): Animation; prototype: Animation; }
@@ -11,7 +11,7 @@ Animation.AnimationModel.ScreenshotCapture.Request;
 
 /** @typedef {{ endTime: number, screenshots: !B.<string>}} */
 Animation.AnimationModel.ScreenshotCapture.Request;
->Animation.AnimationModel.ScreenshotCapture.Request : any
+>Animation.AnimationModel.ScreenshotCapture.Request : error
 >Animation.AnimationModel.ScreenshotCapture : any
 >Animation.AnimationModel : any
 >Animation : { new (effect?: AnimationEffect, timeline?: AnimationTimeline): Animation; prototype: Animation; }

--- a/tests/baselines/reference/moduleAugmentationInDependency.types
+++ b/tests/baselines/reference/moduleAugmentationInDependency.types
@@ -1,6 +1,6 @@
 === /node_modules/A/index.d.ts ===
 declare module "ext" {
->"ext" : any
+>"ext" : error
 }
 export {};
 

--- a/tests/baselines/reference/moduleResolution_relativeImportJsFile.types
+++ b/tests/baselines/reference/moduleResolution_relativeImportJsFile.types
@@ -1,4 +1,4 @@
 === /src/a.ts ===
 import * as b from "./b";
->b : any
+>b : error
 

--- a/tests/baselines/reference/moduledecl.types
+++ b/tests/baselines/reference/moduledecl.types
@@ -8,13 +8,13 @@ module b.a {
 module c.a.b {
     import ma = a;
 >ma : any
->a : any
+>a : error
 }
 
 module mImport {
     import d = a;
 >d : any
->a : any
+>a : error
 
     import e = b.a;
 >e : any
@@ -23,7 +23,7 @@ module mImport {
 
     import d1 = a;
 >d1 : any
->a : any
+>a : error
 
     import e1 = b.a;
 >e1 : any
@@ -75,11 +75,11 @@ module m0 {
 
     import m2 = a;
 >m2 : any
->a : any
+>a : error
 
     import m3 = b;
 >m3 : any
->b : any
+>b : error
 
     import m4 = b.a;
 >m4 : any
@@ -88,7 +88,7 @@ module m0 {
 
     import m5 = c;
 >m5 : any
->c : any
+>c : error
 
     import m6 = c.a;
 >m6 : any
@@ -165,11 +165,11 @@ module m1 {
 
     import m2 = a;
 >m2 : any
->a : any
+>a : error
 
     import m3 = b;
 >m3 : any
->b : any
+>b : error
 
     import m4 = b.a;
 >m4 : any
@@ -178,7 +178,7 @@ module m1 {
 
     import m5 = c;
 >m5 : any
->c : any
+>c : error
 
     import m6 = c.a;
 >m6 : any

--- a/tests/baselines/reference/multipleDeclarations.types
+++ b/tests/baselines/reference/multipleDeclarations.types
@@ -19,8 +19,8 @@ C.prototype.m = function() {
 >function() {    this.nothing();} : () => void
 
     this.nothing();
->this.nothing() : any
->this.nothing : any
+>this.nothing() : error
+>this.nothing : error
 >this : C
 >nothing : any
 }

--- a/tests/baselines/reference/packageJsonMain.types
+++ b/tests/baselines/reference/packageJsonMain.types
@@ -9,9 +9,9 @@ import baz = require("baz");
 >baz : any
 
 foo + bar + baz;
->foo + bar + baz : any
->foo + bar : any
->foo : any
->bar : any
->baz : any
+>foo + bar + baz : error
+>foo + bar : error
+>foo : error
+>bar : error
+>baz : error
 

--- a/tests/baselines/reference/parserES5ForOfStatement18.types
+++ b/tests/baselines/reference/parserES5ForOfStatement18.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement18.ts ===
 for (var of of of) { }
 >of : any
->of : any
+>of : error
 

--- a/tests/baselines/reference/parserES5ForOfStatement19.types
+++ b/tests/baselines/reference/parserES5ForOfStatement19.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts ===
 for (var of in of) { }
 >of : any
->of : any
+>of : error
 

--- a/tests/baselines/reference/parserForOfStatement18.types
+++ b/tests/baselines/reference/parserForOfStatement18.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement18.ts ===
 for (var of of of) { }
 >of : any
->of : any
+>of : error
 

--- a/tests/baselines/reference/parserForOfStatement19.types
+++ b/tests/baselines/reference/parserForOfStatement19.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts ===
 for (var of in of) { }
 >of : any
->of : any
+>of : error
 

--- a/tests/baselines/reference/reactImportDropped.types
+++ b/tests/baselines/reference/reactImportDropped.types
@@ -56,11 +56,11 @@ import {layout} from '../../utils/theme'; // <- DO NOT DROP this import
 >layout : any
 
 const x = <TabBar height={layout.footerHeight} />;
->x : any
-><TabBar height={layout.footerHeight} /> : any
+>x : error
+><TabBar height={layout.footerHeight} /> : error
 >TabBar : import("tests/cases/compiler/react").ClassicComponentClass
->height : any
->layout.footerHeight : any
+>height : error
+>layout.footerHeight : error
 >layout : any
 >footerHeight : any
 

--- a/tests/baselines/reference/reactNamespaceImportPresevation.types
+++ b/tests/baselines/reference/reactNamespaceImportPresevation.types
@@ -17,7 +17,7 @@ declare var foo: any;
 >foo : any
 
 <foo data/>;
-><foo data/> : any
+><foo data/> : error
 >foo : any
 >data : true
 

--- a/tests/baselines/reference/reactNamespaceJSXEmit.types
+++ b/tests/baselines/reference/reactNamespaceJSXEmit.types
@@ -15,34 +15,34 @@ declare var x: any;
 >x : any
 
 <foo data/>;
-><foo data/> : any
+><foo data/> : error
 >foo : any
 >data : true
 
 <Bar x={x} />;
-><Bar x={x} /> : any
+><Bar x={x} /> : error
 >Bar : any
 >x : any
 >x : any
 
 <x-component />;
-><x-component /> : any
+><x-component /> : error
 >x-component : any
 
 <Bar {...x} />;
-><Bar {...x} /> : any
+><Bar {...x} /> : error
 >Bar : any
 >x : any
 
 <Bar { ...x } y={2} />;
-><Bar { ...x } y={2} /> : any
+><Bar { ...x } y={2} /> : error
 >Bar : any
 >x : any
 >y : number
 >2 : 2
 
 <_Bar { ...x } />;
-><_Bar { ...x } /> : any
+><_Bar { ...x } /> : error
 >_Bar : any
 >x : any
 

--- a/tests/baselines/reference/reactTransitiveImportHasValidDeclaration.types
+++ b/tests/baselines/reference/reactTransitiveImportHasValidDeclaration.types
@@ -7,12 +7,12 @@ export = React;
 >React : any
 
 export as namespace React;
->React : any
+>React : error
 
 === tests/cases/compiler/node_modules/create-emotion-styled/types/react/index.d.ts ===
 /// <reference types="react" />
 declare module 'react' { // augment
->'react' : any
+>'react' : error
 
     interface HTMLAttributes<T> {
         css?: unknown;

--- a/tests/baselines/reference/recur1.types
+++ b/tests/baselines/reference/recur1.types
@@ -15,7 +15,7 @@ salt.pepper = function() {}
 
 var cobalt = new cobalt.pitch();   
 >cobalt : any
->new cobalt.pitch() : any
+>new cobalt.pitch() : error
 >cobalt.pitch : any
 >cobalt : any
 >pitch : any

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.types
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.types
@@ -14,7 +14,7 @@ import self = require("recursiveExportAssignmentAndFindAliasedType7_moduleD");
 
 var selfVar = self;
 >selfVar : any
->self : any
+>self : error
 
 export = selfVar;
 >selfVar : any

--- a/tests/baselines/reference/reservedNameOnModuleImport.types
+++ b/tests/baselines/reference/reservedNameOnModuleImport.types
@@ -7,6 +7,6 @@ declare module test {
     // Should be fine; this does not clobber any declared values.
     export import string = mstring;
 >string : any
->mstring : any
+>mstring : error
 }
 

--- a/tests/baselines/reference/spreadIntersectionJsx.types
+++ b/tests/baselines/reference/spreadIntersectionJsx.types
@@ -15,8 +15,8 @@ let intersected: A & C;
 >intersected : A & C
 
 let element = <div { ...intersected } />;
->element : any
-><div { ...intersected } /> : any
+>element : error
+><div { ...intersected } /> : error
 >div : any
 >intersected : A & C
 

--- a/tests/baselines/reference/superNoModifiersCrash.types
+++ b/tests/baselines/reference/superNoModifiersCrash.types
@@ -6,8 +6,8 @@ class Parent {
 >initialize : (...args: any[]) => string
 
         super.initialize(...arguments)
->super.initialize(...arguments) : any
->super.initialize : any
+>super.initialize(...arguments) : error
+>super.initialize : error
 >super : any
 >initialize : any
 >...arguments : any

--- a/tests/baselines/reference/topLevelThisAssignment.types
+++ b/tests/baselines/reference/topLevelThisAssignment.types
@@ -12,7 +12,7 @@ this.a;
 >a : any
 
 a;
->a : any
+>a : error
 
 === tests/cases/conformance/salsa/b.js ===
 this.a;
@@ -21,5 +21,5 @@ this.a;
 >a : any
 
 a;
->a : any
+>a : error
 

--- a/tests/baselines/reference/tsxAttributeResolution13.types
+++ b/tests/baselines/reference/tsxAttributeResolution13.types
@@ -3,7 +3,7 @@ function Test() { }
 >Test : () => void
 
 <Test></Test>
-><Test></Test> : any
+><Test></Test> : error
 >Test : () => void
 >Test : () => void
 

--- a/tests/baselines/reference/tsxAttributesHasInferrableIndex.types
+++ b/tests/baselines/reference/tsxAttributesHasInferrableIndex.types
@@ -29,8 +29,8 @@ function Button(attributes: Attributes | undefined, contents: string[]) {
 >'' : ""
 }
 const b = <Button></Button>
->b : any
-><Button></Button> : any
+>b : error
+><Button></Button> : error
 >Button : (attributes: Attributes | undefined, contents: string[]) => string
 >Button : (attributes: Attributes | undefined, contents: string[]) => string
 

--- a/tests/baselines/reference/tsxCorrectlyParseLessThanComparison1.types
+++ b/tests/baselines/reference/tsxCorrectlyParseLessThanComparison1.types
@@ -41,8 +41,8 @@ export class ShortDetails extends React.Component<{ id: number }, {}> {
 >1 : 1
 
             return (<div></div>);
->(<div></div>) : any
-><div></div> : any
+>(<div></div>) : error
+><div></div> : error
 >div : any
 >div : any
         }

--- a/tests/baselines/reference/tsxDynamicTagName1.types
+++ b/tests/baselines/reference/tsxDynamicTagName1.types
@@ -4,7 +4,7 @@ var CustomTag = "h1";
 >"h1" : "h1"
 
 <CustomTag> Hello World </CustomTag>  // No error
-><CustomTag> Hello World </CustomTag> : any
+><CustomTag> Hello World </CustomTag> : error
 >CustomTag : string
 >CustomTag : string
 

--- a/tests/baselines/reference/tsxDynamicTagName5.types
+++ b/tests/baselines/reference/tsxDynamicTagName5.types
@@ -24,10 +24,10 @@ export class Text extends React.Component<{}, {}> {
 >render : () => any
 
     return (
->(      <this._tagName />    ) : any
+>(      <this._tagName />    ) : error
 
       <this._tagName />
-><this._tagName /> : any
+><this._tagName /> : error
 >this._tagName : string
 >this : this
 >_tagName : string

--- a/tests/baselines/reference/tsxDynamicTagName8.types
+++ b/tests/baselines/reference/tsxDynamicTagName8.types
@@ -24,10 +24,10 @@ export class Text extends React.Component<{}, {}> {
 >render : () => any
 
     return (
->(      <this._tagName> Hello world </this._tagName>    ) : any
+>(      <this._tagName> Hello world </this._tagName>    ) : error
 
       <this._tagName> Hello world </this._tagName>
-><this._tagName> Hello world </this._tagName> : any
+><this._tagName> Hello world </this._tagName> : error
 >this._tagName : string
 >this : this
 >_tagName : string

--- a/tests/baselines/reference/tsxDynamicTagName9.types
+++ b/tests/baselines/reference/tsxDynamicTagName9.types
@@ -24,10 +24,10 @@ export class Text extends React.Component<{}, {}> {
 >render : () => any
 
     return (
->(      <this._tagName> Hello world </this._tagName>    ) : any
+>(      <this._tagName> Hello world </this._tagName>    ) : error
 
       <this._tagName> Hello world </this._tagName>
-><this._tagName> Hello world </this._tagName> : any
+><this._tagName> Hello world </this._tagName> : error
 >this._tagName : "div"
 >this : this
 >_tagName : "div"

--- a/tests/baselines/reference/tsxElementResolution.types
+++ b/tests/baselines/reference/tsxElementResolution.types
@@ -28,27 +28,27 @@ module Dotted {
 
 // Should find the intrinsic element, not the class element
 var a = <foundFirst  x="hello" />;
->a : any
-><foundFirst  x="hello" /> : any
+>a : error
+><foundFirst  x="hello" /> : error
 >foundFirst : typeof foundFirst
 >x : string
 
 var b = <string_named />;
->b : any
-><string_named /> : any
+>b : error
+><string_named /> : error
 >string_named : any
 
 // TODO: This should not be a parse error (should
 //        parse a property name here, not identifier)
 // var c = <var />;
 var d = <Other />;
->d : any
-><Other /> : any
+>d : error
+><Other /> : error
 >Other : typeof Other
 
 var e = <Dotted.Name />;
->e : any
-><Dotted.Name /> : any
+>e : error
+><Dotted.Name /> : error
 >Dotted.Name : typeof Dotted.Name
 >Dotted : typeof Dotted
 >Name : typeof Dotted.Name

--- a/tests/baselines/reference/tsxElementResolution19.types
+++ b/tests/baselines/reference/tsxElementResolution19.types
@@ -20,6 +20,6 @@ import {MyClass} from './file1';
 >MyClass : typeof MyClass
 
 <MyClass />;
-><MyClass /> : any
+><MyClass /> : error
 >MyClass : typeof MyClass
 

--- a/tests/baselines/reference/tsxExternalModuleEmit1.types
+++ b/tests/baselines/reference/tsxExternalModuleEmit1.types
@@ -24,7 +24,7 @@ export class App extends React.Component<any, any> {
 >render : () => any
 
         return <Button />;
-><Button /> : any
+><Button /> : error
 >Button : typeof Button
     }
 
@@ -44,7 +44,7 @@ export class Button extends React.Component<any, any> {
 >render : () => any
 
         return <button>Some button</button>;
-><button>Some button</button> : any
+><button>Some button</button> : error
 >button : any
 >button : any
     }

--- a/tests/baselines/reference/tsxExternalModuleEmit2.types
+++ b/tests/baselines/reference/tsxExternalModuleEmit2.types
@@ -19,7 +19,7 @@ declare var Foo, React;
 
 // Should see mod_1['default'] in emit here
 <Foo handler={Main}></Foo>;
-><Foo handler={Main}></Foo> : any
+><Foo handler={Main}></Foo> : error
 >Foo : any
 >handler : any
 >Main : any
@@ -27,7 +27,7 @@ declare var Foo, React;
 
 // Should see mod_1['default'] in emit here
 <Foo {...Main}></Foo>;
-><Foo {...Main}></Foo> : any
+><Foo {...Main}></Foo> : error
 >Foo : any
 >Main : any
 >Foo : any

--- a/tests/baselines/reference/tsxNoJsx.types
+++ b/tests/baselines/reference/tsxNoJsx.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/jsx/tsxNoJsx.tsx ===
 <nope />;
-><nope /> : any
+><nope /> : error
 >nope : any
 

--- a/tests/baselines/reference/tsxPreserveEmit1.types
+++ b/tests/baselines/reference/tsxPreserveEmit1.types
@@ -12,8 +12,8 @@ import Route = ReactRouter.Route;
 >Route : any
 
 var routes1 = <Route />;
->routes1 : any
-><Route /> : any
+>routes1 : error
+><Route /> : error
 >Route : any
 
 module M {
@@ -27,8 +27,8 @@ module M {
 
 	// Should emit 'M.X' in both opening and closing tags
 	var y = <X></X>;
->y : any
-><X></X> : any
+>y : error
+><X></X> : error
 >X : any
 >X : any
 }

--- a/tests/baselines/reference/tsxPreserveEmit2.types
+++ b/tests/baselines/reference/tsxPreserveEmit2.types
@@ -3,7 +3,7 @@ var Route: any;
 >Route : any
 
 var routes1 = <Route />;
->routes1 : any
-><Route /> : any
+>routes1 : error
+><Route /> : error
 >Route : any
 

--- a/tests/baselines/reference/tsxReactEmitNesting.types
+++ b/tests/baselines/reference/tsxReactEmitNesting.types
@@ -16,22 +16,22 @@ let render = (ctrl, model) =>
 >model : any
 
     <section class="todoapp">
-><section class="todoapp">        <header class="header">            <h1>todos &lt;x&gt;</h1>            <input class="new-todo" autofocus autocomplete="off" placeholder="What needs to be done?" value={model.newTodo} onKeyup={ctrl.addTodo.bind(ctrl, model)} />        </header>        <section class="main" style={{display:(model.todos && model.todos.length) ? "block" : "none"}}>            <input class="toggle-all" type="checkbox" onChange={ctrl.toggleAll.bind(ctrl)}/>            <ul class="todo-list">                {model.filteredTodos.map((todo) =>                    <li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>                        <div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div>                    </li>                )}            </ul>        </section>    </section> : any
+><section class="todoapp">        <header class="header">            <h1>todos &lt;x&gt;</h1>            <input class="new-todo" autofocus autocomplete="off" placeholder="What needs to be done?" value={model.newTodo} onKeyup={ctrl.addTodo.bind(ctrl, model)} />        </header>        <section class="main" style={{display:(model.todos && model.todos.length) ? "block" : "none"}}>            <input class="toggle-all" type="checkbox" onChange={ctrl.toggleAll.bind(ctrl)}/>            <ul class="todo-list">                {model.filteredTodos.map((todo) =>                    <li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>                        <div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div>                    </li>                )}            </ul>        </section>    </section> : error
 >section : any
 >class : string
 
         <header class="header">
-><header class="header">            <h1>todos &lt;x&gt;</h1>            <input class="new-todo" autofocus autocomplete="off" placeholder="What needs to be done?" value={model.newTodo} onKeyup={ctrl.addTodo.bind(ctrl, model)} />        </header> : any
+><header class="header">            <h1>todos &lt;x&gt;</h1>            <input class="new-todo" autofocus autocomplete="off" placeholder="What needs to be done?" value={model.newTodo} onKeyup={ctrl.addTodo.bind(ctrl, model)} />        </header> : error
 >header : any
 >class : string
 
             <h1>todos &lt;x&gt;</h1>
-><h1>todos &lt;x&gt;</h1> : any
+><h1>todos &lt;x&gt;</h1> : error
 >h1 : any
 >h1 : any
 
             <input class="new-todo" autofocus autocomplete="off" placeholder="What needs to be done?" value={model.newTodo} onKeyup={ctrl.addTodo.bind(ctrl, model)} />
-><input class="new-todo" autofocus autocomplete="off" placeholder="What needs to be done?" value={model.newTodo} onKeyup={ctrl.addTodo.bind(ctrl, model)} /> : any
+><input class="new-todo" autofocus autocomplete="off" placeholder="What needs to be done?" value={model.newTodo} onKeyup={ctrl.addTodo.bind(ctrl, model)} /> : error
 >input : any
 >class : string
 >autofocus : true
@@ -55,7 +55,7 @@ let render = (ctrl, model) =>
 >header : any
 
         <section class="main" style={{display:(model.todos && model.todos.length) ? "block" : "none"}}>
-><section class="main" style={{display:(model.todos && model.todos.length) ? "block" : "none"}}>            <input class="toggle-all" type="checkbox" onChange={ctrl.toggleAll.bind(ctrl)}/>            <ul class="todo-list">                {model.filteredTodos.map((todo) =>                    <li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>                        <div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div>                    </li>                )}            </ul>        </section> : any
+><section class="main" style={{display:(model.todos && model.todos.length) ? "block" : "none"}}>            <input class="toggle-all" type="checkbox" onChange={ctrl.toggleAll.bind(ctrl)}/>            <ul class="todo-list">                {model.filteredTodos.map((todo) =>                    <li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>                        <div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div>                    </li>                )}            </ul>        </section> : error
 >section : any
 >class : string
 >style : { display: string; }
@@ -76,7 +76,7 @@ let render = (ctrl, model) =>
 >"none" : "none"
 
             <input class="toggle-all" type="checkbox" onChange={ctrl.toggleAll.bind(ctrl)}/>
-><input class="toggle-all" type="checkbox" onChange={ctrl.toggleAll.bind(ctrl)}/> : any
+><input class="toggle-all" type="checkbox" onChange={ctrl.toggleAll.bind(ctrl)}/> : error
 >input : any
 >class : string
 >type : string
@@ -90,7 +90,7 @@ let render = (ctrl, model) =>
 >ctrl : any
 
             <ul class="todo-list">
-><ul class="todo-list">                {model.filteredTodos.map((todo) =>                    <li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>                        <div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div>                    </li>                )}            </ul> : any
+><ul class="todo-list">                {model.filteredTodos.map((todo) =>                    <li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>                        <div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div>                    </li>                )}            </ul> : error
 >ul : any
 >class : string
 
@@ -105,7 +105,7 @@ let render = (ctrl, model) =>
 >todo : any
 
                     <li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>
-><li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>                        <div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div>                    </li> : any
+><li class={{todo: true, completed: todo.completed, editing: todo == model.editedTodo}}>                        <div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div>                    </li> : error
 >li : any
 >class : { todo: boolean; completed: any; editing: boolean; }
 >{todo: true, completed: todo.completed, editing: todo == model.editedTodo} : { todo: boolean; completed: any; editing: boolean; }
@@ -123,7 +123,7 @@ let render = (ctrl, model) =>
 >editedTodo : any
 
                         <div class="view">
-><div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div> : any
+><div class="view">                            {(!todo.editable) ?                                <input class="toggle" type="checkbox"></input>                                : null                            }                            <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>                            <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>                            <div class="iconBorder">                                <div class="icon"/>                            </div>                        </div> : error
 >div : any
 >class : string
 
@@ -136,7 +136,7 @@ let render = (ctrl, model) =>
 >editable : any
 
                                 <input class="toggle" type="checkbox"></input>
-><input class="toggle" type="checkbox"></input> : any
+><input class="toggle" type="checkbox"></input> : error
 >input : any
 >class : string
 >type : string
@@ -146,7 +146,7 @@ let render = (ctrl, model) =>
 >null : null
                             }
                             <label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label>
-><label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label> : any
+><label onDoubleClick={()=>{ctrl.editTodo(todo)}}>{todo.title}</label> : error
 >label : any
 >onDoubleClick : () => void
 >()=>{ctrl.editTodo(todo)} : () => void
@@ -161,7 +161,7 @@ let render = (ctrl, model) =>
 >label : any
 
                             <button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button>
-><button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button> : any
+><button class="destroy" onClick={ctrl.removeTodo.bind(ctrl,todo)}></button> : error
 >button : any
 >class : string
 >onClick : any
@@ -176,12 +176,12 @@ let render = (ctrl, model) =>
 >button : any
 
                             <div class="iconBorder">
-><div class="iconBorder">                                <div class="icon"/>                            </div> : any
+><div class="iconBorder">                                <div class="icon"/>                            </div> : error
 >div : any
 >class : string
 
                                 <div class="icon"/>
-><div class="icon"/> : any
+><div class="icon"/> : error
 >div : any
 >class : string
 

--- a/tests/baselines/reference/tsxUnionSpread.types
+++ b/tests/baselines/reference/tsxUnionSpread.types
@@ -43,8 +43,8 @@ var props:AnimalInfo = getProps();
 >getProps : () => AnimalInfo
 
 var component = <AnimalComponent {...props} />
->component : any
-><AnimalComponent {...props} /> : any
+>component : error
+><AnimalComponent {...props} /> : error
 >AnimalComponent : (info: AnimalInfo) => JSX.Element
 >props : AnimalInfo
 
@@ -57,8 +57,8 @@ var props2:AnimalInfo = { type: 'Cat', subType: 'Large' };
 >'Large' : "Large"
 
 var component2 = <AnimalComponent {...props2} />
->component2 : any
-><AnimalComponent {...props2} /> : any
+>component2 : error
+><AnimalComponent {...props2} /> : error
 >AnimalComponent : (info: AnimalInfo) => JSX.Element
 >props2 : CatInfo
 

--- a/tests/baselines/reference/typeFromPropertyAssignment8.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment8.types
@@ -49,7 +49,7 @@ my.app.Application()
 var min = window.min || {};
 >min : typeof min
 >window.min || {} : any
->window.min : any
+>window.min : error
 >window : Window
 >min : any
 >{} : {}

--- a/tests/baselines/reference/typeFromPropertyAssignment9.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment9.types
@@ -146,7 +146,7 @@ my.predicate.type = class {
 var min = window.min || {};
 >min : typeof min
 >window.min || {} : any
->window.min : any
+>window.min : error
 >window : Window
 >min : any
 >{} : {}
@@ -172,7 +172,7 @@ min.nest.other = self.min.nest.other || class { };
 >nest : { (): void; other: typeof other; }
 >other : typeof other
 >self.min.nest.other || class { } : typeof other
->self.min.nest.other : any
+>self.min.nest.other : error
 >self.min.nest : any
 >self.min : any
 >self : Window
@@ -187,7 +187,7 @@ min.property = global.min.property || {};
 >min : typeof min
 >property : {}
 >global.min.property || {} : {}
->global.min.property : any
+>global.min.property : error
 >global.min : any
 >global : any
 >min : any

--- a/tests/baselines/reference/untypedModuleImport.types
+++ b/tests/baselines/reference/untypedModuleImport.types
@@ -6,18 +6,18 @@ import foo, { bar } from "foo";
 import "./a";
 import "./b";
 foo(bar());
->foo(bar()) : any
->foo : any
->bar() : any
->bar : any
+>foo(bar()) : error
+>foo : error
+>bar() : error
+>bar : error
 
 === /a.ts ===
 import * as foo from "foo";
->foo : any
+>foo : error
 
 foo.bar();
->foo.bar() : any
->foo.bar : any
+>foo.bar() : error
+>foo.bar : error
 >foo : any
 >bar : any
 
@@ -26,6 +26,6 @@ import foo = require("foo");
 >foo : any
 
 foo();
->foo() : any
->foo : any
+>foo() : error
+>foo : error
 

--- a/tests/baselines/reference/unusedImports13.types
+++ b/tests/baselines/reference/unusedImports13.types
@@ -3,8 +3,8 @@ import React = require("react");
 >React : typeof React
 
 export const FooComponent = <div></div>
->FooComponent : any
-><div></div> : any
+>FooComponent : error
+><div></div> : error
 >div : any
 >div : any
 

--- a/tests/baselines/reference/unusedImports14.types
+++ b/tests/baselines/reference/unusedImports14.types
@@ -3,8 +3,8 @@ import React = require("react");
 >React : typeof React
 
 export const FooComponent = <div></div>
->FooComponent : any
-><div></div> : any
+>FooComponent : error
+><div></div> : error
 >div : any
 >div : any
 

--- a/tests/baselines/reference/unusedImports15.types
+++ b/tests/baselines/reference/unusedImports15.types
@@ -3,8 +3,8 @@ import Element = require("react");
 >Element : typeof Element
 
 export const FooComponent = <div></div>
->FooComponent : any
-><div></div> : any
+>FooComponent : error
+><div></div> : error
 >div : any
 >div : any
 

--- a/tests/baselines/reference/unusedImports16.types
+++ b/tests/baselines/reference/unusedImports16.types
@@ -3,8 +3,8 @@ import Element = require("react");
 >Element : typeof Element
 
 export const FooComponent = <div></div>
->FooComponent : any
-><div></div> : any
+>FooComponent : error
+><div></div> : error
 >div : any
 >div : any
 


### PR DESCRIPTION
In this iteration, only `any`'s in files from certain locations that we're pretty sure aren't almost guaranteed to be an `error` are marked (and only in files without any diagnostics). There's a exactly one indexed access instantiation (`indexingTypesWithNever.types`), but mostly JSX tests with no JSX.Element type defined.