### PR TITLE
Better errors for indexing gettable/settable values

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4272,7 +4272,10 @@
         "category": "Error",
         "code": 7051
     },
-
+    "Element implicitly has an 'any' type because type '{0}' has no index signature. Did you mean to call '{1}' ?": {
+        "category": "Error",
+        "code": 7052
+    },
     "You cannot rename this element.": {
         "category": "Error",
         "code": 8000

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3960,6 +3960,16 @@ namespace ts {
         return isPropertyAccessExpression(node) && isEntityNameExpression(node.expression);
     }
 
+    export function tryGetPropertyAccessOrIdentifierToString(expr: Expression): string | undefined {
+        if (isPropertyAccessExpression(expr)) {
+            return tryGetPropertyAccessOrIdentifierToString(expr.expression) + "." + expr.name;
+        }
+        if (isIdentifier(expr)) {
+            return unescapeLeadingUnderscores(expr.escapedText);
+        }
+        return undefined;
+    }
+
     export function isPrototypeAccess(node: Node): node is PropertyAccessExpression {
         return isPropertyAccessExpression(node) && node.name.escapedText === "prototype";
     }

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.errors.txt
@@ -1,8 +1,37 @@
 tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(1,9): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(8,1): error TS7043: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'c.get' ?
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(14,1): error TS7043: Element implicitly has an 'any' type because type '{ set: (key: string) => string; }' has no index signature. Did you mean to call 'd.set' ?
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(21,1): error TS7043: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'e.get or e.set' ?
 
 
-==== tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts (1 errors) ====
-    var x = {}["hello"];
+==== tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts (4 errors) ====
+    var a = {}["hello"];
             ~~~~~~~~~~~
 !!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
-    var y: string = { '': 'foo' }[''];
+    var b: string = { '': 'foo' }[''];
+    
+    // Should give suggestion 'c.get'
+    var c = {
+      get: (key: string) => 'foobar'
+    };
+    c['hello'];
+    ~~~~~~~~~~
+!!! error TS7043: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'c.get' ?
+    
+    // Should give suggestion 'd.set'
+    var d = {
+      set: (key: string) => 'foobar'
+    };
+    d['hello'];
+    ~~~~~~~~~~
+!!! error TS7043: Element implicitly has an 'any' type because type '{ set: (key: string) => string; }' has no index signature. Did you mean to call 'd.set' ?
+    
+    // Should give suggestion 'e.get or e.set'
+    var e = {
+      set: (key: string) => 'foobar',
+      get: (key: string) => 'foobar'
+    };
+    e['hello'];
+    ~~~~~~~~~~
+!!! error TS7043: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'e.get or e.set' ?
+    

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.errors.txt
@@ -1,37 +1,47 @@
 tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(1,9): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
-tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(8,1): error TS7043: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'c.get' ?
-tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(14,1): error TS7043: Element implicitly has an 'any' type because type '{ set: (key: string) => string; }' has no index signature. Did you mean to call 'd.set' ?
-tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(21,1): error TS7043: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'e.get or e.set' ?
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(7,1): error TS7052: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'get' ?
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(8,13): error TS7052: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'get' ?
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(13,13): error TS7017: Element implicitly has an 'any' type because type '{ set: (key: string) => string; }' has no index signature.
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(19,1): error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(20,1): error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(21,1): error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
 
 
-==== tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts (4 errors) ====
+==== tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts (7 errors) ====
     var a = {}["hello"];
             ~~~~~~~~~~~
 !!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
     var b: string = { '': 'foo' }[''];
     
-    // Should give suggestion 'c.get'
     var c = {
       get: (key: string) => 'foobar'
     };
     c['hello'];
     ~~~~~~~~~~
-!!! error TS7043: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'c.get' ?
+!!! error TS7052: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'get' ?
+    const foo = c['hello'];
+                ~~~~~~~~~~
+!!! error TS7052: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'get' ?
     
-    // Should give suggestion 'd.set'
     var d = {
       set: (key: string) => 'foobar'
     };
-    d['hello'];
-    ~~~~~~~~~~
-!!! error TS7043: Element implicitly has an 'any' type because type '{ set: (key: string) => string; }' has no index signature. Did you mean to call 'd.set' ?
+    const bar = d['hello'];
+                ~~~~~~~~~~
+!!! error TS7017: Element implicitly has an 'any' type because type '{ set: (key: string) => string; }' has no index signature.
     
-    // Should give suggestion 'e.get or e.set'
     var e = {
       set: (key: string) => 'foobar',
       get: (key: string) => 'foobar'
     };
-    e['hello'];
+    e['hello'] = 'modified';
     ~~~~~~~~~~
-!!! error TS7043: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'e.get or e.set' ?
+!!! error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
+    e['hello'] += 1;
+    ~~~~~~~~~~
+!!! error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
+    e['hello'] ++;
+    ~~~~~~~~~~
+!!! error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
+    
     

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.js
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.js
@@ -1,7 +1,43 @@
 //// [noImplicitAnyStringIndexerOnObject.ts]
-var x = {}["hello"];
-var y: string = { '': 'foo' }[''];
+var a = {}["hello"];
+var b: string = { '': 'foo' }[''];
+
+// Should give suggestion 'c.get'
+var c = {
+  get: (key: string) => 'foobar'
+};
+c['hello'];
+
+// Should give suggestion 'd.set'
+var d = {
+  set: (key: string) => 'foobar'
+};
+d['hello'];
+
+// Should give suggestion 'e.get or e.set'
+var e = {
+  set: (key: string) => 'foobar',
+  get: (key: string) => 'foobar'
+};
+e['hello'];
+
 
 //// [noImplicitAnyStringIndexerOnObject.js]
-var x = {}["hello"];
-var y = { '': 'foo' }[''];
+var a = {}["hello"];
+var b = { '': 'foo' }[''];
+// Should give suggestion 'c.get'
+var c = {
+    get: function (key) { return 'foobar'; }
+};
+c['hello'];
+// Should give suggestion 'd.set'
+var d = {
+    set: function (key) { return 'foobar'; }
+};
+d['hello'];
+// Should give suggestion 'e.get or e.set'
+var e = {
+    set: function (key) { return 'foobar'; },
+    get: function (key) { return 'foobar'; }
+};
+e['hello'];

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.js
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.js
@@ -2,42 +2,43 @@
 var a = {}["hello"];
 var b: string = { '': 'foo' }[''];
 
-// Should give suggestion 'c.get'
 var c = {
   get: (key: string) => 'foobar'
 };
 c['hello'];
+const foo = c['hello'];
 
-// Should give suggestion 'd.set'
 var d = {
   set: (key: string) => 'foobar'
 };
-d['hello'];
+const bar = d['hello'];
 
-// Should give suggestion 'e.get or e.set'
 var e = {
   set: (key: string) => 'foobar',
   get: (key: string) => 'foobar'
 };
-e['hello'];
+e['hello'] = 'modified';
+e['hello'] += 1;
+e['hello'] ++;
+
 
 
 //// [noImplicitAnyStringIndexerOnObject.js]
 var a = {}["hello"];
 var b = { '': 'foo' }[''];
-// Should give suggestion 'c.get'
 var c = {
     get: function (key) { return 'foobar'; }
 };
 c['hello'];
-// Should give suggestion 'd.set'
+var foo = c['hello'];
 var d = {
     set: function (key) { return 'foobar'; }
 };
-d['hello'];
-// Should give suggestion 'e.get or e.set'
+var bar = d['hello'];
 var e = {
     set: function (key) { return 'foobar'; },
     get: function (key) { return 'foobar'; }
 };
-e['hello'];
+e['hello'] = 'modified';
+e['hello'] += 1;
+e['hello']++;

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.symbols
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.symbols
@@ -7,43 +7,52 @@ var b: string = { '': 'foo' }[''];
 >'' : Symbol('', Decl(noImplicitAnyStringIndexerOnObject.ts, 1, 17))
 >'' : Symbol('', Decl(noImplicitAnyStringIndexerOnObject.ts, 1, 17))
 
-// Should give suggestion 'c.get'
 var c = {
->c : Symbol(c, Decl(noImplicitAnyStringIndexerOnObject.ts, 4, 3))
+>c : Symbol(c, Decl(noImplicitAnyStringIndexerOnObject.ts, 3, 3))
 
   get: (key: string) => 'foobar'
->get : Symbol(get, Decl(noImplicitAnyStringIndexerOnObject.ts, 4, 9))
->key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 5, 8))
+>get : Symbol(get, Decl(noImplicitAnyStringIndexerOnObject.ts, 3, 9))
+>key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 4, 8))
 
 };
 c['hello'];
