### PR TITLE
Remove unnecessary callback in runBaseline

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1639,11 +1639,7 @@ Actual: ${stringify(fullActual)}`);
                 baselineFile = baselineFile.replace(ts.Extension.Ts, ".baseline");
 
             }
-            Harness.Baseline.runBaseline(
-                baselineFile,
-                () => {
-                    return this.baselineCurrentFileLocations(pos => this.getBreakpointStatementLocation(pos)!);
-                });
+            Harness.Baseline.runBaseline(baselineFile, this.baselineCurrentFileLocations(pos => this.getBreakpointStatementLocation(pos)!));
         }
 
         private getEmitFiles(): ReadonlyArray<FourSlashFile> {
@@ -1680,44 +1676,40 @@ Actual: ${stringify(fullActual)}`);
         }
 
         public baselineGetEmitOutput(): void {
-            Harness.Baseline.runBaseline(
-                ts.Debug.assertDefined(this.testData.globalOptions[MetadataOptionNames.baselineFile]),
-                () => {
-                    let resultString = "";
-                    // Loop through all the emittedFiles and emit them one by one
-                    for (const emitFile of this.getEmitFiles()) {
-                        const emitOutput = this.languageService.getEmitOutput(emitFile.fileName);
-                        // Print emitOutputStatus in readable format
-                        resultString += "EmitSkipped: " + emitOutput.emitSkipped + Harness.IO.newLine();
+            let resultString = "";
+            // Loop through all the emittedFiles and emit them one by one
+            for (const emitFile of this.getEmitFiles()) {
+                const emitOutput = this.languageService.getEmitOutput(emitFile.fileName);
+                // Print emitOutputStatus in readable format
+                resultString += "EmitSkipped: " + emitOutput.emitSkipped + Harness.IO.newLine();
 
-                        if (emitOutput.emitSkipped) {
-                            resultString += "Diagnostics:" + Harness.IO.newLine();
-                            const diagnostics = ts.getPreEmitDiagnostics(this.languageService.getProgram()!); // TODO: GH#18217
-                            for (const diagnostic of diagnostics) {
-                                if (!ts.isString(diagnostic.messageText)) {
-                                    let chainedMessage: ts.DiagnosticMessageChain | undefined = diagnostic.messageText;
-                                    let indentation = " ";
-                                    while (chainedMessage) {
-                                        resultString += indentation + chainedMessage.messageText + Harness.IO.newLine();
-                                        chainedMessage = chainedMessage.next;
-                                        indentation = indentation + " ";
-                                    }
-                                }
-                                else {
-                                    resultString += "  " + diagnostic.messageText + Harness.IO.newLine();
-                                }
+                if (emitOutput.emitSkipped) {
+                    resultString += "Diagnostics:" + Harness.IO.newLine();
+                    const diagnostics = ts.getPreEmitDiagnostics(this.languageService.getProgram()!); // TODO: GH#18217
+                    for (const diagnostic of diagnostics) {
+                        if (!ts.isString(diagnostic.messageText)) {
+                            let chainedMessage: ts.DiagnosticMessageChain | undefined = diagnostic.messageText;
+                            let indentation = " ";
+                            while (chainedMessage) {
+                                resultString += indentation + chainedMessage.messageText + Harness.IO.newLine();
+                                chainedMessage = chainedMessage.next;
+                                indentation = indentation + " ";
                             }
                         }
-
-                        for (const outputFile of emitOutput.outputFiles) {
-                            const fileName = "FileName : " + outputFile.name + Harness.IO.newLine();
-                            resultString = resultString + Harness.IO.newLine() + fileName + outputFile.text;
+                        else {
+                            resultString += "  " + diagnostic.messageText + Harness.IO.newLine();
                         }
-                        resultString += Harness.IO.newLine();
                     }
+                }
 
-                    return resultString;
-                });
+                for (const outputFile of emitOutput.outputFiles) {
+                    const fileName = "FileName : " + outputFile.name + Harness.IO.newLine();
+                    resultString = resultString + Harness.IO.newLine() + fileName + outputFile.text;
+                }
+                resultString += Harness.IO.newLine();
+            }
+
+            Harness.Baseline.runBaseline(ts.Debug.assertDefined(this.testData.globalOptions[MetadataOptionNames.baselineFile]), resultString);
         }
 
         public baselineQuickInfo() {
@@ -1728,12 +1720,11 @@ Actual: ${stringify(fullActual)}`);
 
             Harness.Baseline.runBaseline(
                 baselineFile,
-                () => stringify(
+                stringify(
                     this.testData.markers.map(marker => ({
                         marker,
                         quickInfo: this.languageService.getQuickInfoAtPosition(marker.fileName, marker.position)
-                    }))
-                ));
+                    }))));
         }
 
         public printBreakpointLocation(pos: number) {
@@ -2347,10 +2338,7 @@ Actual: ${stringify(fullActual)}`);
         public baselineCurrentFileNameOrDottedNameSpans() {
             Harness.Baseline.runBaseline(
                 this.testData.globalOptions[MetadataOptionNames.baselineFile],
-                () => {
-                    return this.baselineCurrentFileLocations(pos =>
-                        this.getNameOrDottedNameSpan(pos)!);
-                });
+                this.baselineCurrentFileLocations(pos => this.getNameOrDottedNameSpan(pos)!));
         }
 
         public printNameOrDottedNameSpans(pos: number) {

--- a/src/testRunner/compilerRunner.ts
+++ b/src/testRunner/compilerRunner.ts
@@ -207,24 +207,19 @@ class CompilerTest {
 
     public verifyModuleResolution() {
         if (this.options.traceResolution) {
-            Harness.Baseline.runBaseline(this.justName.replace(/\.tsx?$/, ".trace.json"), () => {
-                return utils.removeTestPathPrefixes(JSON.stringify(this.result.traces, undefined, 4));
-            });
+            Harness.Baseline.runBaseline(this.justName.replace(/\.tsx?$/, ".trace.json"),
+                utils.removeTestPathPrefixes(JSON.stringify(this.result.traces, undefined, 4)));
         }
     }
 
     public verifySourceMapRecord() {
         if (this.options.sourceMap || this.options.inlineSourceMap || this.options.declarationMap) {
-            Harness.Baseline.runBaseline(this.justName.replace(/\.tsx?$/, ".sourcemap.txt"), () => {
-                const record = utils.removeTestPathPrefixes(this.result.getSourceMapRecord()!);
-                if ((this.options.noEmitOnError && this.result.diagnostics.length !== 0) || record === undefined) {
-                    // Because of the noEmitOnError option no files are created. We need to return null because baselining isn't required.
-                    /* tslint:disable:no-null-keyword */
-                    return null;
-                    /* tslint:enable:no-null-keyword */
-                }
-                return record;
-            });
+            const record = utils.removeTestPathPrefixes(this.result.getSourceMapRecord()!);
+            const baseline = (this.options.noEmitOnError && this.result.diagnostics.length !== 0) || record === undefined
+                // Because of the noEmitOnError option no files are created. We need to return null because baselining isn't required.
+                ? null // tslint:disable-line no-null-keyword
+                : record;
+            Harness.Baseline.runBaseline(this.justName.replace(/\.tsx?$/, ".sourcemap.txt"), baseline);
         }
     }
 

--- a/src/testRunner/externalCompileRunner.ts
+++ b/src/testRunner/externalCompileRunner.ts
@@ -80,9 +80,7 @@ abstract class ExternalCompileRunnerBase extends RunnerBase {
                     if (install.status !== 0) throw new Error(`NPM Install types for ${directoryName} failed: ${install.stderr.toString()}`);
                 }
                 args.push("--noEmit");
-                Harness.Baseline.runBaseline(`${cls.kind()}/${directoryName}.log`, () => {
-                    return cls.report(cp.spawnSync(`node`, args, { cwd, timeout, shell: true }), cwd);
-                });
+                Harness.Baseline.runBaseline(`${cls.kind()}/${directoryName}.log`, cls.report(cp.spawnSync(`node`, args, { cwd, timeout, shell: true }), cwd));
             });
         });
     }

