### PR TITLE
Avoid circularly resolving names when looking up type members using resolveName

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1312,7 +1312,7 @@ namespace ts {
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.ClassExpression:
                     case SyntaxKind.InterfaceDeclaration:
-                        if (result = lookup(getMembersOfSymbol(getSymbolOfNode(location as ClassLikeDeclaration | InterfaceDeclaration)), name, meaning & SymbolFlags.Type)) {
+                        if (result = lookup(getSymbolOfNode(location as ClassLikeDeclaration | InterfaceDeclaration).members || emptySymbols, name, meaning & SymbolFlags.Type)) {
                             if (!isTypeParameterSymbolDeclaredInContainer(result, location)) {
                                 // ignore type parameters not declared in this container
                                 result = undefined;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1312,6 +1312,9 @@ namespace ts {
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.ClassExpression:
                     case SyntaxKind.InterfaceDeclaration:
+                        // The below is used to lookup type parameters within a class or interface, as they are added to the class/interface locals
+                        // These can never be latebound, so the symbol's raw members are sufficient. `getMembersOfNode` cannot be used, as it would
+                        // trigger resolving late-bound names, which we may already be in the process of doing while we're here!
                         if (result = lookup(getSymbolOfNode(location as ClassLikeDeclaration | InterfaceDeclaration).members || emptySymbols, name, meaning & SymbolFlags.Type)) {
                             if (!isTypeParameterSymbolDeclaredInContainer(result, location)) {
                                 // ignore type parameters not declared in this container

--- a/tests/baselines/reference/declarationTypecheckNoUseBeforeReferenceCheck.symbols
+++ b/tests/baselines/reference/declarationTypecheckNoUseBeforeReferenceCheck.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/index.d.ts ===
+export class C extends Object {
+>C : Symbol(C, Decl(index.d.ts, 0, 0))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    static readonly p: unique symbol;
+>p : Symbol(C.p, Decl(index.d.ts, 0, 31))
+
+    [C.p](): void;
+>[C.p] : Symbol(C[C.p], Decl(index.d.ts, 1, 37))
+>C.p : Symbol(C.p, Decl(index.d.ts, 0, 31))
+>C : Symbol(C, Decl(index.d.ts, 0, 0))
+>p : Symbol(C.p, Decl(index.d.ts, 0, 31))
+}

--- a/tests/baselines/reference/declarationTypecheckNoUseBeforeReferenceCheck.types
+++ b/tests/baselines/reference/declarationTypecheckNoUseBeforeReferenceCheck.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/index.d.ts ===
+export class C extends Object {
+>C : C
+>Object : Object
+
+    static readonly p: unique symbol;
+>p : unique symbol
+
+    [C.p](): void;
+>[C.p] : () => void
+>C.p : unique symbol
+>C : typeof C
+>p : unique symbol
+}

--- a/tests/cases/compiler/declarationTypecheckNoUseBeforeReferenceCheck.ts
+++ b/tests/cases/compiler/declarationTypecheckNoUseBeforeReferenceCheck.ts
@@ -1,0 +1,5 @@
+// @filename: index.d.ts
+export class C extends Object {
+    static readonly p: unique symbol;
+    [C.p](): void;
+}


### PR DESCRIPTION
`getMembersOfType` causes computed late bound names to be evaluated and bound, which shouldn't happen during name resolution, as it is used.... during computed name and base type resolution (which must finish before late bound names are actually bindable).


Fixes #23828

