### PR TITLE
When renaming module, ensure rename span is just the last component of the path

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4145,6 +4145,10 @@
         "category": "Error",
         "code": 8030
     },
+    "You cannot rename a module via a global import.": {
+        "category": "Error",
+        "code": 8031
+    },
     "Only identifiers/qualified-names with optional type arguments are currently supported in a class 'extends' clause.": {
         "category": "Error",
         "code": 9002

--- a/tests/cases/fourslash/findAllRefs_importType_exportEquals.ts
+++ b/tests/cases/fourslash/findAllRefs_importType_exportEquals.ts
@@ -8,12 +8,12 @@
 ////export = [|T|];
 
 // @Filename: /b.ts
-////const x: import("[|./a|]") = 0;
-////const y: import("[|./a|]").U = "";
+////const x: import("[|./[|a|]|]") = 0;
+////const y: import("[|./[|a|]|]").U = "";
 
 verify.noErrors();
 
-const [r0, r1, r2, r3, r4] = test.ranges();
+const [r0, r1, r2, r3, r3b, r4, r4b] = test.ranges();
 verify.referenceGroups(r0, [{ definition: "type T = number\nnamespace T", ranges: [r0, r2, r3] }]);
 verify.referenceGroups(r1, [{ definition: "namespace T", ranges: [r1, r2] }]);
 verify.referenceGroups(r2, [{ definition: "type T = number\nnamespace T", ranges: [r0, r1, r2, r3] }]);
@@ -25,7 +25,7 @@ verify.referenceGroups([r3, r4], [
 verify.renameLocations(r0, [r0, r2]);
 verify.renameLocations(r1, [r1, r2]);
 verify.renameLocations(r2, [r0, r1, r2]);
-for (const range of [r3, r4]) {
+for (const range of [r3b, r4b]) {
     goTo.rangeStart(range);
     verify.renameInfoSucceeded(/*displayName*/ "/a.ts", /*fullDisplayName*/ "/a.ts", /*kind*/ "module", /*kindModifiers*/ "", /*fileToRename*/ "/a.ts", range);
 }

--- a/tests/cases/fourslash/renameImport.ts
+++ b/tests/cases/fourslash/renameImport.ts
@@ -2,6 +2,9 @@
 
 // @allowJs: true
 
+// @Filename: /node_modules/global/index.d.ts
+////export const x: number;
+
 // @Filename: /a.ts
 ////export const x = 0;
 
@@ -9,13 +12,14 @@
 ////export const x = 0;
 
 // @Filename: /b.ts
-////import * as a from "[|./a|]";
-////import a2 = require("[|./a|]");
-////import * as dir from "[|{| "target": "dir" |}./dir|]";
-////import * as dir2 from "[|{| "target": "dir/index" |}./dir/index|]";
+////import * as a from "./[|a|]";
+////import a2 = require("./[|a|]");
+////import * as dir from "./[|{| "target": "dir" |}dir|]";
+////import * as dir2 from "./dir/[|{| "target": "dir/index" |}index|]";
 
 // @Filename: /c.js
-////const a = require("[|./a|]");
+////const a = require("./[|a|]");
+////const global = require("/*global*/global");
 
 verify.noErrors();
 goTo.eachRange(range => {
@@ -24,3 +28,6 @@ goTo.eachRange(range => {
     const kind = target === "dir" ? "directory" : "module";
     verify.renameInfoSucceeded(/*displayName*/ name, /*fullDisplayName*/ name, /*kind*/ kind, /*kindModifiers*/ "", /*fileToRename*/ name, range);
 });
+
+goTo.marker("global");
+verify.renameInfoFailed("You cannot rename a module via a global import.");


### PR DESCRIPTION
Sequel to #24702

Discussed with @mjbvz that editors don't want to handle changing complex paths, but changing just the last component is easier.