### PR TITLE
fix getExtendedConfig in commandLineParser

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -2143,12 +2143,7 @@ namespace ts {
     ): ParsedTsconfig | undefined {
         const extendedResult = readJsonConfigFile(extendedConfigPath, path => host.readFile(path));
         if (sourceFile) {
-            if (sourceFile.extendedSourceFiles) {
-                pushIfUnique(sourceFile.extendedSourceFiles, extendedResult.fileName);
-            }
-            else {
-                sourceFile.extendedSourceFiles = [extendedResult.fileName];
-            }
+            sourceFile.extendedSourceFiles = [extendedResult.fileName];
         }
         if (extendedResult.parseDiagnostics.length) {
             errors.push(...extendedResult.parseDiagnostics);
@@ -2159,9 +2154,7 @@ namespace ts {
         const extendedConfig = parseConfig(/*json*/ undefined, extendedResult, host, extendedDirname,
             getBaseFileName(extendedConfigPath), resolutionStack, errors);
         if (sourceFile && extendedResult.extendedSourceFiles) {
-            for (const extended of extendedResult.extendedSourceFiles) {
-                pushIfUnique(sourceFile.extendedSourceFiles!, extended);
-            }
+            sourceFile.extendedSourceFiles!.push(...extendedResult.extendedSourceFiles);
         }
 
         if (isSuccessfulParsedTsconfig(extendedConfig)) {

--- a/src/testRunner/unittests/configurationExtension.ts
+++ b/src/testRunner/unittests/configurationExtension.ts
@@ -244,6 +244,20 @@ namespace ts {
                 }, [
                     combinePaths(basePath, "main.ts")
                 ]);
+
+                it("adds extendedSourceFiles only once", () => {
+                    const sourceFile = readJsonConfigFile("configs/fourth.json", (path) => host.readFile(path));
+                    const dir = combinePaths(basePath, "configs");
+                    const expected = [
+                        combinePaths(dir, "third.json"),
+                        combinePaths(dir, "second.json"),
+                        combinePaths(dir, "base.json"),
+                    ];
+                    parseJsonSourceFileConfigFileContent(sourceFile, host, dir, {}, "fourth.json");
+                    assert.deepEqual(sourceFile.extendedSourceFiles, expected);
+                    parseJsonSourceFileConfigFileContent(sourceFile, host, dir, {}, "fourth.json");
+                    assert.deepEqual(sourceFile.extendedSourceFiles, expected);
+                });
             });
         });
     });


### PR DESCRIPTION
* remove invalid assertion
* fix invalid array spread on possibly undefined value
* only add unique files to extendedSourceFiles, preventing the array from growing infinitely

Pushing to `extendedSourceFiles` unconditionally causes it to grow larger accumulating duplicates on each call to `parseJsonSourceFileConfigFileContent`. This happens if you call `ts.createProgram` a lot with `projectReferences` (where one of them `extends` another config) and a host that caches TsConfigSourceFiles.