### PR TITLE
Report async code fix diagnostic on name whenever it exists

### DIFF
--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -132,7 +132,7 @@ namespace ts {
         // check that a property access expression exists in there and that it is a handler
         const returnStatements = getReturnStatementsWithPromiseHandlers(node);
         if (returnStatements.length > 0) {
-            diags.push(createDiagnosticForNode(isVariableDeclaration(node.parent) ? node.parent.name : node, Diagnostics.This_may_be_converted_to_an_async_function));
+            diags.push(createDiagnosticForNode(isVariableDeclaration(node.parent) && !node.name ? node.parent.name : node, Diagnostics.This_may_be_converted_to_an_async_function));
         }
     }
 

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -132,7 +132,7 @@ namespace ts {
         // check that a property access expression exists in there and that it is a handler
         const returnStatements = getReturnStatementsWithPromiseHandlers(node);
         if (returnStatements.length > 0) {
-            diags.push(createDiagnosticForNode(isVariableDeclaration(node.parent) && !node.name ? node.parent.name : node, Diagnostics.This_may_be_converted_to_an_async_function));
+            diags.push(createDiagnosticForNode(!node.name && isVariableDeclaration(node.parent) && isIdentifier(node.parent.name) ? node.parent.name : node, Diagnostics.This_may_be_converted_to_an_async_function));
         }
     }
 

--- a/src/testRunner/unittests/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/convertToAsyncFunction.ts
@@ -1140,6 +1140,12 @@ const foo = function [#|f|]() {
 } 
 `);
 
+    _testConvertToAsyncFunction("convertToAsyncFunction_simpleFunctionExpressionAssignedToBindingPattern", `
+const { length } = [#|function|] () {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+} 
+`);
+
     _testConvertToAsyncFunction("convertToAsyncFunction_catchBlockUniqueParams", `
 function [#|f|]() {
 	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x); 

--- a/src/testRunner/unittests/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/convertToAsyncFunction.ts
@@ -1134,6 +1134,12 @@ const [#|foo|] = function () {
 } 
 `);
 
+    _testConvertToAsyncFunction("convertToAsyncFunction_simpleFunctionExpressionWithName", `
+const foo = function [#|f|]() {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+} 
+`);
+
     _testConvertToAsyncFunction("convertToAsyncFunction_catchBlockUniqueParams", `
 function [#|f|]() {
 	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x); 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionAssignedToBindingPattern.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionAssignedToBindingPattern.js
@@ -1,0 +1,12 @@
+// ==ORIGINAL==
+
+const { length } = /*[#|*/function/*|]*/ () {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+} 
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+const { length } = async function () {
+    const result = await fetch('https://typescriptlang.org');
+    console.log(result);
+} 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionAssignedToBindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionAssignedToBindingPattern.ts
@@ -1,0 +1,12 @@
+// ==ORIGINAL==
+
+const { length } = /*[#|*/function/*|]*/ () {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+} 
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+const { length } = async function () {
+    const result = await fetch('https://typescriptlang.org');
+    console.log(result);
+} 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionWithName.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionWithName.js
@@ -1,0 +1,12 @@
+// ==ORIGINAL==
+
+const foo = function /*[#|*/f/*|]*/() {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+} 
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+const foo = async function f() {
+    const result = await fetch('https://typescriptlang.org');
+    console.log(result);
+} 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionWithName.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionWithName.ts
@@ -1,0 +1,12 @@
+// ==ORIGINAL==
+
+const foo = function /*[#|*/f/*|]*/() {
+    return fetch('https://typescriptlang.org').then(result => { console.log(result) });
+} 
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+const foo = async function f() {
+    const result = await fetch('https://typescriptlang.org');
+    console.log(result);
+} 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #26801.

If a function expression that can be transformed into an async function is assigned to a variable but also has a name, we'd like to offer the fix on the function's name rather than the variable it's being assigned to.
