### PR TITLE
Improve 'isWriteAccess' for findAllReferences

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -739,6 +739,7 @@ namespace ts {
     }
 
     export interface ComputedPropertyName extends Node {
+        parent: Declaration;
         kind: SyntaxKind.ComputedPropertyName;
         expression: Expression;
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2369,29 +2369,33 @@ namespace ts {
     }
 
     // See GH#16030
-    export function isAnyDeclarationName(name: Node): boolean {
+    export function getDeclarationFromName(name: Node): Declaration | undefined {
+        const parent = name.parent;
         switch (name.kind) {
-            case SyntaxKind.Identifier:
             case SyntaxKind.StringLiteral:
-            case SyntaxKind.NumericLiteral: {
-                const parent = name.parent;
+            case SyntaxKind.NumericLiteral:
+                if (isComputedPropertyName(parent)) return parent.parent;
+                // falls through
+
+            case SyntaxKind.Identifier:
                 if (isDeclaration(parent)) {
-                    return parent.name === name;
+                    return parent.name === name ? parent : undefined;
                 }
-                else if (isQualifiedName(name.parent)) {
-                    const tag = name.parent.parent;
-                    return isJSDocParameterTag(tag) && tag.name === name.parent;
+                else if (isQualifiedName(parent)) {
+                    const tag = parent.parent;
+                    return isJSDocParameterTag(tag) && tag.name === parent ? tag : undefined;
                 }
                 else {
-                    const binExp = name.parent.parent;
+                    const binExp = parent.parent;
                     return isBinaryExpression(binExp) &&
                         getSpecialPropertyAssignmentKind(binExp) !== SpecialPropertyAssignmentKind.None &&
                         (binExp.left.symbol || binExp.symbol) &&
-                        getNameOfDeclaration(binExp) === name;
+                        getNameOfDeclaration(binExp) === name
+                        ? binExp
+                        : undefined;
                 }
-            }
             default:
-                return false;
+                return undefined;
         }
     }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -536,6 +536,7 @@ declare namespace ts {
         name?: Identifier | StringLiteral | NumericLiteral;
     }
     interface ComputedPropertyName extends Node {
+        parent: Declaration;
         kind: SyntaxKind.ComputedPropertyName;
         expression: Expression;
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -536,6 +536,7 @@ declare namespace ts {
         name?: Identifier | StringLiteral | NumericLiteral;
     }
     interface ComputedPropertyName extends Node {
+        parent: Declaration;
         kind: SyntaxKind.ComputedPropertyName;
         expression: Expression;
     }

--- a/tests/cases/fourslash/findAllReferencesJsDocTypeLiteral.ts
+++ b/tests/cases/fourslash/findAllReferencesJsDocTypeLiteral.ts
@@ -8,7 +8,7 @@
 //// * @param {string} o.x - a thing, its ok
 //// * @param {number} o.y - another thing
 //// * @param {Object} o.nested - very nested
-//// * @param {boolean} o.nested.[|{| "isWriteAccess": true, "isDefinition": true |}great|] - much greatness
+//// * @param {boolean} o.nested.[|{| "isDefinition": true |}great|] - much greatness
 //// * @param {number} o.nested.times - twice? probably!??
 //// */
 //// function f(o) { return o.nested.[|great|]; }

--- a/tests/cases/fourslash/findAllRefsDestructureGeneric.ts
+++ b/tests/cases/fourslash/findAllRefsDestructureGeneric.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 ////interface I<T> {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}x|]: boolean;
+////    [|{| "isDefinition": true |}x|]: boolean;
 ////}
 ////declare const i: I<number>;
 ////const { [|{| "isWriteAccess": true, "isDefinition": true |}x|] } = i;

--- a/tests/cases/fourslash/findAllRefsForComputedProperties.ts
+++ b/tests/cases/fourslash/findAllRefsForComputedProperties.ts
@@ -9,7 +9,7 @@
 ////}
 ////
 ////var x: I = {
-////    ["[|{| "isDefinition": true |}prop1|]"]: function () { },
+////    ["[|{| "isWriteAccess": true, "isDefinition": true |}prop1|]"]: function () { },
 ////}
 
 const ranges = test.ranges();

--- a/tests/cases/fourslash/findAllRefsForComputedProperties2.ts
+++ b/tests/cases/fourslash/findAllRefsForComputedProperties2.ts
@@ -9,7 +9,7 @@
 ////}
 ////
 ////var x: I = {
-////    ["[|{| "isDefinition": true |}42|]"]: function () { }
+////    ["[|{| "isWriteAccess": true, "isDefinition": true |}42|]"]: function () { }
 ////}
 
 const ranges = test.ranges();

--- a/tests/cases/fourslash/findAllRefsForMappedType.ts
+++ b/tests/cases/fourslash/findAllRefsForMappedType.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
-////interface T { [|{| "isWriteAccess": true, "isDefinition": true |}a|]: number };
+////interface T { [|{| "isDefinition": true |}a|]: number };
 ////type U = { [K in keyof T]: string };
 ////type V = { [K in keyof U]: boolean };
 ////const u: U = { [|{| "isWriteAccess": true, "isDefinition": true |}a|]: "" }

--- a/tests/cases/fourslash/findAllRefsForObjectSpread.ts
+++ b/tests/cases/fourslash/findAllRefsForObjectSpread.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
-////interface A1 { readonly [|{| "isWriteAccess": true, "isDefinition": true |}a|]: string };
-////interface A2 { [|{| "isWriteAccess": true, "isDefinition": true |}a|]?: number };
+////interface A1 { readonly [|{| "isDefinition": true |}a|]: string };
+////interface A2 { [|{| "isDefinition": true |}a|]?: number };
 ////let a1: A1;
 ////let a2: A2;
 ////let a12 = { ...a1, ...a2 };

--- a/tests/cases/fourslash/findAllRefsForRest.ts
+++ b/tests/cases/fourslash/findAllRefsForRest.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 ////interface Gen {
 ////    x: number
-////    [|{| "isWriteAccess": true, "isDefinition": true |}parent|]: Gen;
+////    [|{| "isDefinition": true |}parent|]: Gen;
 ////    millenial: string;
 ////}
 ////let t: Gen;

--- a/tests/cases/fourslash/findAllRefsInClassExpression.ts
+++ b/tests/cases/fourslash/findAllRefsInClassExpression.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
-////interface I { [|{| "isWriteAccess": true, "isDefinition": true |}boom|](): void; }
+////interface I { [|{| "isDefinition": true |}boom|](): void; }
 ////new class C implements I {
 ////   [|{| "isWriteAccess": true, "isDefinition": true |}boom|](){}
 ////}

--- a/tests/cases/fourslash/findAllRefsIndexedAccessTypes.ts
+++ b/tests/cases/fourslash/findAllRefsIndexedAccessTypes.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
 ////interface I {
-////    [|{| "isDefinition": true, "isWriteAccess": true |}0|]: number;
-////    [|{| "isDefinition": true, "isWriteAccess": true |}s|]: string;
+////    [|{| "isDefinition": true |}0|]: number;
+////    [|{| "isDefinition": true |}s|]: string;
 ////}
 ////interface J {
 ////    a: I[[|0|]],

--- a/tests/cases/fourslash/findAllRefsInheritedProperties1.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties1.ts
@@ -2,7 +2,7 @@
 
 //// class class1 extends class1 {
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|]() { }
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
+////    [|{| "isDefinition": true |}propName|]: string;
 //// }
 ////
 //// var v: class1;

--- a/tests/cases/fourslash/findAllRefsInheritedProperties2.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties2.ts
@@ -1,8 +1,8 @@
 ﻿/// <reference path='fourslash.ts'/>
 
 //// interface interface1 extends interface1 {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;   // r0
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;  // r1
+////    [|{| "isDefinition": true |}doStuff|](): void;   // r0
+////    [|{| "isDefinition": true |}propName|]: string;  // r1
 //// }
 ////
 //// var v: interface1;

--- a/tests/cases/fourslash/findAllRefsInheritedProperties3.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties3.ts
@@ -2,15 +2,15 @@
 
 //// class class1 extends class1 {
 ////     [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|]() { }     // r0
-////     [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string; // r1
+////     [|{| "isDefinition": true |}propName|]: string; // r1
 //// }
 //// interface interface1 extends interface1 {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;   // r2
-////     [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;  // r3
+////     [|{| "isDefinition": true |}doStuff|](): void;   // r2
+////     [|{| "isDefinition": true |}propName|]: string;  // r3
 //// }
 //// class class2 extends class1 implements interface1 {
 ////     [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|]() { }      // r4
-////     [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;  // r5
+////     [|{| "isDefinition": true |}propName|]: string;  // r5
 //// }
 ////
 //// var v: class2;

--- a/tests/cases/fourslash/findAllRefsInheritedProperties4.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties4.ts
@@ -1,12 +1,12 @@
 ﻿/// <reference path='fourslash.ts'/>
 
 //// interface C extends D {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}prop0|]: string;  // r0
-////     [|{| "isWriteAccess": true, "isDefinition": true |}prop1|]: number;  // r1
+////     [|{| "isDefinition": true |}prop0|]: string;  // r0
+////     [|{| "isDefinition": true |}prop1|]: number;  // r1
 //// }
 ////
 //// interface D extends C {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}prop0|]: string;  // r2
+////     [|{| "isDefinition": true |}prop0|]: string;  // r2
 //// }
 ////
 //// var d: D;

--- a/tests/cases/fourslash/findAllRefsInheritedProperties5.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties5.ts
@@ -1,12 +1,12 @@
 ﻿/// <reference path='fourslash.ts'/>
 
 //// class C extends D {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}prop0|]: string;  // r0
-////     [|{| "isWriteAccess": true, "isDefinition": true |}prop1|]: number;  // r1
+////     [|{| "isDefinition": true |}prop0|]: string;  // r0
+////     [|{| "isDefinition": true |}prop1|]: number;  // r1
 //// }
 ////
 //// class D extends C {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}prop0|]: string;  // r2
+////     [|{| "isDefinition": true |}prop0|]: string;  // r2
 //// }
 ////
 //// var d: D;

--- a/tests/cases/fourslash/findAllRefsMappedType.ts
+++ b/tests/cases/fourslash/findAllRefsMappedType.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
-////interface T { [|{| "isWriteAccess": true, "isDefinition": true |}a|]: number; }
+////interface T { [|{| "isDefinition": true |}a|]: number; }
 ////type U = { readonly [K in keyof T]?: string };
 ////declare const t: T;
 ////t.[|a|];

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName01.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName01.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface I {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}property1|]: number;
+////    [|{| "isDefinition": true |}property1|]: number;
 ////    property2: string;
 ////}
 ////

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName02.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName02.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface I {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}property1|]: number;
+////    [|{| "isDefinition": true |}property1|]: number;
 ////    property2: string;
 ////}
 ////

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName03.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName03.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface I {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}property1|]: number;
+////    [|{| "isDefinition": true |}property1|]: number;
 ////    property2: string;
 ////}
 ////

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName04.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName04.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface I {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}property1|]: number;
+////    [|{| "isDefinition": true |}property1|]: number;
 ////    property2: string;
 ////}
 ////

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName06.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName06.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface I {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}property1|]: number;
+////    [|{| "isDefinition": true |}property1|]: number;
 ////    property2: string;
 ////}
 ////

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName10.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName10.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface Recursive {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}next|]?: Recursive;
+////    [|{| "isDefinition": true |}next|]?: Recursive;
 ////    value: any;
 ////}
 ////

