### PR TITLE
Fix iterated type in for-await-of

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25260,14 +25260,18 @@ namespace ts {
 
                 if (allowSyncIterables) {
                     if (typeAsIterable.iteratedTypeOfIterable) {
-                        return typeAsIterable.iteratedTypeOfIterable;
+                        return allowAsyncIterables
+                            ? typeAsIterable.iteratedTypeOfAsyncIterable = getAwaitedType(typeAsIterable.iteratedTypeOfIterable)
+                            : typeAsIterable.iteratedTypeOfIterable;
                     }
 
                     // As an optimization, if the type is an instantiation of the global `Iterable<T>` or
                     // `IterableIterator<T>` then just grab its type argument.
                     if (isReferenceToType(type, getGlobalIterableType(/*reportErrors*/ false)) ||
                         isReferenceToType(type, getGlobalIterableIteratorType(/*reportErrors*/ false))) {
-                        return typeAsIterable.iteratedTypeOfIterable = (<GenericType>type).typeArguments![0];
+                        return allowAsyncIterables
+                            ? typeAsIterable.iteratedTypeOfAsyncIterable = getAwaitedType((<GenericType>type).typeArguments![0])
+                            : typeAsIterable.iteratedTypeOfIterable = (<GenericType>type).typeArguments![0];
                     }
                 }
 
@@ -25298,9 +25302,11 @@ namespace ts {
                         : createIterableType(iteratedType), errorNode);
                 }
 
-                return asyncMethodType
-                    ? typeAsIterable.iteratedTypeOfAsyncIterable = iteratedType
-                    : typeAsIterable.iteratedTypeOfIterable = iteratedType;
+                if (iteratedType) {
+                    return allowAsyncIterables
+                        ? typeAsIterable.iteratedTypeOfAsyncIterable = asyncMethodType ? iteratedType : getAwaitedType(iteratedType)
+                        : typeAsIterable.iteratedTypeOfIterable = iteratedType;
+                }
             }
         }
 

--- a/tests/baselines/reference/types.forAwait.esnext.1.symbols
+++ b/tests/baselines/reference/types.forAwait.esnext.1.symbols
@@ -7,49 +7,70 @@ declare const iterable: Iterable<number>;
 >iterable : Symbol(iterable, Decl(types.forAwait.esnext.1.ts, 1, 13))
 >Iterable : Symbol(Iterable, Decl(lib.es2015.iterable.d.ts, --, --))
 
+declare const iterableOfPromise: Iterable<Promise<number>>;
+>iterableOfPromise : Symbol(iterableOfPromise, Decl(types.forAwait.esnext.1.ts, 2, 13))
+>Iterable : Symbol(Iterable, Decl(lib.es2015.iterable.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
 async function f1() {
->f1 : Symbol(f1, Decl(types.forAwait.esnext.1.ts, 1, 41))
+>f1 : Symbol(f1, Decl(types.forAwait.esnext.1.ts, 2, 59))
 
     let y: number;
->y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 3, 7))
+>y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 4, 7))
 
     for await (const x of asyncIterable) {
->x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 4, 20))
+>x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 5, 20))
 >asyncIterable : Symbol(asyncIterable, Decl(types.forAwait.esnext.1.ts, 0, 13))
     }
     for await (const x of iterable) {
->x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 6, 20))
+>x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 7, 20))
 >iterable : Symbol(iterable, Decl(types.forAwait.esnext.1.ts, 1, 13))
     }
+    for await (const x of iterableOfPromise) {
+>x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 9, 20))
+>iterableOfPromise : Symbol(iterableOfPromise, Decl(types.forAwait.esnext.1.ts, 2, 13))
+    }
     for await (y of asyncIterable) {
->y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 3, 7))
+>y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 4, 7))
 >asyncIterable : Symbol(asyncIterable, Decl(types.forAwait.esnext.1.ts, 0, 13))
     }
     for await (y of iterable) {
->y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 3, 7))
+>y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 4, 7))
 >iterable : Symbol(iterable, Decl(types.forAwait.esnext.1.ts, 1, 13))
+    }
+    for await (y of iterableOfPromise) {
+>y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 4, 7))
+>iterableOfPromise : Symbol(iterableOfPromise, Decl(types.forAwait.esnext.1.ts, 2, 13))
     }
 }
 async function * f2() {
->f2 : Symbol(f2, Decl(types.forAwait.esnext.1.ts, 12, 1))
+>f2 : Symbol(f2, Decl(types.forAwait.esnext.1.ts, 17, 1))
 
     let y: number;
->y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 14, 7))
+>y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 19, 7))
 
     for await (const x of asyncIterable) {
->x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 15, 20))
+>x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 20, 20))
 >asyncIterable : Symbol(asyncIterable, Decl(types.forAwait.esnext.1.ts, 0, 13))
     }
     for await (const x of iterable) {
->x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 17, 20))
+>x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 22, 20))
 >iterable : Symbol(iterable, Decl(types.forAwait.esnext.1.ts, 1, 13))
     }
