### PR TITLE
Revert the API change to resolveProjectReferencePath introduced in #27062

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2820,13 +2820,20 @@ namespace ts {
         };
     }
 
+    // For backward compatibility
+    /** @deprecated */ export interface ResolveProjectReferencePathHost {
+        fileExists(fileName: string): boolean;
+    }
+
     /**
      * Returns the target config filename of a project reference.
      * Note: The file might not exist.
      */
-    // TODO: Does this need to be exposed
-    export function resolveProjectReferencePath(ref: ProjectReference): ResolvedConfigFileName {
-        return resolveConfigFileProjectName(ref.path);
+    export function resolveProjectReferencePath(ref: ProjectReference): ResolvedConfigFileName;
+    /** @deprecated */ export function resolveProjectReferencePath(host: ResolveProjectReferencePathHost, ref: ProjectReference): ResolvedConfigFileName;
+    export function resolveProjectReferencePath(hostOrRef: ResolveProjectReferencePathHost | ProjectReference, ref?: ProjectReference): ResolvedConfigFileName {
+        const passedInRef = ref ? ref : hostOrRef as ProjectReference;
+        return resolveConfigFileProjectName(passedInRef.path);
     }
 
     /* @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4182,11 +4182,15 @@ declare namespace ts {
      * @returns A 'Program' object.
      */
     function createProgram(rootNames: ReadonlyArray<string>, options: CompilerOptions, host?: CompilerHost, oldProgram?: Program, configFileParsingDiagnostics?: ReadonlyArray<Diagnostic>): Program;
+    /** @deprecated */ interface ResolveProjectReferencePathHost {
+        fileExists(fileName: string): boolean;
+    }
     /**
      * Returns the target config filename of a project reference.
      * Note: The file might not exist.
      */
     function resolveProjectReferencePath(ref: ProjectReference): ResolvedConfigFileName;
+    /** @deprecated */ function resolveProjectReferencePath(host: ResolveProjectReferencePathHost, ref: ProjectReference): ResolvedConfigFileName;
 }
 declare namespace ts {
     interface EmitOutput {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4182,11 +4182,15 @@ declare namespace ts {
      * @returns A 'Program' object.
      */
     function createProgram(rootNames: ReadonlyArray<string>, options: CompilerOptions, host?: CompilerHost, oldProgram?: Program, configFileParsingDiagnostics?: ReadonlyArray<Diagnostic>): Program;
+    /** @deprecated */ interface ResolveProjectReferencePathHost {
+        fileExists(fileName: string): boolean;
+    }
     /**
      * Returns the target config filename of a project reference.
      * Note: The file might not exist.
      */
     function resolveProjectReferencePath(ref: ProjectReference): ResolvedConfigFileName;
+    /** @deprecated */ function resolveProjectReferencePath(host: ResolveProjectReferencePathHost, ref: ProjectReference): ResolvedConfigFileName;
 }
 declare namespace ts {
     interface EmitOutput {


### PR DESCRIPTION
Fixes the api change introduced in #27062 as per https://github.com/Microsoft/TypeScript/pull/27062/files#r217820896
