### PR TITLE
Use context free expression types in evolving array checking and cache context free type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14407,8 +14407,8 @@ namespace ts {
             return resultType;
 
             function getTypeAtFlowNode(flow: FlowNode): FlowType {
-                if (flowDepth === 2250) {
-                    // We have made 2250 recursive invocations. To avoid overflowing the call stack we report an error
+                if (flowDepth === 2000) {
+                    // We have made 2000 recursive invocations. To avoid overflowing the call stack we report an error
                     // and disable further control flow analysis in the containing function or module body.
                     flowAnalysisDisabled = true;
                     reportFlowControlError(reference);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14407,8 +14407,8 @@ namespace ts {
             return resultType;
 
             function getTypeAtFlowNode(flow: FlowNode): FlowType {
-                if (flowDepth === 2500) {
-                    // We have made 2500 recursive invocations. To avoid overflowing the call stack we report an error
+                if (flowDepth === 2250) {
+                    // We have made 2250 recursive invocations. To avoid overflowing the call stack we report an error
                     // and disable further control flow analysis in the containing function or module body.
                     flowAnalysisDisabled = true;
                     reportFlowControlError(reference);

--- a/tests/baselines/reference/deeplyDependentLargeArrayMutation.symbols
+++ b/tests/baselines/reference/deeplyDependentLargeArrayMutation.symbols
@@ -1,0 +1,158 @@
+=== tests/cases/compiler/foo.js ===
+// repro from #26031
+function build() {
+>build : Symbol(build, Decl(foo.js, 0, 0))
+
+    var arr = [];
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+
+    arr[arr.length] = 'value'; 
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value'; 
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value'; 
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value'; 
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value'; 
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value';
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+
+    arr[arr.length] = 'value'; 
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>arr.length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(foo.js, 2, 7))
+>length : Symbol(Array.length, Decl(lib.es5.d.ts, --, --))
+}

--- a/tests/baselines/reference/deeplyDependentLargeArrayMutation.types
+++ b/tests/baselines/reference/deeplyDependentLargeArrayMutation.types
@@ -1,0 +1,234 @@
+=== tests/cases/compiler/foo.js ===
+// repro from #26031
+function build() {
+>build : () => void
+
+    var arr = [];
+>arr : any[]
+>[] : undefined[]
+
+    arr[arr.length] = 'value'; 
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value'; 
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value'; 
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value'; 
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value'; 
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value';
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+
+    arr[arr.length] = 'value'; 
+>arr[arr.length] = 'value' : "value"
+>arr[arr.length] : any
+>arr : any[]
+>arr.length : number
+>arr : any[]
+>length : number
+>'value' : "value"
+}

--- a/tests/baselines/reference/deeplyDependentLargeArrayMutation2.symbols
+++ b/tests/baselines/reference/deeplyDependentLargeArrayMutation2.symbols
@@ -1,0 +1,1924 @@
+=== tests/cases/compiler/foo.js ===
+// Exerpt from https://github.com/archilogic-com/3dio-js - MIT Licenced
+function generateMeshes3d(a) {
+>generateMeshes3d : Symbol(generateMeshes3d, Decl(foo.js, 0, 0))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+    var step = 0,
+>step : Symbol(step, Decl(foo.js, 3, 7))
+
+        elementNum = Math.round(a.l / 0.6),
+>elementNum : Symbol(elementNum, Decl(foo.js, 3, 17))
+>Math.round : Symbol(Math.round, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>round : Symbol(Math.round, Decl(lib.es5.d.ts, --, --))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        elementLength = a.l / elementNum,
+>elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+>elementNum : Symbol(elementNum, Decl(foo.js, 3, 17))
+
+        handlePos = elementLength * 0.8,
+>handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
+>elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
+
+        //handleWidth = a.handleWidth+ a.doorWidth,
+        handleDistance = 0.05,
+>handleDistance : Symbol(handleDistance, Decl(foo.js, 6, 40))
+
+        offsetY = -0.01,
+>offsetY : Symbol(offsetY, Decl(foo.js, 9, 30))
+
+
+        // internals
+        closetVertices = [],
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+
+        cvPos = 0;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+    //CLOSET DOORS
+
+    // FRONT VIEW VERTICES
+    //
+    // A------------C
+    // |E\I------G\K|
+    // | |        | |
+    // | |M\Q-O\S | |
+    // | ||   |   | |
+    // | |N\R-P\T | |
+    // |F\J------H\L|
+    // B------------D
+
+    var aX = step,
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+
+        aY = a.h + offsetY,
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+>offsetY : Symbol(offsetY, Decl(foo.js, 9, 30))
+
+        aZ = a.w,
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        bY = 0,
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+        cX = step + elementLength,
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
+
+        eX = step + a.doorWidth / 2,
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        eY = a.h - a.doorWidth,
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        fY = a.baseboard,
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        gX = step + elementLength - a.doorWidth / 2,
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        iZ = a.w + a.doorWidth,
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        mX = step + handlePos,
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
+
+        mY = 1 + a.handleHeight / 2,
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        nY = 1 - a.handleHeight / 2,
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        oX = step + handlePos + a.handleLength,
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        qZ = a.w + a.doorWidth + a.handleWidth;
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+    for (var c = 0; c < elementNum; c++) {
+>c : Symbol(c, Decl(foo.js, 46, 12))
+>c : Symbol(c, Decl(foo.js, 46, 12))
+>elementNum : Symbol(elementNum, Decl(foo.js, 3, 17))
+>c : Symbol(c, Decl(foo.js, 46, 12))
+
+        if (c % 2 == 1 || c === elementNum - 1) {
+>c : Symbol(c, Decl(foo.js, 46, 12))
+>c : Symbol(c, Decl(foo.js, 46, 12))
+>elementNum : Symbol(elementNum, Decl(foo.js, 3, 17))
+
+            handlePos = handleDistance + a.handleLength / 2;
+>handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
+>handleDistance : Symbol(handleDistance, Decl(foo.js, 6, 40))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        } else {
+            handlePos = elementLength - handleDistance - a.handleLength / 2;
+>handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
+>elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
+>handleDistance : Symbol(handleDistance, Decl(foo.js, 6, 40))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+        }
+        aX = step;
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+
+        cX = step + elementLength;
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
+
+        eX = step + a.doorWidth / 2;
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        gX = step + elementLength - a.doorWidth / 2;
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        mX = step + handlePos - a.handleLength / 2;
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        oX = step + handlePos + a.handleLength / 2;
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+        // DOOR FRAME
+        //A
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //B
+        closetVertices[cvPos + 3] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+        closetVertices[cvPos + 4] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //F
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //E
+        closetVertices[cvPos + 15] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //F
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //B
+        closetVertices[cvPos + 3] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+        closetVertices[cvPos + 4] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //D
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //H
+        closetVertices[cvPos + 15] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 16] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //G
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //H
+        closetVertices[cvPos + 3] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //D
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //C
+        closetVertices[cvPos + 15] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+        closetVertices[cvPos + 16] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //A
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //E
+        closetVertices[cvPos + 3] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 4] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //G
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //C
+        closetVertices[cvPos + 15] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+        closetVertices[cvPos + 16] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        // DOOR LEAF
+
+        //E
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //F
+        closetVertices[cvPos + 3] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //J
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //I
+        closetVertices[cvPos + 15] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //J
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //F
+        closetVertices[cvPos + 3] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //H
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //L
+        closetVertices[cvPos + 15] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 16] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //K
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //L
+        closetVertices[cvPos + 3] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //H
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //G
+        closetVertices[cvPos + 15] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //E
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        //I
+        closetVertices[cvPos + 3] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 4] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //K
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //G
+        closetVertices[cvPos + 15] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //I
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //J
+        closetVertices[cvPos + 3] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //N
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //M
+        closetVertices[cvPos + 15] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+        closetVertices[cvPos + 16] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //N
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //J
+        closetVertices[cvPos + 3] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //L
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //P
+        closetVertices[cvPos + 15] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+        closetVertices[cvPos + 16] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //O
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //P
+        closetVertices[cvPos + 3] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+        closetVertices[cvPos + 4] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //L
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>fY : Symbol(fY, Decl(foo.js, 36, 31))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //K
+        closetVertices[cvPos + 15] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        //I
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eX : Symbol(eX, Decl(foo.js, 34, 34))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //M
+        closetVertices[cvPos + 3] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+        closetVertices[cvPos + 4] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //O
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        //K
+        closetVertices[cvPos + 15] = gX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>gX : Symbol(gX, Decl(foo.js, 37, 25))
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eY : Symbol(eY, Decl(foo.js, 35, 36))
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        // HANDLE
+        if (a.handleWidth > 0) {
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+            // HANDLE SIDES
+            //M
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+            //N
+            closetVertices[cvPos + 3] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+            closetVertices[cvPos + 4] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+            closetVertices[cvPos + 5] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+            //R
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+            //Q
+            closetVertices[cvPos + 15] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+            closetVertices[cvPos + 16] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+            closetVertices[cvPos + 17] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+            cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+            //R
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+            //N
+            closetVertices[cvPos + 3] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+            closetVertices[cvPos + 4] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+            closetVertices[cvPos + 5] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+            //P
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+            //T
+            closetVertices[cvPos + 15] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+            closetVertices[cvPos + 16] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+            closetVertices[cvPos + 17] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+            cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+            //S
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+            //T
+            closetVertices[cvPos + 3] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+            closetVertices[cvPos + 4] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+            closetVertices[cvPos + 5] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+            //P
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+            //O
+            closetVertices[cvPos + 15] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+            closetVertices[cvPos + 16] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+            closetVertices[cvPos + 17] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+            cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+            //M
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+            //Q
+            closetVertices[cvPos + 3] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+            closetVertices[cvPos + 4] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+            closetVertices[cvPos + 5] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+            //S
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+            //O
+            closetVertices[cvPos + 15] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+            closetVertices[cvPos + 16] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+            closetVertices[cvPos + 17] = iZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>iZ : Symbol(iZ, Decl(foo.js, 38, 52))
+
+            cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+        }
+        // HANDLE FRONT
+        //Q
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+        //R
+        closetVertices[cvPos + 3] = mX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mX : Symbol(mX, Decl(foo.js, 39, 31))
+
+        closetVertices[cvPos + 4] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+        closetVertices[cvPos + 5] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+        //T
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>nY : Symbol(nY, Decl(foo.js, 41, 36))
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+        //S
+        closetVertices[cvPos + 15] = oX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>oX : Symbol(oX, Decl(foo.js, 42, 36))
+
+        closetVertices[cvPos + 16] = mY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>mY : Symbol(mY, Decl(foo.js, 40, 30))
+
+        closetVertices[cvPos + 17] = qZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>qZ : Symbol(qZ, Decl(foo.js, 43, 47))
+
+        cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+        step += elementLength;
+>step : Symbol(step, Decl(foo.js, 3, 7))
+>elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
+    }
+
+    //CLOSET BOX
+
+    // FRONT VIEW VERTICES
+    //
+    // A/E---C/G
+    //  |     |
+    //  |     |
+    //  |     |
+    // B/F---D/H
+
+    aX = 0;
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+    aY = a.h + offsetY;
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+>offsetY : Symbol(offsetY, Decl(foo.js, 9, 30))
+
+    aZ = a.w;
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+    bY = 0;
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+    cX = a.l;
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+>a : Symbol(a, Decl(foo.js, 1, 26))
+
+    var eZ = 0;
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    //E
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    //F
+    closetVertices[cvPos + 3] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+    closetVertices[cvPos + 4] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+    closetVertices[cvPos + 5] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    //B
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+    //A
+    closetVertices[cvPos + 15] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+    closetVertices[cvPos + 16] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 17] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+    cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+    //E
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    //A
+    closetVertices[cvPos + 3] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+    closetVertices[cvPos + 4] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 5] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+    //C
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+    //G
+    closetVertices[cvPos + 15] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+    closetVertices[cvPos + 16] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 17] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+    //C
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+    //D
+    closetVertices[cvPos + 3] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+    closetVertices[cvPos + 4] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+    closetVertices[cvPos + 5] = aZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aZ : Symbol(aZ, Decl(foo.js, 31, 27))
+
+    //H
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    //G
+    closetVertices[cvPos + 15] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+    closetVertices[cvPos + 16] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 17] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    cvPos = cvPos + 18;
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+
+    //G
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    //H
+    closetVertices[cvPos + 3] = cX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>cX : Symbol(cX, Decl(foo.js, 33, 15))
+
+    closetVertices[cvPos + 4] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+    closetVertices[cvPos + 5] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    //F
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>bY : Symbol(bY, Decl(foo.js, 32, 17))
+
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    //E
+    closetVertices[cvPos + 15] = aX;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aX : Symbol(aX, Decl(foo.js, 30, 7))
+
+    closetVertices[cvPos + 16] = aY;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>aY : Symbol(aY, Decl(foo.js, 30, 18))
+
+    closetVertices[cvPos + 17] = eZ;
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+>cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
+>eZ : Symbol(eZ, Decl(foo.js, 408, 7))
+
+    return Promise.resolve({
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+        closet: {
+>closet : Symbol(closet, Decl(foo.js, 484, 28))
+
+            positions: new Float32Array(closetVertices),
+>positions : Symbol(positions, Decl(foo.js, 485, 17))
+>Float32Array : Symbol(Float32Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
+
+            material: 'closet'
+>material : Symbol(material, Decl(foo.js, 486, 56))
+        }
+    });
+}
+
+const a = generateMeshes3d(null);
+>a : Symbol(a, Decl(foo.js, 492, 5))
+>generateMeshes3d : Symbol(generateMeshes3d, Decl(foo.js, 0, 0))
+

--- a/tests/baselines/reference/deeplyDependentLargeArrayMutation2.symbols
+++ b/tests/baselines/reference/deeplyDependentLargeArrayMutation2.symbols
@@ -1,1924 +1,1847 @@
 === tests/cases/compiler/foo.js ===
-// Exerpt from https://github.com/archilogic-com/3dio-js - MIT Licenced
-function generateMeshes3d(a) {
->generateMeshes3d : Symbol(generateMeshes3d, Decl(foo.js, 0, 0))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-    var step = 0,
->step : Symbol(step, Decl(foo.js, 3, 7))
-
-        elementNum = Math.round(a.l / 0.6),
->elementNum : Symbol(elementNum, Decl(foo.js, 3, 17))
->Math.round : Symbol(Math.round, Decl(lib.es5.d.ts, --, --))
->Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->round : Symbol(Math.round, Decl(lib.es5.d.ts, --, --))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        elementLength = a.l / elementNum,
->elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
->a : Symbol(a, Decl(foo.js, 1, 26))
->elementNum : Symbol(elementNum, Decl(foo.js, 3, 17))
-
-        handlePos = elementLength * 0.8,
->handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
->elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
-
-        //handleWidth = a.handleWidth+ a.doorWidth,
-        handleDistance = 0.05,
->handleDistance : Symbol(handleDistance, Decl(foo.js, 6, 40))
-
-        offsetY = -0.01,
->offsetY : Symbol(offsetY, Decl(foo.js, 9, 30))
-
-
-        // internals
-        closetVertices = [],
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
-
-        cvPos = 0;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-    //CLOSET DOORS
-
-    // FRONT VIEW VERTICES
-    //
-    // A------------C
-    // |E\I------G\K|
-    // | |        | |
-    // | |M\Q-O\S | |
-    // | ||   |   | |
-    // | |N\R-P\T | |
-    // |F\J------H\L|
-    // B------------D
-
-    var aX = step,
->aX : Symbol(aX, Decl(foo.js, 30, 7))
->step : Symbol(step, Decl(foo.js, 3, 7))
-
-        aY = a.h + offsetY,
->aY : Symbol(aY, Decl(foo.js, 30, 18))
->a : Symbol(a, Decl(foo.js, 1, 26))
->offsetY : Symbol(offsetY, Decl(foo.js, 9, 30))
-
-        aZ = a.w,
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        bY = 0,
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-        cX = step + elementLength,
->cX : Symbol(cX, Decl(foo.js, 33, 15))
->step : Symbol(step, Decl(foo.js, 3, 7))
->elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
-
-        eX = step + a.doorWidth / 2,
->eX : Symbol(eX, Decl(foo.js, 34, 34))
->step : Symbol(step, Decl(foo.js, 3, 7))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        eY = a.h - a.doorWidth,
->eY : Symbol(eY, Decl(foo.js, 35, 36))
->a : Symbol(a, Decl(foo.js, 1, 26))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        fY = a.baseboard,
->fY : Symbol(fY, Decl(foo.js, 36, 31))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        gX = step + elementLength - a.doorWidth / 2,
->gX : Symbol(gX, Decl(foo.js, 37, 25))
->step : Symbol(step, Decl(foo.js, 3, 7))
->elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        iZ = a.w + a.doorWidth,
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
->a : Symbol(a, Decl(foo.js, 1, 26))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        mX = step + handlePos,
->mX : Symbol(mX, Decl(foo.js, 39, 31))
->step : Symbol(step, Decl(foo.js, 3, 7))
->handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
-
-        mY = 1 + a.handleHeight / 2,
->mY : Symbol(mY, Decl(foo.js, 40, 30))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        nY = 1 - a.handleHeight / 2,
->nY : Symbol(nY, Decl(foo.js, 41, 36))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        oX = step + handlePos + a.handleLength,
->oX : Symbol(oX, Decl(foo.js, 42, 36))
->step : Symbol(step, Decl(foo.js, 3, 7))
->handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        qZ = a.w + a.doorWidth + a.handleWidth;
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
->a : Symbol(a, Decl(foo.js, 1, 26))
->a : Symbol(a, Decl(foo.js, 1, 26))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-    for (var c = 0; c < elementNum; c++) {
->c : Symbol(c, Decl(foo.js, 46, 12))
->c : Symbol(c, Decl(foo.js, 46, 12))
->elementNum : Symbol(elementNum, Decl(foo.js, 3, 17))
->c : Symbol(c, Decl(foo.js, 46, 12))
-
-        if (c % 2 == 1 || c === elementNum - 1) {
->c : Symbol(c, Decl(foo.js, 46, 12))
->c : Symbol(c, Decl(foo.js, 46, 12))
->elementNum : Symbol(elementNum, Decl(foo.js, 3, 17))
-
-            handlePos = handleDistance + a.handleLength / 2;
->handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
->handleDistance : Symbol(handleDistance, Decl(foo.js, 6, 40))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        } else {
-            handlePos = elementLength - handleDistance - a.handleLength / 2;
->handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
->elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
->handleDistance : Symbol(handleDistance, Decl(foo.js, 6, 40))
->a : Symbol(a, Decl(foo.js, 1, 26))
-        }
-        aX = step;
->aX : Symbol(aX, Decl(foo.js, 30, 7))
->step : Symbol(step, Decl(foo.js, 3, 7))
-
-        cX = step + elementLength;
->cX : Symbol(cX, Decl(foo.js, 33, 15))
->step : Symbol(step, Decl(foo.js, 3, 7))
->elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
-
-        eX = step + a.doorWidth / 2;
->eX : Symbol(eX, Decl(foo.js, 34, 34))
->step : Symbol(step, Decl(foo.js, 3, 7))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        gX = step + elementLength - a.doorWidth / 2;
->gX : Symbol(gX, Decl(foo.js, 37, 25))
->step : Symbol(step, Decl(foo.js, 3, 7))
->elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        mX = step + handlePos - a.handleLength / 2;
->mX : Symbol(mX, Decl(foo.js, 39, 31))
->step : Symbol(step, Decl(foo.js, 3, 7))
->handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        oX = step + handlePos + a.handleLength / 2;
->oX : Symbol(oX, Decl(foo.js, 42, 36))
->step : Symbol(step, Decl(foo.js, 3, 7))
->handlePos : Symbol(handlePos, Decl(foo.js, 5, 41))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-        // DOOR FRAME
-        //A
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //B
-        closetVertices[cvPos + 3] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-        closetVertices[cvPos + 4] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //F
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //E
-        closetVertices[cvPos + 15] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //F
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //B
-        closetVertices[cvPos + 3] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-        closetVertices[cvPos + 4] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //D
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //H
-        closetVertices[cvPos + 15] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 16] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //G
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //H
-        closetVertices[cvPos + 3] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //D
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //C
-        closetVertices[cvPos + 15] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-        closetVertices[cvPos + 16] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //A
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //E
-        closetVertices[cvPos + 3] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 4] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //G
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //C
-        closetVertices[cvPos + 15] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-        closetVertices[cvPos + 16] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        // DOOR LEAF
-
-        //E
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //F
-        closetVertices[cvPos + 3] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //J
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //I
-        closetVertices[cvPos + 15] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //J
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //F
-        closetVertices[cvPos + 3] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //H
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //L
-        closetVertices[cvPos + 15] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 16] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //K
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //L
-        closetVertices[cvPos + 3] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //H
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //G
-        closetVertices[cvPos + 15] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //E
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        //I
-        closetVertices[cvPos + 3] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 4] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //K
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //G
-        closetVertices[cvPos + 15] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //I
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //J
-        closetVertices[cvPos + 3] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //N
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //M
-        closetVertices[cvPos + 15] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-        closetVertices[cvPos + 16] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //N
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //J
-        closetVertices[cvPos + 3] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //L
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //P
-        closetVertices[cvPos + 15] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-        closetVertices[cvPos + 16] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //O
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //P
-        closetVertices[cvPos + 3] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-        closetVertices[cvPos + 4] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //L
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->fY : Symbol(fY, Decl(foo.js, 36, 31))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //K
-        closetVertices[cvPos + 15] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        //I
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eX : Symbol(eX, Decl(foo.js, 34, 34))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //M
-        closetVertices[cvPos + 3] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-        closetVertices[cvPos + 4] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //O
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        //K
-        closetVertices[cvPos + 15] = gX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->gX : Symbol(gX, Decl(foo.js, 37, 25))
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eY : Symbol(eY, Decl(foo.js, 35, 36))
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        // HANDLE
-        if (a.handleWidth > 0) {
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-            // HANDLE SIDES
-            //M
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-            //N
-            closetVertices[cvPos + 3] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-            closetVertices[cvPos + 4] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-            closetVertices[cvPos + 5] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-            //R
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-            //Q
-            closetVertices[cvPos + 15] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-            closetVertices[cvPos + 16] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-            closetVertices[cvPos + 17] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-            cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-            //R
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-            //N
-            closetVertices[cvPos + 3] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-            closetVertices[cvPos + 4] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-            closetVertices[cvPos + 5] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-            //P
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-            //T
-            closetVertices[cvPos + 15] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-            closetVertices[cvPos + 16] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-            closetVertices[cvPos + 17] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-            cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-            //S
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-            //T
-            closetVertices[cvPos + 3] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-            closetVertices[cvPos + 4] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-            closetVertices[cvPos + 5] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-            //P
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-            //O
-            closetVertices[cvPos + 15] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-            closetVertices[cvPos + 16] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-            closetVertices[cvPos + 17] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-            cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-            //M
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-            //Q
-            closetVertices[cvPos + 3] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-            closetVertices[cvPos + 4] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-            closetVertices[cvPos + 5] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-            //S
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-            //O
-            closetVertices[cvPos + 15] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-            closetVertices[cvPos + 16] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-            closetVertices[cvPos + 17] = iZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->iZ : Symbol(iZ, Decl(foo.js, 38, 52))
-
-            cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-        }
-        // HANDLE FRONT
-        //Q
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-        //R
-        closetVertices[cvPos + 3] = mX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mX : Symbol(mX, Decl(foo.js, 39, 31))
-
-        closetVertices[cvPos + 4] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-        closetVertices[cvPos + 5] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-        //T
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->nY : Symbol(nY, Decl(foo.js, 41, 36))
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-        //S
-        closetVertices[cvPos + 15] = oX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->oX : Symbol(oX, Decl(foo.js, 42, 36))
-
-        closetVertices[cvPos + 16] = mY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->mY : Symbol(mY, Decl(foo.js, 40, 30))
-
-        closetVertices[cvPos + 17] = qZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->qZ : Symbol(qZ, Decl(foo.js, 43, 47))
-
-        cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-        step += elementLength;
->step : Symbol(step, Decl(foo.js, 3, 7))
->elementLength : Symbol(elementLength, Decl(foo.js, 4, 43))
-    }
-
-    //CLOSET BOX
-
-    // FRONT VIEW VERTICES
-    //
-    // A/E---C/G
-    //  |     |
-    //  |     |
-    //  |     |
-    // B/F---D/H
-
-    aX = 0;
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-    aY = a.h + offsetY;
->aY : Symbol(aY, Decl(foo.js, 30, 18))
->a : Symbol(a, Decl(foo.js, 1, 26))
->offsetY : Symbol(offsetY, Decl(foo.js, 9, 30))
-
-    aZ = a.w;
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-    bY = 0;
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-    cX = a.l;
->cX : Symbol(cX, Decl(foo.js, 33, 15))
->a : Symbol(a, Decl(foo.js, 1, 26))
-
-    var eZ = 0;
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    //E
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    //F
-    closetVertices[cvPos + 3] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-    closetVertices[cvPos + 4] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-    closetVertices[cvPos + 5] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    //B
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-    //A
-    closetVertices[cvPos + 15] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-    closetVertices[cvPos + 16] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 17] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-    cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-    //E
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    //A
-    closetVertices[cvPos + 3] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-    closetVertices[cvPos + 4] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 5] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-    //C
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-    //G
-    closetVertices[cvPos + 15] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-    closetVertices[cvPos + 16] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 17] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-    //C
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-    //D
-    closetVertices[cvPos + 3] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-    closetVertices[cvPos + 4] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-    closetVertices[cvPos + 5] = aZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aZ : Symbol(aZ, Decl(foo.js, 31, 27))
-
-    //H
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    //G
-    closetVertices[cvPos + 15] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-    closetVertices[cvPos + 16] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 17] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    cvPos = cvPos + 18;
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
-
-    //G
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    //H
-    closetVertices[cvPos + 3] = cX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->cX : Symbol(cX, Decl(foo.js, 33, 15))
-
-    closetVertices[cvPos + 4] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-    closetVertices[cvPos + 5] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    //F
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->bY : Symbol(bY, Decl(foo.js, 32, 17))
-
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    //E
-    closetVertices[cvPos + 15] = aX;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aX : Symbol(aX, Decl(foo.js, 30, 7))
-
-    closetVertices[cvPos + 16] = aY;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->aY : Symbol(aY, Decl(foo.js, 30, 18))
-
-    closetVertices[cvPos + 17] = eZ;
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
->cvPos : Symbol(cvPos, Decl(foo.js, 14, 28))
->eZ : Symbol(eZ, Decl(foo.js, 408, 7))
-
-    return Promise.resolve({
->Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
-
-        closet: {
->closet : Symbol(closet, Decl(foo.js, 484, 28))
-
-            positions: new Float32Array(closetVertices),
->positions : Symbol(positions, Decl(foo.js, 485, 17))
->Float32Array : Symbol(Float32Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->closetVertices : Symbol(closetVertices, Decl(foo.js, 10, 24))
-
-            material: 'closet'
->material : Symbol(material, Decl(foo.js, 486, 56))
-        }
-    });
+// Looking at this test and thinking "that's silly, nobody would write code like that" and thinking it's OK to break this test?
+// You'd be wrong - https://raw.githubusercontent.com/archilogic-com/3dio-js/master/build/3dio.js and plenty of other codebases
+// have js code exactly like this! This pattern (even at this size!) with a few more embellishments is a common way to encode
+// polygons or verticies into a buffer from a formulaic object definition! So while this is a lot more regular than a real piece
+// of code, this is still representative of a common pattern.
+function build() {
+>build : Symbol(build, Decl(foo.js, 0, 0))
+
+    let i = 0;
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    const arr = [];
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    arr[i++] = arr[i] + 1;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
+>i : Symbol(i, Decl(foo.js, 6, 7))
+
+    return arr;
+>arr : Symbol(arr, Decl(foo.js, 7, 9))
 }
 
-const a = generateMeshes3d(null);
->a : Symbol(a, Decl(foo.js, 492, 5))
->generateMeshes3d : Symbol(generateMeshes3d, Decl(foo.js, 0, 0))
+const a = build();
+>a : Symbol(a, Decl(foo.js, 315, 5))
+>build : Symbol(build, Decl(foo.js, 0, 0))
 

--- a/tests/baselines/reference/deeplyDependentLargeArrayMutation2.types
+++ b/tests/baselines/reference/deeplyDependentLargeArrayMutation2.types
@@ -1,3606 +1,3674 @@
 === tests/cases/compiler/foo.js ===
-// Exerpt from https://github.com/archilogic-com/3dio-js - MIT Licenced
-function generateMeshes3d(a) {
->generateMeshes3d : (a: any) => Promise<{ closet: { positions: Float32Array; material: string; }; }>
->a : any
+// Looking at this test and thinking "that's silly, nobody would write code like that" and thinking it's OK to break this test?
+// You'd be wrong - https://raw.githubusercontent.com/archilogic-com/3dio-js/master/build/3dio.js and plenty of other codebases
+// have js code exactly like this! This pattern (even at this size!) with a few more embellishments is a common way to encode
+// polygons or verticies into a buffer from a formulaic object definition! So while this is a lot more regular than a real piece
+// of code, this is still representative of a common pattern.
+function build() {
+>build : () => any[]
 
-    var step = 0,
->step : number
+    let i = 0;
+>i : number
 >0 : 0
 
-        elementNum = Math.round(a.l / 0.6),
->elementNum : number
->Math.round(a.l / 0.6) : number
->Math.round : (x: number) => number
->Math : Math
->round : (x: number) => number
->a.l / 0.6 : number
->a.l : any
->a : any
->l : any
->0.6 : 0.6
-
-        elementLength = a.l / elementNum,
->elementLength : number
->a.l / elementNum : number
->a.l : any
->a : any
->l : any
->elementNum : number
-
-        handlePos = elementLength * 0.8,
->handlePos : number
->elementLength * 0.8 : number
->elementLength : number
->0.8 : 0.8
-
-        //handleWidth = a.handleWidth+ a.doorWidth,
-        handleDistance = 0.05,
->handleDistance : number
->0.05 : 0.05
-
-        offsetY = -0.01,
->offsetY : number
->-0.01 : -0.01
->0.01 : 0.01
-
-
-        // internals
-        closetVertices = [],
->closetVertices : any[]
+    const arr = [];
+>arr : any[]
 >[] : undefined[]
 
-        cvPos = 0;
->cvPos : number
->0 : 0
-
-    //CLOSET DOORS
-
-    // FRONT VIEW VERTICES
-    //
-    // A------------C
-    // |E\I------G\K|
-    // | |        | |
-    // | |M\Q-O\S | |
-    // | ||   |   | |
-    // | |N\R-P\T | |
-    // |F\J------H\L|
-    // B------------D
-
-    var aX = step,
->aX : number
->step : number
-
-        aY = a.h + offsetY,
->aY : any
->a.h + offsetY : any
->a.h : any
->a : any
->h : any
->offsetY : number
-
-        aZ = a.w,
->aZ : any
->a.w : any
->a : any
->w : any
-
-        bY = 0,
->bY : number
->0 : 0
-
-        cX = step + elementLength,
->cX : number
->step + elementLength : number
->step : number
->elementLength : number
-
-        eX = step + a.doorWidth / 2,
->eX : number
->step + a.doorWidth / 2 : number
->step : number
->a.doorWidth / 2 : number
->a.doorWidth : any
->a : any
->doorWidth : any
->2 : 2
-
-        eY = a.h - a.doorWidth,
->eY : number
->a.h - a.doorWidth : number
->a.h : any
->a : any
->h : any
->a.doorWidth : any
->a : any
->doorWidth : any
-
-        fY = a.baseboard,
->fY : any
->a.baseboard : any
->a : any
->baseboard : any
-
-        gX = step + elementLength - a.doorWidth / 2,
->gX : number
->step + elementLength - a.doorWidth / 2 : number
->step + elementLength : number
->step : number
->elementLength : number
->a.doorWidth / 2 : number
->a.doorWidth : any
->a : any
->doorWidth : any
->2 : 2
-
-        iZ = a.w + a.doorWidth,
->iZ : any
->a.w + a.doorWidth : any
->a.w : any
->a : any
->w : any
->a.doorWidth : any
->a : any
->doorWidth : any
-
-        mX = step + handlePos,
->mX : number
->step + handlePos : number
->step : number
->handlePos : number
-
-        mY = 1 + a.handleHeight / 2,
->mY : number
->1 + a.handleHeight / 2 : number
->1 : 1
->a.handleHeight / 2 : number
->a.handleHeight : any
->a : any
->handleHeight : any
->2 : 2
-
-        nY = 1 - a.handleHeight / 2,
->nY : number
->1 - a.handleHeight / 2 : number
->1 : 1
->a.handleHeight / 2 : number
->a.handleHeight : any
->a : any
->handleHeight : any
->2 : 2
-
-        oX = step + handlePos + a.handleLength,
->oX : any
->step + handlePos + a.handleLength : any
->step + handlePos : number
->step : number
->handlePos : number
->a.handleLength : any
->a : any
->handleLength : any
-
-        qZ = a.w + a.doorWidth + a.handleWidth;
->qZ : any
->a.w + a.doorWidth + a.handleWidth : any
->a.w + a.doorWidth : any
->a.w : any
->a : any
->w : any
->a.doorWidth : any
->a : any
->doorWidth : any
->a.handleWidth : any
->a : any
->handleWidth : any
-
-    for (var c = 0; c < elementNum; c++) {
->c : number
->0 : 0
->c < elementNum : boolean
->c : number
->elementNum : number
->c++ : number
->c : number
-
-        if (c % 2 == 1 || c === elementNum - 1) {
->c % 2 == 1 || c === elementNum - 1 : boolean
->c % 2 == 1 : boolean
->c % 2 : number
->c : number
->2 : 2
->1 : 1
->c === elementNum - 1 : boolean
->c : number
->elementNum - 1 : number
->elementNum : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
 
-            handlePos = handleDistance + a.handleLength / 2;
->handlePos = handleDistance + a.handleLength / 2 : number
->handlePos : number
->handleDistance + a.handleLength / 2 : number
->handleDistance : number
->a.handleLength / 2 : number
->a.handleLength : any
->a : any
->handleLength : any
->2 : 2
-
-        } else {
-            handlePos = elementLength - handleDistance - a.handleLength / 2;
->handlePos = elementLength - handleDistance - a.handleLength / 2 : number
->handlePos : number
->elementLength - handleDistance - a.handleLength / 2 : number
->elementLength - handleDistance : number
->elementLength : number
->handleDistance : number
->a.handleLength / 2 : number
->a.handleLength : any
->a : any
->handleLength : any
->2 : 2
-        }
-        aX = step;
->aX = step : number
->aX : number
->step : number
-
-        cX = step + elementLength;
->cX = step + elementLength : number
->cX : number
->step + elementLength : number
->step : number
->elementLength : number
-
-        eX = step + a.doorWidth / 2;
->eX = step + a.doorWidth / 2 : number
->eX : number
->step + a.doorWidth / 2 : number
->step : number
->a.doorWidth / 2 : number
->a.doorWidth : any
->a : any
->doorWidth : any
->2 : 2
-
-        gX = step + elementLength - a.doorWidth / 2;
->gX = step + elementLength - a.doorWidth / 2 : number
->gX : number
->step + elementLength - a.doorWidth / 2 : number
->step + elementLength : number
->step : number
->elementLength : number
->a.doorWidth / 2 : number
->a.doorWidth : any
->a : any
->doorWidth : any
->2 : 2
-
-        mX = step + handlePos - a.handleLength / 2;
->mX = step + handlePos - a.handleLength / 2 : number
->mX : number
->step + handlePos - a.handleLength / 2 : number
->step + handlePos : number
->step : number
->handlePos : number
->a.handleLength / 2 : number
->a.handleLength : any
->a : any
->handleLength : any
->2 : 2
-
-        oX = step + handlePos + a.handleLength / 2;
->oX = step + handlePos + a.handleLength / 2 : number
->oX : any
->step + handlePos + a.handleLength / 2 : number
->step + handlePos : number
->step : number
->handlePos : number
->a.handleLength / 2 : number
->a.handleLength : any
->a : any
->handleLength : any
->2 : 2
-
-        // DOOR FRAME
-        //A
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = aX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = aX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->aX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->aY : any
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->aZ : any
-
-        //B
-        closetVertices[cvPos + 3] = aX;
->closetVertices[cvPos + 3] = aX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->aX : number
-
-        closetVertices[cvPos + 4] = bY;
->closetVertices[cvPos + 4] = bY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->bY : number
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices[cvPos + 5] = aZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->aZ : any
-
-        //F
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = eX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->eX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->fY : any
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->aZ : any
-
-        //E
-        closetVertices[cvPos + 15] = eX;
->closetVertices[cvPos + 15] = eX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->eX : number
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices[cvPos + 16] = eY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->eY : number
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices[cvPos + 17] = aZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->aZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //F
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->eX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY : any
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = fY : any
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->fY : any
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->aZ : any
-
-        //B
-        closetVertices[cvPos + 3] = aX;
->closetVertices[cvPos + 3] = aX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->aX : number
-
-        closetVertices[cvPos + 4] = bY;
->closetVertices[cvPos + 4] = bY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->bY : number
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices[cvPos + 5] = aZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->aZ : any
-
-        //D
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = cX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->cX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->bY : number
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->aZ : any
-
-        //H
-        closetVertices[cvPos + 15] = gX;
->closetVertices[cvPos + 15] = gX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->gX : number
-
-        closetVertices[cvPos + 16] = fY;
->closetVertices[cvPos + 16] = fY : any
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->fY : any
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices[cvPos + 17] = aZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->aZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //G
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = gX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = gX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->gX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->eY : number
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->aZ : any
-
-        //H
-        closetVertices[cvPos + 3] = gX;
->closetVertices[cvPos + 3] = gX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->gX : number
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices[cvPos + 4] = fY : any
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->fY : any
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices[cvPos + 5] = aZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->aZ : any
-
-        //D
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = cX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->cX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->bY : number
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->aZ : any
-
-        //C
-        closetVertices[cvPos + 15] = cX;
->closetVertices[cvPos + 15] = cX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->cX : number
-
-        closetVertices[cvPos + 16] = aY;
->closetVertices[cvPos + 16] = aY : any
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->aY : any
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices[cvPos + 17] = aZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->aZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //A
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = aX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = aX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->aX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->aY : any
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->aZ : any
-
-        //E
-        closetVertices[cvPos + 3] = eX;
->closetVertices[cvPos + 3] = eX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->eX : number
-
-        closetVertices[cvPos + 4] = eY;
->closetVertices[cvPos + 4] = eY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->eY : number
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices[cvPos + 5] = aZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->aZ : any
-
-        //G
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->gX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = eY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->eY : number
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->aZ : any
-
-        //C
-        closetVertices[cvPos + 15] = cX;
->closetVertices[cvPos + 15] = cX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->cX : number
-
-        closetVertices[cvPos + 16] = aY;
->closetVertices[cvPos + 16] = aY : any
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->aY : any
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices[cvPos + 17] = aZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->aZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        // DOOR LEAF
-
-        //E
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->eX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->eY : number
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->aZ : any
-
-        //F
-        closetVertices[cvPos + 3] = eX;
->closetVertices[cvPos + 3] = eX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->eX : number
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices[cvPos + 4] = fY : any
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->fY : any
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices[cvPos + 5] = aZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->aZ : any
-
-        //J
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = eX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->eX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->fY : any
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->iZ : any
-
-        //I
-        closetVertices[cvPos + 15] = eX;
->closetVertices[cvPos + 15] = eX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->eX : number
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices[cvPos + 16] = eY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->eY : number
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices[cvPos + 17] = iZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->iZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //J
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->eX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY : any
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = fY : any
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->fY : any
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->iZ : any
-
-        //F
-        closetVertices[cvPos + 3] = eX;
->closetVertices[cvPos + 3] = eX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->eX : number
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices[cvPos + 4] = fY : any
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->fY : any
-
-        closetVertices[cvPos + 5] = aZ;
->closetVertices[cvPos + 5] = aZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->aZ : any
-
-        //H
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->gX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->fY : any
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->aZ : any
-
-        //L
-        closetVertices[cvPos + 15] = gX;
->closetVertices[cvPos + 15] = gX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->gX : number
-
-        closetVertices[cvPos + 16] = fY;
->closetVertices[cvPos + 16] = fY : any
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->fY : any
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices[cvPos + 17] = iZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->iZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //K
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = gX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = gX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->gX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->eY : number
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->iZ : any
-
-        //L
-        closetVertices[cvPos + 3] = gX;
->closetVertices[cvPos + 3] = gX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->gX : number
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices[cvPos + 4] = fY : any
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->fY : any
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices[cvPos + 5] = iZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->iZ : any
-
-        //H
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->gX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->fY : any
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->aZ : any
-
-        //G
-        closetVertices[cvPos + 15] = gX;
->closetVertices[cvPos + 15] = gX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->gX : number
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices[cvPos + 16] = eY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->eY : number
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices[cvPos + 17] = aZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->aZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //E
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->eX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->eY : number
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->aZ : any
-
-        //I
-        closetVertices[cvPos + 3] = eX;
->closetVertices[cvPos + 3] = eX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->eX : number
-
-        closetVertices[cvPos + 4] = eY;
->closetVertices[cvPos + 4] = eY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->eY : number
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices[cvPos + 5] = iZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->iZ : any
-
-        //K
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->gX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = eY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->eY : number
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->iZ : any
-
-        //G
-        closetVertices[cvPos + 15] = gX;
->closetVertices[cvPos + 15] = gX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->gX : number
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices[cvPos + 16] = eY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->eY : number
-
-        closetVertices[cvPos + 17] = aZ;
->closetVertices[cvPos + 17] = aZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->aZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //I
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->eX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->eY : number
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->iZ : any
-
-        //J
-        closetVertices[cvPos + 3] = eX;
->closetVertices[cvPos + 3] = eX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->eX : number
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices[cvPos + 4] = fY : any
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->fY : any
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices[cvPos + 5] = iZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->iZ : any
-
-        //N
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = mX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->mX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->nY : number
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->iZ : any
-
-        //M
-        closetVertices[cvPos + 15] = mX;
->closetVertices[cvPos + 15] = mX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->mX : number
-
-        closetVertices[cvPos + 16] = mY;
->closetVertices[cvPos + 16] = mY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->mY : number
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices[cvPos + 17] = iZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->iZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //N
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->mX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = nY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->nY : number
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->iZ : any
-
-        //J
-        closetVertices[cvPos + 3] = eX;
->closetVertices[cvPos + 3] = eX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->eX : number
-
-        closetVertices[cvPos + 4] = fY;
->closetVertices[cvPos + 4] = fY : any
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->fY : any
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices[cvPos + 5] = iZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->iZ : any
-
-        //L
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->gX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->fY : any
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->iZ : any
-
-        //P
-        closetVertices[cvPos + 15] = oX;
->closetVertices[cvPos + 15] = oX : any
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->oX : any
-
-        closetVertices[cvPos + 16] = nY;
->closetVertices[cvPos + 16] = nY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->nY : number
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices[cvPos + 17] = iZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->iZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //O
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = oX : any
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = oX : any
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->oX : any
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->mY : number
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->iZ : any
-
-        //P
-        closetVertices[cvPos + 3] = oX;
->closetVertices[cvPos + 3] = oX : any
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->oX : any
-
-        closetVertices[cvPos + 4] = nY;
->closetVertices[cvPos + 4] = nY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->nY : number
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices[cvPos + 5] = iZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->iZ : any
-
-        //L
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = gX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->gX : number
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = fY : any
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->fY : any
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->iZ : any
-
-        //K
-        closetVertices[cvPos + 15] = gX;
->closetVertices[cvPos + 15] = gX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->gX : number
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices[cvPos + 16] = eY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->eY : number
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices[cvPos + 17] = iZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->iZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        //I
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = eX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->eX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = eY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->eY : number
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->iZ : any
-
-        //M
-        closetVertices[cvPos + 3] = mX;
->closetVertices[cvPos + 3] = mX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->mX : number
-
-        closetVertices[cvPos + 4] = mY;
->closetVertices[cvPos + 4] = mY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->mY : number
-
-        closetVertices[cvPos + 5] = iZ;
->closetVertices[cvPos + 5] = iZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->iZ : any
-
-        //O
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->oX : any
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = mY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->mY : number
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->iZ : any
-
-        //K
-        closetVertices[cvPos + 15] = gX;
->closetVertices[cvPos + 15] = gX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->gX : number
-
-        closetVertices[cvPos + 16] = eY;
->closetVertices[cvPos + 16] = eY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->eY : number
-
-        closetVertices[cvPos + 17] = iZ;
->closetVertices[cvPos + 17] = iZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->iZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        // HANDLE
-        if (a.handleWidth > 0) {
->a.handleWidth > 0 : boolean
->a.handleWidth : any
->a : any
->handleWidth : any
->0 : 0
-
-            // HANDLE SIDES
-            //M
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->mX : number
-
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->mY : number
 
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->iZ : any
-
-            //N
-            closetVertices[cvPos + 3] = mX;
->closetVertices[cvPos + 3] = mX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->mX : number
-
-            closetVertices[cvPos + 4] = nY;
->closetVertices[cvPos + 4] = nY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->nY : number
-
-            closetVertices[cvPos + 5] = iZ;
->closetVertices[cvPos + 5] = iZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->iZ : any
-
-            //R
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = mX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->mX : number
-
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->nY : number
-
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = qZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->qZ : any
-
-            //Q
-            closetVertices[cvPos + 15] = mX;
->closetVertices[cvPos + 15] = mX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->mX : number
-
-            closetVertices[cvPos + 16] = mY;
->closetVertices[cvPos + 16] = mY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->mY : number
-
-            closetVertices[cvPos + 17] = qZ;
->closetVertices[cvPos + 17] = qZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->qZ : any
-
-            cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-            //R
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->mX : number
-
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = nY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->nY : number
 
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = qZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->qZ : any
-
-            //N
-            closetVertices[cvPos + 3] = mX;
->closetVertices[cvPos + 3] = mX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->mX : number
-
-            closetVertices[cvPos + 4] = nY;
->closetVertices[cvPos + 4] = nY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->nY : number
-
-            closetVertices[cvPos + 5] = iZ;
->closetVertices[cvPos + 5] = iZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->iZ : any
-
-            //P
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->oX : any
-
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->nY : number
-
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->iZ : any
-
-            //T
-            closetVertices[cvPos + 15] = oX;
->closetVertices[cvPos + 15] = oX : any
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->oX : any
-
-            closetVertices[cvPos + 16] = nY;
->closetVertices[cvPos + 16] = nY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->nY : number
-
-            closetVertices[cvPos + 17] = qZ;
->closetVertices[cvPos + 17] = qZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->qZ : any
-
-            cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-            //S
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = oX : any
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = oX : any
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->oX : any
-
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->mY : number
 
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = qZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->qZ : any
-
-            //T
-            closetVertices[cvPos + 3] = oX;
->closetVertices[cvPos + 3] = oX : any
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->oX : any
-
-            closetVertices[cvPos + 4] = nY;
->closetVertices[cvPos + 4] = nY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->nY : number
-
-            closetVertices[cvPos + 5] = qZ;
->closetVertices[cvPos + 5] = qZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->qZ : any
-
-            //P
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->oX : any
-
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->nY : number
-
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = iZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->iZ : any
-
-            //O
-            closetVertices[cvPos + 15] = oX;
->closetVertices[cvPos + 15] = oX : any
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->oX : any
-
-            closetVertices[cvPos + 16] = mY;
->closetVertices[cvPos + 16] = mY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->mY : number
-
-            closetVertices[cvPos + 17] = iZ;
->closetVertices[cvPos + 17] = iZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->iZ : any
-
-            cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-            //M
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->mX : number
-
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->mY : number
 
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = iZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->iZ : any
-
-            //Q
-            closetVertices[cvPos + 3] = mX;
->closetVertices[cvPos + 3] = mX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->mX : number
-
-            closetVertices[cvPos + 4] = mY;
->closetVertices[cvPos + 4] = mY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->mY : number
-
-            closetVertices[cvPos + 5] = qZ;
->closetVertices[cvPos + 5] = qZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->qZ : any
-
-            //S
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->oX : any
-
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = mY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->mY : number
-
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = qZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->qZ : any
-
-            //O
-            closetVertices[cvPos + 15] = oX;
->closetVertices[cvPos + 15] = oX : any
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->oX : any
-
-            closetVertices[cvPos + 16] = mY;
->closetVertices[cvPos + 16] = mY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->mY : number
-
-            closetVertices[cvPos + 17] = iZ;
->closetVertices[cvPos + 17] = iZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->iZ : any
-
-            cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-        }
-        // HANDLE FRONT
-        //Q
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = mX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->mX : number
-
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = mY : number
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->mY : number
 
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = qZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->qZ : any
-
-        //R
-        closetVertices[cvPos + 3] = mX;
->closetVertices[cvPos + 3] = mX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->mX : number
-
-        closetVertices[cvPos + 4] = nY;
->closetVertices[cvPos + 4] = nY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->nY : number
-
-        closetVertices[cvPos + 5] = qZ;
->closetVertices[cvPos + 5] = qZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->qZ : any
-
-        //T
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = oX : any
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->oX : any
-
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = nY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->nY : number
-
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = qZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->qZ : any
-
-        //S
-        closetVertices[cvPos + 15] = oX;
->closetVertices[cvPos + 15] = oX : any
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->oX : any
-
-        closetVertices[cvPos + 16] = mY;
->closetVertices[cvPos + 16] = mY : number
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->mY : number
-
-        closetVertices[cvPos + 17] = qZ;
->closetVertices[cvPos + 17] = qZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->qZ : any
-
-        cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-        step += elementLength;
->step += elementLength : number
->step : number
->elementLength : number
-    }
-
-    //CLOSET BOX
-
-    // FRONT VIEW VERTICES
-    //
-    // A/E---C/G
-    //  |     |
-    //  |     |
-    //  |     |
-    // B/F---D/H
-
-    aX = 0;
->aX = 0 : 0
->aX : number
->0 : 0
-
-    aY = a.h + offsetY;
->aY = a.h + offsetY : any
->aY : any
->a.h + offsetY : any
->a.h : any
->a : any
->h : any
->offsetY : number
-
-    aZ = a.w;
->aZ = a.w : any
->aZ : any
->a.w : any
->a : any
->w : any
-
-    bY = 0;
->bY = 0 : 0
->bY : number
->0 : 0
-
-    cX = a.l;
->cX = a.l : any
->cX : number
->a.l : any
->a : any
->l : any
-
-    var eZ = 0;
->eZ : number
->0 : 0
-
-    //E
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = aX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = aX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->aX : number
-
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->aY : any
 
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ : number
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = eZ : number
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->eZ : number
-
-    //F
-    closetVertices[cvPos + 3] = aX;
->closetVertices[cvPos + 3] = aX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->aX : number
-
-    closetVertices[cvPos + 4] = bY;
->closetVertices[cvPos + 4] = bY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->bY : number
-
-    closetVertices[cvPos + 5] = eZ;
->closetVertices[cvPos + 5] = eZ : number
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->eZ : number
-
-    //B
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = aX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->aX : number
-
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->bY : number
-
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->aZ : any
-
-    //A
-    closetVertices[cvPos + 15] = aX;
->closetVertices[cvPos + 15] = aX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->aX : number
-
-    closetVertices[cvPos + 16] = aY;
->closetVertices[cvPos + 16] = aY : any
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->aY : any
-
-    closetVertices[cvPos + 17] = aZ;
->closetVertices[cvPos + 17] = aZ : any
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->aZ : any
-
-    cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-    //E
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = aX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = aX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->aX : number
-
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->aY : any
 
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ : number
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = eZ : number
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->eZ : number
-
-    //A
-    closetVertices[cvPos + 3] = aX;
->closetVertices[cvPos + 3] = aX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->aX : number
-
-    closetVertices[cvPos + 4] = aY;
->closetVertices[cvPos + 4] = aY : any
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->aY : any
-
-    closetVertices[cvPos + 5] = aZ;
->closetVertices[cvPos + 5] = aZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->aZ : any
-
-    //C
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = cX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->cX : number
-
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = aY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = aY : any
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = aY : any
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->aY : any
-
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = aZ : any
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->aZ : any
-
-    //G
-    closetVertices[cvPos + 15] = cX;
->closetVertices[cvPos + 15] = cX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->cX : number
-
-    closetVertices[cvPos + 16] = aY;
->closetVertices[cvPos + 16] = aY : any
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->aY : any
-
-    closetVertices[cvPos + 17] = eZ;
->closetVertices[cvPos + 17] = eZ : number
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->eZ : number
-
-    cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-    //C
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = cX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = cX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->cX : number
-
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->aY : any
 
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = aZ : any
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->aZ : any
-
-    //D
-    closetVertices[cvPos + 3] = cX;
->closetVertices[cvPos + 3] = cX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->cX : number
-
-    closetVertices[cvPos + 4] = bY;
->closetVertices[cvPos + 4] = bY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->bY : number
-
-    closetVertices[cvPos + 5] = aZ;
->closetVertices[cvPos + 5] = aZ : any
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->aZ : any
-
-    //H
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = cX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->cX : number
-
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->bY : number
-
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ : number
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = eZ : number
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->eZ : number
-
-    //G
-    closetVertices[cvPos + 15] = cX;
->closetVertices[cvPos + 15] = cX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->cX : number
-
-    closetVertices[cvPos + 16] = aY;
->closetVertices[cvPos + 16] = aY : any
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->aY : any
-
-    closetVertices[cvPos + 17] = eZ;
->closetVertices[cvPos + 17] = eZ : number
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->eZ : number
-
-    cvPos = cvPos + 18;
->cvPos = cvPos + 18 : number
->cvPos : number
->cvPos + 18 : number
->cvPos : number
->18 : 18
-
-    //G
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
->closetVertices[cvPos] = closetVertices[cvPos + 9] = cX : number
->closetVertices[cvPos] : any
->closetVertices : any[]
->cvPos : number
->closetVertices[cvPos + 9] = cX : number
->closetVertices[cvPos + 9] : any
->closetVertices : any[]
->cvPos + 9 : number
->cvPos : number
->9 : 9
->cX : number
-
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
->closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 1] : any
->closetVertices : any[]
->cvPos + 1 : number
->cvPos : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
 >1 : 1
->closetVertices[cvPos + 10] = aY : any
->closetVertices[cvPos + 10] : any
->closetVertices : any[]
->cvPos + 10 : number
->cvPos : number
->10 : 10
->aY : any
 
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
->closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ : number
->closetVertices[cvPos + 2] : any
->closetVertices : any[]
->cvPos + 2 : number
->cvPos : number
->2 : 2
->closetVertices[cvPos + 11] = eZ : number
->closetVertices[cvPos + 11] : any
->closetVertices : any[]
->cvPos + 11 : number
->cvPos : number
->11 : 11
->eZ : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    //H
-    closetVertices[cvPos + 3] = cX;
->closetVertices[cvPos + 3] = cX : number
->closetVertices[cvPos + 3] : any
->closetVertices : any[]
->cvPos + 3 : number
->cvPos : number
->3 : 3
->cX : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    closetVertices[cvPos + 4] = bY;
->closetVertices[cvPos + 4] = bY : number
->closetVertices[cvPos + 4] : any
->closetVertices : any[]
->cvPos + 4 : number
->cvPos : number
->4 : 4
->bY : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    closetVertices[cvPos + 5] = eZ;
->closetVertices[cvPos + 5] = eZ : number
->closetVertices[cvPos + 5] : any
->closetVertices : any[]
->cvPos + 5 : number
->cvPos : number
->5 : 5
->eZ : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    //F
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
->closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX : number
->closetVertices[cvPos + 6] : any
->closetVertices : any[]
->cvPos + 6 : number
->cvPos : number
->6 : 6
->closetVertices[cvPos + 12] = aX : number
->closetVertices[cvPos + 12] : any
->closetVertices : any[]
->cvPos + 12 : number
->cvPos : number
->12 : 12
->aX : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
->closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 7] : any
->closetVertices : any[]
->cvPos + 7 : number
->cvPos : number
->7 : 7
->closetVertices[cvPos + 13] = bY : number
->closetVertices[cvPos + 13] : any
->closetVertices : any[]
->cvPos + 13 : number
->cvPos : number
->13 : 13
->bY : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
->closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ : number
->closetVertices[cvPos + 8] : any
->closetVertices : any[]
->cvPos + 8 : number
->cvPos : number
->8 : 8
->closetVertices[cvPos + 14] = eZ : number
->closetVertices[cvPos + 14] : any
->closetVertices : any[]
->cvPos + 14 : number
->cvPos : number
->14 : 14
->eZ : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    //E
-    closetVertices[cvPos + 15] = aX;
->closetVertices[cvPos + 15] = aX : number
->closetVertices[cvPos + 15] : any
->closetVertices : any[]
->cvPos + 15 : number
->cvPos : number
->15 : 15
->aX : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    closetVertices[cvPos + 16] = aY;
->closetVertices[cvPos + 16] = aY : any
->closetVertices[cvPos + 16] : any
->closetVertices : any[]
->cvPos + 16 : number
->cvPos : number
->16 : 16
->aY : any
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    closetVertices[cvPos + 17] = eZ;
->closetVertices[cvPos + 17] = eZ : number
->closetVertices[cvPos + 17] : any
->closetVertices : any[]
->cvPos + 17 : number
->cvPos : number
->17 : 17
->eZ : number
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-    return Promise.resolve({
->Promise.resolve({        closet: {            positions: new Float32Array(closetVertices),            material: 'closet'        }    }) : Promise<{ closet: { positions: Float32Array; material: string; }; }>
->Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
->Promise : PromiseConstructor
->resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
->{        closet: {            positions: new Float32Array(closetVertices),            material: 'closet'        }    } : { closet: { positions: Float32Array; material: string; }; }
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-        closet: {
->closet : { positions: Float32Array; material: string; }
->{            positions: new Float32Array(closetVertices),            material: 'closet'        } : { positions: Float32Array; material: string; }
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-            positions: new Float32Array(closetVertices),
->positions : Float32Array
->new Float32Array(closetVertices) : Float32Array
->Float32Array : Float32ArrayConstructor
->closetVertices : any[]
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
 
-            material: 'closet'
->material : string
->'closet' : "closet"
-        }
-    });
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    arr[i++] = arr[i] + 1;
+>arr[i++] = arr[i] + 1 : any
+>arr[i++] : any
+>arr : any[]
+>i++ : number
+>i : number
+>arr[i] + 1 : any
+>arr[i] : any
+>arr : any[]
+>i : number
+>1 : 1
+
+    return arr;
+>arr : any[]
 }
 
