### PR TITLE
Remove special handling for JSDocPropertyLikeTag in getJSSpecialType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5090,9 +5090,6 @@ namespace ts {
             if (!isInJavaScriptFile(decl)) {
                 return undefined;
             }
-            else if (isJSDocPropertyLikeTag(decl) && decl.typeExpression) {
-                return getTypeFromTypeNode(decl.typeExpression.type);
-            }
             // Handle certain special assignment kinds, which happen to union across multiple declarations:
             // * module.exports = expr
             // * exports.p = expr

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3358,8 +3358,9 @@ namespace ts {
      * parsed in a JavaScript file, gets the type annotation from JSDoc.
      */
     export function getEffectiveTypeAnnotationNode(node: Node): TypeNode | undefined {
-        return (node as HasType).type || (
-            isInJavaScriptFile(node) ? isJSDocPropertyLikeTag(node) ? node.typeExpression && node.typeExpression.type : getJSDocType(node) : undefined);
+        const type = (node as HasType).type;
+        if (type || !isInJavaScriptFile(node)) return type;
+        return isJSDocPropertyLikeTag(node) ? node.typeExpression && node.typeExpression.type : getJSDocType(node);
     }
 
     export function getTypeAnnotationNode(node: Node): TypeNode | undefined {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3358,7 +3358,8 @@ namespace ts {
      * parsed in a JavaScript file, gets the type annotation from JSDoc.
      */
     export function getEffectiveTypeAnnotationNode(node: Node): TypeNode | undefined {
-        return (node as HasType).type || (isInJavaScriptFile(node) ? getJSDocType(node) : undefined);
+        return (node as HasType).type || (
+            isInJavaScriptFile(node) ? isJSDocPropertyLikeTag(node) ? node.typeExpression && node.typeExpression.type : getJSDocType(node) : undefined);
     }
 
     export function getTypeAnnotationNode(node: Node): TypeNode | undefined {


### PR DESCRIPTION
Noticed while reviewing  #26428 -- this isn't really a special type, we just need to handle it correctly in `getEffectiveTypeAnnotationNode`.