--- a/src/testRunner/projectsRunner.ts
+++ b/src/testRunner/projectsRunner.ts
@@ -211,14 +211,12 @@ namespace project {
                 .map(output => utils.removeTestPathPrefixes(vpath.isAbsolute(output) ? vpath.relative(cwd, output, ignoreCase) : output));
 
             const content = JSON.stringify(resolutionInfo, undefined, "    ");
-            Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + this.testCaseJustName + ".json", () => content);
+            Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + this.testCaseJustName + ".json", content);
         }
 
         public verifyDiagnostics() {
             if (this.compilerResult.errors.length) {
-                Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + this.testCaseJustName + ".errors.txt", () => {
-                    return getErrorsBaseline(this.compilerResult);
-                });
+                Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + this.testCaseJustName + ".errors.txt", getErrorsBaseline(this.compilerResult));
             }
         }
 
@@ -244,7 +242,7 @@ namespace project {
                         }
 
                         const content = utils.removeTestPathPrefixes(output.text, /*retainTrailingDirectorySeparator*/ true);
-                        Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + diskRelativeName, () => content as string | null); // TODO: GH#18217
+                        Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + diskRelativeName, content as string | null); // TODO: GH#18217
                     }
                     catch (e) {
                         errs.push(e);
@@ -271,9 +269,7 @@ namespace project {
             if (!this.compilerResult.errors.length && this.testCase.declaration) {
                 const dTsCompileResult = this.compileDeclarations(this.compilerResult);
                 if (dTsCompileResult && dTsCompileResult.errors.length) {
-                    Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + this.testCaseJustName + ".dts.errors.txt", () => {
-                        return getErrorsBaseline(dTsCompileResult);
-                    });
+                    Harness.Baseline.runBaseline(this.getBaselineFolder(this.compilerResult.moduleKind) + this.testCaseJustName + ".dts.errors.txt", getErrorsBaseline(dTsCompileResult));
                 }
             }
         }

