### PR TITLE
Return the nonrecursive directory watcher correctly on platforms that  dont support recrusive directory watching

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -756,8 +756,7 @@ namespace ts {
                     if (recursive) {
                         return watchDirectoryRecursively(directoryName, callback);
                     }
-                    watchDirectory(directoryName, callback);
-                    return undefined!; // TODO: GH#18217
+                    return watchDirectory(directoryName, callback);
                 };
             }
 


### PR DESCRIPTION
Fixes #26288
