### PR TITLE
Export `getOutputJavaScriptFileName` from tsbuild

### DIFF
--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -290,7 +290,7 @@ namespace ts {
         return changeExtension(outputPath, Extension.Dts);
     }
 
-    function getOutputJavaScriptFileName(inputFileName: string, configFile: ParsedCommandLine) {
+    export function getOutputJavaScriptFileName(inputFileName: string, configFile: ParsedCommandLine) {
         const relativePath = getRelativePathFromDirectory(rootDirOfOptions(configFile.options, configFile.options.configFilePath!), inputFileName, /*ignoreCase*/ true);
         const outputPath = resolvePath(configFile.options.outDir || getDirectoryPath(configFile.options.configFilePath!), relativePath);
         const newExtension = fileExtensionIs(inputFileName, Extension.Json) ? Extension.Json :


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #26410 

Waiting to hear:

- Since the function will become public, should there be a unit test added for it, or does coverage by existing tsbuild tests suffice?
- Should we also export `getOutputDeclarationFileName` for symmetry? What about `getOutputFileNames`?
- Any other feedback about implementation, e.g. is `tsbuild.ts` still the right place for this now that it's being exported, should we add JSDoc comments to it (some exported functions have it, others don't)?