### PR TITLE
Use original path from resolved module cache when available.

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -29,6 +29,14 @@ namespace ts {
         path: string;
         extension: Extension;
         packageId: PackageId | undefined;
+        /**
+         * When the resolved is not created from cache, the value is
+         *  - string if original Path if it is symbolic link to the resolved path
+         *  - undefined if path is not a symbolic link
+         * When the resolved is created using value from cache of ResolvedModuleWithFailedLookupLocations, the value is:
+         *  - string if original Path if it is symbolic link to the resolved path
+         *  - true if path is not a symbolic link - this indicates that the originalPath calculation is already done and needs to be skipped
+         */
         originalPath?: string | true;
     }
 

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -8415,7 +8415,7 @@ new C();`
             expectedTrace.push(`Loading module '${moduleName}' from 'node_modules' folder, target file type 'TypeScript'.`);
             getExpectedMissedLocationResolutionTrace(host, expectedTrace, getDirectoryPath(file.path), module, moduleName, /*useNodeModules*/ true, cacheLocation);
             expectedTrace.push(`Resolution for module '${moduleName}' was found in cache from location '${cacheLocation}'.`);
-            getExpectedResolutionTraceFooter(expectedTrace, module, moduleName, /*addRealPathTrace*/ true, /*ignoreModuleFileFound*/ true);
+            getExpectedResolutionTraceFooter(expectedTrace, module, moduleName, /*addRealPathTrace*/ false, /*ignoreModuleFileFound*/ true);
             return expectedTrace;
         }
 

--- a/tests/baselines/reference/cachedModuleResolution1.trace.json
+++ b/tests/baselines/reference/cachedModuleResolution1.trace.json
@@ -14,6 +14,5 @@
     "Explicitly specified module resolution kind: 'NodeJs'.",
     "Loading module 'foo' from 'node_modules' folder, target file type 'TypeScript'.",
     "Resolution for module 'foo' was found in cache from location '/a/b/c'.",
-    "Resolving real path for '/a/b/node_modules/foo.d.ts', result '/a/b/node_modules/foo.d.ts'.",
     "======== Module name 'foo' was successfully resolved to '/a/b/node_modules/foo.d.ts'. ========"
 ]

--- a/tests/baselines/reference/cachedModuleResolution2.trace.json
+++ b/tests/baselines/reference/cachedModuleResolution2.trace.json
@@ -14,6 +14,5 @@
     "Directory '/a/b/c/d/e/node_modules' does not exist, skipping all lookups in it.",
     "Directory '/a/b/c/d/node_modules' does not exist, skipping all lookups in it.",
     "Resolution for module 'foo' was found in cache from location '/a/b/c'.",
-    "Resolving real path for '/a/b/node_modules/foo.d.ts', result '/a/b/node_modules/foo.d.ts'.",
     "======== Module name 'foo' was successfully resolved to '/a/b/node_modules/foo.d.ts'. ========"
 ]

--- a/tests/baselines/reference/cachedModuleResolution5.trace.json
+++ b/tests/baselines/reference/cachedModuleResolution5.trace.json
@@ -14,6 +14,5 @@
     "Explicitly specified module resolution kind: 'NodeJs'.",
     "Loading module 'foo' from 'node_modules' folder, target file type 'TypeScript'.",
     "Resolution for module 'foo' was found in cache from location '/a/b'.",
-    "Resolving real path for '/a/b/node_modules/foo.d.ts', result '/a/b/node_modules/foo.d.ts'.",
     "======== Module name 'foo' was successfully resolved to '/a/b/node_modules/foo.d.ts'. ========"
 ]


### PR DESCRIPTION
Fixes #26273
Thanks to @ajafff, for partial fix  and test (#26310)