### PR TITLE
fix: do not parse mpeg-ts files as typescript files

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -989,13 +989,13 @@ namespace ts {
                 {
                     // GH#21136: check if this is an MPEG-TS file
                     const buffer = Buffer.alloc(50 * 188);
-                    const fd = _fs.openSync(fileName);
+                    const fd = _fs.openSync(fileName, "r");
                     try {
                         const bytesRead = _fs.readSync(fd, buffer, 0, 50 * 188);
                         // check if we have a multiple of 188 bytes (frames)
-                        if (bytesRead % 188 === 0) {
+                        if (bytesRead > 0 && bytesRead % 188 === 0) {
                             let allHex47 = true;
-                            for (let i = 0, n = i * 188; i < n; i = i + 188) {
+                            for (let i = 0, n = 50 * 188; i < n; i = i + 188) {
                                 if (i < bytesRead && buffer[i] !== 0x47) {
                                     allHex47 = false;
                                 }


### PR DESCRIPTION
MPEG-TS files consist of frames each 188 bytes long.
These files should not be parsed as typescript files
and therefore we look into the first 50 frames and
check if we find a 'valid' header.

Here's a checklist you might find useful.
* [x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `jake runtests` locally
* [x] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Fixes #21136