### PR TITLE
Fix enum tag circular references

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2112,6 +2112,10 @@
         "category": "Error",
         "code": 2585
     },
+    "Enum type '{0}' circularly references itself.": {
+        "category": "Error",
+        "code": 2586
+    },
     "JSX element attributes type '{0}' may not be a union type.": {
         "category": "Error",
         "code": 2600

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3670,6 +3670,7 @@ namespace ts {
     export interface NodeLinks {
         flags: NodeCheckFlags;           // Set of flags specific to Node
         resolvedType?: Type;              // Cached type of type node
+        resolvedEnumType?: Type;          // UGH
         resolvedSignature?: Signature;    // Cached signature of signature node or call expression
         resolvedSignatures?: Map<Signature[]>;   // Cached signatures of jsx node
         resolvedSymbol?: Symbol;          // Cached name resolution result

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3670,7 +3670,7 @@ namespace ts {
     export interface NodeLinks {
         flags: NodeCheckFlags;           // Set of flags specific to Node
         resolvedType?: Type;              // Cached type of type node
-        resolvedEnumType?: Type;          // UGH
+        resolvedEnumType?: Type;          // Cached constraint type from enum jsdoc tag
         resolvedSignature?: Signature;    // Cached signature of signature node or call expression
         resolvedSignatures?: Map<Signature[]>;   // Cached signatures of jsx node
         resolvedSymbol?: Symbol;          // Cached name resolution result

--- a/tests/baselines/reference/enumTagCircularReference.errors.txt
+++ b/tests/baselines/reference/enumTagCircularReference.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/jsdoc/bug27142.js(1,12): error TS2586: Enum type 'E' circularly references itself.
+
+
+==== tests/cases/conformance/jsdoc/bug27142.js (1 errors) ====
+    /** @enum {E} */
+               ~
+!!! error TS2586: Enum type 'E' circularly references itself.
+    const E = { x: 0 };
+    

--- a/tests/baselines/reference/enumTagCircularReference.symbols
+++ b/tests/baselines/reference/enumTagCircularReference.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/conformance/jsdoc/bug27142.js ===
+/** @enum {E} */
+const E = { x: 0 };
+>E : Symbol(E, Decl(bug27142.js, 1, 5))
+>x : Symbol(x, Decl(bug27142.js, 1, 11))
+

--- a/tests/baselines/reference/enumTagCircularReference.types
+++ b/tests/baselines/reference/enumTagCircularReference.types
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/jsdoc/bug27142.js ===
+/** @enum {E} */
+const E = { x: 0 };
+>E : { x: number; }
+>{ x: 0 } : { x: number; }
+>x : number
+>0 : 0
+

--- a/tests/cases/conformance/jsdoc/enumTagCircularReference.ts
+++ b/tests/cases/conformance/jsdoc/enumTagCircularReference.ts
@@ -1,0 +1,7 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: bug27142.js
+
+/** @enum {E} */
+const E = { x: 0 };


### PR DESCRIPTION
Also, don't try to resolve enum tag types in Typescript.

Fixes #27142

I'm not sure it's the right solution because I had to extend `TypeSystemEntity` to include node, add a new TypeSystemPropertyName, etc. But I wanted to scope the circularity detection to just enums.