### PR TITLE
Bind non-expando property assignments at top-level

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2512,11 +2512,10 @@ namespace ts {
 
         function bindPropertyAssignment(name: EntityNameExpression, propertyAccess: PropertyAccessEntityNameExpression, isPrototypeProperty: boolean) {
             let namespaceSymbol = lookupSymbolForPropertyAccess(name);
-            const isToplevelNamespaceableInitializer = isBinaryExpression(propertyAccess.parent)
-                ? getParentOfBinaryExpression(propertyAccess.parent).parent.kind === SyntaxKind.SourceFile &&
-                    !!getJavascriptInitializer(getInitializerOfBinaryExpression(propertyAccess.parent), isPrototypeAccess(propertyAccess.parent.left))
+            const isToplevel = isBinaryExpression(propertyAccess.parent)
+                ? getParentOfBinaryExpression(propertyAccess.parent).parent.kind === SyntaxKind.SourceFile
                 : propertyAccess.parent.parent.kind === SyntaxKind.SourceFile;
-            if (!isPrototypeProperty && (!namespaceSymbol || !(namespaceSymbol.flags & SymbolFlags.Namespace)) && isToplevelNamespaceableInitializer) {
+            if (!isPrototypeProperty && (!namespaceSymbol || !(namespaceSymbol.flags & SymbolFlags.Namespace)) && isToplevel) {
                 // make symbols or add declarations for intermediate containers
                 const flags = SymbolFlags.Module | SymbolFlags.JSContainer;
                 const excludeFlags = SymbolFlags.ValueModuleExcludes & ~SymbolFlags.JSContainer;
@@ -2573,7 +2572,7 @@ namespace ts {
             return false;
         }
 
-        function getParentOfBinaryExpression(expr: BinaryExpression) {
+        function getParentOfBinaryExpression(expr: Node) {
             while (isBinaryExpression(expr.parent)) {
                 expr = expr.parent;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16189,7 +16189,7 @@ namespace ts {
                         else if (isIdentifier(lhs.expression)) {
                             const id = lhs.expression;
                             const parentSymbol = resolveName(id, id.escapedText, SymbolFlags.Value, undefined, id.escapedText, /*isUse*/ true);
-                            if (parentSymbol && isFunctionSymbol(parentSymbol)) {
+                            if (parentSymbol) {
                                 const annotated = getEffectiveTypeAnnotationNode(parentSymbol.valueDeclaration);
                                 if (annotated) {
                                     const type = getTypeOfPropertyOfContextualType(getTypeFromTypeNode(annotated), lhs.name.escapedText);

--- a/tests/baselines/reference/checkJsdocTypeTagOnObjectProperty1.symbols
+++ b/tests/baselines/reference/checkJsdocTypeTagOnObjectProperty1.symbols
@@ -4,7 +4,7 @@ var lol = "hello Lol"
 >lol : Symbol(lol, Decl(0.js, 1, 3))
 
 const obj = {
->obj : Symbol(obj, Decl(0.js, 2, 5))
+>obj : Symbol(obj, Decl(0.js, 2, 5), Decl(0.js, 17, 1))
 
   /** @type {string|undefined} */
   foo: undefined,
@@ -40,31 +40,31 @@ const obj = {
 }
 obj.foo = 'string'
 >obj.foo : Symbol(foo, Decl(0.js, 2, 13))
->obj : Symbol(obj, Decl(0.js, 2, 5))
+>obj : Symbol(obj, Decl(0.js, 2, 5), Decl(0.js, 17, 1))
 >foo : Symbol(foo, Decl(0.js, 2, 13))
 
 obj.lol
 >obj.lol : Symbol(lol, Decl(0.js, 10, 4))
->obj : Symbol(obj, Decl(0.js, 2, 5))
+>obj : Symbol(obj, Decl(0.js, 2, 5), Decl(0.js, 17, 1))
 >lol : Symbol(lol, Decl(0.js, 10, 4))
 
 obj.bar = undefined;
 >obj.bar : Symbol(bar, Decl(0.js, 4, 17))
->obj : Symbol(obj, Decl(0.js, 2, 5))
+>obj : Symbol(obj, Decl(0.js, 2, 5), Decl(0.js, 17, 1))
 >bar : Symbol(bar, Decl(0.js, 4, 17))
 >undefined : Symbol(undefined)
 
 var k = obj.method1(0);
 >k : Symbol(k, Decl(0.js, 21, 3))
 >obj.method1 : Symbol(method1, Decl(0.js, 6, 12))
->obj : Symbol(obj, Decl(0.js, 2, 5))
+>obj : Symbol(obj, Decl(0.js, 2, 5), Decl(0.js, 17, 1))
 >method1 : Symbol(method1, Decl(0.js, 6, 12))
 
 obj.bar1 = "42";
->obj : Symbol(obj, Decl(0.js, 2, 5))
+>obj : Symbol(obj, Decl(0.js, 2, 5), Decl(0.js, 17, 1))
 
 obj.arrowFunc(0);
 >obj.arrowFunc : Symbol(arrowFunc, Decl(0.js, 14, 20))
->obj : Symbol(obj, Decl(0.js, 2, 5))
+>obj : Symbol(obj, Decl(0.js, 2, 5), Decl(0.js, 17, 1))
 >arrowFunc : Symbol(arrowFunc, Decl(0.js, 14, 20))
 

--- a/tests/baselines/reference/classCanExtendConstructorFunction.symbols
+++ b/tests/baselines/reference/classCanExtendConstructorFunction.symbols
@@ -107,15 +107,15 @@ class Sql extends Wagon {
     }
 }
 var db = new Sql();
->db : Symbol(db, Decl(first.js, 42, 3))
+>db : Symbol(db, Decl(first.js, 42, 3), Decl(first.js, 42, 19))
 >Sql : Symbol(Sql, Decl(first.js, 18, 1))
 
 db.numberOxen = db.foonly
 >db.numberOxen : Symbol(Wagon.numberOxen, Decl(first.js, 4, 28))
->db : Symbol(db, Decl(first.js, 42, 3))
+>db : Symbol(db, Decl(first.js, 42, 3), Decl(first.js, 42, 19))
 >numberOxen : Symbol(Wagon.numberOxen, Decl(first.js, 4, 28))
 >db.foonly : Symbol(Sql.foonly, Decl(first.js, 22, 16))
->db : Symbol(db, Decl(first.js, 42, 3))
+>db : Symbol(db, Decl(first.js, 42, 3), Decl(first.js, 42, 19))
 >foonly : Symbol(Sql.foonly, Decl(first.js, 22, 16))
 
 // error, can't extend a TS constructor function

--- a/tests/baselines/reference/constructorFunctions3.symbols
+++ b/tests/baselines/reference/constructorFunctions3.symbols
@@ -16,25 +16,25 @@ i;
 >i : Symbol(i, Decl(a.js, 3, 3))
 
 function StaticToo() {
->StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2))
+>StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2), Decl(a.js, 9, 1))
 
     this.i = 'more complex'
 >i : Symbol(StaticToo.i, Decl(a.js, 7, 22))
 }
 StaticToo.property = 'yep'
 >StaticToo.property : Symbol(StaticToo.property, Decl(a.js, 9, 1))
->StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2))
+>StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2), Decl(a.js, 9, 1))
 >property : Symbol(StaticToo.property, Decl(a.js, 9, 1))
 
 var s = new StaticToo();
 >s : Symbol(s, Decl(a.js, 11, 3))
->StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2))
+>StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2), Decl(a.js, 9, 1))
 
 s;
 >s : Symbol(s, Decl(a.js, 11, 3))
 
 StaticToo;
->StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2))
+>StaticToo : Symbol(StaticToo, Decl(a.js, 5, 2), Decl(a.js, 9, 1))
 
 // Both!
 function A () {
@@ -74,12 +74,12 @@ A.t = function g(m) {
 >m : Symbol(m, Decl(a.js, 26, 17))
 }
 var a = new A()
->a : Symbol(a, Decl(a.js, 29, 3))
+>a : Symbol(a, Decl(a.js, 29, 3), Decl(a.js, 31, 6))
 >A : Symbol(A, Decl(a.js, 13, 10), Decl(a.js, 24, 1))
 
 a.z(3)
 >a.z : Symbol(A.z, Decl(a.js, 20, 1))
->a : Symbol(a, Decl(a.js, 29, 3))
+>a : Symbol(a, Decl(a.js, 29, 3), Decl(a.js, 31, 6))
 >z : Symbol(A.z, Decl(a.js, 20, 1))
 
 A.t(2)
@@ -89,6 +89,6 @@ A.t(2)
 
 a.second = 1
 >a.second : Symbol(A.second, Decl(a.js, 17, 14))
->a : Symbol(a, Decl(a.js, 29, 3))
+>a : Symbol(a, Decl(a.js, 29, 3), Decl(a.js, 31, 6))
 >second : Symbol(A.second, Decl(a.js, 17, 14))
 

--- a/tests/baselines/reference/constructorFunctionsStrict.symbols
+++ b/tests/baselines/reference/constructorFunctionsStrict.symbols
@@ -20,18 +20,18 @@ C.prototype.m = function() {
 >y : Symbol(C.y, Decl(a.js, 4, 28))
 }
 var c = new C(1)
->c : Symbol(c, Decl(a.js, 7, 3))
+>c : Symbol(c, Decl(a.js, 7, 3), Decl(a.js, 7, 16))
 >C : Symbol(C, Decl(a.js, 0, 0))
 
 c.x = undefined // should error
 >c.x : Symbol(C.x, Decl(a.js, 1, 15))
->c : Symbol(c, Decl(a.js, 7, 3))
+>c : Symbol(c, Decl(a.js, 7, 3), Decl(a.js, 7, 16))
 >x : Symbol(C.x, Decl(a.js, 1, 15))
 >undefined : Symbol(undefined)
 
 c.y = undefined // ok
 >c.y : Symbol(C.y, Decl(a.js, 4, 28))
->c : Symbol(c, Decl(a.js, 7, 3))
+>c : Symbol(c, Decl(a.js, 7, 3), Decl(a.js, 7, 16))
 >y : Symbol(C.y, Decl(a.js, 4, 28))
 >undefined : Symbol(undefined)
 

--- a/tests/baselines/reference/contextualTypedSpecialAssignment.symbols
+++ b/tests/baselines/reference/contextualTypedSpecialAssignment.symbols
@@ -6,12 +6,12 @@
 
 // property assignment
 var ns = {}
->ns : Symbol(ns, Decl(test.js, 6, 3))
+>ns : Symbol(ns, Decl(test.js, 6, 3), Decl(test.js, 6, 11))
 
 /** @type {DoneStatus} */
 ns.x = {
 >ns.x : Symbol(ns.x, Decl(test.js, 6, 11), Decl(test.js, 11, 1))
->ns : Symbol(ns, Decl(test.js, 6, 3))
+>ns : Symbol(ns, Decl(test.js, 6, 3), Decl(test.js, 6, 11))
 >x : Symbol(ns.x, Decl(test.js, 6, 11), Decl(test.js, 11, 1))
 
     status: 'done',
@@ -24,7 +24,7 @@ ns.x = {
 
 ns.x = {
 >ns.x : Symbol(ns.x, Decl(test.js, 6, 11), Decl(test.js, 11, 1))
->ns : Symbol(ns, Decl(test.js, 6, 3))
+>ns : Symbol(ns, Decl(test.js, 6, 3), Decl(test.js, 6, 11))
 >x : Symbol(ns.x, Decl(test.js, 6, 11), Decl(test.js, 11, 1))
 
     status: 'done',
@@ -36,7 +36,7 @@ ns.x = {
 }
 ns.x
 >ns.x : Symbol(ns.x, Decl(test.js, 6, 11), Decl(test.js, 11, 1))
->ns : Symbol(ns, Decl(test.js, 6, 3))
+>ns : Symbol(ns, Decl(test.js, 6, 3), Decl(test.js, 6, 11))
 >x : Symbol(ns.x, Decl(test.js, 6, 11), Decl(test.js, 11, 1))
 
 

--- a/tests/baselines/reference/contextualTypedSpecialAssignment.types
+++ b/tests/baselines/reference/contextualTypedSpecialAssignment.types
@@ -6,14 +6,14 @@
 
 // property assignment
 var ns = {}
->ns : { x: { status: "done"; m(n: number): void; }; }
+>ns : typeof ns
 >{} : {}
 
 /** @type {DoneStatus} */
 ns.x = {
 >ns.x = {    status: 'done',    m(n) { }} : { status: "done"; m(n: number): void; }
 >ns.x : { status: "done"; m(n: number): void; }
->ns : { x: { status: "done"; m(n: number): void; }; }
+>ns : typeof ns
 >x : { status: "done"; m(n: number): void; }
 >{    status: 'done',    m(n) { }} : { status: "done"; m(n: number): void; }
 
@@ -29,7 +29,7 @@ ns.x = {
 ns.x = {
 >ns.x = {    status: 'done',    m(n) { }} : { status: "done"; m(n: number): void; }
 >ns.x : { status: "done"; m(n: number): void; }
->ns : { x: { status: "done"; m(n: number): void; }; }
+>ns : typeof ns
 >x : { status: "done"; m(n: number): void; }
 >{    status: 'done',    m(n) { }} : { status: "done"; m(n: number): void; }
 
@@ -43,7 +43,7 @@ ns.x = {
 }
 ns.x
 >ns.x : { status: "done"; m(n: number): void; }
->ns : { x: { status: "done"; m(n: number): void; }; }
+>ns : typeof ns
 >x : { status: "done"; m(n: number): void; }
 
 

--- a/tests/baselines/reference/expandoFunctionContextualTypes.symbols
+++ b/tests/baselines/reference/expandoFunctionContextualTypes.symbols
@@ -18,13 +18,13 @@ interface StatelessComponent<P> {
 }
 
 const MyComponent: StatelessComponent<MyComponentProps> = () => null as any;
->MyComponent : Symbol(MyComponent, Decl(expandoFunctionContextualTypes.ts, 9, 5))
+>MyComponent : Symbol(MyComponent, Decl(expandoFunctionContextualTypes.ts, 9, 5), Decl(expandoFunctionContextualTypes.ts, 9, 76))
 >StatelessComponent : Symbol(StatelessComponent, Decl(expandoFunctionContextualTypes.ts, 2, 1))
 >MyComponentProps : Symbol(MyComponentProps, Decl(expandoFunctionContextualTypes.ts, 0, 0))
 
 MyComponent.defaultProps = {
 >MyComponent.defaultProps : Symbol(StatelessComponent.defaultProps, Decl(expandoFunctionContextualTypes.ts, 5, 12))
->MyComponent : Symbol(MyComponent, Decl(expandoFunctionContextualTypes.ts, 9, 5))
+>MyComponent : Symbol(MyComponent, Decl(expandoFunctionContextualTypes.ts, 9, 5), Decl(expandoFunctionContextualTypes.ts, 9, 76))
 >defaultProps : Symbol(StatelessComponent.defaultProps, Decl(expandoFunctionContextualTypes.ts, 5, 12))
 
     color: "red"

--- a/tests/baselines/reference/expandoFunctionContextualTypesJs.symbols
+++ b/tests/baselines/reference/expandoFunctionContextualTypesJs.symbols
@@ -9,11 +9,11 @@
   * @type {StatelessComponent<MyComponentProps>}
   */
 const MyComponent = () => /* @type {any} */(null);
->MyComponent : Symbol(MyComponent, Decl(input.js, 9, 5))
+>MyComponent : Symbol(MyComponent, Decl(input.js, 9, 5), Decl(input.js, 9, 50))
 
 MyComponent.defaultProps = {
 >MyComponent.defaultProps : Symbol(defaultProps, Decl(input.js, 4, 23))
->MyComponent : Symbol(MyComponent, Decl(input.js, 9, 5))
+>MyComponent : Symbol(MyComponent, Decl(input.js, 9, 5), Decl(input.js, 9, 50))
 >defaultProps : Symbol(defaultProps, Decl(input.js, 4, 23))
 
     color: "red"
@@ -22,14 +22,14 @@ MyComponent.defaultProps = {
 };
 
 const MyComponent2 = () => null;
->MyComponent2 : Symbol(MyComponent2, Decl(input.js, 15, 5))
+>MyComponent2 : Symbol(MyComponent2, Decl(input.js, 15, 5), Decl(input.js, 15, 32))
 
 /**
  * @type {MyComponentProps}
  */
 MyComponent2.defaultProps = {
 >MyComponent2.defaultProps : Symbol(MyComponent2.defaultProps, Decl(input.js, 15, 32))
->MyComponent2 : Symbol(MyComponent2, Decl(input.js, 15, 5))
+>MyComponent2 : Symbol(MyComponent2, Decl(input.js, 15, 5), Decl(input.js, 15, 32))
 >defaultProps : Symbol(MyComponent2.defaultProps, Decl(input.js, 15, 32))
 
     color: "red"
@@ -41,7 +41,7 @@ MyComponent2.defaultProps = {
  */
 const check = MyComponent2;
 >check : Symbol(check, Decl(input.js, 27, 5))
->MyComponent2 : Symbol(MyComponent2, Decl(input.js, 15, 5))
+>MyComponent2 : Symbol(MyComponent2, Decl(input.js, 15, 5), Decl(input.js, 15, 32))
 
 /**
  * 

--- a/tests/baselines/reference/inferringClassStaticMembersFromAssignments.symbols
+++ b/tests/baselines/reference/inferringClassStaticMembersFromAssignments.symbols
@@ -1,67 +1,67 @@
 === tests/cases/conformance/salsa/a.js ===
 export class C1 { }
->C1 : Symbol(C1, Decl(a.js, 0, 0))
+>C1 : Symbol(C1, Decl(a.js, 0, 0), Decl(a.js, 0, 19))
 
 C1.staticProp = 0;
 >C1.staticProp : Symbol(C1.staticProp, Decl(a.js, 0, 19))
->C1 : Symbol(C1, Decl(a.js, 0, 0))
+>C1 : Symbol(C1, Decl(a.js, 0, 0), Decl(a.js, 0, 19))
 >staticProp : Symbol(C1.staticProp, Decl(a.js, 0, 19))
 
 export function F1() { }
->F1 : Symbol(F1, Decl(a.js, 1, 18))
+>F1 : Symbol(F1, Decl(a.js, 1, 18), Decl(a.js, 3, 24))
 
 F1.staticProp = 0;
 >F1.staticProp : Symbol(F1.staticProp, Decl(a.js, 3, 24))
->F1 : Symbol(F1, Decl(a.js, 1, 18))
+>F1 : Symbol(F1, Decl(a.js, 1, 18), Decl(a.js, 3, 24))
 >staticProp : Symbol(F1.staticProp, Decl(a.js, 3, 24))
 
 export var C2 = class { };
->C2 : Symbol(C2, Decl(a.js, 6, 10))
+>C2 : Symbol(C2, Decl(a.js, 6, 10), Decl(a.js, 6, 26))
 
 C2.staticProp = 0;
 >C2.staticProp : Symbol(C2.staticProp, Decl(a.js, 6, 26))
->C2 : Symbol(C2, Decl(a.js, 6, 10))
+>C2 : Symbol(C2, Decl(a.js, 6, 10), Decl(a.js, 6, 26))
 >staticProp : Symbol(C2.staticProp, Decl(a.js, 6, 26))
 
 export let F2 = function () { };
->F2 : Symbol(F2, Decl(a.js, 9, 10))
+>F2 : Symbol(F2, Decl(a.js, 9, 10), Decl(a.js, 9, 32))
 
 F2.staticProp = 0;
 >F2.staticProp : Symbol(F2.staticProp, Decl(a.js, 9, 32))
->F2 : Symbol(F2, Decl(a.js, 9, 10))
+>F2 : Symbol(F2, Decl(a.js, 9, 10), Decl(a.js, 9, 32))
 >staticProp : Symbol(F2.staticProp, Decl(a.js, 9, 32))
 
 === tests/cases/conformance/salsa/global.js ===
 class C3 { }
->C3 : Symbol(C3, Decl(global.js, 0, 0))
+>C3 : Symbol(C3, Decl(global.js, 0, 0), Decl(global.js, 0, 12))
 
 C3.staticProp = 0;
 >C3.staticProp : Symbol(C3.staticProp, Decl(global.js, 0, 12))
->C3 : Symbol(C3, Decl(global.js, 0, 0))
+>C3 : Symbol(C3, Decl(global.js, 0, 0), Decl(global.js, 0, 12))
 >staticProp : Symbol(C3.staticProp, Decl(global.js, 0, 12))
 
 function F3() { }
->F3 : Symbol(F3, Decl(global.js, 1, 18))
+>F3 : Symbol(F3, Decl(global.js, 1, 18), Decl(global.js, 3, 17))
 
 F3.staticProp = 0;
 >F3.staticProp : Symbol(F3.staticProp, Decl(global.js, 3, 17))
->F3 : Symbol(F3, Decl(global.js, 1, 18))
+>F3 : Symbol(F3, Decl(global.js, 1, 18), Decl(global.js, 3, 17))
 >staticProp : Symbol(F3.staticProp, Decl(global.js, 3, 17))
 
 var C4 = class { };
->C4 : Symbol(C4, Decl(global.js, 6, 3))
+>C4 : Symbol(C4, Decl(global.js, 6, 3), Decl(global.js, 6, 19))
 
 C4.staticProp = 0;
 >C4.staticProp : Symbol(C4.staticProp, Decl(global.js, 6, 19))
->C4 : Symbol(C4, Decl(global.js, 6, 3))
+>C4 : Symbol(C4, Decl(global.js, 6, 3), Decl(global.js, 6, 19))
 >staticProp : Symbol(C4.staticProp, Decl(global.js, 6, 19))
 
 let F4 = function () { };
->F4 : Symbol(F4, Decl(global.js, 9, 3))
+>F4 : Symbol(F4, Decl(global.js, 9, 3), Decl(global.js, 9, 25))
 
 F4.staticProp = 0;
 >F4.staticProp : Symbol(F4.staticProp, Decl(global.js, 9, 25))
->F4 : Symbol(F4, Decl(global.js, 9, 3))
+>F4 : Symbol(F4, Decl(global.js, 9, 3), Decl(global.js, 9, 25))
 >staticProp : Symbol(F4.staticProp, Decl(global.js, 9, 25))
 
 === tests/cases/conformance/salsa/b.ts ===
@@ -74,57 +74,57 @@ var n: number;
 var n = a.C1.staticProp;
 >n : Symbol(n, Decl(b.ts, 1, 3), Decl(b.ts, 3, 3), Decl(b.ts, 4, 3), Decl(b.ts, 5, 3), Decl(b.ts, 6, 3) ... and 4 more)
 >a.C1.staticProp : Symbol(a.C1.staticProp, Decl(a.js, 0, 19))
->a.C1 : Symbol(a.C1, Decl(a.js, 0, 0))
+>a.C1 : Symbol(a.C1, Decl(a.js, 0, 0), Decl(a.js, 0, 19))
 >a : Symbol(a, Decl(b.ts, 0, 6))
->C1 : Symbol(a.C1, Decl(a.js, 0, 0))
+>C1 : Symbol(a.C1, Decl(a.js, 0, 0), Decl(a.js, 0, 19))
 >staticProp : Symbol(a.C1.staticProp, Decl(a.js, 0, 19))
 
 var n = a.C2.staticProp;
 >n : Symbol(n, Decl(b.ts, 1, 3), Decl(b.ts, 3, 3), Decl(b.ts, 4, 3), Decl(b.ts, 5, 3), Decl(b.ts, 6, 3) ... and 4 more)
 >a.C2.staticProp : Symbol(a.C2.staticProp, Decl(a.js, 6, 26))
->a.C2 : Symbol(a.C2, Decl(a.js, 6, 10))
+>a.C2 : Symbol(a.C2, Decl(a.js, 6, 10), Decl(a.js, 6, 26))
 >a : Symbol(a, Decl(b.ts, 0, 6))
->C2 : Symbol(a.C2, Decl(a.js, 6, 10))
+>C2 : Symbol(a.C2, Decl(a.js, 6, 10), Decl(a.js, 6, 26))
 >staticProp : Symbol(a.C2.staticProp, Decl(a.js, 6, 26))
 
 var n = a.F1.staticProp;
 >n : Symbol(n, Decl(b.ts, 1, 3), Decl(b.ts, 3, 3), Decl(b.ts, 4, 3), Decl(b.ts, 5, 3), Decl(b.ts, 6, 3) ... and 4 more)
 >a.F1.staticProp : Symbol(a.F1.staticProp, Decl(a.js, 3, 24))
->a.F1 : Symbol(a.F1, Decl(a.js, 1, 18))
+>a.F1 : Symbol(a.F1, Decl(a.js, 1, 18), Decl(a.js, 3, 24))
 >a : Symbol(a, Decl(b.ts, 0, 6))
->F1 : Symbol(a.F1, Decl(a.js, 1, 18))
+>F1 : Symbol(a.F1, Decl(a.js, 1, 18), Decl(a.js, 3, 24))
 >staticProp : Symbol(a.F1.staticProp, Decl(a.js, 3, 24))
 
 var n = a.F2.staticProp;
 >n : Symbol(n, Decl(b.ts, 1, 3), Decl(b.ts, 3, 3), Decl(b.ts, 4, 3), Decl(b.ts, 5, 3), Decl(b.ts, 6, 3) ... and 4 more)
 >a.F2.staticProp : Symbol(a.F2.staticProp, Decl(a.js, 9, 32))
->a.F2 : Symbol(a.F2, Decl(a.js, 9, 10))
+>a.F2 : Symbol(a.F2, Decl(a.js, 9, 10), Decl(a.js, 9, 32))
 >a : Symbol(a, Decl(b.ts, 0, 6))
->F2 : Symbol(a.F2, Decl(a.js, 9, 10))
+>F2 : Symbol(a.F2, Decl(a.js, 9, 10), Decl(a.js, 9, 32))
 >staticProp : Symbol(a.F2.staticProp, Decl(a.js, 9, 32))
 
 
 var n = C3.staticProp;
 >n : Symbol(n, Decl(b.ts, 1, 3), Decl(b.ts, 3, 3), Decl(b.ts, 4, 3), Decl(b.ts, 5, 3), Decl(b.ts, 6, 3) ... and 4 more)
 >C3.staticProp : Symbol(C3.staticProp, Decl(global.js, 0, 12))
->C3 : Symbol(C3, Decl(global.js, 0, 0))
+>C3 : Symbol(C3, Decl(global.js, 0, 0), Decl(global.js, 0, 12))
 >staticProp : Symbol(C3.staticProp, Decl(global.js, 0, 12))
 
 var n = C4.staticProp;
 >n : Symbol(n, Decl(b.ts, 1, 3), Decl(b.ts, 3, 3), Decl(b.ts, 4, 3), Decl(b.ts, 5, 3), Decl(b.ts, 6, 3) ... and 4 more)
 >C4.staticProp : Symbol(C4.staticProp, Decl(global.js, 6, 19))
->C4 : Symbol(C4, Decl(global.js, 6, 3))
+>C4 : Symbol(C4, Decl(global.js, 6, 3), Decl(global.js, 6, 19))
 >staticProp : Symbol(C4.staticProp, Decl(global.js, 6, 19))
 
 var n = F3.staticProp;
 >n : Symbol(n, Decl(b.ts, 1, 3), Decl(b.ts, 3, 3), Decl(b.ts, 4, 3), Decl(b.ts, 5, 3), Decl(b.ts, 6, 3) ... and 4 more)
 >F3.staticProp : Symbol(F3.staticProp, Decl(global.js, 3, 17))
->F3 : Symbol(F3, Decl(global.js, 1, 18))
+>F3 : Symbol(F3, Decl(global.js, 1, 18), Decl(global.js, 3, 17))
 >staticProp : Symbol(F3.staticProp, Decl(global.js, 3, 17))
 
 var n = F4.staticProp;
 >n : Symbol(n, Decl(b.ts, 1, 3), Decl(b.ts, 3, 3), Decl(b.ts, 4, 3), Decl(b.ts, 5, 3), Decl(b.ts, 6, 3) ... and 4 more)
 >F4.staticProp : Symbol(F4.staticProp, Decl(global.js, 9, 25))
->F4 : Symbol(F4, Decl(global.js, 9, 3))
+>F4 : Symbol(F4, Decl(global.js, 9, 3), Decl(global.js, 9, 25))
 >staticProp : Symbol(F4.staticProp, Decl(global.js, 9, 25))
 

--- a/tests/baselines/reference/inferringClassStaticMembersFromAssignments.types
+++ b/tests/baselines/reference/inferringClassStaticMembersFromAssignments.types
@@ -10,12 +10,12 @@ C1.staticProp = 0;
 >0 : 0
 
 export function F1() { }
->F1 : { (): void; staticProp: number; }
+>F1 : typeof F1
 
 F1.staticProp = 0;
 >F1.staticProp = 0 : 0
 >F1.staticProp : number
->F1 : { (): void; staticProp: number; }
+>F1 : typeof F1
 >staticProp : number
 >0 : 0
 
@@ -53,12 +53,12 @@ C3.staticProp = 0;
 >0 : 0
 
 function F3() { }
->F3 : { (): void; staticProp: number; }
+>F3 : typeof F3
 
 F3.staticProp = 0;
 >F3.staticProp = 0 : 0
 >F3.staticProp : number
->F3 : { (): void; staticProp: number; }
+>F3 : typeof F3
 >staticProp : number
 >0 : 0
 
@@ -110,9 +110,9 @@ var n = a.C2.staticProp;
 var n = a.F1.staticProp;
 >n : number
 >a.F1.staticProp : number
->a.F1 : { (): void; staticProp: number; }
+>a.F1 : typeof a.F1
 >a : typeof a
->F1 : { (): void; staticProp: number; }
+>F1 : typeof a.F1
 >staticProp : number
 
 var n = a.F2.staticProp;
@@ -139,7 +139,7 @@ var n = C4.staticProp;
 var n = F3.staticProp;
 >n : number
 >F3.staticProp : number
->F3 : { (): void; staticProp: number; }
+>F3 : typeof F3
 >staticProp : number
 
 var n = F4.staticProp;

--- a/tests/baselines/reference/jsObjectsMarkedAsOpenEnded.symbols
+++ b/tests/baselines/reference/jsObjectsMarkedAsOpenEnded.symbols
@@ -1,10 +1,10 @@
 === tests/cases/conformance/salsa/a.js ===
 var variable = {};
->variable : Symbol(variable, Decl(a.js, 0, 3))
+>variable : Symbol(variable, Decl(a.js, 0, 3), Decl(a.js, 0, 18))
 
 variable.a = 0;
 >variable.a : Symbol(variable.a, Decl(a.js, 0, 18))
->variable : Symbol(variable, Decl(a.js, 0, 3))
+>variable : Symbol(variable, Decl(a.js, 0, 3), Decl(a.js, 0, 18))
 >a : Symbol(variable.a, Decl(a.js, 0, 18))
 
 class C {
@@ -27,7 +27,7 @@ class C {
 }
 
 var obj = {
->obj : Symbol(obj, Decl(a.js, 11, 3))
+>obj : Symbol(obj, Decl(a.js, 11, 3), Decl(a.js, 13, 2))
 
     property: {}
 >property : Symbol(property, Decl(a.js, 11, 11))
@@ -36,7 +36,7 @@ var obj = {
 
 obj.property.a = 0;
 >obj.property : Symbol(property, Decl(a.js, 11, 11))
->obj : Symbol(obj, Decl(a.js, 11, 3))
+>obj : Symbol(obj, Decl(a.js, 11, 3), Decl(a.js, 13, 2))
 >property : Symbol(property, Decl(a.js, 11, 11))
 
 var arr = [{}];
@@ -52,7 +52,7 @@ function getObj() {
 === tests/cases/conformance/salsa/b.ts ===
 variable.a = 1;
 >variable.a : Symbol(variable.a, Decl(a.js, 0, 18))
->variable : Symbol(variable, Decl(a.js, 0, 3))
+>variable : Symbol(variable, Decl(a.js, 0, 3), Decl(a.js, 0, 18))
 >a : Symbol(variable.a, Decl(a.js, 0, 18))
 
 (new C()).member.a = 1;
@@ -67,7 +67,7 @@ variable.a = 1;
 
 obj.property.a = 1;
 >obj.property : Symbol(property, Decl(a.js, 11, 11))
->obj : Symbol(obj, Decl(a.js, 11, 3))
+>obj : Symbol(obj, Decl(a.js, 11, 3), Decl(a.js, 13, 2))
 >property : Symbol(property, Decl(a.js, 11, 11))
 
 arr[0].a = 1;

--- a/tests/baselines/reference/jsObjectsMarkedAsOpenEnded.types
+++ b/tests/baselines/reference/jsObjectsMarkedAsOpenEnded.types
@@ -1,12 +1,12 @@
 === tests/cases/conformance/salsa/a.js ===
 var variable = {};
->variable : { a: number; }
+>variable : typeof variable
 >{} : {}
 
 variable.a = 0;
 >variable.a = 0 : 0
 >variable.a : number
->variable : { a: number; }
+>variable : typeof variable
 >a : number
 >0 : 0
 
@@ -72,7 +72,7 @@ function getObj() {
 variable.a = 1;
 >variable.a = 1 : 1
 >variable.a : number
->variable : { a: number; }
+>variable : typeof variable
 >a : number
 >1 : 1
 

--- a/tests/baselines/reference/jsdocTemplateClass.symbols
+++ b/tests/baselines/reference/jsdocTemplateClass.symbols
@@ -38,7 +38,7 @@ class Foo {
     }
 }
 var f = new Foo(1)
->f : Symbol(f, Decl(templateTagOnClasses.js, 22, 3))
+>f : Symbol(f, Decl(templateTagOnClasses.js, 22, 3), Decl(templateTagOnClasses.js, 23, 22))
 >Foo : Symbol(Foo, Decl(templateTagOnClasses.js, 0, 0))
 
 var g = new Foo(false)
@@ -47,7 +47,7 @@ var g = new Foo(false)
 
 f.a = g.a
 >f.a : Symbol(Foo.a, Decl(templateTagOnClasses.js, 8, 21))
->f : Symbol(f, Decl(templateTagOnClasses.js, 22, 3))
+>f : Symbol(f, Decl(templateTagOnClasses.js, 22, 3), Decl(templateTagOnClasses.js, 23, 22))
 >a : Symbol(Foo.a, Decl(templateTagOnClasses.js, 8, 21))
 >g.a : Symbol(Foo.a, Decl(templateTagOnClasses.js, 8, 21))
 >g : Symbol(g, Decl(templateTagOnClasses.js, 23, 3))

--- a/tests/baselines/reference/jsdocTemplateConstructorFunction.symbols
+++ b/tests/baselines/reference/jsdocTemplateConstructorFunction.symbols
@@ -45,16 +45,16 @@ Zet.prototype.add = function(v, id) {
 >u : Symbol(Zet.u, Decl(templateTagOnConstructorFunctions.js, 8, 17), Decl(templateTagOnConstructorFunctions.js, 17, 37))
 }
 var z = new Zet(1)
->z : Symbol(z, Decl(templateTagOnConstructorFunctions.js, 21, 3))
+>z : Symbol(z, Decl(templateTagOnConstructorFunctions.js, 21, 3), Decl(templateTagOnConstructorFunctions.js, 21, 18))
 >Zet : Symbol(Zet, Decl(templateTagOnConstructorFunctions.js, 0, 0))
 
 z.t = 2
 >z.t : Symbol(Zet.t, Decl(templateTagOnConstructorFunctions.js, 10, 10))
->z : Symbol(z, Decl(templateTagOnConstructorFunctions.js, 21, 3))
+>z : Symbol(z, Decl(templateTagOnConstructorFunctions.js, 21, 3), Decl(templateTagOnConstructorFunctions.js, 21, 18))
 >t : Symbol(Zet.t, Decl(templateTagOnConstructorFunctions.js, 10, 10))
 
 z.u = false
 >z.u : Symbol(Zet.u, Decl(templateTagOnConstructorFunctions.js, 8, 17), Decl(templateTagOnConstructorFunctions.js, 17, 37))
->z : Symbol(z, Decl(templateTagOnConstructorFunctions.js, 21, 3))
+>z : Symbol(z, Decl(templateTagOnConstructorFunctions.js, 21, 3), Decl(templateTagOnConstructorFunctions.js, 21, 18))
 >u : Symbol(Zet.u, Decl(templateTagOnConstructorFunctions.js, 8, 17), Decl(templateTagOnConstructorFunctions.js, 17, 37))
 

--- a/tests/baselines/reference/jsdocTemplateConstructorFunction2.symbols
+++ b/tests/baselines/reference/jsdocTemplateConstructorFunction2.symbols
@@ -41,17 +41,17 @@ Zet.prototype.add = function(v, o) {
 >u : Symbol(Zet.u, Decl(templateTagWithNestedTypeLiteral.js, 4, 17), Decl(templateTagWithNestedTypeLiteral.js, 14, 36))
 }
 var z = new Zet(1)
->z : Symbol(z, Decl(templateTagWithNestedTypeLiteral.js, 18, 3))
+>z : Symbol(z, Decl(templateTagWithNestedTypeLiteral.js, 18, 3), Decl(templateTagWithNestedTypeLiteral.js, 18, 18))
 >Zet : Symbol(Zet, Decl(templateTagWithNestedTypeLiteral.js, 0, 0))
 
 z.t = 2
 >z.t : Symbol(Zet.t, Decl(templateTagWithNestedTypeLiteral.js, 6, 10))
->z : Symbol(z, Decl(templateTagWithNestedTypeLiteral.js, 18, 3))
+>z : Symbol(z, Decl(templateTagWithNestedTypeLiteral.js, 18, 3), Decl(templateTagWithNestedTypeLiteral.js, 18, 18))
 >t : Symbol(Zet.t, Decl(templateTagWithNestedTypeLiteral.js, 6, 10))
 
 z.u = false
 >z.u : Symbol(Zet.u, Decl(templateTagWithNestedTypeLiteral.js, 4, 17), Decl(templateTagWithNestedTypeLiteral.js, 14, 36))
->z : Symbol(z, Decl(templateTagWithNestedTypeLiteral.js, 18, 3))
+>z : Symbol(z, Decl(templateTagWithNestedTypeLiteral.js, 18, 3), Decl(templateTagWithNestedTypeLiteral.js, 18, 18))
 >u : Symbol(Zet.u, Decl(templateTagWithNestedTypeLiteral.js, 4, 17), Decl(templateTagWithNestedTypeLiteral.js, 14, 36))
 
 // lookup in typedef should not crash the compiler, even when the type is unknown

--- a/tests/baselines/reference/jsdocTypeFromChainedAssignment.symbols
+++ b/tests/baselines/reference/jsdocTypeFromChainedAssignment.symbols
@@ -45,17 +45,17 @@ A.s = A.t = function g(m) {
 >this : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
 }
 var a = new A()
->a : Symbol(a, Decl(a.js, 13, 3))
+>a : Symbol(a, Decl(a.js, 13, 3), Decl(a.js, 17, 22))
 >A : Symbol(A, Decl(a.js, 0, 0), Decl(a.js, 8, 1))
 
 a.y('no') // error
 >a.y : Symbol(A.y, Decl(a.js, 4, 1))
->a : Symbol(a, Decl(a.js, 13, 3))
+>a : Symbol(a, Decl(a.js, 13, 3), Decl(a.js, 17, 22))
 >y : Symbol(A.y, Decl(a.js, 4, 1))
 
 a.z('not really') // error
 >a.z : Symbol(A.z, Decl(a.js, 6, 15))
->a : Symbol(a, Decl(a.js, 13, 3))
+>a : Symbol(a, Decl(a.js, 13, 3), Decl(a.js, 17, 22))
 >z : Symbol(A.z, Decl(a.js, 6, 15))
 
 A.s('still no') // error
@@ -70,6 +70,6 @@ A.t('not here either') // error
 
 a.first = 10 // error: '10' isn't assignable to '1'
 >a.first : Symbol(A.first, Decl(a.js, 1, 14))
->a : Symbol(a, Decl(a.js, 13, 3))
+>a : Symbol(a, Decl(a.js, 13, 3), Decl(a.js, 17, 22))
 >first : Symbol(A.first, Decl(a.js, 1, 14))
 

--- a/tests/baselines/reference/moduleExportAlias5.symbols
+++ b/tests/baselines/reference/moduleExportAlias5.symbols
@@ -1,14 +1,14 @@
 === tests/cases/conformance/salsa/bug24754.js ===
 // #24754
 const webpack = function (){
->webpack : Symbol(webpack, Decl(bug24754.js, 1, 5))
+>webpack : Symbol(webpack, Decl(bug24754.js, 1, 5), Decl(bug24754.js, 4, 23))
 }
 exports = module.exports = webpack;
 >exports : Symbol("tests/cases/conformance/salsa/bug24754", Decl(bug24754.js, 0, 0))
 >module.exports : Symbol("tests/cases/conformance/salsa/bug24754", Decl(bug24754.js, 0, 0))
 >module : Symbol(export=, Decl(bug24754.js, 3, 9))
 >exports : Symbol(export=, Decl(bug24754.js, 3, 9))
->webpack : Symbol(webpack, Decl(bug24754.js, 1, 5))
+>webpack : Symbol(webpack, Decl(bug24754.js, 1, 5), Decl(bug24754.js, 4, 23))
 
 exports.version = 1001;
 >exports.version : Symbol(version, Decl(bug24754.js, 3, 35))
@@ -17,6 +17,6 @@ exports.version = 1001;
 
 webpack.WebpackOptionsDefaulter = 1111;
 >webpack.WebpackOptionsDefaulter : Symbol(webpack.WebpackOptionsDefaulter, Decl(bug24754.js, 4, 23))
->webpack : Symbol(webpack, Decl(bug24754.js, 1, 5))
+>webpack : Symbol(webpack, Decl(bug24754.js, 1, 5), Decl(bug24754.js, 4, 23))
 >WebpackOptionsDefaulter : Symbol(webpack.WebpackOptionsDefaulter, Decl(bug24754.js, 4, 23))
 

--- a/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.symbols
+++ b/tests/baselines/reference/moduleExportWithExportPropertyAssignment4.symbols
@@ -49,27 +49,27 @@ module.exports.bothBefore = 'string'
 
 A.justExport = 4
 >A.justExport : Symbol(A.justExport, Decl(mod1.js, 1, 36))
->A : Symbol(A, Decl(mod1.js, 5, 18))
+>A : Symbol(A, Decl(mod1.js, 5, 18), Decl(mod1.js, 1, 36))
 >justExport : Symbol(A.justExport, Decl(mod1.js, 1, 36))
 
 A.bothBefore = 2
 >A.bothBefore : Symbol(A.bothBefore, Decl(mod1.js, 2, 16), Decl(mod1.js, 0, 0))
->A : Symbol(A, Decl(mod1.js, 5, 18))
+>A : Symbol(A, Decl(mod1.js, 5, 18), Decl(mod1.js, 1, 36))
 >bothBefore : Symbol(A.bothBefore, Decl(mod1.js, 2, 16), Decl(mod1.js, 0, 0))
 
 A.bothAfter = 3
 >A.bothAfter : Symbol(A.bothAfter, Decl(mod1.js, 3, 16), Decl(mod1.js, 8, 1))
->A : Symbol(A, Decl(mod1.js, 5, 18))
+>A : Symbol(A, Decl(mod1.js, 5, 18), Decl(mod1.js, 1, 36))
 >bothAfter : Symbol(A.bothAfter, Decl(mod1.js, 3, 16), Decl(mod1.js, 8, 1))
 
 module.exports = A
 >module.exports : Symbol("tests/cases/conformance/salsa/mod1", Decl(mod1.js, 0, 0))
 >module : Symbol(export=, Decl(mod1.js, 4, 15))
 >exports : Symbol(export=, Decl(mod1.js, 4, 15))
->A : Symbol(A, Decl(mod1.js, 5, 18))
+>A : Symbol(A, Decl(mod1.js, 5, 18), Decl(mod1.js, 1, 36))
 
 function A() {
->A : Symbol(A, Decl(mod1.js, 5, 18))
+>A : Symbol(A, Decl(mod1.js, 5, 18), Decl(mod1.js, 1, 36))
 
     this.p = 1
 >p : Symbol(A.p, Decl(mod1.js, 6, 14))

--- a/tests/baselines/reference/propertyAssignmentOnImportedSymbol.errors.txt
+++ b/tests/baselines/reference/propertyAssignmentOnImportedSymbol.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/salsa/bug24658.js(1,10): error TS2440: Import declaration conflicts with local declaration of 'hurk'.
+
+
+==== tests/cases/conformance/salsa/mod1.js (0 errors) ====
+    export var hurk = {}
+==== tests/cases/conformance/salsa/bug24658.js (1 errors) ====
+    import { hurk } from './mod1'
+             ~~~~
+!!! error TS2440: Import declaration conflicts with local declaration of 'hurk'.
+    hurk.expando = 4
+    

--- a/tests/baselines/reference/propertyAssignmentOnImportedSymbol.symbols
+++ b/tests/baselines/reference/propertyAssignmentOnImportedSymbol.symbols
@@ -4,8 +4,10 @@ export var hurk = {}
 
 === tests/cases/conformance/salsa/bug24658.js ===
 import { hurk } from './mod1'
->hurk : Symbol(hurk, Decl(bug24658.js, 0, 8))
+>hurk : Symbol(hurk, Decl(bug24658.js, 0, 8), Decl(bug24658.js, 0, 29))
 
 hurk.expando = 4
->hurk : Symbol(hurk, Decl(bug24658.js, 0, 8))
+>hurk.expando : Symbol(hurk.expando, Decl(bug24658.js, 0, 29))
+>hurk : Symbol(hurk, Decl(bug24658.js, 0, 8), Decl(bug24658.js, 0, 29))
+>expando : Symbol(hurk.expando, Decl(bug24658.js, 0, 29))
 

--- a/tests/baselines/reference/propertyAssignmentOnImportedSymbol.types
+++ b/tests/baselines/reference/propertyAssignmentOnImportedSymbol.types
@@ -5,12 +5,12 @@ export var hurk = {}
 
 === tests/cases/conformance/salsa/bug24658.js ===
 import { hurk } from './mod1'
->hurk : {}
+>hurk : typeof hurk
 
 hurk.expando = 4
 >hurk.expando = 4 : 4
->hurk.expando : any
->hurk : {}
->expando : any
+>hurk.expando : number
+>hurk : typeof hurk
+>expando : number
 >4 : 4
 

--- a/tests/baselines/reference/targetTypeTest1.errors.txt
+++ b/tests/baselines/reference/targetTypeTest1.errors.txt
@@ -1,13 +1,11 @@
 tests/cases/compiler/targetTypeTest1.ts(1,15): error TS2300: Duplicate identifier 'Point'.
-tests/cases/compiler/targetTypeTest1.ts(6,43): error TS2304: Cannot find name 'Point'.
-tests/cases/compiler/targetTypeTest1.ts(7,22): error TS2304: Cannot find name 'Point'.
 tests/cases/compiler/targetTypeTest1.ts(14,10): error TS2300: Duplicate identifier 'Point'.
 tests/cases/compiler/targetTypeTest1.ts(19,18): error TS2384: Overload signatures must all be ambient or non-ambient.
 tests/cases/compiler/targetTypeTest1.ts(53,15): error TS2300: Duplicate identifier 'C'.
 tests/cases/compiler/targetTypeTest1.ts(60,10): error TS2300: Duplicate identifier 'C'.
 
 
-==== tests/cases/compiler/targetTypeTest1.ts (7 errors) ====
+==== tests/cases/compiler/targetTypeTest1.ts (5 errors) ====
     declare class Point
                   ~~~~~
 !!! error TS2300: Duplicate identifier 'Point'.
@@ -16,11 +14,7 @@ tests/cases/compiler/targetTypeTest1.ts(60,10): error TS2300: Duplicate identifi
           public x: number;
           public y: number;
           public add(dx: number, dy: number): Point;
-                                              ~~~~~
-!!! error TS2304: Cannot find name 'Point'.
           static origin: Point;
-                         ~~~~~
-!!! error TS2304: Cannot find name 'Point'.
     
     }
     

--- a/tests/baselines/reference/targetTypeTest1.symbols
+++ b/tests/baselines/reference/targetTypeTest1.symbols
@@ -16,9 +16,11 @@ declare class Point
 >add : Symbol(Point.add, Decl(targetTypeTest1.ts, 4, 23))
 >dx : Symbol(dx, Decl(targetTypeTest1.ts, 5, 17))
 >dy : Symbol(dy, Decl(targetTypeTest1.ts, 5, 28))
+>Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1), Decl(targetTypeTest1.ts, 22, 17))
 
       static origin: Point;
 >origin : Symbol(Point.origin, Decl(targetTypeTest1.ts, 5, 48))
+>Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1), Decl(targetTypeTest1.ts, 22, 17))
 
 }
 
@@ -26,7 +28,7 @@ declare class Point
 // Because Point is a constructor function, this is inferred
 // to be Point and return type is inferred to be void
 function Point(x, y) {
->Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1))
+>Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1), Decl(targetTypeTest1.ts, 22, 17))
 >x : Symbol(x, Decl(targetTypeTest1.ts, 13, 15))
 >y : Symbol(y, Decl(targetTypeTest1.ts, 13, 17))
 
@@ -56,22 +58,22 @@ var x = EF1(1,2);
 // Point.origin declared as type Point
 Point.origin = new Point(0, 0);
 >Point.origin : Symbol(Point.origin, Decl(targetTypeTest1.ts, 22, 17))
->Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1))
+>Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1), Decl(targetTypeTest1.ts, 22, 17))
 >origin : Symbol(Point.origin, Decl(targetTypeTest1.ts, 22, 17))
->Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1))
+>Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1), Decl(targetTypeTest1.ts, 22, 17))
 
 // Point.prototype declared as type Point
 // this inferred as Point because of obj.prop assignment
 // dx, dy, and return type inferred using target typing
 Point.prototype.add = function(dx, dy) {
 >Point.prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
->Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1))
+>Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1), Decl(targetTypeTest1.ts, 22, 17))
 >prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
 >dx : Symbol(dx, Decl(targetTypeTest1.ts, 30, 31))
 >dy : Symbol(dy, Decl(targetTypeTest1.ts, 30, 34))
 
     return new Point(this.x + dx, this.y + dy);
->Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1))
+>Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1), Decl(targetTypeTest1.ts, 22, 17))
 >dx : Symbol(dx, Decl(targetTypeTest1.ts, 30, 31))
 >dy : Symbol(dy, Decl(targetTypeTest1.ts, 30, 34))
 
@@ -85,7 +87,7 @@ var f : number = 5;
 // dx, dy, and return type of add inferred using target typing
 Point.prototype = {
 >Point.prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
->Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1))
+>Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1), Decl(targetTypeTest1.ts, 22, 17))
 >prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
 
     x: 0,
@@ -100,7 +102,7 @@ Point.prototype = {
 >dy : Symbol(dy, Decl(targetTypeTest1.ts, 42, 21))
 
         return new Point(this.x + dx, this.y + dy);
->Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1))
+>Point : Symbol(Point, Decl(targetTypeTest1.ts, 8, 1), Decl(targetTypeTest1.ts, 22, 17))
 >dx : Symbol(dx, Decl(targetTypeTest1.ts, 42, 18))
 >dy : Symbol(dy, Decl(targetTypeTest1.ts, 42, 21))
     }

--- a/tests/baselines/reference/targetTypeTest1.types
+++ b/tests/baselines/reference/targetTypeTest1.types
@@ -26,7 +26,7 @@ declare class Point
 // Because Point is a constructor function, this is inferred
 // to be Point and return type is inferred to be void
 function Point(x, y) {
->Point : { (x: any, y: any): void; origin: any; }
+>Point : typeof Point
 >x : any
 >y : any
 
@@ -69,10 +69,10 @@ var x = EF1(1,2);
 Point.origin = new Point(0, 0);
 >Point.origin = new Point(0, 0) : any
 >Point.origin : any
->Point : { (x: any, y: any): void; origin: any; }
+>Point : typeof Point
 >origin : any
 >new Point(0, 0) : any
->Point : { (x: any, y: any): void; origin: any; }
+>Point : typeof Point
 >0 : 0
 >0 : 0
 
@@ -83,7 +83,7 @@ Point.prototype.add = function(dx, dy) {
 >Point.prototype.add = function(dx, dy) {    return new Point(this.x + dx, this.y + dy);} : (dx: any, dy: any) => any
 >Point.prototype.add : any
 >Point.prototype : any
->Point : { (x: any, y: any): void; origin: any; }
+>Point : typeof Point
 >prototype : any
 >add : any
 >function(dx, dy) {    return new Point(this.x + dx, this.y + dy);} : (dx: any, dy: any) => any
@@ -92,7 +92,7 @@ Point.prototype.add = function(dx, dy) {
 
     return new Point(this.x + dx, this.y + dy);
 >new Point(this.x + dx, this.y + dy) : any
->Point : { (x: any, y: any): void; origin: any; }
+>Point : typeof Point
 >this.x + dx : any
 >this.x : any
 >this : any
@@ -116,7 +116,7 @@ var f : number = 5;
 Point.prototype = {
 >Point.prototype = {    x: 0,    y: 0,    add: function(dx, dy) {        return new Point(this.x + dx, this.y + dy);    }} : { x: number; y: number; add: (dx: any, dy: any) => any; }
 >Point.prototype : any
->Point : { (x: any, y: any): void; origin: any; }
+>Point : typeof Point
 >prototype : any
 >{    x: 0,    y: 0,    add: function(dx, dy) {        return new Point(this.x + dx, this.y + dy);    }} : { x: number; y: number; add: (dx: any, dy: any) => any; }
 
@@ -136,7 +136,7 @@ Point.prototype = {
 
         return new Point(this.x + dx, this.y + dy);
 >new Point(this.x + dx, this.y + dy) : any
->Point : { (x: any, y: any): void; origin: any; }
+>Point : typeof Point
 >this.x + dx : any
 >this.x : any
 >this : any

--- a/tests/baselines/reference/typeFromJSInitializer.symbols
+++ b/tests/baselines/reference/typeFromJSInitializer.symbols
@@ -14,74 +14,74 @@ function A () {
 >empty : Symbol(A.empty, Decl(a.js, 3, 31))
 }
 var a = new A()
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >A : Symbol(A, Decl(a.js, 0, 0))
 
 a.unknown = 1
 >a.unknown : Symbol(A.unknown, Decl(a.js, 0, 15))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >unknown : Symbol(A.unknown, Decl(a.js, 0, 15))
 
 a.unknown = true
 >a.unknown : Symbol(A.unknown, Decl(a.js, 0, 15))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >unknown : Symbol(A.unknown, Decl(a.js, 0, 15))
 
 a.unknown = {}
 >a.unknown : Symbol(A.unknown, Decl(a.js, 0, 15))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >unknown : Symbol(A.unknown, Decl(a.js, 0, 15))
 
 a.unknown = 'hi'
 >a.unknown : Symbol(A.unknown, Decl(a.js, 0, 15))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >unknown : Symbol(A.unknown, Decl(a.js, 0, 15))
 
 a.unknowable = 1
 >a.unknowable : Symbol(A.unknowable, Decl(a.js, 2, 23))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >unknowable : Symbol(A.unknowable, Decl(a.js, 2, 23))
 
 a.unknowable = true
 >a.unknowable : Symbol(A.unknowable, Decl(a.js, 2, 23))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >unknowable : Symbol(A.unknowable, Decl(a.js, 2, 23))
 
 a.unknowable = {}
 >a.unknowable : Symbol(A.unknowable, Decl(a.js, 2, 23))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >unknowable : Symbol(A.unknowable, Decl(a.js, 2, 23))
 
 a.unknowable = 'hi'
 >a.unknowable : Symbol(A.unknowable, Decl(a.js, 2, 23))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >unknowable : Symbol(A.unknowable, Decl(a.js, 2, 23))
 
 a.empty.push(1)
 >a.empty.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
 >a.empty : Symbol(A.empty, Decl(a.js, 3, 31))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >empty : Symbol(A.empty, Decl(a.js, 3, 31))
 >push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
 
 a.empty.push(true)
 >a.empty.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
 >a.empty : Symbol(A.empty, Decl(a.js, 3, 31))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >empty : Symbol(A.empty, Decl(a.js, 3, 31))
 >push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
 
 a.empty.push({})
 >a.empty.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
 >a.empty : Symbol(A.empty, Decl(a.js, 3, 31))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >empty : Symbol(A.empty, Decl(a.js, 3, 31))
 >push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
 
 a.empty.push('hi')
 >a.empty.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
 >a.empty : Symbol(A.empty, Decl(a.js, 3, 31))
->a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 8, 16))
+>a : Symbol(a, Decl(a.js, 6, 3), Decl(a.js, 6, 15))
 >empty : Symbol(A.empty, Decl(a.js, 3, 31))
 >push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment17.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment17.symbols
@@ -41,17 +41,17 @@ module.exports = minimatch
 >module.exports : Symbol("tests/cases/conformance/salsa/minimatch", Decl(minimatch.js, 0, 0))
 >module : Symbol(export=, Decl(minimatch.js, 0, 0))
 >exports : Symbol(export=, Decl(minimatch.js, 0, 0))
->minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1))
+>minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1), Decl(minimatch.js, 1, 26))
 
 minimatch.M = M
 >minimatch.M : Symbol(minimatch.M, Decl(minimatch.js, 1, 26))
->minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1))
+>minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1), Decl(minimatch.js, 1, 26))
 >M : Symbol(minimatch.M, Decl(minimatch.js, 1, 26))
 >M : Symbol(M, Decl(minimatch.js, 13, 1), Decl(minimatch.js, 8, 1))
 
 minimatch.filter = filter
 >minimatch.filter : Symbol(minimatch.filter, Decl(minimatch.js, 2, 15))
->minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1))
+>minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1), Decl(minimatch.js, 1, 26))
 >filter : Symbol(minimatch.filter, Decl(minimatch.js, 2, 15))
 >filter : Symbol(filter, Decl(minimatch.js, 3, 25))
 
@@ -59,10 +59,10 @@ function filter() {
 >filter : Symbol(filter, Decl(minimatch.js, 3, 25))
 
     return minimatch()
->minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1))
+>minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1), Decl(minimatch.js, 1, 26))
 }
 function minimatch() {
->minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1))
+>minimatch : Symbol(minimatch, Decl(minimatch.js, 6, 1), Decl(minimatch.js, 1, 26))
 }
 M.defaults = function (def) {
 >M.defaults : Symbol(M.defaults, Decl(minimatch.js, 8, 1))

--- a/tests/baselines/reference/typeFromPropertyAssignment17.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment17.types
@@ -1,8 +1,8 @@
 === tests/cases/conformance/salsa/use.js ===
 /// <reference path='./types.d.ts'/>
 var mini = require('./minimatch')
->mini : { (): void; M: typeof M; filter: () => void; }
->require('./minimatch') : { (): void; M: typeof M; filter: () => void; }
+>mini : typeof minimatch
+>require('./minimatch') : typeof minimatch
 >require : any
 >'./minimatch' : "./minimatch"
 
@@ -10,7 +10,7 @@ mini.M.defaults()
 >mini.M.defaults() : any
 >mini.M.defaults : (def: any) => any
 >mini.M : typeof M
->mini : { (): void; M: typeof M; filter: () => void; }
+>mini : typeof minimatch
 >M : typeof M
 >defaults : (def: any) => any
 
@@ -18,7 +18,7 @@ var m = new mini.M()
 >m : M
 >new mini.M() : M
 >mini.M : typeof M
->mini : { (): void; M: typeof M; filter: () => void; }
+>mini : typeof minimatch
 >M : typeof M
 
 m.m()
@@ -30,7 +30,7 @@ m.m()
 mini.filter()
 >mini.filter() : void
 >mini.filter : () => void
->mini : { (): void; M: typeof M; filter: () => void; }
+>mini : typeof minimatch
 >filter : () => void
 
 === tests/cases/conformance/salsa/types.d.ts ===
@@ -43,23 +43,23 @@ declare var module: any;
 === tests/cases/conformance/salsa/minimatch.js ===
 /// <reference path='./types.d.ts'/>
 module.exports = minimatch
->module.exports = minimatch : { (): void; M: typeof M; filter: () => void; }
->module.exports : { (): void; M: typeof M; filter: () => void; }
->module : { "tests/cases/conformance/salsa/minimatch": { (): void; M: typeof M; filter: () => void; }; }
->exports : { (): void; M: typeof M; filter: () => void; }
->minimatch : { (): void; M: typeof M; filter: () => void; }
+>module.exports = minimatch : typeof minimatch
+>module.exports : typeof minimatch
+>module : { "tests/cases/conformance/salsa/minimatch": typeof minimatch; }
+>exports : typeof minimatch
+>minimatch : typeof minimatch
 
 minimatch.M = M
 >minimatch.M = M : typeof M
 >minimatch.M : typeof M
->minimatch : { (): void; M: typeof M; filter: () => void; }
+>minimatch : typeof minimatch
 >M : typeof M
 >M : typeof M
 
 minimatch.filter = filter
 >minimatch.filter = filter : () => void
 >minimatch.filter : () => void
->minimatch : { (): void; M: typeof M; filter: () => void; }
+>minimatch : typeof minimatch
 >filter : () => void
 >filter : () => void
 
@@ -68,10 +68,10 @@ function filter() {
 
     return minimatch()
 >minimatch() : void
->minimatch : { (): void; M: typeof M; filter: () => void; }
+>minimatch : typeof minimatch
 }
 function minimatch() {
->minimatch : { (): void; M: typeof M; filter: () => void; }
+>minimatch : typeof minimatch
 }
 M.defaults = function (def) {
 >M.defaults = function (def) {    return def} : (def: any) => any

--- a/tests/baselines/reference/typeFromPropertyAssignment18.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment18.symbols
@@ -1,46 +1,46 @@
 === tests/cases/conformance/salsa/a.js ===
 var GLOBSTAR = m.GLOBSTAR = {}
->GLOBSTAR : Symbol(GLOBSTAR, Decl(a.js, 0, 3))
->m.GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14))
->m : Symbol(m, Decl(a.js, 0, 30))
->GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14))
+>GLOBSTAR : Symbol(GLOBSTAR, Decl(a.js, 0, 3), Decl(a.js, 2, 1))
+>m.GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14), Decl(a.js, 4, 2))
+>m : Symbol(m, Decl(a.js, 0, 30), Decl(a.js, 3, 14))
+>GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14), Decl(a.js, 4, 2))
 
 function m() {
->m : Symbol(m, Decl(a.js, 0, 30))
+>m : Symbol(m, Decl(a.js, 0, 30), Decl(a.js, 3, 14))
 }
 GLOBSTAR.p = 1
 >GLOBSTAR.p : Symbol(GLOBSTAR.p, Decl(a.js, 2, 1))
->GLOBSTAR : Symbol(GLOBSTAR, Decl(a.js, 0, 3))
+>GLOBSTAR : Symbol(GLOBSTAR, Decl(a.js, 0, 3), Decl(a.js, 2, 1))
 >p : Symbol(GLOBSTAR.p, Decl(a.js, 2, 1))
 
 m.GLOBSTAR.q = 2
 >m.GLOBSTAR.q : Symbol(m.GLOBSTAR.q, Decl(a.js, 3, 14))
->m.GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14))
->m : Symbol(m, Decl(a.js, 0, 30))
->GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14))
+>m.GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14), Decl(a.js, 4, 2))
+>m : Symbol(m, Decl(a.js, 0, 30), Decl(a.js, 3, 14))
+>GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14), Decl(a.js, 4, 2))
 >q : Symbol(m.GLOBSTAR.q, Decl(a.js, 3, 14))
 
 GLOBSTAR.p
 >GLOBSTAR.p : Symbol(GLOBSTAR.p, Decl(a.js, 2, 1))
->GLOBSTAR : Symbol(GLOBSTAR, Decl(a.js, 0, 3))
+>GLOBSTAR : Symbol(GLOBSTAR, Decl(a.js, 0, 3), Decl(a.js, 2, 1))
 >p : Symbol(GLOBSTAR.p, Decl(a.js, 2, 1))
 
 GLOBSTAR.q
 >GLOBSTAR.q : Symbol(m.GLOBSTAR.q, Decl(a.js, 3, 14))
->GLOBSTAR : Symbol(GLOBSTAR, Decl(a.js, 0, 3))
+>GLOBSTAR : Symbol(GLOBSTAR, Decl(a.js, 0, 3), Decl(a.js, 2, 1))
 >q : Symbol(m.GLOBSTAR.q, Decl(a.js, 3, 14))
 
 m.GLOBSTAR.p
 >m.GLOBSTAR.p : Symbol(GLOBSTAR.p, Decl(a.js, 2, 1))
->m.GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14))
->m : Symbol(m, Decl(a.js, 0, 30))
->GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14))
+>m.GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14), Decl(a.js, 4, 2))
+>m : Symbol(m, Decl(a.js, 0, 30), Decl(a.js, 3, 14))
+>GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14), Decl(a.js, 4, 2))
 >p : Symbol(GLOBSTAR.p, Decl(a.js, 2, 1))
 
 m.GLOBSTAR.q
 >m.GLOBSTAR.q : Symbol(m.GLOBSTAR.q, Decl(a.js, 3, 14))
->m.GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14))
->m : Symbol(m, Decl(a.js, 0, 30))
->GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14))
+>m.GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14), Decl(a.js, 4, 2))
+>m : Symbol(m, Decl(a.js, 0, 30), Decl(a.js, 3, 14))
+>GLOBSTAR : Symbol(m.GLOBSTAR, Decl(a.js, 0, 14), Decl(a.js, 4, 2))
 >q : Symbol(m.GLOBSTAR.q, Decl(a.js, 3, 14))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment18.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment18.types
@@ -1,52 +1,52 @@
 === tests/cases/conformance/salsa/a.js ===
 var GLOBSTAR = m.GLOBSTAR = {}
->GLOBSTAR : { q: number; p: number; }
->m.GLOBSTAR = {} : { q: number; p: number; }
->m.GLOBSTAR : { q: number; p: number; }
->m : { (): void; GLOBSTAR: { q: number; p: number; }; }
->GLOBSTAR : { q: number; p: number; }
+>GLOBSTAR : typeof m.GLOBSTAR
+>m.GLOBSTAR = {} : typeof m.GLOBSTAR
+>m.GLOBSTAR : typeof m.GLOBSTAR
+>m : typeof m
+>GLOBSTAR : typeof m.GLOBSTAR
 >{} : {}
 
 function m() {
->m : { (): void; GLOBSTAR: { q: number; p: number; }; }
+>m : typeof m
 }
 GLOBSTAR.p = 1
 >GLOBSTAR.p = 1 : 1
 >GLOBSTAR.p : number
->GLOBSTAR : { q: number; p: number; }
+>GLOBSTAR : typeof m.GLOBSTAR
 >p : number
 >1 : 1
 
 m.GLOBSTAR.q = 2
 >m.GLOBSTAR.q = 2 : 2
 >m.GLOBSTAR.q : number
->m.GLOBSTAR : { q: number; p: number; }
->m : { (): void; GLOBSTAR: { q: number; p: number; }; }
->GLOBSTAR : { q: number; p: number; }
+>m.GLOBSTAR : typeof m.GLOBSTAR
+>m : typeof m
+>GLOBSTAR : typeof m.GLOBSTAR
 >q : number
 >2 : 2
 
 GLOBSTAR.p
 >GLOBSTAR.p : number
->GLOBSTAR : { q: number; p: number; }
+>GLOBSTAR : typeof m.GLOBSTAR
 >p : number
 
 GLOBSTAR.q
 >GLOBSTAR.q : number
->GLOBSTAR : { q: number; p: number; }
+>GLOBSTAR : typeof m.GLOBSTAR
 >q : number
 
 m.GLOBSTAR.p
 >m.GLOBSTAR.p : number
->m.GLOBSTAR : { q: number; p: number; }
->m : { (): void; GLOBSTAR: { q: number; p: number; }; }
->GLOBSTAR : { q: number; p: number; }
+>m.GLOBSTAR : typeof m.GLOBSTAR
+>m : typeof m
+>GLOBSTAR : typeof m.GLOBSTAR
 >p : number
 
 m.GLOBSTAR.q
 >m.GLOBSTAR.q : number
->m.GLOBSTAR : { q: number; p: number; }
->m : { (): void; GLOBSTAR: { q: number; p: number; }; }
->GLOBSTAR : { q: number; p: number; }
+>m.GLOBSTAR : typeof m.GLOBSTAR
+>m : typeof m
+>GLOBSTAR : typeof m.GLOBSTAR
 >q : number
 

--- a/tests/baselines/reference/typeFromPropertyAssignment22.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment22.symbols
@@ -28,14 +28,14 @@ Installer.prototype.loadArgMetadata = function (next) {
     }
 }
 var i = new Installer()
->i : Symbol(i, Decl(npm-install.js, 10, 3))
+>i : Symbol(i, Decl(npm-install.js, 10, 3), Decl(npm-install.js, 10, 23))
 >Installer : Symbol(Installer, Decl(npm-install.js, 0, 0))
 
 i.newProperty = i.args // ok, number ==> number | undefined
 >i.newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 24))
->i : Symbol(i, Decl(npm-install.js, 10, 3))
+>i : Symbol(i, Decl(npm-install.js, 10, 3), Decl(npm-install.js, 10, 23))
 >newProperty : Symbol(Installer.newProperty, Decl(npm-install.js, 6, 24))
 >i.args : Symbol(Installer.args, Decl(npm-install.js, 0, 23), Decl(npm-install.js, 5, 15))
->i : Symbol(i, Decl(npm-install.js, 10, 3))
+>i : Symbol(i, Decl(npm-install.js, 10, 3), Decl(npm-install.js, 10, 23))
 >args : Symbol(Installer.args, Decl(npm-install.js, 0, 23), Decl(npm-install.js, 5, 15))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment29.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment29.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/salsa/typeFromPropertyAssignment29.ts ===
 function ExpandoDecl(n: number) {
->ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 3, 20))
+>ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 2, 1))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 0, 21))
 
     return n.toString();
@@ -10,12 +10,12 @@ function ExpandoDecl(n: number) {
 }
 ExpandoDecl.prop = 2
 >ExpandoDecl.prop : Symbol(ExpandoDecl.prop, Decl(typeFromPropertyAssignment29.ts, 2, 1))
->ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 3, 20))
+>ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 2, 1))
 >prop : Symbol(ExpandoDecl.prop, Decl(typeFromPropertyAssignment29.ts, 2, 1))
 
 ExpandoDecl.m = function(n: number) {
 >ExpandoDecl.m : Symbol(ExpandoDecl.m, Decl(typeFromPropertyAssignment29.ts, 3, 20))
->ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 3, 20))
+>ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 2, 1))
 >m : Symbol(ExpandoDecl.m, Decl(typeFromPropertyAssignment29.ts, 3, 20))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 4, 25))
 
@@ -25,17 +25,17 @@ ExpandoDecl.m = function(n: number) {
 var n = ExpandoDecl.prop + ExpandoDecl.m(12) + ExpandoDecl(101).length
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 7, 3), Decl(typeFromPropertyAssignment29.ts, 17, 3), Decl(typeFromPropertyAssignment29.ts, 45, 3), Decl(typeFromPropertyAssignment29.ts, 63, 3), Decl(typeFromPropertyAssignment29.ts, 73, 3) ... and 1 more)
 >ExpandoDecl.prop : Symbol(ExpandoDecl.prop, Decl(typeFromPropertyAssignment29.ts, 2, 1))
->ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 3, 20))
+>ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 2, 1))
 >prop : Symbol(ExpandoDecl.prop, Decl(typeFromPropertyAssignment29.ts, 2, 1))
 >ExpandoDecl.m : Symbol(ExpandoDecl.m, Decl(typeFromPropertyAssignment29.ts, 3, 20))
->ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 3, 20))
+>ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 2, 1))
 >m : Symbol(ExpandoDecl.m, Decl(typeFromPropertyAssignment29.ts, 3, 20))
 >ExpandoDecl(101).length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 3, 20))
+>ExpandoDecl : Symbol(ExpandoDecl, Decl(typeFromPropertyAssignment29.ts, 0, 0), Decl(typeFromPropertyAssignment29.ts, 2, 1))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
 const ExpandoExpr = function (n: number) {
->ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 13, 28))
+>ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 11, 1))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 9, 30))
 
     return n.toString();
@@ -45,19 +45,19 @@ const ExpandoExpr = function (n: number) {
 }
 ExpandoExpr.prop = { x: 2 }
 >ExpandoExpr.prop : Symbol(ExpandoExpr.prop, Decl(typeFromPropertyAssignment29.ts, 11, 1), Decl(typeFromPropertyAssignment29.ts, 12, 27))
->ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 13, 28))
+>ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 11, 1))
 >prop : Symbol(ExpandoExpr.prop, Decl(typeFromPropertyAssignment29.ts, 11, 1), Decl(typeFromPropertyAssignment29.ts, 12, 27))
 >x : Symbol(x, Decl(typeFromPropertyAssignment29.ts, 12, 20))
 
 ExpandoExpr.prop = { y: "" }
 >ExpandoExpr.prop : Symbol(ExpandoExpr.prop, Decl(typeFromPropertyAssignment29.ts, 11, 1), Decl(typeFromPropertyAssignment29.ts, 12, 27))
->ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 13, 28))
+>ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 11, 1))
 >prop : Symbol(ExpandoExpr.prop, Decl(typeFromPropertyAssignment29.ts, 11, 1), Decl(typeFromPropertyAssignment29.ts, 12, 27))
 >y : Symbol(y, Decl(typeFromPropertyAssignment29.ts, 13, 20))
 
 ExpandoExpr.m = function(n: number) {
 >ExpandoExpr.m : Symbol(ExpandoExpr.m, Decl(typeFromPropertyAssignment29.ts, 13, 28))
->ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 13, 28))
+>ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 11, 1))
 >m : Symbol(ExpandoExpr.m, Decl(typeFromPropertyAssignment29.ts, 13, 28))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 14, 25))
 
@@ -68,18 +68,18 @@ var n = (ExpandoExpr.prop.x || 0) + ExpandoExpr.m(12) + ExpandoExpr(101).length
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 7, 3), Decl(typeFromPropertyAssignment29.ts, 17, 3), Decl(typeFromPropertyAssignment29.ts, 45, 3), Decl(typeFromPropertyAssignment29.ts, 63, 3), Decl(typeFromPropertyAssignment29.ts, 73, 3) ... and 1 more)
 >ExpandoExpr.prop.x : Symbol(x, Decl(typeFromPropertyAssignment29.ts, 12, 20))
 >ExpandoExpr.prop : Symbol(ExpandoExpr.prop, Decl(typeFromPropertyAssignment29.ts, 11, 1), Decl(typeFromPropertyAssignment29.ts, 12, 27))
->ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 13, 28))
+>ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 11, 1))
 >prop : Symbol(ExpandoExpr.prop, Decl(typeFromPropertyAssignment29.ts, 11, 1), Decl(typeFromPropertyAssignment29.ts, 12, 27))
 >x : Symbol(x, Decl(typeFromPropertyAssignment29.ts, 12, 20))
 >ExpandoExpr.m : Symbol(ExpandoExpr.m, Decl(typeFromPropertyAssignment29.ts, 13, 28))
->ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 13, 28))
+>ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 11, 1))
 >m : Symbol(ExpandoExpr.m, Decl(typeFromPropertyAssignment29.ts, 13, 28))
 >ExpandoExpr(101).length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 13, 28))
+>ExpandoExpr : Symbol(ExpandoExpr, Decl(typeFromPropertyAssignment29.ts, 9, 5), Decl(typeFromPropertyAssignment29.ts, 11, 1))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
 const ExpandoArrow = (n: number) => n.toString();
->ExpandoArrow : Symbol(ExpandoArrow, Decl(typeFromPropertyAssignment29.ts, 19, 5), Decl(typeFromPropertyAssignment29.ts, 20, 21))
+>ExpandoArrow : Symbol(ExpandoArrow, Decl(typeFromPropertyAssignment29.ts, 19, 5), Decl(typeFromPropertyAssignment29.ts, 19, 49))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 19, 22))
 >n.toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 19, 22))
@@ -87,12 +87,12 @@ const ExpandoArrow = (n: number) => n.toString();
 
 ExpandoArrow.prop = 2
 >ExpandoArrow.prop : Symbol(ExpandoArrow.prop, Decl(typeFromPropertyAssignment29.ts, 19, 49))
->ExpandoArrow : Symbol(ExpandoArrow, Decl(typeFromPropertyAssignment29.ts, 19, 5), Decl(typeFromPropertyAssignment29.ts, 20, 21))
+>ExpandoArrow : Symbol(ExpandoArrow, Decl(typeFromPropertyAssignment29.ts, 19, 5), Decl(typeFromPropertyAssignment29.ts, 19, 49))
 >prop : Symbol(ExpandoArrow.prop, Decl(typeFromPropertyAssignment29.ts, 19, 49))
 
 ExpandoArrow.m = function(n: number) {
 >ExpandoArrow.m : Symbol(ExpandoArrow.m, Decl(typeFromPropertyAssignment29.ts, 20, 21))
->ExpandoArrow : Symbol(ExpandoArrow, Decl(typeFromPropertyAssignment29.ts, 19, 5), Decl(typeFromPropertyAssignment29.ts, 20, 21))
+>ExpandoArrow : Symbol(ExpandoArrow, Decl(typeFromPropertyAssignment29.ts, 19, 5), Decl(typeFromPropertyAssignment29.ts, 19, 49))
 >m : Symbol(ExpandoArrow.m, Decl(typeFromPropertyAssignment29.ts, 20, 21))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 21, 26))
 
@@ -102,7 +102,7 @@ ExpandoArrow.m = function(n: number) {
 }
 
 function ExpandoNested(n: number) {
->ExpandoNested : Symbol(ExpandoNested, Decl(typeFromPropertyAssignment29.ts, 24, 1))
+>ExpandoNested : Symbol(ExpandoNested, Decl(typeFromPropertyAssignment29.ts, 24, 1), Decl(typeFromPropertyAssignment29.ts, 32, 1))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 26, 23))
 
     const nested = function (m: number) {
@@ -125,11 +125,11 @@ function ExpandoNested(n: number) {
 }
 ExpandoNested.also = -1;
 >ExpandoNested.also : Symbol(ExpandoNested.also, Decl(typeFromPropertyAssignment29.ts, 32, 1))
->ExpandoNested : Symbol(ExpandoNested, Decl(typeFromPropertyAssignment29.ts, 24, 1))
+>ExpandoNested : Symbol(ExpandoNested, Decl(typeFromPropertyAssignment29.ts, 24, 1), Decl(typeFromPropertyAssignment29.ts, 32, 1))
 >also : Symbol(ExpandoNested.also, Decl(typeFromPropertyAssignment29.ts, 32, 1))
 
 function ExpandoMerge(n: number) {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 37, 1), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 35, 22))
 
     return n * 100;
@@ -137,17 +137,17 @@ function ExpandoMerge(n: number) {
 }
 ExpandoMerge.p1 = 111
 >ExpandoMerge.p1 : Symbol(ExpandoMerge.p1, Decl(typeFromPropertyAssignment29.ts, 37, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 37, 1), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
 >p1 : Symbol(ExpandoMerge.p1, Decl(typeFromPropertyAssignment29.ts, 37, 1))
 
 namespace ExpandoMerge {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 37, 1), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
 
     export var p2 = 222;
 >p2 : Symbol(p2, Decl(typeFromPropertyAssignment29.ts, 40, 14))
 }
 namespace ExpandoMerge {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 37, 1), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
 
     export var p3 = 333;
 >p3 : Symbol(p3, Decl(typeFromPropertyAssignment29.ts, 43, 14))
@@ -155,15 +155,15 @@ namespace ExpandoMerge {
 var n = ExpandoMerge.p1 + ExpandoMerge.p2 + ExpandoMerge.p3 + ExpandoMerge(1);
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 7, 3), Decl(typeFromPropertyAssignment29.ts, 17, 3), Decl(typeFromPropertyAssignment29.ts, 45, 3), Decl(typeFromPropertyAssignment29.ts, 63, 3), Decl(typeFromPropertyAssignment29.ts, 73, 3) ... and 1 more)
 >ExpandoMerge.p1 : Symbol(ExpandoMerge.p1, Decl(typeFromPropertyAssignment29.ts, 37, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 37, 1), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
 >p1 : Symbol(ExpandoMerge.p1, Decl(typeFromPropertyAssignment29.ts, 37, 1))
 >ExpandoMerge.p2 : Symbol(ExpandoMerge.p2, Decl(typeFromPropertyAssignment29.ts, 40, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 37, 1), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
 >p2 : Symbol(ExpandoMerge.p2, Decl(typeFromPropertyAssignment29.ts, 40, 14))
 >ExpandoMerge.p3 : Symbol(ExpandoMerge.p3, Decl(typeFromPropertyAssignment29.ts, 43, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 37, 1), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
 >p3 : Symbol(ExpandoMerge.p3, Decl(typeFromPropertyAssignment29.ts, 43, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment29.ts, 33, 24), Decl(typeFromPropertyAssignment29.ts, 37, 1), Decl(typeFromPropertyAssignment29.ts, 38, 21), Decl(typeFromPropertyAssignment29.ts, 41, 1))
 
 namespace Ns {
 >Ns : Symbol(Ns, Decl(typeFromPropertyAssignment29.ts, 45, 78))
@@ -186,7 +186,7 @@ namespace Ns {
 
 // Should not work in Typescript -- must be const
 var ExpandoExpr2 = function (n: number) {
->ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 59, 21))
+>ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 58, 1))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 56, 29))
 
     return n.toString();
@@ -195,10 +195,10 @@ var ExpandoExpr2 = function (n: number) {
 >toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
 }
 ExpandoExpr2.prop = 2
->ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 59, 21))
+>ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 58, 1))
 
 ExpandoExpr2.m = function(n: number) {
->ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 59, 21))
+>ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 58, 1))
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 60, 26))
 
     return n + 1;
@@ -206,10 +206,10 @@ ExpandoExpr2.m = function(n: number) {
 }
 var n = ExpandoExpr2.prop + ExpandoExpr2.m(12) + ExpandoExpr2(101).length
 >n : Symbol(n, Decl(typeFromPropertyAssignment29.ts, 7, 3), Decl(typeFromPropertyAssignment29.ts, 17, 3), Decl(typeFromPropertyAssignment29.ts, 45, 3), Decl(typeFromPropertyAssignment29.ts, 63, 3), Decl(typeFromPropertyAssignment29.ts, 73, 3) ... and 1 more)
->ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 59, 21))
->ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 59, 21))
+>ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 58, 1))
+>ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 58, 1))
 >ExpandoExpr2(101).length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
->ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 59, 21))
+>ExpandoExpr2 : Symbol(ExpandoExpr2, Decl(typeFromPropertyAssignment29.ts, 56, 3), Decl(typeFromPropertyAssignment29.ts, 58, 1))
 >length : Symbol(String.length, Decl(lib.es5.d.ts, --, --))
 
 // Should not work in typescript -- classes already have statics

--- a/tests/baselines/reference/typeFromPropertyAssignment29.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment29.types
@@ -144,7 +144,7 @@ ExpandoArrow.m = function(n: number) {
 }
 
 function ExpandoNested(n: number) {
->ExpandoNested : { (n: number): { (m: number): number; total: number; }; also: number; }
+>ExpandoNested : typeof ExpandoNested
 >n : number
 
     const nested = function (m: number) {
@@ -173,7 +173,7 @@ function ExpandoNested(n: number) {
 ExpandoNested.also = -1;
 >ExpandoNested.also = -1 : -1
 >ExpandoNested.also : number
->ExpandoNested : { (n: number): { (m: number): number; total: number; }; also: number; }
+>ExpandoNested : typeof ExpandoNested
 >also : number
 >-1 : -1
 >1 : 1

--- a/tests/baselines/reference/typeFromPropertyAssignment31.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment31.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/salsa/typeFromPropertyAssignment31.ts ===
 function ExpandoMerge(n: number) {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >n : Symbol(n, Decl(typeFromPropertyAssignment31.ts, 0, 22))
 
     return n;
@@ -8,12 +8,12 @@ function ExpandoMerge(n: number) {
 }
 ExpandoMerge.p1 = 111
 >ExpandoMerge.p1 : Symbol(ExpandoMerge.p1, Decl(typeFromPropertyAssignment31.ts, 2, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p1 : Symbol(ExpandoMerge.p1, Decl(typeFromPropertyAssignment31.ts, 2, 1))
 
 ExpandoMerge.m = function(n: number) {
 >ExpandoMerge.m : Symbol(ExpandoMerge.m, Decl(typeFromPropertyAssignment31.ts, 3, 21))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >m : Symbol(ExpandoMerge.m, Decl(typeFromPropertyAssignment31.ts, 3, 21))
 >n : Symbol(n, Decl(typeFromPropertyAssignment31.ts, 4, 26))
 
@@ -21,28 +21,28 @@ ExpandoMerge.m = function(n: number) {
 >n : Symbol(n, Decl(typeFromPropertyAssignment31.ts, 4, 26))
 }
 namespace ExpandoMerge {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 
     export var p2 = 222;
 >p2 : Symbol(p2, Decl(typeFromPropertyAssignment31.ts, 8, 14))
 }
 ExpandoMerge.p4 = 44444; // ok
 >ExpandoMerge.p4 : Symbol(ExpandoMerge.p4, Decl(typeFromPropertyAssignment31.ts, 9, 1), Decl(typeFromPropertyAssignment31.ts, 15, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p4 : Symbol(ExpandoMerge.p4, Decl(typeFromPropertyAssignment31.ts, 9, 1), Decl(typeFromPropertyAssignment31.ts, 15, 14))
 
 ExpandoMerge.p6 = 66666; // ok
 >ExpandoMerge.p6 : Symbol(ExpandoMerge.p6, Decl(typeFromPropertyAssignment31.ts, 10, 24), Decl(typeFromPropertyAssignment31.ts, 17, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p6 : Symbol(ExpandoMerge.p6, Decl(typeFromPropertyAssignment31.ts, 10, 24), Decl(typeFromPropertyAssignment31.ts, 17, 14))
 
 ExpandoMerge.p8 = false; // type error
 >ExpandoMerge.p8 : Symbol(ExpandoMerge.p8, Decl(typeFromPropertyAssignment31.ts, 11, 24), Decl(typeFromPropertyAssignment31.ts, 19, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p8 : Symbol(ExpandoMerge.p8, Decl(typeFromPropertyAssignment31.ts, 11, 24), Decl(typeFromPropertyAssignment31.ts, 19, 14))
 
 namespace ExpandoMerge {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 
     export var p3 = 333;
 >p3 : Symbol(p3, Decl(typeFromPropertyAssignment31.ts, 14, 14))
@@ -67,50 +67,50 @@ namespace ExpandoMerge {
 }
 ExpandoMerge.p5 = 555555; // ok
 >ExpandoMerge.p5 : Symbol(ExpandoMerge.p5, Decl(typeFromPropertyAssignment31.ts, 16, 14), Decl(typeFromPropertyAssignment31.ts, 21, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p5 : Symbol(ExpandoMerge.p5, Decl(typeFromPropertyAssignment31.ts, 16, 14), Decl(typeFromPropertyAssignment31.ts, 21, 1))
 
 ExpandoMerge.p7 = 777777; // ok
 >ExpandoMerge.p7 : Symbol(ExpandoMerge.p7, Decl(typeFromPropertyAssignment31.ts, 18, 14), Decl(typeFromPropertyAssignment31.ts, 22, 25))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p7 : Symbol(ExpandoMerge.p7, Decl(typeFromPropertyAssignment31.ts, 18, 14), Decl(typeFromPropertyAssignment31.ts, 22, 25))
 
 ExpandoMerge.p9 = false; // type error
 >ExpandoMerge.p9 : Symbol(ExpandoMerge.p9, Decl(typeFromPropertyAssignment31.ts, 20, 14), Decl(typeFromPropertyAssignment31.ts, 23, 25))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p9 : Symbol(ExpandoMerge.p9, Decl(typeFromPropertyAssignment31.ts, 20, 14), Decl(typeFromPropertyAssignment31.ts, 23, 25))
 
 var n = ExpandoMerge.p1 + ExpandoMerge.p2 + ExpandoMerge.p3 + ExpandoMerge.p4 + ExpandoMerge.p5 + ExpandoMerge.p6 + ExpandoMerge.p7 + ExpandoMerge.p8 + ExpandoMerge.p9 + ExpandoMerge.m(12) + ExpandoMerge(1001);
 >n : Symbol(n, Decl(typeFromPropertyAssignment31.ts, 25, 3))
 >ExpandoMerge.p1 : Symbol(ExpandoMerge.p1, Decl(typeFromPropertyAssignment31.ts, 2, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p1 : Symbol(ExpandoMerge.p1, Decl(typeFromPropertyAssignment31.ts, 2, 1))
 >ExpandoMerge.p2 : Symbol(ExpandoMerge.p2, Decl(typeFromPropertyAssignment31.ts, 8, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p2 : Symbol(ExpandoMerge.p2, Decl(typeFromPropertyAssignment31.ts, 8, 14))
 >ExpandoMerge.p3 : Symbol(ExpandoMerge.p3, Decl(typeFromPropertyAssignment31.ts, 14, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p3 : Symbol(ExpandoMerge.p3, Decl(typeFromPropertyAssignment31.ts, 14, 14))
 >ExpandoMerge.p4 : Symbol(ExpandoMerge.p4, Decl(typeFromPropertyAssignment31.ts, 9, 1), Decl(typeFromPropertyAssignment31.ts, 15, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p4 : Symbol(ExpandoMerge.p4, Decl(typeFromPropertyAssignment31.ts, 9, 1), Decl(typeFromPropertyAssignment31.ts, 15, 14))
 >ExpandoMerge.p5 : Symbol(ExpandoMerge.p5, Decl(typeFromPropertyAssignment31.ts, 16, 14), Decl(typeFromPropertyAssignment31.ts, 21, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p5 : Symbol(ExpandoMerge.p5, Decl(typeFromPropertyAssignment31.ts, 16, 14), Decl(typeFromPropertyAssignment31.ts, 21, 1))
 >ExpandoMerge.p6 : Symbol(ExpandoMerge.p6, Decl(typeFromPropertyAssignment31.ts, 10, 24), Decl(typeFromPropertyAssignment31.ts, 17, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p6 : Symbol(ExpandoMerge.p6, Decl(typeFromPropertyAssignment31.ts, 10, 24), Decl(typeFromPropertyAssignment31.ts, 17, 14))
 >ExpandoMerge.p7 : Symbol(ExpandoMerge.p7, Decl(typeFromPropertyAssignment31.ts, 18, 14), Decl(typeFromPropertyAssignment31.ts, 22, 25))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p7 : Symbol(ExpandoMerge.p7, Decl(typeFromPropertyAssignment31.ts, 18, 14), Decl(typeFromPropertyAssignment31.ts, 22, 25))
 >ExpandoMerge.p8 : Symbol(ExpandoMerge.p8, Decl(typeFromPropertyAssignment31.ts, 11, 24), Decl(typeFromPropertyAssignment31.ts, 19, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p8 : Symbol(ExpandoMerge.p8, Decl(typeFromPropertyAssignment31.ts, 11, 24), Decl(typeFromPropertyAssignment31.ts, 19, 14))
 >ExpandoMerge.p9 : Symbol(ExpandoMerge.p9, Decl(typeFromPropertyAssignment31.ts, 20, 14), Decl(typeFromPropertyAssignment31.ts, 23, 25))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >p9 : Symbol(ExpandoMerge.p9, Decl(typeFromPropertyAssignment31.ts, 20, 14), Decl(typeFromPropertyAssignment31.ts, 23, 25))
 >ExpandoMerge.m : Symbol(ExpandoMerge.m, Decl(typeFromPropertyAssignment31.ts, 3, 21))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 >m : Symbol(ExpandoMerge.m, Decl(typeFromPropertyAssignment31.ts, 3, 21))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 3, 21), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(typeFromPropertyAssignment31.ts, 0, 0), Decl(typeFromPropertyAssignment31.ts, 2, 1), Decl(typeFromPropertyAssignment31.ts, 6, 1), Decl(typeFromPropertyAssignment31.ts, 12, 24))
 

--- a/tests/baselines/reference/typeFromPropertyAssignment32.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment32.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/salsa/expando.ts ===
 function ExpandoMerge(n: number) {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >n : Symbol(n, Decl(expando.ts, 0, 22))
 
     return n;
@@ -8,12 +8,12 @@ function ExpandoMerge(n: number) {
 }
 ExpandoMerge.p1 = 111
 >ExpandoMerge.p1 : Symbol(ExpandoMerge.p1, Decl(expando.ts, 2, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p1 : Symbol(ExpandoMerge.p1, Decl(expando.ts, 2, 1))
 
 ExpandoMerge.m = function(n: number) {
 >ExpandoMerge.m : Symbol(ExpandoMerge.m, Decl(expando.ts, 3, 21))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >m : Symbol(ExpandoMerge.m, Decl(expando.ts, 3, 21))
 >n : Symbol(n, Decl(expando.ts, 4, 26))
 
@@ -22,71 +22,71 @@ ExpandoMerge.m = function(n: number) {
 }
 ExpandoMerge.p4 = 44444;
 >ExpandoMerge.p4 : Symbol(ExpandoMerge.p4, Decl(expando.ts, 6, 1), Decl(ns.ts, 2, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p4 : Symbol(ExpandoMerge.p4, Decl(expando.ts, 6, 1), Decl(ns.ts, 2, 14))
 
 ExpandoMerge.p5 = 555555;
 >ExpandoMerge.p5 : Symbol(ExpandoMerge.p5, Decl(expando.ts, 7, 24), Decl(ns.ts, 3, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p5 : Symbol(ExpandoMerge.p5, Decl(expando.ts, 7, 24), Decl(ns.ts, 3, 14))
 
 ExpandoMerge.p6 = 66666;
 >ExpandoMerge.p6 : Symbol(ExpandoMerge.p6, Decl(expando.ts, 8, 25), Decl(ns.ts, 4, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p6 : Symbol(ExpandoMerge.p6, Decl(expando.ts, 8, 25), Decl(ns.ts, 4, 14))
 
 ExpandoMerge.p7 = 777777;
 >ExpandoMerge.p7 : Symbol(ExpandoMerge.p7, Decl(expando.ts, 9, 24), Decl(ns.ts, 5, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p7 : Symbol(ExpandoMerge.p7, Decl(expando.ts, 9, 24), Decl(ns.ts, 5, 14))
 
 ExpandoMerge.p8 = false; // type error
 >ExpandoMerge.p8 : Symbol(ExpandoMerge.p8, Decl(expando.ts, 10, 25), Decl(ns.ts, 6, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p8 : Symbol(ExpandoMerge.p8, Decl(expando.ts, 10, 25), Decl(ns.ts, 6, 14))
 
 ExpandoMerge.p9 = false; // type error
 >ExpandoMerge.p9 : Symbol(ExpandoMerge.p9, Decl(expando.ts, 11, 24), Decl(ns.ts, 7, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p9 : Symbol(ExpandoMerge.p9, Decl(expando.ts, 11, 24), Decl(ns.ts, 7, 14))
 
 var n = ExpandoMerge.p1 + ExpandoMerge.p2 + ExpandoMerge.p3 + ExpandoMerge.p4 + ExpandoMerge.p5 + ExpandoMerge.p6 + ExpandoMerge.p7 + ExpandoMerge.p8 + ExpandoMerge.p9 + ExpandoMerge.m(12) + ExpandoMerge(1001);
 >n : Symbol(n, Decl(expando.ts, 13, 3))
 >ExpandoMerge.p1 : Symbol(ExpandoMerge.p1, Decl(expando.ts, 2, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p1 : Symbol(ExpandoMerge.p1, Decl(expando.ts, 2, 1))
 >ExpandoMerge.p2 : Symbol(ExpandoMerge.p2, Decl(ns.ts, 10, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p2 : Symbol(ExpandoMerge.p2, Decl(ns.ts, 10, 14))
 >ExpandoMerge.p3 : Symbol(ExpandoMerge.p3, Decl(ns.ts, 1, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p3 : Symbol(ExpandoMerge.p3, Decl(ns.ts, 1, 14))
 >ExpandoMerge.p4 : Symbol(ExpandoMerge.p4, Decl(expando.ts, 6, 1), Decl(ns.ts, 2, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p4 : Symbol(ExpandoMerge.p4, Decl(expando.ts, 6, 1), Decl(ns.ts, 2, 14))
 >ExpandoMerge.p5 : Symbol(ExpandoMerge.p5, Decl(expando.ts, 7, 24), Decl(ns.ts, 3, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p5 : Symbol(ExpandoMerge.p5, Decl(expando.ts, 7, 24), Decl(ns.ts, 3, 14))
 >ExpandoMerge.p6 : Symbol(ExpandoMerge.p6, Decl(expando.ts, 8, 25), Decl(ns.ts, 4, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p6 : Symbol(ExpandoMerge.p6, Decl(expando.ts, 8, 25), Decl(ns.ts, 4, 14))
 >ExpandoMerge.p7 : Symbol(ExpandoMerge.p7, Decl(expando.ts, 9, 24), Decl(ns.ts, 5, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p7 : Symbol(ExpandoMerge.p7, Decl(expando.ts, 9, 24), Decl(ns.ts, 5, 14))
 >ExpandoMerge.p8 : Symbol(ExpandoMerge.p8, Decl(expando.ts, 10, 25), Decl(ns.ts, 6, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p8 : Symbol(ExpandoMerge.p8, Decl(expando.ts, 10, 25), Decl(ns.ts, 6, 14))
 >ExpandoMerge.p9 : Symbol(ExpandoMerge.p9, Decl(expando.ts, 11, 24), Decl(ns.ts, 7, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >p9 : Symbol(ExpandoMerge.p9, Decl(expando.ts, 11, 24), Decl(ns.ts, 7, 14))
 >ExpandoMerge.m : Symbol(ExpandoMerge.m, Decl(expando.ts, 3, 21))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 >m : Symbol(ExpandoMerge.m, Decl(expando.ts, 3, 21))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 
 === tests/cases/conformance/salsa/ns.ts ===
 namespace ExpandoMerge {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 
     export var p3 = 333;
 >p3 : Symbol(p3, Decl(ns.ts, 1, 14))
@@ -110,7 +110,7 @@ namespace ExpandoMerge {
 >p9 : Symbol(p9, Decl(expando.ts, 11, 24), Decl(ns.ts, 7, 14))
 }
 namespace ExpandoMerge {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1), Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1))
 
     export var p2 = 222;
 >p2 : Symbol(p2, Decl(ns.ts, 10, 14))

--- a/tests/baselines/reference/typeFromPropertyAssignment33.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment33.symbols
@@ -1,6 +1,6 @@
 === tests/cases/conformance/salsa/ns.ts ===
 namespace ExpandoMerge {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 
     export var p3 = 333;
 >p3 : Symbol(p3, Decl(ns.ts, 1, 14))
@@ -24,7 +24,7 @@ namespace ExpandoMerge {
 >p9 : Symbol(p9, Decl(ns.ts, 7, 14), Decl(expando.ts, 11, 24))
 }
 namespace ExpandoMerge {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 
     export var p2 = 222;
 >p2 : Symbol(p2, Decl(ns.ts, 10, 14))
@@ -33,7 +33,7 @@ namespace ExpandoMerge {
 
 === tests/cases/conformance/salsa/expando.ts ===
 function ExpandoMerge(n: number) {
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >n : Symbol(n, Decl(expando.ts, 0, 22))
 
     return n;
@@ -41,12 +41,12 @@ function ExpandoMerge(n: number) {
 }
 ExpandoMerge.p1 = 111
 >ExpandoMerge.p1 : Symbol(ExpandoMerge.p1, Decl(expando.ts, 2, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p1 : Symbol(ExpandoMerge.p1, Decl(expando.ts, 2, 1))
 
 ExpandoMerge.m = function(n: number) {
 >ExpandoMerge.m : Symbol(ExpandoMerge.m, Decl(expando.ts, 3, 21))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >m : Symbol(ExpandoMerge.m, Decl(expando.ts, 3, 21))
 >n : Symbol(n, Decl(expando.ts, 4, 26))
 
@@ -55,66 +55,66 @@ ExpandoMerge.m = function(n: number) {
 }
 ExpandoMerge.p4 = 44444;
 >ExpandoMerge.p4 : Symbol(ExpandoMerge.p4, Decl(ns.ts, 2, 14), Decl(expando.ts, 6, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p4 : Symbol(ExpandoMerge.p4, Decl(ns.ts, 2, 14), Decl(expando.ts, 6, 1))
 
 ExpandoMerge.p5 = 555555;
 >ExpandoMerge.p5 : Symbol(ExpandoMerge.p5, Decl(ns.ts, 3, 14), Decl(expando.ts, 7, 24))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p5 : Symbol(ExpandoMerge.p5, Decl(ns.ts, 3, 14), Decl(expando.ts, 7, 24))
 
 ExpandoMerge.p6 = 66666;
 >ExpandoMerge.p6 : Symbol(ExpandoMerge.p6, Decl(ns.ts, 4, 14), Decl(expando.ts, 8, 25))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p6 : Symbol(ExpandoMerge.p6, Decl(ns.ts, 4, 14), Decl(expando.ts, 8, 25))
 
 ExpandoMerge.p7 = 777777;
 >ExpandoMerge.p7 : Symbol(ExpandoMerge.p7, Decl(ns.ts, 5, 14), Decl(expando.ts, 9, 24))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p7 : Symbol(ExpandoMerge.p7, Decl(ns.ts, 5, 14), Decl(expando.ts, 9, 24))
 
 ExpandoMerge.p8 = false; // type error
 >ExpandoMerge.p8 : Symbol(ExpandoMerge.p8, Decl(ns.ts, 6, 14), Decl(expando.ts, 10, 25))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p8 : Symbol(ExpandoMerge.p8, Decl(ns.ts, 6, 14), Decl(expando.ts, 10, 25))
 
 ExpandoMerge.p9 = false; // type error
 >ExpandoMerge.p9 : Symbol(ExpandoMerge.p9, Decl(ns.ts, 7, 14), Decl(expando.ts, 11, 24))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p9 : Symbol(ExpandoMerge.p9, Decl(ns.ts, 7, 14), Decl(expando.ts, 11, 24))
 
 var n = ExpandoMerge.p1 + ExpandoMerge.p2 + ExpandoMerge.p3 + ExpandoMerge.p4 + ExpandoMerge.p5 + ExpandoMerge.p6 + ExpandoMerge.p7 + ExpandoMerge.p8 + ExpandoMerge.p9 + ExpandoMerge.m(12) + ExpandoMerge(1001);
 >n : Symbol(n, Decl(expando.ts, 13, 3))
 >ExpandoMerge.p1 : Symbol(ExpandoMerge.p1, Decl(expando.ts, 2, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p1 : Symbol(ExpandoMerge.p1, Decl(expando.ts, 2, 1))
 >ExpandoMerge.p2 : Symbol(ExpandoMerge.p2, Decl(ns.ts, 10, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p2 : Symbol(ExpandoMerge.p2, Decl(ns.ts, 10, 14))
 >ExpandoMerge.p3 : Symbol(ExpandoMerge.p3, Decl(ns.ts, 1, 14))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p3 : Symbol(ExpandoMerge.p3, Decl(ns.ts, 1, 14))
 >ExpandoMerge.p4 : Symbol(ExpandoMerge.p4, Decl(ns.ts, 2, 14), Decl(expando.ts, 6, 1))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p4 : Symbol(ExpandoMerge.p4, Decl(ns.ts, 2, 14), Decl(expando.ts, 6, 1))
 >ExpandoMerge.p5 : Symbol(ExpandoMerge.p5, Decl(ns.ts, 3, 14), Decl(expando.ts, 7, 24))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p5 : Symbol(ExpandoMerge.p5, Decl(ns.ts, 3, 14), Decl(expando.ts, 7, 24))
 >ExpandoMerge.p6 : Symbol(ExpandoMerge.p6, Decl(ns.ts, 4, 14), Decl(expando.ts, 8, 25))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p6 : Symbol(ExpandoMerge.p6, Decl(ns.ts, 4, 14), Decl(expando.ts, 8, 25))
 >ExpandoMerge.p7 : Symbol(ExpandoMerge.p7, Decl(ns.ts, 5, 14), Decl(expando.ts, 9, 24))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p7 : Symbol(ExpandoMerge.p7, Decl(ns.ts, 5, 14), Decl(expando.ts, 9, 24))
 >ExpandoMerge.p8 : Symbol(ExpandoMerge.p8, Decl(ns.ts, 6, 14), Decl(expando.ts, 10, 25))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p8 : Symbol(ExpandoMerge.p8, Decl(ns.ts, 6, 14), Decl(expando.ts, 10, 25))
 >ExpandoMerge.p9 : Symbol(ExpandoMerge.p9, Decl(ns.ts, 7, 14), Decl(expando.ts, 11, 24))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >p9 : Symbol(ExpandoMerge.p9, Decl(ns.ts, 7, 14), Decl(expando.ts, 11, 24))
 >ExpandoMerge.m : Symbol(ExpandoMerge.m, Decl(expando.ts, 3, 21))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 >m : Symbol(ExpandoMerge.m, Decl(expando.ts, 3, 21))
->ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 21))
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(ns.ts, 0, 0), Decl(ns.ts, 8, 1), Decl(expando.ts, 0, 0), Decl(expando.ts, 2, 1))
 
 

--- a/tests/baselines/reference/typeFromPropertyAssignment34.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment34.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/salsa/file1.js ===
+var N = {};
+>N : Symbol(N, Decl(file1.js, 0, 3), Decl(file1.js, 0, 11), Decl(file2.js, 0, 0))
+
+N.commands = {};
+>N.commands : Symbol(N.commands, Decl(file1.js, 0, 11), Decl(file2.js, 0, 2))
+>N : Symbol(N, Decl(file1.js, 0, 3), Decl(file1.js, 0, 11), Decl(file2.js, 0, 0))
+>commands : Symbol(N.commands, Decl(file1.js, 0, 11), Decl(file2.js, 0, 2))
+
+=== tests/cases/conformance/salsa/file2.js ===
+N.commands.a = 111;
+>N.commands.a : Symbol(N.commands.a, Decl(file2.js, 0, 0))
+>N.commands : Symbol(N.commands, Decl(file1.js, 0, 11), Decl(file2.js, 0, 2))
+>N : Symbol(N, Decl(file1.js, 0, 3), Decl(file1.js, 0, 11), Decl(file2.js, 0, 0))
+>commands : Symbol(N.commands, Decl(file1.js, 0, 11), Decl(file2.js, 0, 2))
+>a : Symbol(N.commands.a, Decl(file2.js, 0, 0))
+
+N.commands.b = function () { };
+>N.commands.b : Symbol(N.commands.b, Decl(file2.js, 0, 19))
+>N.commands : Symbol(N.commands, Decl(file1.js, 0, 11), Decl(file2.js, 0, 2))
+>N : Symbol(N, Decl(file1.js, 0, 3), Decl(file1.js, 0, 11), Decl(file2.js, 0, 0))
+>commands : Symbol(N.commands, Decl(file1.js, 0, 11), Decl(file2.js, 0, 2))
+>b : Symbol(N.commands.b, Decl(file2.js, 0, 19))
+

--- a/tests/baselines/reference/typeFromPropertyAssignment34.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment34.types
@@ -1,0 +1,31 @@
+=== tests/cases/conformance/salsa/file1.js ===
+var N = {};
+>N : typeof N
+>{} : {}
+
+N.commands = {};
+>N.commands = {} : typeof N.commands
+>N.commands : typeof N.commands
+>N : typeof N
+>commands : typeof N.commands
+>{} : {}
+
+=== tests/cases/conformance/salsa/file2.js ===
+N.commands.a = 111;
+>N.commands.a = 111 : 111
+>N.commands.a : number
+>N.commands : typeof N.commands
+>N : typeof N
+>commands : typeof N.commands
+>a : number
+>111 : 111
+
+N.commands.b = function () { };
+>N.commands.b = function () { } : () => void
+>N.commands.b : () => void
+>N.commands : typeof N.commands
+>N : typeof N
+>commands : typeof N.commands
+>b : () => void
+>function () { } : () => void
+

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment34.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment34.ts
@@ -1,0 +1,10 @@
+// @noEmit: true
+// @allowjs: true
+// @checkjs: true
+// @Filename: file1.js
+var N = {};
+N.commands = {};
+
+// @Filename: file2.js
+N.commands.a = 111;
+N.commands.b = function () { };

--- a/tests/cases/fourslash/functionTypes.ts
+++ b/tests/cases/fourslash/functionTypes.ts
@@ -21,4 +21,10 @@
 ////l./*7*/prototype = Object.prototype;
 
 verify.noErrors();
-verify.completionsAt(test.markerNames(), ["apply", "call", "bind", "toString", "prototype", "length", "arguments", "caller" ]);
+verify.completionsAt('1', ["apply", "call", "bind", "toString", "prototype", "length", "arguments", "caller" ]);
+verify.completionsAt('2', ["apply", "call", "bind", "toString", "prototype", "length", "arguments", "caller" ]);
+verify.completionsAt('3', ["apply", "call", "bind", "toString", "prototype", "length", "arguments", "caller" ]);
+verify.completionsAt('4', ["apply", "call", "bind", "toString", "prototype", "length", "arguments", "caller" ]);
+verify.completionsAt('5', ["apply", "call", "bind", "toString", "prototype", "length", "arguments", "caller" ]);
+verify.completionsAt('6', ["apply", "call", "bind", "toString", "prototype", "length", "arguments", "caller" ]);
+verify.completionsAt('7', ["prototype", "apply", "call", "bind", "toString", "length", "arguments", "caller" ]);

--- a/tests/cases/fourslash/referencesForStringLiteralPropertyNames7.ts
+++ b/tests/cases/fourslash/referencesForStringLiteralPropertyNames7.ts
@@ -6,7 +6,7 @@
 
 ////var x = { "[|{| "isWriteAccess": true, "isDefinition": true |}someProperty|]": 0 }
 ////x["[|someProperty|]"] = 3;
-////x.[|{| "isWriteAccess": true, "isDefinition": false |}someProperty|] = 5;
+////x.[|{| "isWriteAccess": true, "isDefinition": true |}someProperty|] = 5;
 
 const ranges = test.ranges();
 const [r0, r1, r2] = ranges;


### PR DESCRIPTION
Previously, only property assignments with expando initialisers were bound in top-level statements. Now, all property assignments are bound.

This requires a matching change in the checker to make sure that these assignments remain context sensitive if their valueDeclaration is a 'real' declaration (ie a non assignment-declaration).

Note that this accords with the recent change of SymbolFlags.JSContainer &rarr; SymbolFlags.Assignment such that all assignment declarations are marked instead of just ones that could be a container later.

Fixes #26875