### PR TITLE
Fix incremental watch when project built has project references

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -842,7 +842,7 @@ namespace ts {
         return deduplicateSorted(sort(array, comparer), equalityComparer || comparer);
     }
 
-    export function arrayIsEqualTo<T>(array1: ReadonlyArray<T> | undefined, array2: ReadonlyArray<T> | undefined, equalityComparer: (a: T, b: T) => boolean = equateValues): boolean {
+    export function arrayIsEqualTo<T>(array1: ReadonlyArray<T> | undefined, array2: ReadonlyArray<T> | undefined, equalityComparer: (a: T, b: T, index: number) => boolean = equateValues): boolean {
         if (!array1 || !array2) {
             return array1 === array2;
         }
@@ -852,7 +852,7 @@ namespace ts {
         }
 
         for (let i = 0; i < array1.length; i++) {
-            if (!equalityComparer(array1[i], array2[i])) {
+            if (!equalityComparer(array1[i], array2[i], i)) {
                 return false;
             }
         }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -758,7 +758,8 @@ namespace ts {
             getConfigFileParsingDiagnostics,
             getResolvedModuleWithFailedLookupLocationsFromCache,
             getProjectReferences,
-            getResolvedProjectReferences
+            getResolvedProjectReferences,
+            getProjectReferenceRedirect
         };
 
         verifyCompilerOptions();

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -862,7 +862,7 @@ namespace ts {
             if (buildProject) {
                 buildSingleInvalidatedProject(buildProject.project, buildProject.reloadLevel);
                 if (hasPendingInvalidatedProjects()) {
-                    if (!timerToBuildInvalidatedProject) {
+                    if (options.watch && !timerToBuildInvalidatedProject) {
                         scheduleBuildInvalidatedProject();
                     }
                 }

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -285,16 +285,17 @@ namespace ts {
     }
 
     function getOutFileOutputs(project: ParsedCommandLine): ReadonlyArray<string> {
-        if (!project.options.outFile) {
+        const out = project.options.outFile || project.options.out;
+        if (!out) {
             return Debug.fail("outFile must be set");
         }
         const outputs: string[] = [];
-        outputs.push(project.options.outFile);
+        outputs.push(out);
         if (project.options.sourceMap) {
-            outputs.push(`${project.options.outFile}.map`);
+            outputs.push(`${out}.map`);
         }
         if (getEmitDeclarations(project.options)) {
-            const dts = changeExtension(project.options.outFile, Extension.Dts);
+            const dts = changeExtension(out, Extension.Dts);
             outputs.push(dts);
             if (project.options.declarationMap) {
                 outputs.push(`${dts}.map`);
@@ -1248,7 +1249,7 @@ namespace ts {
     }
 
     export function getAllProjectOutputs(project: ParsedCommandLine): ReadonlyArray<string> {
-        if (project.options.outFile) {
+        if (project.options.outFile || project.options.out) {
             return getOutFileOutputs(project);
         }
         else {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2551,6 +2551,11 @@ namespace ts {
         fileName: string;
         /* @internal */ path: Path;
         text: string;
+        /** Resolved path can be different from path property,
+         * when file is included through project reference is mapped to its output instead of source
+         * in that case resolvedPath = path to output file
+         * path = input file's path
+         */
         /* @internal */ resolvedPath: Path;
 
         /**
@@ -2819,6 +2824,7 @@ namespace ts {
 
         getProjectReferences(): ReadonlyArray<ProjectReference> | undefined;
         getResolvedProjectReferences(): (ResolvedProjectReference | undefined)[] | undefined;
+        /*@internal*/ getProjectReferenceRedirect(fileName: string): string | undefined;
     }
 
     /* @internal */

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -934,7 +934,12 @@ interface Array<T> {}`
             const folder = this.fs.get(base) as FsFolder;
             Debug.assert(isFsFolder(folder));
 
-            this.addFileOrFolderInFolder(folder, file);
+            if (!this.fs.has(file.path)) {
+                this.addFileOrFolderInFolder(folder, file);
+            }
+            else {
+                this.modifyFile(path, content);
+            }
         }
 
         write(message: string) {

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -187,9 +187,10 @@ interface Array<T> {}`
     }
 
     export function checkArray(caption: string, actual: ReadonlyArray<string>, expected: ReadonlyArray<string>) {
+        checkMapKeys(caption, arrayToMap(actual, identity), expected);
         assert.equal(actual.length, expected.length, `${caption}: incorrect actual number of files, expected:\r\n${expected.join("\r\n")}\r\ngot: ${actual.join("\r\n")}`);
         for (const f of expected) {
-            assert.equal(true, contains(actual, f), `${caption}: expected to find ${f} in ${actual}`);
+            assert.isTrue(contains(actual, f), `${caption}: expected to find ${f} in ${actual}`);
         }
     }
 

--- a/src/testRunner/unittests/tscWatchMode.ts
+++ b/src/testRunner/unittests/tscWatchMode.ts
@@ -20,6 +20,13 @@ namespace ts.tscWatch {
         checkArray(`Program rootFileNames`, program.getRootFileNames(), expectedFiles);
     }
 
+    export function createWatchOfConfigFileReturningBuilder(configFileName: string, host: WatchedSystem, maxNumberOfFilesToIterateForInvalidation?: number) {
+        const compilerHost = createWatchCompilerHostOfConfigFile(configFileName, {}, host);
+        compilerHost.maxNumberOfFilesToIterateForInvalidation = maxNumberOfFilesToIterateForInvalidation;
+        const watch = createWatchProgram(compilerHost);
+        return () => watch.getCurrentProgram();
+    }
+
     export function createWatchOfConfigFile(configFileName: string, host: WatchedSystem, maxNumberOfFilesToIterateForInvalidation?: number) {
         const compilerHost = createWatchCompilerHostOfConfigFile(configFileName, {}, host);
         compilerHost.maxNumberOfFilesToIterateForInvalidation = maxNumberOfFilesToIterateForInvalidation;


### PR DESCRIPTION
Sequel to #27082 to ensure edits after watch API is invoked, are updated correctly.

