### PR TITLE
JSON.parse is not supposed to return any

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -986,7 +986,7 @@ interface JSON {
       * @param reviver A function that transforms the results. This function is called for each member of the object.
       * If a member contains nested objects, the nested objects are transformed before the parent object is.
       */
-    parse(text: string, reviver?: (key: any, value: any) => any): any;
+    parse(text: string, reviver?: (key: any, value: any) => any): object | number | string | boolean | null;
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
       * @param value A JavaScript value, usually an object or array, to be converted.

--- a/tests/lib/lib.d.ts
+++ b/tests/lib/lib.d.ts
@@ -974,7 +974,7 @@ interface JSON {
       * @param reviver A function that transforms the results. This function is called for each member of the object.
       * If a member contains nested objects, the nested objects are transformed before the parent object is.
       */
-    parse(text: string, reviver?: (key: any, value: any) => any): any;
+    parse(text: string, reviver?: (key: any, value: any) => any): object | number | string | boolean | null;
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
       * @param value A JavaScript value, usually an object or array, to be converted.


### PR DESCRIPTION
As [discussed within DefinitelyTyped project](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/28529#event-1831129225) with @theodorejb and as described by [JSON specification](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf) `JSON.parse` do not return `any` but `object |  number | string | boolean | null`.

Fixes https://github.com/Microsoft/TypeScript/issues/26993

