### PR TITLE
Ignore newline and asterisk when parsing JSDoc typedef

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6856,7 +6856,7 @@ namespace ts {
 
                 function parseTypedefTag(atToken: AtToken, tagName: Identifier, indent: number): JSDocTypedefTag {
                     const typeExpression = tryParseTypeExpression();
-                    skipWhitespace();
+                    skipWhitespaceOrAsterisk();
 
                     const typedefTag = <JSDocTypedefTag>createNode(SyntaxKind.JSDocTypedefTag, atToken.pos);
                     typedefTag.atToken = atToken;

--- a/tests/baselines/reference/typedefTagWrapping.symbols
+++ b/tests/baselines/reference/typedefTagWrapping.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/jsdoc/mod1.js ===
+/** 
+ * @typedef {function(string): boolean}
+ * MyType
+ */
+
+/**
+ * Tries to use a type whose name is on a different
+ * line than the typedef tag.
+ * @param {MyType} func The function to call.
+ * @param {string} arg The argument to call it with.
+ * @returns {boolean} The return.
+ */
+function callIt(func, arg) {
+>callIt : Symbol(callIt, Decl(mod1.js, 0, 0))
+>func : Symbol(func, Decl(mod1.js, 12, 16))
+>arg : Symbol(arg, Decl(mod1.js, 12, 21))
+
+  return func(arg);
+>func : Symbol(func, Decl(mod1.js, 12, 16))
+>arg : Symbol(arg, Decl(mod1.js, 12, 21))
+}
+

--- a/tests/baselines/reference/typedefTagWrapping.types
+++ b/tests/baselines/reference/typedefTagWrapping.types
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/jsdoc/mod1.js ===
+/** 
+ * @typedef {function(string): boolean}
+ * MyType
+ */
+
+/**
+ * Tries to use a type whose name is on a different
+ * line than the typedef tag.
+ * @param {MyType} func The function to call.
+ * @param {string} arg The argument to call it with.
+ * @returns {boolean} The return.
+ */
+function callIt(func, arg) {
+>callIt : (func: (arg0: string) => boolean, arg: string) => boolean
+>func : (arg0: string) => boolean
+>arg : string
+
+  return func(arg);
+>func(arg) : boolean
+>func : (arg0: string) => boolean
+>arg : string
+}
+

--- a/tests/cases/conformance/jsdoc/typedefTagWrapping.ts
+++ b/tests/cases/conformance/jsdoc/typedefTagWrapping.ts
@@ -1,0 +1,20 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: mod1.js
+
+/** 
+ * @typedef {function(string): boolean}
+ * MyType
+ */
+
+/**
+ * Tries to use a type whose name is on a different
+ * line than the typedef tag.
+ * @param {MyType} func The function to call.
+ * @param {string} arg The argument to call it with.
+ * @returns {boolean} The return.
+ */
+function callIt(func, arg) {
+  return func(arg);
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This makes it possible to typecheck JSDoc types like this:
```js
/** 
 * @typedef {function(string): boolean}
 * MyType
 */

/**
 * @param {MyType} func The function to call.
 * @param {string} arg The argument to call it with.
 * @returns {boolean} The return.
 */
function callIt(func, arg) {
  return func(arg);
}
```

Fixes #26774.

See also #26067.

