### PR TITLE
Fix non-selfclosing JSX tag contextual types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16795,6 +16795,12 @@ namespace ts {
         }
 
         function getContextualJsxElementAttributesType(node: JsxOpeningLikeElement) {
+            if (isJsxOpeningElement(node) && node.parent.contextualType) {
+                // Contextually applied type is moved from attributes up to the outer jsx attributes so when walking up from the children they get hit
+                // _However_ to hit them from the _attributes_ we must look for them here; otherwise we'll used the declared type
+                // (as below) instead!
+                return node.parent.contextualType;
+            }
             if (isJsxIntrinsicIdentifier(node.tagName)) {
                 return getIntrinsicAttributesTypeFromJsxOpeningLikeElement(node);
             }

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.errors.txt
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.errors.txt
@@ -1,14 +1,13 @@
 tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(20,46): error TS2322: Type '"y"' is not assignable to type '"x"'.
-tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(21,19): error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
-  Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x" | "y">'.
+tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(21,19): error TS2322: Type '{ children: (p: LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
+  Type '{ children: (p: LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x" | "y">'.
     Types of property 'children' are incompatible.
-      Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x" | "y">) => "x" | "y"'.
+      Type '(p: LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x" | "y">) => "x" | "y"'.
         Types of parameters 'p' and 'x' are incompatible.
-          Type 'LitProps<"x" | "y">' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
-            Type 'LitProps<"x" | "y">' is not assignable to type 'LitProps<"x">'.
-              Types of property 'prop' are incompatible.
-                Type '"x" | "y"' is not assignable to type '"x"'.
-                  Type '"y"' is not assignable to type '"x"'.
+          Type 'LitProps<"x" | "y">' is not assignable to type 'LitProps<"x">'.
+            Types of property 'prop' are incompatible.
+              Type '"x" | "y"' is not assignable to type '"x"'.
+                Type '"y"' is not assignable to type '"x"'.
 tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,21): error TS2322: Type '{ children: () => number; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
   Type '{ children: () => number; prop: "x"; }' is not assignable to type 'LitProps<"x">'.
     Types of property 'children' are incompatible.
@@ -42,16 +41,15 @@ tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx(22,21): error TS2322:
 !!! related TS6502 tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx:13:44: The expected type comes from the return type of this signature.
     const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
                       ~~~~~~~
-!!! error TS2322: Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
-!!! error TS2322:   Type '{ children: (p: IntrinsicAttributes & LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x" | "y">'.
+!!! error TS2322: Type '{ children: (p: LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x" | "y">'.
+!!! error TS2322:   Type '{ children: (p: LitProps<"x">) => "y"; prop: "x"; }' is not assignable to type 'LitProps<"x" | "y">'.
 !!! error TS2322:     Types of property 'children' are incompatible.
-!!! error TS2322:       Type '(p: IntrinsicAttributes & LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x" | "y">) => "x" | "y"'.
+!!! error TS2322:       Type '(p: LitProps<"x">) => "y"' is not assignable to type '(x: LitProps<"x" | "y">) => "x" | "y"'.
 !!! error TS2322:         Types of parameters 'p' and 'x' are incompatible.
-!!! error TS2322:           Type 'LitProps<"x" | "y">' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.
-!!! error TS2322:             Type 'LitProps<"x" | "y">' is not assignable to type 'LitProps<"x">'.
-!!! error TS2322:               Types of property 'prop' are incompatible.
-!!! error TS2322:                 Type '"x" | "y"' is not assignable to type '"x"'.
-!!! error TS2322:                   Type '"y"' is not assignable to type '"x"'.
+!!! error TS2322:           Type 'LitProps<"x" | "y">' is not assignable to type 'LitProps<"x">'.
+!!! error TS2322:             Types of property 'prop' are incompatible.
+!!! error TS2322:               Type '"x" | "y"' is not assignable to type '"x"'.
+!!! error TS2322:                 Type '"y"' is not assignable to type '"x"'.
     const mismatched = <ElemLit prop="x">{() => 12}</ElemLit>
                         ~~~~~~~
 !!! error TS2322: Type '{ children: () => number; prop: "x"; }' is not assignable to type 'IntrinsicAttributes & LitProps<"x">'.

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.types
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.types
@@ -127,8 +127,8 @@ const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
 ><ElemLit prop="x">{p => "y"}</ElemLit> : JSX.Element
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
 >prop : "x"
