### PR TITLE
isExpandoFunctionDeclaration only checks values

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28154,7 +28154,7 @@ namespace ts {
             if (!symbol || !(symbol.flags & SymbolFlags.Function)) {
                 return false;
             }
-            return !!forEachEntry(getExportsOfSymbol(symbol), p => isPropertyAccessExpression(p.valueDeclaration));
+            return !!forEachEntry(getExportsOfSymbol(symbol), p => p.flags & SymbolFlags.Value && isPropertyAccessExpression(p.valueDeclaration));
         }
 
         function getPropertiesOfContainerFunction(node: Declaration): Symbol[] {

--- a/tests/baselines/reference/declarationEmitOfFuncspace.js
+++ b/tests/baselines/reference/declarationEmitOfFuncspace.js
@@ -1,0 +1,23 @@
+//// [expando.ts]
+// #27032
+function ExpandoMerge(n: number) {
+    return n;
+}
+namespace ExpandoMerge {
+    export interface I { }
+}
+
+
+//// [expando.js]
+// #27032
+function ExpandoMerge(n) {
+    return n;
+}
+
+
+//// [expando.d.ts]
+declare function ExpandoMerge(n: number): number;
+declare namespace ExpandoMerge {
+    interface I {
+    }
+}

--- a/tests/baselines/reference/declarationEmitOfFuncspace.symbols
+++ b/tests/baselines/reference/declarationEmitOfFuncspace.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/expando.ts ===
+// #27032
+function ExpandoMerge(n: number) {
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 1))
+>n : Symbol(n, Decl(expando.ts, 1, 22))
+
+    return n;
+>n : Symbol(n, Decl(expando.ts, 1, 22))
+}
+namespace ExpandoMerge {
+>ExpandoMerge : Symbol(ExpandoMerge, Decl(expando.ts, 0, 0), Decl(expando.ts, 3, 1))
+
+    export interface I { }
+>I : Symbol(I, Decl(expando.ts, 4, 24))
+}
+

--- a/tests/baselines/reference/declarationEmitOfFuncspace.types
+++ b/tests/baselines/reference/declarationEmitOfFuncspace.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/expando.ts ===
+// #27032
+function ExpandoMerge(n: number) {
+>ExpandoMerge : (n: number) => number
+>n : number
+
+    return n;
+>n : number
+}
+namespace ExpandoMerge {
+    export interface I { }
+}
+

--- a/tests/cases/compiler/declarationEmitOfFuncspace.ts
+++ b/tests/cases/compiler/declarationEmitOfFuncspace.ts
@@ -1,0 +1,9 @@
+// @declaration: true
+// @Filename: expando.ts
+// #27032
+function ExpandoMerge(n: number) {
+    return n;
+}
+namespace ExpandoMerge {
+    export interface I { }
+}


### PR DESCRIPTION
Previously it checked types too, which caused a crash because types don't have valueDeclaration set. But expando functions can't export types, only values.

Fixes #27032

