### PR TITLE
Don't infer unions for disjoint callback parameter candidates

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4175,9 +4175,8 @@ namespace ts {
     /* @internal */
     export const enum InferenceFlags {
         None            =      0,  // No special inference behaviors
-        InferUnionTypes = 1 << 0,  // Infer union types for disjoint candidates (otherwise unknownType)
-        NoDefault       = 1 << 1,  // Infer unknownType for no inferences (otherwise anyType or emptyObjectType)
-        AnyDefault      = 1 << 2,  // Infer anyType for no inferences (otherwise emptyObjectType)
+        NoDefault       = 1 << 0,  // Infer unknownType for no inferences (otherwise anyType or emptyObjectType)
+        AnyDefault      = 1 << 1,  // Infer anyType for no inferences (otherwise emptyObjectType)
     }
 
     /**

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures3.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures3.errors.txt
@@ -45,6 +45,11 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
           Property 'baz' is missing in type 'Base'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts(83,1): error TS2322: Type '(x: Base[], y: Derived[]) => Derived[]' is not assignable to type '<T extends Derived[]>(x: Base[], y: T) => T'.
   Type 'Derived[]' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts(85,1): error TS2322: Type '<T>(x: { a: T; b: T; }) => T' is not assignable to type '(x: { a: string; b: number; }) => Object'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+      Types of property 'b' are incompatible.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts(86,1): error TS2322: Type '(x: { a: string; b: number; }) => Object' is not assignable to type '<T>(x: { a: T; b: T; }) => T'.
   Types of parameters 'x' and 'x' are incompatible.
     Type '{ a: T; b: T; }' is not assignable to type '{ a: string; b: number; }'.
@@ -52,7 +57,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         Type 'T' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts (14 errors) ====
+==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures3.ts (15 errors) ====
     // these are all permitted with the current rules, since we do not do contextual signature instantiation
     
     class Base { foo: string; }
@@ -198,6 +203,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322:   Type 'Derived[]' is not assignable to type 'T'.
     var b14: <T>(x: { a: T; b: T }) => T; 
     a14 = b14; // ok
+    ~~~
+!!! error TS2322: Type '<T>(x: { a: T; b: T; }) => T' is not assignable to type '(x: { a: string; b: number; }) => Object'.
+!!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2322:     Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+!!! error TS2322:       Types of property 'b' are incompatible.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     b14 = a14; // ok
     ~~~
 !!! error TS2322: Type '(x: { a: string; b: number; }) => Object' is not assignable to type '<T>(x: { a: T; b: T; }) => T'.

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures4.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures4.errors.txt
@@ -22,8 +22,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures4.ts(66,9): error TS2322: Type '(x: Base[], y: Derived2[]) => Derived[]' is not assignable to type '<T extends Derived2[]>(x: Base[], y: Base[]) => T'.
   Type 'Derived[]' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures4.ts(69,9): error TS2322: Type '<T>(x: { a: T; b: T; }) => T' is not assignable to type '(x: { a: string; b: number; }) => number'.
-  Type 'string | number' is not assignable to type 'number'.
-    Type 'string' is not assignable to type 'number'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+      Types of property 'b' are incompatible.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures4.ts(70,9): error TS2322: Type '(x: { a: string; b: number; }) => number' is not assignable to type '<T>(x: { a: T; b: T; }) => T'.
   Types of parameters 'x' and 'x' are incompatible.
     Type '{ a: T; b: T; }' is not assignable to type '{ a: string; b: number; }'.
@@ -156,8 +158,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
             a15 = b15;
             ~~~
 !!! error TS2322: Type '<T>(x: { a: T; b: T; }) => T' is not assignable to type '(x: { a: string; b: number; }) => number'.
-!!! error TS2322:   Type 'string | number' is not assignable to type 'number'.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2322:     Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+!!! error TS2322:       Types of property 'b' are incompatible.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
             b15 = a15;
             ~~~
 !!! error TS2322: Type '(x: { a: string; b: number; }) => number' is not assignable to type '<T>(x: { a: T; b: T; }) => T'.

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures5.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures5.errors.txt
@@ -1,9 +1,15 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5.ts(40,1): error TS2322: Type '<T>(x: T) => void' is not assignable to type '<T>(x: T) => T'.
   Type 'void' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5.ts(52,1): error TS2322: Type '<T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base' is not assignable to type '<T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type '{ foo: U; bar: U; }' is not assignable to type '{ foo: T; bar: T; }'.
+      Types of property 'foo' are incompatible.
+        Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5.ts(55,1): error TS2322: Type '<T>(x: { a: T; b: T; }) => T[]' is not assignable to type '<U, V>(x: { a: U; b: V; }) => U[]'.
-  Type '(U | V)[]' is not assignable to type 'U[]'.
-    Type 'U | V' is not assignable to type 'U'.
-      Type 'V' is not assignable to type 'U'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type '{ a: U; b: V; }' is not assignable to type '{ a: U; b: U; }'.
+      Types of property 'b' are incompatible.
+        Type 'V' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5.ts(58,1): error TS2322: Type '<T extends Base>(x: { a: T; b: T; }) => T[]' is not assignable to type '<U, V>(x: { a: U; b: V; }) => U[]'.
   Types of parameters 'x' and 'x' are incompatible.
     Type '{ a: U; b: V; }' is not assignable to type '{ a: Base; b: Base; }'.
@@ -11,7 +17,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         Type 'U' is not assignable to type 'Base'.
 
 
-==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5.ts (3 errors) ====
+==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures5.ts (4 errors) ====
     // checking assignment compat for function types. No errors in this file
     
     class Base { foo: string; }
@@ -67,14 +73,21 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     var b11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
     a11 = b11; // ok
     b11 = a11; // ok
+    ~~~
+!!! error TS2322: Type '<T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base' is not assignable to type '<T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base'.
+!!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2322:     Type '{ foo: U; bar: U; }' is not assignable to type '{ foo: T; bar: T; }'.
+!!! error TS2322:       Types of property 'foo' are incompatible.
+!!! error TS2322:         Type 'U' is not assignable to type 'T'.
     var b15: <U, V>(x: { a: U; b: V; }) => U[]; 
     a15 = b15; // ok, T = U, T = V
     b15 = a15; // ok
     ~~~
 !!! error TS2322: Type '<T>(x: { a: T; b: T; }) => T[]' is not assignable to type '<U, V>(x: { a: U; b: V; }) => U[]'.
-!!! error TS2322:   Type '(U | V)[]' is not assignable to type 'U[]'.
-!!! error TS2322:     Type 'U | V' is not assignable to type 'U'.
-!!! error TS2322:       Type 'V' is not assignable to type 'U'.
+!!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2322:     Type '{ a: U; b: V; }' is not assignable to type '{ a: U; b: U; }'.
+!!! error TS2322:       Types of property 'b' are incompatible.
+!!! error TS2322:         Type 'V' is not assignable to type 'U'.
     var b16: <T>(x: { a: T; b: T }) => T[]; 
     a15 = b16; // ok
     b15 = a16; // ok

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures6.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures6.errors.txt
@@ -1,5 +1,10 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6.ts(30,1): error TS2322: Type '<T>(x: T) => void' is not assignable to type '<T>(x: T) => T'.
   Type 'void' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6.ts(39,1): error TS2322: Type '<T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base' is not assignable to type '<T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type '{ foo: U; bar: U; }' is not assignable to type '{ foo: T; bar: T; }'.
+      Types of property 'foo' are incompatible.
+        Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6.ts(42,1): error TS2322: Type '<T extends Base>(x: { a: T; b: T; }) => T[]' is not assignable to type '<T>(x: { a: T; b: T; }) => T[]'.
   Types of parameters 'x' and 'x' are incompatible.
     Type '{ a: T; b: T; }' is not assignable to type '{ a: Base; b: Base; }'.
@@ -7,7 +12,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         Type 'T' is not assignable to type 'Base'.
 
 
-==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6.ts (2 errors) ====
+==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures6.ts (3 errors) ====
     // checking assignment compatibility relations for function types. All valid
     
     class Base { foo: string; }
@@ -50,6 +55,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     var b11: <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
     x.a11 = b11;
     b11 = x.a11;
+    ~~~
+!!! error TS2322: Type '<T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base' is not assignable to type '<T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base'.
+!!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2322:     Type '{ foo: U; bar: U; }' is not assignable to type '{ foo: T; bar: T; }'.
+!!! error TS2322:       Types of property 'foo' are incompatible.
+!!! error TS2322:         Type 'U' is not assignable to type 'T'.
     var b16: <T>(x: { a: T; b: T }) => T[]; 
     x.a16 = b16;
     b16 = x.a16;

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures3.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures3.errors.txt
@@ -45,6 +45,11 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
           Property 'baz' is missing in type 'Base'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts(83,1): error TS2322: Type 'new (x: Base[], y: Derived[]) => Derived[]' is not assignable to type 'new <T extends Derived[]>(x: Base[], y: T) => T'.
   Type 'Derived[]' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts(85,1): error TS2322: Type 'new <T>(x: { a: T; b: T; }) => T' is not assignable to type 'new (x: { a: string; b: number; }) => Object'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+      Types of property 'b' are incompatible.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts(86,1): error TS2322: Type 'new (x: { a: string; b: number; }) => Object' is not assignable to type 'new <T>(x: { a: T; b: T; }) => T'.
   Types of parameters 'x' and 'x' are incompatible.
     Type '{ a: T; b: T; }' is not assignable to type '{ a: string; b: number; }'.
@@ -52,7 +57,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         Type 'T' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts (14 errors) ====
+==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures3.ts (15 errors) ====
     // checking assignment compatibility relations for function types. All of these are valid.
     
     class Base { foo: string; }
@@ -198,6 +203,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322:   Type 'Derived[]' is not assignable to type 'T'.
     var b14: new <T>(x: { a: T; b: T }) => T; 
     a14 = b14; // ok
+    ~~~
+!!! error TS2322: Type 'new <T>(x: { a: T; b: T; }) => T' is not assignable to type 'new (x: { a: string; b: number; }) => Object'.
+!!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2322:     Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+!!! error TS2322:       Types of property 'b' are incompatible.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     b14 = a14; // ok
     ~~~
 !!! error TS2322: Type 'new (x: { a: string; b: number; }) => Object' is not assignable to type 'new <T>(x: { a: T; b: T; }) => T'.

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures4.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures4.errors.txt
@@ -22,8 +22,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(66,9): error TS2322: Type 'new (x: Base[], y: Derived2[]) => Derived[]' is not assignable to type 'new <T extends Derived2[]>(x: Base[], y: Base[]) => T'.
   Type 'Derived[]' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(69,9): error TS2322: Type 'new <T>(x: { a: T; b: T; }) => T' is not assignable to type 'new (x: { a: string; b: number; }) => number'.
-  Type 'string | number' is not assignable to type 'number'.
-    Type 'string' is not assignable to type 'number'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+      Types of property 'b' are incompatible.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(70,9): error TS2322: Type 'new (x: { a: string; b: number; }) => number' is not assignable to type 'new <T>(x: { a: T; b: T; }) => T'.
   Types of parameters 'x' and 'x' are incompatible.
     Type '{ a: T; b: T; }' is not assignable to type '{ a: string; b: number; }'.
@@ -172,8 +174,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
             a15 = b15; // ok
             ~~~
 !!! error TS2322: Type 'new <T>(x: { a: T; b: T; }) => T' is not assignable to type 'new (x: { a: string; b: number; }) => number'.
-!!! error TS2322:   Type 'string | number' is not assignable to type 'number'.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2322:     Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+!!! error TS2322:       Types of property 'b' are incompatible.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
             b15 = a15; // ok
             ~~~
 !!! error TS2322: Type 'new (x: { a: string; b: number; }) => number' is not assignable to type 'new <T>(x: { a: T; b: T; }) => T'.

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures5.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures5.errors.txt
@@ -1,9 +1,15 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures5.ts(40,1): error TS2322: Type 'new <T>(x: T) => void' is not assignable to type 'new <T>(x: T) => T'.
   Type 'void' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures5.ts(52,1): error TS2322: Type 'new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base' is not assignable to type 'new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type '{ foo: U; bar: U; }' is not assignable to type '{ foo: T; bar: T; }'.
+      Types of property 'foo' are incompatible.
+        Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures5.ts(55,1): error TS2322: Type 'new <T>(x: { a: T; b: T; }) => T[]' is not assignable to type 'new <U, V>(x: { a: U; b: V; }) => U[]'.
-  Type '(U | V)[]' is not assignable to type 'U[]'.
-    Type 'U | V' is not assignable to type 'U'.
-      Type 'V' is not assignable to type 'U'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type '{ a: U; b: V; }' is not assignable to type '{ a: U; b: U; }'.
+      Types of property 'b' are incompatible.
+        Type 'V' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures5.ts(58,1): error TS2322: Type 'new <T extends Base>(x: { a: T; b: T; }) => T[]' is not assignable to type 'new <U, V>(x: { a: U; b: V; }) => U[]'.
   Types of parameters 'x' and 'x' are incompatible.
     Type '{ a: U; b: V; }' is not assignable to type '{ a: Base; b: Base; }'.
@@ -11,7 +17,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         Type 'U' is not assignable to type 'Base'.
 
 
-==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures5.ts (3 errors) ====
+==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures5.ts (4 errors) ====
     // checking assignment compat for function types. All valid
     
     class Base { foo: string; }
@@ -67,14 +73,21 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     var b11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
     a11 = b11; // ok
     b11 = a11; // ok
+    ~~~
+!!! error TS2322: Type 'new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base' is not assignable to type 'new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base'.
+!!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2322:     Type '{ foo: U; bar: U; }' is not assignable to type '{ foo: T; bar: T; }'.
+!!! error TS2322:       Types of property 'foo' are incompatible.
+!!! error TS2322:         Type 'U' is not assignable to type 'T'.
     var b15: new <U, V>(x: { a: U; b: V; }) => U[]; 
     a15 = b15; // ok
     b15 = a15; // ok
     ~~~
 !!! error TS2322: Type 'new <T>(x: { a: T; b: T; }) => T[]' is not assignable to type 'new <U, V>(x: { a: U; b: V; }) => U[]'.
-!!! error TS2322:   Type '(U | V)[]' is not assignable to type 'U[]'.
-!!! error TS2322:     Type 'U | V' is not assignable to type 'U'.
-!!! error TS2322:       Type 'V' is not assignable to type 'U'.
+!!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2322:     Type '{ a: U; b: V; }' is not assignable to type '{ a: U; b: U; }'.
+!!! error TS2322:       Types of property 'b' are incompatible.
+!!! error TS2322:         Type 'V' is not assignable to type 'U'.
     var b16: new <T>(x: { a: T; b: T }) => T[]; 
     a15 = b16; // ok
     b15 = a16; // ok

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures6.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures6.errors.txt
@@ -1,5 +1,10 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures6.ts(30,1): error TS2322: Type 'new <T>(x: T) => void' is not assignable to type 'new <T>(x: T) => T'.
   Type 'void' is not assignable to type 'T'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures6.ts(39,1): error TS2322: Type 'new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base' is not assignable to type 'new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type '{ foo: U; bar: U; }' is not assignable to type '{ foo: T; bar: T; }'.
+      Types of property 'foo' are incompatible.
+        Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures6.ts(42,1): error TS2322: Type 'new <T extends Base>(x: { a: T; b: T; }) => T[]' is not assignable to type 'new <T>(x: { a: T; b: T; }) => T[]'.
   Types of parameters 'x' and 'x' are incompatible.
     Type '{ a: T; b: T; }' is not assignable to type '{ a: Base; b: Base; }'.
@@ -7,7 +12,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         Type 'T' is not assignable to type 'Base'.
 
 
-==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures6.ts (2 errors) ====
+==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures6.ts (3 errors) ====
     // checking assignment compatibility relations for function types. All valid.
     
     class Base { foo: string; }
@@ -50,6 +55,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     var b11: new <T, U>(x: { foo: T }, y: { foo: U; bar: U }) => Base; 
     x.a11 = b11;
     b11 = x.a11;
+    ~~~
+!!! error TS2322: Type 'new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base' is not assignable to type 'new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base'.
+!!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2322:     Type '{ foo: U; bar: U; }' is not assignable to type '{ foo: T; bar: T; }'.
+!!! error TS2322:       Types of property 'foo' are incompatible.
+!!! error TS2322:         Type 'U' is not assignable to type 'T'.
     var b16: new <T>(x: { a: T; b: T }) => T[]; 
     x.a16 = b16;
     b16 = x.a16;

--- a/tests/baselines/reference/assignmentCompatWithGenericCallSignatures2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithGenericCallSignatures2.errors.txt
@@ -1,9 +1,12 @@
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures2.ts(15,1): error TS2322: Type 'B' is not assignable to type 'A'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type 'T[]' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures2.ts(16,1): error TS2322: Type 'A' is not assignable to type 'B'.
   Types of parameters 'y' and 'y' are incompatible.
     Type 'S' is not assignable to type 'S[]'.
 
 
-==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures2.ts (1 errors) ====
+==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures2.ts (2 errors) ====
     // some complex cases of assignment compat of generic signatures. No contextual signature instantiation
     
     interface A {
@@ -17,8 +20,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     var a: A;
     var b: B;
     
-    // Both ok
+    // Both errors
     a = b;
+    ~
+!!! error TS2322: Type 'B' is not assignable to type 'A'.
+!!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2322:     Type 'T[]' is not assignable to type 'T'.
     b = a;
     ~
 !!! error TS2322: Type 'A' is not assignable to type 'B'.

--- a/tests/baselines/reference/assignmentCompatWithGenericCallSignatures2.js
+++ b/tests/baselines/reference/assignmentCompatWithGenericCallSignatures2.js
@@ -12,7 +12,7 @@ interface B {
 var a: A;
 var b: B;
 
-// Both ok
+// Both errors
 a = b;
 b = a;
 
@@ -21,6 +21,6 @@ b = a;
 // some complex cases of assignment compat of generic signatures. No contextual signature instantiation
 var a;
 var b;
-// Both ok
+// Both errors
 a = b;
 b = a;

--- a/tests/baselines/reference/assignmentCompatWithGenericCallSignatures2.symbols
+++ b/tests/baselines/reference/assignmentCompatWithGenericCallSignatures2.symbols
@@ -31,7 +31,7 @@ var b: B;
 >b : Symbol(b, Decl(assignmentCompatWithGenericCallSignatures2.ts, 11, 3))
 >B : Symbol(B, Decl(assignmentCompatWithGenericCallSignatures2.ts, 4, 1))
 
-// Both ok
+// Both errors
 a = b;
 >a : Symbol(a, Decl(assignmentCompatWithGenericCallSignatures2.ts, 10, 3))
 >b : Symbol(b, Decl(assignmentCompatWithGenericCallSignatures2.ts, 11, 3))

--- a/tests/baselines/reference/assignmentCompatWithGenericCallSignatures2.types
+++ b/tests/baselines/reference/assignmentCompatWithGenericCallSignatures2.types
@@ -19,7 +19,7 @@ var a: A;
 var b: B;
 >b : B
 
-// Both ok
+// Both errors
 a = b;
 >a = b : B
 >a : A

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance2.js
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance2.js
@@ -62,7 +62,7 @@ interface I extends A {
     a11: <T extends Base>(x: T, y: T) => T; // ok
     a12: <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: <T, U>(x: { a: T; b: U }) => T; // ok
     a15: <T>(x: T) => T[]; // ok
     a16: <T extends Base>(x: T) => number[]; // ok
     a17: <T>(x: (a: T) => T) => T[]; // ok

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance2.symbols
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance2.symbols
@@ -354,18 +354,19 @@ interface I extends A {
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance2.ts, 62, 10))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance2.ts, 62, 10))
 
-    a14: <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: <T, U>(x: { a: T; b: U }) => T; // ok
 >a14 : Symbol(I.a14, Decl(callSignatureAssignabilityInInheritance2.ts, 62, 63))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 10))
->x : Symbol(x, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 13))
->a : Symbol(a, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 17))
+>U : Symbol(U, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 12))
+>x : Symbol(x, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 16))
+>a : Symbol(a, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 20))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 10))
->b : Symbol(b, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 23))
->T : Symbol(T, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 10))
+>b : Symbol(b, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 26))
+>U : Symbol(U, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 12))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 10))
 
     a15: <T>(x: T) => T[]; // ok
->a15 : Symbol(I.a15, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 37))
+>a15 : Symbol(I.a15, Decl(callSignatureAssignabilityInInheritance2.ts, 63, 40))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance2.ts, 64, 10))
 >x : Symbol(x, Decl(callSignatureAssignabilityInInheritance2.ts, 64, 13))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance2.ts, 64, 10))

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance2.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance2.types
@@ -230,11 +230,11 @@ interface I extends A {
 >x : Base[]
 >y : T
 
-    a14: <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
->a14 : <T>(x: { a: T; b: T; }) => T
->x : { a: T; b: T; }
+    a14: <T, U>(x: { a: T; b: U }) => T; // ok
+>a14 : <T, U>(x: { a: T; b: U; }) => T
+>x : { a: T; b: U; }
 >a : T
->b : T
+>b : U
 
     a15: <T>(x: T) => T[]; // ok
 >a15 : <T>(x: T) => T[]

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance3.errors.txt
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance3.errors.txt
@@ -14,8 +14,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSign
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance3.ts(76,19): error TS2430: Interface 'I6' incorrectly extends interface 'A'.
   Types of property 'a15' are incompatible.
     Type '<T>(x: { a: T; b: T; }) => T' is not assignable to type '(x: { a: string; b: number; }) => number'.
-      Type 'string | number' is not assignable to type 'number'.
-        Type 'string' is not assignable to type 'number'.
+      Types of parameters 'x' and 'x' are incompatible.
+        Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+          Types of property 'b' are incompatible.
+            Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance3.ts(80,19): error TS2430: Interface 'I7' incorrectly extends interface 'A'.
   Types of property 'a15' are incompatible.
     Type '<T extends Base>(x: { a: T; b: T; }) => number' is not assignable to type '(x: { a: string; b: number; }) => number'.
@@ -131,8 +133,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSign
 !!! error TS2430: Interface 'I6' incorrectly extends interface 'A'.
 !!! error TS2430:   Types of property 'a15' are incompatible.
 !!! error TS2430:     Type '<T>(x: { a: T; b: T; }) => T' is not assignable to type '(x: { a: string; b: number; }) => number'.
-!!! error TS2430:       Type 'string | number' is not assignable to type 'number'.
-!!! error TS2430:         Type 'string' is not assignable to type 'number'.
+!!! error TS2430:       Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2430:         Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+!!! error TS2430:           Types of property 'b' are incompatible.
+!!! error TS2430:             Type 'number' is not assignable to type 'string'.
                 a15: <T>(x: { a: T; b: T }) => T; // error, T is {} which isn't an acceptable return type
             }
     

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance5.js
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance5.js
@@ -45,7 +45,7 @@ interface I extends B {
     a11: <T extends Base>(x: T, y: T) => T; // ok
     a12: <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: <T, U>(x: { a: T; b: U }) => T; // ok
 }
 
 //// [callSignatureAssignabilityInInheritance5.js]

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance5.symbols
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance5.symbols
@@ -302,13 +302,14 @@ interface I extends B {
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance5.ts, 45, 10))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance5.ts, 45, 10))
 
-    a14: <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: <T, U>(x: { a: T; b: U }) => T; // ok
 >a14 : Symbol(I.a14, Decl(callSignatureAssignabilityInInheritance5.ts, 45, 63))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 10))
->x : Symbol(x, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 13))
->a : Symbol(a, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 17))
+>U : Symbol(U, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 12))
+>x : Symbol(x, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 16))
+>a : Symbol(a, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 20))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 10))
->b : Symbol(b, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 23))
->T : Symbol(T, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 10))
+>b : Symbol(b, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 26))
+>U : Symbol(U, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 12))
 >T : Symbol(T, Decl(callSignatureAssignabilityInInheritance5.ts, 46, 10))
 }

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance5.types
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance5.types
@@ -180,9 +180,9 @@ interface I extends B {
 >x : Base[]
 >y : T
 
-    a14: <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
->a14 : <T>(x: { a: T; b: T; }) => T
->x : { a: T; b: T; }
+    a14: <T, U>(x: { a: T; b: U }) => T; // ok
+>a14 : <T, U>(x: { a: T; b: U; }) => T
+>x : { a: T; b: U; }
 >a : T
->b : T
+>b : U
 }

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.js
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.js
@@ -62,7 +62,7 @@ interface I extends A {
     a11: new <T extends Base>(x: T, y: T) => T; // ok
     a12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
     a15: new <T>(x: T) => T[]; // ok
     a16: new <T extends Base>(x: T) => number[]; // ok
     a17: new <T>(x: new (a: T) => T) => T[]; // ok

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.symbols
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.symbols
@@ -354,18 +354,19 @@ interface I extends A {
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance2.ts, 62, 14))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance2.ts, 62, 14))
 
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
 >a14 : Symbol(I.a14, Decl(constructSignatureAssignabilityInInheritance2.ts, 62, 67))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 14))
->x : Symbol(x, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 17))
->a : Symbol(a, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 21))
+>U : Symbol(U, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 16))
+>x : Symbol(x, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 20))
+>a : Symbol(a, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 24))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 14))
->b : Symbol(b, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 27))
->T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 14))
+>b : Symbol(b, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 30))
+>U : Symbol(U, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 16))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 14))
 
     a15: new <T>(x: T) => T[]; // ok
->a15 : Symbol(I.a15, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 41))
+>a15 : Symbol(I.a15, Decl(constructSignatureAssignabilityInInheritance2.ts, 63, 44))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance2.ts, 64, 14))
 >x : Symbol(x, Decl(constructSignatureAssignabilityInInheritance2.ts, 64, 17))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance2.ts, 64, 14))

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance2.types
@@ -230,11 +230,11 @@ interface I extends A {
 >x : Base[]
 >y : T
 
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
->a14 : new <T>(x: { a: T; b: T; }) => T
->x : { a: T; b: T; }
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
+>a14 : new <T, U>(x: { a: T; b: U; }) => T
+>x : { a: T; b: U; }
 >a : T
->b : T
+>b : U
 
     a15: new <T>(x: T) => T[]; // ok
 >a15 : new <T>(x: T) => T[]

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance3.errors.txt
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance3.errors.txt
@@ -14,8 +14,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/construc
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance3.ts(66,19): error TS2430: Interface 'I6' incorrectly extends interface 'A'.
   Types of property 'a15' are incompatible.
     Type 'new <T>(x: { a: T; b: T; }) => T' is not assignable to type 'new (x: { a: string; b: number; }) => number'.
-      Type 'string | number' is not assignable to type 'number'.
-        Type 'string' is not assignable to type 'number'.
+      Types of parameters 'x' and 'x' are incompatible.
+        Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+          Types of property 'b' are incompatible.
+            Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance3.ts(70,19): error TS2430: Interface 'I7' incorrectly extends interface 'A'.
   Types of property 'a15' are incompatible.
     Type 'new <T extends Base>(x: { a: T; b: T; }) => number' is not assignable to type 'new (x: { a: string; b: number; }) => number'.
@@ -121,8 +123,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/construc
 !!! error TS2430: Interface 'I6' incorrectly extends interface 'A'.
 !!! error TS2430:   Types of property 'a15' are incompatible.
 !!! error TS2430:     Type 'new <T>(x: { a: T; b: T; }) => T' is not assignable to type 'new (x: { a: string; b: number; }) => number'.
-!!! error TS2430:       Type 'string | number' is not assignable to type 'number'.
-!!! error TS2430:         Type 'string' is not assignable to type 'number'.
+!!! error TS2430:       Types of parameters 'x' and 'x' are incompatible.
+!!! error TS2430:         Type '{ a: string; b: number; }' is not assignable to type '{ a: string; b: string; }'.
+!!! error TS2430:           Types of property 'b' are incompatible.
+!!! error TS2430:             Type 'number' is not assignable to type 'string'.
                 a15: new <T>(x: { a: T; b: T }) => T; // error, T is {} which isn't an acceptable return type
             }
     

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.js
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.js
@@ -45,7 +45,7 @@ interface I extends B {
     a11: new <T extends Base>(x: T, y: T) => T; // ok
     a12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
 }
 
 //// [constructSignatureAssignabilityInInheritance5.js]

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.symbols
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.symbols
@@ -302,13 +302,14 @@ interface I extends B {
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance5.ts, 45, 14))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance5.ts, 45, 14))
 
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
 >a14 : Symbol(I.a14, Decl(constructSignatureAssignabilityInInheritance5.ts, 45, 67))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 14))
->x : Symbol(x, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 17))
->a : Symbol(a, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 21))
+>U : Symbol(U, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 16))
+>x : Symbol(x, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 20))
+>a : Symbol(a, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 24))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 14))
->b : Symbol(b, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 27))
->T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 14))
+>b : Symbol(b, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 30))
+>U : Symbol(U, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 16))
 >T : Symbol(T, Decl(constructSignatureAssignabilityInInheritance5.ts, 46, 14))
 }

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.types
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance5.types
@@ -180,9 +180,9 @@ interface I extends B {
 >x : Base[]
 >y : T
 
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
->a14 : new <T>(x: { a: T; b: T; }) => T
->x : { a: T; b: T; }
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
+>a14 : new <T, U>(x: { a: T; b: U; }) => T
+>x : { a: T; b: U; }
 >a : T
->b : T
+>b : U
 }

--- a/tests/baselines/reference/contextualSignatureInstantiation.errors.txt
+++ b/tests/baselines/reference/contextualSignatureInstantiation.errors.txt
@@ -1,0 +1,53 @@
+tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts(19,13): error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: number, y: string) => number'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts(20,23): error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: number, y: string) => number'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts(21,23): error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: string, y: number) => string'.
+  Types of parameters 'y' and 'y' are incompatible.
+    Type 'number' is not assignable to type 'string'.
+
+
+==== tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts (3 errors) ====
+    // TypeScript Spec, section 4.12.2:
+    // If e is an expression of a function type that contains exactly one generic call signature and no other members,
+    // and T is a function type with exactly one non - generic call signature and no other members, then any inferences
+    // made for type parameters referenced by the parameters of T's call signature are fixed, and e's type is changed
+    // to a function type with e's call signature instantiated in the context of T's call signature (section 3.8.5).
+    
+    declare function foo<T>(cb: (x: number, y: string) => T): T;
+    declare function bar<T, U, V>(x: T, y: U, cb: (x: T, y: U) => V): V;
+    declare function baz<T, U>(x: T, y: T, cb: (x: T, y: T) => U): U;
+    
+    declare function g<T>(x: T, y: T): T;
+    declare function h<T, U>(x: T, y: U): T[] | U[];
+    
+    var a: number;
+    var a = bar(1, 1, g);      // Should be number
+    var a = baz(1, 1, g);      // Should be number
+    
+    var b: number | string;
+    var b = foo(g);            // Error, number and string are disjoint types
+                ~
+!!! error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: number, y: string) => number'.
+!!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    var b = bar(1, "one", g);  // Error, number and string are disjoint types
+                          ~
+!!! error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: number, y: string) => number'.
+!!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    var b = bar("one", 1, g);  // Error, number and string are disjoint types
+                          ~
+!!! error TS2345: Argument of type '<T>(x: T, y: T) => T' is not assignable to parameter of type '(x: string, y: number) => string'.
+!!! error TS2345:   Types of parameters 'y' and 'y' are incompatible.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+    var b = baz(b, b, g);      // Should be number | string
+    
+    var d: number[] | string[];
+    var d = foo(h);            // Should be number[] | string[]
+    var d = bar(1, "one", h);  // Should be number[] | string[]
+    var d = bar("one", 1, h);  // Should be number[] | string[]
+    var d = baz(d, d, g);      // Should be number[] | string[]
+    

--- a/tests/baselines/reference/contextualSignatureInstantiation.js
+++ b/tests/baselines/reference/contextualSignatureInstantiation.js
@@ -17,9 +17,9 @@ var a = bar(1, 1, g);      // Should be number
 var a = baz(1, 1, g);      // Should be number
 
 var b: number | string;
-var b = foo(g);            // Should be number | string
-var b = bar(1, "one", g);  // Should be number | string
-var b = bar("one", 1, g);  // Should be number | string
+var b = foo(g);            // Error, number and string are disjoint types
+var b = bar(1, "one", g);  // Error, number and string are disjoint types
+var b = bar("one", 1, g);  // Error, number and string are disjoint types
 var b = baz(b, b, g);      // Should be number | string
 
 var d: number[] | string[];
@@ -39,9 +39,9 @@ var a;
 var a = bar(1, 1, g); // Should be number
 var a = baz(1, 1, g); // Should be number
 var b;
-var b = foo(g); // Should be number | string
-var b = bar(1, "one", g); // Should be number | string
-var b = bar("one", 1, g); // Should be number | string
+var b = foo(g); // Error, number and string are disjoint types
+var b = bar(1, "one", g); // Error, number and string are disjoint types
+var b = bar("one", 1, g); // Error, number and string are disjoint types
 var b = baz(b, b, g); // Should be number | string
 var d;
 var d = foo(h); // Should be number[] | string[]

--- a/tests/baselines/reference/contextualSignatureInstantiation.symbols
+++ b/tests/baselines/reference/contextualSignatureInstantiation.symbols
@@ -83,17 +83,17 @@ var a = baz(1, 1, g);      // Should be number
 var b: number | string;
 >b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
 
-var b = foo(g);            // Should be number | string
+var b = foo(g);            // Error, number and string are disjoint types
 >b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
 >foo : Symbol(foo, Decl(contextualSignatureInstantiation.ts, 0, 0))
 >g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
 
-var b = bar(1, "one", g);  // Should be number | string
+var b = bar(1, "one", g);  // Error, number and string are disjoint types
 >b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
 >bar : Symbol(bar, Decl(contextualSignatureInstantiation.ts, 6, 60))
 >g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))
 
-var b = bar("one", 1, g);  // Should be number | string
+var b = bar("one", 1, g);  // Error, number and string are disjoint types
 >b : Symbol(b, Decl(contextualSignatureInstantiation.ts, 17, 3), Decl(contextualSignatureInstantiation.ts, 18, 3), Decl(contextualSignatureInstantiation.ts, 19, 3), Decl(contextualSignatureInstantiation.ts, 20, 3), Decl(contextualSignatureInstantiation.ts, 21, 3))
 >bar : Symbol(bar, Decl(contextualSignatureInstantiation.ts, 6, 60))
 >g : Symbol(g, Decl(contextualSignatureInstantiation.ts, 8, 65))

--- a/tests/baselines/reference/contextualSignatureInstantiation.types
+++ b/tests/baselines/reference/contextualSignatureInstantiation.types
@@ -59,23 +59,23 @@ var a = baz(1, 1, g);      // Should be number
 var b: number | string;
 >b : string | number
 
-var b = foo(g);            // Should be number | string
+var b = foo(g);            // Error, number and string are disjoint types
 >b : string | number
->foo(g) : string | number
+>foo(g) : any
 >foo : <T>(cb: (x: number, y: string) => T) => T
 >g : <T>(x: T, y: T) => T
 
-var b = bar(1, "one", g);  // Should be number | string
+var b = bar(1, "one", g);  // Error, number and string are disjoint types
 >b : string | number
->bar(1, "one", g) : string | number
+>bar(1, "one", g) : any
 >bar : <T, U, V>(x: T, y: U, cb: (x: T, y: U) => V) => V
 >1 : 1
 >"one" : "one"
 >g : <T>(x: T, y: T) => T
 
-var b = bar("one", 1, g);  // Should be number | string
+var b = bar("one", 1, g);  // Error, number and string are disjoint types
 >b : string | number
->bar("one", 1, g) : string | number
+>bar("one", 1, g) : any
 >bar : <T, U, V>(x: T, y: U, cb: (x: T, y: U) => V) => V
 >"one" : "one"
 >1 : 1

--- a/tests/baselines/reference/contextualSignatureInstatiationContravariance.errors.txt
+++ b/tests/baselines/reference/contextualSignatureInstatiationContravariance.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/compiler/contextualSignatureInstatiationContravariance.ts(8,1): error TS2322: Type '<T extends Animal>(x: T, y: T) => void' is not assignable to type '(g: Giraffe, e: Elephant) => void'.
+  Types of parameters 'y' and 'e' are incompatible.
+    Type 'Elephant' is not assignable to type 'Giraffe'.
+      Property 'y' is missing in type 'Elephant'.
+
+
+==== tests/cases/compiler/contextualSignatureInstatiationContravariance.ts (1 errors) ====
+    interface Animal { x }
+    interface Giraffe extends Animal { y }
+    interface Elephant extends Animal { y2 }
+    
+    var f2: <T extends Animal>(x: T, y: T) => void;
+    
+    var g2: (g: Giraffe, e: Elephant) => void;
+    g2 = f2; // error because Giraffe and Elephant are disjoint types
+    ~~
+!!! error TS2322: Type '<T extends Animal>(x: T, y: T) => void' is not assignable to type '(g: Giraffe, e: Elephant) => void'.
+!!! error TS2322:   Types of parameters 'y' and 'e' are incompatible.
+!!! error TS2322:     Type 'Elephant' is not assignable to type 'Giraffe'.
+!!! error TS2322:       Property 'y' is missing in type 'Elephant'.
+    
+    var h2: (g1: Giraffe, g2: Giraffe) => void;
+    h2 = f2; // valid because Giraffe satisfies the constraint. It is safe in the traditional contravariant fashion.

--- a/tests/baselines/reference/contextualSignatureInstatiationContravariance.js
+++ b/tests/baselines/reference/contextualSignatureInstatiationContravariance.js
@@ -6,7 +6,7 @@ interface Elephant extends Animal { y2 }
 var f2: <T extends Animal>(x: T, y: T) => void;
 
 var g2: (g: Giraffe, e: Elephant) => void;
-g2 = f2; // valid because both Giraffe and Elephant satisfy the constraint. T is Animal
+g2 = f2; // error because Giraffe and Elephant are disjoint types
 
 var h2: (g1: Giraffe, g2: Giraffe) => void;
 h2 = f2; // valid because Giraffe satisfies the constraint. It is safe in the traditional contravariant fashion.
@@ -14,6 +14,6 @@ h2 = f2; // valid because Giraffe satisfies the constraint. It is safe in the tr
 //// [contextualSignatureInstatiationContravariance.js]
 var f2;
 var g2;
-g2 = f2; // valid because both Giraffe and Elephant satisfy the constraint. T is Animal
+g2 = f2; // error because Giraffe and Elephant are disjoint types
 var h2;
 h2 = f2; // valid because Giraffe satisfies the constraint. It is safe in the traditional contravariant fashion.

--- a/tests/baselines/reference/contextualSignatureInstatiationContravariance.symbols
+++ b/tests/baselines/reference/contextualSignatureInstatiationContravariance.symbols
@@ -29,7 +29,7 @@ var g2: (g: Giraffe, e: Elephant) => void;
 >e : Symbol(e, Decl(contextualSignatureInstatiationContravariance.ts, 6, 20))
 >Elephant : Symbol(Elephant, Decl(contextualSignatureInstatiationContravariance.ts, 1, 38))
 
-g2 = f2; // valid because both Giraffe and Elephant satisfy the constraint. T is Animal
+g2 = f2; // error because Giraffe and Elephant are disjoint types
 >g2 : Symbol(g2, Decl(contextualSignatureInstatiationContravariance.ts, 6, 3))
 >f2 : Symbol(f2, Decl(contextualSignatureInstatiationContravariance.ts, 4, 3))
 

--- a/tests/baselines/reference/contextualSignatureInstatiationContravariance.types
+++ b/tests/baselines/reference/contextualSignatureInstatiationContravariance.types
@@ -18,7 +18,7 @@ var g2: (g: Giraffe, e: Elephant) => void;
 >g : Giraffe
 >e : Elephant
 
-g2 = f2; // valid because both Giraffe and Elephant satisfy the constraint. T is Animal
+g2 = f2; // error because Giraffe and Elephant are disjoint types
 >g2 = f2 : <T extends Animal>(x: T, y: T) => void
 >g2 : (g: Giraffe, e: Elephant) => void
 >f2 : <T extends Animal>(x: T, y: T) => void

--- a/tests/baselines/reference/subtypingWithCallSignatures2.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures2.types
@@ -737,20 +737,20 @@ var r14arg2 = (x: { a: string; b: number }) => <Object>null;
 >null : null
 
 var r14 = foo14(r14arg1); // any
->r14 : (x: { a: string; b: number; }) => Object
->foo14(r14arg1) : (x: { a: string; b: number; }) => Object
+>r14 : any
+>foo14(r14arg1) : any
 >foo14 : { (a: (x: { a: string; b: number; }) => Object): (x: { a: string; b: number; }) => Object; (a: any): any; }
 >r14arg1 : <T>(x: { a: T; b: T; }) => T
 
 var r14a = [r14arg1, r14arg2];
->r14a : ((x: { a: string; b: number; }) => Object)[]
->[r14arg1, r14arg2] : ((x: { a: string; b: number; }) => Object)[]
+>r14a : ((<T>(x: { a: T; b: T; }) => T) | ((x: { a: string; b: number; }) => Object))[]
+>[r14arg1, r14arg2] : ((<T>(x: { a: T; b: T; }) => T) | ((x: { a: string; b: number; }) => Object))[]
 >r14arg1 : <T>(x: { a: T; b: T; }) => T
 >r14arg2 : (x: { a: string; b: number; }) => Object
 
 var r14b = [r14arg2, r14arg1];
->r14b : ((x: { a: string; b: number; }) => Object)[]
->[r14arg2, r14arg1] : ((x: { a: string; b: number; }) => Object)[]
+>r14b : ((<T>(x: { a: T; b: T; }) => T) | ((x: { a: string; b: number; }) => Object))[]
+>[r14arg2, r14arg1] : ((<T>(x: { a: T; b: T; }) => T) | ((x: { a: string; b: number; }) => Object))[]
 >r14arg2 : (x: { a: string; b: number; }) => Object
 >r14arg1 : <T>(x: { a: T; b: T; }) => T
 

--- a/tests/baselines/reference/subtypingWithCallSignatures4.types
+++ b/tests/baselines/reference/subtypingWithCallSignatures4.types
@@ -381,14 +381,14 @@ var r11 = foo11(r11arg);
 >r11arg : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 
 var r11a = [r11arg, r11arg2];
->r11a : (<T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base)[]
->[r11arg, r11arg2] : (<T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base)[]
+>r11a : (<T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base)[]
+>[r11arg, r11arg2] : (<T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base)[]
 >r11arg : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >r11arg2 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var r11b = [r11arg2, r11arg];
->r11b : (<T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base)[]
->[r11arg2, r11arg] : (<T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base)[]
+>r11b : (<T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base)[]
+>[r11arg2, r11arg] : (<T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base)[]
 >r11arg2 : <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >r11arg : <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 

--- a/tests/baselines/reference/subtypingWithConstructSignatures2.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures2.types
@@ -653,20 +653,20 @@ var r14arg2: new (x: { a: string; b: number }) => Object;
 >b : number
 
 var r14 = foo14(r14arg1); // any
->r14 : new (x: { a: string; b: number; }) => Object
->foo14(r14arg1) : new (x: { a: string; b: number; }) => Object
+>r14 : any
+>foo14(r14arg1) : any
 >foo14 : { (a: new (x: { a: string; b: number; }) => Object): new (x: { a: string; b: number; }) => Object; (a: any): any; }
 >r14arg1 : new <T>(x: { a: T; b: T; }) => T
 
 var r14a = [r14arg1, r14arg2];
->r14a : (new (x: { a: string; b: number; }) => Object)[]
->[r14arg1, r14arg2] : (new (x: { a: string; b: number; }) => Object)[]
+>r14a : ((new <T>(x: { a: T; b: T; }) => T) | (new (x: { a: string; b: number; }) => Object))[]
+>[r14arg1, r14arg2] : ((new <T>(x: { a: T; b: T; }) => T) | (new (x: { a: string; b: number; }) => Object))[]
 >r14arg1 : new <T>(x: { a: T; b: T; }) => T
 >r14arg2 : new (x: { a: string; b: number; }) => Object
 
 var r14b = [r14arg2, r14arg1];
->r14b : (new (x: { a: string; b: number; }) => Object)[]
->[r14arg2, r14arg1] : (new (x: { a: string; b: number; }) => Object)[]
+>r14b : ((new <T>(x: { a: T; b: T; }) => T) | (new (x: { a: string; b: number; }) => Object))[]
+>[r14arg2, r14arg1] : ((new <T>(x: { a: T; b: T; }) => T) | (new (x: { a: string; b: number; }) => Object))[]
 >r14arg2 : new (x: { a: string; b: number; }) => Object
 >r14arg1 : new <T>(x: { a: T; b: T; }) => T
 

--- a/tests/baselines/reference/subtypingWithConstructSignatures4.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures4.types
@@ -343,14 +343,14 @@ var r11 = foo11(r11arg);
 >r11arg : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 
 var r11a = [r11arg, r11arg2];
->r11a : (new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base)[]
->[r11arg, r11arg2] : (new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base)[]
+>r11a : (new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base)[]
+>[r11arg, r11arg2] : (new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base)[]
 >r11arg : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 >r11arg2 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 
 var r11b = [r11arg2, r11arg];
->r11b : (new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base)[]
->[r11arg2, r11arg] : (new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base)[]
+>r11b : (new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base)[]
+>[r11arg2, r11arg] : (new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base)[]
 >r11arg2 : new <T>(x: { foo: T; }, y: { foo: T; bar: T; }) => Base
 >r11arg : new <T, U>(x: { foo: T; }, y: { foo: U; bar: U; }) => Base
 

--- a/tests/baselines/reference/subtypingWithConstructSignatures5.js
+++ b/tests/baselines/reference/subtypingWithConstructSignatures5.js
@@ -45,7 +45,7 @@ interface I extends B {
     a11: new <T extends Base>(x: T, y: T) => T; // ok
     a12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
 }
 
 //// [subtypingWithConstructSignatures5.js]

--- a/tests/baselines/reference/subtypingWithConstructSignatures5.symbols
+++ b/tests/baselines/reference/subtypingWithConstructSignatures5.symbols
@@ -302,13 +302,14 @@ interface I extends B {
 >T : Symbol(T, Decl(subtypingWithConstructSignatures5.ts, 45, 14))
 >T : Symbol(T, Decl(subtypingWithConstructSignatures5.ts, 45, 14))
 
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
 >a14 : Symbol(I.a14, Decl(subtypingWithConstructSignatures5.ts, 45, 67))
 >T : Symbol(T, Decl(subtypingWithConstructSignatures5.ts, 46, 14))
->x : Symbol(x, Decl(subtypingWithConstructSignatures5.ts, 46, 17))
->a : Symbol(a, Decl(subtypingWithConstructSignatures5.ts, 46, 21))
+>U : Symbol(U, Decl(subtypingWithConstructSignatures5.ts, 46, 16))
+>x : Symbol(x, Decl(subtypingWithConstructSignatures5.ts, 46, 20))
+>a : Symbol(a, Decl(subtypingWithConstructSignatures5.ts, 46, 24))
 >T : Symbol(T, Decl(subtypingWithConstructSignatures5.ts, 46, 14))
->b : Symbol(b, Decl(subtypingWithConstructSignatures5.ts, 46, 27))
->T : Symbol(T, Decl(subtypingWithConstructSignatures5.ts, 46, 14))
+>b : Symbol(b, Decl(subtypingWithConstructSignatures5.ts, 46, 30))
+>U : Symbol(U, Decl(subtypingWithConstructSignatures5.ts, 46, 16))
 >T : Symbol(T, Decl(subtypingWithConstructSignatures5.ts, 46, 14))
 }

--- a/tests/baselines/reference/subtypingWithConstructSignatures5.types
+++ b/tests/baselines/reference/subtypingWithConstructSignatures5.types
@@ -180,9 +180,9 @@ interface I extends B {
 >x : Base[]
 >y : T
 
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
->a14 : new <T>(x: { a: T; b: T; }) => T
->x : { a: T; b: T; }
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
+>a14 : new <T, U>(x: { a: T; b: U; }) => T
+>x : { a: T; b: U; }
 >a : T
->b : T
+>b : U
 }

--- a/tests/cases/compiler/contextualSignatureInstatiationContravariance.ts
+++ b/tests/cases/compiler/contextualSignatureInstatiationContravariance.ts
@@ -5,7 +5,7 @@ interface Elephant extends Animal { y2 }
 var f2: <T extends Animal>(x: T, y: T) => void;
 
 var g2: (g: Giraffe, e: Elephant) => void;
-g2 = f2; // valid because both Giraffe and Elephant satisfy the constraint. T is Animal
+g2 = f2; // error because Giraffe and Elephant are disjoint types
 
 var h2: (g1: Giraffe, g2: Giraffe) => void;
 h2 = f2; // valid because Giraffe satisfies the constraint. It is safe in the traditional contravariant fashion.

--- a/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures2.ts
+++ b/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithGenericCallSignatures2.ts
@@ -11,6 +11,6 @@ interface B {
 var a: A;
 var b: B;
 
-// Both ok
+// Both errors
 a = b;
 b = a;

--- a/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance2.ts
+++ b/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance2.ts
@@ -61,7 +61,7 @@ interface I extends A {
     a11: <T extends Base>(x: T, y: T) => T; // ok
     a12: <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: <T, U>(x: { a: T; b: U }) => T; // ok
     a15: <T>(x: T) => T[]; // ok
     a16: <T extends Base>(x: T) => number[]; // ok
     a17: <T>(x: (a: T) => T) => T[]; // ok

--- a/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance5.ts
+++ b/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance5.ts
@@ -44,5 +44,5 @@ interface I extends B {
     a11: <T extends Base>(x: T, y: T) => T; // ok
     a12: <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: <T, U>(x: { a: T; b: U }) => T; // ok
 }

--- a/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance2.ts
+++ b/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance2.ts
@@ -61,7 +61,7 @@ interface I extends A {
     a11: new <T extends Base>(x: T, y: T) => T; // ok
     a12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
     a15: new <T>(x: T) => T[]; // ok
     a16: new <T extends Base>(x: T) => number[]; // ok
     a17: new <T>(x: new (a: T) => T) => T[]; // ok

--- a/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance5.ts
+++ b/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance5.ts
@@ -44,5 +44,5 @@ interface I extends B {
     a11: new <T extends Base>(x: T, y: T) => T; // ok
     a12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
 }

--- a/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures5.ts
+++ b/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures5.ts
@@ -44,5 +44,5 @@ interface I extends B {
     a11: new <T extends Base>(x: T, y: T) => T; // ok
     a12: new <T extends Array<Base>>(x: Array<Base>, y: T) => Array<Derived>; // ok, less specific parameter type
     a13: new <T extends Array<Derived>>(x: Array<Base>, y: T) => T; // ok, T = Array<Derived>, satisfies constraint, contextual signature instantiation succeeds
-    a14: new <T>(x: { a: T; b: T }) => T; // ok, best common type yields T = {} but that's satisfactory for this signature
+    a14: new <T, U>(x: { a: T; b: U }) => T; // ok
 }

--- a/tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeInference/contextualSignatureInstantiation.ts
@@ -16,9 +16,9 @@ var a = bar(1, 1, g);      // Should be number
 var a = baz(1, 1, g);      // Should be number
 
 var b: number | string;
-var b = foo(g);            // Should be number | string
-var b = bar(1, "one", g);  // Should be number | string
-var b = bar("one", 1, g);  // Should be number | string
+var b = foo(g);            // Error, number and string are disjoint types
+var b = bar(1, "one", g);  // Error, number and string are disjoint types
+var b = bar("one", 1, g);  // Error, number and string are disjoint types
 var b = baz(b, b, g);      // Should be number | string
 
 var d: number[] | string[];


### PR DESCRIPTION
The following has always been an error because we require a common supertype to exist among the candidate inferences for a particular type parameter:

```ts
declare function choose<T>(x: T, y: T): T;
let a = choose(10, "abc");  // Error, type '"abc"' not assignable to type '10'
```

However, because we currently infer union types when instantiating a generic function type in the context of a non-generic function type, we don't report an error on the following:

```ts
declare function foo<T>(cb: (x: number, y: string) => T, x: T, y: T): T;
let b = foo(choose, "abc", 10);  // Not an error, but should be
```

With this PR we stop inferring union types in cases such as the above.

This is a breaking change. All errors uncovered in the test baselines seem reasonable, but we'll have to see what results from the RWC tests. Worst case we can tighten the rules only in `--strictFunctionTypes` mode.

Fixes #16107.