->p => "y" : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "y"
->p : JSX.IntrinsicAttributes & LitProps<"x">
+>p => "y" : (p: LitProps<"x">) => "y"
+>p : LitProps<"x">
 >"y" : "y"
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
 

--- a/tests/baselines/reference/reactDefaultPropsInferenceSuccess.errors.txt
+++ b/tests/baselines/reference/reactDefaultPropsInferenceSuccess.errors.txt
@@ -1,16 +1,21 @@
-tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(26,36): error TS2322: Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
-  Type 'void' is not assignable to type 'boolean'.
-tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(48,37): error TS2322: Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
+tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(27,36): error TS2322: Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
+  Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
+    Type 'void' is not assignable to type 'boolean'.
+tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(43,41): error TS2322: Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
+  Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
+    Type 'void' is not assignable to type 'boolean'.
+tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(64,37): error TS2322: Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
   Type 'void' is not assignable to type 'boolean'.
 
 
-==== tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx (2 errors) ====
+==== tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx (3 errors) ====
     /// <reference path="/.lib/react16.d.ts" />
     
     import React from 'react';
     
     interface BaseProps {
-      when?: (value: string) => boolean;
+      when?: ((value: string) => boolean) | "a" | "b";
+      error?: boolean;
     }
     
     interface Props extends BaseProps {
@@ -32,10 +37,31 @@ tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(48,37): error TS2322:
     // Error: Void not assignable to boolean
     const Test2 = () => <FieldFeedback when={value => console.log(value)} />;
                                        ~~~~
-!!! error TS2322: Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
-!!! error TS2322:   Type 'void' is not assignable to type 'boolean'.
-!!! related TS6500 tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx:6:3: The expected type comes from property 'when' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<FieldFeedback<Props>> & Pick<Readonly<{ children?: ReactNode; }> & Readonly<Props>, "children"> & Partial<Pick<Readonly<{ children?: ReactNode; }> & Readonly<Props>, "when">> & Partial<Pick<{ when: () => boolean; }, never>>'
+!!! error TS2322: Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
+!!! error TS2322:   Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
+!!! error TS2322:     Type 'void' is not assignable to type 'boolean'.
+!!! related TS6500 tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx:6:3: The expected type comes from property 'when' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<FieldFeedback<Props>> & Pick<Readonly<{ children?: ReactNode; }> & Readonly<Props>, "children" | "error"> & Partial<Pick<Readonly<{ children?: ReactNode; }> & Readonly<Props>, "when">> & Partial<Pick<{ when: () => boolean; }, never>>'
     
+    class FieldFeedbackBeta<P extends Props = BaseProps> extends React.Component<P> {
+      static defaultProps: BaseProps = {
+        when: () => true
+      };
+    
+      render() {
+        return <div>Hello</div>;
+      }
+    }
+    
+    // OK
+    const Test1a = () => <FieldFeedbackBeta when={value => !!value} error>Hah</FieldFeedbackBeta>;
+    
+    // Error: Void not assignable to boolean
+    const Test2a = () => <FieldFeedbackBeta when={value => console.log(value)} error>Hah</FieldFeedbackBeta>;
+                                            ~~~~
+!!! error TS2322: Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
+!!! error TS2322:   Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
+!!! error TS2322:     Type 'void' is not assignable to type 'boolean'.
+!!! related TS6500 tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx:6:3: The expected type comes from property 'when' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<FieldFeedbackBeta<Props>> & Pick<Readonly<{ children?: ReactNode; }> & Readonly<Props>, "children"> & Partial<Pick<Readonly<{ children?: ReactNode; }> & Readonly<Props>, "when" | "error">> & Partial<Pick<BaseProps, never>>'
     
     interface MyPropsProps extends Props {
       when: (value: string) => boolean;
@@ -60,7 +86,7 @@ tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(48,37): error TS2322:
                                         ~~~~
 !!! error TS2322: Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
 !!! error TS2322:   Type 'void' is not assignable to type 'boolean'.
-!!! related TS6500 tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx:30:3: The expected type comes from property 'when' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<FieldFeedback2<MyPropsProps>> & Pick<Readonly<{ children?: ReactNode; }> & Readonly<MyPropsProps>, "children"> & Partial<Pick<Readonly<{ children?: ReactNode; }> & Readonly<MyPropsProps>, "when">> & Partial<Pick<{ when: () => boolean; }, never>>'
+!!! related TS6500 tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx:46:3: The expected type comes from property 'when' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<FieldFeedback2<MyPropsProps>> & Pick<Readonly<{ children?: ReactNode; }> & Readonly<MyPropsProps>, "children" | "error"> & Partial<Pick<Readonly<{ children?: ReactNode; }> & Readonly<MyPropsProps>, "when">> & Partial<Pick<{ when: () => boolean; }, never>>'
     
     // OK
     const Test5 = () => <FieldFeedback2 />;

--- a/tests/baselines/reference/reactDefaultPropsInferenceSuccess.js
+++ b/tests/baselines/reference/reactDefaultPropsInferenceSuccess.js
@@ -4,7 +4,8 @@
 import React from 'react';
 
 interface BaseProps {
-  when?: (value: string) => boolean;
+  when?: ((value: string) => boolean) | "a" | "b";
+  error?: boolean;
 }
 
 interface Props extends BaseProps {
@@ -26,6 +27,21 @@ const Test1 = () => <FieldFeedback when={value => !!value} />;
 // Error: Void not assignable to boolean
 const Test2 = () => <FieldFeedback when={value => console.log(value)} />;
 
+class FieldFeedbackBeta<P extends Props = BaseProps> extends React.Component<P> {
+  static defaultProps: BaseProps = {
+    when: () => true
+  };
+
+  render() {
+    return <div>Hello</div>;
+  }
+}
+
+// OK
+const Test1a = () => <FieldFeedbackBeta when={value => !!value} error>Hah</FieldFeedbackBeta>;
+
+// Error: Void not assignable to boolean
+const Test2a = () => <FieldFeedbackBeta when={value => console.log(value)} error>Hah</FieldFeedbackBeta>;
 
 interface MyPropsProps extends Props {
   when: (value: string) => boolean;
@@ -90,6 +106,23 @@ var FieldFeedback = /** @class */ (function (_super) {
 var Test1 = function () { return react_1["default"].createElement(FieldFeedback, { when: function (value) { return !!value; } }); };
 // Error: Void not assignable to boolean
 var Test2 = function () { return react_1["default"].createElement(FieldFeedback, { when: function (value) { return console.log(value); } }); };
+var FieldFeedbackBeta = /** @class */ (function (_super) {
+    __extends(FieldFeedbackBeta, _super);
+    function FieldFeedbackBeta() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    FieldFeedbackBeta.prototype.render = function () {
+        return react_1["default"].createElement("div", null, "Hello");
+    };
+    FieldFeedbackBeta.defaultProps = {
+        when: function () { return true; }
+    };
+    return FieldFeedbackBeta;
+}(react_1["default"].Component));
+// OK
+var Test1a = function () { return react_1["default"].createElement(FieldFeedbackBeta, { when: function (value) { return !!value; }, error: true }, "Hah"); };
+// Error: Void not assignable to boolean
+var Test2a = function () { return react_1["default"].createElement(FieldFeedbackBeta, { when: function (value) { return console.log(value); }, error: true }, "Hah"); };
 var FieldFeedback2 = /** @class */ (function (_super) {
     __extends(FieldFeedback2, _super);
     function FieldFeedback2() {

--- a/tests/baselines/reference/reactDefaultPropsInferenceSuccess.symbols
+++ b/tests/baselines/reference/reactDefaultPropsInferenceSuccess.symbols
@@ -7,36 +7,39 @@ import React from 'react';
 interface BaseProps {
 >BaseProps : Symbol(BaseProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 2, 26))
 
-  when?: (value: string) => boolean;
+  when?: ((value: string) => boolean) | "a" | "b";
 >when : Symbol(BaseProps.when, Decl(reactDefaultPropsInferenceSuccess.tsx, 4, 21))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 5, 10))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 5, 11))
+
+  error?: boolean;
+>error : Symbol(BaseProps.error, Decl(reactDefaultPropsInferenceSuccess.tsx, 5, 50))
 }
 
 interface Props extends BaseProps {
->Props : Symbol(Props, Decl(reactDefaultPropsInferenceSuccess.tsx, 6, 1))
+>Props : Symbol(Props, Decl(reactDefaultPropsInferenceSuccess.tsx, 7, 1))
 >BaseProps : Symbol(BaseProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 2, 26))
 }
 
 class FieldFeedback<P extends Props = BaseProps> extends React.Component<P> {
->FieldFeedback : Symbol(FieldFeedback, Decl(reactDefaultPropsInferenceSuccess.tsx, 9, 1))
->P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 11, 20))
->Props : Symbol(Props, Decl(reactDefaultPropsInferenceSuccess.tsx, 6, 1))
+>FieldFeedback : Symbol(FieldFeedback, Decl(reactDefaultPropsInferenceSuccess.tsx, 10, 1))
+>P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 12, 20))
+>Props : Symbol(Props, Decl(reactDefaultPropsInferenceSuccess.tsx, 7, 1))
 >BaseProps : Symbol(BaseProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 2, 26))
 >React.Component : Symbol(React.Component, Decl(react16.d.ts, 345, 54), Decl(react16.d.ts, 349, 94))
 >React : Symbol(React, Decl(reactDefaultPropsInferenceSuccess.tsx, 2, 6))
 >Component : Symbol(React.Component, Decl(react16.d.ts, 345, 54), Decl(react16.d.ts, 349, 94))
