### PR TITLE
For consistency, don't make inferences for unused type parameters when comparing two references to the same generic type.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12298,12 +12298,9 @@ namespace ts {
         // a digest of the type comparisons that occur for each type argument when instantiations of the
         // generic type are structurally compared. We infer the variance information by comparing
         // instantiations of the generic type for type arguments with known relations. The function
-        // returns the emptyArray singleton if we're not in strictFunctionTypes mode or if the function
-        // has been invoked recursively for the given generic type.
+        // returns the emptyArray singleton if the function has been invoked recursively for the given
+        // generic type.
         function getVariances(type: GenericType): Variance[] {
-            if (!strictFunctionTypes) {
-                return emptyArray;
-            }
             const typeParameters = type.typeParameters || emptyArray;
             let variances = type.variances;
             if (!variances) {
@@ -13379,7 +13376,7 @@ namespace ts {
                         if (i < variances.length && variances[i] === Variance.Contravariant) {
                             inferFromContravariantTypes(sourceTypes[i], targetTypes[i]);
                         }
-                        else {
+                        else if (!(i < variances.length && variances[i] === Variance.Independent)) {
                             inferFromTypes(sourceTypes[i], targetTypes[i]);
                         }
                     }

--- a/tests/baselines/reference/complexRecursiveCollections.types
+++ b/tests/baselines/reference/complexRecursiveCollections.types
@@ -1137,7 +1137,7 @@ declare module Immutable {
 >Seq : typeof Seq
 
     function isSeq(maybeSeq: any): maybeSeq is Seq.Indexed<any> | Seq.Keyed<any, any>;
->isSeq : (maybeSeq: any) => maybeSeq is Keyed<any, any> | Indexed<any>
+>isSeq : (maybeSeq: any) => maybeSeq is Indexed<any> | Keyed<any, any>
 >maybeSeq : any
 >Seq : any
 >Seq : any

--- a/tests/baselines/reference/independentTypeParameter.js
+++ b/tests/baselines/reference/independentTypeParameter.js
@@ -1,0 +1,12 @@
+//// [independentTypeParameter.ts]
+// Repro for #26815
+interface Foo<T> {}
+function f<T>(arg: Foo<T>): T { return undefined!; }
+let x: Foo<number> = {};
+f(x);
+
+
+//// [independentTypeParameter.js]
+function f(arg) { return undefined; }
+var x = {};
+f(x);

--- a/tests/baselines/reference/independentTypeParameter.symbols
+++ b/tests/baselines/reference/independentTypeParameter.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/independentTypeParameter.ts ===
+// Repro for #26815
+interface Foo<T> {}
+>Foo : Symbol(Foo, Decl(independentTypeParameter.ts, 0, 0))
+>T : Symbol(T, Decl(independentTypeParameter.ts, 1, 14))
+
+function f<T>(arg: Foo<T>): T { return undefined!; }
+>f : Symbol(f, Decl(independentTypeParameter.ts, 1, 19))
+>T : Symbol(T, Decl(independentTypeParameter.ts, 2, 11))
+>arg : Symbol(arg, Decl(independentTypeParameter.ts, 2, 14))
+>Foo : Symbol(Foo, Decl(independentTypeParameter.ts, 0, 0))
+>T : Symbol(T, Decl(independentTypeParameter.ts, 2, 11))
+>T : Symbol(T, Decl(independentTypeParameter.ts, 2, 11))
+>undefined : Symbol(undefined)
+
+let x: Foo<number> = {};
+>x : Symbol(x, Decl(independentTypeParameter.ts, 3, 3))
+>Foo : Symbol(Foo, Decl(independentTypeParameter.ts, 0, 0))
+
+f(x);
+>f : Symbol(f, Decl(independentTypeParameter.ts, 1, 19))
+>x : Symbol(x, Decl(independentTypeParameter.ts, 3, 3))
+

--- a/tests/baselines/reference/independentTypeParameter.types
+++ b/tests/baselines/reference/independentTypeParameter.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/independentTypeParameter.ts ===
+// Repro for #26815
+interface Foo<T> {}
+function f<T>(arg: Foo<T>): T { return undefined!; }
+>f : <T>(arg: Foo<T>) => T
+>arg : Foo<T>
+>undefined! : undefined
+>undefined : undefined
+
+let x: Foo<number> = {};
+>x : Foo<number>
+>{} : {}
+
+f(x);
+>f(x) : {}
+>f : <T>(arg: Foo<T>) => T
+>x : Foo<number>
+

--- a/tests/cases/compiler/independentTypeParameter.ts
+++ b/tests/cases/compiler/independentTypeParameter.ts
@@ -1,0 +1,5 @@
+// Repro for #26815
+interface Foo<T> {}
+function f<T>(arg: Foo<T>): T { return undefined!; }
+let x: Foo<number> = {};
+f(x);

--- a/tests/cases/fourslash/genericCombinators3.ts
+++ b/tests/cases/fourslash/genericCombinators3.ts
@@ -1,6 +1,8 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface Collection<T, U> {
+////    dummyT: T;
+////    dummyU: U;
 ////}
 ////
 ////interface Combinators {

--- a/tests/cases/fourslash/staticGenericOverloads1.ts
+++ b/tests/cases/fourslash/staticGenericOverloads1.ts
@@ -1,6 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////class A<T> {
+////    dummy: T;
 ////    static B<S>(v: A<S>): A<S>;
 ////    static B<S>(v: S): A<S>;
 ////    static B<S>(v: any): A<S> {


### PR DESCRIPTION
We want this even when strictFunctionTypes is off.  Variance computation
was previously disabled when strictFunctionTypes is off, but I removed
that check without breaking any tests.

Fixes #26815.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone (no, but RyanCavanaugh said he would consider a PR)
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
