### PR TITLE
Don't reformat body of arrow function when deleting its parameter

### DIFF
--- a/tests/cases/fourslash/unusedParameterInLambda1.ts
+++ b/tests/cases/fourslash/unusedParameterInLambda1.ts
@@ -4,9 +4,8 @@
 // @noUnusedParameters: true
 ////[|/*~a*/(/*~b*/x/*~c*/:/*~d*/number/*~e*/)/*~f*/ => /*~g*/{/*~h*/}/*~i*/|]
 
-// In a perfect world, /*~f*/ and /*~h*/ would probably be retained.
 verify.codeFix({
     description: "Remove declaration for: 'x'",
     index: 0,
-    newRangeContent: "/*~a*/() => /*~g*/ { }/*~i*/",
+    newRangeContent: "/*~a*/(/*~e*/)/*~f*/ => /*~g*/{/*~h*/}/*~i*/",
 });

--- a/tests/cases/fourslash/unusedParameterInLambda2.ts
+++ b/tests/cases/fourslash/unusedParameterInLambda2.ts
@@ -4,9 +4,8 @@
 // @noUnusedParameters: true
 ////[|/*~a*/x/*~b*/ /*~c*/=>/*~d*/ {/*~e*/}/*~f*/|]
 
-// In a perfect world, /*~c*/ and /*~e*/ would probably be retained.
 verify.codeFix({
     description: "Remove declaration for: 'x'",
     index: 0,
-    newRangeContent: "/*~a*/() => /*~d*/ { }/*~f*/",
+    newRangeContent: "/*~a*/()/*~b*/ /*~c*/=>/*~d*/ {/*~e*/}/*~f*/",
 });


### PR DESCRIPTION
Basically a port of #23973

We no longer crash on the original repro, but still a good idea to not avoid reformatting any nodes we don't need to.