--- a/tests/cases/fourslash/findAllRefsPropertyContextuallyTypedByTypeParam01.ts
+++ b/tests/cases/fourslash/findAllRefsPropertyContextuallyTypedByTypeParam01.ts
@@ -1,7 +1,7 @@
 /// <reference path="./fourslash.ts" />
 
 ////interface IFoo {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}a|]: string;
+////    [|{| "isDefinition": true |}a|]: string;
 ////}
 ////class C<T extends IFoo> {
 ////    method() {

--- a/tests/cases/fourslash/findAllRefsReExportLocal.ts
+++ b/tests/cases/fourslash/findAllRefsReExportLocal.ts
@@ -3,7 +3,7 @@
 // @noLib: true
 
 // @Filename: /a.ts
-////var [|{| "isWriteAccess": true, "isDefinition": true |}x|];
+////var [|{| "isDefinition": true |}x|];
 ////export { [|{| "isWriteAccess": true, "isDefinition": true |}x|] };
 ////export { [|x|] as [|{| "isWriteAccess": true, "isDefinition": true |}y|] };
 

--- a/tests/cases/fourslash/findAllRefsRedeclaredPropertyInDerivedInterface.ts
+++ b/tests/cases/fourslash/findAllRefsRedeclaredPropertyInDerivedInterface.ts
@@ -3,10 +3,10 @@
 // @noLib: true
 
 ////interface A {
