### PR TITLE
Avoid adding duplicate completion from contextual keyword

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -144,7 +144,14 @@ namespace ts.Completions {
             getCompletionEntriesFromSymbols(symbols, entries, location, sourceFile, typeChecker, compilerOptions.target!, log, completionKind, preferences, propertyAccessToConvert, isJsxInitializer, recommendedCompletion, symbolToOriginInfoMap);
         }
 
-        addRange(entries, getKeywordCompletions(keywordFilters));
+        if (keywordFilters !== KeywordCompletionFilters.None) {
+            const entryNames = arrayToSet(entries, e => e.name);
+            for (const keywordEntry of getKeywordCompletions(keywordFilters)) {
+                if (!entryNames.has(keywordEntry.name)) {
+                    entries.push(keywordEntry);
+                }
+            }
+        }
 
         for (const literal of literals) {
             entries.push(createCompletionEntryForLiteral(literal));
@@ -180,7 +187,7 @@ namespace ts.Completions {
                 return;
             }
             const realName = unescapeLeadingUnderscores(name);
-            if (addToSeen(uniqueNames, realName) && isIdentifierText(realName, target) && !isStringANonContextualKeyword(realName)) {
+            if (addToSeen(uniqueNames, realName) && isIdentifierText(realName, target)) {
                 entries.push({
                     name: realName,
                     kind: ScriptElementKind.warning,

--- a/tests/cases/fourslash/server/completionEntryDetailAcrossFiles02.ts
+++ b/tests/cases/fourslash/server/completionEntryDetailAcrossFiles02.ts
@@ -14,7 +14,7 @@
 //// import a = require("./a");
 //// a.fo/*2*/
 
-goTo.marker('1');
-verify.completionEntryDetailIs("foo", "var foo: (p1: string) => void", "Modify the parameter");
-goTo.marker('2');
-verify.completionEntryDetailIs("foo", "(property) a.foo: (p1: string) => void", "Modify the parameter");
+verify.completions(
+    { marker: "1", includes: { name: "foo", text: "var foo: (p1: string) => void", documentation: "Modify the parameter" } },
+    { marker: "2", exact: { name: "foo", text: "(property) a.foo: (p1: string) => void", documentation: "Modify the parameter" } },
+);


### PR DESCRIPTION
Since some completion keywords are contextual keywords, there may already be a variable with that name.