### PR TITLE
Add option --lazyConfiguredProjectsFromExternalProject to enable lazy load of configured projects referenced by external project

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -465,6 +465,7 @@ namespace ts.server {
         cancellationToken: ServerCancellationToken;
         useSingleInferredProject: boolean;
         useInferredProjectPerProjectRoot: boolean;
+        lazyConfiguredProjectsFromExternalProject?: boolean;
         typingsInstaller: ITypingsInstaller;
         byteLength: (buf: string, encoding?: string) => number;
         hrtime: (start?: number[]) => number[];
@@ -536,6 +537,7 @@ namespace ts.server {
                 cancellationToken: this.cancellationToken,
                 useSingleInferredProject: opts.useSingleInferredProject,
                 useInferredProjectPerProjectRoot: opts.useInferredProjectPerProjectRoot,
+                lazyConfiguredProjectsFromExternalProject: opts.lazyConfiguredProjectsFromExternalProject,
                 typingsInstaller: this.typingsInstaller,
                 throttleWaitMilliseconds,
                 eventHandler: this.eventHandler,

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -499,6 +499,7 @@ namespace ts.server {
                 cancellationToken,
                 useSingleInferredProject,
                 useInferredProjectPerProjectRoot,
+                lazyConfiguredProjectsFromExternalProject,
                 typingsInstaller: typingsInstaller || nullTypingsInstaller,
                 byteLength: Buffer.byteLength,
                 hrtime: process.hrtime,
@@ -937,6 +938,7 @@ namespace ts.server {
 
     const useSingleInferredProject = hasArgument("--useSingleInferredProject");
     const useInferredProjectPerProjectRoot = hasArgument("--useInferredProjectPerProjectRoot");
+    const lazyConfiguredProjectsFromExternalProject = hasArgument("--lazyConfiguredProjectsFromExternalProject");
     const disableAutomaticTypingAcquisition = hasArgument("--disableAutomaticTypingAcquisition");
     const suppressDiagnosticEvents = hasArgument("--suppressDiagnosticEvents");
     const syntaxOnly = hasArgument("--syntaxOnly");

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8325,6 +8325,7 @@ declare namespace ts.server {
         cancellationToken: HostCancellationToken;
         useSingleInferredProject: boolean;
         useInferredProjectPerProjectRoot: boolean;
+        lazyConfiguredProjectsFromExternalProject?: boolean;
         typingsInstaller: ITypingsInstaller;
         eventHandler?: ProjectServiceEventHandler;
         suppressDiagnosticEvents?: boolean;
@@ -8397,6 +8398,7 @@ declare namespace ts.server {
         readonly cancellationToken: HostCancellationToken;
         readonly useSingleInferredProject: boolean;
         readonly useInferredProjectPerProjectRoot: boolean;
+        private readonly lazyConfiguredProjectsFromExternalProject?;
         readonly typingsInstaller: ITypingsInstaller;
         private readonly globalCacheLocationDirectoryPath;
         readonly throttleWaitMilliseconds?: number;
@@ -8598,6 +8600,7 @@ declare namespace ts.server {
         cancellationToken: ServerCancellationToken;
         useSingleInferredProject: boolean;
         useInferredProjectPerProjectRoot: boolean;
+        lazyConfiguredProjectsFromExternalProject?: boolean;
         typingsInstaller: ITypingsInstaller;
         byteLength: (buf: string, encoding?: string) => number;
         hrtime: (start?: number[]) => number[];


### PR DESCRIPTION
Fixes #26696