### PR TITLE
findAllReferences: Fix declarationIsWriteAccess for PropertyAssignment in destructuring

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -255,11 +255,14 @@ namespace ts.FindAllReferences {
             case SyntaxKind.NamespaceExportDeclaration:
             case SyntaxKind.NamespaceImport:
             case SyntaxKind.Parameter:
-            case SyntaxKind.PropertyAssignment:
             case SyntaxKind.ShorthandPropertyAssignment:
             case SyntaxKind.TypeAliasDeclaration:
             case SyntaxKind.TypeParameter:
                 return true;
+
+            case SyntaxKind.PropertyAssignment:
+                // In `({ x: y } = 0);`, `x` is not a write access. (Won't call this function for `y`.)
+                return !isArrayLiteralOrObjectLiteralDestructuringPattern((decl as PropertyAssignment).parent);
 
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionExpression:

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName07.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName07.ts
@@ -2,6 +2,6 @@
 
 ////let p, b;
 ////
-////p, [{ [|{| "isWriteAccess": true, "isDefinition": true |}a|]: p, b }] = [{ [|{| "isWriteAccess": true, "isDefinition": true |}a|]: 10, b: true }];
+////p, [{ [|{| "isDefinition": true |}a|]: p, b }] = [{ [|{| "isWriteAccess": true, "isDefinition": true |}a|]: 10, b: true }];
 
 verify.singleReferenceGroup("(property) a: any");


### PR DESCRIPTION
(part of #13766)

