### PR TITLE
Fix bug: Ensure `export =` symbol always has a valueDeclaration

### DIFF
--- a/tests/baselines/reference/errorForConflictingExportEqualsValue.errors.txt
+++ b/tests/baselines/reference/errorForConflictingExportEqualsValue.errors.txt
@@ -1,9 +1,10 @@
-tests/cases/compiler/errorForConflictingExportEqualsValue.ts(2,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
+/a.ts(2,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 
 
-==== tests/cases/compiler/errorForConflictingExportEqualsValue.ts (1 errors) ====
+==== /a.ts (1 errors) ====
     export var x;
-    export = {};
-    ~~~~~~~~~~~~
+    export = x;
+    ~~~~~~~~~~~
 !!! error TS2309: An export assignment cannot be used in a module with other exported elements.
+    import("./a");
     

--- a/tests/baselines/reference/errorForConflictingExportEqualsValue.js
+++ b/tests/baselines/reference/errorForConflictingExportEqualsValue.js
@@ -1,8 +1,10 @@
-//// [errorForConflictingExportEqualsValue.ts]
+//// [a.ts]
 export var x;
-export = {};
+export = x;
+import("./a");
 
 
-//// [errorForConflictingExportEqualsValue.js]
+//// [a.js]
 "use strict";
-module.exports = {};
+Promise.resolve().then(function () { return require("./a"); });
+module.exports = exports.x;

--- a/tests/baselines/reference/errorForConflictingExportEqualsValue.symbols
+++ b/tests/baselines/reference/errorForConflictingExportEqualsValue.symbols
@@ -1,6 +1,10 @@
-=== tests/cases/compiler/errorForConflictingExportEqualsValue.ts ===
+=== /a.ts ===
 export var x;
->x : Symbol(x, Decl(errorForConflictingExportEqualsValue.ts, 0, 10))
+>x : Symbol(x, Decl(a.ts, 0, 10))
 
-export = {};
+export = x;
+>x : Symbol(x, Decl(a.ts, 0, 10))
+
+import("./a");
+>"./a" : Symbol("/a", Decl(a.ts, 0, 0))
 

--- a/tests/baselines/reference/errorForConflictingExportEqualsValue.types
+++ b/tests/baselines/reference/errorForConflictingExportEqualsValue.types
@@ -1,7 +1,11 @@
-=== tests/cases/compiler/errorForConflictingExportEqualsValue.ts ===
+=== /a.ts ===
 export var x;
 >x : any
 
-export = {};
->{} : {}
+export = x;
+>x : any
+
+import("./a");
+>import("./a") : Promise<typeof import("/a").x>
+>"./a" : "./a"
 

--- a/tests/cases/compiler/errorForConflictingExportEqualsValue.ts
+++ b/tests/cases/compiler/errorForConflictingExportEqualsValue.ts
@@ -1,2 +1,5 @@
+// @lib: es6
+// @Filename: /a.ts
 export var x;
-export = {};
+export = x;
+import("./a");


### PR DESCRIPTION
Fixes #26964