-const a = generateMeshes3d(null);
->a : Promise<{ closet: { positions: Float32Array; material: string; }; }>
->generateMeshes3d(null) : Promise<{ closet: { positions: Float32Array; material: string; }; }>
->generateMeshes3d : (a: any) => Promise<{ closet: { positions: Float32Array; material: string; }; }>
->null : null
+const a = build();
+>a : any[]
+>build() : any[]
+>build : () => any[]
 

--- a/tests/baselines/reference/deeplyDependentLargeArrayMutation2.types
+++ b/tests/baselines/reference/deeplyDependentLargeArrayMutation2.types
@@ -1,0 +1,3606 @@
+=== tests/cases/compiler/foo.js ===
+// Exerpt from https://github.com/archilogic-com/3dio-js - MIT Licenced
+function generateMeshes3d(a) {
+>generateMeshes3d : (a: any) => Promise<{ closet: { positions: Float32Array; material: string; }; }>
+>a : any
+
+    var step = 0,
+>step : number
+>0 : 0
+
+        elementNum = Math.round(a.l / 0.6),
+>elementNum : number
+>Math.round(a.l / 0.6) : number
+>Math.round : (x: number) => number
+>Math : Math
+>round : (x: number) => number
+>a.l / 0.6 : number
+>a.l : any
+>a : any
+>l : any
+>0.6 : 0.6
+
+        elementLength = a.l / elementNum,
+>elementLength : number
+>a.l / elementNum : number
+>a.l : any
+>a : any
+>l : any
+>elementNum : number
+
+        handlePos = elementLength * 0.8,
+>handlePos : number
+>elementLength * 0.8 : number
+>elementLength : number
+>0.8 : 0.8
+
+        //handleWidth = a.handleWidth+ a.doorWidth,
+        handleDistance = 0.05,
+>handleDistance : number
+>0.05 : 0.05
+
+        offsetY = -0.01,
+>offsetY : number
+>-0.01 : -0.01
+>0.01 : 0.01
+
+
+        // internals
+        closetVertices = [],
+>closetVertices : any[]
+>[] : undefined[]
+
+        cvPos = 0;
+>cvPos : number
+>0 : 0
+
+    //CLOSET DOORS
+
+    // FRONT VIEW VERTICES
+    //
+    // A------------C
+    // |E\I------G\K|
+    // | |        | |
+    // | |M\Q-O\S | |
+    // | ||   |   | |
+    // | |N\R-P\T | |
+    // |F\J------H\L|
+    // B------------D
+
+    var aX = step,
+>aX : number
+>step : number
+
+        aY = a.h + offsetY,
+>aY : any
+>a.h + offsetY : any
+>a.h : any
+>a : any
+>h : any
+>offsetY : number
+
+        aZ = a.w,
+>aZ : any
+>a.w : any
+>a : any
+>w : any
+
+        bY = 0,
+>bY : number
+>0 : 0
+
+        cX = step + elementLength,
+>cX : number
+>step + elementLength : number
+>step : number
+>elementLength : number
+
+        eX = step + a.doorWidth / 2,
+>eX : number
+>step + a.doorWidth / 2 : number
+>step : number
+>a.doorWidth / 2 : number
+>a.doorWidth : any
+>a : any
+>doorWidth : any
+>2 : 2
+
+        eY = a.h - a.doorWidth,
+>eY : number
+>a.h - a.doorWidth : number
+>a.h : any
+>a : any
+>h : any
+>a.doorWidth : any
+>a : any
+>doorWidth : any
+
+        fY = a.baseboard,
+>fY : any
+>a.baseboard : any
+>a : any
+>baseboard : any
+
+        gX = step + elementLength - a.doorWidth / 2,
+>gX : number
+>step + elementLength - a.doorWidth / 2 : number
+>step + elementLength : number
+>step : number
+>elementLength : number
+>a.doorWidth / 2 : number
+>a.doorWidth : any
+>a : any
+>doorWidth : any
+>2 : 2
+
+        iZ = a.w + a.doorWidth,
+>iZ : any
+>a.w + a.doorWidth : any
+>a.w : any
+>a : any
+>w : any
+>a.doorWidth : any
+>a : any
+>doorWidth : any
+
+        mX = step + handlePos,
+>mX : number
+>step + handlePos : number
+>step : number
+>handlePos : number
+
+        mY = 1 + a.handleHeight / 2,
+>mY : number
+>1 + a.handleHeight / 2 : number
+>1 : 1
+>a.handleHeight / 2 : number
+>a.handleHeight : any
+>a : any
+>handleHeight : any
+>2 : 2
+
+        nY = 1 - a.handleHeight / 2,
+>nY : number
+>1 - a.handleHeight / 2 : number
+>1 : 1
+>a.handleHeight / 2 : number
+>a.handleHeight : any
+>a : any
+>handleHeight : any
+>2 : 2
+
+        oX = step + handlePos + a.handleLength,
+>oX : any
+>step + handlePos + a.handleLength : any
+>step + handlePos : number
+>step : number
+>handlePos : number
+>a.handleLength : any
+>a : any
+>handleLength : any
+
+        qZ = a.w + a.doorWidth + a.handleWidth;
+>qZ : any
+>a.w + a.doorWidth + a.handleWidth : any
+>a.w + a.doorWidth : any
+>a.w : any
+>a : any
+>w : any
+>a.doorWidth : any
+>a : any
+>doorWidth : any
+>a.handleWidth : any
+>a : any
+>handleWidth : any
+
+    for (var c = 0; c < elementNum; c++) {
+>c : number
+>0 : 0
+>c < elementNum : boolean
+>c : number
+>elementNum : number
+>c++ : number
+>c : number
+
+        if (c % 2 == 1 || c === elementNum - 1) {
+>c % 2 == 1 || c === elementNum - 1 : boolean
+>c % 2 == 1 : boolean
+>c % 2 : number
+>c : number
+>2 : 2
+>1 : 1
+>c === elementNum - 1 : boolean
+>c : number
+>elementNum - 1 : number
+>elementNum : number
+>1 : 1
+
+            handlePos = handleDistance + a.handleLength / 2;
+>handlePos = handleDistance + a.handleLength / 2 : number
+>handlePos : number
+>handleDistance + a.handleLength / 2 : number
+>handleDistance : number
+>a.handleLength / 2 : number
+>a.handleLength : any
+>a : any
+>handleLength : any
+>2 : 2
+
+        } else {
+            handlePos = elementLength - handleDistance - a.handleLength / 2;
+>handlePos = elementLength - handleDistance - a.handleLength / 2 : number
+>handlePos : number
+>elementLength - handleDistance - a.handleLength / 2 : number
+>elementLength - handleDistance : number
+>elementLength : number
+>handleDistance : number
+>a.handleLength / 2 : number
+>a.handleLength : any
+>a : any
+>handleLength : any
+>2 : 2
+        }
+        aX = step;
+>aX = step : number
+>aX : number
+>step : number
+
+        cX = step + elementLength;
+>cX = step + elementLength : number
+>cX : number
+>step + elementLength : number
+>step : number
+>elementLength : number
+
+        eX = step + a.doorWidth / 2;
+>eX = step + a.doorWidth / 2 : number
+>eX : number
+>step + a.doorWidth / 2 : number
+>step : number
+>a.doorWidth / 2 : number
+>a.doorWidth : any
+>a : any
+>doorWidth : any
+>2 : 2
+
+        gX = step + elementLength - a.doorWidth / 2;
+>gX = step + elementLength - a.doorWidth / 2 : number
+>gX : number
+>step + elementLength - a.doorWidth / 2 : number
+>step + elementLength : number
+>step : number
+>elementLength : number
+>a.doorWidth / 2 : number
+>a.doorWidth : any
+>a : any
+>doorWidth : any
+>2 : 2
+
+        mX = step + handlePos - a.handleLength / 2;
+>mX = step + handlePos - a.handleLength / 2 : number
+>mX : number
+>step + handlePos - a.handleLength / 2 : number
+>step + handlePos : number
+>step : number
+>handlePos : number
+>a.handleLength / 2 : number
+>a.handleLength : any
+>a : any
+>handleLength : any
+>2 : 2
+
+        oX = step + handlePos + a.handleLength / 2;
+>oX = step + handlePos + a.handleLength / 2 : number
+>oX : any
+>step + handlePos + a.handleLength / 2 : number
+>step + handlePos : number
+>step : number
+>handlePos : number
+>a.handleLength / 2 : number
+>a.handleLength : any
+>a : any
+>handleLength : any
+>2 : 2
+
+        // DOOR FRAME
+        //A
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = aX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = aX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>aX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>aY : any
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>aZ : any
+
+        //B
+        closetVertices[cvPos + 3] = aX;
+>closetVertices[cvPos + 3] = aX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>aX : number
+
+        closetVertices[cvPos + 4] = bY;
+>closetVertices[cvPos + 4] = bY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>bY : number
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices[cvPos + 5] = aZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>aZ : any
+
+        //F
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = eX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>eX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>fY : any
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>aZ : any
+
+        //E
+        closetVertices[cvPos + 15] = eX;
+>closetVertices[cvPos + 15] = eX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>eX : number
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices[cvPos + 16] = eY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>eY : number
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices[cvPos + 17] = aZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>aZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //F
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>eX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY : any
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = fY : any
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>fY : any
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>aZ : any
+
+        //B
+        closetVertices[cvPos + 3] = aX;
+>closetVertices[cvPos + 3] = aX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>aX : number
+
+        closetVertices[cvPos + 4] = bY;
+>closetVertices[cvPos + 4] = bY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>bY : number
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices[cvPos + 5] = aZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>aZ : any
+
+        //D
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = cX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>cX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>bY : number
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>aZ : any
+
+        //H
+        closetVertices[cvPos + 15] = gX;
+>closetVertices[cvPos + 15] = gX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>gX : number
+
+        closetVertices[cvPos + 16] = fY;
+>closetVertices[cvPos + 16] = fY : any
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>fY : any
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices[cvPos + 17] = aZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>aZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //G
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = gX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = gX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>gX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>eY : number
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>aZ : any
+
+        //H
+        closetVertices[cvPos + 3] = gX;
+>closetVertices[cvPos + 3] = gX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>gX : number
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices[cvPos + 4] = fY : any
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>fY : any
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices[cvPos + 5] = aZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>aZ : any
+
+        //D
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = cX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>cX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>bY : number
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>aZ : any
+
+        //C
+        closetVertices[cvPos + 15] = cX;
+>closetVertices[cvPos + 15] = cX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>cX : number
+
+        closetVertices[cvPos + 16] = aY;
+>closetVertices[cvPos + 16] = aY : any
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>aY : any
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices[cvPos + 17] = aZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>aZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //A
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = aX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = aX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>aX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>aY : any
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>aZ : any
+
+        //E
+        closetVertices[cvPos + 3] = eX;
+>closetVertices[cvPos + 3] = eX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>eX : number
+
+        closetVertices[cvPos + 4] = eY;
+>closetVertices[cvPos + 4] = eY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>eY : number
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices[cvPos + 5] = aZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>aZ : any
+
+        //G
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>gX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = eY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>eY : number
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>aZ : any
+
+        //C
+        closetVertices[cvPos + 15] = cX;
+>closetVertices[cvPos + 15] = cX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>cX : number
+
+        closetVertices[cvPos + 16] = aY;
+>closetVertices[cvPos + 16] = aY : any
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>aY : any
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices[cvPos + 17] = aZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>aZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        // DOOR LEAF
+
+        //E
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>eX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>eY : number
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>aZ : any
+
+        //F
+        closetVertices[cvPos + 3] = eX;
+>closetVertices[cvPos + 3] = eX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>eX : number
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices[cvPos + 4] = fY : any
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>fY : any
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices[cvPos + 5] = aZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>aZ : any
+
+        //J
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = eX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>eX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>fY : any
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>iZ : any
+
+        //I
+        closetVertices[cvPos + 15] = eX;
+>closetVertices[cvPos + 15] = eX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>eX : number
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices[cvPos + 16] = eY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>eY : number
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices[cvPos + 17] = iZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>iZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //J
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>eX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY : any
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = fY : any
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>fY : any
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>iZ : any
+
+        //F
+        closetVertices[cvPos + 3] = eX;
+>closetVertices[cvPos + 3] = eX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>eX : number
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices[cvPos + 4] = fY : any
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>fY : any
+
+        closetVertices[cvPos + 5] = aZ;
+>closetVertices[cvPos + 5] = aZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>aZ : any
+
+        //H
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>gX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>fY : any
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>aZ : any
+
+        //L
+        closetVertices[cvPos + 15] = gX;
+>closetVertices[cvPos + 15] = gX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>gX : number
+
+        closetVertices[cvPos + 16] = fY;
+>closetVertices[cvPos + 16] = fY : any
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>fY : any
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices[cvPos + 17] = iZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>iZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //K
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = gX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = gX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>gX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>eY : number
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>iZ : any
+
+        //L
+        closetVertices[cvPos + 3] = gX;
+>closetVertices[cvPos + 3] = gX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>gX : number
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices[cvPos + 4] = fY : any
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>fY : any
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices[cvPos + 5] = iZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>iZ : any
+
+        //H
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>gX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>fY : any
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>aZ : any
+
+        //G
+        closetVertices[cvPos + 15] = gX;
+>closetVertices[cvPos + 15] = gX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>gX : number
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices[cvPos + 16] = eY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>eY : number
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices[cvPos + 17] = aZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>aZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //E
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>eX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>eY : number
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>aZ : any
+
+        //I
+        closetVertices[cvPos + 3] = eX;
+>closetVertices[cvPos + 3] = eX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>eX : number
+
+        closetVertices[cvPos + 4] = eY;
+>closetVertices[cvPos + 4] = eY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>eY : number
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices[cvPos + 5] = iZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>iZ : any
+
+        //K
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>gX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = eY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>eY : number
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>iZ : any
+
+        //G
+        closetVertices[cvPos + 15] = gX;
+>closetVertices[cvPos + 15] = gX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>gX : number
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices[cvPos + 16] = eY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>eY : number
+
+        closetVertices[cvPos + 17] = aZ;
+>closetVertices[cvPos + 17] = aZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>aZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //I
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>eX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>eY : number
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>iZ : any
+
+        //J
+        closetVertices[cvPos + 3] = eX;
+>closetVertices[cvPos + 3] = eX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>eX : number
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices[cvPos + 4] = fY : any
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>fY : any
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices[cvPos + 5] = iZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>iZ : any
+
+        //N
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = mX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>mX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>nY : number
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>iZ : any
+
+        //M
+        closetVertices[cvPos + 15] = mX;
+>closetVertices[cvPos + 15] = mX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>mX : number
+
+        closetVertices[cvPos + 16] = mY;
+>closetVertices[cvPos + 16] = mY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>mY : number
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices[cvPos + 17] = iZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>iZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //N
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>mX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = nY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>nY : number
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>iZ : any
+
+        //J
+        closetVertices[cvPos + 3] = eX;
+>closetVertices[cvPos + 3] = eX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>eX : number
+
+        closetVertices[cvPos + 4] = fY;
+>closetVertices[cvPos + 4] = fY : any
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>fY : any
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices[cvPos + 5] = iZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>iZ : any
+
+        //L
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>gX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>fY : any
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>iZ : any
+
+        //P
+        closetVertices[cvPos + 15] = oX;
+>closetVertices[cvPos + 15] = oX : any
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>oX : any
+
+        closetVertices[cvPos + 16] = nY;
+>closetVertices[cvPos + 16] = nY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>nY : number
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices[cvPos + 17] = iZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>iZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //O
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = oX : any
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = oX : any
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>oX : any
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>mY : number
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>iZ : any
+
+        //P
+        closetVertices[cvPos + 3] = oX;
+>closetVertices[cvPos + 3] = oX : any
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>oX : any
+
+        closetVertices[cvPos + 4] = nY;
+>closetVertices[cvPos + 4] = nY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>nY : number
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices[cvPos + 5] = iZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>iZ : any
+
+        //L
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = gX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>gX : number
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = fY : any
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>fY : any
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>iZ : any
+
+        //K
+        closetVertices[cvPos + 15] = gX;
+>closetVertices[cvPos + 15] = gX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>gX : number
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices[cvPos + 16] = eY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>eY : number
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices[cvPos + 17] = iZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>iZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        //I
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = eX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>eX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = eY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>eY : number
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>iZ : any
+
+        //M
+        closetVertices[cvPos + 3] = mX;
+>closetVertices[cvPos + 3] = mX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>mX : number
+
+        closetVertices[cvPos + 4] = mY;
+>closetVertices[cvPos + 4] = mY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>mY : number
+
+        closetVertices[cvPos + 5] = iZ;
+>closetVertices[cvPos + 5] = iZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>iZ : any
+
+        //O
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>oX : any
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = mY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>mY : number
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>iZ : any
+
+        //K
+        closetVertices[cvPos + 15] = gX;
+>closetVertices[cvPos + 15] = gX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>gX : number
+
+        closetVertices[cvPos + 16] = eY;
+>closetVertices[cvPos + 16] = eY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>eY : number
+
+        closetVertices[cvPos + 17] = iZ;
+>closetVertices[cvPos + 17] = iZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>iZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        // HANDLE
+        if (a.handleWidth > 0) {
+>a.handleWidth > 0 : boolean
+>a.handleWidth : any
+>a : any
+>handleWidth : any
+>0 : 0
+
+            // HANDLE SIDES
+            //M
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>mX : number
+
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>mY : number
+
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>iZ : any
+
+            //N
+            closetVertices[cvPos + 3] = mX;
+>closetVertices[cvPos + 3] = mX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>mX : number
+
+            closetVertices[cvPos + 4] = nY;
+>closetVertices[cvPos + 4] = nY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>nY : number
+
+            closetVertices[cvPos + 5] = iZ;
+>closetVertices[cvPos + 5] = iZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>iZ : any
+
+            //R
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = mX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>mX : number
+
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>nY : number
+
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = qZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>qZ : any
+
+            //Q
+            closetVertices[cvPos + 15] = mX;
+>closetVertices[cvPos + 15] = mX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>mX : number
+
+            closetVertices[cvPos + 16] = mY;
+>closetVertices[cvPos + 16] = mY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>mY : number
+
+            closetVertices[cvPos + 17] = qZ;
+>closetVertices[cvPos + 17] = qZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>qZ : any
+
+            cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+            //R
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>mX : number
+
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = nY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>nY : number
+
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = qZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>qZ : any
+
+            //N
+            closetVertices[cvPos + 3] = mX;
+>closetVertices[cvPos + 3] = mX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>mX : number
+
+            closetVertices[cvPos + 4] = nY;
+>closetVertices[cvPos + 4] = nY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>nY : number
+
+            closetVertices[cvPos + 5] = iZ;
+>closetVertices[cvPos + 5] = iZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>iZ : any
+
+            //P
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>oX : any
+
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>nY : number
+
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>iZ : any
+
+            //T
+            closetVertices[cvPos + 15] = oX;
+>closetVertices[cvPos + 15] = oX : any
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>oX : any
+
+            closetVertices[cvPos + 16] = nY;
+>closetVertices[cvPos + 16] = nY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>nY : number
+
+            closetVertices[cvPos + 17] = qZ;
+>closetVertices[cvPos + 17] = qZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>qZ : any
+
+            cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+            //S
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = oX : any
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = oX : any
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>oX : any
+
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>mY : number
+
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = qZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>qZ : any
+
+            //T
+            closetVertices[cvPos + 3] = oX;
+>closetVertices[cvPos + 3] = oX : any
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>oX : any
+
+            closetVertices[cvPos + 4] = nY;
+>closetVertices[cvPos + 4] = nY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>nY : number
+
+            closetVertices[cvPos + 5] = qZ;
+>closetVertices[cvPos + 5] = qZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>qZ : any
+
+            //P
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>oX : any
+
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>nY : number
+
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = iZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>iZ : any
+
+            //O
+            closetVertices[cvPos + 15] = oX;
+>closetVertices[cvPos + 15] = oX : any
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>oX : any
+
+            closetVertices[cvPos + 16] = mY;
+>closetVertices[cvPos + 16] = mY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>mY : number
+
+            closetVertices[cvPos + 17] = iZ;
+>closetVertices[cvPos + 17] = iZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>iZ : any
+
+            cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+            //M
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>mX : number
+
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>mY : number
+
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = iZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>iZ : any
+
+            //Q
+            closetVertices[cvPos + 3] = mX;
+>closetVertices[cvPos + 3] = mX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>mX : number
+
+            closetVertices[cvPos + 4] = mY;
+>closetVertices[cvPos + 4] = mY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>mY : number
+
+            closetVertices[cvPos + 5] = qZ;
+>closetVertices[cvPos + 5] = qZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>qZ : any
+
+            //S
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>oX : any
+
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = mY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>mY : number
+
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = qZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>qZ : any
+
+            //O
+            closetVertices[cvPos + 15] = oX;
+>closetVertices[cvPos + 15] = oX : any
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>oX : any
+
+            closetVertices[cvPos + 16] = mY;
+>closetVertices[cvPos + 16] = mY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>mY : number
+
+            closetVertices[cvPos + 17] = iZ;
+>closetVertices[cvPos + 17] = iZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>iZ : any
+
+            cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+        }
+        // HANDLE FRONT
+        //Q
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = mX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>mX : number
+
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = mY : number
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>mY : number
+
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = qZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>qZ : any
+
+        //R
+        closetVertices[cvPos + 3] = mX;
+>closetVertices[cvPos + 3] = mX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>mX : number
+
+        closetVertices[cvPos + 4] = nY;
+>closetVertices[cvPos + 4] = nY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>nY : number
+
+        closetVertices[cvPos + 5] = qZ;
+>closetVertices[cvPos + 5] = qZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>qZ : any
+
+        //T
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = oX : any
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>oX : any
+
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = nY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>nY : number
+
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = qZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>qZ : any
+
+        //S
+        closetVertices[cvPos + 15] = oX;
+>closetVertices[cvPos + 15] = oX : any
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>oX : any
+
+        closetVertices[cvPos + 16] = mY;
+>closetVertices[cvPos + 16] = mY : number
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>mY : number
+
+        closetVertices[cvPos + 17] = qZ;
+>closetVertices[cvPos + 17] = qZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>qZ : any
+
+        cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+        step += elementLength;
+>step += elementLength : number
+>step : number
+>elementLength : number
+    }
+
+    //CLOSET BOX
+
+    // FRONT VIEW VERTICES
+    //
+    // A/E---C/G
+    //  |     |
+    //  |     |
+    //  |     |
+    // B/F---D/H
+
+    aX = 0;
+>aX = 0 : 0
+>aX : number
+>0 : 0
+
+    aY = a.h + offsetY;
+>aY = a.h + offsetY : any
+>aY : any
+>a.h + offsetY : any
+>a.h : any
+>a : any
+>h : any
+>offsetY : number
+
+    aZ = a.w;
+>aZ = a.w : any
+>aZ : any
+>a.w : any
+>a : any
+>w : any
+
+    bY = 0;
+>bY = 0 : 0
+>bY : number
+>0 : 0
+
+    cX = a.l;
+>cX = a.l : any
+>cX : number
+>a.l : any
+>a : any
+>l : any
+
+    var eZ = 0;
+>eZ : number
+>0 : 0
+
+    //E
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = aX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = aX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>aX : number
+
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>aY : any
+
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ : number
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = eZ : number
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>eZ : number
+
+    //F
+    closetVertices[cvPos + 3] = aX;
+>closetVertices[cvPos + 3] = aX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>aX : number
+
+    closetVertices[cvPos + 4] = bY;
+>closetVertices[cvPos + 4] = bY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>bY : number
+
+    closetVertices[cvPos + 5] = eZ;
+>closetVertices[cvPos + 5] = eZ : number
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>eZ : number
+
+    //B
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = aX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>aX : number
+
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>bY : number
+
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>aZ : any
+
+    //A
+    closetVertices[cvPos + 15] = aX;
+>closetVertices[cvPos + 15] = aX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>aX : number
+
+    closetVertices[cvPos + 16] = aY;
+>closetVertices[cvPos + 16] = aY : any
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>aY : any
+
+    closetVertices[cvPos + 17] = aZ;
+>closetVertices[cvPos + 17] = aZ : any
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>aZ : any
+
+    cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+    //E
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = aX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = aX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>aX : number
+
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>aY : any
+
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ : number
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = eZ : number
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>eZ : number
+
+    //A
+    closetVertices[cvPos + 3] = aX;
+>closetVertices[cvPos + 3] = aX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>aX : number
+
+    closetVertices[cvPos + 4] = aY;
+>closetVertices[cvPos + 4] = aY : any
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>aY : any
+
+    closetVertices[cvPos + 5] = aZ;
+>closetVertices[cvPos + 5] = aZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>aZ : any
+
+    //C
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = cX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>cX : number
+
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = aY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = aY : any
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = aY : any
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>aY : any
+
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = aZ : any
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>aZ : any
+
+    //G
+    closetVertices[cvPos + 15] = cX;
+>closetVertices[cvPos + 15] = cX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>cX : number
+
+    closetVertices[cvPos + 16] = aY;
+>closetVertices[cvPos + 16] = aY : any
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>aY : any
+
+    closetVertices[cvPos + 17] = eZ;
+>closetVertices[cvPos + 17] = eZ : number
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>eZ : number
+
+    cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+    //C
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = cX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = cX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>cX : number
+
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>aY : any
+
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = aZ : any
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>aZ : any
+
+    //D
+    closetVertices[cvPos + 3] = cX;
+>closetVertices[cvPos + 3] = cX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>cX : number
+
+    closetVertices[cvPos + 4] = bY;
+>closetVertices[cvPos + 4] = bY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>bY : number
+
+    closetVertices[cvPos + 5] = aZ;
+>closetVertices[cvPos + 5] = aZ : any
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>aZ : any
+
+    //H
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = cX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>cX : number
+
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>bY : number
+
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ : number
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = eZ : number
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>eZ : number
+
+    //G
+    closetVertices[cvPos + 15] = cX;
+>closetVertices[cvPos + 15] = cX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>cX : number
+
+    closetVertices[cvPos + 16] = aY;
+>closetVertices[cvPos + 16] = aY : any
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>aY : any
+
+    closetVertices[cvPos + 17] = eZ;
+>closetVertices[cvPos + 17] = eZ : number
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>eZ : number
+
+    cvPos = cvPos + 18;
+>cvPos = cvPos + 18 : number
+>cvPos : number
+>cvPos + 18 : number
+>cvPos : number
+>18 : 18
+
+    //G
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
+>closetVertices[cvPos] = closetVertices[cvPos + 9] = cX : number
+>closetVertices[cvPos] : any
+>closetVertices : any[]
+>cvPos : number
+>closetVertices[cvPos + 9] = cX : number
+>closetVertices[cvPos + 9] : any
+>closetVertices : any[]
+>cvPos + 9 : number
+>cvPos : number
+>9 : 9
+>cX : number
+
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+>closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 1] : any
+>closetVertices : any[]
+>cvPos + 1 : number
+>cvPos : number
+>1 : 1
+>closetVertices[cvPos + 10] = aY : any
+>closetVertices[cvPos + 10] : any
+>closetVertices : any[]
+>cvPos + 10 : number
+>cvPos : number
+>10 : 10
+>aY : any
+
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
+>closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ : number
+>closetVertices[cvPos + 2] : any
+>closetVertices : any[]
+>cvPos + 2 : number
+>cvPos : number
+>2 : 2
+>closetVertices[cvPos + 11] = eZ : number
+>closetVertices[cvPos + 11] : any
+>closetVertices : any[]
+>cvPos + 11 : number
+>cvPos : number
+>11 : 11
+>eZ : number
+
+    //H
+    closetVertices[cvPos + 3] = cX;
+>closetVertices[cvPos + 3] = cX : number
+>closetVertices[cvPos + 3] : any
+>closetVertices : any[]
+>cvPos + 3 : number
+>cvPos : number
+>3 : 3
+>cX : number
+
+    closetVertices[cvPos + 4] = bY;
+>closetVertices[cvPos + 4] = bY : number
+>closetVertices[cvPos + 4] : any
+>closetVertices : any[]
+>cvPos + 4 : number
+>cvPos : number
+>4 : 4
+>bY : number
+
+    closetVertices[cvPos + 5] = eZ;
+>closetVertices[cvPos + 5] = eZ : number
+>closetVertices[cvPos + 5] : any
+>closetVertices : any[]
+>cvPos + 5 : number
+>cvPos : number
+>5 : 5
+>eZ : number
+
+    //F
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
+>closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX : number
+>closetVertices[cvPos + 6] : any
+>closetVertices : any[]
+>cvPos + 6 : number
+>cvPos : number
+>6 : 6
+>closetVertices[cvPos + 12] = aX : number
+>closetVertices[cvPos + 12] : any
+>closetVertices : any[]
+>cvPos + 12 : number
+>cvPos : number
+>12 : 12
+>aX : number
+
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+>closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 7] : any
+>closetVertices : any[]
+>cvPos + 7 : number
+>cvPos : number
+>7 : 7
+>closetVertices[cvPos + 13] = bY : number
+>closetVertices[cvPos + 13] : any
+>closetVertices : any[]
+>cvPos + 13 : number
+>cvPos : number
+>13 : 13
+>bY : number
+
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
+>closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ : number
+>closetVertices[cvPos + 8] : any
+>closetVertices : any[]
+>cvPos + 8 : number
+>cvPos : number
+>8 : 8
+>closetVertices[cvPos + 14] = eZ : number
+>closetVertices[cvPos + 14] : any
+>closetVertices : any[]
+>cvPos + 14 : number
+>cvPos : number
+>14 : 14
+>eZ : number
+
+    //E
+    closetVertices[cvPos + 15] = aX;
+>closetVertices[cvPos + 15] = aX : number
+>closetVertices[cvPos + 15] : any
+>closetVertices : any[]
+>cvPos + 15 : number
+>cvPos : number
+>15 : 15
+>aX : number
+
+    closetVertices[cvPos + 16] = aY;
+>closetVertices[cvPos + 16] = aY : any
+>closetVertices[cvPos + 16] : any
+>closetVertices : any[]
+>cvPos + 16 : number
+>cvPos : number
+>16 : 16
+>aY : any
+
+    closetVertices[cvPos + 17] = eZ;
+>closetVertices[cvPos + 17] = eZ : number
+>closetVertices[cvPos + 17] : any
+>closetVertices : any[]
+>cvPos + 17 : number
+>cvPos : number
+>17 : 17
+>eZ : number
+
+    return Promise.resolve({
+>Promise.resolve({        closet: {            positions: new Float32Array(closetVertices),            material: 'closet'        }    }) : Promise<{ closet: { positions: Float32Array; material: string; }; }>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>{        closet: {            positions: new Float32Array(closetVertices),            material: 'closet'        }    } : { closet: { positions: Float32Array; material: string; }; }
+
+        closet: {
+>closet : { positions: Float32Array; material: string; }
+>{            positions: new Float32Array(closetVertices),            material: 'closet'        } : { positions: Float32Array; material: string; }
+
+            positions: new Float32Array(closetVertices),
+>positions : Float32Array
+>new Float32Array(closetVertices) : Float32Array
+>Float32Array : Float32ArrayConstructor
+>closetVertices : any[]
+
+            material: 'closet'
+>material : string
+>'closet' : "closet"
+        }
+    });
+}
+
+const a = generateMeshes3d(null);
+>a : Promise<{ closet: { positions: Float32Array; material: string; }; }>
+>generateMeshes3d(null) : Promise<{ closet: { positions: Float32Array; material: string; }; }>
+>generateMeshes3d : (a: any) => Promise<{ closet: { positions: Float32Array; material: string; }; }>
+>null : null
+

