### PR TITLE
Argument arity error should only consider signatures with correct type argument arity.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19174,14 +19174,17 @@ namespace ts {
             else if (candidateForTypeArgumentError) {
                 checkTypeArguments(candidateForTypeArgumentError, (node as CallExpression | TaggedTemplateExpression).typeArguments!, /*reportErrors*/ true, fallbackError);
             }
-            else if (typeArguments && every(signatures, sig => typeArguments!.length < getMinTypeArgumentCount(sig.typeParameters) || typeArguments!.length > length(sig.typeParameters))) {
-                diagnostics.add(getTypeArgumentArityError(node, signatures, typeArguments));
-            }
-            else if (!isDecorator) {
-                diagnostics.add(getArgumentArityError(node, signatures, args));
-            }
-            else if (fallbackError) {
-                diagnostics.add(createDiagnosticForNode(node, fallbackError));
+            else {
+                const signaturesWithCorrectTypeArgumentArity = filter(signatures, s => hasCorrectTypeArgumentArity(s, typeArguments));
+                if (signaturesWithCorrectTypeArgumentArity.length === 0) {
+                    diagnostics.add(getTypeArgumentArityError(node, signatures, typeArguments!));
+                }
+                else if (!isDecorator) {
+                    diagnostics.add(getArgumentArityError(node, signaturesWithCorrectTypeArgumentArity, args));
+                }
+                else if (fallbackError) {
+                    diagnostics.add(createDiagnosticForNode(node, fallbackError));
+                }
             }
 
             return produceDiagnostics || !args ? resolveErrorCall(node) : getCandidateForOverloadFailure(node, candidates, args, !!candidatesOutArray);

--- a/tests/baselines/reference/functionCall18.errors.txt
+++ b/tests/baselines/reference/functionCall18.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/functionCall18.ts(4,1): error TS2554: Expected 2 arguments, but got 1.
+
+
+==== tests/cases/compiler/functionCall18.ts (1 errors) ====
+    // Repro from #26835
+    declare function foo<T>(a: T, b: T);
+    declare function foo(a: {});
+    foo<string>("hello");
+    ~~~~~~~~~~~~~~~~~~~~
+!!! error TS2554: Expected 2 arguments, but got 1.
+    

--- a/tests/baselines/reference/functionCall18.js
+++ b/tests/baselines/reference/functionCall18.js
@@ -1,0 +1,9 @@
+//// [functionCall18.ts]
+// Repro from #26835
+declare function foo<T>(a: T, b: T);
+declare function foo(a: {});
+foo<string>("hello");
+
+
+//// [functionCall18.js]
+foo("hello");

--- a/tests/baselines/reference/functionCall18.symbols
+++ b/tests/baselines/reference/functionCall18.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/functionCall18.ts ===
+// Repro from #26835
+declare function foo<T>(a: T, b: T);
+>foo : Symbol(foo, Decl(functionCall18.ts, 0, 0), Decl(functionCall18.ts, 1, 36))
+>T : Symbol(T, Decl(functionCall18.ts, 1, 21))
+>a : Symbol(a, Decl(functionCall18.ts, 1, 24))
+>T : Symbol(T, Decl(functionCall18.ts, 1, 21))
+>b : Symbol(b, Decl(functionCall18.ts, 1, 29))
+>T : Symbol(T, Decl(functionCall18.ts, 1, 21))
+
+declare function foo(a: {});
+>foo : Symbol(foo, Decl(functionCall18.ts, 0, 0), Decl(functionCall18.ts, 1, 36))
+>a : Symbol(a, Decl(functionCall18.ts, 2, 21))
+
+foo<string>("hello");
+>foo : Symbol(foo, Decl(functionCall18.ts, 0, 0), Decl(functionCall18.ts, 1, 36))
+

--- a/tests/baselines/reference/functionCall18.types
+++ b/tests/baselines/reference/functionCall18.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/functionCall18.ts ===
+// Repro from #26835
+declare function foo<T>(a: T, b: T);
+>foo : { <T>(a: T, b: T): any; (a: {}): any; }
+>a : T
+>b : T
+
+declare function foo(a: {});
+>foo : { <T>(a: T, b: T): any; (a: {}): any; }
+>a : {}
+
+foo<string>("hello");
+>foo<string>("hello") : any
+>foo : { <T>(a: T, b: T): any; (a: {}): any; }
+>"hello" : "hello"
+

--- a/tests/cases/compiler/functionCall18.ts
+++ b/tests/cases/compiler/functionCall18.ts
@@ -1,0 +1,4 @@
+// Repro from #26835
+declare function foo<T>(a: T, b: T);
+declare function foo(a: {});
+foo<string>("hello");


### PR DESCRIPTION

Fixes #26835.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone (Not yet)
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->