->c : Symbol(c, Decl(noImplicitAnyStringIndexerOnObject.ts, 4, 3))
+>c : Symbol(c, Decl(noImplicitAnyStringIndexerOnObject.ts, 3, 3))
 
-// Should give suggestion 'd.set'
+const foo = c['hello'];
+>foo : Symbol(foo, Decl(noImplicitAnyStringIndexerOnObject.ts, 7, 5))
+>c : Symbol(c, Decl(noImplicitAnyStringIndexerOnObject.ts, 3, 3))
+
 var d = {
->d : Symbol(d, Decl(noImplicitAnyStringIndexerOnObject.ts, 10, 3))
+>d : Symbol(d, Decl(noImplicitAnyStringIndexerOnObject.ts, 9, 3))
 
   set: (key: string) => 'foobar'
->set : Symbol(set, Decl(noImplicitAnyStringIndexerOnObject.ts, 10, 9))
->key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 11, 8))
+>set : Symbol(set, Decl(noImplicitAnyStringIndexerOnObject.ts, 9, 9))
+>key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 10, 8))
 
 };
-d['hello'];
->d : Symbol(d, Decl(noImplicitAnyStringIndexerOnObject.ts, 10, 3))
+const bar = d['hello'];
+>bar : Symbol(bar, Decl(noImplicitAnyStringIndexerOnObject.ts, 12, 5))
+>d : Symbol(d, Decl(noImplicitAnyStringIndexerOnObject.ts, 9, 3))
 
