### PR TITLE
Narrow on element access of literal

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -738,20 +738,11 @@ namespace ts {
         }
 
         function isNarrowableReference(expr: Expression): boolean {
-            if (expr.kind === SyntaxKind.Identifier || expr.kind === SyntaxKind.ThisKeyword || expr.kind === SyntaxKind.SuperKeyword) {
-                return true;
-            }
-            if (expr.kind === SyntaxKind.PropertyAccessExpression) {
-                return isNarrowableReference((expr as PropertyAccessExpression).expression);
-            }
-            if (expr.kind === SyntaxKind.ElementAccessExpression) {
-                const access = expr as ElementAccessExpression;
-                const isArgumentLiteral = access.argumentExpression &&
-                    (access.argumentExpression.kind === SyntaxKind.StringLiteral ||
-                     access.argumentExpression.kind === SyntaxKind.NumericLiteral);
-                return isArgumentLiteral && isNarrowableReference(access.expression);
-            }
-            return false;
+            return expr.kind === SyntaxKind.Identifier || expr.kind === SyntaxKind.ThisKeyword || expr.kind === SyntaxKind.SuperKeyword ||
+                isPropertyAccessExpression(expr) && isNarrowableReference(expr.expression) ||
+                isElementAccessExpression(expr) && expr.argumentExpression &&
+                (isStringLiteral(expr.argumentExpression) || isNumericLiteral(expr.argumentExpression)) &&
+                isNarrowableReference(expr.expression);
         }
 
         function hasNarrowableArgument(expr: CallExpression) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14439,7 +14439,10 @@ namespace ts {
                     else if (flags & FlowFlags.Start) {
                         // Check if we should continue with the control flow of the containing function.
                         const container = (<FlowStart>flow).container;
-                        if (container && container !== flowContainer && reference.kind !== SyntaxKind.PropertyAccessExpression && reference.kind !== SyntaxKind.ThisKeyword) {
+                        if (container && container !== flowContainer &&
+                            reference.kind !== SyntaxKind.PropertyAccessExpression &&
+                            reference.kind !== SyntaxKind.ElementAccessExpression &&
+                            reference.kind !== SyntaxKind.ThisKeyword) {
                             flow = container.flowNode!;
                             continue;
                         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22437,7 +22437,6 @@ namespace ts {
                 for (const decl of indexSymbol.declarations) {
                     const declaration = <SignatureDeclaration>decl;
                     if (declaration.parameters.length === 1 && declaration.parameters[0].type) {
-                        // const workaround = 0;
                         switch (declaration.parameters[0].type!.kind) {
                             case SyntaxKind.StringKeyword:
                                 if (!seenStringIndexer) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14437,7 +14437,7 @@ namespace ts {
                         }
                     }
                     else if (flags & FlowFlags.Start) {
-                        // Check if we should continue with the control flow of the containing function. TODO: Should probably make this access element access too
+                        // Check if we should continue with the control flow of the containing function.
                         const container = (<FlowStart>flow).container;
                         if (container && container !== flowContainer && reference.kind !== SyntaxKind.PropertyAccessExpression && reference.kind !== SyntaxKind.ThisKeyword) {
                             flow = container.flowNode!;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9155,8 +9155,8 @@ namespace ts {
                             getNodeLinks(accessNode!).resolvedSymbol = prop;
                         }
                     }
-                    const t = getTypeOfSymbol(prop);
-                    return accessExpression ? getFlowTypeOfReference(accessExpression, t) : t;
+                    const propType = getTypeOfSymbol(prop);
+                    return accessExpression ? getFlowTypeOfReference(accessExpression, propType) : propType;
                 }
                 if (isTupleType(objectType)) {
                     const restType = getRestTypeOfTupleType(objectType);
@@ -13772,10 +13772,9 @@ namespace ts {
                     if (target.kind !== SyntaxKind.PropertyAccessExpression && target.kind !== SyntaxKind.ElementAccessExpression) {
                         return false;
                     }
-                    const sourceAccess = source as PropertyAccessExpression | ElementAccessExpression;
-                    const targetAccess = target as PropertyAccessExpression | ElementAccessExpression;
-                    return getAccessedPropertyName(sourceAccess) === getAccessedPropertyName(targetAccess)
-                        && isMatchingReference(sourceAccess.expression, targetAccess.expression);
+                    return (isPropertyAccessExpression(target) || isElementAccessExpression(target)) &&
+                        getAccessedPropertyName(source as PropertyAccessExpression | ElementAccessExpression) === getAccessedPropertyName(target) &&
+                        isMatchingReference((source as PropertyAccessExpression | ElementAccessExpression).expression, target.expression);
                 case SyntaxKind.BindingElement:
                     if (target.kind !== SyntaxKind.PropertyAccessExpression) return false;
                     const t = target as PropertyAccessExpression;
@@ -14559,9 +14558,10 @@ namespace ts {
                     type = narrowTypeBySwitchOnDiscriminant(type, flow.switchStatement, flow.clauseStart, flow.clauseEnd);
                 }
                 else if (isMatchingReferenceDiscriminant(expr, type)) {
-                    type = narrowTypeByDiscriminant(type,
-                                                    expr as PropertyAccessExpression | ElementAccessExpression,
-                                                    t => narrowTypeBySwitchOnDiscriminant(t, flow.switchStatement, flow.clauseStart, flow.clauseEnd));
+                    type = narrowTypeByDiscriminant(
+                        type,
+                        expr as PropertyAccessExpression | ElementAccessExpression,
+                        t => narrowTypeBySwitchOnDiscriminant(t, flow.switchStatement, flow.clauseStart, flow.clauseEnd));
                 }
                 return createFlowType(type, isIncomplete(flowType));
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13769,9 +13769,6 @@ namespace ts {
                     return target.kind === SyntaxKind.SuperKeyword;
                 case SyntaxKind.PropertyAccessExpression:
                 case SyntaxKind.ElementAccessExpression:
-                    if (target.kind !== SyntaxKind.PropertyAccessExpression && target.kind !== SyntaxKind.ElementAccessExpression) {
-                        return false;
-                    }
                     return (isPropertyAccessExpression(target) || isElementAccessExpression(target)) &&
                         getAccessedPropertyName(source as PropertyAccessExpression | ElementAccessExpression) === getAccessedPropertyName(target) &&
                         isMatchingReference((source as PropertyAccessExpression | ElementAccessExpression).expression, target.expression);

--- a/tests/baselines/reference/constDeclarations-access3.types
+++ b/tests/baselines/reference/constDeclarations-access3.types
@@ -135,9 +135,9 @@ M["x"] = 0;
 var a = M.x + 1;
 >a : number
 >M.x + 1 : number
->M.x : number
+>M.x : 0
 >M : typeof M
->x : number
+>x : 0
 >1 : 1
 
 function f(v: number) { }
@@ -147,43 +147,43 @@ function f(v: number) { }
 f(M.x);
 >f(M.x) : void
 >f : (v: number) => void
->M.x : number
+>M.x : 0
 >M : typeof M
->x : number
+>x : 0
 
 if (M.x) { }
->M.x : number
+>M.x : 0
 >M : typeof M
->x : number
+>x : 0
 
 M.x;
->M.x : number
+>M.x : 0
 >M : typeof M
->x : number
+>x : 0
 
 (M.x);
->(M.x) : number
->M.x : number
+>(M.x) : 0
+>M.x : 0
 >M : typeof M
->x : number
+>x : 0
 
 -M.x;
 >-M.x : number
->M.x : number
+>M.x : 0
 >M : typeof M
->x : number
+>x : 0
 
 +M.x;
 >+M.x : number
->M.x : number
+>M.x : 0
 >M : typeof M
->x : number
+>x : 0
 
 M.x.toString();
 >M.x.toString() : string
 >M.x.toString : (radix?: number) => string
->M.x : number
+>M.x : 0
 >M : typeof M
->x : number
+>x : 0
 >toString : (radix?: number) => string
 

--- a/tests/baselines/reference/constDeclarations-access5.types
+++ b/tests/baselines/reference/constDeclarations-access5.types
@@ -134,9 +134,9 @@ m["x"] = 0;
 var a = m.x + 1;
 >a : number
 >m.x + 1 : number
->m.x : number
+>m.x : 0
 >m : typeof m
->x : number
+>x : 0
 >1 : 1
 
 function f(v: number) { }
@@ -146,44 +146,44 @@ function f(v: number) { }
 f(m.x);
 >f(m.x) : void
 >f : (v: number) => void
->m.x : number
+>m.x : 0
 >m : typeof m
->x : number
+>x : 0
 
 if (m.x) { }
->m.x : number
+>m.x : 0
 >m : typeof m
->x : number
+>x : 0
 
 m.x;
->m.x : number
+>m.x : 0
 >m : typeof m
->x : number
+>x : 0
 
 (m.x);
->(m.x) : number
->m.x : number
+>(m.x) : 0
+>m.x : 0
 >m : typeof m
->x : number
+>x : 0
 
 -m.x;
 >-m.x : number
->m.x : number
+>m.x : 0
 >m : typeof m
->x : number
+>x : 0
 
 +m.x;
 >+m.x : number
->m.x : number
+>m.x : 0
 >m : typeof m
->x : number
+>x : 0
 
 m.x.toString();
 >m.x.toString() : string
 >m.x.toString : (radix?: number) => string
->m.x : number
+>m.x : 0
 >m : typeof m
->x : number
+>x : 0
 >toString : (radix?: number) => string
 
 === tests/cases/compiler/constDeclarations_access_1.ts ===

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.js
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.js
@@ -1,15 +1,15 @@
 //// [typeGuardNarrowsIndexedAccessOfKnownProperty.ts]
 interface Square {
-    kind: "square";
-    size: number;
+    ["dash-ok"]: "square";
+    ["square-size"]: number;
 }
  interface Rectangle {
-    kind: "rectangle";
+    ["dash-ok"]: "rectangle";
     width: number;
     height: number;
 }
  interface Circle {
-    kind: "circle";
+    ["dash-ok"]: "circle";
     radius: number;
 }
  type Shape = Square | Rectangle | Circle;
@@ -23,15 +23,15 @@ interface Subshape {
     }
 }
 function area(s: Shape): number {
-    switch(s['kind']) {
-        case "square": return s.size * s['size'];
+    switch(s['dash-ok']) {
+        case "square": return s['square-size'] * s['square-size'];
         case "rectangle": return s.width * s['height'];
         case "circle": return Math.PI * s['radius'] * s.radius;
     }
 }
 function subarea(s: Subshape): number {
-    switch(s[0]["sub"].under["shape"]["kind"]) {
-        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+    switch(s[0]["sub"].under["shape"]["dash-ok"]) {
+        case "square": return s[0].sub.under.shape["square-size"] * s[0].sub.under.shape["square-size"];
         case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
         case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
     }
@@ -84,15 +84,15 @@ export function g(pair: [number, string?]): string {
 "use strict";
 exports.__esModule = true;
 function area(s) {
-    switch (s['kind']) {
-        case "square": return s.size * s['size'];
+    switch (s['dash-ok']) {
+        case "square": return s['square-size'] * s['square-size'];
         case "rectangle": return s.width * s['height'];
         case "circle": return Math.PI * s['radius'] * s.radius;
     }
 }
 function subarea(s) {
-    switch (s[0]["sub"].under["shape"]["kind"]) {
-        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+    switch (s[0]["sub"].under["shape"]["dash-ok"]) {
+        case "square": return s[0].sub.under.shape["square-size"] * s[0].sub.under.shape["square-size"];
         case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
         case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
     }

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.js
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.js
@@ -1,0 +1,123 @@
+//// [typeGuardNarrowsIndexedAccessOfKnownProperty.ts]
+interface Square {
+    kind: "square";
+    size: number;
+}
+ interface Rectangle {
+    kind: "rectangle";
+    width: number;
+    height: number;
+}
+ interface Circle {
+    kind: "circle";
+    radius: number;
+}
+ type Shape = Square | Rectangle | Circle;
+interface Subshape {
+    "0": {
+        sub: {
+            under: {
+                shape: Shape;
+            }
+        }
+    }
+}
+function area(s: Shape): number {
+    switch(s['kind']) {
+        case "square": return s.size * s['size'];
+        case "rectangle": return s.width * s['height'];
+        case "circle": return Math.PI * s['radius'] * s.radius;
+    }
+}
+function subarea(s: Subshape): number {
+    switch(s[0]["sub"].under["shape"]["kind"]) {
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
+    }
+}
+
+interface X {
+    0: "xx",
+    1: number
+}
+
+interface Y {
+    0: "yy",
+    1: string
+}
+
+type A = ["aa", number];
+type B = ["bb", string];
+
+type Z = X | Y;
+
+type C = A | B;
+
+function check(z: Z, c: C) {
+    z[0] // fine, typescript sees "xx" | "yy"
+    switch (z[0]) {
+        case "xx":
+            var xx: number = z[1] // should be number
+            break;
+        case "yy":
+            var yy: string = z[1] // should be string
+            break;
+    }
+    c[0] // fine, typescript sees "xx" | "yy"
+    switch (c[0]) {
+        case "aa":
+            var aa: number = c[1] // should be number
+            break;
+        case "bb":
+            var bb: string = c[1] // should be string
+            break;
+    }
+}
+
+export function g(pair: [number, string?]): string {
+    return pair[1] ? pair[1] : 'nope';
+}
+
+
+//// [typeGuardNarrowsIndexedAccessOfKnownProperty.js]
+"use strict";
+exports.__esModule = true;
+function area(s) {
+    switch (s['kind']) {
+        case "square": return s.size * s['size'];
+        case "rectangle": return s.width * s['height'];
+        case "circle": return Math.PI * s['radius'] * s.radius;
+    }
+}
+function subarea(s) {
+    switch (s[0]["sub"].under["shape"]["kind"]) {
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
+    }
+}
+function check(z, c) {
+    z[0]; // fine, typescript sees "xx" | "yy"
+    switch (z[0]) {
+        case "xx":
+            var xx = z[1]; // should be number
+            break;
+        case "yy":
+            var yy = z[1]; // should be string
+            break;
+    }
+    c[0]; // fine, typescript sees "xx" | "yy"
+    switch (c[0]) {
+        case "aa":
+            var aa = c[1]; // should be number
+            break;
+        case "bb":
+            var bb = c[1]; // should be string
+            break;
+    }
+}
+function g(pair) {
+    return pair[1] ? pair[1] : 'nope';
+}
+exports.g = g;

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.symbols
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.symbols
@@ -1,0 +1,267 @@
+=== tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts ===
+interface Square {
+>Square : Symbol(Square, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 0))
+
+    kind: "square";
+>kind : Symbol(Square.kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18))
+
+    size: number;
+>size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+}
+ interface Rectangle {
+>Rectangle : Symbol(Rectangle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 3, 1))
+
+    kind: "rectangle";
+>kind : Symbol(Rectangle.kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22))
+
+    width: number;
+>width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 22))
+
+    height: number;
+>height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 18))
+}
+ interface Circle {
+>Circle : Symbol(Circle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 8, 1))
+
+    kind: "circle";
+>kind : Symbol(Circle.kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
+
+    radius: number;
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+}
+ type Shape = Square | Rectangle | Circle;
+>Shape : Symbol(Shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 1))
+>Square : Symbol(Square, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 0))
+>Rectangle : Symbol(Rectangle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 3, 1))
+>Circle : Symbol(Circle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 8, 1))
+
+interface Subshape {
+>Subshape : Symbol(Subshape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 13, 42))
+
+    "0": {
+>"0" : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
+
+        sub: {
+>sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+
+            under: {
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+
+                shape: Shape;
+>shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>Shape : Symbol(Shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 1))
+            }
+        }
+    }
+}
+function area(s: Shape): number {
+>area : Symbol(area, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 22, 1))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
+>Shape : Symbol(Shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 1))
+
+    switch(s['kind']) {
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
+>'kind' : Symbol(kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
+
+        case "square": return s.size * s['size'];
+>s.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
+>size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
+>'size' : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+
+        case "rectangle": return s.width * s['height'];
+>s.width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 22))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
+>width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 22))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
+>'height' : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 18))
+
+        case "circle": return Math.PI * s['radius'] * s.radius;
+>Math.PI : Symbol(Math.PI, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>PI : Symbol(Math.PI, Decl(lib.es5.d.ts, --, --))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
+>'radius' : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>s.radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+    }
+}
+function subarea(s: Subshape): number {
+>subarea : Symbol(subarea, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 29, 1))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
+>Subshape : Symbol(Subshape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 13, 42))
+
+    switch(s[0]["sub"].under["shape"]["kind"]) {
+>s[0]["sub"].under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
+>"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>"kind" : Symbol(kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
+
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+>s[0].sub.under.shape.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s[0].sub.under.shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>s[0].sub.under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>s[0].sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
+>sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s[0].sub.under.shape.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s[0].sub.under.shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>s[0].sub.under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>s[0].sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
+>sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
+>"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>"under" : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>"width" : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 22))
+>s[0]["sub"]["under"]["shape"].height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 18))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
+>"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>"under" : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 18))
+
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
+>Math.PI : Symbol(Math.PI, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>PI : Symbol(Math.PI, Decl(lib.es5.d.ts, --, --))
+>s[0].sub.under["shape"].radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>s[0].sub.under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>s[0].sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
+>sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>s[0]["sub"].under.shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>s[0]["sub"].under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
+>"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
+>shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>"radius" : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+    }
+}
+
+interface X {
+>X : Symbol(X, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 36, 1))
+
+    0: "xx",
+>0 : Symbol(X[0], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 38, 13))
+
+    1: number
+>1 : Symbol(X[1], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 39, 12))
+}
+
+interface Y {
+>Y : Symbol(Y, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 41, 1))
+
+    0: "yy",
+>0 : Symbol(Y[0], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 43, 13))
+
+    1: string
+>1 : Symbol(Y[1], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 44, 12))
+}
+
+type A = ["aa", number];
+>A : Symbol(A, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 46, 1))
+
+type B = ["bb", string];
+>B : Symbol(B, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 48, 24))
+
+type Z = X | Y;
+>Z : Symbol(Z, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 49, 24))
+>X : Symbol(X, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 36, 1))
+>Y : Symbol(Y, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 41, 1))
+
+type C = A | B;
+>C : Symbol(C, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 51, 15))
+>A : Symbol(A, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 46, 1))
+>B : Symbol(B, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 48, 24))
+
+function check(z: Z, c: C) {
+>check : Symbol(check, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 53, 15))
+>z : Symbol(z, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 15))
+>Z : Symbol(Z, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 49, 24))
+>c : Symbol(c, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 20))
+>C : Symbol(C, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 51, 15))
+
+    z[0] // fine, typescript sees "xx" | "yy"
+>z : Symbol(z, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 15))
+>0 : Symbol(0, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 38, 13), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 43, 13))
+
+    switch (z[0]) {
+>z : Symbol(z, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 15))
+>0 : Symbol(0, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 38, 13), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 43, 13))
+
+        case "xx":
+            var xx: number = z[1] // should be number
+>xx : Symbol(xx, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 59, 15))
+>z : Symbol(z, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 15))
+>1 : Symbol(X[1], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 39, 12))
+
+            break;
+        case "yy":
+            var yy: string = z[1] // should be string
+>yy : Symbol(yy, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 62, 15))
+>z : Symbol(z, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 15))
+>1 : Symbol(Y[1], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 44, 12))
+
+            break;
+    }
+    c[0] // fine, typescript sees "xx" | "yy"
+>c : Symbol(c, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 20))
+>0 : Symbol(0)
+
+    switch (c[0]) {
+>c : Symbol(c, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 20))
+>0 : Symbol(0)
+
+        case "aa":
+            var aa: number = c[1] // should be number
+>aa : Symbol(aa, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 68, 15))
+>c : Symbol(c, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 20))
+>1 : Symbol(1)
+
+            break;
+        case "bb":
+            var bb: string = c[1] // should be string
+>bb : Symbol(bb, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 71, 15))
+>c : Symbol(c, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 55, 20))
+>1 : Symbol(1)
+
+            break;
+    }
+}
+
+export function g(pair: [number, string?]): string {
+>g : Symbol(g, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 74, 1))
+>pair : Symbol(pair, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 76, 18))
+
+    return pair[1] ? pair[1] : 'nope';
+>pair : Symbol(pair, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 76, 18))
+>1 : Symbol(1)
+>pair : Symbol(pair, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 76, 18))
+>1 : Symbol(1)
+}
+

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.symbols
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.symbols
@@ -2,20 +2,23 @@
 interface Square {
 >Square : Symbol(Square, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 0))
 
