### PR TITLE
Fix signature help not showing in block body bug

### DIFF
--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -38,7 +38,8 @@ namespace ts.SignatureHelp {
             return undefined;
         }
 
-        const argumentInfo = getContainingArgumentInfo(startingToken, position, sourceFile, typeChecker);
+        const isManuallyInvoked = !!triggerReason && triggerReason.kind === "invoked";
+        const argumentInfo = getContainingArgumentInfo(startingToken, position, sourceFile, typeChecker, isManuallyInvoked);
         if (!argumentInfo) return undefined;
 
         cancellationToken.throwIfCancellationRequested();
@@ -450,8 +451,8 @@ namespace ts.SignatureHelp {
         return createTextSpan(applicableSpanStart, applicableSpanEnd - applicableSpanStart);
     }
 
-    function getContainingArgumentInfo(node: Node, position: number, sourceFile: SourceFile, checker: TypeChecker): ArgumentListInfo | undefined {
-        for (let n = node; !isBlock(n) && !isSourceFile(n); n = n.parent) {
+    function getContainingArgumentInfo(node: Node, position: number, sourceFile: SourceFile, checker: TypeChecker, isManuallyInvoked: boolean): ArgumentListInfo | undefined {
+        for (let n = node; isManuallyInvoked || (!isBlock(n) && !isSourceFile(n)); n = n.parent) {
             // If the node is not a subspan of its parent, this is a big problem.
             // There have been crashes that might be caused by this violation.
             Debug.assert(rangeContainsRange(n.parent, n), "Not a subspan", () => `Child: ${Debug.showSyntaxKind(n)}, parent: ${Debug.showSyntaxKind(n.parent)}`);

--- a/tests/cases/fourslash/signatureHelpInAdjacentBlockBody.ts
+++ b/tests/cases/fourslash/signatureHelpInAdjacentBlockBody.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+////declare function foo(...args);
+////
+////foo(() => {/*1*/}/*2*/)
+
+goTo.marker("1");
+verify.signatureHelpPresentForTriggerReason({
+    kind: "invoked",
+});
+
+goTo.marker("2");
+verify.signatureHelpPresentForTriggerReason({
+    kind: "invoked",
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
This change fixes manual triggering inside adjacent block body.

Basically if it was a manual invocation it keeps walking up.

Fixes issue #27056 