-// Should give suggestion 'e.get or e.set'
 var e = {
->e : Symbol(e, Decl(noImplicitAnyStringIndexerOnObject.ts, 16, 3))
+>e : Symbol(e, Decl(noImplicitAnyStringIndexerOnObject.ts, 14, 3))
 
   set: (key: string) => 'foobar',
->set : Symbol(set, Decl(noImplicitAnyStringIndexerOnObject.ts, 16, 9))
->key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 17, 8))
+>set : Symbol(set, Decl(noImplicitAnyStringIndexerOnObject.ts, 14, 9))
+>key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 15, 8))
 
   get: (key: string) => 'foobar'
->get : Symbol(get, Decl(noImplicitAnyStringIndexerOnObject.ts, 17, 33))
->key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 18, 8))
+>get : Symbol(get, Decl(noImplicitAnyStringIndexerOnObject.ts, 15, 33))
+>key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 16, 8))
 
 };
-e['hello'];
->e : Symbol(e, Decl(noImplicitAnyStringIndexerOnObject.ts, 16, 3))
+e['hello'] = 'modified';
+>e : Symbol(e, Decl(noImplicitAnyStringIndexerOnObject.ts, 14, 3))
+
+e['hello'] += 1;
+>e : Symbol(e, Decl(noImplicitAnyStringIndexerOnObject.ts, 14, 3))
+
+e['hello'] ++;
+>e : Symbol(e, Decl(noImplicitAnyStringIndexerOnObject.ts, 14, 3))
+
 

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.symbols
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.symbols
@@ -1,9 +1,49 @@
 === tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts ===
-var x = {}["hello"];
->x : Symbol(x, Decl(noImplicitAnyStringIndexerOnObject.ts, 0, 3))
+var a = {}["hello"];
+>a : Symbol(a, Decl(noImplicitAnyStringIndexerOnObject.ts, 0, 3))
 
-var y: string = { '': 'foo' }[''];
->y : Symbol(y, Decl(noImplicitAnyStringIndexerOnObject.ts, 1, 3))
+var b: string = { '': 'foo' }[''];
+>b : Symbol(b, Decl(noImplicitAnyStringIndexerOnObject.ts, 1, 3))
 >'' : Symbol('', Decl(noImplicitAnyStringIndexerOnObject.ts, 1, 17))
 >'' : Symbol('', Decl(noImplicitAnyStringIndexerOnObject.ts, 1, 17))
