### PR TITLE
Simplify call resolution logic

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15826,7 +15826,7 @@ namespace ts {
             }
             const iife = getImmediatelyInvokedFunctionExpression(func);
             if (iife && iife.arguments) {
-                const args = getEffectiveCallArguments(iife)!;
+                const args = getEffectiveCallArguments(iife);
                 const indexOfParameter = func.parameters.indexOf(parameter);
                 if (parameter.dotDotDotToken) {
                     return getSpreadArgumentType(args, indexOfParameter, args.length, anyType, /*context*/ undefined);
@@ -15955,7 +15955,7 @@ namespace ts {
 
         // In a typed function call, an argument or substitution expression is contextually typed by the type of the corresponding parameter.
         function getContextualTypeForArgument(callTarget: CallLikeExpression, arg: Expression): Type | undefined {
-            const args = getEffectiveCallArguments(callTarget)!; // TODO: GH#18217
+            const args = getEffectiveCallArguments(callTarget);
             const argIndex = args.indexOf(arg); // -1 for e.g. the expression of a CallExpression, or the tag of a TaggedTemplateExpression
             return argIndex === -1 ? undefined : getContextualTypeForArgumentAtIndex(callTarget, argIndex);
         }
@@ -18461,7 +18461,7 @@ namespace ts {
                 }
             }
             else if (node.kind === SyntaxKind.Decorator) {
-                argCount = getDecoratorArgumentCount(<Decorator>node, signature);
+                argCount = getDecoratorArgumentCount(node, signature);
             }
             else {
                 if (!node.arguments) {
@@ -18783,7 +18783,7 @@ namespace ts {
                 return args;
             }
             if (node.kind === SyntaxKind.Decorator) {
-                return getEffectiveDecoratorArguments(<Decorator>node);
+                return getEffectiveDecoratorArguments(node);
             }
             if (isJsxOpeningLikeElement(node)) {
                 return node.attributes.properties.length > 0 ? [node.attributes] : emptyArray;

--- a/tests/baselines/reference/fixingTypeParametersRepeatedly1.symbols
+++ b/tests/baselines/reference/fixingTypeParametersRepeatedly1.symbols
@@ -45,5 +45,7 @@ g("", x => null, x => x.toLowerCase());
 >g : Symbol(g, Decl(fixingTypeParametersRepeatedly1.ts, 1, 39), Decl(fixingTypeParametersRepeatedly1.ts, 4, 63))
 >x : Symbol(x, Decl(fixingTypeParametersRepeatedly1.ts, 6, 5))
 >x : Symbol(x, Decl(fixingTypeParametersRepeatedly1.ts, 6, 16))
+>x.toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
 >x : Symbol(x, Decl(fixingTypeParametersRepeatedly1.ts, 6, 16))
+>toLowerCase : Symbol(String.toLowerCase, Decl(lib.es5.d.ts, --, --))
 

--- a/tests/baselines/reference/fixingTypeParametersRepeatedly1.types
+++ b/tests/baselines/reference/fixingTypeParametersRepeatedly1.types
@@ -40,10 +40,10 @@ g("", x => null, x => x.toLowerCase());
 >x => null : (x: string) => any
 >x : string
 >null : null
->x => x.toLowerCase() : (x: any) => any
->x : any
->x.toLowerCase() : any
->x.toLowerCase : any
->x : any
->toLowerCase : any
+>x => x.toLowerCase() : (x: string) => string
+>x : string
+>x.toLowerCase() : string
+>x.toLowerCase : () => string
+>x : string
+>toLowerCase : () => string
 

--- a/tests/baselines/reference/parenthesizedContexualTyping1.types
+++ b/tests/baselines/reference/parenthesizedContexualTyping1.types
@@ -189,9 +189,9 @@ var k = fun((Math.random() < 0.5 ? (x => x) : (x => undefined)), x => x, 10);
 >x => undefined : (x: number) => any
 >x : number
 >undefined : undefined
->x => x : (x: any) => any
->x : any
->x : any
+>x => x : (x: number) => number
+>x : number
+>x : number
 >10 : 10
 
 var l = fun(((Math.random() < 0.5 ? ((x => x)) : ((x => undefined)))), ((x => x)), 10);
@@ -217,11 +217,11 @@ var l = fun(((Math.random() < 0.5 ? ((x => x)) : ((x => undefined)))), ((x => x)
 >x => undefined : (x: number) => any
 >x : number
 >undefined : undefined
->((x => x)) : (x: any) => any
->(x => x) : (x: any) => any
->x => x : (x: any) => any
->x : any
->x : any
+>((x => x)) : (x: number) => number
+>(x => x) : (x: number) => number
+>x => x : (x: number) => number
+>x : number
+>x : number
 >10 : 10
 
 var lambda1: (x: number) => number = x => x;


### PR DESCRIPTION
This PR simplifies our call resolution logic. Over time the `resolveCall` function had gotten quite unwieldy, particularly in the `getEffectiveArgumentXXX` functions that abstracted over access to the argument list. We now always construct an argument list and use `SyntheticExpression` nodes to represent synthetic arguments. Also, for reasons not entirely clear, we would include context sensitive arguments one at a time, with intervening full rounds of inference and applicability checking, instead of just including all of them in one go. The code is now easier to follow and about 250 lines shorter.