### PR TITLE
include leading non-ASCII horizontal whitespace

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1390,6 +1390,24 @@ namespace ts {
                     case CharacterCodes.verticalTab:
                     case CharacterCodes.formFeed:
                     case CharacterCodes.space:
+                    case CharacterCodes.nonBreakingSpace:
+                    case CharacterCodes.ogham:
+                    case CharacterCodes.enQuad:
+                    case CharacterCodes.emQuad:
+                    case CharacterCodes.enSpace:
+                    case CharacterCodes.emSpace:
+                    case CharacterCodes.threePerEmSpace:
+                    case CharacterCodes.fourPerEmSpace:
+                    case CharacterCodes.sixPerEmSpace:
+                    case CharacterCodes.figureSpace:
+                    case CharacterCodes.punctuationSpace:
+                    case CharacterCodes.thinSpace:
+                    case CharacterCodes.hairSpace:
+                    case CharacterCodes.zeroWidthSpace:
+                    case CharacterCodes.narrowNoBreakSpace:
+                    case CharacterCodes.mathematicalSpace:
+                    case CharacterCodes.ideographicSpace:
+                    case CharacterCodes.byteOrderMark:
                         if (skipTrivia) {
                             pos++;
                             continue;

--- a/tests/baselines/reference/scannerNonAsciiHorizontalWhitespace.js
+++ b/tests/baselines/reference/scannerNonAsciiHorizontalWhitespace.js
@@ -1,0 +1,14 @@
+//// [scannerNonAsciiHorizontalWhitespace.ts]
+//// [scannerNonAsciiHorizontalWhitespace.ts]
+"  function f() {}"
+
+//// [scannerNonAsciiHorizontalWhitespace.js]
+"  function f() {}"
+
+
+
+//// [scannerNonAsciiHorizontalWhitespace.js]
+//// [scannerNonAsciiHorizontalWhitespace.ts]
+"  function f() {}";
+//// [scannerNonAsciiHorizontalWhitespace.js]
+"  function f() {}";

--- a/tests/baselines/reference/scannerNonAsciiHorizontalWhitespace.symbols
+++ b/tests/baselines/reference/scannerNonAsciiHorizontalWhitespace.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/scanner/ecmascript5/scannerNonAsciiHorizontalWhitespace.ts ===
+//// [scannerNonAsciiHorizontalWhitespace.ts]
+No type information for this code."  function f() {}"
+No type information for this code.
+No type information for this code.//// [scannerNonAsciiHorizontalWhitespace.js]
+No type information for this code."  function f() {}"
+No type information for this code.
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/scannerNonAsciiHorizontalWhitespace.types
+++ b/tests/baselines/reference/scannerNonAsciiHorizontalWhitespace.types
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/scanner/ecmascript5/scannerNonAsciiHorizontalWhitespace.ts ===
+//// [scannerNonAsciiHorizontalWhitespace.ts]
+"  function f() {}"
+>"  function f() {}" : "  function f() {}"
+
+//// [scannerNonAsciiHorizontalWhitespace.js]
+"  function f() {}"
+>"  function f() {}" : "  function f() {}"
+
+

--- a/tests/cases/conformance/scanner/ecmascript5/scannerNonAsciiHorizontalWhitespace.ts
+++ b/tests/cases/conformance/scanner/ecmascript5/scannerNonAsciiHorizontalWhitespace.ts
@@ -1,0 +1,6 @@
+//// [scannerNonAsciiHorizontalWhitespace.ts]
+"  function f() {}"
+
+//// [scannerNonAsciiHorizontalWhitespace.js]
+"  function f() {}"
+


### PR DESCRIPTION
Fixes #26464 
The included test case is not passing with `jake runtests tests=scannerNonAsciiHorizontalWhitespace`. Any pointers on scanner test cases?