--- a/src/testRunner/test262Runner.ts
+++ b/src/testRunner/test262Runner.ts
@@ -63,21 +63,14 @@ class Test262BaselineRunner extends RunnerBase {
             });
 
             it("has the expected emitted code", () => {
-                Harness.Baseline.runBaseline(testState.filename + ".output.js", () => {
-                    const files = Array.from(testState.compilerResult.js.values()).filter(f => f.file !== Test262BaselineRunner.helpersFilePath);
-                    return Harness.Compiler.collateOutputs(files);
-                }, Test262BaselineRunner.baselineOptions);
+                const files = Array.from(testState.compilerResult.js.values()).filter(f => f.file !== Test262BaselineRunner.helpersFilePath);
+                Harness.Baseline.runBaseline(testState.filename + ".output.js", Harness.Compiler.collateOutputs(files), Test262BaselineRunner.baselineOptions);
             });
 
             it("has the expected errors", () => {
-                Harness.Baseline.runBaseline(testState.filename + ".errors.txt", () => {
-                    const errors = testState.compilerResult.diagnostics;
-                    if (errors.length === 0) {
-                        return null;
-                    }
-
-                    return Harness.Compiler.getErrorBaseline(testState.inputFiles, errors);
-                }, Test262BaselineRunner.baselineOptions);
+                const errors = testState.compilerResult.diagnostics;
+                const baseline = errors.length === 0 ? null : Harness.Compiler.getErrorBaseline(testState.inputFiles, errors);
+                Harness.Baseline.runBaseline(testState.filename + ".errors.txt", baseline, Test262BaselineRunner.baselineOptions);
             });
 
             it("satisfies invariants", () => {
@@ -86,10 +79,8 @@ class Test262BaselineRunner extends RunnerBase {
             });
 
             it("has the expected AST", () => {
-                Harness.Baseline.runBaseline(testState.filename + ".AST.txt", () => {
-                    const sourceFile = testState.compilerResult.program!.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename))!;
-                    return Utils.sourceFileToJSON(sourceFile);
-                }, Test262BaselineRunner.baselineOptions);
+                const sourceFile = testState.compilerResult.program!.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename))!;
+                Harness.Baseline.runBaseline(testState.filename + ".AST.txt", Utils.sourceFileToJSON(sourceFile), Test262BaselineRunner.baselineOptions);
             });
         });
     }

--- a/src/testRunner/unittests/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/convertToAsyncFunction.ts
@@ -400,21 +400,19 @@ interface Array<T> {}`
             const action = find(actions, action => action.description === description.message)!;
             assert.isNotNull(action);
 
-            Harness.Baseline.runBaseline(`${baselineFolder}/${caption}${extension}`, () => {
-                const data: string[] = [];
-                data.push(`// ==ORIGINAL==`);
-                data.push(text.replace("[#|", "/*[#|*/").replace("|]", "/*|]*/"));
-                const changes = action.changes;
-                assert.lengthOf(changes, 1);
+            const data: string[] = [];
+            data.push(`// ==ORIGINAL==`);
+            data.push(text.replace("[#|", "/*[#|*/").replace("|]", "/*|]*/"));
+            const changes = action.changes;
+            assert.lengthOf(changes, 1);
 
-                data.push(`// ==ASYNC FUNCTION::${action.description}==`);
-                const newText = textChanges.applyChanges(sourceFile.text, changes[0].textChanges);
-                data.push(newText);
+            data.push(`// ==ASYNC FUNCTION::${action.description}==`);
+            const newText = textChanges.applyChanges(sourceFile.text, changes[0].textChanges);
+            data.push(newText);
 
