### PR TITLE
Use qutemarks around new instead of ticks around `new` in diagnostic

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3751,7 +3751,7 @@
         "category": "Message",
         "code": 6212
     },
-    "Did you mean to use `new` with this expression?": {
+    "Did you mean to use 'new' with this expression?": {
         "category": "Message",
         "code": 6213
     },

--- a/tests/baselines/reference/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.errors.txt
+++ b/tests/baselines/reference/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.errors.txt
@@ -20,12 +20,12 @@ tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(2
            ~~~
 !!! error TS2322: Type 'typeof Bar' is not assignable to type 'Bar'.
 !!! error TS2322:   Property 'x' is missing in type 'typeof Bar'.
-!!! related TS6213 tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts:10:8: Did you mean to use `new` with this expression?
+!!! related TS6213 tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts:10:8: Did you mean to use 'new' with this expression?
         y: Date
            ~~~~
 !!! error TS2322: Type 'DateConstructor' is not assignable to type 'Date'.
 !!! error TS2322:   Property 'toDateString' is missing in type 'DateConstructor'.
-!!! related TS6213 tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts:11:8: Did you mean to use `new` with this expression?
+!!! related TS6213 tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts:11:8: Did you mean to use 'new' with this expression?
     }, getNum());
     
     foo({

--- a/tests/baselines/reference/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.errors.txt
+++ b/tests/baselines/reference/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.errors.txt
@@ -28,7 +28,7 @@ tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.
         ~
 !!! error TS2322: Type 'typeof B' is not assignable to type 'A'.
 !!! error TS2322:   Property 'prop' is missing in type 'typeof B'.
-!!! related TS6213 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:13:5: Did you mean to use `new` with this expression?
+!!! related TS6213 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:13:5: Did you mean to use 'new' with this expression?
     a = C;
     
     var b: B = new C(); // error prop is missing
@@ -39,7 +39,7 @@ tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.
         ~
 !!! error TS2322: Type 'typeof B' is not assignable to type 'B'.
 !!! error TS2322:   Property 'prop' is missing in type 'typeof B'.
-!!! related TS6213 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:17:5: Did you mean to use `new` with this expression?
+!!! related TS6213 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:17:5: Did you mean to use 'new' with this expression?
     b = C;
     b = a;
     

--- a/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations2.errors.txt
+++ b/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations2.errors.txt
@@ -63,10 +63,10 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerCon
            ~
 !!! error TS2322: Type 'typeof A' is not assignable to type 'A'.
 !!! error TS2322:   Property 'foo' is missing in type 'typeof A'.
-!!! related TS6213 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts:37:8: Did you mean to use `new` with this expression?
+!!! related TS6213 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts:37:8: Did you mean to use 'new' with this expression?
         b: B
            ~
 !!! error TS2322: Type 'typeof B' is not assignable to type 'A'.
 !!! error TS2322:   Property 'foo' is missing in type 'typeof B'.
-!!! related TS6213 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts:38:8: Did you mean to use `new` with this expression?
+!!! related TS6213 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts:38:8: Did you mean to use 'new' with this expression?
     }

--- a/tests/baselines/reference/typeMatch1.errors.txt
+++ b/tests/baselines/reference/typeMatch1.errors.txt
@@ -31,7 +31,7 @@ tests/cases/compiler/typeMatch1.ts(20,1): error TS2367: This condition will alwa
        ~
 !!! error TS2322: Type 'typeof C' is not assignable to type 'C'.
 !!! error TS2322:   Property 'x' is missing in type 'typeof C'.
-!!! related TS6213 tests/cases/compiler/typeMatch1.ts:19:4: Did you mean to use `new` with this expression?
+!!! related TS6213 tests/cases/compiler/typeMatch1.ts:19:4: Did you mean to use 'new' with this expression?
     C==D;
     ~~~~
 !!! error TS2367: This condition will always return 'false' since the types 'typeof C' and 'typeof D' have no overlap.

--- a/tests/baselines/reference/weakType.errors.txt
+++ b/tests/baselines/reference/weakType.errors.txt
@@ -37,7 +37,7 @@ tests/cases/compiler/weakType.ts(62,5): error TS2322: Type '{ properties: { wron
     doSomething(null as CtorOnly);
                 ~~~~~~~~~~~~~~~~
 !!! error TS2560: Value of type 'CtorOnly' has no properties in common with type 'Settings'. Did you mean to call it?
-!!! related TS6213 tests/cases/compiler/weakType.ts:17:13: Did you mean to use `new` with this expression?
+!!! related TS6213 tests/cases/compiler/weakType.ts:17:13: Did you mean to use 'new' with this expression?
     doSomething(12);
                 ~~
 !!! error TS2559: Type '12' has no properties in common with type 'Settings'.


### PR DESCRIPTION
Fixes [this comment](https://github.com/Microsoft/TypeScript/pull/27016/files/7af89a899e6ceed88b22d255df806981242f5608#diff-e119cc28df9582f9e1ca0d41720ea142)

