### PR TITLE
When function parameters span multiple lines, make the function span start at the `(`

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4118,6 +4118,10 @@ namespace ts {
         return positionsAreOnSameLine(range1.end, getStartPositionOfRange(range2, sourceFile), sourceFile);
     }
 
+    export function isNodeArrayMultiLine(list: NodeArray<Node>, sourceFile: SourceFile): boolean {
+        return !positionsAreOnSameLine(list.pos, list.end, sourceFile);
+    }
+
     export function positionsAreOnSameLine(pos1: number, pos2: number, sourceFile: SourceFile) {
         return pos1 === pos2 ||
             getLineOfLocalPosition(sourceFile, pos1) === getLineOfLocalPosition(sourceFile, pos2);

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -212,13 +212,7 @@ namespace ts.OutliningElementsCollector {
             return spanForNode(node, /*autoCollapse*/ false, /*useFullStart*/ !isArrayLiteralExpression(node.parent), open);
         }
 
-        function spanForNode(
-            hintSpanNode: Node,
-            autoCollapse = false,
-            useFullStart = true,
-            open: SyntaxKind.OpenBraceToken | SyntaxKind.OpenBracketToken | SyntaxKind.OpenParenToken = SyntaxKind.OpenBraceToken,
-            close: SyntaxKind = open === SyntaxKind.OpenBraceToken ? SyntaxKind.CloseBraceToken : SyntaxKind.CloseBracketToken,
-        ): OutliningSpan | undefined {
+        function spanForNode(hintSpanNode: Node, autoCollapse = false, useFullStart = true, open: SyntaxKind.OpenBraceToken | SyntaxKind.OpenBracketToken = SyntaxKind.OpenBraceToken, close: SyntaxKind = open === SyntaxKind.OpenBraceToken ? SyntaxKind.CloseBraceToken : SyntaxKind.CloseBracketToken): OutliningSpan | undefined {
             const openToken = findChildOfKind(n, open, sourceFile);
             const closeToken = findChildOfKind(n, close, sourceFile);
             return openToken && closeToken && spanBetweenTokens(openToken, closeToken, hintSpanNode, sourceFile, autoCollapse, useFullStart);

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -141,8 +141,8 @@ namespace ts.OutliningElementsCollector {
     function getOutliningSpanForNode(n: Node, sourceFile: SourceFile): OutliningSpan | undefined {
         switch (n.kind) {
             case SyntaxKind.Block:
-                if (isFunctionBlock(n)) {
-                    return spanForNode(n.parent, /*autoCollapse*/ n.parent.kind !== SyntaxKind.ArrowFunction);
+                if (isFunctionLike(n.parent)) {
+                    return functionSpan(n.parent, n as Block, sourceFile);
                 }
                 // Check if the block is standalone, or 'attached' to some parent statement.
                 // If the latter, we want to collapse the block, but consider its hint span
@@ -212,16 +212,30 @@ namespace ts.OutliningElementsCollector {
             return spanForNode(node, /*autoCollapse*/ false, /*useFullStart*/ !isArrayLiteralExpression(node.parent), open);
         }
 
-        function spanForNode(hintSpanNode: Node, autoCollapse = false, useFullStart = true, open: SyntaxKind.OpenBraceToken | SyntaxKind.OpenBracketToken = SyntaxKind.OpenBraceToken): OutliningSpan | undefined {
+        function spanForNode(
+            hintSpanNode: Node,
+            autoCollapse = false,
+            useFullStart = true,
+            open: SyntaxKind.OpenBraceToken | SyntaxKind.OpenBracketToken | SyntaxKind.OpenParenToken = SyntaxKind.OpenBraceToken,
+            close: SyntaxKind = open === SyntaxKind.OpenBraceToken ? SyntaxKind.CloseBraceToken : SyntaxKind.CloseBracketToken,
+        ): OutliningSpan | undefined {
             const openToken = findChildOfKind(n, open, sourceFile);
-            const close = open === SyntaxKind.OpenBraceToken ? SyntaxKind.CloseBraceToken : SyntaxKind.CloseBracketToken;
             const closeToken = findChildOfKind(n, close, sourceFile);
-            if (!openToken || !closeToken) {
-                return undefined;
-            }
-            const textSpan = createTextSpanFromBounds(useFullStart ? openToken.getFullStart() : openToken.getStart(sourceFile), closeToken.getEnd());
-            return createOutliningSpan(textSpan, OutliningSpanKind.Code, createTextSpanFromNode(hintSpanNode, sourceFile), autoCollapse);
+            return openToken && closeToken && spanBetweenTokens(openToken, closeToken, hintSpanNode, sourceFile, autoCollapse, useFullStart);
         }
+    }
+
+    function functionSpan(node: FunctionLike, body: Block, sourceFile: SourceFile): OutliningSpan | undefined {
+        const openToken = isNodeArrayMultiLine(node.parameters, sourceFile)
+            ? findChildOfKind(node, SyntaxKind.OpenParenToken, sourceFile)
+            : findChildOfKind(body, SyntaxKind.OpenBraceToken, sourceFile);
+        const closeToken = findChildOfKind(body, SyntaxKind.CloseBraceToken, sourceFile);
+        return openToken && closeToken && spanBetweenTokens(openToken, closeToken, node.parent, sourceFile, /*autoCollapse*/ node.parent.kind !== SyntaxKind.ArrowFunction);
+    }
+
+    function spanBetweenTokens(openToken: Node, closeToken: Node, hintSpanNode: Node, sourceFile: SourceFile, autoCollapse = false, useFullStart = true): OutliningSpan {
+        const textSpan = createTextSpanFromBounds(useFullStart ? openToken.getFullStart() : openToken.getStart(sourceFile), closeToken.getEnd());
+        return createOutliningSpan(textSpan, OutliningSpanKind.Code, createTextSpanFromNode(hintSpanNode, sourceFile), autoCollapse);
     }
 
     function createOutliningSpan(textSpan: TextSpan, kind: OutliningSpanKind, hintSpan: TextSpan = textSpan, autoCollapse = false, bannerText = "..."): OutliningSpan {

--- a/tests/cases/fourslash/outliningSpansForFunction.ts
+++ b/tests/cases/fourslash/outliningSpansForFunction.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts"/>
+
+////function f(x: number, y: number)[| {
+////    return x + y;
+////}|]
+////
+////function g[|(
+////    x: number,
+////    y: number,
+////): number {
+////    return x + y;
+////}|]
+
+verify.outliningSpansInCurrentFile(test.ranges());


### PR DESCRIPTION
Fixes #22915

Should be convenient in codebases formatted by prettier which often formats parameters on multiple lines.
Unlike  #26692 this works in both vscode and visual studio without modification.

![outlining_vscode](https://user-images.githubusercontent.com/19274678/45105551-55506200-b0e9-11e8-8038-f1c7b03f9d61.jpg)

![outlining_vs](https://user-images.githubusercontent.com/19274678/45105476-2cc86800-b0e9-11e8-85ce-55b0aaf220d9.jpg)