->P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 11, 20))
+>P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 12, 20))
 
   static defaultProps = {
->defaultProps : Symbol(FieldFeedback.defaultProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 11, 77))
+>defaultProps : Symbol(FieldFeedback.defaultProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 12, 77))
 
     when: () => true
->when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 12, 25))
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 13, 25))
 
   };
 
   render() {
->render : Symbol(FieldFeedback.render, Decl(reactDefaultPropsInferenceSuccess.tsx, 14, 4))
+>render : Symbol(FieldFeedback.render, Decl(reactDefaultPropsInferenceSuccess.tsx, 15, 4))
 
     return <div>Hello</div>;
 >div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
@@ -46,58 +49,108 @@ class FieldFeedback<P extends Props = BaseProps> extends React.Component<P> {
 
 // OK
 const Test1 = () => <FieldFeedback when={value => !!value} />;
->Test1 : Symbol(Test1, Decl(reactDefaultPropsInferenceSuccess.tsx, 22, 5))
->FieldFeedback : Symbol(FieldFeedback, Decl(reactDefaultPropsInferenceSuccess.tsx, 9, 1))
->when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 22, 34))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 22, 41))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 22, 41))
+>Test1 : Symbol(Test1, Decl(reactDefaultPropsInferenceSuccess.tsx, 23, 5))
+>FieldFeedback : Symbol(FieldFeedback, Decl(reactDefaultPropsInferenceSuccess.tsx, 10, 1))
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 23, 34))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 23, 41))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 23, 41))
 
 // Error: Void not assignable to boolean
 const Test2 = () => <FieldFeedback when={value => console.log(value)} />;
