### PR TITLE
Fix 27086. Ignore directories starting with a dot.

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -381,8 +381,13 @@ namespace ts {
                             // tslint:disable-next-line:no-null-keyword
                             const isNotNeededPackage = host.fileExists(packageJsonPath) && (readJson(packageJsonPath, host) as PackageJson).typings === null;
                             if (!isNotNeededPackage) {
-                                // Return just the type directive names
-                                result.push(getBaseFileName(normalized));
+                                const baseFileName = getBaseFileName(normalized);
+
+                                // At this stage, skip results with leading dot.
+                                if (baseFileName.charCodeAt(0) !== CharacterCodes.dot) {
+                                    // Return just the type directive names
+                                    result.push(baseFileName);
+                                }
                             }
                         }
                     }

--- a/tests/baselines/reference/moduleResolution_automaticTypeDirectiveNames.js
+++ b/tests/baselines/reference/moduleResolution_automaticTypeDirectiveNames.js
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/moduleResolution_automaticTypeDirectiveNames.ts] ////
+
+//// [index.d.ts]
+declare const a: number;
+
+//// [index.d.ts]
+declare const a: string;
+
+//// [a.ts]
+a;
+
+
+//// [a.js]
+a;

--- a/tests/baselines/reference/moduleResolution_automaticTypeDirectiveNames.symbols
+++ b/tests/baselines/reference/moduleResolution_automaticTypeDirectiveNames.symbols
@@ -1,0 +1,8 @@
+=== /a.ts ===
+a;
+>a : Symbol(a, Decl(index.d.ts, 0, 13))
+
+=== /node_modules/@types/a/index.d.ts ===
+declare const a: string;
+>a : Symbol(a, Decl(index.d.ts, 0, 13))
+

--- a/tests/baselines/reference/moduleResolution_automaticTypeDirectiveNames.types
+++ b/tests/baselines/reference/moduleResolution_automaticTypeDirectiveNames.types
@@ -1,0 +1,8 @@
+=== /a.ts ===
+a;
+>a : string
+
+=== /node_modules/@types/a/index.d.ts ===
+declare const a: string;
+>a : string
+

--- a/tests/baselines/reference/moduleResolution_noLeadingDot.js
+++ b/tests/baselines/reference/moduleResolution_noLeadingDot.js
@@ -1,0 +1,11 @@
+//// [tests/cases/compiler/moduleResolution_noLeadingDot.ts] ////
+
+//// [README.md]
+This is a test.
+
+//// [a.ts]
+true;
+
+
+//// [a.js]
+true;

--- a/tests/baselines/reference/moduleResolution_noLeadingDot.symbols
+++ b/tests/baselines/reference/moduleResolution_noLeadingDot.symbols
@@ -1,0 +1,4 @@
+=== /a.ts ===
+true;
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/moduleResolution_noLeadingDot.types
+++ b/tests/baselines/reference/moduleResolution_noLeadingDot.types
@@ -1,0 +1,4 @@
+=== /a.ts ===
+true;
+>true : true
+

--- a/tests/cases/compiler/moduleResolution_automaticTypeDirectiveNames.ts
+++ b/tests/cases/compiler/moduleResolution_automaticTypeDirectiveNames.ts
@@ -1,0 +1,10 @@
+// @noImplicitReferences: true
+
+// @Filename: /node_modules/@types/.a/index.d.ts
+declare const a: number;
+
+// @Filename: /node_modules/@types/a/index.d.ts
+declare const a: string;
+
+// @Filename: /a.ts
+a;

--- a/tests/cases/compiler/moduleResolution_noLeadingDot.ts
+++ b/tests/cases/compiler/moduleResolution_noLeadingDot.ts
@@ -1,0 +1,7 @@
+// @noImplicitReferences: true
+
+// @Filename: /node_modules/@types/.svn/README.md
+This is a test.
+
+// @Filename: /a.ts
+true;


### PR DESCRIPTION
Fix for https://github.com/Microsoft/TypeScript/issues/27086 .

If we find a folder in `@types` with a name starting with `.` (dot), and this folder doesn't have a `package.json` file, then we should ignore this folder, and not throw an error.