### PR TITLE
Rename FileReader.readAsText second parameter from 'label' to 'encoding'

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -5013,7 +5013,7 @@ interface FileReader extends EventTarget {
     readAsArrayBuffer(blob: Blob): void;
     readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
-    readAsText(blob: Blob, label?: string): void;
+    readAsText(blob: Blob, encoding?: string): void;
     readonly DONE: number;
     readonly EMPTY: number;
     readonly LOADING: number;

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -1197,7 +1197,7 @@ interface FileReader extends EventTarget {
     readAsArrayBuffer(blob: Blob): void;
     readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
-    readAsText(blob: Blob, label?: string): void;
+    readAsText(blob: Blob, encoding?: string): void;
     readonly DONE: number;
     readonly EMPTY: number;
     readonly LOADING: number;


### PR DESCRIPTION
Fixes #25797

Note that files in `lib/[dom|webworker].generated.ts` are not modified.