->Test2 : Symbol(Test2, Decl(reactDefaultPropsInferenceSuccess.tsx, 25, 5))
->FieldFeedback : Symbol(FieldFeedback, Decl(reactDefaultPropsInferenceSuccess.tsx, 9, 1))
->when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 25, 34))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 25, 41))
+>Test2 : Symbol(Test2, Decl(reactDefaultPropsInferenceSuccess.tsx, 26, 5))
+>FieldFeedback : Symbol(FieldFeedback, Decl(reactDefaultPropsInferenceSuccess.tsx, 10, 1))
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 26, 34))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 26, 41))
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 25, 41))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 26, 41))
 
+class FieldFeedbackBeta<P extends Props = BaseProps> extends React.Component<P> {
+>FieldFeedbackBeta : Symbol(FieldFeedbackBeta, Decl(reactDefaultPropsInferenceSuccess.tsx, 26, 73))
+>P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 28, 24))
+>Props : Symbol(Props, Decl(reactDefaultPropsInferenceSuccess.tsx, 7, 1))
+>BaseProps : Symbol(BaseProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 2, 26))
+>React.Component : Symbol(React.Component, Decl(react16.d.ts, 345, 54), Decl(react16.d.ts, 349, 94))
+>React : Symbol(React, Decl(reactDefaultPropsInferenceSuccess.tsx, 2, 6))
+>Component : Symbol(React.Component, Decl(react16.d.ts, 345, 54), Decl(react16.d.ts, 349, 94))
+>P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 28, 24))
 
