### PR TITLE
remove Animation from chrome-devtools' user test shim

### DIFF
--- a/tests/cases/user/chrome-devtools-frontend/definitions.js
+++ b/tests/cases/user/chrome-devtools-frontend/definitions.js
@@ -1,6 +1,5 @@
 var Accessibility = {};
 var AccessibilityTestRunner = {};
-var Animation = {};
 var ApplicationTestRunner = {};
 var Audits = {};
 var Audits2 = {};


### PR DESCRIPTION
It looks like it's successfully merging with the DOM definition now instead.

