### PR TITLE
noUnusedLocals: `f(x = 1)` does not use `x`

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4202,7 +4202,9 @@ namespace ts {
                 return operator === SyntaxKind.PlusPlusToken || operator === SyntaxKind.MinusMinusToken ? writeOrReadWrite() : AccessKind.Read;
             case SyntaxKind.BinaryExpression:
                 const { left, operatorToken } = parent as BinaryExpression;
-                return left === node && isAssignmentOperator(operatorToken.kind) ? writeOrReadWrite() : AccessKind.Read;
+                return left === node && isAssignmentOperator(operatorToken.kind) ?
+                    operatorToken.kind === SyntaxKind.EqualsToken ? AccessKind.Write : writeOrReadWrite()
+                    : AccessKind.Read;
             case SyntaxKind.PropertyAccessExpression:
                 return (parent as PropertyAccessExpression).name !== node ? AccessKind.Read : accessKind(parent);
             default:

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -183,6 +183,7 @@ namespace ts {
         }
 
         let host: DirectoryStructureHost = system;
+        host; // tslint:disable-line no-unused-expression (TODO: `host` is unused!)
         const useCaseSensitiveFileNames = () => system.useCaseSensitiveFileNames;
         const writeFileName = (s: string) => system.write(s + system.newLine);
         const onWatchStatusChange = reportWatchStatus || createWatchStatusReporter(system);

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -328,7 +328,6 @@ namespace ts {
     }
 
     export class LanguageServiceShimHostAdapter implements LanguageServiceHost {
-        private files: string[];
         private loggingEnabled = false;
         private tracingEnabled = false;
 
@@ -408,7 +407,7 @@ namespace ts {
 
         public getScriptFileNames(): string[] {
             const encoded = this.shimHost.getScriptFileNames();
-            return this.files = JSON.parse(encoded);
+            return JSON.parse(encoded);
         }
 
         public getScriptSnapshot(fileName: string): IScriptSnapshot | undefined {

--- a/tests/baselines/reference/noUnusedLocals_writeOnly.errors.txt
+++ b/tests/baselines/reference/noUnusedLocals_writeOnly.errors.txt
@@ -1,7 +1,8 @@
 tests/cases/compiler/noUnusedLocals_writeOnly.ts(1,12): error TS6133: 'x' is declared but its value is never read.
+tests/cases/compiler/noUnusedLocals_writeOnly.ts(10,9): error TS6133: 'z' is declared but its value is never read.
 
 
-==== tests/cases/compiler/noUnusedLocals_writeOnly.ts (1 errors) ====
+==== tests/cases/compiler/noUnusedLocals_writeOnly.ts (2 errors) ====
     function f(x = 0) {
                ~
 !!! error TS6133: 'x' is declared but its value is never read.
@@ -12,5 +13,10 @@ tests/cases/compiler/noUnusedLocals_writeOnly.ts(1,12): error TS6133: 'x' is dec
         let y = 0;
         // This is a write access to y, but not a write-*only* access.
         f(y++);
+    
+        let z = 0;
+            ~
+!!! error TS6133: 'z' is declared but its value is never read.
+        f(z = 1); // This effectively doesn't use `z`, values just pass through it.
     }
     

--- a/tests/baselines/reference/noUnusedLocals_writeOnly.js
+++ b/tests/baselines/reference/noUnusedLocals_writeOnly.js
@@ -7,6 +7,9 @@ function f(x = 0) {
     let y = 0;
     // This is a write access to y, but not a write-*only* access.
     f(y++);
+
+    let z = 0;
+    f(z = 1); // This effectively doesn't use `z`, values just pass through it.
 }
 
 
@@ -19,4 +22,6 @@ function f(x) {
     var y = 0;
     // This is a write access to y, but not a write-*only* access.
     f(y++);
+    var z = 0;
+    f(z = 1); // This effectively doesn't use `z`, values just pass through it.
 }

--- a/tests/baselines/reference/noUnusedLocals_writeOnly.symbols
+++ b/tests/baselines/reference/noUnusedLocals_writeOnly.symbols
@@ -19,5 +19,12 @@ function f(x = 0) {
     f(y++);
 >f : Symbol(f, Decl(noUnusedLocals_writeOnly.ts, 0, 0))
 >y : Symbol(y, Decl(noUnusedLocals_writeOnly.ts, 5, 7))
+
+    let z = 0;
+>z : Symbol(z, Decl(noUnusedLocals_writeOnly.ts, 9, 7))
+
+    f(z = 1); // This effectively doesn't use `z`, values just pass through it.
+>f : Symbol(f, Decl(noUnusedLocals_writeOnly.ts, 0, 0))
+>z : Symbol(z, Decl(noUnusedLocals_writeOnly.ts, 9, 7))
 }
 

--- a/tests/baselines/reference/noUnusedLocals_writeOnly.types
+++ b/tests/baselines/reference/noUnusedLocals_writeOnly.types
@@ -28,5 +28,16 @@ function f(x = 0) {
 >f : (x?: number) => void
 >y++ : number
 >y : number
+
+    let z = 0;
+>z : number
+>0 : 0
+
+    f(z = 1); // This effectively doesn't use `z`, values just pass through it.
+>f(z = 1) : void
+>f : (x?: number) => void
+>z = 1 : 1
+>z : number
+>1 : 1
 }
 

--- a/tests/cases/compiler/noUnusedLocals_writeOnly.ts
+++ b/tests/cases/compiler/noUnusedLocals_writeOnly.ts
@@ -9,4 +9,7 @@ function f(x = 0) {
     let y = 0;
     // This is a write access to y, but not a write-*only* access.
     f(y++);
+
+    let z = 0;
+    f(z = 1); // This effectively doesn't use `z`, values just pass through it.
 }


### PR DESCRIPTION
Contrast with `f(x += 1)` which depends on the value of `x`.
Caught a few bugs in our own code too.