-                const diagProgram = makeProgram({ path, content: newText }, includeLib)!;
-                assert.isFalse(hasSyntacticDiagnostics(diagProgram));
-                return data.join(newLineCharacter);
-            });
+            const diagProgram = makeProgram({ path, content: newText }, includeLib)!;
+            assert.isFalse(hasSyntacticDiagnostics(diagProgram));
+            Harness.Baseline.runBaseline(`${baselineFolder}/${caption}${extension}`, data.join(newLineCharacter));
         }
 
         function makeProgram(f: { path: string, content: string }, includeLib?: boolean) {
@@ -462,7 +460,7 @@ function [#|f|](): Promise<void>{
 function [#|f|](): Promise<void>{
     /* Note - some of these comments are removed during the refactor. This is not ideal. */
 
-    // a 
+    // a
     /*b*/ return /*c*/ fetch( /*d*/ 'https://typescriptlang.org' /*e*/).then( /*f*/ result /*g*/ => { /*h*/ console.log(/*i*/ result /*j*/) /*k*/}/*l*/);
     // m
 }`);
@@ -580,7 +578,7 @@ function [#|f|]():Promise<Response> {
         _testConvertToAsyncFunction("convertToAsyncFunction_PromiseDotAll", `
 function [#|f|]():Promise<void>{
     return Promise.all([fetch('https://typescriptlang.org'), fetch('https://microsoft.com'), fetch('https://youtube.com')]).then(function(vals){
-        vals.forEach(console.log); 
+        vals.forEach(console.log);
     });
 }
 `
@@ -664,7 +662,7 @@ function [#|innerPromise|](): Promise<string> {
         var blob2 = resp.blob().then(blob => blob.byteOffset).catch(err => 'Error');
         return blob2;
     }).then(blob => {
-        return blob.toString();   
+        return blob.toString();
     });
 }
 `
@@ -674,7 +672,7 @@ function [#|innerPromise|](): Promise<string> {
     return fetch("https://typescriptlang.org").then(resp => {
         return resp.blob().then(blob => blob.byteOffset).catch(err => 'Error');
     }).then(blob => {
-        return blob.toString();   
+        return blob.toString();
     });
 }
 `
@@ -914,7 +912,7 @@ function [#|f|]() {
         _testConvertToAsyncFunction("convertToAsyncFunction_Scope1", `
 function [#|f|]() {
     var var1:Promise<Response>, var2;
-    return fetch('https://typescriptlang.org').then( _ => 
+    return fetch('https://typescriptlang.org').then( _ =>
       Promise.resolve().then( res => {
         var2 = "test";
         return fetch("https://microsoft.com");
@@ -933,11 +931,11 @@ function [#|f|](){
     return fetch("https://typescriptlang.org").then(res => {
       if (res.ok) {
         return fetch("https://microsoft.com");
-      } 
+      }
       else {
         if (res.buffer.length > 5) {
           return res;
-        } 
+        }
         else {
             return fetch("https://github.com");
         }
@@ -1177,7 +1175,7 @@ function [#|f|]() {
       }
     };
   });
-} 
+}
 `
         );
 
@@ -1190,25 +1188,25 @@ function [#|f|]() {
         return fn3();
     }
     return fn2();
-} 
+}
 `);
 
         _testConvertToAsyncFunction("convertToAsyncFunction_UntypedFunction", `
 function [#|f|]() {
     return Promise.resolve().then(res => console.log(res));
-} 
+}
 `);
 
         _testConvertToAsyncFunction("convertToAsyncFunction_TernaryConditional", `
 function [#|f|]() {
     let i;
     return Promise.resolve().then(res => res ? i = res : i = 100);
-} 
+}
 `);
 
     _testConvertToAsyncFunction("convertToAsyncFunction_ResRejNoArgsArrow", `
     function [#|f|]() {
-        return Promise.resolve().then(() => 1, () => "a"); 
+        return Promise.resolve().then(() => 1, () => "a");
     }
 `);
 

--- a/src/testRunner/unittests/customTransforms.ts
+++ b/src/testRunner/unittests/customTransforms.ts
@@ -20,15 +20,13 @@ namespace ts {
 
                 const program = createProgram(arrayFrom(fileMap.keys()), options, host);
                 program.emit(/*targetSourceFile*/ undefined, host.writeFile, /*cancellationToken*/ undefined, /*emitOnlyDtsFiles*/ false, customTransformers);
-                Harness.Baseline.runBaseline(`customTransforms/${name}.js`, () => {
-                    let content = "";
-                    for (const [file, text] of arrayFrom(outputs.entries())) {
-                        if (content) content += "\n\n";
-                        content += `// [${file}]\n`;
-                        content += text;
-                    }
-                    return content;
-                });
+                let content = "";
+                for (const [file, text] of arrayFrom(outputs.entries())) {
+                    if (content) content += "\n\n";
+                    content += `// [${file}]\n`;
+                    content += text;
+                }
+                Harness.Baseline.runBaseline(`customTransforms/${name}.js`, content);
             });
         }
 

--- a/src/testRunner/unittests/extractTestHelpers.ts
+++ b/src/testRunner/unittests/extractTestHelpers.ts
@@ -131,23 +131,21 @@ namespace ts {
             const infos = refactor.extractSymbol.getAvailableActions(context)!;
             const actions = find(infos, info => info.description === description.message)!.actions;
 
-            Harness.Baseline.runBaseline(`${baselineFolder}/${caption}${extension}`, () => {
-                const data: string[] = [];
-                data.push(`// ==ORIGINAL==`);
-                data.push(text.replace("[#|", "/*[#|*/").replace("|]", "/*|]*/"));
-                for (const action of actions) {
-                    const { renameLocation, edits } = refactor.extractSymbol.getEditsForAction(context, action.name)!;
-                    assert.lengthOf(edits, 1);
-                    data.push(`// ==SCOPE::${action.description}==`);
-                    const newText = textChanges.applyChanges(sourceFile.text, edits[0].textChanges);
-                    const newTextWithRename = newText.slice(0, renameLocation) + "/*RENAME*/" + newText.slice(renameLocation);
-                    data.push(newTextWithRename);
+            const data: string[] = [];
+            data.push(`// ==ORIGINAL==`);
+            data.push(text.replace("[#|", "/*[#|*/").replace("|]", "/*|]*/"));
+            for (const action of actions) {
+                const { renameLocation, edits } = refactor.extractSymbol.getEditsForAction(context, action.name)!;
+                assert.lengthOf(edits, 1);
+                data.push(`// ==SCOPE::${action.description}==`);
+                const newText = textChanges.applyChanges(sourceFile.text, edits[0].textChanges);
+                const newTextWithRename = newText.slice(0, renameLocation) + "/*RENAME*/" + newText.slice(renameLocation);
+                data.push(newTextWithRename);
 
-                    const diagProgram = makeProgram({ path, content: newText }, includeLib);
-                    assert.isFalse(hasSyntacticDiagnostics(diagProgram));
-                }
-                return data.join(newLineCharacter);
-            });
+                const diagProgram = makeProgram({ path, content: newText }, includeLib);
+                assert.isFalse(hasSyntacticDiagnostics(diagProgram));
+            }
+            Harness.Baseline.runBaseline(`${baselineFolder}/${caption}${extension}`, data.join(newLineCharacter));
         }
 
         function makeProgram(f: {path: string, content: string }, includeLib?: boolean) {

--- a/src/testRunner/unittests/initializeTSConfig.ts
+++ b/src/testRunner/unittests/initializeTSConfig.ts
@@ -7,7 +7,7 @@ namespace ts {
                 const outputFileName = `tsConfig/${name.replace(/[^a-z0-9\-. ]/ig, "")}/tsconfig.json`;
 
                 it(`Correct output for ${outputFileName}`, () => {
-                    Harness.Baseline.runBaseline(outputFileName, () => initResult);
+                    Harness.Baseline.runBaseline(outputFileName, initResult);
                 });
             });
         }