-interface MyPropsProps extends Props {
->MyPropsProps : Symbol(MyPropsProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 25, 73))
->Props : Symbol(Props, Decl(reactDefaultPropsInferenceSuccess.tsx, 6, 1))
-
-  when: (value: string) => boolean;
->when : Symbol(MyPropsProps.when, Decl(reactDefaultPropsInferenceSuccess.tsx, 28, 38))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 29, 9))
-}
-
-class FieldFeedback2<P extends MyPropsProps = MyPropsProps> extends FieldFeedback<P> {
->FieldFeedback2 : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 30, 1))
->P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 32, 21))
->MyPropsProps : Symbol(MyPropsProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 25, 73))
->MyPropsProps : Symbol(MyPropsProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 25, 73))
->FieldFeedback : Symbol(FieldFeedback, Decl(reactDefaultPropsInferenceSuccess.tsx, 9, 1))
->P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 32, 21))
-
-  static defaultProps = {
->defaultProps : Symbol(FieldFeedback2.defaultProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 32, 86))
+  static defaultProps: BaseProps = {
+>defaultProps : Symbol(FieldFeedbackBeta.defaultProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 28, 81))
+>BaseProps : Symbol(BaseProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 2, 26))
 
     when: () => true
->when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 33, 25))
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 29, 36))
 
   };
 
   render() {
->render : Symbol(FieldFeedback2.render, Decl(reactDefaultPropsInferenceSuccess.tsx, 35, 4))
+>render : Symbol(FieldFeedbackBeta.render, Decl(reactDefaultPropsInferenceSuccess.tsx, 31, 4))
+
+    return <div>Hello</div>;
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+  }
+}
+
+// OK
+const Test1a = () => <FieldFeedbackBeta when={value => !!value} error>Hah</FieldFeedbackBeta>;
+>Test1a : Symbol(Test1a, Decl(reactDefaultPropsInferenceSuccess.tsx, 39, 5))
+>FieldFeedbackBeta : Symbol(FieldFeedbackBeta, Decl(reactDefaultPropsInferenceSuccess.tsx, 26, 73))
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 39, 39))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 39, 46))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 39, 46))
+>error : Symbol(error, Decl(reactDefaultPropsInferenceSuccess.tsx, 39, 63))
+>FieldFeedbackBeta : Symbol(FieldFeedbackBeta, Decl(reactDefaultPropsInferenceSuccess.tsx, 26, 73))
+
+// Error: Void not assignable to boolean
+const Test2a = () => <FieldFeedbackBeta when={value => console.log(value)} error>Hah</FieldFeedbackBeta>;
+>Test2a : Symbol(Test2a, Decl(reactDefaultPropsInferenceSuccess.tsx, 42, 5))
+>FieldFeedbackBeta : Symbol(FieldFeedbackBeta, Decl(reactDefaultPropsInferenceSuccess.tsx, 26, 73))
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 42, 39))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 42, 46))
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 42, 46))
+>error : Symbol(error, Decl(reactDefaultPropsInferenceSuccess.tsx, 42, 74))
+>FieldFeedbackBeta : Symbol(FieldFeedbackBeta, Decl(reactDefaultPropsInferenceSuccess.tsx, 26, 73))
+
+interface MyPropsProps extends Props {
+>MyPropsProps : Symbol(MyPropsProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 42, 105))
+>Props : Symbol(Props, Decl(reactDefaultPropsInferenceSuccess.tsx, 7, 1))
+
+  when: (value: string) => boolean;
+>when : Symbol(MyPropsProps.when, Decl(reactDefaultPropsInferenceSuccess.tsx, 44, 38))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 45, 9))
+}
+
+class FieldFeedback2<P extends MyPropsProps = MyPropsProps> extends FieldFeedback<P> {
+>FieldFeedback2 : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 46, 1))
+>P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 48, 21))
+>MyPropsProps : Symbol(MyPropsProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 42, 105))
+>MyPropsProps : Symbol(MyPropsProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 42, 105))
+>FieldFeedback : Symbol(FieldFeedback, Decl(reactDefaultPropsInferenceSuccess.tsx, 10, 1))
+>P : Symbol(P, Decl(reactDefaultPropsInferenceSuccess.tsx, 48, 21))
+
+  static defaultProps = {
+>defaultProps : Symbol(FieldFeedback2.defaultProps, Decl(reactDefaultPropsInferenceSuccess.tsx, 48, 86))
+
+    when: () => true
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 49, 25))
+
+  };
+
+  render() {
+>render : Symbol(FieldFeedback2.render, Decl(reactDefaultPropsInferenceSuccess.tsx, 51, 4))
 
     this.props.when("now"); // OK, always defined
->this.props.when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 28, 38))
+>this.props.when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 44, 38))
 >this.props : Symbol(React.Component.props, Decl(react16.d.ts, 367, 32))
