### PR TITLE
Fix error message for class type in JSDoc missing type arguments

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8158,7 +8158,7 @@ namespace ts {
                 const isJs = isInJSFile(node);
                 const isJsImplicitAny = !noImplicitAny && isJs;
                 if (!isJsImplicitAny && (numTypeArguments < minTypeArgumentCount || numTypeArguments > typeParameters.length)) {
-                    const missingAugmentsTag = isJs && node.parent.kind !== SyntaxKind.JSDocAugmentsTag;
+                    const missingAugmentsTag = isJs && isExpressionWithTypeArguments(node) && !isJSDocAugmentsTag(node.parent);
                     const diag = minTypeArgumentCount === typeParameters.length
                         ? missingAugmentsTag
                         ? Diagnostics.Expected_0_type_arguments_provide_these_with_an_extends_tag

--- a/tests/baselines/reference/jsdocClassMissingTypeArguments.errors.txt
+++ b/tests/baselines/reference/jsdocClassMissingTypeArguments.errors.txt
@@ -1,0 +1,12 @@
+/a.js(4,13): error TS2314: Generic type 'C<T>' requires 1 type argument(s).
+
+
+==== /a.js (1 errors) ====
+    /** @template T */
+    class C {}
+    
+    /** @param {C} p */
+                ~
+!!! error TS2314: Generic type 'C<T>' requires 1 type argument(s).
+    function f(p) {}
+    

--- a/tests/baselines/reference/jsdocClassMissingTypeArguments.symbols
+++ b/tests/baselines/reference/jsdocClassMissingTypeArguments.symbols
@@ -1,0 +1,10 @@
+=== /a.js ===
+/** @template T */
+class C {}
+>C : Symbol(C, Decl(a.js, 0, 0))
+
+/** @param {C} p */
+function f(p) {}
+>f : Symbol(f, Decl(a.js, 1, 10))
+>p : Symbol(p, Decl(a.js, 4, 11))
+

--- a/tests/baselines/reference/jsdocClassMissingTypeArguments.types
+++ b/tests/baselines/reference/jsdocClassMissingTypeArguments.types
@@ -1,0 +1,10 @@
+=== /a.js ===
+/** @template T */
+class C {}
+>C : C<T>
+
+/** @param {C} p */
+function f(p) {}
+>f : (p: C<any>) => void
+>p : C<any>
+

--- a/tests/cases/compiler/jsdocClassMissingTypeArguments.ts
+++ b/tests/cases/compiler/jsdocClassMissingTypeArguments.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @noImplicitAny: true
+
+// @Filename: /a.js
+/** @template T */
+class C {}
+
+/** @param {C} p */
+function f(p) {}


### PR DESCRIPTION
Previously there would be an error telling users to add an `@extends` tag, but that's only appropriate if we're at `extends C` -- if we're at `{C}` we can just change to `{C<T>}`.