--- a/src/testRunner/unittests/jsDocParsing.ts
+++ b/src/testRunner/unittests/jsDocParsing.ts
@@ -7,7 +7,7 @@ namespace ts {
                     assert.isTrue(typeAndDiagnostics && typeAndDiagnostics.diagnostics.length === 0, "no errors issued");
 
                     Harness.Baseline.runBaseline("JSDocParsing/TypeExpressions.parsesCorrectly." + name + ".json",
-                        () => Utils.sourceFileToJSON(typeAndDiagnostics!.jsDocTypeExpression.type));
+                        Utils.sourceFileToJSON(typeAndDiagnostics!.jsDocTypeExpression.type));
                 });
             }
 
@@ -95,7 +95,7 @@ namespace ts {
                     }
 
                     Harness.Baseline.runBaseline("JSDocParsing/DocComments.parsesCorrectly." + name + ".json",
-                        () => JSON.stringify(comment.jsDoc,
+                        JSON.stringify(comment.jsDoc,
                             (_, v) => v && v.pos !== undefined ? JSON.parse(Utils.sourceFileToJSON(v)) : v, 4));
                 });
             }

--- a/src/testRunner/unittests/organizeImports.ts
+++ b/src/testRunner/unittests/organizeImports.ts
@@ -745,15 +745,13 @@ export * from "lib";
                 assert.equal(changes.length, 1);
                 assert.equal(changes[0].fileName, testPath);
 
