### PR TITLE
Don't offer module completions in non-module JS files

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1268,10 +1268,10 @@ namespace ts.Completions {
             if (sourceFile.externalModuleIndicator) return true;
             // If already using commonjs, don't introduce ES6.
             if (sourceFile.commonJsModuleIndicator) return false;
-            // If some file is using ES6 modules, assume that it's OK to add more.
-            if (programContainsEs6Modules(program)) return true;
             // For JS, stay on the safe side.
             if (isUncheckedFile) return false;
+            // If some file is using ES6 modules, assume that it's OK to add more.
+            if (programContainsEs6Modules(program)) return true;
             // If module transpilation is enabled or we're targeting es6 or above, or not emitting, OK.
             return compilerOptionsIndicateEs6Modules(program.getCompilerOptions());
         }

--- a/tests/cases/fourslash/completionsImport_importType.ts
+++ b/tests/cases/fourslash/completionsImport_importType.ts
@@ -3,13 +3,14 @@
 // @allowJs: true
 
 // @Filename: /a.js
-////export const x = 0;
-////export class C {}
-/////** @typedef {number} T */
+//// export const x = 0;
+//// export class C {}
+//// /** @typedef {number} T */
 
 // @Filename: /b.js
-/////** @type {/*0*/} */
-/////** @type {/*1*/} */
+//// export const m = 0;
+//// /** @type {/*0*/} */
+//// /** @type {/*1*/} */
 
 verify.completions({
     marker: ["0", "1"],
@@ -43,6 +44,7 @@ verify.applyCodeActionFromCompletion("0", {
     newFileContent:
 `import { C } from "./a";
 
+export const m = 0;
 /** @type {} */
 /** @type {} */`,
 });
@@ -55,6 +57,7 @@ verify.applyCodeActionFromCompletion("1", {
     newFileContent:
 `import { C } from "./a";
 
+export const m = 0;
 /** @type {} */
 /** @type {import("./a").} */`,
 });

--- a/tests/cases/fourslash/noImportCompletionsInOtherJavaScriptFile.ts
+++ b/tests/cases/fourslash/noImportCompletionsInOtherJavaScriptFile.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @module: esnext
+
+// @Filename: /node_modules/foo/index.d.ts
+//// export const fail: number;
+
+// @Filename: /a.js
+//// export const x = 0;
+//// export class C {}
+//// 
+
+// @Filename: /b.js
+//// /**/
+
+goTo.file("/b.js");
+goTo.marker();
+verify.not.completionListContains("fail", undefined, undefined, undefined, undefined, undefined, { includeCompletionsForModuleExports: true });
+edit.insert("export const k = 10;\r\nf");
+verify.completionListContains(
+    { name: "fail", source: "/node_modules/foo/index" },
+    "const fail: number",
+    "",
+    "const",
+    undefined,
+    true,
+    {
+        includeCompletionsForModuleExports: true,
+        sourceDisplay: "./node_modules/foo/index"
+    });


### PR DESCRIPTION
Fixes an issue reported offline - in a JS program, other files having a module indicator is not a strong enough signal that the current file can be arbitrarily converted into a module.