### PR TITLE
Fix bug: VariableDeclaration may have SemanticMeaning.All if an `@enum` in JS

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -23,8 +23,10 @@ namespace ts {
 
     export function getMeaningFromDeclaration(node: Node): SemanticMeaning {
         switch (node.kind) {
-            case SyntaxKind.Parameter:
             case SyntaxKind.VariableDeclaration:
+                return isInJSFile(node) && getJSDocEnumTag(node) ? SemanticMeaning.All : SemanticMeaning.Value;
+
+            case SyntaxKind.Parameter:
             case SyntaxKind.BindingElement:
             case SyntaxKind.PropertyDeclaration:
             case SyntaxKind.PropertySignature:

--- a/tests/cases/fourslash/findAllRefs_jsEnum.ts
+++ b/tests/cases/fourslash/findAllRefs_jsEnum.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+
+// @Filename: /a.js
+/////** @enum {string} */
+////const [|{| "isWriteAccess": true, "isDefinition": true |}E|] = { A: "" };
+////[|E|]["A"];
+/////** @type {[|E|]} */
+////const e = [|E|].A;
+
+verify.singleReferenceGroup(
+`enum E
+const E: {
+    A: string;
+}`);


### PR DESCRIPTION
Fixes #27084