-                Harness.Baseline.runBaseline(baselinePath, () => {
-                    const newText = textChanges.applyChanges(testContent, changes[0].textChanges);
-                    return [
-                        "// ==ORIGINAL==",
-                        testContent,
-                        "// ==ORGANIZED==",
-                        newText,
-                    ].join(newLineCharacter);
-                });
+                const newText = textChanges.applyChanges(testContent, changes[0].textChanges);
+                Harness.Baseline.runBaseline(baselinePath, [
+                    "// ==ORIGINAL==",
+                    testContent,
+                    "// ==ORGANIZED==",
+                    newText,
+                ].join(newLineCharacter));
             }
 
             function makeLanguageService(...files: TestFSWithWatch.File[]) {

--- a/src/testRunner/unittests/printer.ts
+++ b/src/testRunner/unittests/printer.ts
@@ -3,7 +3,7 @@ namespace ts {
         function makePrintsCorrectly(prefix: string) {
             return function printsCorrectly(name: string, options: PrinterOptions, printCallback: (printer: Printer) => string) {
                 it(name, () => {
-                    Harness.Baseline.runBaseline(`printerApi/${prefix}.${name}.js`, () =>
+                    Harness.Baseline.runBaseline(`printerApi/${prefix}.${name}.js`,
                         printCallback(createPrinter({ newLine: NewLineKind.CarriageReturnLineFeed, ...options })));
                 });
             };

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -10,7 +10,7 @@ describe("Public APIs", () => {
         });
 
         it("should be acknowledged when they change", () => {
-            Harness.Baseline.runBaseline(api, () => fileContent);
+            Harness.Baseline.runBaseline(api, fileContent);
         });
 
         it("should compile", () => {

--- a/src/testRunner/unittests/textChanges.ts
+++ b/src/testRunner/unittests/textChanges.ts
@@ -47,17 +47,15 @@ namespace ts {
 
         function runSingleFileTest(caption: string, placeOpenBraceOnNewLineForFunctions: boolean, text: string, validateNodes: boolean, testBlock: (sourceFile: SourceFile, changeTracker: textChanges.ChangeTracker) => void) {
             it(caption, () => {
-                Harness.Baseline.runBaseline(`textChanges/${caption}.js`, () => {
-                    const sourceFile = createSourceFile("source.ts", text, ScriptTarget.ES2015, /*setParentNodes*/ true);
-                    const rulesProvider = getRuleProvider(placeOpenBraceOnNewLineForFunctions);
-                    const changeTracker = new textChanges.ChangeTracker(newLineCharacter, rulesProvider);
-                    testBlock(sourceFile, changeTracker);
-                    const changes = changeTracker.getChanges(validateNodes ? verifyPositions : undefined);
-                    assert.equal(changes.length, 1);
-                    assert.equal(changes[0].fileName, sourceFile.fileName);
-                    const modified = textChanges.applyChanges(sourceFile.text, changes[0].textChanges);
-                    return `===ORIGINAL===${newLineCharacter}${text}${newLineCharacter}===MODIFIED===${newLineCharacter}${modified}`;
-                });
+                const sourceFile = createSourceFile("source.ts", text, ScriptTarget.ES2015, /*setParentNodes*/ true);
+                const rulesProvider = getRuleProvider(placeOpenBraceOnNewLineForFunctions);
+                const changeTracker = new textChanges.ChangeTracker(newLineCharacter, rulesProvider);
+                testBlock(sourceFile, changeTracker);
+                const changes = changeTracker.getChanges(validateNodes ? verifyPositions : undefined);
+                assert.equal(changes.length, 1);
+                assert.equal(changes[0].fileName, sourceFile.fileName);
+                const modified = textChanges.applyChanges(sourceFile.text, changes[0].textChanges);
+                Harness.Baseline.runBaseline(`textChanges/${caption}.js`, `===ORIGINAL===${newLineCharacter}${text}${newLineCharacter}===MODIFIED===${newLineCharacter}${modified}`);
             });
         }
 

--- a/src/testRunner/unittests/transform.ts
+++ b/src/testRunner/unittests/transform.ts
@@ -53,7 +53,7 @@ namespace ts {
 
         function testBaseline(testName: string, test: () => string) {
             it(testName, () => {
-                Harness.Baseline.runBaseline(`transformApi/transformsCorrectly.${testName}.js`, test);
+                Harness.Baseline.runBaseline(`transformApi/transformsCorrectly.${testName}.js`, test());
             });
         }
 

--- a/src/testRunner/unittests/transpile.ts
+++ b/src/testRunner/unittests/transpile.ts
@@ -57,50 +57,26 @@ namespace ts {
                 });
 
                 it("Correct errors for " + justName, () => {
-                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".errors.txt"), () => {
-                        if (transpileResult.diagnostics!.length === 0) {
-                            /* tslint:disable:no-null-keyword */
-                            return null;
-                            /* tslint:enable:no-null-keyword */
-                        }
-
-                        return Harness.Compiler.getErrorBaseline(toBeCompiled, transpileResult.diagnostics!);
-                    });
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".errors.txt"),
+                        // tslint:disable-next-line no-null-keyword
+                        transpileResult.diagnostics!.length === 0 ? null : Harness.Compiler.getErrorBaseline(toBeCompiled, transpileResult.diagnostics!));
                 });
 
                 if (canUseOldTranspile) {
                     it("Correct errors (old transpile) for " + justName, () => {
-                        Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".oldTranspile.errors.txt"), () => {
-                            if (oldTranspileDiagnostics.length === 0) {
-                                /* tslint:disable:no-null-keyword */
-                                return null;
-                                /* tslint:enable:no-null-keyword */
-                            }
-
-                            return Harness.Compiler.getErrorBaseline(toBeCompiled, oldTranspileDiagnostics);
-                        });
+                        Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".oldTranspile.errors.txt"),
+                            // tslint:disable-next-line no-null-keyword
+                            oldTranspileDiagnostics.length === 0 ? null : Harness.Compiler.getErrorBaseline(toBeCompiled, oldTranspileDiagnostics));
                     });
                 }
 
                 it("Correct output for " + justName, () => {
-                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, Extension.Js), () => {
-                        if (transpileResult.outputText) {
-                            return transpileResult.outputText;
-                        }
-                        else {
-                            // This can happen if compiler recieve invalid compiler-options
-                            /* tslint:disable:no-null-keyword */
-                            return null;
-                            /* tslint:enable:no-null-keyword */
-                        }
-                    });
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, Extension.Js), transpileResult.outputText);
                 });
 
                 if (canUseOldTranspile) {
                     it("Correct output (old transpile) for " + justName, () => {
-                        Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".oldTranspile.js"), () => {
-                            return oldTranspileResult;
-                        });
+                        Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".oldTranspile.js"), oldTranspileResult);
                     });
                 }
             });

