### PR TITLE
[fix] ES5 Object.keys only accepts an object

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -299,6 +299,12 @@ interface ObjectConstructor {
     getOwnPropertySymbols(o: any): symbol[];
 
     /**
+      * Returns the names of the enumerable string properties and methods of an object.
+      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+      */
+    keys(o: {}): string[];
+
+    /**
      * Returns true if the values are the same value, false otherwise.
      * @param value1 The first value.
      * @param value2 The second value.

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -235,10 +235,10 @@ interface ObjectConstructor {
     isExtensible(o: any): boolean;
 
     /**
-      * Returns the names of the enumerable properties and methods of an object.
+      * Returns the names of the enumerable string properties and methods of an object.
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
-    keys(o: {}): string[];
+     keys(o: object): string[];
 }
 
 /**

--- a/tests/baselines/reference/conditionalTypeDoesntSpinForever.symbols
+++ b/tests/baselines/reference/conditionalTypeDoesntSpinForever.symbols
@@ -403,9 +403,9 @@ export enum PubSubRecordIsStoredInRedisAsA {
       fields: () => new Set(Object.keys(soFar) as (keyof SO_FAR)[]),
 >fields : Symbol(fields, Decl(conditionalTypeDoesntSpinForever.ts, 94, 18))
 >Set : Symbol(Set, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
->Object.keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>Object.keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
 >Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
 >soFar : Symbol(soFar, Decl(conditionalTypeDoesntSpinForever.ts, 92, 29))
 >SO_FAR : Symbol(SO_FAR, Decl(conditionalTypeDoesntSpinForever.ts, 92, 21))
 

--- a/tests/baselines/reference/conditionalTypeDoesntSpinForever.types
+++ b/tests/baselines/reference/conditionalTypeDoesntSpinForever.types
@@ -410,9 +410,9 @@ export enum PubSubRecordIsStoredInRedisAsA {
 >Set : SetConstructor
 >Object.keys(soFar) as (keyof SO_FAR)[] : (keyof SO_FAR)[]
 >Object.keys(soFar) : string[]
->Object.keys : (o: {}) => string[]
+>Object.keys : { (o: object): string[]; (o: {}): string[]; }
 >Object : ObjectConstructor
->keys : (o: {}) => string[]
+>keys : { (o: object): string[]; (o: {}): string[]; }
 >soFar : SO_FAR
 
       hasField: (fieldName: string | number | symbol) => fieldName in soFar

--- a/tests/baselines/reference/contextualExpressionTypecheckingDoesntBlowStack.symbols
+++ b/tests/baselines/reference/contextualExpressionTypecheckingDoesntBlowStack.symbols
@@ -21,9 +21,9 @@ export default class Operation {
 
         for(const parameterLocation of Object.keys(parameterValues)) {
 >parameterLocation : Symbol(parameterLocation, Decl(contextualExpressionTypecheckingDoesntBlowStack.ts, 8, 17))
->Object.keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>Object.keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
 >Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
 >parameterValues : Symbol(parameterValues, Decl(contextualExpressionTypecheckingDoesntBlowStack.ts, 6, 23))
 
             const parameter: any = (this as any).getParameter();;

--- a/tests/baselines/reference/contextualExpressionTypecheckingDoesntBlowStack.types
+++ b/tests/baselines/reference/contextualExpressionTypecheckingDoesntBlowStack.types
@@ -21,9 +21,9 @@ export default class Operation {
         for(const parameterLocation of Object.keys(parameterValues)) {
 >parameterLocation : string
 >Object.keys(parameterValues) : string[]
->Object.keys : (o: {}) => string[]
+>Object.keys : { (o: object): string[]; (o: {}): string[]; }
 >Object : ObjectConstructor
->keys : (o: {}) => string[]
+>keys : { (o: object): string[]; (o: {}): string[]; }
 >parameterValues : any
 
             const parameter: any = (this as any).getParameter();;

--- a/tests/baselines/reference/genericIndexedAccessMethodIntersectionCanBeAccessed.types
+++ b/tests/baselines/reference/genericIndexedAccessMethodIntersectionCanBeAccessed.types
@@ -32,9 +32,9 @@ export const createService = <T>(
 >Object.keys(ServiceCtr).forEach(key => {        const method = (ServiceCtr)[key as keyof T];        const {__$daemonMode, __$action, id} = method;    }) : void
 >Object.keys(ServiceCtr).forEach : (callbackfn: (value: string, index: number, array: string[]) => void, thisArg?: any) => void
 >Object.keys(ServiceCtr) : string[]
->Object.keys : (o: {}) => string[]
+>Object.keys : (o: object) => string[]
 >Object : ObjectConstructor
->keys : (o: {}) => string[]
+>keys : (o: object) => string[]
 >ServiceCtr : ExtendedService<T> & Service<T>
 >forEach : (callbackfn: (value: string, index: number, array: string[]) => void, thisArg?: any) => void
 >key => {        const method = (ServiceCtr)[key as keyof T];        const {__$daemonMode, __$action, id} = method;    } : (key: string) => void

--- a/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.symbols
+++ b/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.symbols
@@ -204,9 +204,9 @@ function objectToMap(obj: any) {
 	return new Map(Object.keys(obj).map(key => [key, obj[key]]));
 >Map : Symbol(Map, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >Object.keys(obj).map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
->Object.keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>Object.keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
 >Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --))
+>keys : Symbol(ObjectConstructor.keys, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
 >obj : Symbol(obj, Decl(inferFromGenericFunctionReturnTypes3.ts, 83, 21))
 >map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
 >key : Symbol(key, Decl(inferFromGenericFunctionReturnTypes3.ts, 84, 37))

--- a/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.types
+++ b/tests/baselines/reference/inferFromGenericFunctionReturnTypes3.types
@@ -231,9 +231,9 @@ function objectToMap(obj: any) {
 >Object.keys(obj).map(key => [key, obj[key]]) : [string, any][]
 >Object.keys(obj).map : <U>(callbackfn: (value: string, index: number, array: string[]) => U, thisArg?: any) => U[]
 >Object.keys(obj) : string[]
->Object.keys : (o: {}) => string[]
+>Object.keys : { (o: object): string[]; (o: {}): string[]; }
 >Object : ObjectConstructor
->keys : (o: {}) => string[]
+>keys : { (o: object): string[]; (o: {}): string[]; }
 >obj : any
 >map : <U>(callbackfn: (value: string, index: number, array: string[]) => U, thisArg?: any) => U[]
 >key => [key, obj[key]] : (key: string) => [string, any]

--- a/tests/baselines/reference/literalTypeWidening.types
+++ b/tests/baselines/reference/literalTypeWidening.types
@@ -391,9 +391,9 @@ export function keys<K extends string, V>(obj: Record<K, V>): K[] {
   return Object.keys(obj) as K[]
 >Object.keys(obj) as K[] : K[]
 >Object.keys(obj) : string[]
->Object.keys : (o: {}) => string[]
+>Object.keys : (o: object) => string[]
 >Object : ObjectConstructor
->keys : (o: {}) => string[]
+>keys : (o: object) => string[]
 >obj : Record<K, V>
 }
 

--- a/tests/baselines/reference/recursiveTypeRelations.types
+++ b/tests/baselines/reference/recursiveTypeRelations.types
@@ -72,9 +72,9 @@ export function css<S extends { [K in keyof S]: string }>(styles: S, ...classNam
 >Object.keys(arg).reduce<ClassNameObject>((obj: ClassNameObject, key: keyof S) => {        const exportedClassName = styles[key];        obj[exportedClassName] = (arg as ClassNameMap<S>)[key];         return obj;      }, {}) : any
 >Object.keys(arg).reduce : { (callbackfn: (previousValue: string, currentValue: string, currentIndex: number, array: string[]) => string): string; (callbackfn: (previousValue: string, currentValue: string, currentIndex: number, array: string[]) => string, initialValue: string): string; <U>(callbackfn: (previousValue: U, currentValue: string, currentIndex: number, array: string[]) => U, initialValue: U): U; }
 >Object.keys(arg) : string[]
->Object.keys : (o: {}) => string[]
+>Object.keys : (o: object) => string[]
 >Object : ObjectConstructor
->keys : (o: {}) => string[]
+>keys : (o: object) => string[]
 >arg : ClassNameObjectMap<S>
 >reduce : { (callbackfn: (previousValue: string, currentValue: string, currentIndex: number, array: string[]) => string): string; (callbackfn: (previousValue: string, currentValue: string, currentIndex: number, array: string[]) => string, initialValue: string): string; <U>(callbackfn: (previousValue: U, currentValue: string, currentIndex: number, array: string[]) => U, initialValue: U): U; }
 >(obj: ClassNameObject, key: keyof S) => {        const exportedClassName = styles[key];        obj[exportedClassName] = (arg as ClassNameMap<S>)[key];         return obj;      } : (obj: any, key: keyof S) => any

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.errors.txt
@@ -89,7 +89,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     fn5 `${ (n) => n.toFixed() }`; // will error; 'n' should have type 'string'.
                      ~~~~~~~
 !!! error TS2551: Property 'toFixed' does not exist on type 'string'. Did you mean 'fixed'?
-!!! related TS2728 /.ts/lib.es2015.core.d.ts:466:5: 'fixed' is declared here.
+!!! related TS2728 /.ts/lib.es2015.core.d.ts:472:5: 'fixed' is declared here.
     fn5 `${ (n) => n.substr(0) }`;
     
     


### PR DESCRIPTION
ES5 Object.keys throws on non-objects: http://www.ecma-international.org/ecma-262/5.1/#sec-15.2.3.14 - which is type `object`.

ES2015 Object.keys allows any "object coercible", ie any non-null non-undefined value - which is `{}`: http://www.ecma-international.org/ecma-262/6.0/#sec-object.keys

This attempts to fix the types.

* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `jake runtests` locally
* [x] You've signed the CLA
* [x] There are new or updated unit tests validating the change

This is my first PR to TypeScript; if you can point me to where I should add unit tests, I'll be happy to do so.