### PR TITLE
Use correct type for async refactoring diagnostics 

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -42,7 +42,16 @@ namespace ts.codefix {
 
     function convertToAsyncFunction(changes: textChanges.ChangeTracker, sourceFile: SourceFile, position: number, checker: TypeChecker, context: CodeFixContextBase): void {
         // get the function declaration - returns a promise
-        const functionToConvert: FunctionLikeDeclaration = getContainingFunction(getTokenAtPosition(sourceFile, position)) as FunctionLikeDeclaration;
+        const tokenAtPosition = getTokenAtPosition(sourceFile, position);
+        let functionToConvert: FunctionLikeDeclaration;
+        if (isIdentifier(tokenAtPosition) && isVariableDeclaration(tokenAtPosition.parent) &&
+            tokenAtPosition.parent.initializer && isFunctionLikeDeclaration(tokenAtPosition.parent.initializer)) {
+            functionToConvert = tokenAtPosition.parent.initializer;
+        }
+        else {
+            functionToConvert = getContainingFunction(getTokenAtPosition(sourceFile, position)) as FunctionLikeDeclaration;
+        }
+
         if (!functionToConvert) {
             return;
         }

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -43,7 +43,7 @@ namespace ts.codefix {
     function convertToAsyncFunction(changes: textChanges.ChangeTracker, sourceFile: SourceFile, position: number, checker: TypeChecker, context: CodeFixContextBase): void {
         // get the function declaration - returns a promise
         const tokenAtPosition = getTokenAtPosition(sourceFile, position);
-        let functionToConvert: FunctionLikeDeclaration;
+        let functionToConvert: FunctionLikeDeclaration | undefined;
 
         // if the parent of a FunctionLikeDeclaration is a variable declaration, the convertToAsync diagnostic will be reported on the variable name
         if (isIdentifier(tokenAtPosition) && isVariableDeclaration(tokenAtPosition.parent) &&
@@ -51,7 +51,7 @@ namespace ts.codefix {
             functionToConvert = tokenAtPosition.parent.initializer;
         }
         else {
-            functionToConvert = getContainingFunction(getTokenAtPosition(sourceFile, position)) as FunctionLikeDeclaration;
+            functionToConvert = tryCast(getContainingFunction(getTokenAtPosition(sourceFile, position)), isFunctionLikeDeclaration);
         }
 
         if (!functionToConvert) {

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -44,6 +44,8 @@ namespace ts.codefix {
         // get the function declaration - returns a promise
         const tokenAtPosition = getTokenAtPosition(sourceFile, position);
         let functionToConvert: FunctionLikeDeclaration;
+
+        // if the parent of a FunctionLikeDeclaration is a variable declaration, the convertToAsync diagnostic will be reported on the variable name
         if (isIdentifier(tokenAtPosition) && isVariableDeclaration(tokenAtPosition.parent) &&
             tokenAtPosition.parent.initializer && isFunctionLikeDeclaration(tokenAtPosition.parent.initializer)) {
             functionToConvert = tokenAtPosition.parent.initializer;

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -3,7 +3,7 @@ namespace ts {
     export function computeSuggestionDiagnostics(sourceFile: SourceFile, program: Program, cancellationToken: CancellationToken): DiagnosticWithLocation[] {
         program.getSemanticDiagnostics(sourceFile, cancellationToken);
         const diags: DiagnosticWithLocation[] = [];
-        const checker = program.getDiagnosticsProducingTypeChecker();
+        const checker = program.getTypeChecker();
 
         if (sourceFile.commonJsModuleIndicator &&
             (programContainsEs6Modules(program) || compilerOptionsIndicateEs6Modules(program.getCompilerOptions())) &&
@@ -115,10 +115,11 @@ namespace ts {
 
     function addConvertToAsyncFunctionDiagnostics(node: FunctionLikeDeclaration, checker: TypeChecker, diags: DiagnosticWithLocation[]): void {
 
-        const functionType = node.type ? checker.getTypeFromTypeNode(node.type) : undefined;
-        if (isAsyncFunction(node) || !node.body || !functionType) {
+        if (isAsyncFunction(node) || !node.body) {
             return;
         }
+
+        const functionType = checker.getTypeAtLocation(node);
 
         const callSignatures = checker.getSignaturesOfType(functionType, SignatureKind.Call);
         const returnType = callSignatures.length ? checker.getReturnTypeOfSignature(callSignatures[0]) : undefined;

--- a/src/testRunner/unittests/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/convertToAsyncFunction.ts
@@ -363,6 +363,8 @@ interface Array<T> {}`
             const diagnostics = languageService.getSuggestionDiagnostics(f.path);
             const diagnostic = find(diagnostics, diagnostic => diagnostic.messageText === diagnosticDescription.message);
             assert.exists(diagnostic);
+            assert.equal(diagnostic!.start, context.span.start);
+            assert.equal(diagnostic!.length, context.span.length);
 
             const actions = codefix.getFixes(context);
             const action = find(actions, action => action.description === codeFixDescription.message)!;
@@ -424,6 +426,10 @@ interface Array<T> {}`
 function [#|f|](): Promise<void>{
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });
 }`);
+    _testConvertToAsyncFunction("convertToAsyncFunction_basicNoReturnTypeAnnotation", `
+function [#|f|]() {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+}`);
     _testConvertToAsyncFunction("convertToAsyncFunction_basicWithComments", `
 function [#|f|](): Promise<void>{
     /* Note - some of these comments are removed during the refactor. This is not ideal. */
@@ -435,6 +441,10 @@ function [#|f|](): Promise<void>{
 
         _testConvertToAsyncFunction("convertToAsyncFunction_ArrowFunction", `
 [#|():Promise<void> => {|]
+    return fetch('https://typescriptlang.org').then(result => console.log(result));
+}`);
+    _testConvertToAsyncFunction("convertToAsyncFunction_ArrowFunctionNoAnnotation", `
+[#|() => {|]
     return fetch('https://typescriptlang.org').then(result => console.log(result));
 }`);
         _testConvertToAsyncFunction("convertToAsyncFunction_Catch", `
@@ -1176,6 +1186,12 @@ function [#|f|]() {
     function [#|f|]() {
         return Promise.resolve().then(() => 1, () => "a");
     }
+`);
+
+    _testConvertToAsyncFunction("convertToAsyncFunction_simpleFunctionExpression", `
+const [#|foo|] = function () {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+} 
 `);
 
 

--- a/src/testRunner/unittests/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/convertToAsyncFunction.ts
@@ -382,7 +382,7 @@ interface Array<T> {}`
 
             const diagProgram = makeProgram({ path, content: newText }, includeLib)!;
             assert.isFalse(hasSyntacticDiagnostics(diagProgram));
-            Harness.Baseline.runBaseline(`${baselineFolder}/${caption}${extension}`, () => data.join(newLineCharacter));
+            Harness.Baseline.runBaseline(`${baselineFolder}/${caption}${extension}`, data.join(newLineCharacter));
         }
 
         function makeProgram(f: { path: string, content: string }, includeLib?: boolean) {

--- a/src/testRunner/unittests/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/convertToAsyncFunction.ts
@@ -362,11 +362,11 @@ interface Array<T> {}`
 
             const diagnostics = languageService.getSuggestionDiagnostics(f.path);
             const diagnostic = find(diagnostics, diagnostic => diagnostic.messageText === description.message);
-            assert.isNotNull(diagnostic);
+            assert.exists(diagnostic);
 
             const actions = codefix.getFixes(context);
             const action = find(actions, action => action.description === description.message)!;
-            assert.isNotNull(action);
+            assert.exists(action);
 
             const data: string[] = [];
             data.push(`// ==ORIGINAL==`);

--- a/src/testRunner/unittests/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/convertToAsyncFunction.ts
@@ -319,7 +319,7 @@ interface String { charAt: any; }
 interface Array<T> {}`
     };
 
-    function testConvertToAsyncFunction(caption: string, text: string, baselineFolder: string, description: DiagnosticMessage, includeLib?: boolean) {
+    function testConvertToAsyncFunction(caption: string, text: string, baselineFolder: string, diagnosticDescription: DiagnosticMessage, codeFixDescription: DiagnosticMessage, includeLib?: boolean) {
         const t = getTest(text);
         const selectionRange = t.ranges.get("selection")!;
         if (!selectionRange) {
@@ -361,11 +361,11 @@ interface Array<T> {}`
             };
 
             const diagnostics = languageService.getSuggestionDiagnostics(f.path);
-            const diagnostic = find(diagnostics, diagnostic => diagnostic.messageText === description.message);
+            const diagnostic = find(diagnostics, diagnostic => diagnostic.messageText === diagnosticDescription.message);
             assert.exists(diagnostic);
 
             const actions = codefix.getFixes(context);
-            const action = find(actions, action => action.description === description.message)!;
+            const action = find(actions, action => action.description === codeFixDescription.message)!;
             assert.exists(action);
 
             const data: string[] = [];
@@ -380,7 +380,7 @@ interface Array<T> {}`
 
             const diagProgram = makeProgram({ path, content: newText }, includeLib)!;
             assert.isFalse(hasSyntacticDiagnostics(diagProgram));
-            Harness.Baseline.runBaseline(`${baselineFolder}/${caption}${extension}`, data.join(newLineCharacter));
+            Harness.Baseline.runBaseline(`${baselineFolder}/${caption}${extension}`, () => data.join(newLineCharacter));
         }
 
         function makeProgram(f: { path: string, content: string }, includeLib?: boolean) {
@@ -1182,7 +1182,7 @@ function [#|f|]() {
     });
 
     function _testConvertToAsyncFunction(caption: string, text: string) {
-        testConvertToAsyncFunction(caption, text, "convertToAsyncFunction", Diagnostics.Convert_to_async_function, /*includeLib*/ true);
+        testConvertToAsyncFunction(caption, text, "convertToAsyncFunction", Diagnostics.This_may_be_converted_to_an_async_function, Diagnostics.Convert_to_async_function, /*includeLib*/ true);
     }
 
     function _testConvertToAsyncFunctionFailed(caption: string, text: string) {

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ArrowFunctionNoAnnotation.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ArrowFunctionNoAnnotation.js
@@ -1,0 +1,11 @@
+// ==ORIGINAL==
+
+/*[#|*/() => {/*|]*/
+    return fetch('https://typescriptlang.org').then(result => console.log(result));
+}
+// ==ASYNC FUNCTION::Convert to async function==
+
+async () => {
+    const result = await fetch('https://typescriptlang.org');
+    return console.log(result);
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ArrowFunctionNoAnnotation.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ArrowFunctionNoAnnotation.ts
@@ -1,0 +1,11 @@
+// ==ORIGINAL==
+
+/*[#|*/() => {/*|]*/
+    return fetch('https://typescriptlang.org').then(result => console.log(result));
+}
+// ==ASYNC FUNCTION::Convert to async function==
+
+async () => {
+    const result = await fetch('https://typescriptlang.org');
+    return console.log(result);
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicNoReturnTypeAnnotation.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicNoReturnTypeAnnotation.js
@@ -1,0 +1,11 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/() {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+}
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f() {
+    const result = await fetch('https://typescriptlang.org');
+    console.log(result);
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicNoReturnTypeAnnotation.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicNoReturnTypeAnnotation.ts
@@ -1,0 +1,11 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/() {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+}
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f() {
+    const result = await fetch('https://typescriptlang.org');
+    console.log(result);
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpression.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpression.js
@@ -1,0 +1,12 @@
+// ==ORIGINAL==
+
+const /*[#|*/foo/*|]*/ = function () {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+} 
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+const foo = async function () {
+    const result = await fetch('https://typescriptlang.org');
+    console.log(result);
+} 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpression.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpression.ts
@@ -1,0 +1,12 @@
+// ==ORIGINAL==
+
+const /*[#|*/foo/*|]*/ = function () {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+} 
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+const foo = async function () {
+    const result = await fetch('https://typescriptlang.org');
+    console.log(result);
+} 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #26374, supersedes #26720 .

This PR aims to fix a few issues:
- Currently, we look to report suggestion diagnostics for the async code fix by checking the signatures of the return type annotation of a `FunctionLikeDeclaration`. Here, we change it to inspect the signatures of the entire declaration. Attempting this without changing the checker used to a non-diagnostics-producing checker caused issues elsewhere, but this change fixed those issues.
- Currently, if a `FunctionExpression` that is fixable is the direct child of a `VariableDeclaration`, then it reports a diagnostic on the variable name. However, triggering the code fix on the variable name will not successfully perform the change. This PR specifically handles this scenario when performing the code fix.
- We also add test coverage for `FunctionExpression`s, as well as `FunctionLikeDeclaration`s without a return type annotation.
- Lastly, we now validate spans that are reported as suggestion diagnostics against what is expected by the test.

