### PR TITLE
Distribute indexes of indexed access types first

### DIFF
--- a/tests/baselines/reference/contextualTypeOfIndexedAccessParameter.js
+++ b/tests/baselines/reference/contextualTypeOfIndexedAccessParameter.js
@@ -1,0 +1,25 @@
+//// [contextualTypeOfIndexedAccessParameter.ts]
+type Keys = "a" | "b";
+
+type OptionsForKey = { a: { cb: (p: number) => number } } & { b: {} };
+
+declare function f<K extends Keys>(key: K, options: OptionsForKey[K]): void;
+
+f("a", {
+    cb: p => p,
+});
+
+function g<
+    K extends "a" | "b">(x: ({ a: string } & { b: string })[K], y: string) {
+    x = y;
+}
+
+
+//// [contextualTypeOfIndexedAccessParameter.js]
+"use strict";
+f("a", {
+    cb: function (p) { return p; }
+});
+function g(x, y) {
+    x = y;
+}

--- a/tests/baselines/reference/contextualTypeOfIndexedAccessParameter.symbols
+++ b/tests/baselines/reference/contextualTypeOfIndexedAccessParameter.symbols
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/contextualTypeOfIndexedAccessParameter.ts ===
+type Keys = "a" | "b";
+>Keys : Symbol(Keys, Decl(contextualTypeOfIndexedAccessParameter.ts, 0, 0))
+
+type OptionsForKey = { a: { cb: (p: number) => number } } & { b: {} };
+>OptionsForKey : Symbol(OptionsForKey, Decl(contextualTypeOfIndexedAccessParameter.ts, 0, 22))
+>a : Symbol(a, Decl(contextualTypeOfIndexedAccessParameter.ts, 2, 22))
+>cb : Symbol(cb, Decl(contextualTypeOfIndexedAccessParameter.ts, 2, 27))
+>p : Symbol(p, Decl(contextualTypeOfIndexedAccessParameter.ts, 2, 33))
+>b : Symbol(b, Decl(contextualTypeOfIndexedAccessParameter.ts, 2, 61))
+
+declare function f<K extends Keys>(key: K, options: OptionsForKey[K]): void;
+>f : Symbol(f, Decl(contextualTypeOfIndexedAccessParameter.ts, 2, 70))
+>K : Symbol(K, Decl(contextualTypeOfIndexedAccessParameter.ts, 4, 19))
+>Keys : Symbol(Keys, Decl(contextualTypeOfIndexedAccessParameter.ts, 0, 0))
+>key : Symbol(key, Decl(contextualTypeOfIndexedAccessParameter.ts, 4, 35))
+>K : Symbol(K, Decl(contextualTypeOfIndexedAccessParameter.ts, 4, 19))
+>options : Symbol(options, Decl(contextualTypeOfIndexedAccessParameter.ts, 4, 42))
+>OptionsForKey : Symbol(OptionsForKey, Decl(contextualTypeOfIndexedAccessParameter.ts, 0, 22))
+>K : Symbol(K, Decl(contextualTypeOfIndexedAccessParameter.ts, 4, 19))
+
+f("a", {
+>f : Symbol(f, Decl(contextualTypeOfIndexedAccessParameter.ts, 2, 70))
+
+    cb: p => p,
+>cb : Symbol(cb, Decl(contextualTypeOfIndexedAccessParameter.ts, 6, 8))
+>p : Symbol(p, Decl(contextualTypeOfIndexedAccessParameter.ts, 7, 7))
+>p : Symbol(p, Decl(contextualTypeOfIndexedAccessParameter.ts, 7, 7))
+
+});
+
+function g<
+>g : Symbol(g, Decl(contextualTypeOfIndexedAccessParameter.ts, 8, 3))
+
+    K extends "a" | "b">(x: ({ a: string } & { b: string })[K], y: string) {
+>K : Symbol(K, Decl(contextualTypeOfIndexedAccessParameter.ts, 10, 11))
+>x : Symbol(x, Decl(contextualTypeOfIndexedAccessParameter.ts, 11, 25))
+>a : Symbol(a, Decl(contextualTypeOfIndexedAccessParameter.ts, 11, 30))
+>b : Symbol(b, Decl(contextualTypeOfIndexedAccessParameter.ts, 11, 46))
+>K : Symbol(K, Decl(contextualTypeOfIndexedAccessParameter.ts, 10, 11))
+>y : Symbol(y, Decl(contextualTypeOfIndexedAccessParameter.ts, 11, 63))
+
+    x = y;
+>x : Symbol(x, Decl(contextualTypeOfIndexedAccessParameter.ts, 11, 25))
+>y : Symbol(y, Decl(contextualTypeOfIndexedAccessParameter.ts, 11, 63))
+}
+

