### PR TITLE
getEditsForFileRename: Don't resolve to `a.js` when `a.ts` is moved

### DIFF
--- a/src/services/getEditsForFileRename.ts
+++ b/src/services/getEditsForFileRename.ts
@@ -196,15 +196,23 @@ namespace ts {
     }
 
     function getSourceFileToImportFromResolved(resolved: ResolvedModuleWithFailedLookupLocations | undefined, oldToNew: PathUpdater, host: LanguageServiceHost): ToImport | undefined {
-        return resolved && (
-            (resolved.resolvedModule && getIfExists(resolved.resolvedModule.resolvedFileName)) || firstDefined(resolved.failedLookupLocations, getIfExists));
+        // Search through all locations looking for a moved file, and only then test already existing files.
+        // This is because if `a.ts` is compiled to `a.js` and `a.ts` is moved, we don't want to resolve anything to `a.js`, but to `a.ts`'s new location.
+        return tryEach(tryGetNewFile) || tryEach(tryGetOldFile);
 
-        function getIfExists(oldLocation: string): ToImport | undefined {
-            const newLocation = oldToNew(oldLocation);
+        function tryEach(cb: (oldFileName: string) => ToImport | undefined): ToImport | undefined {
+            return resolved && (
+                (resolved.resolvedModule && cb(resolved.resolvedModule.resolvedFileName)) || firstDefined(resolved.failedLookupLocations, cb));
+        }
 
-            return host.fileExists!(oldLocation) || newLocation !== undefined && host.fileExists!(newLocation) // TODO: GH#18217
-                ? newLocation !== undefined ? { newFileName: newLocation, updated: true } : { newFileName: oldLocation, updated: false }
-                : undefined;
+        function tryGetNewFile(oldFileName: string): ToImport | undefined {
+            const newFileName = oldToNew(oldFileName);
+            return newFileName !== undefined && host.fileExists!(newFileName) ? { newFileName, updated: true } : undefined; // TODO: GH#18217
+        }
+
+        function tryGetOldFile(oldFileName: string): ToImport | undefined {
+            const newFileName = oldToNew(oldFileName);
+            return host.fileExists!(oldFileName) ? newFileName !== undefined ? { newFileName, updated: true } : { newFileName: oldFileName, updated: false } : undefined; // TODO: GH#18217
         }
     }
 

--- a/tests/cases/fourslash/getEditsForFileRename_notAffectedByJsFile.ts
+++ b/tests/cases/fourslash/getEditsForFileRename_notAffectedByJsFile.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////export const x = 0;
+
+// @Filename: /a.js
+////exports.x = 0;
+
+// @Filename: /b.ts
+////import { x } from "./a";
+
+verify.getEditsForFileRename({
+    oldPath: "/a.ts",
+    newPath: "/a2.ts",
+    newFileContents: {
+        "/b.ts": 'import { x } from "./a2";',
+    },
+});


### PR DESCRIPTION
Fixes an issue in projects where `a.ts` and compiled to `a.js` right next to it -- we would resolve to `a.js` and not update the import. Now we will always look for a moved file before searching through non-moved files.
(Note the only reason we search through non-moved files is that the moved file's *own* imports can resolve to non-moved files and need updating if the moved file changed directories.)