### PR TITLE
Ensure for-in loop variable is checked

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18321,7 +18321,7 @@ namespace ts {
                 return errorType;
             }
 
-            const indexType = isForInVariableForNumericPropertyNames(indexExpression) ? numberType : checkExpression(indexExpression);
+            const indexType = checkExpression(indexExpression);
 
             if (objectType === errorType || objectType === silentNeverType) {
                 return objectType;
@@ -18332,7 +18332,7 @@ namespace ts {
                 return errorType;
             }
 
-            return checkIndexedAccessIndexType(getIndexedAccessType(objectType, indexType, node), node);
+            return checkIndexedAccessIndexType(getIndexedAccessType(objectType, isForInVariableForNumericPropertyNames(indexExpression) ? numberType : indexType, node), node);
         }
 
         function checkThatExpressionIsProperSymbolReference(expression: Expression, expressionType: Type, reportError: boolean): boolean {

--- a/tests/baselines/reference/capturedLetConstInLoop1.js
+++ b/tests/baselines/reference/capturedLetConstInLoop1.js
@@ -113,6 +113,16 @@ for (const y = 0; y < 1;) {
     (() => x + y);
 }
 
+// https://github.com/Microsoft/TypeScript/issues/20594
+declare const sobj: { [x: string]: any };
+for (let sx in sobj) {
+    (() => sobj[sx]);
+}
+declare const iobj: { [x: number]: any };
+for (let ix in iobj) {
+    (() => iobj[ix]);
+}
+
 //// [capturedLetConstInLoop1.js]
 var _loop_1 = function (x) {
     (function () { return x; });
@@ -269,4 +279,16 @@ var _loop_20 = function (y) {
 };
 for (var y = 0; y < 1;) {
     _loop_20(y);
+}
+var _loop_21 = function (sx) {
+    (function () { return sobj[sx]; });
+};
+for (var sx in sobj) {
+    _loop_21(sx);
+}
+var _loop_22 = function (ix) {
+    (function () { return iobj[ix]; });
+};
+for (var ix in iobj) {
+    _loop_22(ix);
 }

--- a/tests/baselines/reference/capturedLetConstInLoop1.symbols
+++ b/tests/baselines/reference/capturedLetConstInLoop1.symbols
@@ -258,3 +258,29 @@ for (const y = 0; y < 1;) {
 >x : Symbol(x, Decl(capturedLetConstInLoop1.ts, 109, 9))
 >y : Symbol(y, Decl(capturedLetConstInLoop1.ts, 108, 10))
 }
+
+// https://github.com/Microsoft/TypeScript/issues/20594
+declare const sobj: { [x: string]: any };
+>sobj : Symbol(sobj, Decl(capturedLetConstInLoop1.ts, 115, 13))
+>x : Symbol(x, Decl(capturedLetConstInLoop1.ts, 115, 23))
+
+for (let sx in sobj) {
+>sx : Symbol(sx, Decl(capturedLetConstInLoop1.ts, 116, 8))
+>sobj : Symbol(sobj, Decl(capturedLetConstInLoop1.ts, 115, 13))
+
+    (() => sobj[sx]);
+>sobj : Symbol(sobj, Decl(capturedLetConstInLoop1.ts, 115, 13))
+>sx : Symbol(sx, Decl(capturedLetConstInLoop1.ts, 116, 8))
+}
+declare const iobj: { [x: number]: any };
+>iobj : Symbol(iobj, Decl(capturedLetConstInLoop1.ts, 119, 13))
+>x : Symbol(x, Decl(capturedLetConstInLoop1.ts, 119, 23))
+
+for (let ix in iobj) {
+>ix : Symbol(ix, Decl(capturedLetConstInLoop1.ts, 120, 8))
+>iobj : Symbol(iobj, Decl(capturedLetConstInLoop1.ts, 119, 13))
+
+    (() => iobj[ix]);
+>iobj : Symbol(iobj, Decl(capturedLetConstInLoop1.ts, 119, 13))
+>ix : Symbol(ix, Decl(capturedLetConstInLoop1.ts, 120, 8))
+}

--- a/tests/baselines/reference/capturedLetConstInLoop1.types
+++ b/tests/baselines/reference/capturedLetConstInLoop1.types
@@ -426,3 +426,35 @@ for (const y = 0; y < 1;) {
 >x : 1
 >y : 0
 }
+
+// https://github.com/Microsoft/TypeScript/issues/20594
+declare const sobj: { [x: string]: any };
+>sobj : { [x: string]: any; }
+>x : string
+
+for (let sx in sobj) {
+>sx : string
+>sobj : { [x: string]: any; }
+
+    (() => sobj[sx]);
+>(() => sobj[sx]) : () => any
+>() => sobj[sx] : () => any
+>sobj[sx] : any
+>sobj : { [x: string]: any; }
+>sx : string
+}
+declare const iobj: { [x: number]: any };
+>iobj : { [x: number]: any; }
+>x : number
+
+for (let ix in iobj) {
+>ix : string
+>iobj : { [x: number]: any; }
+
+    (() => iobj[ix]);
+>(() => iobj[ix]) : () => any
+>() => iobj[ix] : () => any
+>iobj[ix] : any
+>iobj : { [x: number]: any; }
+>ix : string
+}

--- a/tests/cases/compiler/capturedLetConstInLoop1.ts
+++ b/tests/cases/compiler/capturedLetConstInLoop1.ts
@@ -111,3 +111,13 @@ for (const y = 0; y < 1;) {
     (function() { return x + y});
     (() => x + y);
 }
+
+// https://github.com/Microsoft/TypeScript/issues/20594
+declare const sobj: { [x: string]: any };
+for (let sx in sobj) {
+    (() => sobj[sx]);
+}
+declare const iobj: { [x: number]: any };
+for (let ix in iobj) {
+    (() => iobj[ix]);
+}


### PR DESCRIPTION
Our logic in `checkIndexedAccess` skips calling `checkExpression` when the index expression is a variable of a `for..in` statement whose expression has a number indexer, and shortcuts to just using `numberType`. By not calling `checkExpression`, we never end up calling `checkIdentifier`. As a result, we never set the check flag indicating whether the identifier is a block scope variable captured by a function in a loop.

This PR changes our current behavior so that we always call `checkExpression` to preserve its side-effects, even if we don't use its type.

Fixes #20594 