->this : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 30, 1))
+>this : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 46, 1))
 >props : Symbol(React.Component.props, Decl(react16.d.ts, 367, 32))
->when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 28, 38))
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 44, 38))
 
     return <div>Hello</div>;
 >div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
@@ -107,25 +160,25 @@ class FieldFeedback2<P extends MyPropsProps = MyPropsProps> extends FieldFeedbac
 
 // OK
 const Test3 = () => <FieldFeedback2 when={value => !!value} />;
->Test3 : Symbol(Test3, Decl(reactDefaultPropsInferenceSuccess.tsx, 44, 5))
->FieldFeedback2 : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 30, 1))
->when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 44, 35))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 44, 42))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 44, 42))
+>Test3 : Symbol(Test3, Decl(reactDefaultPropsInferenceSuccess.tsx, 60, 5))
+>FieldFeedback2 : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 46, 1))
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 60, 35))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 60, 42))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 60, 42))
 
 // Error: Void not assignable to boolean
 const Test4 = () => <FieldFeedback2 when={value => console.log(value)} />;
->Test4 : Symbol(Test4, Decl(reactDefaultPropsInferenceSuccess.tsx, 47, 5))
->FieldFeedback2 : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 30, 1))
->when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 47, 35))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 47, 42))
+>Test4 : Symbol(Test4, Decl(reactDefaultPropsInferenceSuccess.tsx, 63, 5))
+>FieldFeedback2 : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 46, 1))
+>when : Symbol(when, Decl(reactDefaultPropsInferenceSuccess.tsx, 63, 35))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 63, 42))
 >console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
 >console : Symbol(console, Decl(lib.dom.d.ts, --, --))
 >log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
->value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 47, 42))
+>value : Symbol(value, Decl(reactDefaultPropsInferenceSuccess.tsx, 63, 42))
 
 // OK
 const Test5 = () => <FieldFeedback2 />;
->Test5 : Symbol(Test5, Decl(reactDefaultPropsInferenceSuccess.tsx, 50, 5))
->FieldFeedback2 : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 30, 1))
+>Test5 : Symbol(Test5, Decl(reactDefaultPropsInferenceSuccess.tsx, 66, 5))
+>FieldFeedback2 : Symbol(FieldFeedback2, Decl(reactDefaultPropsInferenceSuccess.tsx, 46, 1))
 