+    for await (const x of iterableOfPromise) {
+>x : Symbol(x, Decl(types.forAwait.esnext.1.ts, 24, 20))
+>iterableOfPromise : Symbol(iterableOfPromise, Decl(types.forAwait.esnext.1.ts, 2, 13))
+    }
     for await (y of asyncIterable) {
->y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 14, 7))
+>y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 19, 7))
 >asyncIterable : Symbol(asyncIterable, Decl(types.forAwait.esnext.1.ts, 0, 13))
     }
     for await (y of iterable) {
->y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 14, 7))
+>y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 19, 7))
 >iterable : Symbol(iterable, Decl(types.forAwait.esnext.1.ts, 1, 13))
+    }
+    for await (y of iterableOfPromise) {
+>y : Symbol(y, Decl(types.forAwait.esnext.1.ts, 19, 7))
+>iterableOfPromise : Symbol(iterableOfPromise, Decl(types.forAwait.esnext.1.ts, 2, 13))
     }
 }

--- a/tests/baselines/reference/types.forAwait.esnext.1.types
+++ b/tests/baselines/reference/types.forAwait.esnext.1.types
@@ -5,6 +5,9 @@ declare const asyncIterable: AsyncIterable<number>;
 declare const iterable: Iterable<number>;
 >iterable : Iterable<number>
 
+declare const iterableOfPromise: Iterable<Promise<number>>;
+>iterableOfPromise : Iterable<Promise<number>>
+
 async function f1() {
 >f1 : () => Promise<void>
 
@@ -19,6 +22,10 @@ async function f1() {
 >x : number
 >iterable : Iterable<number>
     }
+    for await (const x of iterableOfPromise) {
+>x : number
+>iterableOfPromise : Iterable<Promise<number>>
+    }
     for await (y of asyncIterable) {
 >y : number
 >asyncIterable : AsyncIterable<number>
@@ -26,6 +33,10 @@ async function f1() {
     for await (y of iterable) {
 >y : number
 >iterable : Iterable<number>
+    }
+    for await (y of iterableOfPromise) {
+>y : number
+>iterableOfPromise : Iterable<Promise<number>>
     }
 }
 async function * f2() {
@@ -42,6 +53,10 @@ async function * f2() {
 >x : number
 >iterable : Iterable<number>
     }
+    for await (const x of iterableOfPromise) {
+>x : number
+>iterableOfPromise : Iterable<Promise<number>>
+    }
     for await (y of asyncIterable) {
 >y : number
 >asyncIterable : AsyncIterable<number>
@@ -49,5 +64,9 @@ async function * f2() {
     for await (y of iterable) {
 >y : number
 >iterable : Iterable<number>
+    }
+    for await (y of iterableOfPromise) {
+>y : number
+>iterableOfPromise : Iterable<Promise<number>>
     }
 }

--- a/tests/cases/conformance/types/forAwait/types.forAwait.esnext.1.ts
+++ b/tests/cases/conformance/types/forAwait/types.forAwait.esnext.1.ts
@@ -3,15 +3,20 @@
 // @noEmit: true
 declare const asyncIterable: AsyncIterable<number>;
 declare const iterable: Iterable<number>;
+declare const iterableOfPromise: Iterable<Promise<number>>;
 async function f1() {
     let y: number;
     for await (const x of asyncIterable) {
     }
     for await (const x of iterable) {
     }
+    for await (const x of iterableOfPromise) {
+    }
     for await (y of asyncIterable) {
     }
     for await (y of iterable) {
+    }
+    for await (y of iterableOfPromise) {
     }
 }
 async function * f2() {
@@ -20,8 +25,12 @@ async function * f2() {
     }
     for await (const x of iterable) {
     }
+    for await (const x of iterableOfPromise) {
+    }
     for await (y of asyncIterable) {
     }
     for await (y of iterable) {
+    }
+    for await (y of iterableOfPromise) {
     }
 }


### PR DESCRIPTION
Fixes the type we return in `getIteratedTypeOfIterable` for `for..await..of`. and `yield*` when the expression is an `Iterable<Promise<T>>`.

Fixes #24570

