### PR TITLE
Defer union and intersection type reduction

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8691,10 +8691,7 @@ namespace ts {
                     const len = typeSet.length;
                     const index = len && type.id > typeSet[len - 1].id ? ~len : binarySearch(typeSet, type, getTypeId, compareValues);
                     if (index < 0) {
-                        if (!(flags & TypeFlags.Object && (<ObjectType>type).objectFlags & ObjectFlags.Anonymous &&
-                            type.symbol && type.symbol.flags & (SymbolFlags.Function | SymbolFlags.Method) && containsIdenticalType(typeSet, type))) {
-                            typeSet.splice(~index, 0, type);
-                        }
+                        typeSet.splice(~index, 0, type);
                     }
                 }
             }
@@ -8708,15 +8705,6 @@ namespace ts {
                 includes = addTypeToUnion(typeSet, includes, type);
             }
             return includes;
-        }
-
-        function containsIdenticalType(types: ReadonlyArray<Type>, type: Type) {
-            for (const t of types) {
-                if (isTypeIdenticalTo(t, type)) {
-                    return true;
-                }
-            }
-            return false;
         }
 
         function isSubtypeOfAny(source: Type, targets: ReadonlyArray<Type>): boolean {
@@ -8899,10 +8887,7 @@ namespace ts {
                 if (flags & TypeFlags.AnyOrUnknown) {
                     if (type === wildcardType) includes |= TypeFlags.Wildcard;
                 }
-                else if ((strictNullChecks || !(flags & TypeFlags.Nullable)) && !contains(typeSet, type) &&
-                    !(flags & TypeFlags.Object && (<ObjectType>type).objectFlags & ObjectFlags.Anonymous &&
-                    type.symbol && type.symbol.flags & (SymbolFlags.Function | SymbolFlags.Method) &&
-                    containsIdenticalType(typeSet, type))) {
+                else if ((strictNullChecks || !(flags & TypeFlags.Nullable)) && !contains(typeSet, type)) {
                     typeSet.push(type);
                 }
             }

--- a/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/conformance/jsx/file.tsx(24,28): error TS2551: Property 'NAme' does not exist on type 'IUser'. Did you mean 'Name'?
-tests/cases/conformance/jsx/file.tsx(32,10): error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
+tests/cases/conformance/jsx/file.tsx(32,10): error TS2322: Type '{ children: (((user: IUser) => Element) | ((user: IUser) => Element))[]; }' is not assignable to type 'IFetchUserProps'.
   Types of property 'children' are incompatible.
-    Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
-      Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
+    Type '(((user: IUser) => Element) | ((user: IUser) => Element))[]' is not assignable to type '(user: IUser) => Element'.
+      Type '(((user: IUser) => Element) | ((user: IUser) => Element))[]' provides no match for the signature '(user: IUser): Element'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -42,10 +42,10 @@ tests/cases/conformance/jsx/file.tsx(32,10): error TS2322: Type '{ children: ((u
         return (
             <FetchUser>
              ~~~~~~~~~
-!!! error TS2322: Type '{ children: ((user: IUser) => Element)[]; }' is not assignable to type 'IFetchUserProps'.
+!!! error TS2322: Type '{ children: (((user: IUser) => Element) | ((user: IUser) => Element))[]; }' is not assignable to type 'IFetchUserProps'.
 !!! error TS2322:   Types of property 'children' are incompatible.
-!!! error TS2322:     Type '((user: IUser) => Element)[]' is not assignable to type '(user: IUser) => Element'.
-!!! error TS2322:       Type '((user: IUser) => Element)[]' provides no match for the signature '(user: IUser): Element'.
+!!! error TS2322:     Type '(((user: IUser) => Element) | ((user: IUser) => Element))[]' is not assignable to type '(user: IUser) => Element'.
+!!! error TS2322:       Type '(((user: IUser) => Element) | ((user: IUser) => Element))[]' provides no match for the signature '(user: IUser): Element'.
     
     
                 

--- a/tests/baselines/reference/overrideBaseIntersectionMethod.types
+++ b/tests/baselines/reference/overrideBaseIntersectionMethod.types
@@ -78,9 +78,9 @@ class Foo extends WithLocation(Point) {
 
     return super.getLocation()
 >super.getLocation() : [number, number]
->super.getLocation : () => [number, number]
+>super.getLocation : (() => [number, number]) & (() => [number, number])
 >super : WithLocation<typeof Point>.(Anonymous class) & Point
->getLocation : () => [number, number]
+>getLocation : (() => [number, number]) & (() => [number, number])
   }
   whereAmI() {
 >whereAmI : () => [number, number]

--- a/tests/baselines/reference/typeParameterExtendingUnion1.types
+++ b/tests/baselines/reference/typeParameterExtendingUnion1.types
@@ -30,9 +30,9 @@ function f<T extends Cat | Dog>(a: T) {
 
     a.run();
 >a.run() : void
->a.run : () => void
+>a.run : (() => void) | (() => void)
 >a : T
->run : () => void
+>run : (() => void) | (() => void)
 
     run(a);
 >run(a) : void

--- a/tests/baselines/reference/typeParameterExtendingUnion2.types
+++ b/tests/baselines/reference/typeParameterExtendingUnion2.types
@@ -19,9 +19,9 @@ function run(a: Cat | Dog) {
 
     a.run();
 >a.run() : void
->a.run : () => void
+>a.run : (() => void) | (() => void)
 >a : Cat | Dog
->run : () => void
+>run : (() => void) | (() => void)
 }
 
 function f<T extends Cat | Dog>(a: T) {
@@ -30,9 +30,9 @@ function f<T extends Cat | Dog>(a: T) {
 
     a.run();
 >a.run() : void
->a.run : () => void
+>a.run : (() => void) | (() => void)
 >a : T
->run : () => void
+>run : (() => void) | (() => void)
 
     run(a);
 >run(a) : void

--- a/tests/baselines/reference/unionTypeMembers.types
+++ b/tests/baselines/reference/unionTypeMembers.types
@@ -95,9 +95,9 @@ str = x.commonMethodType(str); // (a: string) => string so result should be stri
 >str = x.commonMethodType(str) : string
 >str : string
 >x.commonMethodType(str) : string
->x.commonMethodType : (a: string) => string
+>x.commonMethodType : ((a: string) => string) | ((a: string) => string)
 >x : I1<number> | I2<number>
->commonMethodType : (a: string) => string
+>commonMethodType : ((a: string) => string) | ((a: string) => string)
 >str : string
 
 strOrNum = x.commonPropertyDifferenType;
@@ -133,36 +133,36 @@ num = x.commonMethodWithTypeParameter(num);
 >num = x.commonMethodWithTypeParameter(num) : number
 >num : number
 >x.commonMethodWithTypeParameter(num) : number
->x.commonMethodWithTypeParameter : (a: number) => number
+>x.commonMethodWithTypeParameter : ((a: number) => number) | ((a: number) => number)
 >x : I1<number> | I2<number>
->commonMethodWithTypeParameter : (a: number) => number
+>commonMethodWithTypeParameter : ((a: number) => number) | ((a: number) => number)
 >num : number
 
 num = x.commonMethodWithOwnTypeParameter(num);
 >num = x.commonMethodWithOwnTypeParameter(num) : number
 >num : number
 >x.commonMethodWithOwnTypeParameter(num) : number
->x.commonMethodWithOwnTypeParameter : <U>(a: U) => U
+>x.commonMethodWithOwnTypeParameter : (<U>(a: U) => U) | (<U>(a: U) => U)
 >x : I1<number> | I2<number>
->commonMethodWithOwnTypeParameter : <U>(a: U) => U
+>commonMethodWithOwnTypeParameter : (<U>(a: U) => U) | (<U>(a: U) => U)
 >num : number
 
 str = x.commonMethodWithOwnTypeParameter(str);
 >str = x.commonMethodWithOwnTypeParameter(str) : string
 >str : string
 >x.commonMethodWithOwnTypeParameter(str) : string
->x.commonMethodWithOwnTypeParameter : <U>(a: U) => U
+>x.commonMethodWithOwnTypeParameter : (<U>(a: U) => U) | (<U>(a: U) => U)
 >x : I1<number> | I2<number>
->commonMethodWithOwnTypeParameter : <U>(a: U) => U
+>commonMethodWithOwnTypeParameter : (<U>(a: U) => U) | (<U>(a: U) => U)
 >str : string
 
 strOrNum = x.commonMethodWithOwnTypeParameter(strOrNum);
 >strOrNum = x.commonMethodWithOwnTypeParameter(strOrNum) : string | number
 >strOrNum : string | number
 >x.commonMethodWithOwnTypeParameter(strOrNum) : string | number
->x.commonMethodWithOwnTypeParameter : <U>(a: U) => U
+>x.commonMethodWithOwnTypeParameter : (<U>(a: U) => U) | (<U>(a: U) => U)
 >x : I1<number> | I2<number>
->commonMethodWithOwnTypeParameter : <U>(a: U) => U
+>commonMethodWithOwnTypeParameter : (<U>(a: U) => U) | (<U>(a: U) => U)
 >strOrNum : string | number
 
 x.propertyOnlyInI1; // error


### PR DESCRIPTION
When constructing union and intersection types, we eagerly remove duplicate function types that originate in function or method declarations. This eager reduction can be very expensive when resolving the members of unions of a large number of array or tuple types. We used to rely on the eager reduction, but it is no longer necessary because a similar and more efficient reduction happens later (and in a deferred manner) when we compute the signature lists of union and intersection types.

With this PR we remove the unnecessary eager reduction. This makes our behavior more consistent since the eager reduction was never done for other types.

One example that directly benefits is this code in #26756. When requesting statement completion:

```ts
function sendCommand<C extends keyof Commands>(method: C, ...params: Commands[C]['paramsType']) {
    params.  // Statement completion here
}
```

we currently spend 5-6 seconds grinding away before bringing up a completion list. With this PR the completion time drops to less than half a second.

Only one RWC project, fp-ts, is affected by this. Upon inspection the new errors in fp-ts look correct, and with the latest code here https://github.com/gcanti/fp-ts the errors are no longer present. I suspect the errors were not reported before because the eager reduction uses type parameter erasure which can lead to false positives.