-////    readonly [|{| "isWriteAccess": true, "isDefinition": true |}x|]: number | string;
+////    readonly [|{| "isDefinition": true |}x|]: number | string;
 ////}
 ////interface B extends A {
-////    readonly [|{| "isWriteAccess": true, "isDefinition": true |}x|]: number;
+////    readonly [|{| "isDefinition": true |}x|]: number;
 ////}
 ////const a: A = { [|{| "isWriteAccess": true, "isDefinition": true |}x|]: 0 };
 ////const b: B = { [|{| "isWriteAccess": true, "isDefinition": true |}x|]: 0 };

--- a/tests/cases/fourslash/findAllRefsRootSymbols.ts
+++ b/tests/cases/fourslash/findAllRefsRootSymbols.ts
@@ -1,7 +1,7 @@
 /// <reference path="fourslash.ts" />
 
-////interface I { [|{| "isWriteAccess": true, "isDefinition": true |}x|]: {}; }
-////interface J { [|{| "isWriteAccess": true, "isDefinition": true |}x|]: {}; }
+////interface I { [|{| "isDefinition": true |}x|]: {}; }
+////interface J { [|{| "isDefinition": true |}x|]: {}; }
 ////declare const o: (I | J) & { [|{| "isWriteAccess": true, "isDefinition": true |}x|]: string };
 ////o.[|x|];
 

