### PR TITLE
Sanitize module resolution logs for typesVersions entries

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7671,6 +7671,15 @@ namespace ts {
     // It may be inefficient (we could just match (/[-[\]{}()*+?.,\\^$|#\s]/g), but this is future
     // proof.
     const reservedCharacterPattern = /[^\w\s\/]/g;
+
+    export function regExpEscape(text: string) {
+        return text.replace(reservedCharacterPattern, escapeRegExpCharacter);
+    }
+
+    function escapeRegExpCharacter(match: string) {
+        return "\\" + match;
+    }
+
     const wildcardCharCodes = [CharacterCodes.asterisk, CharacterCodes.question];
 
     export function hasExtension(fileName: string): boolean {

--- a/src/harness/utils.ts
+++ b/src/harness/utils.ts
@@ -7,6 +7,21 @@ namespace utils {
         return text !== undefined ? text.replace(testPathPrefixRegExp, (_, scheme) => scheme || (retainTrailingDirectorySeparator ? "/" : "")) : undefined!; // TODO: GH#18217
     }
 
+    function createDiagnosticMessageReplacer<R extends (messageArgs: string[], ...args: string[]) => string[]>(diagnosticMessage: ts.DiagnosticMessage, replacer: R) {
+        const messageParts = diagnosticMessage.message.split(/{\d+}/g);
+        const regExp = new RegExp(`^(?:${messageParts.map(ts.regExpEscape).join("(.*?)")})$`);
+        type Args<R> = R extends (messageArgs: string[], ...args: infer A) => string[] ? A : [];
+        return (text: string, ...args: Args<R>) => text.replace(regExp, (_, ...fixedArgs) => ts.formatStringFromArgs(diagnosticMessage.message, replacer(fixedArgs, ...args)));
+    }
+
+    const replaceTypesVersionsMessage = createDiagnosticMessageReplacer(
+        ts.Diagnostics.package_json_has_a_typesVersions_entry_0_that_matches_compiler_version_1_looking_for_a_pattern_to_match_module_name_2,
+        ([entry, , moduleName], compilerVersion) => [entry, compilerVersion, moduleName]);
+
+    export function sanitizeTraceResolutionLogEntry(text: string) {
+        return text && removeTestPathPrefixes(replaceTypesVersionsMessage(text, "3.1.0-dev"));
+    }
+
     /**
      * Removes leading indentation from a template literal string.
      */

--- a/src/testRunner/compilerRunner.ts
+++ b/src/testRunner/compilerRunner.ts
@@ -208,7 +208,7 @@ class CompilerTest {
     public verifyModuleResolution() {
         if (this.options.traceResolution) {
             Harness.Baseline.runBaseline(this.justName.replace(/\.tsx?$/, ".trace.json"),
-                utils.removeTestPathPrefixes(JSON.stringify(this.result.traces, undefined, 4)));
+                JSON.stringify(this.result.traces.map(utils.sanitizeTraceResolutionLogEntry), undefined, 4));
         }
     }
 


### PR DESCRIPTION
Fixes an issue with tests that use `traceResolution` when the typescript version changes.