-    kind: "square";
->kind : Symbol(Square.kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18))
+    ["dash-ok"]: "square";
+>["dash-ok"] : Symbol(Square["dash-ok"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18))
+>"dash-ok" : Symbol(Square["dash-ok"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18))
 
-    size: number;
->size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+    ["square-size"]: number;
+>["square-size"] : Symbol(Square["square-size"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 26))
+>"square-size" : Symbol(Square["square-size"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 26))
 }
  interface Rectangle {
 >Rectangle : Symbol(Rectangle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 3, 1))
 
-    kind: "rectangle";
->kind : Symbol(Rectangle.kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22))
+    ["dash-ok"]: "rectangle";
+>["dash-ok"] : Symbol(Rectangle["dash-ok"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22))
+>"dash-ok" : Symbol(Rectangle["dash-ok"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22))
 
     width: number;
->width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 22))
+>width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 29))
 
     height: number;
 >height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 18))
@@ -23,11 +26,12 @@ interface Square {
  interface Circle {
 >Circle : Symbol(Circle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 8, 1))
 
-    kind: "circle";
->kind : Symbol(Circle.kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
+    ["dash-ok"]: "circle";
+>["dash-ok"] : Symbol(Circle["dash-ok"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
+>"dash-ok" : Symbol(Circle["dash-ok"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
 
     radius: number;
->radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 26))
 }
  type Shape = Square | Rectangle | Circle;
 >Shape : Symbol(Shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 1))
@@ -59,21 +63,20 @@ function area(s: Shape): number {
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
 >Shape : Symbol(Shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 1))
 
-    switch(s['kind']) {
+    switch(s['dash-ok']) {
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
->'kind' : Symbol(kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
+>'dash-ok' : Symbol(["dash-ok"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
 
-        case "square": return s.size * s['size'];
->s.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+        case "square": return s['square-size'] * s['square-size'];
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
->size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>'square-size' : Symbol(Square["square-size"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 26))
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
->'size' : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>'square-size' : Symbol(Square["square-size"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 26))
 
         case "rectangle": return s.width * s['height'];
->s.width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 22))
+>s.width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 29))
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
->width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 22))
+>width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 29))
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
 >'height' : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 18))
 
