### PR TITLE
typo: missing word: "to"

### DIFF
--- a/src/lib/es2015.promise.d.ts
+++ b/src/lib/es2015.promise.d.ts
@@ -7,7 +7,7 @@ interface PromiseConstructor {
     /**
      * Creates a new Promise.
      * @param executor A callback used to initialize the promise. This callback is passed two arguments:
-     * a resolve callback used resolve the promise with a value or the result of another promise,
+     * a resolve callback used to resolve the promise with a value or the result of another promise,
      * and a reject callback used to reject the promise with a provided reason or error.
      */
     new <T>(executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;


### PR DESCRIPTION
Change:
...a resolve callback used resolve the promise...
to: 
...a resolve callback used to resolve the promise...

This PR suggested in prior PR on generated files: https://github.com/Microsoft/TypeScript/pull/27075

Still not sure why that newline is being injected by the GitHub editor UI. Then again, maybe the source files should have terminating newlines? (let the debate ensue). ;)

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

