### PR TITLE
Lack of distanceFilter

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -1235,6 +1235,7 @@ interface PositionOptions {
     enableHighAccuracy?: boolean;
     maximumAge?: number;
     timeout?: number;
+    distanceFilter?: number;                      
 }
 
 interface ProgressEventInit extends EventInit {


### PR DESCRIPTION
I couldn't find distanceFilter so I've open a question https://stackoverflow.com/questions/51872946/distancefilter-disappeared-from-positionoptions. Then I saw that here: https://github.com/facebook/react-native/blob/e1577df1fd70049ce7f288f91f6e2b18d512ff4d/Libraries/Geolocation/RCTLocationObserver.m#L273 is the distanceFiler.

After adding it into the ts file watchPosistion starts to work properly accepting the distanceFilter prop.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