@@ -82,10 +85,10 @@ function area(s: Shape): number {
 >Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >PI : Symbol(Math.PI, Decl(lib.es5.d.ts, --, --))
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
->'radius' : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
->s.radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>'radius' : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 26))
+>s.radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 26))
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 23, 14))
->radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 26))
     }
 }
 function subarea(s: Subshape): number {
@@ -93,17 +96,16 @@ function subarea(s: Subshape): number {
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
 >Subshape : Symbol(Subshape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 13, 42))
 
-    switch(s[0]["sub"].under["shape"]["kind"]) {
+    switch(s[0]["sub"].under["shape"]["dash-ok"]) {
 >s[0]["sub"].under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
 >0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
 >"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
 >under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
->"kind" : Symbol(kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
+>"dash-ok" : Symbol(["dash-ok"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 4, 22), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 19))
 
-        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
->s[0].sub.under.shape.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+        case "square": return s[0].sub.under.shape["square-size"] * s[0].sub.under.shape["square-size"];
 >s[0].sub.under.shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
 >s[0].sub.under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >s[0].sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
@@ -112,8 +114,7 @@ function subarea(s: Subshape): number {
 >sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
 >under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
->size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
->s[0].sub.under.shape.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>"square-size" : Symbol(Square["square-size"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 26))
 >s[0].sub.under.shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
 >s[0].sub.under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >s[0].sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
@@ -122,7 +123,7 @@ function subarea(s: Subshape): number {
 >sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
 >under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
->size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>"square-size" : Symbol(Square["square-size"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 26))
 
         case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
@@ -130,7 +131,7 @@ function subarea(s: Subshape): number {
 >"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
 >"under" : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
->"width" : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 22))
+>"width" : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 29))
 >s[0]["sub"]["under"]["shape"].height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 18))
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
 >0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 20))
