### PR TITLE
Unused asterisks in multiline JSDoc were removed

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -783,7 +783,7 @@ namespace ts {
             IdentifierConstructor = objectAllocator.getIdentifierConstructor();
             SourceFileConstructor = objectAllocator.getSourceFileConstructor();
 
-            sourceText = _sourceText;
+            sourceText = _sourceText.replace(/\/\*\*([^\/]*?)\*\//g, (_, content) => `/**${content.replace(/(\n\s*)\*/g, '$1 ')}*/`);
             syntaxCursor = _syntaxCursor;
 
             parseDiagnostics = [];


### PR DESCRIPTION
Allows multiline parameters in JSDoc

For example:
```
/**
 * @param {{
 *   val: string,
 * }} arg
 */
function foo(arg) {}
```