--- a/tests/cases/fourslash/findAllRefsTypedef.ts
+++ b/tests/cases/fourslash/findAllRefsTypedef.ts
@@ -5,7 +5,7 @@
 // @Filename: /a.js
 /////**
 //// * @typedef I {Object}
-//// * @prop [|{| "isWriteAccess": true, "isDefinition": true |}p|] {number}
+//// * @prop [|{| "isDefinition": true |}p|] {number}
 //// */
 ////
 /////** @type {I} */

--- a/tests/cases/fourslash/findAllRefsUnionProperty.ts
+++ b/tests/cases/fourslash/findAllRefsUnionProperty.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts'/>
 
 ////type T =
-////    | { [|{| "isWriteAccess": true, "isDefinition": true |}type|]: "a", [|{| "isWriteAccess": true, "isDefinition": true |}prop|]: number }
-////    | { [|{| "isWriteAccess": true, "isDefinition": true |}type|]: "b", [|{| "isWriteAccess": true, "isDefinition": true |}prop|]: string };
+////    | { [|{| "isDefinition": true |}type|]: "a", [|{| "isDefinition": true |}prop|]: number }
+////    | { [|{| "isDefinition": true |}type|]: "b", [|{| "isDefinition": true |}prop|]: string };
 ////const tt: T = {
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}type|]: "a",
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}prop|]: 0,

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames5.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames5.ts
@@ -3,7 +3,7 @@
 ////class Foo {
 ////    public _bar;
 ////    public __bar;
-////    public [|{| "isWriteAccess": true, "isDefinition": true |}___bar|];
+////    public [|{| "isDefinition": true |}___bar|];
 ////    public ____bar;
 ////}
 ////

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames6.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames6.ts
@@ -2,7 +2,7 @@
 
 ////class Foo {
 ////    public _bar;
-////    public [|{| "isWriteAccess": true, "isDefinition": true |}__bar|];
+////    public [|{| "isDefinition": true |}__bar|];
 ////    public ___bar;
 ////    public ____bar;
 ////}

--- a/tests/cases/fourslash/findAllRefsWithShorthandPropertyAssignment2.ts
+++ b/tests/cases/fourslash/findAllRefsWithShorthandPropertyAssignment2.ts
@@ -2,7 +2,7 @@
 
 //// var [|{| "isWriteAccess": true, "isDefinition": true |}dx|] = "Foo";
 ////
-//// module M { export var [|{| "isWriteAccess": true, "isDefinition": true |}dx|]; }
+//// module M { export var [|{| "isDefinition": true |}dx|]; }
 //// module M {
 ////    var z = 100;
 ////    export var y = { [|{| "isWriteAccess": true, "isDefinition": true |}dx|], z };

--- a/tests/cases/fourslash/findReferencesAcrossMultipleProjects.ts
+++ b/tests/cases/fourslash/findReferencesAcrossMultipleProjects.ts
@@ -1,7 +1,7 @@
 /// <reference path="fourslash.ts" />
 
 //@Filename: a.ts
-////var [|{| "isWriteAccess": true, "isDefinition": true |}x|]: number;
+////var [|{| "isDefinition": true |}x|]: number;
 
 //@Filename: b.ts
 /////// <reference path="a.ts" />

--- a/tests/cases/fourslash/findReferencesAfterEdit.ts
+++ b/tests/cases/fourslash/findReferencesAfterEdit.ts
@@ -2,7 +2,7 @@
 
 // @Filename: a.ts
 ////interface A {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}foo|]: string;