--- a/src/testRunner/unittests/tsbuild.ts
+++ b/src/testRunner/unittests/tsbuild.ts
@@ -284,11 +284,9 @@ namespace ts {
                 fs = undefined;
             });
             it(`Generates files matching the baseline`, () => {
-                Harness.Baseline.runBaseline("outfile-concat.js", () => {
-                    const patch = fs!.diff();
-                    // tslint:disable-next-line:no-null-keyword
-                    return patch ? vfs.formatPatch(patch) : null;
-                });
+                const patch = fs!.diff();
+                // tslint:disable-next-line:no-null-keyword
+                Harness.Baseline.runBaseline("outfile-concat.js", patch ? vfs.formatPatch(patch) : null);
             });
         });
 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Conditionals.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Conditionals.js
@@ -4,11 +4,11 @@ function /*[#|*/f/*|]*/(){
     return fetch("https://typescriptlang.org").then(res => {
       if (res.ok) {
         return fetch("https://microsoft.com");
-      } 
+      }
       else {
         if (res.buffer.length > 5) {
           return res;
-        } 
+        }
         else {
             return fetch("https://github.com");
         }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Conditionals.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Conditionals.ts
@@ -4,11 +4,11 @@ function /*[#|*/f/*|]*/(){
     return fetch("https://typescriptlang.org").then(res => {
       if (res.ok) {
         return fetch("https://microsoft.com");
-      } 
+      }
       else {
         if (res.buffer.length > 5) {
           return res;
-        } 
+        }
         else {
             return fetch("https://github.com");
         }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromise.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromise.ts
@@ -5,7 +5,7 @@ function /*[#|*/innerPromise/*|]*/(): Promise<string> {
         var blob2 = resp.blob().then(blob => blob.byteOffset).catch(err => 'Error');
         return blob2;
     }).then(blob => {
-        return blob.toString();   
+        return blob.toString();
     });
 }
 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRet.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRet.ts
@@ -4,7 +4,7 @@ function /*[#|*/innerPromise/*|]*/(): Promise<string> {
     return fetch("https://typescriptlang.org").then(resp => {
         return resp.blob().then(blob => blob.byteOffset).catch(err => 'Error');
     }).then(blob => {
-        return blob.toString();   
+        return blob.toString();
     });
 }
 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_PromiseDotAll.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_PromiseDotAll.ts
@@ -2,7 +2,7 @@
 
 function /*[#|*/f/*|]*/():Promise<void>{
     return Promise.all([fetch('https://typescriptlang.org'), fetch('https://microsoft.com'), fetch('https://youtube.com')]).then(function(vals){
-        vals.forEach(console.log); 
+        vals.forEach(console.log);
     });
 }
 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ResRejNoArgsArrow.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ResRejNoArgsArrow.js
@@ -1,7 +1,7 @@
 // ==ORIGINAL==
 
     function /*[#|*/f/*|]*/() {
-        return Promise.resolve().then(() => 1, () => "a"); 
+        return Promise.resolve().then(() => 1, () => "a");
     }
 
 // ==ASYNC FUNCTION::Convert to async function==
@@ -13,5 +13,5 @@
         }
         catch (e) {
             return "a";
-        } 
+        }
     }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ResRejNoArgsArrow.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ResRejNoArgsArrow.ts
