### PR TITLE
Revert #26360: Don't error on destructure of private property with computed property syntax

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24250,7 +24250,7 @@ namespace ts {
                     if (nameText) {
                         const property = getPropertyOfType(parentType!, nameText)!; // TODO: GH#18217
                         markPropertyAsReferenced(property, /*nodeForCheckWriteOnly*/ undefined, /*isThisAccess*/ false); // A destructuring is never a write-only reference.
-                        if (parent.initializer && property && !isComputedPropertyName(name)) {
+                        if (parent.initializer && property) {
                             checkPropertyAccessibility(parent, parent.initializer.kind === SyntaxKind.SuperKeyword, parentType!, property);
                         }
                     }

--- a/tests/baselines/reference/destructureComputedProperty.errors.txt
+++ b/tests/baselines/reference/destructureComputedProperty.errors.txt
@@ -1,8 +1,9 @@
 tests/cases/compiler/destructureComputedProperty.ts(7,7): error TS2341: Property 'p' is private and only accessible within class 'C'.
+tests/cases/compiler/destructureComputedProperty.ts(8,7): error TS2341: Property 'p' is private and only accessible within class 'C'.
 tests/cases/compiler/destructureComputedProperty.ts(10,7): error TS2341: Property 'p' is private and only accessible within class 'C'.
 
 
-==== tests/cases/compiler/destructureComputedProperty.ts (2 errors) ====
+==== tests/cases/compiler/destructureComputedProperty.ts (3 errors) ====
     declare const ab: { n: number } | { n: string };
     const nameN = "n";
     const { [nameN]: n } = ab;
@@ -13,6 +14,8 @@ tests/cases/compiler/destructureComputedProperty.ts(10,7): error TS2341: Propert
           ~~~~~~~~~~~
 !!! error TS2341: Property 'p' is private and only accessible within class 'C'.
     const { ["p"]: p1 } = new C();
+          ~~~~~~~~~~~~~
+!!! error TS2341: Property 'p' is private and only accessible within class 'C'.
     const { [nameP]: p2 } = new C();
     const { p: p3 } = new C();
           ~~~~~~~~~


### PR DESCRIPTION
The conclusion of #26572 was to not suppress accessibility errors on destructuring assignment with computed name. For consistency this should also apply to destructuring binding properties.