### PR TITLE
No assert for nameless typedefs

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4853,13 +4853,13 @@ namespace ts {
         if (isDeclaration(hostNode)) {
             return getDeclarationIdentifier(hostNode);
         }
-        // Covers remaining cases
+        // Covers remaining cases (returning undefined if none match).
         switch (hostNode.kind) {
             case SyntaxKind.VariableStatement:
                 if (hostNode.declarationList && hostNode.declarationList.declarations[0]) {
                     return getDeclarationIdentifier(hostNode.declarationList.declarations[0]);
                 }
-                return undefined;
+                break;
             case SyntaxKind.ExpressionStatement:
                 const expr = hostNode.expression;
                 switch (expr.kind) {
@@ -4871,9 +4871,7 @@ namespace ts {
                             return arg;
                         }
                 }
-                return undefined;
-            case SyntaxKind.EndOfFileToken:
-                return undefined;
+                break;
             case SyntaxKind.ParenthesizedExpression: {
                 return getDeclarationIdentifier(hostNode.expression);
             }
@@ -4881,10 +4879,8 @@ namespace ts {
                 if (isDeclaration(hostNode.statement) || isExpression(hostNode.statement)) {
                     return getDeclarationIdentifier(hostNode.statement);
                 }
-                return undefined;
+                break;
             }
-            default:
-                Debug.assertNever(hostNode, "Found typedef tag attached to node which it should not be!");
         }
     }
 

--- a/tests/baselines/reference/noAssertForUnparseableTypedefs.errors.txt
+++ b/tests/baselines/reference/noAssertForUnparseableTypedefs.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/conformance/jsdoc/bug26693.js(1,15): error TS2304: Cannot find name 'module'.
+tests/cases/conformance/jsdoc/bug26693.js(1,21): error TS1005: '}' expected.
+tests/cases/conformance/jsdoc/bug26693.js(2,22): error TS2307: Cannot find module 'nope'.
+
+
+==== tests/cases/conformance/jsdoc/bug26693.js (3 errors) ====
+    /** @typedef {module:locale} hi */
+                  ~~~~~~
+!!! error TS2304: Cannot find name 'module'.
+                        ~
+!!! error TS1005: '}' expected.
+    import { nope } from 'nope';
+                         ~~~~~~
+!!! error TS2307: Cannot find module 'nope'.
+    

--- a/tests/baselines/reference/noAssertForUnparseableTypedefs.symbols
+++ b/tests/baselines/reference/noAssertForUnparseableTypedefs.symbols
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/jsdoc/bug26693.js ===
+/** @typedef {module:locale} hi */
+import { nope } from 'nope';
+>nope : Symbol(nope, Decl(bug26693.js, 1, 8))
+

--- a/tests/baselines/reference/noAssertForUnparseableTypedefs.types
+++ b/tests/baselines/reference/noAssertForUnparseableTypedefs.types
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/jsdoc/bug26693.js ===
+/** @typedef {module:locale} hi */
+import { nope } from 'nope';
+>nope : any
+

--- a/tests/cases/conformance/jsdoc/noAssertForUnparseableTypedefs.ts
+++ b/tests/cases/conformance/jsdoc/noAssertForUnparseableTypedefs.ts
@@ -1,0 +1,7 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: bug26693.js
+
+/** @typedef {module:locale} hi */
+import { nope } from 'nope';


### PR DESCRIPTION
The assert is over-optimistic and should be removed until we can parse every possible thing that people might put in a JSDoc type position.

Fixes #26693