### PR TITLE
Support outlining span for function parameters

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4116,6 +4116,10 @@ namespace ts {
             getLineOfLocalPosition(sourceFile, pos1) === getLineOfLocalPosition(sourceFile, pos2);
     }
 
+    export function isNodeArrayMultiLine(list: NodeArray<Node>, sourceFile: SourceFile): boolean {
+        return !positionsAreOnSameLine(list.pos, list.end, sourceFile);
+    }
+
     export function getStartPositionOfRange(range: TextRange, sourceFile: SourceFile) {
         return positionIsSynthesized(range.pos) ? -1 : skipTrivia(sourceFile.text, range.pos);
     }
@@ -8252,5 +8256,28 @@ namespace ts {
         // If skipDefaultLibCheck is enabled, skip reporting errors if file contains a
         // '/// <reference no-default-lib="true"/>' directive.
         return options.skipLibCheck && sourceFile.isDeclarationFile || options.skipDefaultLibCheck && sourceFile.hasNoDefaultLib;
+    }
+
+    export function getBodyOfFunctionLike(node: FunctionLike): Node | undefined {
+        switch (node.kind) {
+            case SyntaxKind.CallSignature:
+            case SyntaxKind.ConstructSignature:
+            case SyntaxKind.MethodSignature:
+            case SyntaxKind.IndexSignature:
+            case SyntaxKind.FunctionType:
+            case SyntaxKind.ConstructorType:
+            case SyntaxKind.JSDocFunctionType:
+                return undefined;
+            case SyntaxKind.FunctionDeclaration:
+            case SyntaxKind.MethodDeclaration:
+            case SyntaxKind.Constructor:
+            case SyntaxKind.GetAccessor:
+            case SyntaxKind.SetAccessor:
+            case SyntaxKind.FunctionExpression:
+            case SyntaxKind.ArrowFunction:
+                return node.body;
+            default:
+                return Debug.assertNever(node);
+        }
     }
 }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1709,18 +1709,10 @@ namespace ts {
             return OutliningElementsCollector.collectElements(sourceFile, cancellationToken);
         }
 
-        const braceMatching = createMapFromTemplate({
-            [SyntaxKind.OpenBraceToken]: SyntaxKind.CloseBraceToken,
-            [SyntaxKind.OpenParenToken]: SyntaxKind.CloseParenToken,
-            [SyntaxKind.OpenBracketToken]: SyntaxKind.CloseBracketToken,
-            [SyntaxKind.GreaterThanToken]: SyntaxKind.LessThanToken,
-        });
-        braceMatching.forEach((value, key) => braceMatching.set(value.toString(), Number(key) as SyntaxKind));
-
         function getBraceMatchingAtPosition(fileName: string, position: number): TextSpan[] {
             const sourceFile = syntaxTreeCache.getCurrentSourceFile(fileName);
             const token = getTouchingToken(sourceFile, position);
-            const matchKind = token.getStart(sourceFile) === position ? braceMatching.get(token.kind.toString()) : undefined;
+            const matchKind = token.getStart(sourceFile) === position ? getBraceMatching(token.kind) : undefined;
             const match = matchKind && findChildOfKind(token.parent, matchKind, sourceFile);
             // We want to order the braces when we return the result.
             return match ? [createTextSpanFromNode(token, sourceFile), createTextSpanFromNode(match, sourceFile)].sort((a, b) => a.start - b.start) : emptyArray;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1813,4 +1813,20 @@ namespace ts {
         if (idx === -1) idx = change.indexOf('"' + name);
         return idx === -1 ? -1 : idx + 1;
     }
+
+    const braceMatching = createMapFromTemplate({
+        [SyntaxKind.OpenBraceToken]: SyntaxKind.CloseBraceToken,
+        [SyntaxKind.OpenParenToken]: SyntaxKind.CloseParenToken,
+        [SyntaxKind.OpenBracketToken]: SyntaxKind.CloseBracketToken,
+        [SyntaxKind.GreaterThanToken]: SyntaxKind.LessThanToken,
+    });
+    braceMatching.forEach((value, key) => braceMatching.set(value.toString(), Number(key) as SyntaxKind));
+    export function getBraceMatching(
+        kind: SyntaxKind.OpenBraceToken | SyntaxKind.OpenParenToken | SyntaxKind.OpenBracketToken | SyntaxKind.GreaterThanToken
+           | SyntaxKind.CloseBraceToken | SyntaxKind.CloseParenToken | SyntaxKind.CloseBracketToken | SyntaxKind.LessThanToken
+    ): SyntaxKind;
+    export function getBraceMatching(kind: SyntaxKind): SyntaxKind | undefined;
+    export function getBraceMatching(kind: SyntaxKind): SyntaxKind | undefined {
+        return braceMatching.get(kind.toString());
+    }
 }

--- a/tests/cases/fourslash/getOutliningSpansForFunction.ts
+++ b/tests/cases/fourslash/getOutliningSpansForFunction.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts"/>
+
+////function f(x: number, y: number)[| {
+////    return x + y;
+////}|]
+////
+////function g[|(
+////    x: number,
+////    y: number,
+////)|]: number[| {
+////    return x + y;
+////}|]
+
+verify.outliningSpansInCurrentFile(test.ranges());


### PR DESCRIPTION
Fixes #22915

@mjbvz This has issues when used in vscode because if I fold the parameter list, the body's folding marker disappears, since it begins on the same line that the parameters end on, so it can't be collapsed too. But for some reason there is no similar error for:

```ts
function a() {

} function b() {
    
}
```

where folding `a` doesn't collapse the line with the closing curly brace.