@@ -1,7 +1,7 @@
 // ==ORIGINAL==
 
     function /*[#|*/f/*|]*/() {
-        return Promise.resolve().then(() => 1, () => "a"); 
+        return Promise.resolve().then(() => 1, () => "a");
     }
 
 // ==ASYNC FUNCTION::Convert to async function==
@@ -13,5 +13,5 @@
         }
         catch (e) {
             return "a";
-        } 
+        }
     }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Scope1.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Scope1.ts
@@ -2,7 +2,7 @@
 
 function /*[#|*/f/*|]*/() {
     var var1:Promise<Response>, var2;
-    return fetch('https://typescriptlang.org').then( _ => 
+    return fetch('https://typescriptlang.org').then( _ =>
       Promise.resolve().then( res => {
         var2 = "test";
         return fetch("https://microsoft.com");

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Scope3.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Scope3.js
@@ -9,7 +9,7 @@ function /*[#|*/f/*|]*/() {
       }
     };
   });
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -21,4 +21,4 @@ async function f() {
             console.log(res);
         }
     };
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Scope3.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Scope3.ts
@@ -9,7 +9,7 @@ function /*[#|*/f/*|]*/() {
       }
     };
   });
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -21,4 +21,4 @@ async function f() {
             console.log(res);
         }
     };
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_TernaryConditional.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_TernaryConditional.js
@@ -3,7 +3,7 @@
 function /*[#|*/f/*|]*/() {
     let i;
     return Promise.resolve().then(res => res ? i = res : i = 100);
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -11,4 +11,4 @@ async function f() {
     let i;
     const res = await Promise.resolve();
     return res ? i = res : i = 100;
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_TernaryConditional.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_TernaryConditional.ts
@@ -3,7 +3,7 @@
 function /*[#|*/f/*|]*/() {
     let i;
     return Promise.resolve().then(res => res ? i = res : i = 100);
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -11,4 +11,4 @@ async function f() {
     let i;
     const res = await Promise.resolve();
     return res ? i = res : i = 100;
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_UntypedFunction.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_UntypedFunction.js
@@ -2,11 +2,11 @@
 
 function /*[#|*/f/*|]*/() {
     return Promise.resolve().then(res => console.log(res));
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f() {
     const res = await Promise.resolve();
     return console.log(res);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_UntypedFunction.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_UntypedFunction.ts
@@ -2,11 +2,11 @@
 
 function /*[#|*/f/*|]*/() {
     return Promise.resolve().then(res => console.log(res));
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f() {
     const res = await Promise.resolve();
     return console.log(res);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicWithComments.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicWithComments.ts
@@ -3,7 +3,7 @@
 function /*[#|*/f/*|]*/(): Promise<void>{
     /* Note - some of these comments are removed during the refactor. This is not ideal. */
 
-    // a 
+    // a
     /*b*/ return /*c*/ fetch( /*d*/ 'https://typescriptlang.org' /*e*/).then( /*f*/ result /*g*/ => { /*h*/ console.log(/*i*/ result /*j*/) /*k*/}/*l*/);
     // m
 }
@@ -12,7 +12,7 @@ function /*[#|*/f/*|]*/(): Promise<void>{
 async function f(): Promise<void>{
     /* Note - some of these comments are removed during the refactor. This is not ideal. */
 
-    // a 
+    // a
     /*b*/ const result = await fetch(/*d*/ 'https://typescriptlang.org' /*e*/);
     console.log(result); /*k*/
     // m


### PR DESCRIPTION
The callback is always invoked immediately, unconditionally.
View diff with [`?w=1`](https://github.com/Microsoft/TypeScript/pull/26500/files?w=1)