+////    [|{| "isDefinition": true |}foo|]: string;
 ////}
 
 // @Filename: b.ts

--- a/tests/cases/fourslash/findReferencesJSXTagName3.ts
+++ b/tests/cases/fourslash/findReferencesJSXTagName3.ts
@@ -6,7 +6,7 @@
 ////namespace JSX {
 ////    export interface Element { }
 ////    export interface IntrinsicElements {
-////        [|{| "isWriteAccess": true, "isDefinition": true |}div|]: any;
+////        [|{| "isDefinition": true |}div|]: any;
 ////    }
 ////}
 ////

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
@@ -1,5 +1,5 @@
 /// <reference path='fourslash.ts' />
-////let o = { ["[|{| "isDefinition": true |}foo|]"]: 12 };
+////let o = { ["[|{| "isWriteAccess": true, "isDefinition": true |}foo|]"]: 12 };
 ////let y = o.[|foo|];
 ////let z = o['[|foo|]'];
 

--- a/tests/cases/fourslash/referencesForClassMembers.ts
+++ b/tests/cases/fourslash/referencesForClassMembers.ts
@@ -1,11 +1,11 @@
 /// <reference path='fourslash.ts'/>
 
 ////class Base {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}a|]: number;
+////    [|{| "isDefinition": true |}a|]: number;
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}method|](): void { }
 ////}
 ////class MyClass extends Base {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}a|];
+////    [|{| "isDefinition": true |}a|];
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}method|]() { }
 ////}
 ////

--- a/tests/cases/fourslash/referencesForClassMembersExtendingAbstractClass.ts
+++ b/tests/cases/fourslash/referencesForClassMembersExtendingAbstractClass.ts
@@ -1,11 +1,11 @@
 /// <reference path='fourslash.ts'/>
 
 ////abstract class Base {
-////    abstract [|{| "isWriteAccess": true, "isDefinition": true |}a|]: number;
-////    abstract [|{| "isWriteAccess": true, "isDefinition": true |}method|](): void;
+////    abstract [|{| "isDefinition": true |}a|]: number;
+////    abstract [|{| "isDefinition": true |}method|](): void;
 ////}
 ////class MyClass extends Base {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}a|];
+////    [|{| "isDefinition": true |}a|];
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}method|]() { }
 ////}
 ////

--- a/tests/cases/fourslash/referencesForClassMembersExtendingGenericClass.ts
+++ b/tests/cases/fourslash/referencesForClassMembersExtendingGenericClass.ts
@@ -1,11 +1,11 @@
 /// <reference path='fourslash.ts'/>
 
 ////class Base<T> {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}a|]: this;
+////    [|{| "isDefinition": true |}a|]: this;
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}method|]<U>(a?:T, b?:U): this { }
 ////}
 ////class MyClass extends Base<number> {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}a|];
+////    [|{| "isDefinition": true |}a|];
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}method|]() { }
 ////}
 ////

--- a/tests/cases/fourslash/referencesForContextuallyTypedObjectLiteralProperties.ts
+++ b/tests/cases/fourslash/referencesForContextuallyTypedObjectLiteralProperties.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
-////interface IFoo { [|{| "isWriteAccess": true, "isDefinition": true |}xy|]: number; }
+////interface IFoo { [|{| "isDefinition": true |}xy|]: number; }
 ////
 ////// Assignment
 ////var a1: IFoo = { [|{| "isWriteAccess": true, "isDefinition": true |}xy|]: 0 };

--- a/tests/cases/fourslash/referencesForContextuallyTypedUnionProperties.ts
+++ b/tests/cases/fourslash/referencesForContextuallyTypedUnionProperties.ts
@@ -2,12 +2,12 @@
 
 ////interface A {
 ////    a: number;
-////    [|{| "isWriteAccess": true, "isDefinition": true |}common|]: string;
+////    [|{| "isDefinition": true |}common|]: string;
 ////}
 ////
 ////interface B {
 ////    b: number;
-////    [|{| "isWriteAccess": true, "isDefinition": true |}common|]: number;
+////    [|{| "isDefinition": true |}common|]: number;
 ////}
 ////
 ////// Assignment

--- a/tests/cases/fourslash/referencesForContextuallyTypedUnionProperties2.ts
+++ b/tests/cases/fourslash/referencesForContextuallyTypedUnionProperties2.ts
@@ -6,7 +6,7 @@
 ////}
 ////
 ////interface B {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}b|]: number;
