### PR TITLE
Limit inference from apparent types to one level deep

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13620,14 +13620,13 @@ namespace ts {
                         if (apparentSource !== source && allowComplexConstraintInference && !(apparentSource.flags & (TypeFlags.Object | TypeFlags.Intersection))) {
                             // TODO: The `allowComplexConstraintInference` flag is a hack! This forbids inference from complex constraints within constraints!
                             // This isn't required algorithmically, but rather is used to lower the memory burden caused by performing inference
-                            // that is _too gooisTopLevelInExternalModuleAugmentationd_ in projects with complicated constraints (eg, fp-ts). In such cases, if we did not limit ourselves
+                            // that is _too good_ in projects with complicated constraints (eg, fp-ts). In such cases, if we did not limit ourselves
                             // here, we might produce more valid inferences for types, causing us to do more checks and perform more instantiations
                             // (in addition to the extra stack depth here) which, in turn, can push the already close process over its limit.
                             // TL;DR: If we ever become generally more memory efficienct (or our resource budget ever increases), we should just
                             // remove this `allowComplexConstraintInference` flag.
                             allowComplexConstraintInference = false;
-                            inferFromTypes(apparentSource, target);
-                            return;
+                            return inferFromTypes(apparentSource, target);
                         }
                         source = apparentSource;
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13439,6 +13439,7 @@ namespace ts {
             let visited: Map<boolean>;
             let contravariant = false;
             let propagationType: Type;
+            let top = true;
             inferFromTypes(originalSource, originalTarget);
 
             function inferFromTypes(source: Type, target: Type): void {
@@ -13616,7 +13617,15 @@ namespace ts {
                         // getApparentType can return _any_ type, since an indexed access or conditional may simplify to any other type.
                         // If that occurs and it doesn't simplify to an object or intersection, we'll need to restart `inferFromTypes`
                         // with the simplified source.
-                        if (apparentSource !== source && !(apparentSource.flags & (TypeFlags.Object | TypeFlags.Intersection))) {
+                        if (apparentSource !== source && !(apparentSource.flags & (TypeFlags.Object | TypeFlags.Intersection)) && top === true) {
+                            // TODO: This `top` flag is a hack! This forbids inference from complex constraints within constraints!
+                            // This isn't required algorithmically, but rather is used to lower the memory burden caused by performing inference
+                            // that is _too good_ in projects with complicated constraints (eg, fp-ts). In such cases, if we did not limit ourselves
+                            // here, we might produce more valid inferences for types, causing us to do more checks and perform more instantiations
+                            // (in addition to the extra stack depth here) which, in turn, can push the already close process over its limit.
+                            // TL;DR: If we ever become generally more memory efficienct (or our resource budget ever increases), we should just
+                            // remove this `top` flag.
+                            top = false;
                             return inferFromTypes(apparentSource, target);
                         }
                         source = apparentSource;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13439,7 +13439,7 @@ namespace ts {
             let visited: Map<boolean>;
             let contravariant = false;
             let propagationType: Type;
-            let top = true;
+            let allowComplexConstraintInference = true;
             inferFromTypes(originalSource, originalTarget);
 
             function inferFromTypes(source: Type, target: Type): void {
@@ -13617,16 +13617,17 @@ namespace ts {
                         // getApparentType can return _any_ type, since an indexed access or conditional may simplify to any other type.
                         // If that occurs and it doesn't simplify to an object or intersection, we'll need to restart `inferFromTypes`
                         // with the simplified source.
-                        if (apparentSource !== source && !(apparentSource.flags & (TypeFlags.Object | TypeFlags.Intersection)) && top === true) {
-                            // TODO: This `top` flag is a hack! This forbids inference from complex constraints within constraints!
+                        if (apparentSource !== source && allowComplexConstraintInference && !(apparentSource.flags & (TypeFlags.Object | TypeFlags.Intersection))) {
+                            // TODO: The `allowComplexConstraintInference` flag is a hack! This forbids inference from complex constraints within constraints!
                             // This isn't required algorithmically, but rather is used to lower the memory burden caused by performing inference
-                            // that is _too good_ in projects with complicated constraints (eg, fp-ts). In such cases, if we did not limit ourselves
+                            // that is _too gooisTopLevelInExternalModuleAugmentationd_ in projects with complicated constraints (eg, fp-ts). In such cases, if we did not limit ourselves
                             // here, we might produce more valid inferences for types, causing us to do more checks and perform more instantiations
                             // (in addition to the extra stack depth here) which, in turn, can push the already close process over its limit.
                             // TL;DR: If we ever become generally more memory efficienct (or our resource budget ever increases), we should just
-                            // remove this `top` flag.
-                            top = false;
-                            return inferFromTypes(apparentSource, target);
+                            // remove this `allowComplexConstraintInference` flag.
+                            allowComplexConstraintInference = false;
+                            inferFromTypes(apparentSource, target);
+                            return;
                         }
                         source = apparentSource;
                     }


### PR DESCRIPTION
Fixes the OOM in our `fp-ts` internal RWC test. There's no regression test for this because there was no bug. If you gave the process a handful of extra memory - 100MB more (roughly the overhead of our test harness itself) the build completes just fine with the original change (#27015) as-is (and, in fact, outside of the harness it does still build!). The change was simply enough to push a test already near the memory limit right over the edge.

Limiting inference from apparent types to one layer deep prevents us from using too many more resources, and isn't observably different in most cases (you'd need a type variable that simplifies to a union which contains a type variable which itself simplifies to something which you want to perform inference on to notice the difference - not something which happens at all in our harness!). In any case, this keeps #25274 fixed and the bug this limiter introduces should be difficult to reproduce in the wild (and would have also been a bug in 3.0, so isn't a regression yet).