### PR TITLE
getDefaultExportInfo: Use `getImmediateAliasedSymbol` instead of `getAliasedSymbol`

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -414,8 +414,6 @@ namespace ts.codefix {
     }
 
     function getDefaultExportInfo(defaultExport: Symbol, moduleSymbol: Symbol, program: Program): { readonly symbolForMeaning: Symbol, readonly name: string } | undefined {
-        const checker = program.getTypeChecker();
-
         const localSymbol = getLocalSymbolForExportDefault(defaultExport);
         if (localSymbol) return { symbolForMeaning: localSymbol, name: localSymbol.name };
 
@@ -423,12 +421,11 @@ namespace ts.codefix {
         if (name !== undefined) return { symbolForMeaning: defaultExport, name };
 
         if (defaultExport.flags & SymbolFlags.Alias) {
-            const aliased = checker.getAliasedSymbol(defaultExport);
-            return getDefaultExportInfo(aliased, Debug.assertDefined(aliased.parent), program);
+            const aliased = program.getTypeChecker().getImmediateAliasedSymbol(defaultExport);
+            return aliased && getDefaultExportInfo(aliased, Debug.assertDefined(aliased.parent), program);
         }
         else {
-            const moduleName = moduleSymbolToValidIdentifier(moduleSymbol, program.getCompilerOptions().target!);
-            return moduleName === undefined ? undefined : { symbolForMeaning: defaultExport, name: moduleName };
+            return { symbolForMeaning: defaultExport, name: moduleSymbolToValidIdentifier(moduleSymbol, program.getCompilerOptions().target!) };
         }
     }
 

--- a/tests/cases/fourslash/importNameCodeFix_reExportDefault.ts
+++ b/tests/cases/fourslash/importNameCodeFix_reExportDefault.ts
@@ -1,0 +1,40 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /user.ts
+////foo;
+
+// @Filename: /user2.ts
+////unnamed;
+
+// @Filename: /reExportNamed.ts
+////export { default } from "./named";
+
+// @Filename: /reExportUnnamed.ts
+////export { default } from "./unnamed";
+
+// @Filename: /named.ts
+////function foo() {}
+////export default foo;
+
+// @Filename: /unnamed.ts
+////export default 0;
+
+goTo.file("/user.ts");
+verify.importFixAtPosition([
+`import foo from "./named";
+
+foo;`,
+`import foo from "./reExportNamed";
+
+foo;`,
+]);
+
+goTo.file("/user2.ts");
+verify.importFixAtPosition([
+`import unnamed from "./unnamed";
+
+unnamed;`,
+`import unnamed from "./reExportUnnamed";
+
+unnamed;`,
+]);


### PR DESCRIPTION
Fixes #26333

`getAliasedSymbol` loops until it finds a non-alias, which can take us to something which isn't an export and has no `parent`. For this case, what we need is `getImmediateAliasedSymbol` to take us to the export being reexported.