@@ -143,7 +144,7 @@ function subarea(s: Subshape): number {
 >Math.PI : Symbol(Math.PI, Decl(lib.es5.d.ts, --, --))
 >Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >PI : Symbol(Math.PI, Decl(lib.es5.d.ts, --, --))
->s[0].sub.under["shape"].radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>s[0].sub.under["shape"].radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 26))
 >s[0].sub.under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >s[0].sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
@@ -151,7 +152,7 @@ function subarea(s: Subshape): number {
 >sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
 >under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
->radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 26))
 >s[0]["sub"].under.shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
 >s[0]["sub"].under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 30, 17))
@@ -159,7 +160,7 @@ function subarea(s: Subshape): number {
 >"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 15, 10))
 >under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 14))
 >shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
->"radius" : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 19))
+>"radius" : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 10, 26))
     }
 }
 

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.types
@@ -1,0 +1,301 @@
+=== tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts ===
+interface Square {
+    kind: "square";
+>kind : "square"
+
+    size: number;
+>size : number
+}
+ interface Rectangle {
+    kind: "rectangle";
+>kind : "rectangle"
+
+    width: number;
+>width : number
+
+    height: number;
+>height : number
+}
+ interface Circle {
+    kind: "circle";
+>kind : "circle"
+
+    radius: number;
+>radius : number
+}
+ type Shape = Square | Rectangle | Circle;
+>Shape : Shape
+
+interface Subshape {
+    "0": {
+>"0" : { sub: { under: { shape: Shape; }; }; }
+
+        sub: {
+>sub : { under: { shape: Shape; }; }
+
+            under: {
+>under : { shape: Shape; }
+
+                shape: Shape;
+>shape : Shape
+            }
+        }
+    }
+}
+function area(s: Shape): number {
+>area : (s: Shape) => number
+>s : Shape
+
+    switch(s['kind']) {
+>s['kind'] : "square" | "rectangle" | "circle"
+>s : Shape
+>'kind' : "kind"
+
+        case "square": return s.size * s['size'];
+>"square" : "square"
+>s.size * s['size'] : number
+>s.size : number
+>s : Square
+>size : number
+>s['size'] : number
+>s : Square
+>'size' : "size"
+
+        case "rectangle": return s.width * s['height'];
+>"rectangle" : "rectangle"
+>s.width * s['height'] : number
+>s.width : number
+>s : Rectangle
+>width : number
+>s['height'] : number
+>s : Rectangle
+>'height' : "height"
+
+        case "circle": return Math.PI * s['radius'] * s.radius;
+>"circle" : "circle"
+>Math.PI * s['radius'] * s.radius : number
+>Math.PI * s['radius'] : number
+>Math.PI : number
+>Math : Math
+>PI : number
+>s['radius'] : number
+>s : Circle
+>'radius' : "radius"
+>s.radius : number
+>s : Circle
+>radius : number
+    }
+}
+function subarea(s: Subshape): number {
+>subarea : (s: Subshape) => number
+>s : Subshape
+
+    switch(s[0]["sub"].under["shape"]["kind"]) {
+>s[0]["sub"].under["shape"]["kind"] : "square" | "rectangle" | "circle"
+>s[0]["sub"].under["shape"] : Shape
+>s[0]["sub"].under : { shape: Shape; }
+>s[0]["sub"] : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : 0
+>"sub" : "sub"
+>under : { shape: Shape; }
+>"shape" : "shape"
+>"kind" : "kind"
+
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+>"square" : "square"
+>s[0].sub.under.shape.size * s[0].sub.under.shape.size : number
+>s[0].sub.under.shape.size : number
+>s[0].sub.under.shape : Square
+>s[0].sub.under : { shape: Shape; }
+>s[0].sub : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : 0
+>sub : { under: { shape: Shape; }; }
+>under : { shape: Shape; }
+>shape : Square
+>size : number
+>s[0].sub.under.shape.size : number
+>s[0].sub.under.shape : Square
+>s[0].sub.under : { shape: Shape; }
+>s[0].sub : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : 0
+>sub : { under: { shape: Shape; }; }
+>under : { shape: Shape; }
+>shape : Square
+>size : number
+
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+>"rectangle" : "rectangle"
+>s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height : number
+>s[0]["sub"]["under"]["shape"]["width"] : number
+>s[0]["sub"]["under"]["shape"] : Rectangle
+>s[0]["sub"]["under"] : { shape: Shape; }
+>s[0]["sub"] : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : 0
+>"sub" : "sub"
+>"under" : "under"
+>"shape" : "shape"
+>"width" : "width"
+>s[0]["sub"]["under"]["shape"].height : number
+>s[0]["sub"]["under"]["shape"] : Rectangle
+>s[0]["sub"]["under"] : { shape: Shape; }
+>s[0]["sub"] : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : 0
+>"sub" : "sub"
+>"under" : "under"
+>"shape" : "shape"
+>height : number
+
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
+>"circle" : "circle"
+>Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"] : number
+>Math.PI * s[0].sub.under["shape"].radius : number
+>Math.PI : number
+>Math : Math
+>PI : number
+>s[0].sub.under["shape"].radius : number
+>s[0].sub.under["shape"] : Circle
+>s[0].sub.under : { shape: Shape; }
+>s[0].sub : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : 0
+>sub : { under: { shape: Shape; }; }
+>under : { shape: Shape; }
+>"shape" : "shape"
+>radius : number
+>s[0]["sub"].under.shape["radius"] : number
+>s[0]["sub"].under.shape : Circle
+>s[0]["sub"].under : { shape: Shape; }
+>s[0]["sub"] : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : 0
+>"sub" : "sub"
+>under : { shape: Shape; }
+>shape : Circle
+>"radius" : "radius"
+    }
+}
+
+interface X {
+    0: "xx",
+>0 : "xx"
+
+    1: number
+>1 : number
+}
+
+interface Y {
+    0: "yy",
+>0 : "yy"
+
+    1: string
+>1 : string
+}
+
+type A = ["aa", number];
+>A : ["aa", number]
+
+type B = ["bb", string];
+>B : ["bb", string]
+
+type Z = X | Y;
+>Z : Z
+
+type C = A | B;
+>C : C
+
+function check(z: Z, c: C) {
+>check : (z: Z, c: C) => void
+>z : Z
+>c : C
+
+    z[0] // fine, typescript sees "xx" | "yy"
+>z[0] : "xx" | "yy"
+>z : Z
+>0 : 0
+
+    switch (z[0]) {
+>z[0] : "xx" | "yy"
+>z : Z
+>0 : 0
+
+        case "xx":
+>"xx" : "xx"
+
+            var xx: number = z[1] // should be number
+>xx : number
+>z[1] : number
+>z : X
+>1 : 1
+
+            break;
+        case "yy":
+>"yy" : "yy"
+
+            var yy: string = z[1] // should be string
+>yy : string
+>z[1] : string
+>z : Y
+>1 : 1
+
+            break;
+    }
+    c[0] // fine, typescript sees "xx" | "yy"
+>c[0] : "aa" | "bb"
+>c : C
+>0 : 0
+
+    switch (c[0]) {
+>c[0] : "aa" | "bb"
+>c : C
+>0 : 0
+
+        case "aa":
+>"aa" : "aa"
+
+            var aa: number = c[1] // should be number
+>aa : number
+>c[1] : number
+>c : ["aa", number]
+>1 : 1
+
+            break;
+        case "bb":
+>"bb" : "bb"
+
+            var bb: string = c[1] // should be string
+>bb : string
+>c[1] : string
+>c : ["bb", string]
+>1 : 1
+
+            break;
+    }
+}
+
+export function g(pair: [number, string?]): string {
+>g : (pair: [number, (string | undefined)?]) => string
+>pair : [number, (string | undefined)?]
+
+    return pair[1] ? pair[1] : 'nope';
+>pair[1] ? pair[1] : 'nope' : string
+>pair[1] : string | undefined
+>pair : [number, (string | undefined)?]
+>1 : 1
+>pair[1] : string
+>pair : [number, (string | undefined)?]
+>1 : 1
+>'nope' : "nope"
+}
+

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.types
@@ -1,14 +1,17 @@
 === tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts ===
 interface Square {
-    kind: "square";
->kind : "square"
+    ["dash-ok"]: "square";
+>["dash-ok"] : "square"
+>"dash-ok" : "dash-ok"
 
-    size: number;
->size : number
+    ["square-size"]: number;
+>["square-size"] : number
+>"square-size" : "square-size"
 }
  interface Rectangle {
-    kind: "rectangle";
->kind : "rectangle"
+    ["dash-ok"]: "rectangle";
+>["dash-ok"] : "rectangle"
+>"dash-ok" : "dash-ok"
 
     width: number;
 >width : number
@@ -17,8 +20,9 @@ interface Square {
 >height : number
 }
  interface Circle {
-    kind: "circle";
->kind : "circle"
+    ["dash-ok"]: "circle";
+>["dash-ok"] : "circle"
+>"dash-ok" : "dash-ok"
 
     radius: number;
 >radius : number
@@ -46,20 +50,20 @@ function area(s: Shape): number {
 >area : (s: Shape) => number
 >s : Shape
 
-    switch(s['kind']) {
->s['kind'] : "square" | "rectangle" | "circle"
+    switch(s['dash-ok']) {
+>s['dash-ok'] : "square" | "rectangle" | "circle"
 >s : Shape
->'kind' : "kind"
+>'dash-ok' : "dash-ok"
 
-        case "square": return s.size * s['size'];
+        case "square": return s['square-size'] * s['square-size'];
 >"square" : "square"
->s.size * s['size'] : number
->s.size : number
+>s['square-size'] * s['square-size'] : number
+>s['square-size'] : number
 >s : Square
->size : number
->s['size'] : number
+>'square-size' : "square-size"
+>s['square-size'] : number
 >s : Square
->'size' : "size"
+>'square-size' : "square-size"
 
         case "rectangle": return s.width * s['height'];
 >"rectangle" : "rectangle"
@@ -90,8 +94,8 @@ function subarea(s: Subshape): number {
 >subarea : (s: Subshape) => number
 >s : Subshape
 
-    switch(s[0]["sub"].under["shape"]["kind"]) {
->s[0]["sub"].under["shape"]["kind"] : "square" | "rectangle" | "circle"
+    switch(s[0]["sub"].under["shape"]["dash-ok"]) {
+>s[0]["sub"].under["shape"]["dash-ok"] : "square" | "rectangle" | "circle"
 >s[0]["sub"].under["shape"] : Shape
 >s[0]["sub"].under : { shape: Shape; }
 >s[0]["sub"] : { under: { shape: Shape; }; }
@@ -101,12 +105,12 @@ function subarea(s: Subshape): number {
 >"sub" : "sub"
 >under : { shape: Shape; }
 >"shape" : "shape"
->"kind" : "kind"
+>"dash-ok" : "dash-ok"
 
-        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+        case "square": return s[0].sub.under.shape["square-size"] * s[0].sub.under.shape["square-size"];
 >"square" : "square"
->s[0].sub.under.shape.size * s[0].sub.under.shape.size : number
->s[0].sub.under.shape.size : number
+>s[0].sub.under.shape["square-size"] * s[0].sub.under.shape["square-size"] : number
+>s[0].sub.under.shape["square-size"] : number
 >s[0].sub.under.shape : Square
 >s[0].sub.under : { shape: Shape; }
 >s[0].sub : { under: { shape: Shape; }; }
@@ -116,8 +120,8 @@ function subarea(s: Subshape): number {
 >sub : { under: { shape: Shape; }; }
 >under : { shape: Shape; }
 >shape : Square
->size : number
->s[0].sub.under.shape.size : number
+>"square-size" : "square-size"
+>s[0].sub.under.shape["square-size"] : number
 >s[0].sub.under.shape : Square
 >s[0].sub.under : { shape: Shape; }
 >s[0].sub : { under: { shape: Shape; }; }
@@ -127,7 +131,7 @@ function subarea(s: Subshape): number {
 >sub : { under: { shape: Shape; }; }
 >under : { shape: Shape; }
 >shape : Square
->size : number
+>"square-size" : "square-size"
 
         case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
 >"rectangle" : "rectangle"

--- a/tests/baselines/reference/unionTypeWithIndexSignature.errors.txt
+++ b/tests/baselines/reference/unionTypeWithIndexSignature.errors.txt
@@ -1,12 +1,13 @@
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(11,3): error TS2339: Property 'bar' does not exist on type 'Missing'.
   Property 'bar' does not exist on type '{ [s: string]: string; }'.
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(14,4): error TS2540: Cannot assign to 'foo' because it is a constant or a read-only property.
+tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(18,1): error TS2322: Type '"ok"' is not assignable to type 'number'.
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(24,1): error TS7017: Element implicitly has an 'any' type because type 'Both' has no index signature.
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(25,1): error TS2322: Type '"not ok"' is not assignable to type 'number'.
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(26,1): error TS7017: Element implicitly has an 'any' type because type 'Both' has no index signature.
 
 
-==== tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts (5 errors) ====
+==== tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts (6 errors) ====
     type Two = { foo: { bar: true }, baz: true } | { [s: string]: string };
     declare var u: Two
     u.foo = 'bye'
@@ -30,6 +31,8 @@ tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(26,1): error 
     declare var num: Num
     num[0] = 1
     num['0'] = 'ok'
+    ~~~~~~~~
+!!! error TS2322: Type '"ok"' is not assignable to type 'number'.
     const sym = Symbol()
     type Both = { s: number, '0': number, [sym]: boolean } | { [n: number]: number, [s: string]: string | number }
     declare var both: Both

--- a/tests/baselines/reference/unionTypeWithIndexSignature.types
+++ b/tests/baselines/reference/unionTypeWithIndexSignature.types
@@ -96,7 +96,7 @@ num[0] = 1
 
 num['0'] = 'ok'
 >num['0'] = 'ok' : "ok"
->num['0'] : string | number
+>num['0'] : number
 >num : Num
 >'0' : "0"
 >'ok' : "ok"

--- a/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
+++ b/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
@@ -1,15 +1,15 @@
 // @strict: true
 interface Square {
-    kind: "square";
-    size: number;
+    ["dash-ok"]: "square";
+    ["square-size"]: number;
 }
  interface Rectangle {
-    kind: "rectangle";
+    ["dash-ok"]: "rectangle";
     width: number;
     height: number;
 }
  interface Circle {
-    kind: "circle";
+    ["dash-ok"]: "circle";
     radius: number;
 }
  type Shape = Square | Rectangle | Circle;
@@ -23,15 +23,15 @@ interface Subshape {
     }
 }
 function area(s: Shape): number {
-    switch(s['kind']) {
-        case "square": return s.size * s['size'];
+    switch(s['dash-ok']) {
+        case "square": return s['square-size'] * s['square-size'];
         case "rectangle": return s.width * s['height'];
         case "circle": return Math.PI * s['radius'] * s.radius;
     }
 }
 function subarea(s: Subshape): number {
-    switch(s[0]["sub"].under["shape"]["kind"]) {
-        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+    switch(s[0]["sub"].under["shape"]["dash-ok"]) {
+        case "square": return s[0].sub.under.shape["square-size"] * s[0].sub.under.shape["square-size"];
         case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
         case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
     }

--- a/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
+++ b/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
@@ -1,0 +1,80 @@
+// @strict: true
+interface Square {
+    kind: "square";
+    size: number;
+}
+ interface Rectangle {
+    kind: "rectangle";
+    width: number;
+    height: number;
+}
+ interface Circle {
+    kind: "circle";
+    radius: number;
+}
+ type Shape = Square | Rectangle | Circle;
+interface Subshape {
+    "0": {
+        sub: {
+            under: {
+                shape: Shape;
+            }
+        }
+    }
+}
+function area(s: Shape): number {
+    switch(s['kind']) {
+        case "square": return s.size * s['size'];
+        case "rectangle": return s.width * s['height'];
+        case "circle": return Math.PI * s['radius'] * s.radius;
+    }
+}
+function subarea(s: Subshape): number {
+    switch(s[0]["sub"].under["shape"]["kind"]) {
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
+    }
+}
+
+interface X {
+    0: "xx",
+    1: number
+}
+
+interface Y {
+    0: "yy",
+    1: string
+}
+
+type A = ["aa", number];
+type B = ["bb", string];
+
+type Z = X | Y;
+
+type C = A | B;
+
+function check(z: Z, c: C) {
+    z[0] // fine, typescript sees "xx" | "yy"
+    switch (z[0]) {
+        case "xx":
+            var xx: number = z[1] // should be number
+            break;
+        case "yy":
+            var yy: string = z[1] // should be string
+            break;
+    }
+    c[0] // fine, typescript sees "xx" | "yy"
+    switch (c[0]) {
+        case "aa":
+            var aa: number = c[1] // should be number
+            break;
+        case "bb":
+            var bb: string = c[1] // should be string
+            break;
+    }
+}
+
+export function g(pair: [number, string?]): string {
+    return pair[1] ? pair[1] : 'nope';
+}


### PR DESCRIPTION
This means that, for example, the tuple `[number, string?]` allows its second element to be narrowed with element access:

```ts
export function f(pair: [number, string?]): string {
  return pair[1] ? pair[1] : 'nope';
}
```

Or you can narrow on properties that don't work with property access:

```ts
interface Square {
    ["dash-ok"]: "square";
    ["square-size"]: number;
}
 interface Rectangle {
    ["dash-ok"]: "rectangle";
    width: number;
    height: number;
}
 interface Circle {
    ["dash-ok"]: "circle";
    radius: number;
}
 type Shape = Square | Rectangle | Circle;
function area(s: Shape): number {
    switch(s['dash-ok']) {
        case "square": return s['square-size'] * s['square-size'];
        case "rectangle": return s.width * s['height'];
        case "circle": return Math.PI * s['radius'] * s.radius;
    }
}
```

This only works for actual literal references, not expressions with literal types, to prevent the binder from making the control flow graph much bigger than it is currently. In other words, this doesn't work:

```ts
export function f(pair: [number, string?]): string {
  const one = 1
  return pair[one] ? pair[one] : 'nope';
}
```

Performance is not significantly different from today, even on the Compiler, Unions Edition, which is full of very large unions:

```
┌─────────────┬─────────────────────┬─────────────────────┬───────────────────┬──────────┬──────────┐
│ Project     │            Baseline │             Current │             Delta │     Best │    Worst │
╞═════════════╧═════════════════════╧═════════════════════╧═══════════════════╧══════════╧══════════╡
│ Angular - node (v10.7.0, x64)                                                                     │
├─────────────┬─────────────────────┬─────────────────────┬───────────────────┬──────────┬──────────┤
│ Memory used │ 366,503k (±  0.01%) │ 366,586k (±  0.01%) │   +82k (+  0.02%) │ 366,421k │ 366,712k │
│ Parse Time  │    1.46s (±  0.97%) │    1.47s (±  0.97%) │ +0.01s (+  0.48%) │    1.43s │    1.56s │
│ Bind Time   │    0.66s (±  0.86%) │    0.67s (±  1.05%) │ +0.01s (+  1.29%) │    0.65s │    0.69s │
│ Check Time  │    3.44s (±  0.48%) │    3.47s (±  0.60%) │ +0.02s (+  0.71%) │    3.41s │    3.60s │
│ Emit Time   │    4.85s (±  0.59%) │    4.88s (±  0.52%) │ +0.03s (+  0.55%) │    4.82s │    5.05s │
├─────────────┼─────────────────────┼─────────────────────┼───────────────────┼──────────┼──────────┤
│ Total Time  │   10.41s (±  0.29%) │   10.47s (±  0.35%) │ +0.06s (+  0.62%) │   10.37s │   10.65s │
╞═════════════╧═════════════════════╧═════════════════════╧═══════════════════╧══════════╧══════════╡
│ Compiler - node (v10.7.0, x64)                                                                    │
├─────────────┬─────────────────────┬─────────────────────┬───────────────────┬──────────┬──────────┤
│ Memory used │ 198,369k (±  0.33%) │ 197,846k (±  0.22%) │  -523k (-  0.26%) │ 197,377k │ 200,636k │
│ Parse Time  │    0.61s (±  1.05%) │    0.61s (±  1.76%) │ +0.01s (+  0.91%) │    0.59s │    0.69s │
│ Bind Time   │    0.67s (±  1.26%) │    0.67s (±  1.29%) │ +0.00s (+  0.15%) │    0.65s │    0.71s │
│ Check Time  │    2.88s (±  0.61%) │    2.89s (±  0.95%) │ +0.01s (+  0.33%) │    2.82s │    3.00s │
│ Emit Time   │    2.00s (±  0.69%) │    2.01s (±  0.74%) │ +0.00s (+  0.07%) │    1.97s │    2.09s │
├─────────────┼─────────────────────┼─────────────────────┼───────────────────┼──────────┼──────────┤
│ Total Time  │    6.15s (±  0.38%) │    6.17s (±  0.56%) │ +0.02s (+  0.29%) │    6.07s │    6.33s │
╞═════════════╧═════════════════════╧═════════════════════╧═══════════════════╧══════════╧══════════╡
│ Compiler - Unions - node (v10.7.0, x64)                                                           │
├─────────────┬─────────────────────┬─────────────────────┬───────────────────┬──────────┬──────────┤
│ Memory used │ 219,013k (±  0.27%) │ 218,586k (±  0.13%) │  -427k (-  0.20%) │ 218,148k │ 221,204k │
│ Parse Time  │    0.56s (±  1.42%) │    0.56s (±  1.19%) │ -0.00s (-  0.18%) │    0.54s │    0.59s │
│ Bind Time   │    0.62s (±  1.19%) │    0.62s (±  1.09%) │ +0.00s (+  0.65%) │    0.60s │    0.65s │
│ Check Time  │    9.26s (±  0.46%) │    9.27s (±  0.43%) │ +0.01s (+  0.12%) │    9.09s │    9.42s │
│ Emit Time   │    1.92s (±  0.73%) │    1.90s (±  0.91%) │ -0.02s (-  0.81%) │    1.85s │    1.98s │
├─────────────┼─────────────────────┼─────────────────────┼───────────────────┼──────────┼──────────┤
│ Total Time  │   12.36s (±  0.43%) │   12.36s (±  0.34%) │ -0.00s (-  0.00%) │   12.22s │   12.54s │
╞═════════════╧═════════════════════╧═════════════════════╧═══════════════════╧══════════╧══════════╡
│ Monaco - node (v10.7.0, x64)                                                                      │
├─────────────┬─────────────────────┬─────────────────────┬───────────────────┬──────────┬──────────┤
│ Memory used │ 370,896k (±  0.01%) │ 370,943k (±  0.01%) │   +48k (+  0.01%) │ 370,735k │ 371,128k │
│ Parse Time  │    1.18s (±  1.07%) │    1.18s (±  1.30%) │ +0.01s (+  0.47%) │    1.12s │    1.24s │
│ Bind Time   │    0.60s (±  1.26%) │    0.61s (±  0.93%) │ +0.01s (+  1.00%) │    0.59s │    0.63s │
│ Check Time  │    3.45s (±  0.71%) │    3.47s (±  0.65%) │ +0.02s (+  0.61%) │    3.41s │    3.56s │
│ Emit Time   │    2.43s (±  0.68%) │    2.44s (±  0.55%) │ +0.01s (+  0.39%) │    2.40s │    2.50s │
├─────────────┼─────────────────────┼─────────────────────┼───────────────────┼──────────┼──────────┤
│ Total Time  │    7.65s (±  0.50%) │    7.70s (±  0.35%) │ +0.04s (+  0.59%) │    7.61s │    7.82s │
╞═════════════╧═════════════════════╧═════════════════════╧═══════════════════╧══════════╧══════════╡
│ TFS - node (v10.7.0, x64)                                                                         │
├─────────────┬─────────────────────┬─────────────────────┬───────────────────┬──────────┬──────────┤
│ Memory used │ 328,758k (±  0.01%) │ 328,830k (±  0.02%) │   +72k (+  0.02%) │ 328,637k │ 328,995k │
│ Parse Time  │    0.88s (±  1.52%) │    0.87s (±  1.05%) │ -0.01s (-  0.68%) │    0.85s │    0.92s │
│ Bind Time   │    0.54s (±  1.69%) │    0.54s (±  0.86%) │ -0.00s (-  0.65%) │    0.52s │    0.55s │
│ Check Time  │    3.46s (±  0.66%) │    3.46s (±  0.82%) │ +0.01s (+  0.16%) │    3.39s │    3.64s │
│ Emit Time   │    2.56s (±  0.69%) │    2.57s (±  0.80%) │ +0.01s (+  0.35%) │    2.49s │    2.65s │
├─────────────┼─────────────────────┼─────────────────────┼───────────────────┼──────────┼──────────┤
│ Total Time  │    7.44s (±  0.51%) │    7.44s (±  0.55%) │ +0.01s (+  0.09%) │    7.34s │    7.66s │
╞═════════════╧═════════════════════╧═════════════════════╧═══════════════════╧══════════╧══════════╡
│ skype4life - node (v10.7.0, x64)                                                                  │
├─────────────┬─────────────────────┬─────────────────────┬───────────────────┬──────────┬──────────┤
│ Memory used │ 821,863k (±  0.00%) │ 822,017k (±  0.00%) │  +154k (+  0.02%) │ 821,873k │ 822,173k │
│ Parse Time  │    3.48s (±  1.03%) │    3.46s (±  0.68%) │ -0.02s (-  0.56%) │    3.38s │    3.58s │
│ Bind Time   │    1.37s (±  1.76%) │    1.37s (±  1.25%) │ -0.00s (-  0.07%) │    1.32s │    1.46s │
│ Check Time  │    9.76s (±  0.33%) │    9.79s (±  0.45%) │ +0.03s (+  0.32%) │    9.66s │   10.02s │
│ Emit Time   │    7.13s (±  0.58%) │    7.18s (±  0.59%) │ +0.05s (+  0.76%) │    7.05s │    7.39s │
├─────────────┼─────────────────────┼─────────────────────┼───────────────────┼──────────┼──────────┤
│ Total Time  │   21.74s (±  0.29%) │   21.80s (±  0.32%) │ +0.06s (+  0.29%) │   21.54s │   22.18s │
└─────────────┴─────────────────────┴─────────────────────┴───────────────────┴──────────┴──────────┘
```

Finally, unions with index signatures behave slightly differently:

```ts
type Urg = { 0: string } | { [n: number]: number }
var u: Urg = { 0: 1 }
const n: number = u[0]
u[0] = 'no'
```

Which is visible in one baseline change. I'll check the user tests and Definitely Typed, then report back.

Fixes #10530  (and probably a few others that are still open; there are tons of duplicates of this one.)

