### PR TITLE
Add GDPR annotations

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -44,6 +44,22 @@ namespace ts.server {
         readonly data: ProjectInfoTelemetryEventData;
     }
 
+/* __GDPR__
+   "projectInfo" : {
+        "fileStats": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "compilerOptions": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "extends": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "files": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "include": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "exclude": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "compileOnSave": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "typeAcquisition": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "configFileName": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "projectType": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "languageServiceEnabled": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "version": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+   }
+ */
     export interface ProjectInfoTelemetryEventData {
         /** Cryptographically secure hash of project file location. */
         readonly projectId: string;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2737,6 +2737,13 @@ namespace ts.server.protocol {
         payload: TypingsInstalledTelemetryEventPayload;
     }
 
+/* __GDPR__
+   "typingsinstalled" : {
+        "installedPackages": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
+        "installSuccess": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+        "typingsInstallerVersion": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
+   }
+ */
     export interface TypingsInstalledTelemetryEventPayload {
         /**
          * Comma separated list of installed typing packages


### PR DESCRIPTION
Note that `projectId` is not included in the metadata. It should be, but marked as excluded, I believe. I need to ask @kieferrm whether vscode-gdpr-tooling needs to add support for this combination.
