### PR TITLE
 Correctly mark visibile nodes when declaration isnt explicitly turned on but composite is true

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26347,7 +26347,7 @@ namespace ts {
 
         function checkExportSpecifier(node: ExportSpecifier) {
             checkAliasSymbol(node);
-            if (compilerOptions.declaration) {
+            if (getEmitDeclarations(compilerOptions)) {
                 collectLinkedAliases(node.propertyName || node.name, /*setVisibility*/ true);
             }
             if (!node.parent.parent.moduleSpecifier) {
@@ -26388,7 +26388,7 @@ namespace ts {
             if (node.expression.kind === SyntaxKind.Identifier) {
                 markExportAsReferenced(node);
 
-                if (compilerOptions.declaration) {
+                if (getEmitDeclarations(compilerOptions)) {
                     collectLinkedAliases(node.expression as Identifier, /*setVisibility*/ true);
                 }
             }

--- a/tests/baselines/reference/declarationEmitWithComposite.js
+++ b/tests/baselines/reference/declarationEmitWithComposite.js
@@ -11,4 +11,7 @@ exports.__esModule = true;
 
 
 //// [/foo/out/test.d.ts]
+interface Foo {
+    x: number;
+}
 export default Foo;

--- a/tests/baselines/reference/declarationEmitWithComposite.js
+++ b/tests/baselines/reference/declarationEmitWithComposite.js
@@ -1,0 +1,14 @@
+//// [test.ts]
+interface Foo {
+    x: number;
+}
+export default Foo;
+
+
+//// [/foo/out/test.js]
+"use strict";
+exports.__esModule = true;
+
+
+//// [/foo/out/test.d.ts]
+export default Foo;

--- a/tests/baselines/reference/declarationEmitWithComposite.symbols
+++ b/tests/baselines/reference/declarationEmitWithComposite.symbols
@@ -1,0 +1,10 @@
+=== /foo/test.ts ===
+interface Foo {
+>Foo : Symbol(Foo, Decl(test.ts, 0, 0))
+
+    x: number;
+>x : Symbol(Foo.x, Decl(test.ts, 0, 15))
+}
+export default Foo;
+>Foo : Symbol(Foo, Decl(test.ts, 0, 0))
+

--- a/tests/baselines/reference/declarationEmitWithComposite.types
+++ b/tests/baselines/reference/declarationEmitWithComposite.types
@@ -1,0 +1,8 @@
+=== /foo/test.ts ===
+interface Foo {
+    x: number;
+>x : number
+}
+export default Foo;
+>Foo : Foo
+

--- a/tests/cases/compiler/declarationEmitWithComposite.ts
+++ b/tests/cases/compiler/declarationEmitWithComposite.ts
@@ -1,0 +1,13 @@
+// @composite: true
+// @fullEmitPaths: true
+
+// @filename: /foo/tsconfig.json
+{
+    "compilerOptions": { "composite": true, "outDir": "out" }
+}
+
+// @filename: /foo/test.ts
+interface Foo {
+    x: number;
+}
+export default Foo;


### PR DESCRIPTION
Fixes #26669

