### PR TITLE
Update GDPR annotations

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -47,7 +47,7 @@ namespace ts.server {
 /* __GDPR__
    "projectInfo" : {
         "${include}": ["${TypeScriptCommonProperties}"],
-        "projectInfo": { classification: "EndUserPseudonymizedInformation", purpose: "FeatureInsight" },
+        "projectId": { "classification": "EndUserPseudonymizedInformation", "purpose": "FeatureInsight", "endpoint": "ProjectId" },
         "fileStats": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
         "compilerOptions": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
         "extends": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -46,6 +46,8 @@ namespace ts.server {
 
 /* __GDPR__
    "projectInfo" : {
+        "${include}": ["${TypeScriptCommonProperties}"],
+        "projectInfo": { classification: "EndUserPseudonymizedInformation", purpose: "FeatureInsight" },
         "fileStats": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
         "compilerOptions": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
         "extends": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2739,6 +2739,7 @@ namespace ts.server.protocol {
 
 /* __GDPR__
    "typingsinstalled" : {
+        "${include}": ["${TypeScriptCommonProperties}"],
         "installedPackages": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight" },
         "installSuccess": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
         "typingsInstallerVersion": { "classification": "SystemMetaData", "purpose": "FeatureInsight" }


### PR DESCRIPTION
1. Use TypeScriptCommonProperties -- after moving Typescript to the extension extract step in https://github.com/Microsoft/vscode-gdpr-tooling/pull/4, TypeScriptCommonProperties is properly resolved.
2. Add projectInfo. Based on what @kieferrm said, I think that EndUserPseudonymizedInformation is correct for projectInfo.