--- a/tests/baselines/reference/reactDefaultPropsInferenceSuccess.types
+++ b/tests/baselines/reference/reactDefaultPropsInferenceSuccess.types
@@ -5,9 +5,12 @@ import React from 'react';
 >React : typeof React
 
 interface BaseProps {
-  when?: (value: string) => boolean;
->when : ((value: string) => boolean) | undefined
+  when?: ((value: string) => boolean) | "a" | "b";
+>when : "a" | "b" | ((value: string) => boolean) | undefined
 >value : string
+
+  error?: boolean;
+>error : boolean | undefined
 }
 
 interface Props extends BaseProps {
@@ -68,6 +71,64 @@ const Test2 = () => <FieldFeedback when={value => console.log(value)} />;
 >log : (message?: any, ...optionalParams: any[]) => void
 >value : string
 
+class FieldFeedbackBeta<P extends Props = BaseProps> extends React.Component<P> {
+>FieldFeedbackBeta : FieldFeedbackBeta<P>
+>React.Component : React.Component<P, {}, any>
+>React : typeof React
+>Component : typeof React.Component
+
+  static defaultProps: BaseProps = {
+>defaultProps : BaseProps
+>{    when: () => true  } : { when: () => true; }
+
+    when: () => true
+>when : () => true
+>() => true : () => true
+>true : true
+
+  };
+
+  render() {
+>render : () => JSX.Element
+
+    return <div>Hello</div>;
+><div>Hello</div> : JSX.Element
+>div : any
+>div : any
+  }
+}
+
+// OK
+const Test1a = () => <FieldFeedbackBeta when={value => !!value} error>Hah</FieldFeedbackBeta>;
+>Test1a : () => JSX.Element
+>() => <FieldFeedbackBeta when={value => !!value} error>Hah</FieldFeedbackBeta> : () => JSX.Element
+><FieldFeedbackBeta when={value => !!value} error>Hah</FieldFeedbackBeta> : JSX.Element
+>FieldFeedbackBeta : typeof FieldFeedbackBeta
+>when : (value: string) => boolean
+>value => !!value : (value: string) => boolean
+>value : string
+>!!value : boolean
+>!value : boolean
+>value : string
+>error : true
+>FieldFeedbackBeta : typeof FieldFeedbackBeta
+
+// Error: Void not assignable to boolean
+const Test2a = () => <FieldFeedbackBeta when={value => console.log(value)} error>Hah</FieldFeedbackBeta>;
+>Test2a : () => JSX.Element
+>() => <FieldFeedbackBeta when={value => console.log(value)} error>Hah</FieldFeedbackBeta> : () => JSX.Element
+><FieldFeedbackBeta when={value => console.log(value)} error>Hah</FieldFeedbackBeta> : JSX.Element
+>FieldFeedbackBeta : typeof FieldFeedbackBeta
+>when : (value: string) => void
+>value => console.log(value) : (value: string) => void
+>value : string
+>console.log(value) : void
+>console.log : (message?: any, ...optionalParams: any[]) => void
+>console : Console
+>log : (message?: any, ...optionalParams: any[]) => void
+>value : string
+>error : true
+>FieldFeedbackBeta : typeof FieldFeedbackBeta
 
 interface MyPropsProps extends Props {
   when: (value: string) => boolean;

--- a/tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx
+++ b/tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx
@@ -6,7 +6,8 @@
 import React from 'react';
 
 interface BaseProps {
-  when?: (value: string) => boolean;
+  when?: ((value: string) => boolean) | "a" | "b";
+  error?: boolean;
 }
 
 interface Props extends BaseProps {
@@ -28,6 +29,21 @@ const Test1 = () => <FieldFeedback when={value => !!value} />;
 // Error: Void not assignable to boolean
 const Test2 = () => <FieldFeedback when={value => console.log(value)} />;
 
+class FieldFeedbackBeta<P extends Props = BaseProps> extends React.Component<P> {
+  static defaultProps: BaseProps = {
+    when: () => true
+  };
+
+  render() {
+    return <div>Hello</div>;
+  }
+}
+
+// OK
+const Test1a = () => <FieldFeedbackBeta when={value => !!value} error>Hah</FieldFeedbackBeta>;
+
+// Error: Void not assignable to boolean
+const Test2a = () => <FieldFeedbackBeta when={value => console.log(value)} error>Hah</FieldFeedbackBeta>;
 
 interface MyPropsProps extends Props {
   when: (value: string) => boolean;


### PR DESCRIPTION
Fixes #26395 (another construction of it)

Followup to #27088 (so this should be in 3.1 to complete the fix)