--- a/tests/baselines/reference/contextualTypeOfIndexedAccessParameter.types
+++ b/tests/baselines/reference/contextualTypeOfIndexedAccessParameter.types
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/contextualTypeOfIndexedAccessParameter.ts ===
+type Keys = "a" | "b";
+>Keys : Keys
+
+type OptionsForKey = { a: { cb: (p: number) => number } } & { b: {} };
+>OptionsForKey : OptionsForKey
+>a : { cb: (p: number) => number; }
+>cb : (p: number) => number
+>p : number
+>b : {}
+
+declare function f<K extends Keys>(key: K, options: OptionsForKey[K]): void;
+>f : <K extends Keys>(key: K, options: OptionsForKey[K]) => void
+>key : K
+>options : OptionsForKey[K]
+
+f("a", {
+>f("a", {    cb: p => p,}) : void
+>f : <K extends Keys>(key: K, options: OptionsForKey[K]) => void
+>"a" : "a"
+>{    cb: p => p,} : { cb: (p: number) => number; }
+
+    cb: p => p,
+>cb : (p: number) => number
+>p => p : (p: number) => number
+>p : number
+>p : number
+
+});
+
+function g<
+>g : <K extends Keys>(x: ({ a: string; } & { b: string; })[K], y: string) => void
+
+    K extends "a" | "b">(x: ({ a: string } & { b: string })[K], y: string) {
+>x : ({ a: string; } & { b: string; })[K]
+>a : string
+>b : string
+>y : string
+
+    x = y;
+>x = y : string
+>x : ({ a: string; } & { b: string; })[K]
+>y : string
+}
+

--- a/tests/baselines/reference/infiniteConstraints.errors.txt
+++ b/tests/baselines/reference/infiniteConstraints.errors.txt
@@ -1,4 +1,6 @@
-error TS2321: Excessive stack depth comparing types 'Extract<T[Exclude<keyof T, string | number | symbol>], Record<"val", string>>["val"]' and 'Extract<T[Exclude<keyof T, Exclude<keyof T, string | number | symbol>>], Record<"val", string>>["val"]'.
+error TS2321: Excessive stack depth comparing types 'Extract<T[Exclude<keyof T, number>], Record<"val", string>>["val"]' and 'Extract<T[Exclude<keyof T, Exclude<keyof T, number>>], Record<"val", string>>["val"]'.
+error TS2321: Excessive stack depth comparing types 'Extract<T[Exclude<keyof T, string>], Record<"val", string>>["val"]' and 'Extract<T[Exclude<keyof T, Exclude<keyof T, string>>], Record<"val", string>>["val"]'.
+error TS2321: Excessive stack depth comparing types 'Extract<T[Exclude<keyof T, symbol>], Record<"val", string>>["val"]' and 'Extract<T[Exclude<keyof T, Exclude<keyof T, symbol>>], Record<"val", string>>["val"]'.
 tests/cases/compiler/infiniteConstraints.ts(4,37): error TS2536: Type '"val"' cannot be used to index type 'B[Exclude<keyof B, K>]'.
 tests/cases/compiler/infiniteConstraints.ts(27,37): error TS2322: Type 'Record<"val", "test">' is not assignable to type 'never'.
 tests/cases/compiler/infiniteConstraints.ts(27,58): error TS2322: Type 'Record<"val", "test2">' is not assignable to type 'never'.
