### PR TITLE
better condition for file include exhaustiveness check

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2432,12 +2432,14 @@ namespace ts {
             }
 
             // List of collected files is complete; validate exhautiveness if this is a project with a file list
-            if (options.composite && rootNames.length < files.length) {
-                const normalizedRootNames = rootNames.map(r => normalizePath(r).toLowerCase());
-                const sourceFiles = files.filter(f => !f.isDeclarationFile).map(f => normalizePath(f.path).toLowerCase());
-                for (const file of sourceFiles) {
-                    if (normalizedRootNames.every(r => r !== file)) {
-                        programDiagnostics.add(createCompilerDiagnostic(Diagnostics.File_0_is_not_in_project_file_list_Projects_must_list_all_files_or_use_an_include_pattern, file));
+            if (options.composite) {
+                const sourceFiles = files.filter(f => !f.isDeclarationFile);
+                if (rootNames.length < sourceFiles.length) {
+                    const normalizedRootNames = rootNames.map(r => normalizePath(r).toLowerCase());
+                    for (const file of sourceFiles.map(f => normalizePath(f.path).toLowerCase())) {
+                        if (normalizedRootNames.indexOf(file) === -1) {
+                            programDiagnostics.add(createCompilerDiagnostic(Diagnostics.File_0_is_not_in_project_file_list_Projects_must_list_all_files_or_use_an_include_pattern, file));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
As `files` always contains declaration files of external libraries, lib files and declaration files from typeRoots, the previous condition evaluated to true for probably all projects out there.
This changes the condition to compare array length after filtering out all declaration files.
That avoids unnecessary work of path normalization in the common case where everything is ok.

PTAL @sheetalkamat @RyanCavanaugh 