### PR TITLE
Get symbol at location for class expressions/keywords

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27269,6 +27269,7 @@ namespace ts {
                 case SyntaxKind.DefaultKeyword:
                 case SyntaxKind.FunctionKeyword:
                 case SyntaxKind.EqualsGreaterThanToken:
+                case SyntaxKind.ClassKeyword:
                     return getSymbolOfNode(node.parent);
                 case SyntaxKind.ImportType:
                     return isLiteralImportTypeNode(node) ? getSymbolAtLocation(node.argument.literal) : undefined;

--- a/tests/cases/fourslash/quickInfoClassKeyword.ts
+++ b/tests/cases/fourslash/quickInfoClassKeyword.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts'/>
+
+////[1].forEach(cla/*1*/ss {});
+////[1].forEach(cla/*2*/ss OK{});
+
+verify.quickInfoAt("1", "(local class) (Anonymous class)");
+verify.quickInfoAt("2", "(local class) OK");
+

--- a/tests/cases/fourslash/quickInfoInvalidLocations.ts
+++ b/tests/cases/fourslash/quickInfoInvalidLocations.ts
@@ -8,7 +8,7 @@
 ////    property: string;
 /////*invalid2*/}
 ////
-////cl/*invalid3*/ass bar imple/*invalid4*/ments IFoo {
+////class bar imple/*invalid4*/ments IFoo {
 ////    constructor(   /*invalid5*/  ) {
 ////
 ////    }


### PR DESCRIPTION
Previously, `getSymbolAtLocation` didn't do anything for `class` keywords. It did for function keywords (see the fourslash test `quickInfoClassFunctionKeyword`), so it makes sense for class keywords too, I think.

Might fix #26511, although I think there @ajafff wants getSymbolAtLocation to work for ClassExpression nodes, and those can't be indicated directly from the source text.