+////    [|{| "isDefinition": true |}b|]: number;
 ////    common: number;
 ////}
 ////

--- a/tests/cases/fourslash/referencesForFunctionOverloads.ts
+++ b/tests/cases/fourslash/referencesForFunctionOverloads.ts
@@ -2,7 +2,7 @@
 
 // Function overloads should be highlighted together.
 
-////function [|{| "isWriteAccess": true, "isDefinition": true |}foo|](x: string);
+////function [|{| "isDefinition": true |}foo|](x: string);
 ////function [|{| "isWriteAccess": true, "isDefinition": true |}foo|](x: string, y: number) {
 ////    [|foo|]('', 43);
 ////}

--- a/tests/cases/fourslash/referencesForIndexProperty.ts
+++ b/tests/cases/fourslash/referencesForIndexProperty.ts
@@ -3,7 +3,7 @@
 // References a class property using string index access
 
 ////class Foo {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}property|]: number;
+////    [|{| "isDefinition": true |}property|]: number;
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}method|](): void { }
 ////}
 ////

--- a/tests/cases/fourslash/referencesForIndexProperty3.ts
+++ b/tests/cases/fourslash/referencesForIndexProperty3.ts
@@ -3,7 +3,7 @@
 // References to a property of the apparent type using string indexer
 
 ////interface Object {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}toMyString|]();
+////    [|{| "isDefinition": true |}toMyString|]();
 ////}
 ////
 ////var y: Object;

--- a/tests/cases/fourslash/referencesForInheritedProperties.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties.ts
@@ -1,11 +1,11 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface interface1 {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;
+////    [|{| "isDefinition": true |}doStuff|](): void;
 ////}
 ////
 ////interface interface2  extends interface1{
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;
+////    [|{| "isDefinition": true |}doStuff|](): void;
 ////}
 ////
 ////class class1 implements interface2 {

--- a/tests/cases/fourslash/referencesForInheritedProperties2.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties2.ts
@@ -3,11 +3,11 @@
 // extends statement in a diffrent declaration
 
 ////interface interface1 {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;
+////    [|{| "isDefinition": true |}doStuff|](): void;
 ////}
 ////
 ////interface interface2 {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;
+////    [|{| "isDefinition": true |}doStuff|](): void;
 ////}
 ////
 ////interface interface2 extends interface1 {

--- a/tests/cases/fourslash/referencesForInheritedProperties3.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties3.ts
@@ -1,8 +1,8 @@
 ﻿/// <reference path='fourslash.ts'/>
 
 //// interface interface1 extends interface1 {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
+////    [|{| "isDefinition": true |}doStuff|](): void;
+////    [|{| "isDefinition": true |}propName|]: string;
 //// }
 ////
 //// var v: interface1;

--- a/tests/cases/fourslash/referencesForInheritedProperties4.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties4.ts
@@ -2,7 +2,7 @@
 
 //// class class1 extends class1 {
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|]() { }
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
+////    [|{| "isDefinition": true |}propName|]: string;
 //// }
 ////
 //// var c: class1;

--- a/tests/cases/fourslash/referencesForInheritedProperties5.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties5.ts
@@ -1,12 +1,12 @@
 ﻿/// <reference path='fourslash.ts'/>
 
 //// interface interface1 extends interface1 {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
+////    [|{| "isDefinition": true |}doStuff|](): void;
+////    [|{| "isDefinition": true |}propName|]: string;
 //// }
 //// interface interface2 extends interface1 {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
+////    [|{| "isDefinition": true |}doStuff|](): void;
+////    [|{| "isDefinition": true |}propName|]: string;
 //// }
 ////
 //// var v: interface1;

--- a/tests/cases/fourslash/referencesForInheritedProperties7.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties7.ts
@@ -2,15 +2,15 @@
 
 //// class class1 extends class1 {
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|]() { }
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
+////    [|{| "isDefinition": true |}propName|]: string;
 //// }
 //// interface interface1 extends interface1 {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|](): void;
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
+////    [|{| "isDefinition": true |}doStuff|](): void;
+////    [|{| "isDefinition": true |}propName|]: string;
 //// }
 //// class class2 extends class1 implements interface1 {
 ////    [|{| "isWriteAccess": true, "isDefinition": true |}doStuff|]() { }
-////    [|{| "isWriteAccess": true, "isDefinition": true |}propName|]: string;
+////    [|{| "isDefinition": true |}propName|]: string;
 //// }
 ////
 //// var v: class2;

