### PR TITLE
Housekeeping: Fix equalOwnProperties

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1272,7 +1272,7 @@ namespace ts {
         if (!left || !right) return false;
         for (const key in left) {
             if (hasOwnProperty.call(left, key)) {
-                if (!hasOwnProperty.call(right, key) === undefined) return false;
+                if (!hasOwnProperty.call(right, key)) return false;
                 if (!equalityComparer(left[key], right[key])) return false;
             }
         }

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -46,6 +46,7 @@
         "unittests/cancellableLanguageServiceOperations.ts",
         "unittests/commandLineParsing.ts",
         "unittests/compileOnSave.ts",
+        "unittests/compilerCore.ts",
         "unittests/configurationExtension.ts",
         "unittests/convertCompilerOptionsFromJson.ts",
         "unittests/convertToAsyncFunction.ts",

--- a/src/testRunner/unittests/compilerCore.ts
+++ b/src/testRunner/unittests/compilerCore.ts
@@ -1,0 +1,33 @@
+namespace ts {
+    describe("compilerCore", () => {
+        describe("equalOwnProperties", () => {
+            it("correctly equates objects", () => {
+                assert.isTrue(equalOwnProperties({}, {}));
+                assert.isTrue(equalOwnProperties({ a: 1 }, { a: 1 }));
+                assert.isTrue(equalOwnProperties({ a: 1, b: 2 }, { b: 2, a: 1 }));
+            });
+            it("correctly identifies unmatched objects", () => {
+                assert.isFalse(equalOwnProperties({}, { a: 1 }), "missing left property");
+                assert.isFalse(equalOwnProperties({ a: 1 }, {}), "missing right property");
+                assert.isFalse(equalOwnProperties({ a: 1 }, { a: 2 }), "differing property");
+            });
+            it("correctly identifies undefined vs hasOwnProperty", () => {
+                assert.isFalse(equalOwnProperties({}, { a: undefined }), "missing left property");
+                assert.isFalse(equalOwnProperties({ a: undefined }, {}), "missing right property");
+            });
+            it("truthiness", () => {
+                const trythyTest = (l: any, r: any) => !!l === !!r;
+                assert.isFalse(equalOwnProperties({}, { a: 1 }, trythyTest), "missing left truthy property");
+                assert.isFalse(equalOwnProperties({}, { a: 0 }, trythyTest), "missing left falsey property");
+                assert.isFalse(equalOwnProperties({ a: 1 }, {}, trythyTest), "missing right truthy property");
+                assert.isFalse(equalOwnProperties({ a: 0 }, {}, trythyTest), "missing right falsey property");
+                assert.isTrue(equalOwnProperties({ a: 1 }, { a: "foo" }, trythyTest), "valid equality");
+            });
+            it("all equal", () => {
+                assert.isFalse(equalOwnProperties({}, { a: 1 }, () => true), "missing left property");
+                assert.isFalse(equalOwnProperties({ a: 1 }, {}, () => true), "missing right property");
+                assert.isTrue(equalOwnProperties({ a: 1 }, { a: 2 }, () => true), "valid equality");
+            });
+        });
+    });
+}


### PR DESCRIPTION
`equalOwnProperties()` would incorrectly report two map-like objects as equal in the case where a property defined in `left` was not defined in `right` and whose value was considered "equal" to undefined by the equalityComparer.

This bug was found by an alert [on LGTM.com](https://lgtm.com/projects/g/Microsoft/TypeScript/snapshot/bd694beccec2eef11075a81fcc77add5b609016e/files/src/compiler/core.ts?#V1275)

I've added unit tests that check around this functionality, which fail before the fix, and succeed after the fix commit.

**Before 2c41d8b:**

```
> jake runtests tests=compilerCore

...

Test failure:
correctly identifies undefined vs hasOwnProperty                [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬․․․․․․․․․․․․․․․․․․․․․․․․․]
Test failure:
truthiness                                                      [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬․․․․․․․․․․․․]
Test failure:
all equal                                                       [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  2 passing (2s)
  3 failing

  1) compilerCore
       equalOwnProperties
         correctly identifies undefined vs hasOwnProperty:
     Error: missing right property
      at Function.assert.isFalse (src/harness/harness.ts:10:78)
      at Context.<anonymous> (src/testRunner/unittests/compilerCore.ts:16:24)

  2) compilerCore
       equalOwnProperties
         truthiness:
     Error: missing right falsey property
      at Function.assert.isFalse (src/harness/harness.ts:10:78)
      at Context.<anonymous> (src/testRunner/unittests/compilerCore.ts:23:24)

  3) compilerCore
       equalOwnProperties
         all equal:
     Error: missing right property
      at Function.assert.isFalse (src/harness/harness.ts:10:78)
      at Context.<anonymous> (src/testRunner/unittests/compilerCore.ts:28:24)
```

**After 2c41d8b:**

```
> jake runtests tests=compilerCore

...

    compilerCore                                                [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  5 passing (245ms)
```