### PR TITLE
Completion for tuple index doesn't need to include quotes

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -264,6 +264,9 @@ namespace ts.Completions {
     }
 
     function quote(text: string, preferences: UserPreferences): string {
+        if (/^\d+$/.test(text)) {
+            return text;
+        }
         const quoted = JSON.stringify(text);
         switch (preferences.quotePreference) {
             case undefined:

--- a/tests/cases/fourslash/completionsTuple.ts
+++ b/tests/cases/fourslash/completionsTuple.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+////declare const x: [number, number];
+////x[|./**/|];
+
+const replacementSpan = test.ranges()[0];
+verify.completions({
+    marker: "",
+    includes: [
+        { name: "0", insertText: '[0]', replacementSpan },
+        { name: "1", insertText: '[1]', replacementSpan },
+        "length",
+    ],
+    excludes: "2",
+    preferences: {
+        includeInsertTextCompletions: true,
+    },
+});


### PR DESCRIPTION
Fixes an issue where the completion filled in `x["0"]` rather than `x[0]`.
Does not fix #23958 which would have us giving a completion once at `x[/**/]`, not just after `x.`.