--- a/tests/cases/fourslash/referencesForInheritedProperties8.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties8.ts
@@ -1,11 +1,11 @@
 ﻿/// <reference path='fourslash.ts'/>
 
 //// interface C extends D {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}propD|]: number;
+////     [|{| "isDefinition": true |}propD|]: number;
 //// }
 //// interface D extends C {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}propD|]: string;
-////     [|{| "isWriteAccess": true, "isDefinition": true |}propC|]: number;
+////     [|{| "isDefinition": true |}propD|]: string;
+////     [|{| "isDefinition": true |}propC|]: number;
 //// }
 //// var d: D;
 //// d.[|propD|];

--- a/tests/cases/fourslash/referencesForInheritedProperties9.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties9.ts
@@ -1,11 +1,11 @@
 ﻿/// <reference path='fourslash.ts'/>
 
 //// class D extends C {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}prop1|]: string;
+////     [|{| "isDefinition": true |}prop1|]: string;
 //// }
 ////
 //// class C extends D {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}prop1|]: string;
+////     [|{| "isDefinition": true |}prop1|]: string;
 //// }
 ////
 //// var c: C;

--- a/tests/cases/fourslash/referencesForNumericLiteralPropertyNames.ts
+++ b/tests/cases/fourslash/referencesForNumericLiteralPropertyNames.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////class Foo {
-////    public [|{| "isWriteAccess": true, "isDefinition": true |}12|]: any;
+////    public [|{| "isDefinition": true |}12|]: any;
 ////}
 ////
 ////var x: Foo;

--- a/tests/cases/fourslash/referencesForOverrides.ts
+++ b/tests/cases/fourslash/referencesForOverrides.ts
@@ -14,16 +14,16 @@
 ////
 ////	module SimpleInterfaceTest {
 ////		export interface IFoo {
-////			[|{| "isWriteAccess": true, "isDefinition": true |}ifoo|](): void;
+////			[|{| "isDefinition": true |}ifoo|](): void;
 ////		}
 ////		export interface IBar extends IFoo {
-////			[|{| "isWriteAccess": true, "isDefinition": true |}ifoo|](): void;
+////			[|{| "isDefinition": true |}ifoo|](): void;
 ////		}
 ////	}
 ////
 ////	module SimpleClassInterfaceTest {
 ////		export interface IFoo {
-////			[|{| "isWriteAccess": true, "isDefinition": true |}icfoo|](): void;
+////			[|{| "isDefinition": true |}icfoo|](): void;
 ////		}
 ////		export class Bar implements IFoo {
 ////			public [|{| "isWriteAccess": true, "isDefinition": true |}icfoo|](): void {
@@ -33,29 +33,29 @@
 ////
 ////	module Test {
 ////		export interface IBase {
-////			[|{| "isWriteAccess": true, "isDefinition": true |}field|]: string;
-////			[|{| "isWriteAccess": true, "isDefinition": true |}method|](): void;
+////			[|{| "isDefinition": true |}field|]: string;
+////			[|{| "isDefinition": true |}method|](): void;
 ////		}
 ////
 ////		export interface IBlah extends IBase {
-////			[|{| "isWriteAccess": true, "isDefinition": true |}field|]: string;
+////			[|{| "isDefinition": true |}field|]: string;
 ////		}
 ////
 ////		export interface IBlah2 extends IBlah {
-////			[|{| "isWriteAccess": true, "isDefinition": true |}field|]: string;
+////			[|{| "isDefinition": true |}field|]: string;
 ////		}
 ////
 ////		export interface IDerived extends IBlah2 {
-////			[|{| "isWriteAccess": true, "isDefinition": true |}method|](): void;
+////			[|{| "isDefinition": true |}method|](): void;
 ////		}
 ////
 ////		export class Bar implements IDerived {
-////			public [|{| "isWriteAccess": true, "isDefinition": true |}field|]: string;
+////			public [|{| "isDefinition": true |}field|]: string;
 ////			public [|{| "isWriteAccess": true, "isDefinition": true |}method|](): void { }
 ////		}
 ////
 ////		export class BarBlah extends Bar {
-////			public [|{| "isWriteAccess": true, "isDefinition": true |}field|]: string;
+////			public [|{| "isDefinition": true |}field|]: string;
 ////		}
 ////	}
 ////

--- a/tests/cases/fourslash/referencesForPropertiesOfGenericType.ts
+++ b/tests/cases/fourslash/referencesForPropertiesOfGenericType.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface IFoo<T> {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}doSomething|](v: T): T;
+////    [|{| "isDefinition": true |}doSomething|](v: T): T;
 ////}
 ////
 ////var x: IFoo<string>;

