### PR TITLE
Improve use of SemanticMeaning in symbol display

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -128,13 +128,17 @@ namespace ts.SymbolDisplay {
         let documentation: SymbolDisplayPart[] | undefined;
         let tags: JSDocTagInfo[] | undefined;
         const symbolFlags = getCombinedLocalAndExportSymbolFlags(symbol);
-        let symbolKind = getSymbolKindOfConstructorPropertyMethodAccessorFunctionOrVar(typeChecker, symbol, location);
+        let symbolKind = semanticMeaning & SemanticMeaning.Value ? getSymbolKindOfConstructorPropertyMethodAccessorFunctionOrVar(typeChecker, symbol, location) : ScriptElementKind.unknown;
         let hasAddedSymbolInfo = false;
-        const isThisExpression = location.kind === SyntaxKind.ThisKeyword && isExpression(location);
+        const isThisExpression = location.kind === SyntaxKind.ThisKeyword && isInExpressionContext(location);
         let type: Type | undefined;
         let printer: Printer;
         let documentationFromAlias: SymbolDisplayPart[] | undefined;
         let tagsFromAlias: JSDocTagInfo[] | undefined;
+
+        if (location.kind === SyntaxKind.ThisKeyword && !isThisExpression) {
+            return { displayParts: [keywordPart(SyntaxKind.ThisKeyword)], documentation: [], symbolKind: ScriptElementKind.primitiveType, tags: undefined };
+        }
 
         // Class at constructor site need to be shown as constructor apart from property,method, vars
         if (symbolKind !== ScriptElementKind.unknown || symbolFlags & SymbolFlags.Class || symbolFlags & SymbolFlags.Alias) {
@@ -285,7 +289,7 @@ namespace ts.SymbolDisplay {
             addFullSymbolName(symbol);
             writeTypeParametersOfSymbol(symbol, sourceFile);
         }
-        if (symbolFlags & SymbolFlags.TypeAlias) {
+        if ((symbolFlags & SymbolFlags.TypeAlias) && (semanticMeaning & SemanticMeaning.Type)) {
             prefixNextMeaning();
             displayParts.push(keywordPart(SyntaxKind.TypeKeyword));
             displayParts.push(spacePart());

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -88,7 +88,7 @@ namespace ts {
         if (node.kind === SyntaxKind.SourceFile) {
             return SemanticMeaning.Value;
         }
-        else if (node.parent.kind === SyntaxKind.ExportAssignment) {
+        else if (node.parent.kind === SyntaxKind.ExportAssignment || node.parent.kind === SyntaxKind.ExternalModuleReference) {
             return SemanticMeaning.All;
         }
         else if (isInRightSideOfInternalImportEqualsDeclaration(node)) {

--- a/tests/cases/fourslash/findAllRefsForDefaultExport02.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport02.ts
@@ -15,9 +15,8 @@
 const ranges = test.ranges();
 const [r0, r1, r2, r3, r4] = ranges;
 const fnRanges = [r0, r1, r2, r3];
-const fn = "function DefaultExportedFunction(): () => typeof DefaultExportedFunction";
-verify.singleReferenceGroup(fn, fnRanges);
+verify.singleReferenceGroup("function DefaultExportedFunction(): () => typeof DefaultExportedFunction", fnRanges);
 
 // The namespace and function do not merge,
 // so the namespace should be all alone.
-verify.singleReferenceGroup(`namespace DefaultExportedFunction\n${fn}`, [r4]);
+verify.singleReferenceGroup(`namespace DefaultExportedFunction`, [r4]);

--- a/tests/cases/fourslash/findAllRefs_importType_exportEquals.ts
+++ b/tests/cases/fourslash/findAllRefs_importType_exportEquals.ts
@@ -15,7 +15,7 @@ verify.noErrors();
 
 const [r0, r1, r2, r3, r4] = test.ranges();
 verify.referenceGroups(r0, [{ definition: "type T = number\nnamespace T", ranges: [r0, r2, r3] }]);
-verify.referenceGroups(r1, [{ definition: "type T = number\nnamespace T", ranges: [r1, r2] }]);
+verify.referenceGroups(r1, [{ definition: "namespace T", ranges: [r1, r2] }]);
 verify.referenceGroups(r2, [{ definition: "type T = number\nnamespace T", ranges: [r0, r1, r2, r3] }]);
 verify.referenceGroups([r3, r4], [
     { definition: 'module "/a"', ranges: [r4] },

--- a/tests/cases/fourslash/findAllRefs_importType_meaningAtLocation.ts
+++ b/tests/cases/fourslash/findAllRefs_importType_meaningAtLocation.ts
@@ -9,5 +9,5 @@
 ////const x: typeof import("./a").[|T|] = 0;
 
 const [r0, r1, r2, r3] = test.ranges();
-verify.singleReferenceGroup("type T = 0\nconst T: 0", [r0, r2]);
-verify.singleReferenceGroup("type T = 0\nconst T: 0", [r1, r3]);
+verify.singleReferenceGroup("type T = 0", [r0, r2]);
+verify.singleReferenceGroup("const T: 0", [r1, r3]);

--- a/tests/cases/fourslash/jsdocTypedefTagSemanticMeaning0.ts
+++ b/tests/cases/fourslash/jsdocTypedefTagSemanticMeaning0.ts
@@ -12,5 +12,5 @@
 
 const [t0, v0, t1, v1] = test.ranges();
 
-verify.singleReferenceGroup("type T = number\nconst T: 1", [t0, t1]);
-verify.singleReferenceGroup("type T = number\nconst T: 1", [v0, v1]);
+verify.singleReferenceGroup("type T = number", [t0, t1]);
+verify.singleReferenceGroup("const T: 1", [v0, v1]);

--- a/tests/cases/fourslash/quickInfoImportedTypesWithMergedMeanings.ts
+++ b/tests/cases/fourslash/quickInfoImportedTypesWithMergedMeanings.ts
@@ -10,8 +10,9 @@
 //// export { Original/*1*/ } from './quickInfoImportedTypesWithMergedMeanings';
 
 // @Filename: importer.ts
-//// import { Original as Alias } from './quickInfoImportedTypesWithMergedMeanings';
-//// Alias/*2*/;
+//// import { Original as /*2*/Alias } from './quickInfoImportedTypesWithMergedMeanings';
+//// Alias/*3*/;
+//// let x: Alias/*4*/
 
 verify.quickInfoAt("1", [
     "(alias) function Original(): void",
@@ -22,6 +23,18 @@ verify.quickInfoAt("1", [
 
 verify.quickInfoAt("2", [
     "(alias) function Alias(): void",
+    "(alias) type Alias<T> = () => T",
+    "(alias) namespace Alias",
+    "import Alias",
+].join("\n"), "some docs");
+
+verify.quickInfoAt("3", [
+    "(alias) function Alias(): void",
+    "(alias) namespace Alias",
+    "import Alias",
+].join("\n"), "some docs");
+
+verify.quickInfoAt("4", [
     "(alias) type Alias<T> = () => T",
     "(alias) namespace Alias",
     "import Alias",

--- a/tests/cases/fourslash/quickInfoJsdocEnum.ts
+++ b/tests/cases/fourslash/quickInfoJsdocEnum.ts
@@ -12,12 +12,15 @@
 ////    A: 0,
 ////}
 ////
-/////** @type {/**/E} */
-////const x = E.A;
+/////** @type {/*type*/E} */
+////const x = /*value*/E.A;
 
 verify.noErrors();
 
-verify.quickInfoAt("",
+verify.quickInfoAt("type",
+`enum E`,
+"Doc");
+verify.quickInfoAt("value",
 `enum E
 const E: {
     A: number;

--- a/tests/cases/fourslash/quickInfoOnThis.ts
+++ b/tests/cases/fourslash/quickInfoOnThis.ts
@@ -23,7 +23,7 @@
 ////}
 
 verify.quickInfos({
-    0: "this: this",
+    0: "this",
     1: "this: void",
     2: "this: this",
     3: "(parameter) this: Restricted",

--- a/tests/cases/fourslash/referencesForMergedDeclarations.ts
+++ b/tests/cases/fourslash/referencesForMergedDeclarations.ts
@@ -15,6 +15,6 @@
 ////[|Foo|].bind(this);
 
 const [type1, namespace1, value1, namespace2, type2, value2] = test.ranges();
-verify.singleReferenceGroup("interface Foo\nnamespace Foo\nfunction Foo(): void", [type1, type2]);
-verify.singleReferenceGroup("namespace Foo\nfunction Foo(): void", [namespace1, namespace2]);
+verify.singleReferenceGroup("interface Foo\nnamespace Foo", [type1, type2]);
+verify.singleReferenceGroup("namespace Foo", [namespace1, namespace2]);
 verify.singleReferenceGroup("namespace Foo\nfunction Foo(): void", [value1, value2]);

--- a/tests/cases/fourslash/referencesForMergedDeclarations5.ts
+++ b/tests/cases/fourslash/referencesForMergedDeclarations5.ts
@@ -8,7 +8,7 @@
 
 const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
-verify.referenceGroups(r0, [{ definition: "interface Foo\nnamespace Foo\nfunction Foo(): void", ranges: [r0, r3] }]);
-verify.referenceGroups(r1, [{ definition: "namespace Foo\nfunction Foo(): void", ranges: [r1, r3] }]);
+verify.referenceGroups(r0, [{ definition: "interface Foo\nnamespace Foo", ranges: [r0, r3] }]);
+verify.referenceGroups(r1, [{ definition: "namespace Foo", ranges: [r1, r3] }]);
 verify.referenceGroups(r2, [{ definition: "namespace Foo\nfunction Foo(): void", ranges: [r2, r3] }]);
 verify.referenceGroups(r3, [{ definition: "interface Foo\nnamespace Foo\nfunction Foo(): void", ranges }]);

--- a/tests/cases/fourslash/referencesForMergedDeclarations7.ts
+++ b/tests/cases/fourslash/referencesForMergedDeclarations7.ts
@@ -12,7 +12,7 @@
 
 const ranges = test.ranges();
 const [r0, r1, r2, r3] = ranges;
-verify.referenceGroups(r0, [{ definition: "interface Foo.Bar\nnamespace Foo.Bar\nfunction Foo.Bar(): void", ranges: [r0, r3] }]);
-verify.referenceGroups(r1, [{ definition: "namespace Foo.Bar\nfunction Foo.Bar(): void", ranges: [r1, r3] }]);
+verify.referenceGroups(r0, [{ definition: "interface Foo.Bar\nnamespace Foo.Bar", ranges: [r0, r3] }]);
+verify.referenceGroups(r1, [{ definition: "namespace Foo.Bar", ranges: [r1, r3] }]);
 verify.referenceGroups(r2, [{ definition: "namespace Foo.Bar\nfunction Foo.Bar(): void", ranges: [r2, r3] }]);
 verify.referenceGroups(r3, [{ definition: "interface Foo.Bar\nnamespace Foo.Bar\nfunction Foo.Bar(): void", ranges }]);

--- a/tests/cases/fourslash/referencesForMergedDeclarations8.ts
+++ b/tests/cases/fourslash/referencesForMergedDeclarations8.ts
@@ -10,4 +10,4 @@
 ////// module
 ////import a3 = Foo.[|Bar|].Baz;
 
-verify.singleReferenceGroup("namespace Foo.Bar\nfunction Foo.Bar(): void");
+verify.singleReferenceGroup("namespace Foo.Bar");


### PR DESCRIPTION
* Only set `symbolKind` to "function" if `SemanticMeaning.Value` is set.
* Only display a type alias if `SemanticMeaning.Type` is set.
* Handle `this` type correctly. (Previously was treated as a parameter.)
* `ExternalModuleReferences` should have `SemanticMeaning.All`.

(Part of #13766)
