### PR TITLE
Don't error on destructure of private property with computed property syntax

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24391,7 +24391,7 @@ namespace ts {
                     if (nameText) {
                         const property = getPropertyOfType(parentType!, nameText)!; // TODO: GH#18217
                         markPropertyAsReferenced(property, /*nodeForCheckWriteOnly*/ undefined, /*isThisAccess*/ false); // A destructuring is never a write-only reference.
-                        if (parent.initializer && property) {
+                        if (parent.initializer && property && !isComputedPropertyName(name)) {
                             checkPropertyAccessibility(parent, parent.initializer, parentType!, property);
                         }
                     }

--- a/tests/baselines/reference/destructureComputedProperty.errors.txt
+++ b/tests/baselines/reference/destructureComputedProperty.errors.txt
@@ -1,15 +1,20 @@
-tests/cases/compiler/destructureComputedProperty.ts(8,7): error TS2341: Property 'p' is private and only accessible within class 'C'.
+tests/cases/compiler/destructureComputedProperty.ts(7,7): error TS2341: Property 'p' is private and only accessible within class 'C'.
+tests/cases/compiler/destructureComputedProperty.ts(10,7): error TS2341: Property 'p' is private and only accessible within class 'C'.
 
 
-==== tests/cases/compiler/destructureComputedProperty.ts (1 errors) ====
+==== tests/cases/compiler/destructureComputedProperty.ts (2 errors) ====
     declare const ab: { n: number } | { n: string };
     const nameN = "n";
     const { [nameN]: n } = ab;
     
     class C { private p: number; }
     const nameP = "p";
-    const { [nameP]: p } = new C();
-    const { p: p2 } = new C();
+    const { "p": p0 } = new C();
+          ~~~~~~~~~~~
+!!! error TS2341: Property 'p' is private and only accessible within class 'C'.
+    const { ["p"]: p1 } = new C();
+    const { [nameP]: p2 } = new C();
+    const { p: p3 } = new C();
           ~~~~~~~~~
 !!! error TS2341: Property 'p' is private and only accessible within class 'C'.
     

--- a/tests/baselines/reference/destructureComputedProperty.js
+++ b/tests/baselines/reference/destructureComputedProperty.js
@@ -5,8 +5,10 @@ const { [nameN]: n } = ab;
 
 class C { private p: number; }
 const nameP = "p";
-const { [nameP]: p } = new C();
-const { p: p2 } = new C();
+const { "p": p0 } = new C();
+const { ["p"]: p1 } = new C();
+const { [nameP]: p2 } = new C();
+const { p: p3 } = new C();
 
 
 //// [destructureComputedProperty.js]
@@ -18,5 +20,7 @@ var C = /** @class */ (function () {
     return C;
 }());
 var nameP = "p";
-var _b = nameP, p = new C()[_b];
-var p2 = new C().p;
+var p0 = new C()["p"];
+var p1 = new C()["p"];
+var _b = nameP, p2 = new C()[_b];
+var p3 = new C().p;

--- a/tests/baselines/reference/destructureComputedProperty.symbols
+++ b/tests/baselines/reference/destructureComputedProperty.symbols
@@ -19,13 +19,22 @@ class C { private p: number; }
 const nameP = "p";
 >nameP : Symbol(nameP, Decl(destructureComputedProperty.ts, 5, 5))
 
-const { [nameP]: p } = new C();
->nameP : Symbol(nameP, Decl(destructureComputedProperty.ts, 5, 5))
->p : Symbol(p, Decl(destructureComputedProperty.ts, 6, 7))
+const { "p": p0 } = new C();
+>p0 : Symbol(p0, Decl(destructureComputedProperty.ts, 6, 7))
 >C : Symbol(C, Decl(destructureComputedProperty.ts, 2, 26))
 
-const { p: p2 } = new C();
+const { ["p"]: p1 } = new C();
+>"p" : Symbol(p1, Decl(destructureComputedProperty.ts, 7, 7))
+>p1 : Symbol(p1, Decl(destructureComputedProperty.ts, 7, 7))
+>C : Symbol(C, Decl(destructureComputedProperty.ts, 2, 26))
+
+const { [nameP]: p2 } = new C();
+>nameP : Symbol(nameP, Decl(destructureComputedProperty.ts, 5, 5))
+>p2 : Symbol(p2, Decl(destructureComputedProperty.ts, 8, 7))
+>C : Symbol(C, Decl(destructureComputedProperty.ts, 2, 26))
+
+const { p: p3 } = new C();
 >p : Symbol(C.p, Decl(destructureComputedProperty.ts, 4, 9))
->p2 : Symbol(p2, Decl(destructureComputedProperty.ts, 7, 7))
+>p3 : Symbol(p3, Decl(destructureComputedProperty.ts, 9, 7))
 >C : Symbol(C, Decl(destructureComputedProperty.ts, 2, 26))
 

--- a/tests/baselines/reference/destructureComputedProperty.types
+++ b/tests/baselines/reference/destructureComputedProperty.types
@@ -21,15 +21,26 @@ const nameP = "p";
 >nameP : "p"
 >"p" : "p"
 
-const { [nameP]: p } = new C();
->nameP : "p"
->p : number
+const { "p": p0 } = new C();
+>p0 : number
 >new C() : C
 >C : typeof C
 
-const { p: p2 } = new C();
->p : any
+const { ["p"]: p1 } = new C();
+>"p" : "p"
+>p1 : number
+>new C() : C
+>C : typeof C
+
+const { [nameP]: p2 } = new C();
+>nameP : "p"
 >p2 : number
+>new C() : C
+>C : typeof C
+
+const { p: p3 } = new C();
+>p : any
+>p3 : number
 >new C() : C
 >C : typeof C
 

--- a/tests/cases/compiler/destructureComputedProperty.ts
+++ b/tests/cases/compiler/destructureComputedProperty.ts
@@ -4,5 +4,7 @@ const { [nameN]: n } = ab;
 
 class C { private p: number; }
 const nameP = "p";
-const { [nameP]: p } = new C();
-const { p: p2 } = new C();
+const { "p": p0 } = new C();
+const { ["p"]: p1 } = new C();
+const { [nameP]: p2 } = new C();
+const { p: p3 } = new C();


### PR DESCRIPTION
Fixes #26356

I wasn't sure whether `"p": p` should error or not. Currently it does and you need `["p"]: p` to access a private property.