--- a/tests/cases/fourslash/referencesForStaticsAndMembersWithSameNames.ts
+++ b/tests/cases/fourslash/referencesForStaticsAndMembersWithSameNames.ts
@@ -3,8 +3,8 @@
 ////module FindRef4 {
 ////	module MixedStaticsClassTest {
 ////		export class Foo {
-////			[|{| "isWriteAccess": true, "isDefinition": true |}bar|]: Foo;
-////			static [|{| "isWriteAccess": true, "isDefinition": true |}bar|]: Foo;
+////			[|{| "isDefinition": true |}bar|]: Foo;
+////			static [|{| "isDefinition": true |}bar|]: Foo;
 ////
 ////			public [|{| "isWriteAccess": true, "isDefinition": true |}foo|](): void {
 ////			}

--- a/tests/cases/fourslash/referencesForStringLiteralPropertyNames.ts
+++ b/tests/cases/fourslash/referencesForStringLiteralPropertyNames.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 ////class Foo {
-////    public "[|{| "isWriteAccess": true, "isDefinition": true |}ss|]": any;
+////    public "[|{| "isDefinition": true |}ss|]": any;
 ////}
 ////
 ////var x: Foo;

--- a/tests/cases/fourslash/referencesForUnionProperties.ts
+++ b/tests/cases/fourslash/referencesForUnionProperties.ts
@@ -1,16 +1,16 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface One {
-////    common: { [|{| "isWriteAccess": true, "isDefinition": true |}a|]: number; };
+////    common: { [|{| "isDefinition": true |}a|]: number; };
 ////}
 ////
 ////interface Base {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}a|]: string;
+////    [|{| "isDefinition": true |}a|]: string;
 ////    b: string;
 ////}
 ////
 ////interface HasAOrB extends Base {
-////    [|{| "isWriteAccess": true, "isDefinition": true |}a|]: string;
+////    [|{| "isDefinition": true |}a|]: string;
 ////    b: string;
 ////}
 ////

--- a/tests/cases/fourslash/renameImportAndExportInDiffFiles.ts
+++ b/tests/cases/fourslash/renameImportAndExportInDiffFiles.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: a.ts
-////export var [|{| "isWriteAccess": true, "isDefinition": true |}a|];
+////export var [|{| "isDefinition": true |}a|];
 
 // @Filename: b.ts
 ////import { [|{| "isWriteAccess": true, "isDefinition": true |}a|] } from './a';

--- a/tests/cases/fourslash/tsxFindAllReferences10.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences10.ts
@@ -15,7 +15,7 @@
 ////     className?: string;
 //// }
 //// interface ButtonProps extends ClickableProps {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}onClick|](event?: React.MouseEvent<HTMLButtonElement>): void;
+////     [|{| "isDefinition": true |}onClick|](event?: React.MouseEvent<HTMLButtonElement>): void;
 //// }
 //// interface LinkProps extends ClickableProps {
 ////     goTo: string;

--- a/tests/cases/fourslash/tsxFindAllReferences3.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences3.ts
@@ -9,7 +9,7 @@
 //// }
 //// class MyClass {
 ////   props: {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}name|]?: string;
+////     [|{| "isDefinition": true |}name|]?: string;
 ////     size?: number;
 //// }
 ////

--- a/tests/cases/fourslash/tsxFindAllReferences7.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences7.ts
@@ -11,7 +11,7 @@
 ////     interface ElementAttributesProperty { props; }
 //// }
 //// interface OptionPropBag {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}propx|]: number
+////     [|{| "isDefinition": true |}propx|]: number
 ////     propString: string
 ////     optional?: boolean
 //// }

--- a/tests/cases/fourslash/tsxFindAllReferences9.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences9.ts
@@ -18,7 +18,7 @@
 ////     onClick(event?: React.MouseEvent<HTMLButtonElement>): void;
 //// }
 //// interface LinkProps extends ClickableProps {
-////     [|{| "isWriteAccess": true, "isDefinition": true |}goTo|]: string;
+////     [|{| "isDefinition": true |}goTo|]: string;
 //// }
 //// declare function MainButton(buttonProps: ButtonProps): JSX.Element;
 //// declare function MainButton(linkProps: LinkProps): JSX.Element;


### PR DESCRIPTION
Previously we would consider any declaration a write access, even `let x;` which does not write a value into `x`. Now we will be more careful.

(Part of #13766)
