### PR TITLE
Set configured project type acquisition earlier

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1589,6 +1589,8 @@ namespace ts.server {
                 configFileErrors.push(...parsedCommandLine.errors);
             }
 
+            project.setTypeAcquisition(parsedCommandLine.typeAcquisition!); // TODO: GH#18217
+
             Debug.assert(!!parsedCommandLine.fileNames);
             const compilerOptions = parsedCommandLine.options;
 


### PR DESCRIPTION
Plugins (in particular, Angular) may depend on it being set before external files are computed.

Unfortunately, `setTypeAcquisition` will now be called twice.  The value will be the same both times, so we think it's harmless.