+
+// Should give suggestion 'c.get'
+var c = {
+>c : Symbol(c, Decl(noImplicitAnyStringIndexerOnObject.ts, 4, 3))
+
+  get: (key: string) => 'foobar'
+>get : Symbol(get, Decl(noImplicitAnyStringIndexerOnObject.ts, 4, 9))
+>key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 5, 8))
+
+};
+c['hello'];
+>c : Symbol(c, Decl(noImplicitAnyStringIndexerOnObject.ts, 4, 3))
+
+// Should give suggestion 'd.set'
+var d = {
+>d : Symbol(d, Decl(noImplicitAnyStringIndexerOnObject.ts, 10, 3))
+
+  set: (key: string) => 'foobar'
+>set : Symbol(set, Decl(noImplicitAnyStringIndexerOnObject.ts, 10, 9))
+>key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 11, 8))
+
+};
+d['hello'];
+>d : Symbol(d, Decl(noImplicitAnyStringIndexerOnObject.ts, 10, 3))
+
+// Should give suggestion 'e.get or e.set'
+var e = {
+>e : Symbol(e, Decl(noImplicitAnyStringIndexerOnObject.ts, 16, 3))
+
+  set: (key: string) => 'foobar',
+>set : Symbol(set, Decl(noImplicitAnyStringIndexerOnObject.ts, 16, 9))
+>key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 17, 8))
+
+  get: (key: string) => 'foobar'
+>get : Symbol(get, Decl(noImplicitAnyStringIndexerOnObject.ts, 17, 33))
+>key : Symbol(key, Decl(noImplicitAnyStringIndexerOnObject.ts, 18, 8))
+
+};
+e['hello'];
+>e : Symbol(e, Decl(noImplicitAnyStringIndexerOnObject.ts, 16, 3))
 

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.types
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.types
@@ -1,15 +1,72 @@
 === tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts ===
-var x = {}["hello"];
->x : any
+var a = {}["hello"];
+>a : any
 >{}["hello"] : any
 >{} : {}
 >"hello" : "hello"
 
-var y: string = { '': 'foo' }[''];
->y : string
+var b: string = { '': 'foo' }[''];
+>b : string
 >{ '': 'foo' }[''] : string
 >{ '': 'foo' } : { '': string; }
 >'' : string
 >'foo' : "foo"
 >'' : ""
+
+// Should give suggestion 'c.get'
+var c = {
+>c : { get: (key: string) => string; }
+>{  get: (key: string) => 'foobar'} : { get: (key: string) => string; }
+
+  get: (key: string) => 'foobar'
+>get : (key: string) => string
+>(key: string) => 'foobar' : (key: string) => string
+>key : string
+>'foobar' : "foobar"
+
+};
+c['hello'];
+>c['hello'] : any
+>c : { get: (key: string) => string; }
+>'hello' : "hello"
+
+// Should give suggestion 'd.set'
+var d = {
+>d : { set: (key: string) => string; }
+>{  set: (key: string) => 'foobar'} : { set: (key: string) => string; }
+
+  set: (key: string) => 'foobar'
+>set : (key: string) => string
+>(key: string) => 'foobar' : (key: string) => string
+>key : string
+>'foobar' : "foobar"
+
+};
+d['hello'];
+>d['hello'] : any
+>d : { set: (key: string) => string; }
+>'hello' : "hello"
+
+// Should give suggestion 'e.get or e.set'
+var e = {
+>e : { set: (key: string) => string; get: (key: string) => string; }
+>{  set: (key: string) => 'foobar',  get: (key: string) => 'foobar'} : { set: (key: string) => string; get: (key: string) => string; }
+
+  set: (key: string) => 'foobar',
+>set : (key: string) => string
+>(key: string) => 'foobar' : (key: string) => string
+>key : string
+>'foobar' : "foobar"
+
+  get: (key: string) => 'foobar'
+>get : (key: string) => string
+>(key: string) => 'foobar' : (key: string) => string
+>key : string
+>'foobar' : "foobar"
+
+};
+e['hello'];
+>e['hello'] : any
+>e : { set: (key: string) => string; get: (key: string) => string; }
+>'hello' : "hello"
 

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.types
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.types
@@ -13,7 +13,6 @@ var b: string = { '': 'foo' }[''];
 >'foo' : "foo"
 >'' : ""
 
