### PR TITLE
Only perform async code fix if it can successfully refactor all parts

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -254,6 +254,7 @@ namespace ts.codefix {
     }
 
     // dispatch function to recursively build the refactoring
+    // should be kept up to date with isFixablePromiseHandler in suggestionDiagnostics.ts
     function transformExpression(node: Expression, transformer: Transformer, outermostParent: CallExpression, prevArgName?: SynthIdentifier): Statement[] {
         if (!node) {
             return [];
@@ -275,6 +276,7 @@ namespace ts.codefix {
             return transformPromiseCall(node, transformer, prevArgName);
         }
 
+        codeActionSucceeded = false;
         return [];
     }
 
@@ -383,6 +385,7 @@ namespace ts.codefix {
             (createVariableDeclarationList([createVariableDeclaration(getSynthesizedDeepClone(prevArgName.identifier), /*type*/ undefined, rightHandSide)], getFlagOfIdentifier(prevArgName.identifier, transformer.constIdentifiers))))]);
     }
 
+    // should be kept up to date with isFixablePromiseArgument in suggestionDiagnostics.ts
     function getTransformationBody(func: Node, prevArgName: SynthIdentifier | undefined, argName: SynthIdentifier, parent: CallExpression, transformer: Transformer): NodeArray<Statement> {
 
         const hasPrevArgName = prevArgName && prevArgName.identifier.text.length > 0;
@@ -498,14 +501,6 @@ namespace ts.codefix {
             });
         }
         return innerCbBody;
