### PR TITLE
For a this-property assignment with an empty object initializer, use type annotation if present

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5119,7 +5119,7 @@ namespace ts {
         }
 
         function getJSInitializerType(decl: Node, symbol: Symbol, init: Expression | undefined): Type | undefined {
-            if (init && isInJavaScriptFile(init) && isObjectLiteralExpression(init) && init.properties.length === 0) {
+            if (init && isInJavaScriptFile(init) && isObjectLiteralExpression(init) && init.properties.length === 0 && !getJSDocType(decl)) {
                 const exports = createSymbolTable();
                 while (isBinaryExpression(decl) || isPropertyAccessExpression(decl)) {
                     const s = getSymbolOfNode(decl);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5100,7 +5100,8 @@ namespace ts {
             // * className.prototype.method = expr
             else if (isBinaryExpression(decl) ||
                 isPropertyAccessExpression(decl) && isBinaryExpression(decl.parent)) {
-                return getJSInitializerType(decl, symbol, getAssignedJavascriptInitializer(isBinaryExpression(decl) ? decl.left : decl)) ||
+                const target = isBinaryExpression(decl) ? decl.left as PropertyAccessExpression : decl;
+                return getSpecialPropertyAccessKind(target) !== SpecialPropertyAssignmentKind.ThisProperty && getJSInitializerType(decl, symbol, getAssignedJavascriptInitializer(target)) ||
                     getWidenedTypeFromJSSpecialPropertyDeclarations(symbol);
             }
             else if (isParameter(decl)
@@ -5119,7 +5120,7 @@ namespace ts {
         }
 
         function getJSInitializerType(decl: Node, symbol: Symbol, init: Expression | undefined): Type | undefined {
-            if (init && isInJavaScriptFile(init) && isObjectLiteralExpression(init) && init.properties.length === 0 && !getJSDocType(decl)) {
+            if (init && isObjectLiteralExpression(init) && init.properties.length === 0) {
                 const exports = createSymbolTable();
                 while (isBinaryExpression(decl) || isPropertyAccessExpression(decl)) {
                     const s = getSymbolOfNode(decl);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4658,12 +4658,6 @@ namespace ts {
                 return addOptionality(declaredType, isOptional);
             }
 
-            if (isInJavaScriptFile(declaration)) {
-                const expandoType = getJSExpandoObjectType(declaration, getSymbolOfNode(declaration), getDeclaredJavascriptInitializer(declaration));
-                if (expandoType) {
-                    return expandoType;
-                }
-            }
             if ((noImplicitAny || isInJavaScriptFile(declaration)) &&
                 declaration.kind === SyntaxKind.VariableDeclaration && !isBindingPattern(declaration.name) &&
                 !(getCombinedModifierFlags(declaration) & ModifierFlags.Export) && !(declaration.flags & NodeFlags.Ambient)) {
@@ -4700,6 +4694,12 @@ namespace ts {
                 const type = declaration.symbol.escapedName === InternalSymbolName.This ? getContextualThisParameterType(func) : getContextuallyTypedParameterType(declaration);
                 if (type) {
                     return addOptionality(type, isOptional);
+                }
+            }
+            else if (isInJavaScriptFile(declaration)) {
+                const expandoType = getJSExpandoObjectType(declaration, getSymbolOfNode(declaration), getDeclaredJavascriptInitializer(declaration));
+                if (expandoType) {
+                    return expandoType;
                 }
             }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4733,10 +4733,7 @@ namespace ts {
                     return getTypeFromTypeNode(tag.typeExpression);
                 }
                 const expando = getJSExpandoObjectType(symbol.valueDeclaration, symbol, specialDeclaration);
-                if (expando) {
-                    return expando;
-                }
-                return getWidenedLiteralType(checkExpressionCached(specialDeclaration));
+                return expando || getWidenedLiteralType(checkExpressionCached(specialDeclaration));
             }
             let definedInConstructor = false;
             let definedInMethod = false;

--- a/tests/baselines/reference/annotatedThisPropertyInitializerDoesntNarrow.symbols
+++ b/tests/baselines/reference/annotatedThisPropertyInitializerDoesntNarrow.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/salsa/Compilation.js ===
+// from webpack/lib/Compilation.js and filed at #26427
+/** @param {{ [s: string]: number }} map */
+function mappy(map) {}
+>mappy : Symbol(mappy, Decl(Compilation.js, 0, 0))
+>map : Symbol(map, Decl(Compilation.js, 2, 15))
+
+export class C {
+>C : Symbol(C, Decl(Compilation.js, 2, 22))
+
+    constructor() {
+        /** @type {{ [assetName: string]: number}} */
+        this.assets = {};
+>this.assets : Symbol(C.assets, Decl(Compilation.js, 5, 19))
+>this : Symbol(C, Decl(Compilation.js, 2, 22))
+>assets : Symbol(C.assets, Decl(Compilation.js, 5, 19))
+    }
+    m() {
+>m : Symbol(C.m, Decl(Compilation.js, 8, 5))
+
+        mappy(this.assets)
+>mappy : Symbol(mappy, Decl(Compilation.js, 0, 0))
+>this.assets : Symbol(C.assets, Decl(Compilation.js, 5, 19))
+>this : Symbol(C, Decl(Compilation.js, 2, 22))
+>assets : Symbol(C.assets, Decl(Compilation.js, 5, 19))
+    }
+}
+

--- a/tests/baselines/reference/annotatedThisPropertyInitializerDoesntNarrow.types
+++ b/tests/baselines/reference/annotatedThisPropertyInitializerDoesntNarrow.types
@@ -1,0 +1,31 @@
+=== tests/cases/conformance/salsa/Compilation.js ===
+// from webpack/lib/Compilation.js and filed at #26427
+/** @param {{ [s: string]: number }} map */
+function mappy(map) {}
+>mappy : (map: { [s: string]: number; }) => void
+>map : { [s: string]: number; }
+
+export class C {
+>C : C
+
+    constructor() {
+        /** @type {{ [assetName: string]: number}} */
+        this.assets = {};
+>this.assets = {} : {}
+>this.assets : { [assetName: string]: number; }
+>this : this
+>assets : { [assetName: string]: number; }
+>{} : {}
+    }
+    m() {
+>m : () => void
+
+        mappy(this.assets)
+>mappy(this.assets) : void
+>mappy : (map: { [s: string]: number; }) => void
+>this.assets : { [assetName: string]: number; }
+>this : this
+>assets : { [assetName: string]: number; }
+    }
+}
+

--- a/tests/baselines/reference/checkDestructuringShorthandAssigment.errors.txt
+++ b/tests/baselines/reference/checkDestructuringShorthandAssigment.errors.txt
@@ -1,12 +1,9 @@
-tests/cases/compiler/bug25434.js(2,17): error TS2459: Type '{}' has no property 'b' and no string index signature.
 tests/cases/compiler/bug25434.js(4,9): error TS2304: Cannot find name 'b'.
 
 
-==== tests/cases/compiler/bug25434.js (2 errors) ====
+==== tests/cases/compiler/bug25434.js (1 errors) ====
     // should not crash while checking
     function Test({ b = '' } = {}) {}
-                    ~
-!!! error TS2459: Type '{}' has no property 'b' and no string index signature.
     
     Test(({ b = '5' } = {}));
             ~

--- a/tests/baselines/reference/checkDestructuringShorthandAssigment.errors.txt
+++ b/tests/baselines/reference/checkDestructuringShorthandAssigment.errors.txt
@@ -1,9 +1,12 @@
+tests/cases/compiler/bug25434.js(2,17): error TS2459: Type '{}' has no property 'b' and no string index signature.
 tests/cases/compiler/bug25434.js(4,9): error TS2304: Cannot find name 'b'.
 
 
-==== tests/cases/compiler/bug25434.js (1 errors) ====
+==== tests/cases/compiler/bug25434.js (2 errors) ====
     // should not crash while checking
     function Test({ b = '' } = {}) {}
+                    ~
+!!! error TS2459: Type '{}' has no property 'b' and no string index signature.
     
     Test(({ b = '5' } = {}));
             ~

--- a/tests/baselines/reference/checkDestructuringShorthandAssigment.types
+++ b/tests/baselines/reference/checkDestructuringShorthandAssigment.types
@@ -1,14 +1,14 @@
 === tests/cases/compiler/bug25434.js ===
 // should not crash while checking
 function Test({ b = '' } = {}) {}
->Test : ({ b }?: {}) => void
->b : any
+>Test : ({ b }?: { b?: string; }) => void
+>b : string
 >'' : ""
 >{} : { b?: string; }
 
 Test(({ b = '5' } = {}));
 >Test(({ b = '5' } = {})) : void
->Test : ({ b }?: {}) => void
+>Test : ({ b }?: { b?: string; }) => void
 >({ b = '5' } = {}) : { b?: any; }
 >{ b = '5' } = {} : { b?: any; }
 >{ b = '5' } : { b?: any; }

--- a/tests/baselines/reference/checkDestructuringShorthandAssigment.types
+++ b/tests/baselines/reference/checkDestructuringShorthandAssigment.types
@@ -2,7 +2,7 @@
 // should not crash while checking
 function Test({ b = '' } = {}) {}
 >Test : ({ b }?: {}) => void
->b : string
+>b : any
 >'' : ""
 >{} : { b?: string; }
 

--- a/tests/baselines/reference/jsContainerMergeTsDeclaration3.errors.txt
+++ b/tests/baselines/reference/jsContainerMergeTsDeclaration3.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/conformance/salsa/b.js(1,7): error TS2322: Type '{}' is not assignable to type 'typeof A'.
+  Property 'prototype' is missing in type '{}'.
+
+
+==== tests/cases/conformance/salsa/a.d.ts (0 errors) ====
+    declare class A {}
+==== tests/cases/conformance/salsa/b.js (1 errors) ====
+    const A = { };
+          ~
+!!! error TS2322: Type '{}' is not assignable to type 'typeof A'.
+!!! error TS2322:   Property 'prototype' is missing in type '{}'.
+    A.d = { };
+    

--- a/tests/cases/conformance/salsa/annotatedThisPropertyInitializerDoesntNarrow.ts
+++ b/tests/cases/conformance/salsa/annotatedThisPropertyInitializerDoesntNarrow.ts
@@ -1,0 +1,17 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: Compilation.js
+// from webpack/lib/Compilation.js and filed at #26427
+/** @param {{ [s: string]: number }} map */
+function mappy(map) {}
+
+export class C {
+    constructor() {
+        /** @type {{ [assetName: string]: number}} */
+        this.assets = {};
+    }
+    m() {
+        mappy(this.assets)
+    }
+}


### PR DESCRIPTION
You should only get the expando behaviour for `{}` when there is no existing type annotation. Previously, the expando check didn't check for type annotations before creating an expando object.

Fixes #26427 