-// Should give suggestion 'c.get'
 var c = {
 >c : { get: (key: string) => string; }
 >{  get: (key: string) => 'foobar'} : { get: (key: string) => string; }
@@ -30,7 +29,12 @@ c['hello'];
 >c : { get: (key: string) => string; }
 >'hello' : "hello"
 
-// Should give suggestion 'd.set'
+const foo = c['hello'];
+>foo : any
+>c['hello'] : any
+>c : { get: (key: string) => string; }
+>'hello' : "hello"
+
 var d = {
 >d : { set: (key: string) => string; }
 >{  set: (key: string) => 'foobar'} : { set: (key: string) => string; }
@@ -42,12 +46,12 @@ var d = {
 >'foobar' : "foobar"
 
 };
-d['hello'];
+const bar = d['hello'];
+>bar : any
 >d['hello'] : any
 >d : { set: (key: string) => string; }
 >'hello' : "hello"
 
-// Should give suggestion 'e.get or e.set'
 var e = {
 >e : { set: (key: string) => string; get: (key: string) => string; }
 >{  set: (key: string) => 'foobar',  get: (key: string) => 'foobar'} : { set: (key: string) => string; get: (key: string) => string; }
@@ -65,8 +69,24 @@ var e = {
 >'foobar' : "foobar"
 
 };
-e['hello'];
+e['hello'] = 'modified';
+>e['hello'] = 'modified' : "modified"
 >e['hello'] : any
 >e : { set: (key: string) => string; get: (key: string) => string; }
 >'hello' : "hello"
+>'modified' : "modified"
+
+e['hello'] += 1;
+>e['hello'] += 1 : any
+>e['hello'] : any
+>e : { set: (key: string) => string; get: (key: string) => string; }
+>'hello' : "hello"
+>1 : 1
+
+e['hello'] ++;
+>e['hello'] ++ : number
+>e['hello'] : any
+>e : { set: (key: string) => string; get: (key: string) => string; }
+>'hello' : "hello"
+
 

--- a/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
+++ b/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
@@ -7,14 +7,18 @@ var c = {
   get: (key: string) => 'foobar'
 };
 c['hello'];
+const foo = c['hello'];
 
 var d = {
   set: (key: string) => 'foobar'
 };
-d['hello'];
+const bar = d['hello'];
 
 var e = {
   set: (key: string) => 'foobar',
   get: (key: string) => 'foobar'
 };
-e['hello'];
+e['hello'] = 'modified';
+e['hello'] += 1;
+e['hello'] ++;
+

--- a/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
+++ b/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
@@ -3,19 +3,16 @@
 var a = {}["hello"];
 var b: string = { '': 'foo' }[''];
 
-// Should give suggestion 'c.get'
 var c = {
   get: (key: string) => 'foobar'
 };
 c['hello'];
 
-// Should give suggestion 'd.set'
 var d = {
   set: (key: string) => 'foobar'
 };
 d['hello'];
 
-// Should give suggestion 'e.get or e.set'
 var e = {
   set: (key: string) => 'foobar',
   get: (key: string) => 'foobar'

--- a/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
+++ b/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
@@ -1,4 +1,23 @@
 // @noimplicitany: true
 
-var x = {}["hello"];
-var y: string = { '': 'foo' }[''];
+var a = {}["hello"];
+var b: string = { '': 'foo' }[''];
+
+// Should give suggestion 'c.get'
+var c = {
+  get: (key: string) => 'foobar'
+};
+c['hello'];
+
+// Should give suggestion 'd.set'
+var d = {
+  set: (key: string) => 'foobar'
+};
+d['hello'];
+
+// Should give suggestion 'e.get or e.set'
+var e = {
+  set: (key: string) => 'foobar',
+  get: (key: string) => 'foobar'
+};
+e['hello'];


### PR DESCRIPTION
Gives suggestions where a type has no index signature but has `get` or `set` properties.

Fixes #26098 