@@ -8,7 +10,9 @@ tests/cases/compiler/infiniteConstraints.ts(31,63): error TS2322: Type 'Record<"
 tests/cases/compiler/infiniteConstraints.ts(36,71): error TS2536: Type '"foo"' cannot be used to index type 'T[keyof T]'.
 
 
-!!! error TS2321: Excessive stack depth comparing types 'Extract<T[Exclude<keyof T, string | number | symbol>], Record<"val", string>>["val"]' and 'Extract<T[Exclude<keyof T, Exclude<keyof T, string | number | symbol>>], Record<"val", string>>["val"]'.
+!!! error TS2321: Excessive stack depth comparing types 'Extract<T[Exclude<keyof T, number>], Record<"val", string>>["val"]' and 'Extract<T[Exclude<keyof T, Exclude<keyof T, number>>], Record<"val", string>>["val"]'.
+!!! error TS2321: Excessive stack depth comparing types 'Extract<T[Exclude<keyof T, string>], Record<"val", string>>["val"]' and 'Extract<T[Exclude<keyof T, Exclude<keyof T, string>>], Record<"val", string>>["val"]'.
+!!! error TS2321: Excessive stack depth comparing types 'Extract<T[Exclude<keyof T, symbol>], Record<"val", string>>["val"]' and 'Extract<T[Exclude<keyof T, Exclude<keyof T, symbol>>], Record<"val", string>>["val"]'.
 ==== tests/cases/compiler/infiniteConstraints.ts (7 errors) ====
     // Both of the following types trigger the recursion limiter in getImmediateBaseConstraint
     

--- a/tests/cases/compiler/contextualTypeOfIndexedAccessParameter.ts
+++ b/tests/cases/compiler/contextualTypeOfIndexedAccessParameter.ts
@@ -1,0 +1,15 @@
+// @strict: true
+type Keys = "a" | "b";
+
+type OptionsForKey = { a: { cb: (p: number) => number } } & { b: {} };
+
+declare function f<K extends Keys>(key: K, options: OptionsForKey[K]): void;
+
+f("a", {
+    cb: p => p,
+});
+
+function g<
+    K extends "a" | "b">(x: ({ a: string } & { b: string })[K], y: string) {
+    x = y;
+}


### PR DESCRIPTION
Fixes #27224

This change is a small addition (plus a bunch of comments to illustrate the process) to `getSimplifiedIndexAccessType`. To begin, let me explain the original issue. The contextual typing issue reported boils down to this:

```ts
function g<
    K extends "a" | "b">(x: ({ a: string } & { b: string })[K], y: string) {
    x = y;
}
```
This assignment worked in 3.0, and it should continue to do so. However the distribution change broke that, and in `master` (and 3.1) this assignment fails. Why? This is why: We'd see `({ a: string } & { b: string })[K]` and distribute `K` into the intersection, producing `{ a: string }[K] & { b: string }[K]`. Then for each we would get its apparent type, which means its constraint. That produces `{ a: string }["a" | "b"] & { b: string }["a" | "b"]`, which in turn becomes `({ a: string }["a"] | { a: string }["b"]) & ({ b: string }["a"] | { b: string }["b"])`, which again becomes `(string | unknown) & (unknown | string)` which is simply `unknown` (or for constraint calculation, no constraint - which is subtly different in that no constraint means it's not assignable).

This changes this in two ways:
1. We distribute index types over the object type _before_ distributing into the object type.
2. We do not perform distributions over the inner object type until the index type is no longer instantiable (and therefore might becomes a union we would need to distribute).

This changes how the algebra of the above example proceeds. Starting with `({ a: string } & { b: string })[K]` we _do not_ simplify via distribution, then we get its constraint, `({ a: string } & { b: string })["a" | "b"]`. This distributes into `({ a: string } & { b: string })["a"] | ({ a: string } & { b: string })["b"]` which becomes `({ a: string }["a"] & { b: string }["a"]) | ({ a: string }["b"] & { b: string }["b"])` which becomes `(string & unknown) | (unknown & string)` which is now just `string` (as `unknown` is a noop in an intersection like `never` is in a union), which is our desired type.