### PR TITLE
When --noImplicitAny is enabled, don't report errors suggesting that a 'void' function can be 'new'ed

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19458,11 +19458,13 @@ namespace ts {
             const callSignatures = getSignaturesOfType(expressionType, SignatureKind.Call);
             if (callSignatures.length) {
                 const signature = resolveCall(node, callSignatures, candidatesOutArray, isForSignatureHelp);
-                if (signature.declaration && !isJavascriptConstructor(signature.declaration) && getReturnTypeOfSignature(signature) !== voidType) {
-                    error(node, Diagnostics.Only_a_void_function_can_be_called_with_the_new_keyword);
-                }
-                if (getThisTypeOfSignature(signature) === voidType) {
-                    error(node, Diagnostics.A_function_that_is_called_with_the_new_keyword_cannot_have_a_this_type_that_is_void);
+                if (!noImplicitAny) {
+                    if (signature.declaration && !isJavascriptConstructor(signature.declaration) && getReturnTypeOfSignature(signature) !== voidType) {
+                        error(node, Diagnostics.Only_a_void_function_can_be_called_with_the_new_keyword);
+                    }
+                    if (getThisTypeOfSignature(signature) === voidType) {
+                        error(node, Diagnostics.A_function_that_is_called_with_the_new_keyword_cannot_have_a_this_type_that_is_void);
+                    }
                 }
                 return signature;
             }

--- a/tests/baselines/reference/newOperatorErrorCases_noImplicitAny.errors.txt
+++ b/tests/baselines/reference/newOperatorErrorCases_noImplicitAny.errors.txt
@@ -1,0 +1,21 @@
+tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts(2,1): error TS7009: 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.
+tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts(5,1): error TS7009: 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.
+tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts(8,1): error TS7009: 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts (3 errors) ====
+    function fnNumber(this: void): number { return 90; }
+    new fnNumber(); // Error
+    ~~~~~~~~~~~~~~
+!!! error TS7009: 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.
+    
+    function fnVoid(this: void): void {}
+    new fnVoid(); // Error
+    ~~~~~~~~~~~~
+!!! error TS7009: 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.
+    
+    function functionVoidNoThis(): void {}
+    new functionVoidNoThis(); // Error
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS7009: 'new' expression, whose target lacks a construct signature, implicitly has an 'any' type.
+    

--- a/tests/baselines/reference/newOperatorErrorCases_noImplicitAny.js
+++ b/tests/baselines/reference/newOperatorErrorCases_noImplicitAny.js
@@ -1,0 +1,18 @@
+//// [newOperatorErrorCases_noImplicitAny.ts]
+function fnNumber(this: void): number { return 90; }
+new fnNumber(); // Error
+
+function fnVoid(this: void): void {}
+new fnVoid(); // Error
+
+function functionVoidNoThis(): void {}
+new functionVoidNoThis(); // Error
+
+
+//// [newOperatorErrorCases_noImplicitAny.js]
+function fnNumber() { return 90; }
+new fnNumber(); // Error
+function fnVoid() { }
+new fnVoid(); // Error
+function functionVoidNoThis() { }
+new functionVoidNoThis(); // Error

--- a/tests/baselines/reference/newOperatorErrorCases_noImplicitAny.symbols
+++ b/tests/baselines/reference/newOperatorErrorCases_noImplicitAny.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts ===
+function fnNumber(this: void): number { return 90; }
+>fnNumber : Symbol(fnNumber, Decl(newOperatorErrorCases_noImplicitAny.ts, 0, 0))
+>this : Symbol(this, Decl(newOperatorErrorCases_noImplicitAny.ts, 0, 18))
+
+new fnNumber(); // Error
+>fnNumber : Symbol(fnNumber, Decl(newOperatorErrorCases_noImplicitAny.ts, 0, 0))
+
+function fnVoid(this: void): void {}
+>fnVoid : Symbol(fnVoid, Decl(newOperatorErrorCases_noImplicitAny.ts, 1, 15))
+>this : Symbol(this, Decl(newOperatorErrorCases_noImplicitAny.ts, 3, 16))
+
+new fnVoid(); // Error
+>fnVoid : Symbol(fnVoid, Decl(newOperatorErrorCases_noImplicitAny.ts, 1, 15))
+
+function functionVoidNoThis(): void {}
+>functionVoidNoThis : Symbol(functionVoidNoThis, Decl(newOperatorErrorCases_noImplicitAny.ts, 4, 13))
+
+new functionVoidNoThis(); // Error
+>functionVoidNoThis : Symbol(functionVoidNoThis, Decl(newOperatorErrorCases_noImplicitAny.ts, 4, 13))
+

--- a/tests/baselines/reference/newOperatorErrorCases_noImplicitAny.types
+++ b/tests/baselines/reference/newOperatorErrorCases_noImplicitAny.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts ===
+function fnNumber(this: void): number { return 90; }
+>fnNumber : (this: void) => number
+>this : void
+>90 : 90
+
+new fnNumber(); // Error
+>new fnNumber() : any
+>fnNumber : (this: void) => number
+
+function fnVoid(this: void): void {}
+>fnVoid : (this: void) => void
+>this : void
+
+new fnVoid(); // Error
+>new fnVoid() : any
+>fnVoid : (this: void) => void
+
+function functionVoidNoThis(): void {}
+>functionVoidNoThis : () => void
+
+new functionVoidNoThis(); // Error
+>new functionVoidNoThis() : any
+>functionVoidNoThis : () => void
+

--- a/tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts
+++ b/tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts
@@ -1,0 +1,10 @@
+// @noImplicitAny: true
+
+function fnNumber(this: void): number { return 90; }
+new fnNumber(); // Error
+
+function fnVoid(this: void): void {}
+new fnVoid(); // Error
+
+function functionVoidNoThis(): void {}
+new functionVoidNoThis(); // Error


### PR DESCRIPTION
Previously, on this code:
```ts
function f(this: void): number { return 0; }
new f();
```

With `--noImplicitAny` there were *3* errors: The first saying the return type should be `void`, the second saying it can't have a `this` type, and the third saying it must have a construct signature. The first and second errors are misleading because neither of those will fix the problem -- with `--noImplicitAny` void functions are not new-able.
