### PR TITLE
Allow super references to constructor function methods

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17866,6 +17866,12 @@ namespace ts {
 
         function symbolHasNonMethodDeclaration(symbol: Symbol) {
             return forEachProperty(symbol, prop => {
+                if (prop.valueDeclaration &&
+                    isPropertyAccessExpression(prop.valueDeclaration) &&
+                    getSpecialPropertyAccessKind(prop.valueDeclaration) === SpecialPropertyAssignmentKind.PrototypeProperty) {
+                    const init = getAssignedJavascriptInitializer(prop.valueDeclaration);
+                    return !init || !isFunctionExpressionOrArrowFunction(init);
+                }
                 const propKind = getDeclarationKindFromSymbol(prop);
                 return propKind !== SyntaxKind.MethodDeclaration && propKind !== SyntaxKind.MethodSignature;
             });

--- a/tests/baselines/reference/classCanExtendConstructorFunction.errors.txt
+++ b/tests/baselines/reference/classCanExtendConstructorFunction.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/salsa/first.js(18,9): error TS2554: Expected 1 arguments, but got 0.
-tests/cases/conformance/salsa/first.js(26,5): error TS2416: Property 'load' in type 'Sql' is not assignable to the same property in base type 'Wagon'.
+tests/cases/conformance/salsa/first.js(23,9): error TS2554: Expected 1 arguments, but got 0.
+tests/cases/conformance/salsa/first.js(31,5): error TS2416: Property 'load' in type 'Sql' is not assignable to the same property in base type 'Wagon'.
   Type '(files: string[], format: "csv" | "json" | "xmlolololol") => void' is not assignable to type '(supplies?: any[]) => void'.
-tests/cases/conformance/salsa/first.js(36,24): error TS2507: Type '(numberEaten: number) => void' is not a constructor function type.
+tests/cases/conformance/salsa/first.js(47,24): error TS2507: Type '(numberEaten: number) => void' is not a constructor function type.
 tests/cases/conformance/salsa/generic.js(8,15): error TS2508: No base constructor has the specified number of type arguments.
 tests/cases/conformance/salsa/generic.js(11,21): error TS2339: Property 'flavour' does not exist on type 'Chowder'.
 tests/cases/conformance/salsa/generic.js(18,9): error TS2339: Property 'flavour' does not exist on type 'Chowder'.
@@ -31,6 +31,11 @@ tests/cases/conformance/salsa/second.ts(17,15): error TS2345: Argument of type '
     /** @param {*[]=} supplies - *[]= is my favourite type */
     Wagon.prototype.load = function (supplies) {
     }
+    /** @param {*[]=} supplies - Yep, still a great type */
+    Wagon.prototype.weight = supplies => supplies ? supplies.length : -1
+    Wagon.prototype.speed = function () {
+        return this.numberOxen / this.weight()
+    }
     // ok
     class Sql extends Wagon {
         constructor() {
@@ -50,6 +55,12 @@ tests/cases/conformance/salsa/second.ts(17,15): error TS2345: Argument of type '
 !!! error TS2416:   Type '(files: string[], format: "csv" | "json" | "xmlolololol") => void' is not assignable to type '(supplies?: any[]) => void'.
             if (format === "xmlolololol") {
                 throw new Error("please do not use XML. It was a joke.");
+            }
+            else {
+                super.speed() // run faster
+                if (super.weight() < 0) {
+                    // ????????????????????????
+                }
             }
         }
     }

--- a/tests/baselines/reference/classCanExtendConstructorFunction.symbols
+++ b/tests/baselines/reference/classCanExtendConstructorFunction.symbols
@@ -34,9 +34,35 @@ Wagon.prototype.load = function (supplies) {
 >load : Symbol(Wagon.load, Decl(first.js, 10, 1))
 >supplies : Symbol(supplies, Decl(first.js, 12, 33))
 }
+/** @param {*[]=} supplies - Yep, still a great type */
+Wagon.prototype.weight = supplies => supplies ? supplies.length : -1
+>Wagon.prototype : Symbol(Wagon.weight, Decl(first.js, 13, 1))
+>Wagon : Symbol(Wagon, Decl(first.js, 0, 0), Decl(first.js, 6, 1))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>weight : Symbol(Wagon.weight, Decl(first.js, 13, 1))
+>supplies : Symbol(supplies, Decl(first.js, 15, 24))
+>supplies : Symbol(supplies, Decl(first.js, 15, 24))
+>supplies.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>supplies : Symbol(supplies, Decl(first.js, 15, 24))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+Wagon.prototype.speed = function () {
+>Wagon.prototype : Symbol(Wagon.speed, Decl(first.js, 15, 68))
+>Wagon : Symbol(Wagon, Decl(first.js, 0, 0), Decl(first.js, 6, 1))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>speed : Symbol(Wagon.speed, Decl(first.js, 15, 68))
+
+    return this.numberOxen / this.weight()
+>this.numberOxen : Symbol(Wagon.numberOxen, Decl(first.js, 4, 28))
+>this : Symbol(Wagon, Decl(first.js, 0, 0), Decl(first.js, 6, 1))
+>numberOxen : Symbol(Wagon.numberOxen, Decl(first.js, 4, 28))
+>this.weight : Symbol(Wagon.weight, Decl(first.js, 13, 1))
+>this : Symbol(Wagon, Decl(first.js, 0, 0), Decl(first.js, 6, 1))
+>weight : Symbol(Wagon.weight, Decl(first.js, 13, 1))
+}
 // ok
 class Sql extends Wagon {
->Sql : Symbol(Sql, Decl(first.js, 13, 1))
+>Sql : Symbol(Sql, Decl(first.js, 18, 1))
 >Wagon : Symbol(Wagon, Decl(first.js, 0, 0), Decl(first.js, 6, 1))
 
     constructor() {
@@ -44,9 +70,9 @@ class Sql extends Wagon {
 >super : Symbol(Wagon, Decl(first.js, 0, 0), Decl(first.js, 6, 1))
 
         this.foonly = 12
->this.foonly : Symbol(Sql.foonly, Decl(first.js, 17, 16))
->this : Symbol(Sql, Decl(first.js, 13, 1))
->foonly : Symbol(Sql.foonly, Decl(first.js, 17, 16))
+>this.foonly : Symbol(Sql.foonly, Decl(first.js, 22, 16))
+>this : Symbol(Sql, Decl(first.js, 18, 1))
+>foonly : Symbol(Sql.foonly, Decl(first.js, 22, 16))
     }
     /**
      * @param {Array.<string>} files
@@ -54,33 +80,47 @@ class Sql extends Wagon {
      * This is not assignable, so should have a type error
      */
     load(files, format) {
->load : Symbol(Sql.load, Decl(first.js, 19, 5))
->files : Symbol(files, Decl(first.js, 25, 9))
->format : Symbol(format, Decl(first.js, 25, 15))
+>load : Symbol(Sql.load, Decl(first.js, 24, 5))
+>files : Symbol(files, Decl(first.js, 30, 9))
+>format : Symbol(format, Decl(first.js, 30, 15))
 
         if (format === "xmlolololol") {
->format : Symbol(format, Decl(first.js, 25, 15))
+>format : Symbol(format, Decl(first.js, 30, 15))
 
             throw new Error("please do not use XML. It was a joke.");
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
         }
+        else {
+            super.speed() // run faster
+>super.speed : Symbol(Wagon.speed, Decl(first.js, 15, 68))
+>super : Symbol(Wagon, Decl(first.js, 0, 0), Decl(first.js, 6, 1))
+>speed : Symbol(Wagon.speed, Decl(first.js, 15, 68))
+
+            if (super.weight() < 0) {
+>super.weight : Symbol(Wagon.weight, Decl(first.js, 13, 1))
+>super : Symbol(Wagon, Decl(first.js, 0, 0), Decl(first.js, 6, 1))
+>weight : Symbol(Wagon.weight, Decl(first.js, 13, 1))
+
+                // ????????????????????????
+            }
+        }
     }
 }
 var db = new Sql();
->db : Symbol(db, Decl(first.js, 31, 3))
->Sql : Symbol(Sql, Decl(first.js, 13, 1))
+>db : Symbol(db, Decl(first.js, 42, 3))
+>Sql : Symbol(Sql, Decl(first.js, 18, 1))
 
 db.numberOxen = db.foonly
 >db.numberOxen : Symbol(Wagon.numberOxen, Decl(first.js, 4, 28))
->db : Symbol(db, Decl(first.js, 31, 3))
+>db : Symbol(db, Decl(first.js, 42, 3))
 >numberOxen : Symbol(Wagon.numberOxen, Decl(first.js, 4, 28))
->db.foonly : Symbol(Sql.foonly, Decl(first.js, 17, 16))
->db : Symbol(db, Decl(first.js, 31, 3))
->foonly : Symbol(Sql.foonly, Decl(first.js, 17, 16))
+>db.foonly : Symbol(Sql.foonly, Decl(first.js, 22, 16))
+>db : Symbol(db, Decl(first.js, 42, 3))
+>foonly : Symbol(Sql.foonly, Decl(first.js, 22, 16))
 
 // error, can't extend a TS constructor function
 class Drakkhen extends Dragon {
->Drakkhen : Symbol(Drakkhen, Decl(first.js, 32, 25))
+>Drakkhen : Symbol(Drakkhen, Decl(first.js, 43, 25))
 >Dragon : Symbol(Dragon, Decl(second.ts, 0, 0))
 
 }

--- a/tests/baselines/reference/classCanExtendConstructorFunction.types
+++ b/tests/baselines/reference/classCanExtendConstructorFunction.types
@@ -42,6 +42,43 @@ Wagon.prototype.load = function (supplies) {
 >function (supplies) {} : (supplies?: any[]) => void
 >supplies : any[]
 }
+/** @param {*[]=} supplies - Yep, still a great type */
+Wagon.prototype.weight = supplies => supplies ? supplies.length : -1
+>Wagon.prototype.weight = supplies => supplies ? supplies.length : -1 : (supplies?: any[]) => number
+>Wagon.prototype.weight : any
+>Wagon.prototype : any
+>Wagon : typeof Wagon
+>prototype : any
+>weight : any
+>supplies => supplies ? supplies.length : -1 : (supplies?: any[]) => number
+>supplies : any[]
+>supplies ? supplies.length : -1 : number
+>supplies : any[]
+>supplies.length : number
+>supplies : any[]
+>length : number
+>-1 : -1
+>1 : 1
+
+Wagon.prototype.speed = function () {
+>Wagon.prototype.speed = function () {    return this.numberOxen / this.weight()} : () => number
+>Wagon.prototype.speed : any
+>Wagon.prototype : any
+>Wagon : typeof Wagon
+>prototype : any
+>speed : any
+>function () {    return this.numberOxen / this.weight()} : () => number
+
+    return this.numberOxen / this.weight()
+>this.numberOxen / this.weight() : number
+>this.numberOxen : number
+>this : Wagon
+>numberOxen : number
+>this.weight() : number
+>this.weight : (supplies?: any[]) => number
+>this : Wagon
+>weight : (supplies?: any[]) => number
+}
 // ok
 class Sql extends Wagon {
 >Sql : Sql
@@ -78,6 +115,24 @@ class Sql extends Wagon {
 >new Error("please do not use XML. It was a joke.") : Error
 >Error : ErrorConstructor
 >"please do not use XML. It was a joke." : "please do not use XML. It was a joke."
+        }
+        else {
+            super.speed() // run faster
+>super.speed() : number
+>super.speed : () => number
+>super : Wagon
+>speed : () => number
+
+            if (super.weight() < 0) {
+>super.weight() < 0 : boolean
+>super.weight() : number
+>super.weight : (supplies?: any[]) => number
+>super : Wagon
+>weight : (supplies?: any[]) => number
+>0 : 0
+
+                // ????????????????????????
+            }
         }
     }
 }

--- a/tests/cases/conformance/salsa/classCanExtendConstructorFunction.ts
+++ b/tests/cases/conformance/salsa/classCanExtendConstructorFunction.ts
@@ -2,7 +2,6 @@
 // @allowJs: true
 // @checkJs: true
 // @Filename: first.js
-
 /**
  * @constructor
  * @param {number} numberOxen
@@ -16,6 +15,11 @@ Wagon.circle = function (wagons) {
 }
 /** @param {*[]=} supplies - *[]= is my favourite type */
 Wagon.prototype.load = function (supplies) {
+}
+/** @param {*[]=} supplies - Yep, still a great type */
+Wagon.prototype.weight = supplies => supplies ? supplies.length : -1
+Wagon.prototype.speed = function () {
+    return this.numberOxen / this.weight()
 }
 // ok
 class Sql extends Wagon {
@@ -31,6 +35,12 @@ class Sql extends Wagon {
     load(files, format) {
         if (format === "xmlolololol") {
             throw new Error("please do not use XML. It was a joke.");
+        }
+        else {
+            super.speed() // run faster
+            if (super.weight() < 0) {
+                // ????????????????????????
+            }
         }
     }
 }


### PR DESCRIPTION
Previously, they were mistakenly treated as private because of a check that required all super property accesses (like `super.x()`) to be references to a MethodDeclaration or MethodSignature. This change also allows PrototypeProperty special assignment kinds.

Fixes #26475 