--- a/tests/cases/compiler/deeplyDependentLargeArrayMutation.ts
+++ b/tests/cases/compiler/deeplyDependentLargeArrayMutation.ts
@@ -1,0 +1,35 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @target: es6
+// @filename: foo.js
+// repro from #26031
+function build() {
+    var arr = [];
+
+    arr[arr.length] = 'value'; 
+    arr[arr.length] = 'value'; 
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value'; 
+    arr[arr.length] = 'value'; 
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value'; 
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value';
+    arr[arr.length] = 'value'; 
+}

--- a/tests/cases/compiler/deeplyDependentLargeArrayMutation2.ts
+++ b/tests/cases/compiler/deeplyDependentLargeArrayMutation2.ts
@@ -1,498 +1,320 @@
 // @allowJs: true
 // @checkJs: true
 // @noEmit: true
-// @target: es6
 // @filename: foo.js
-// Exerpt from https://github.com/archilogic-com/3dio-js - MIT Licenced
-function generateMeshes3d(a) {
-
-    var step = 0,
-        elementNum = Math.round(a.l / 0.6),
-        elementLength = a.l / elementNum,
-        handlePos = elementLength * 0.8,
-
-        //handleWidth = a.handleWidth+ a.doorWidth,
-        handleDistance = 0.05,
-        offsetY = -0.01,
-
-
-        // internals
-        closetVertices = [],
-        cvPos = 0;
-
-    //CLOSET DOORS
-
-    // FRONT VIEW VERTICES
-    //
-    // A------------C
-    // |E\I------G\K|
-    // | |        | |
-    // | |M\Q-O\S | |
-    // | ||   |   | |
-    // | |N\R-P\T | |
-    // |F\J------H\L|
-    // B------------D
-
-    var aX = step,
-        aY = a.h + offsetY,
-        aZ = a.w,
-        bY = 0,
-        cX = step + elementLength,
-        eX = step + a.doorWidth / 2,
-        eY = a.h - a.doorWidth,
-        fY = a.baseboard,
-        gX = step + elementLength - a.doorWidth / 2,
-        iZ = a.w + a.doorWidth,
-        mX = step + handlePos,
-        mY = 1 + a.handleHeight / 2,
-        nY = 1 - a.handleHeight / 2,
-        oX = step + handlePos + a.handleLength,
-        qZ = a.w + a.doorWidth + a.handleWidth;
-
-    for (var c = 0; c < elementNum; c++) {
-
-        if (c % 2 == 1 || c === elementNum - 1) {
-            handlePos = handleDistance + a.handleLength / 2;
-        } else {
-            handlePos = elementLength - handleDistance - a.handleLength / 2;
-        }
-        aX = step;
-        cX = step + elementLength;
-        eX = step + a.doorWidth / 2;
-        gX = step + elementLength - a.doorWidth / 2;
-        mX = step + handlePos - a.handleLength / 2;
-        oX = step + handlePos + a.handleLength / 2;
-
-        // DOOR FRAME
-        //A
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
-        //B
-        closetVertices[cvPos + 3] = aX;
-        closetVertices[cvPos + 4] = bY;
-        closetVertices[cvPos + 5] = aZ;
-        //F
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
-        //E
-        closetVertices[cvPos + 15] = eX;
-        closetVertices[cvPos + 16] = eY;
-        closetVertices[cvPos + 17] = aZ;
-
-        cvPos = cvPos + 18;
-
-        //F
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
-        //B
-        closetVertices[cvPos + 3] = aX;
-        closetVertices[cvPos + 4] = bY;
-        closetVertices[cvPos + 5] = aZ;
-        //D
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
-        //H
-        closetVertices[cvPos + 15] = gX;
-        closetVertices[cvPos + 16] = fY;
-        closetVertices[cvPos + 17] = aZ;
-
-        cvPos = cvPos + 18;
-
-        //G
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
-        //H
-        closetVertices[cvPos + 3] = gX;
-        closetVertices[cvPos + 4] = fY;
-        closetVertices[cvPos + 5] = aZ;
-        //D
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
-        //C
-        closetVertices[cvPos + 15] = cX;
-        closetVertices[cvPos + 16] = aY;
-        closetVertices[cvPos + 17] = aZ;
-
-        cvPos = cvPos + 18;
-
-        //A
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
-        //E
-        closetVertices[cvPos + 3] = eX;
-        closetVertices[cvPos + 4] = eY;
-        closetVertices[cvPos + 5] = aZ;
-        //G
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
-        //C
-        closetVertices[cvPos + 15] = cX;
-        closetVertices[cvPos + 16] = aY;
-        closetVertices[cvPos + 17] = aZ;
-
-        cvPos = cvPos + 18;
-
-        // DOOR LEAF
-
-        //E
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
-        //F
-        closetVertices[cvPos + 3] = eX;
-        closetVertices[cvPos + 4] = fY;
-        closetVertices[cvPos + 5] = aZ;
-        //J
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
-        //I
-        closetVertices[cvPos + 15] = eX;
-        closetVertices[cvPos + 16] = eY;
-        closetVertices[cvPos + 17] = iZ;
-
-        cvPos = cvPos + 18;
-
-        //J
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
-        //F
-        closetVertices[cvPos + 3] = eX;
-        closetVertices[cvPos + 4] = fY;
-        closetVertices[cvPos + 5] = aZ;
-        //H
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
-        //L
-        closetVertices[cvPos + 15] = gX;
-        closetVertices[cvPos + 16] = fY;
-        closetVertices[cvPos + 17] = iZ;
-
-        cvPos = cvPos + 18;
-
-        //K
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
-        //L
-        closetVertices[cvPos + 3] = gX;
-        closetVertices[cvPos + 4] = fY;
-        closetVertices[cvPos + 5] = iZ;
-        //H
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
-        //G
-        closetVertices[cvPos + 15] = gX;
-        closetVertices[cvPos + 16] = eY;
-        closetVertices[cvPos + 17] = aZ;
-
-        cvPos = cvPos + 18;
-
-        //E
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
-        //I
-        closetVertices[cvPos + 3] = eX;
-        closetVertices[cvPos + 4] = eY;
-        closetVertices[cvPos + 5] = iZ;
-        //K
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
-        //G
-        closetVertices[cvPos + 15] = gX;
-        closetVertices[cvPos + 16] = eY;
-        closetVertices[cvPos + 17] = aZ;
-
-        cvPos = cvPos + 18;
-
-        //I
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
-        //J
-        closetVertices[cvPos + 3] = eX;
-        closetVertices[cvPos + 4] = fY;
-        closetVertices[cvPos + 5] = iZ;
-        //N
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
-        //M
-        closetVertices[cvPos + 15] = mX;
-        closetVertices[cvPos + 16] = mY;
-        closetVertices[cvPos + 17] = iZ;
-
-        cvPos = cvPos + 18;
-
-        //N
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
-        //J
-        closetVertices[cvPos + 3] = eX;
-        closetVertices[cvPos + 4] = fY;
-        closetVertices[cvPos + 5] = iZ;
-        //L
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
-        //P
-        closetVertices[cvPos + 15] = oX;
-        closetVertices[cvPos + 16] = nY;
-        closetVertices[cvPos + 17] = iZ;
-
-        cvPos = cvPos + 18;
-
-        //O
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
-        //P
-        closetVertices[cvPos + 3] = oX;
-        closetVertices[cvPos + 4] = nY;
-        closetVertices[cvPos + 5] = iZ;
-        //L
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
-        //K
-        closetVertices[cvPos + 15] = gX;
-        closetVertices[cvPos + 16] = eY;
-        closetVertices[cvPos + 17] = iZ;
-
-        cvPos = cvPos + 18;
-
-        //I
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
-        //M
-        closetVertices[cvPos + 3] = mX;
-        closetVertices[cvPos + 4] = mY;
-        closetVertices[cvPos + 5] = iZ;
-        //O
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
-        //K
-        closetVertices[cvPos + 15] = gX;
-        closetVertices[cvPos + 16] = eY;
-        closetVertices[cvPos + 17] = iZ;
-
-        cvPos = cvPos + 18;
-
-        // HANDLE
-        if (a.handleWidth > 0) {
-            // HANDLE SIDES
-            //M
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
-            //N
-            closetVertices[cvPos + 3] = mX;
-            closetVertices[cvPos + 4] = nY;
-            closetVertices[cvPos + 5] = iZ;
-            //R
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
-            //Q
-            closetVertices[cvPos + 15] = mX;
-            closetVertices[cvPos + 16] = mY;
-            closetVertices[cvPos + 17] = qZ;
-
-            cvPos = cvPos + 18;
-
-            //R
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
-            //N
-            closetVertices[cvPos + 3] = mX;
-            closetVertices[cvPos + 4] = nY;
-            closetVertices[cvPos + 5] = iZ;
-            //P
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
-            //T
-            closetVertices[cvPos + 15] = oX;
-            closetVertices[cvPos + 16] = nY;
-            closetVertices[cvPos + 17] = qZ;
-
-            cvPos = cvPos + 18;
-
-            //S
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
-            //T
-            closetVertices[cvPos + 3] = oX;
-            closetVertices[cvPos + 4] = nY;
-            closetVertices[cvPos + 5] = qZ;
-            //P
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
-            //O
-            closetVertices[cvPos + 15] = oX;
-            closetVertices[cvPos + 16] = mY;
-            closetVertices[cvPos + 17] = iZ;
-
-            cvPos = cvPos + 18;
-
-            //M
-            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
-            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
-            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
-            //Q
-            closetVertices[cvPos + 3] = mX;
-            closetVertices[cvPos + 4] = mY;
-            closetVertices[cvPos + 5] = qZ;
-            //S
-            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
-            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
-            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
-            //O
-            closetVertices[cvPos + 15] = oX;
-            closetVertices[cvPos + 16] = mY;
-            closetVertices[cvPos + 17] = iZ;
-
-            cvPos = cvPos + 18;
-        }
-        // HANDLE FRONT
-        //Q
-        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
-        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
-        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
-        //R
-        closetVertices[cvPos + 3] = mX;
-        closetVertices[cvPos + 4] = nY;
-        closetVertices[cvPos + 5] = qZ;
-        //T
-        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
-        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
-        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
-        //S
-        closetVertices[cvPos + 15] = oX;
-        closetVertices[cvPos + 16] = mY;
-        closetVertices[cvPos + 17] = qZ;
-
-        cvPos = cvPos + 18;
-
-        step += elementLength;
-    }
-
-    //CLOSET BOX
-
-    // FRONT VIEW VERTICES
-    //
-    // A/E---C/G
-    //  |     |
-    //  |     |
-    //  |     |
-    // B/F---D/H
-
-    aX = 0;
-    aY = a.h + offsetY;
-    aZ = a.w;
-    bY = 0;
-    cX = a.l;
-    var eZ = 0;
-
-    //E
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
-    //F
-    closetVertices[cvPos + 3] = aX;
-    closetVertices[cvPos + 4] = bY;
-    closetVertices[cvPos + 5] = eZ;
-    //B
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
-    //A
-    closetVertices[cvPos + 15] = aX;
-    closetVertices[cvPos + 16] = aY;
-    closetVertices[cvPos + 17] = aZ;
-
-    cvPos = cvPos + 18;
-
-    //E
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
-    //A
-    closetVertices[cvPos + 3] = aX;
-    closetVertices[cvPos + 4] = aY;
-    closetVertices[cvPos + 5] = aZ;
-    //C
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = aY;
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
-    //G
-    closetVertices[cvPos + 15] = cX;
-    closetVertices[cvPos + 16] = aY;
-    closetVertices[cvPos + 17] = eZ;
-
-    cvPos = cvPos + 18;
-
-    //C
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
-    //D
-    closetVertices[cvPos + 3] = cX;
-    closetVertices[cvPos + 4] = bY;
-    closetVertices[cvPos + 5] = aZ;
-    //H
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
-    //G
-    closetVertices[cvPos + 15] = cX;
-    closetVertices[cvPos + 16] = aY;
-    closetVertices[cvPos + 17] = eZ;
-
-    cvPos = cvPos + 18;
-
-    //G
-    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
-    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
-    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
-    //H
-    closetVertices[cvPos + 3] = cX;
-    closetVertices[cvPos + 4] = bY;
-    closetVertices[cvPos + 5] = eZ;
-    //F
-    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
-    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
-    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
-    //E
-    closetVertices[cvPos + 15] = aX;
-    closetVertices[cvPos + 16] = aY;
-    closetVertices[cvPos + 17] = eZ;
-
-    return Promise.resolve({
-        closet: {
-            positions: new Float32Array(closetVertices),
-            material: 'closet'
-        }
-    });
+// Looking at this test and thinking "that's silly, nobody would write code like that" and thinking it's OK to break this test?
+// You'd be wrong - https://raw.githubusercontent.com/archilogic-com/3dio-js/master/build/3dio.js and plenty of other codebases
+// have js code exactly like this! This pattern (even at this size!) with a few more embellishments is a common way to encode
+// polygons or verticies into a buffer from a formulaic object definition! So while this is a lot more regular than a real piece
+// of code, this is still representative of a common pattern.
+function build() {
+    let i = 0;
+    const arr = [];
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    arr[i++] = arr[i] + 1;
+    return arr;
 }
 
-const a = generateMeshes3d(null);
+const a = build();

--- a/tests/cases/compiler/deeplyDependentLargeArrayMutation2.ts
+++ b/tests/cases/compiler/deeplyDependentLargeArrayMutation2.ts
@@ -1,0 +1,498 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @target: es6
+// @filename: foo.js
+// Exerpt from https://github.com/archilogic-com/3dio-js - MIT Licenced
+function generateMeshes3d(a) {
+
+    var step = 0,
+        elementNum = Math.round(a.l / 0.6),
+        elementLength = a.l / elementNum,
+        handlePos = elementLength * 0.8,
+
+        //handleWidth = a.handleWidth+ a.doorWidth,
+        handleDistance = 0.05,
+        offsetY = -0.01,
+
+
+        // internals
+        closetVertices = [],
+        cvPos = 0;
+
+    //CLOSET DOORS
+
+    // FRONT VIEW VERTICES
+    //
+    // A------------C
+    // |E\I------G\K|
+    // | |        | |
+    // | |M\Q-O\S | |
+    // | ||   |   | |
+    // | |N\R-P\T | |
+    // |F\J------H\L|
+    // B------------D
+
+    var aX = step,
+        aY = a.h + offsetY,
+        aZ = a.w,
+        bY = 0,
+        cX = step + elementLength,
+        eX = step + a.doorWidth / 2,
+        eY = a.h - a.doorWidth,
+        fY = a.baseboard,
+        gX = step + elementLength - a.doorWidth / 2,
+        iZ = a.w + a.doorWidth,
+        mX = step + handlePos,
+        mY = 1 + a.handleHeight / 2,
+        nY = 1 - a.handleHeight / 2,
+        oX = step + handlePos + a.handleLength,
+        qZ = a.w + a.doorWidth + a.handleWidth;
+
+    for (var c = 0; c < elementNum; c++) {
+
+        if (c % 2 == 1 || c === elementNum - 1) {
+            handlePos = handleDistance + a.handleLength / 2;
+        } else {
+            handlePos = elementLength - handleDistance - a.handleLength / 2;
+        }
+        aX = step;
+        cX = step + elementLength;
+        eX = step + a.doorWidth / 2;
+        gX = step + elementLength - a.doorWidth / 2;
+        mX = step + handlePos - a.handleLength / 2;
+        oX = step + handlePos + a.handleLength / 2;
+
+        // DOOR FRAME
+        //A
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+        //B
+        closetVertices[cvPos + 3] = aX;
+        closetVertices[cvPos + 4] = bY;
+        closetVertices[cvPos + 5] = aZ;
+        //F
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+        //E
+        closetVertices[cvPos + 15] = eX;
+        closetVertices[cvPos + 16] = eY;
+        closetVertices[cvPos + 17] = aZ;
+
+        cvPos = cvPos + 18;
+
+        //F
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+        //B
+        closetVertices[cvPos + 3] = aX;
+        closetVertices[cvPos + 4] = bY;
+        closetVertices[cvPos + 5] = aZ;
+        //D
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+        //H
+        closetVertices[cvPos + 15] = gX;
+        closetVertices[cvPos + 16] = fY;
+        closetVertices[cvPos + 17] = aZ;
+
+        cvPos = cvPos + 18;
+
+        //G
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+        //H
+        closetVertices[cvPos + 3] = gX;
+        closetVertices[cvPos + 4] = fY;
+        closetVertices[cvPos + 5] = aZ;
+        //D
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+        //C
+        closetVertices[cvPos + 15] = cX;
+        closetVertices[cvPos + 16] = aY;
+        closetVertices[cvPos + 17] = aZ;
+
+        cvPos = cvPos + 18;
+
+        //A
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+        //E
+        closetVertices[cvPos + 3] = eX;
+        closetVertices[cvPos + 4] = eY;
+        closetVertices[cvPos + 5] = aZ;
+        //G
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+        //C
+        closetVertices[cvPos + 15] = cX;
+        closetVertices[cvPos + 16] = aY;
+        closetVertices[cvPos + 17] = aZ;
+
+        cvPos = cvPos + 18;
+
+        // DOOR LEAF
+
+        //E
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+        //F
+        closetVertices[cvPos + 3] = eX;
+        closetVertices[cvPos + 4] = fY;
+        closetVertices[cvPos + 5] = aZ;
+        //J
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = eX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+        //I
+        closetVertices[cvPos + 15] = eX;
+        closetVertices[cvPos + 16] = eY;
+        closetVertices[cvPos + 17] = iZ;
+
+        cvPos = cvPos + 18;
+
+        //J
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = fY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+        //F
+        closetVertices[cvPos + 3] = eX;
+        closetVertices[cvPos + 4] = fY;
+        closetVertices[cvPos + 5] = aZ;
+        //H
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+        //L
+        closetVertices[cvPos + 15] = gX;
+        closetVertices[cvPos + 16] = fY;
+        closetVertices[cvPos + 17] = iZ;
+
+        cvPos = cvPos + 18;
+
+        //K
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = gX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+        //L
+        closetVertices[cvPos + 3] = gX;
+        closetVertices[cvPos + 4] = fY;
+        closetVertices[cvPos + 5] = iZ;
+        //H
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+        //G
+        closetVertices[cvPos + 15] = gX;
+        closetVertices[cvPos + 16] = eY;
+        closetVertices[cvPos + 17] = aZ;
+
+        cvPos = cvPos + 18;
+
+        //E
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+        //I
+        closetVertices[cvPos + 3] = eX;
+        closetVertices[cvPos + 4] = eY;
+        closetVertices[cvPos + 5] = iZ;
+        //K
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = eY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+        //G
+        closetVertices[cvPos + 15] = gX;
+        closetVertices[cvPos + 16] = eY;
+        closetVertices[cvPos + 17] = aZ;
+
+        cvPos = cvPos + 18;
+
+        //I
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+        //J
+        closetVertices[cvPos + 3] = eX;
+        closetVertices[cvPos + 4] = fY;
+        closetVertices[cvPos + 5] = iZ;
+        //N
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+        //M
+        closetVertices[cvPos + 15] = mX;
+        closetVertices[cvPos + 16] = mY;
+        closetVertices[cvPos + 17] = iZ;
+
+        cvPos = cvPos + 18;
+
+        //N
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+        //J
+        closetVertices[cvPos + 3] = eX;
+        closetVertices[cvPos + 4] = fY;
+        closetVertices[cvPos + 5] = iZ;
+        //L
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+        //P
+        closetVertices[cvPos + 15] = oX;
+        closetVertices[cvPos + 16] = nY;
+        closetVertices[cvPos + 17] = iZ;
+
+        cvPos = cvPos + 18;
+
+        //O
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+        //P
+        closetVertices[cvPos + 3] = oX;
+        closetVertices[cvPos + 4] = nY;
+        closetVertices[cvPos + 5] = iZ;
+        //L
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = gX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = fY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+        //K
+        closetVertices[cvPos + 15] = gX;
+        closetVertices[cvPos + 16] = eY;
+        closetVertices[cvPos + 17] = iZ;
+
+        cvPos = cvPos + 18;
+
+        //I
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = eX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = eY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+        //M
+        closetVertices[cvPos + 3] = mX;
+        closetVertices[cvPos + 4] = mY;
+        closetVertices[cvPos + 5] = iZ;
+        //O
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+        //K
+        closetVertices[cvPos + 15] = gX;
+        closetVertices[cvPos + 16] = eY;
+        closetVertices[cvPos + 17] = iZ;
+
+        cvPos = cvPos + 18;
+
+        // HANDLE
+        if (a.handleWidth > 0) {
+            // HANDLE SIDES
+            //M
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+            //N
+            closetVertices[cvPos + 3] = mX;
+            closetVertices[cvPos + 4] = nY;
+            closetVertices[cvPos + 5] = iZ;
+            //R
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = mX;
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
+            //Q
+            closetVertices[cvPos + 15] = mX;
+            closetVertices[cvPos + 16] = mY;
+            closetVertices[cvPos + 17] = qZ;
+
+            cvPos = cvPos + 18;
+
+            //R
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = nY;
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
+            //N
+            closetVertices[cvPos + 3] = mX;
+            closetVertices[cvPos + 4] = nY;
+            closetVertices[cvPos + 5] = iZ;
+            //P
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+            //T
+            closetVertices[cvPos + 15] = oX;
+            closetVertices[cvPos + 16] = nY;
+            closetVertices[cvPos + 17] = qZ;
+
+            cvPos = cvPos + 18;
+
+            //S
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = oX;
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
+            //T
+            closetVertices[cvPos + 3] = oX;
+            closetVertices[cvPos + 4] = nY;
+            closetVertices[cvPos + 5] = qZ;
+            //P
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = iZ;
+            //O
+            closetVertices[cvPos + 15] = oX;
+            closetVertices[cvPos + 16] = mY;
+            closetVertices[cvPos + 17] = iZ;
+
+            cvPos = cvPos + 18;
+
+            //M
+            closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+            closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+            closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = iZ;
+            //Q
+            closetVertices[cvPos + 3] = mX;
+            closetVertices[cvPos + 4] = mY;
+            closetVertices[cvPos + 5] = qZ;
+            //S
+            closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+            closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = mY;
+            closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
+            //O
+            closetVertices[cvPos + 15] = oX;
+            closetVertices[cvPos + 16] = mY;
+            closetVertices[cvPos + 17] = iZ;
+
+            cvPos = cvPos + 18;
+        }
+        // HANDLE FRONT
+        //Q
+        closetVertices[cvPos] = closetVertices[cvPos + 9] = mX;
+        closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = mY;
+        closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = qZ;
+        //R
+        closetVertices[cvPos + 3] = mX;
+        closetVertices[cvPos + 4] = nY;
+        closetVertices[cvPos + 5] = qZ;
+        //T
+        closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = oX;
+        closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = nY;
+        closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = qZ;
+        //S
+        closetVertices[cvPos + 15] = oX;
+        closetVertices[cvPos + 16] = mY;
+        closetVertices[cvPos + 17] = qZ;
+
+        cvPos = cvPos + 18;
+
+        step += elementLength;
+    }
+
+    //CLOSET BOX
+
+    // FRONT VIEW VERTICES
+    //
+    // A/E---C/G
+    //  |     |
+    //  |     |
+    //  |     |
+    // B/F---D/H
+
+    aX = 0;
+    aY = a.h + offsetY;
+    aZ = a.w;
+    bY = 0;
+    cX = a.l;
+    var eZ = 0;
+
+    //E
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
+    //F
+    closetVertices[cvPos + 3] = aX;
+    closetVertices[cvPos + 4] = bY;
+    closetVertices[cvPos + 5] = eZ;
+    //B
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+    //A
+    closetVertices[cvPos + 15] = aX;
+    closetVertices[cvPos + 16] = aY;
+    closetVertices[cvPos + 17] = aZ;
+
+    cvPos = cvPos + 18;
+
+    //E
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = aX;
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
+    //A
+    closetVertices[cvPos + 3] = aX;
+    closetVertices[cvPos + 4] = aY;
+    closetVertices[cvPos + 5] = aZ;
+    //C
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = aY;
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = aZ;
+    //G
+    closetVertices[cvPos + 15] = cX;
+    closetVertices[cvPos + 16] = aY;
+    closetVertices[cvPos + 17] = eZ;
+
+    cvPos = cvPos + 18;
+
+    //C
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = aZ;
+    //D
+    closetVertices[cvPos + 3] = cX;
+    closetVertices[cvPos + 4] = bY;
+    closetVertices[cvPos + 5] = aZ;
+    //H
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = cX;
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
+    //G
+    closetVertices[cvPos + 15] = cX;
+    closetVertices[cvPos + 16] = aY;
+    closetVertices[cvPos + 17] = eZ;
+
+    cvPos = cvPos + 18;
+
+    //G
+    closetVertices[cvPos] = closetVertices[cvPos + 9] = cX;
+    closetVertices[cvPos + 1] = closetVertices[cvPos + 10] = aY;
+    closetVertices[cvPos + 2] = closetVertices[cvPos + 11] = eZ;
+    //H
+    closetVertices[cvPos + 3] = cX;
+    closetVertices[cvPos + 4] = bY;
+    closetVertices[cvPos + 5] = eZ;
+    //F
+    closetVertices[cvPos + 6] = closetVertices[cvPos + 12] = aX;
+    closetVertices[cvPos + 7] = closetVertices[cvPos + 13] = bY;
+    closetVertices[cvPos + 8] = closetVertices[cvPos + 14] = eZ;
+    //E
+    closetVertices[cvPos + 15] = aX;
+    closetVertices[cvPos + 16] = aY;
+    closetVertices[cvPos + 17] = eZ;
+
+    return Promise.resolve({
+        closet: {
+            positions: new Float32Array(closetVertices),
+            material: 'closet'
+        }
+    });
+}
+
+const a = generateMeshes3d(null);


### PR DESCRIPTION
Fixes #26031

Also includes another similar test case we found in the wild from https://github.com/archilogic-com/3dio-js which fails in a slightly different way prior to this fix because it is right-recursive in the control flow graph instead of left-recursive.

This fix is simply to use the context free expression type [added here](https://github.com/Microsoft/TypeScript/commit/5c2091ad33d3d0446fbfecd7d5efeeafb3ccfa10) for the LHS same as we do on the RHS and cache it in both scenarios, since it is context free. To ensure this is safe, I've also swapped it to using `CheckMode.SkipContextSensitive` (same as the other scenarios where we cache a context free type during inference to produce better inferences), to avoid reporting incorrect or partial types for partially solved context sensitive lambdas and function expressions (which would otherwise be a check order caching hazard). This caching keeps the evolving array type flow control analysis time linear, even when the expressions are both left and right recursive on their own reference.