### PR TITLE
Fix definitely assignable relation for mapped types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11778,6 +11778,9 @@ namespace ts {
                         }
                         return Ternary.False;
                     }
+                    if (relation === definitelyAssignableRelation && isGenericMappedType(source)) {
+                        return Ternary.False;
+                    }
                     const sourceIsPrimitive = !!(source.flags & TypeFlags.Primitive);
                     if (relation !== identityRelation) {
                         source = getApparentType(source);

--- a/tests/baselines/reference/mappedTypeNoTypeNoCrash.types
+++ b/tests/baselines/reference/mappedTypeNoTypeNoCrash.types
@@ -1,4 +1,4 @@
 === tests/cases/compiler/mappedTypeNoTypeNoCrash.ts ===
 type T0<T> = ({[K in keyof T]}) extends ({[key in K]: T[K]}) ? number : never;
->T0 : number
+>T0 : T0<T>
 

--- a/tests/baselines/reference/mappedTypesArraysTuples.js
+++ b/tests/baselines/reference/mappedTypesArraysTuples.js
@@ -84,6 +84,14 @@ function acceptMappedArray<T extends any[]>(arr: T) {
     acceptArray(mapArray(arr));
 }
 
+// Repro from #26163
+
+type Unconstrained<T> = ElementType<Mapped<T>>;
+type T1 = Unconstrained<[string, number, boolean]>;  // string | number | boolean
+
+type Constrained<T extends any[]> = ElementType<Mapped<T>>;
+type T2 = Constrained<[string, number, boolean]>;  // string | number | boolean
+
 
 //// [mappedTypesArraysTuples.js]
 "use strict";
@@ -182,3 +190,7 @@ declare type R2 = ElementType<Mapped<[string, number, boolean]>>;
 declare function acceptArray(arr: any[]): void;
 declare function mapArray<T extends any[]>(arr: T): Mapped<T>;
 declare function acceptMappedArray<T extends any[]>(arr: T): void;
+declare type Unconstrained<T> = ElementType<Mapped<T>>;
+declare type T1 = Unconstrained<[string, number, boolean]>;
+declare type Constrained<T extends any[]> = ElementType<Mapped<T>>;
+declare type T2 = Constrained<[string, number, boolean]>;

--- a/tests/baselines/reference/mappedTypesArraysTuples.symbols
+++ b/tests/baselines/reference/mappedTypesArraysTuples.symbols
@@ -328,3 +328,27 @@ function acceptMappedArray<T extends any[]>(arr: T) {
 >arr : Symbol(arr, Decl(mappedTypesArraysTuples.ts, 81, 44))
 }
 
+// Repro from #26163
+
+type Unconstrained<T> = ElementType<Mapped<T>>;
+>Unconstrained : Symbol(Unconstrained, Decl(mappedTypesArraysTuples.ts, 83, 1))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 87, 19))
+>ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 66, 1))
+>Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 70, 59))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 87, 19))
+
+type T1 = Unconstrained<[string, number, boolean]>;  // string | number | boolean
+>T1 : Symbol(T1, Decl(mappedTypesArraysTuples.ts, 87, 47))
+>Unconstrained : Symbol(Unconstrained, Decl(mappedTypesArraysTuples.ts, 83, 1))
+
+type Constrained<T extends any[]> = ElementType<Mapped<T>>;
+>Constrained : Symbol(Constrained, Decl(mappedTypesArraysTuples.ts, 88, 51))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 90, 17))
+>ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 66, 1))
+>Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 70, 59))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 90, 17))
+
+type T2 = Constrained<[string, number, boolean]>;  // string | number | boolean
+>T2 : Symbol(T2, Decl(mappedTypesArraysTuples.ts, 90, 59))
+>Constrained : Symbol(Constrained, Decl(mappedTypesArraysTuples.ts, 88, 51))
+

--- a/tests/baselines/reference/mappedTypesArraysTuples.types
+++ b/tests/baselines/reference/mappedTypesArraysTuples.types
@@ -241,3 +241,17 @@ function acceptMappedArray<T extends any[]>(arr: T) {
 >arr : T
 }
 
+// Repro from #26163
+
+type Unconstrained<T> = ElementType<Mapped<T>>;
+>Unconstrained : ElementType<Mapped<T>>
+
+type T1 = Unconstrained<[string, number, boolean]>;  // string | number | boolean
+>T1 : string | number | boolean
+
+type Constrained<T extends any[]> = ElementType<Mapped<T>>;
+>Constrained : ElementType<Mapped<T>>
+
+type T2 = Constrained<[string, number, boolean]>;  // string | number | boolean
+>T2 : string | number | boolean
+

--- a/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
@@ -85,3 +85,11 @@ declare function mapArray<T extends any[]>(arr: T): Mapped<T>;
 function acceptMappedArray<T extends any[]>(arr: T) {
     acceptArray(mapArray(arr));
 }
+
+// Repro from #26163
+
+type Unconstrained<T> = ElementType<Mapped<T>>;
+type T1 = Unconstrained<[string, number, boolean]>;  // string | number | boolean
+
+type Constrained<T extends any[]> = ElementType<Mapped<T>>;
+type T2 = Constrained<[string, number, boolean]>;  // string | number | boolean


### PR DESCRIPTION
With this PR we properly ignore constraints of mapped types in the definitely assignable relation.

Fixes #26163.