### PR TITLE
Fix FunctionType emit when only parameter has no type

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2818,7 +2818,8 @@ namespace ts {
             const parameter = singleOrUndefined(parameters);
             return parameter
                 && parameter.pos === parentNode.pos // may not have parsed tokens between parent and parameter
-                && !(isArrowFunction(parentNode) && parentNode.type) // arrow function may not have return type annotation
+                && isArrowFunction(parentNode)      // only arrow functions may have simple arrow head
+                && !parentNode.type                 // arrow function may not have return type annotation
                 && !some(parentNode.decorators)     // parent may not have decorators
                 && !some(parentNode.modifiers)      // parent may not have modifiers
                 && !some(parentNode.typeParameters) // parent may not have type parameters

--- a/tests/baselines/reference/printerApi/printsNodeCorrectly.functionTypes.js
+++ b/tests/baselines/reference/printerApi/printsNodeCorrectly.functionTypes.js
@@ -1,1 +1,1 @@
-[args => any, <T>(args) => any, (...args) => any, (args?) => any, (args: any) => any, ({}) => any]
+[(args) => any, <T>(args) => any, (...args) => any, (args?) => any, (args: any) => any, ({}) => any]


### PR DESCRIPTION
Fixes: #27018 

It turns out there already was a test for that case, but the baseline was wrong.