### PR TITLE
Fix invalid cast

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26672,7 +26672,7 @@ namespace ts {
                 case SyntaxKind.ParenthesizedType:
                 case SyntaxKind.OptionalType:
                 case SyntaxKind.RestType:
-                    return checkSourceElement((<ParenthesizedTypeNode | OptionalTypeNode>node).type);
+                    return checkSourceElement((<ParenthesizedTypeNode | OptionalTypeNode | RestTypeNode>node).type);
                 case SyntaxKind.ThisType:
                     return checkThisType(<ThisTypeNode>node);
                 case SyntaxKind.TypeOperator:


### PR DESCRIPTION
Fills in a missing union member in a cast.
