### PR TITLE
Set parent pointers on manufactured reference for property initialization check

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26185,6 +26185,8 @@ namespace ts {
 
         function isPropertyInitializedInConstructor(propName: Identifier, propType: Type, constructor: ConstructorDeclaration) {
             const reference = createPropertyAccess(createThis(), propName);
+            reference.expression.parent = reference;
+            reference.parent = constructor;
             reference.flowNode = constructor.returnFlowNode;
             const flowType = getFlowTypeOfReference(reference, propType, getOptionalType(propType));
             return !(getFalsyFlags(flowType) & TypeFlags.Undefined);

--- a/tests/baselines/reference/strictBooleanMemberAssignability.js
+++ b/tests/baselines/reference/strictBooleanMemberAssignability.js
@@ -1,0 +1,16 @@
+//// [strictBooleanMemberAssignability.ts]
+class Abc {
+    def: boolean
+    constructor() {
+        this.def = true
+    }
+}
+
+//// [strictBooleanMemberAssignability.js]
+"use strict";
+var Abc = /** @class */ (function () {
+    function Abc() {
+        this.def = true;
+    }
+    return Abc;
+}());

--- a/tests/baselines/reference/strictBooleanMemberAssignability.symbols
+++ b/tests/baselines/reference/strictBooleanMemberAssignability.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/strictBooleanMemberAssignability.ts ===
+class Abc {
+>Abc : Symbol(Abc, Decl(strictBooleanMemberAssignability.ts, 0, 0))
+
+    def: boolean
+>def : Symbol(Abc.def, Decl(strictBooleanMemberAssignability.ts, 0, 11))
+
+    constructor() {
+        this.def = true
+>this.def : Symbol(Abc.def, Decl(strictBooleanMemberAssignability.ts, 0, 11))
+>this : Symbol(Abc, Decl(strictBooleanMemberAssignability.ts, 0, 0))
+>def : Symbol(Abc.def, Decl(strictBooleanMemberAssignability.ts, 0, 11))
+    }
+}

--- a/tests/baselines/reference/strictBooleanMemberAssignability.types
+++ b/tests/baselines/reference/strictBooleanMemberAssignability.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/strictBooleanMemberAssignability.ts ===
+class Abc {
+>Abc : Abc
+
+    def: boolean
+>def : boolean
+
+    constructor() {
+        this.def = true
+>this.def = true : true
+>this.def : boolean
+>this : this
+>def : boolean
+>true : true
+    }
+}

--- a/tests/cases/compiler/strictBooleanMemberAssignability.ts
+++ b/tests/cases/compiler/strictBooleanMemberAssignability.ts
@@ -1,0 +1,7 @@
+// @strict: true
+class Abc {
+    def: boolean
+    constructor() {
+        this.def = true
+    }
+}


### PR DESCRIPTION
Fixes #26978

This fixes a crash bug, so should probably be ported to 3.1.