### PR TITLE
Set rootDir in tsconfig-base.json

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3188,16 +3188,7 @@ namespace ts {
     }
 
     export function getDeclarationEmitOutputFilePath(fileName: string, host: EmitHost) {
-        // TODO: GH#25810 following should work but makes the build break:
-        // return getDeclarationEmitOutputFilePathWorker(fileName, host.getCompilerOptions(), host.getCurrentDirectory(), host.getCommonSourceDirectory(), f => host.getCanonicalFileName(f));
-
-        const options = host.getCompilerOptions();
-        const outputDir = options.declarationDir || options.outDir; // Prefer declaration folder if specified
-
-        const path = outputDir
-            ? getSourceFilePathInNewDir(fileName, host, outputDir)
-            : fileName;
-        return removeFileExtension(path) + Extension.Dts;
+        return getDeclarationEmitOutputFilePathWorker(fileName, host.getCompilerOptions(), host.getCurrentDirectory(), host.getCommonSourceDirectory(), f => host.getCanonicalFileName(f));
     }
 
     export function getDeclarationEmitOutputFilePathWorker(fileName: string, options: CompilerOptions, currentDirectory: string, commonSourceDirectory: string, getCanonicalFileName: GetCanonicalFileName): string {

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -3,6 +3,7 @@
         "pretty": true,
         "lib": ["es2015"],
         "target": "es5",
+        "rootDir": ".",
 
         "declaration": true,
         "declarationMap": true,


### PR DESCRIPTION
Fixes #25810

The problem was that we copy `src/services/tsconfig.json` to `build/local/typescriptServices.tsconfig.json`. But when compiling from `built/local`, we'll get compile errors because the paths aren't in `rootDirectory` which defaults to `options.configFilePath`. These compile errors only happen when calling `getCommonSourceDirectory`, explaining why the change to `utilities.ts` uncovers it.

Note that when the change to `utilities.ts` is made but not the change to `tsconfig-base.json`, the error message is just `Error: ENOENT: no such file or directory, open 'built/local/typescriptServices.out.d.ts'` with no compile errors shown; but I've verifeid that removing the `programDiagnostics.add` call in `checkSourceFilesBelongToPath` made it work again.