### PR TITLE
Only report expando use-before-def for identical control flow containers

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18487,7 +18487,10 @@ namespace ts {
                     }
                 }
             }
-            else if (strictNullChecks && prop && prop.valueDeclaration && isPropertyAccessExpression(prop.valueDeclaration) && getAssignmentDeclarationPropertyAccessKind(prop.valueDeclaration)) {
+            else if (strictNullChecks && prop && prop.valueDeclaration &&
+                isPropertyAccessExpression(prop.valueDeclaration) &&
+                getAssignmentDeclarationPropertyAccessKind(prop.valueDeclaration) &&
+                getControlFlowContainer(node) === getControlFlowContainer(prop.valueDeclaration)) {
                 assumeUninitialized = true;
             }
             const flowType = getFlowTypeOfReference(node, propType, assumeUninitialized ? getOptionalType(propType) : propType);

--- a/tests/baselines/reference/typeFromPropertyAssignment37.symbols
+++ b/tests/baselines/reference/typeFromPropertyAssignment37.symbols
@@ -1,0 +1,34 @@
+=== tests/cases/conformance/salsa/use.js ===
+const util = require('./mod')
+>util : Symbol(util, Decl(use.js, 0, 5))
+>require : Symbol(require)
+>'./mod' : Symbol("tests/cases/conformance/salsa/mod", Decl(mod.js, 0, 0))
+
+function n() {
+>n : Symbol(n, Decl(use.js, 0, 29))
+
+    util.existy // no error
+>util.existy : Symbol(existy, Decl(mod.js, 1, 14))
+>util : Symbol(util, Decl(use.js, 0, 5))
+>existy : Symbol(existy, Decl(mod.js, 1, 14))
+}
+util.existy // no error
+>util.existy : Symbol(existy, Decl(mod.js, 1, 14))
+>util : Symbol(util, Decl(use.js, 0, 5))
+>existy : Symbol(existy, Decl(mod.js, 1, 14))
+
+=== tests/cases/conformance/salsa/mod.js ===
+const util = exports = module.exports = {}
+>util : Symbol(util, Decl(mod.js, 0, 5))
+>exports : Symbol("tests/cases/conformance/salsa/mod", Decl(mod.js, 0, 0))
+>module.exports : Symbol("tests/cases/conformance/salsa/mod", Decl(mod.js, 0, 0))
+>module : Symbol(module, Decl(mod.js, 0, 22))
+>exports : Symbol("tests/cases/conformance/salsa/mod", Decl(mod.js, 0, 0))
+
+if (!!false) {
+    util.existy = function () { }
+>util.existy : Symbol(existy, Decl(mod.js, 1, 14))
+>util : Symbol(util, Decl(mod.js, 0, 5))
+>existy : Symbol(existy, Decl(mod.js, 1, 14))
+}
+

--- a/tests/baselines/reference/typeFromPropertyAssignment37.types
+++ b/tests/baselines/reference/typeFromPropertyAssignment37.types
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/salsa/use.js ===
+const util = require('./mod')
+>util : typeof import("tests/cases/conformance/salsa/mod")
+>require('./mod') : typeof import("tests/cases/conformance/salsa/mod")
+>require : any
+>'./mod' : "./mod"
+
+function n() {
+>n : () => void
+
+    util.existy // no error
+>util.existy : () => void
+>util : typeof import("tests/cases/conformance/salsa/mod")
+>existy : () => void
+}
+util.existy // no error
+>util.existy : () => void
+>util : typeof import("tests/cases/conformance/salsa/mod")
+>existy : () => void
+
+=== tests/cases/conformance/salsa/mod.js ===
+const util = exports = module.exports = {}
+>util : typeof import("tests/cases/conformance/salsa/mod")
+>exports = module.exports = {} : typeof import("tests/cases/conformance/salsa/mod")
+>exports : typeof import("tests/cases/conformance/salsa/mod")
+>module.exports = {} : typeof import("tests/cases/conformance/salsa/mod")
+>module.exports : typeof import("tests/cases/conformance/salsa/mod")
+>module : { "tests/cases/conformance/salsa/mod": typeof import("tests/cases/conformance/salsa/mod"); }
+>exports : typeof import("tests/cases/conformance/salsa/mod")
+>{} : {}
+
+if (!!false) {
+>!!false : boolean
+>!false : true
+>false : false
+
+    util.existy = function () { }
+>util.existy = function () { } : () => void
+>util.existy : () => void
+>util : typeof import("tests/cases/conformance/salsa/mod")
+>existy : () => void
+>function () { } : () => void
+}
+

--- a/tests/cases/conformance/salsa/typeFromPropertyAssignment37.ts
+++ b/tests/cases/conformance/salsa/typeFromPropertyAssignment37.ts
@@ -1,0 +1,15 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: mod.js
+const util = exports = module.exports = {}
+if (!!false) {
+    util.existy = function () { }
+}
+
+// @Filename: use.js
+const util = require('./mod')
+function n() {
+    util.existy // no error
+}
+util.existy // no error


### PR DESCRIPTION
Fixes #27167 

Note that the check is needs to call getControlFlowContainer twice, unlike check for class properties.
