### PR TITLE
Use array helper in computeCommonSourceDirectory and remove two unnecessary tests

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2318,27 +2318,20 @@ namespace ts {
         }
 
         function computeCommonSourceDirectory(sourceFiles: SourceFile[]): string {
-            const fileNames: string[] = [];
-            for (const file of sourceFiles) {
-                if (!file.isDeclarationFile) {
-                    fileNames.push(file.fileName);
-                }
-            }
+            const fileNames = mapDefined(sourceFiles, file => file.isDeclarationFile ? undefined : file.fileName);
             return computeCommonSourceDirectoryOfFilenames(fileNames, currentDirectory, getCanonicalFileName);
         }
 
-        function checkSourceFilesBelongToPath(sourceFiles: SourceFile[], rootDirectory: string): boolean {
+        function checkSourceFilesBelongToPath(sourceFiles: ReadonlyArray<SourceFile>, rootDirectory: string): boolean {
             let allFilesBelongToPath = true;
-            if (sourceFiles) {
-                const absoluteRootDirectoryPath = host.getCanonicalFileName(getNormalizedAbsolutePath(rootDirectory, currentDirectory));
+            const absoluteRootDirectoryPath = host.getCanonicalFileName(getNormalizedAbsolutePath(rootDirectory, currentDirectory));
 
-                for (const sourceFile of sourceFiles) {
-                    if (!sourceFile.isDeclarationFile) {
-                        const absoluteSourceFilePath = host.getCanonicalFileName(getNormalizedAbsolutePath(sourceFile.fileName, currentDirectory));
-                        if (absoluteSourceFilePath.indexOf(absoluteRootDirectoryPath) !== 0) {
-                            programDiagnostics.add(createCompilerDiagnostic(Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, sourceFile.fileName, rootDirectory));
-                            allFilesBelongToPath = false;
-                        }
+            for (const sourceFile of sourceFiles) {
+                if (!sourceFile.isDeclarationFile) {
+                    const absoluteSourceFilePath = host.getCanonicalFileName(getNormalizedAbsolutePath(sourceFile.fileName, currentDirectory));
+                    if (absoluteSourceFilePath.indexOf(absoluteRootDirectoryPath) !== 0) {
+                        programDiagnostics.add(createCompilerDiagnostic(Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, sourceFile.fileName, rootDirectory));
+                        allFilesBelongToPath = false;
                     }
                 }
             }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7280,8 +7280,6 @@ namespace ts {
         if (pathComponents.length === 0) return "";
 
         const root = pathComponents[0] && ensureTrailingDirectorySeparator(pathComponents[0]);
-        if (pathComponents.length === 1) return root;
-
         return root + pathComponents.slice(1).join(directorySeparator);
     }
 


### PR DESCRIPTION
Noticed while working on #26415 but not related.
Used `mapDefined` to simplify some code.
Removed an `if (sourceFiles)` test because `sourceFiles` is non-optional.
Removed `if (pathComponents.length === 1)` test because if so, `pathComponents.slice(1)` is empty anyway.