-    }
-
-    function hasPropertyAccessExpressionWithName(node: CallExpression, funcName: string): boolean {
-        if (!isPropertyAccessExpression(node.expression)) {
-            return false;
-        }
-
-        return node.expression.name.text === funcName;
     }
 
     function getArgName(funcNode: Node, transformer: Transformer): SynthIdentifier {

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -390,7 +390,6 @@ namespace ts.codefix {
         const shouldReturn = transformer.setOfExpressionsToReturn.get(getNodeId(parent).toString());
         switch (func.kind) {
             case SyntaxKind.NullKeyword:
-            case SyntaxKind.UndefinedKeyword:
                 // do not produce a transformed statement for a null or undefined argument
                 break;
             case SyntaxKind.Identifier:

--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -393,9 +393,10 @@ namespace ts.codefix {
         const shouldReturn = transformer.setOfExpressionsToReturn.get(getNodeId(parent).toString());
         switch (func.kind) {
             case SyntaxKind.NullKeyword:
-                // do not produce a transformed statement for a null or undefined argument
+                // do not produce a transformed statement for a null argument
                 break;
             case SyntaxKind.Identifier:
+                // identifier includes undefined
                 if (!hasArgName) break;
 
                 const synthCall = createCall(getSynthesizedDeepClone(func) as Identifier, /*typeArguments*/ undefined, [argName.identifier]);

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -196,7 +196,7 @@ namespace ts {
     function isFixablePromiseArgument(arg: Expression): boolean {
         switch (arg.kind) {
             case SyntaxKind.NullKeyword:
-            case SyntaxKind.Identifier:
+            case SyntaxKind.Identifier: // identifier includes undefined
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionExpression:
             case SyntaxKind.ArrowFunction:

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -160,7 +160,7 @@ namespace ts {
             }
 
             function addHandlers(returnChild: Node) {
-                if (isPromiseHandler(returnChild)) {
+                if (isFixablePromiseHandler(returnChild)) {
                     returnStatements.push(child as ReturnStatement);
                 }
             }
@@ -170,8 +170,39 @@ namespace ts {
         return returnStatements;
     }
 
-    function isPromiseHandler(node: Node): boolean {
-        return (isCallExpression(node) && isPropertyAccessExpression(node.expression) &&
-            (node.expression.name.text === "then" || node.expression.name.text === "catch"));
+    // Should be kept up to date with transformExpression in convertToAsyncFunction.ts
+    function isFixablePromiseHandler(node: Node): boolean {
+        // ensure outermost call exists and is a promise handler
+        if (!isPromiseHandler(node) || !node.arguments.every(isFixablePromiseArgument)) {
+            return false;
+        }
+
+        // ensure all chained calls are valid
+        let currentNode = node.expression;
+        while (isPromiseHandler(currentNode) || isPropertyAccessExpression(currentNode)) {
+            if (isCallExpression(currentNode) && !currentNode.arguments.every(isFixablePromiseArgument)) {
+                return false;
+            }
+            currentNode = currentNode.expression;
+        }
+        return true;
+    }
+
+    function isPromiseHandler(node: Node): node is CallExpression {
+        return isCallExpression(node) && (hasPropertyAccessExpressionWithName(node, "then") || hasPropertyAccessExpressionWithName(node, "catch"));
+    }
+
+    // should be kept up to date with getTransformationBody in convertToAsyncFunction.ts
+    function isFixablePromiseArgument(arg: Expression): boolean {
+        switch (arg.kind) {
+            case SyntaxKind.NullKeyword:
+            case SyntaxKind.Identifier:
+            case SyntaxKind.FunctionDeclaration:
+            case SyntaxKind.FunctionExpression:
+            case SyntaxKind.ArrowFunction:
+                return true;
+            default:
+                return false;
+        }
     }
 }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -224,6 +224,14 @@ namespace ts {
         return undefined;
     }
 
+    export function hasPropertyAccessExpressionWithName(node: CallExpression, funcName: string): boolean {
+        if (!isPropertyAccessExpression(node.expression)) {
+            return false;
+        }
+
+        return node.expression.name.text === funcName;
+    }
+
     export function isJumpStatementTarget(node: Node): node is Identifier & { parent: BreakOrContinueStatement } {
         return node.kind === SyntaxKind.Identifier && isBreakOrContinueStatement(node.parent) && node.parent.label === node;
     }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NestedFunctionRightLocation.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NestedFunctionRightLocation.js
@@ -1,0 +1,24 @@
+// ==ORIGINAL==
+
+function f() {
+    function fn2(){
+        function /*[#|*/fn3/*|]*/(){
+            return fetch("https://typescriptlang.org").then(res => console.log(res));
+        }
+        return fn3();
+    }
+    return fn2();
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+function f() {
+    function fn2(){
+        async function fn3(){
+            const res = await fetch("https://typescriptlang.org");
+            return console.log(res);
+        }
+        return fn3();
+    }
+    return fn2();
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NestedFunctionRightLocation.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NestedFunctionRightLocation.ts
@@ -1,0 +1,24 @@
+// ==ORIGINAL==
+
+function f() {
+    function fn2(){
+        function /*[#|*/fn3/*|]*/(){
+            return fetch("https://typescriptlang.org").then(res => console.log(res));
+        }
+        return fn3();
+    }
+    return fn2();
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+function f() {
+    function fn2(){
+        async function fn3(){
+            const res = await fetch("https://typescriptlang.org");
+            return console.log(res);
+        }
+        return fn3();
+    }
+    return fn2();
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes4.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes4.js
@@ -1,0 +1,16 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/() {
+    return fetch('https://typescriptlang.org').then(undefined, rejection => console.log("rejected:", rejection));
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f() {
+    try {
+        await fetch('https://typescriptlang.org');
+    }
+    catch (rejection) {
+        return console.log("rejected:", rejection);
+    }
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes4.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_NoRes4.ts
@@ -1,0 +1,16 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/() {
+    return fetch('https://typescriptlang.org').then(undefined, rejection => console.log("rejected:", rejection));
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f() {
+    try {
+        await fetch('https://typescriptlang.org');
+    }
+    catch (rejection) {
+        return console.log("rejected:", rejection);
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #26375.
Currently, there's a limited set of syntax forms that we are able to refactor for the async code fix (namely, identifiers, arrow functions, and function expressions). If we try to refactor a promise operation (e.g., `.then`), with one of its arguments not in this form, we end up deleting that code.
This PR handles this more gracefully by not returning a code action if not all promise operations could be refactored successfully. Additionally, this PR introduces the ability to test for this situation (i.e., a diagnostic is produced but no action is available). 

Note that in VS, no suggestion diagnostic is shown due to the lack of available codefixes. However, in VS Code, the suggestion diagnostic is shown, but no lightbulb is offered.