### PR TITLE
Align the ShimMap iterator behavior with native Maps

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -165,10 +165,9 @@ namespace ts {
             }
         }
 
-        class ShimMap<T> implements Map<T> {
-            size = 0;
-
+        return class <T> implements Map<T> {
             private data = createDictionaryObject<MapEntry<T>>();
+            public size = 0;
 
             // Linked list references for iterators.
             // See https://github.com/Microsoft/TypeScript/pull/27292
@@ -242,7 +241,6 @@ namespace ts {
 
                     return true;
                 }
-
                 return false;
             }
 
@@ -292,9 +290,7 @@ namespace ts {
                     action(entry[1], entry[0]);
                 }
             }
-        }
-
-        return ShimMap;
+        };
     }
 
     export function length(array: ReadonlyArray<any> | undefined): number {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -223,21 +223,24 @@ namespace ts {
                     const entry = this.data[key];
                     delete this.data[key];
 
-                    // Adjust the linked list references.
-                    const previousElement = entry.previousEntry!;
-                    previousElement.nextEntry = entry.nextEntry;
+                    // Adjust the linked list references of the neighbor entries.
+                    const previousEntry = entry.previousEntry!;
+                    previousEntry.nextEntry = entry.nextEntry;
+                    if (entry.nextEntry) {
+                        entry.nextEntry.previousEntry = previousEntry;
+                    }
+
+                    // When the deleted entry was the last one, we need to
+                    // adust the endElement reference.
+                    if (this.linkedListEnd === entry) {
+                        this.linkedListEnd = previousEntry;
+                    }
 
                     // Adjust the forward reference of the deleted element
                     // in case an iterator still references it.
                     entry.previousEntry = undefined;
-                    entry.nextEntry = previousElement;
+                    entry.nextEntry = previousEntry;
                     entry.skipNext = true;
-
-                    // When the deleted entry was the last one, we need to
-                    // adust the endElement reference
-                    if (this.linkedListEnd === entry) {
-                        this.linkedListEnd = previousElement;
-                    }
 
                     return true;
                 }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -130,7 +130,7 @@ namespace ts {
             constructor(shimMap: ShimMap<T>, selector: (data: MapLike<T>, key: string) => U) {
                 this.shimMap = shimMap;
                 this.selector = selector;
-                
+
                 if (!shimMap.currentIteratoKeys) {
                     // Create the key array on the map over which we (and other new iterators)
                     // will iterate.
@@ -146,17 +146,18 @@ namespace ts {
                 // Check if we still have the same key array. Otherwise, this means
                 // an element has been deleted from the map in the meanwhile, so we
                 // cannot continue.
-                if (this.index != -1 && this.originalIteratoKeys != this.shimMap.currentIteratoKeys)
+                if (this.index !== -1 && this.originalIteratoKeys !== this.shimMap.currentIteratoKeys) {
                     throw new Error("Cannot continue iteration because a map element has been deleted.");
+                }
 
                 const iteratorKeys = this.originalIteratoKeys;
-                if (this.index != -1 && this.index < iteratorKeys.length) {
+                if (this.index !== -1 && this.index < iteratorKeys.length) {
                     const index = this.index++;
                     return { value: this.selector(this.shimMap.data, iteratorKeys[index]), done: false };
                 }
                 else {
                     // Ensure subsequent invocations will always return done.
-                    this.index = -1;                    
+                    this.index = -1;
 
                     return { value: undefined as never, done: true };
                 }
@@ -167,7 +168,7 @@ namespace ts {
             size = 0;
 
             data = createDictionaryObject<T>();
-            
+
             currentIteratoKeys?: string[];
 
             get(key: string): T | undefined {
@@ -183,7 +184,7 @@ namespace ts {
                         this.currentIteratoKeys.push(key);
                     }
                 }
-                
+
                 this.data[key] = value;
                 return this;
             }
@@ -236,8 +237,9 @@ namespace ts {
                 const iterator = this.entries();
                 while (true) {
                     const { value: entry, done } = iterator.next();
-                    if (done)
+                    if (done) {
                         break;
+                    }
 
                     action(entry[1], entry[0]);
                 }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -124,33 +124,33 @@ namespace ts {
             index = 0;
 
             private shimMap: ShimMap<T>;
-            private originalIteratoKeys: string[];
+            private originalIteratorKeys: string[];
             private selector: (data: MapLike<T>, key: string) => U;
 
             constructor(shimMap: ShimMap<T>, selector: (data: MapLike<T>, key: string) => U) {
                 this.shimMap = shimMap;
                 this.selector = selector;
 
-                if (!shimMap.currentIteratoKeys) {
+                if (!shimMap.currentIteratorKeys) {
                     // Create the key array on the map over which we (and other new iterators)
                     // will iterate.
-                    shimMap.currentIteratoKeys = Object.keys(shimMap.data);
+                    shimMap.currentIteratorKeys = Object.keys(shimMap.data);
                 }
 
                 // Copy the key array to allow us later to check if the map has cleared
                 // or replaced the array.
-                this.originalIteratoKeys = shimMap.currentIteratoKeys;
+                this.originalIteratorKeys = shimMap.currentIteratorKeys;
             }
 
             public next(): { value: U, done: false } | { value: never, done: true } {
                 // Check if we still have the same key array. Otherwise, this means
                 // an element has been deleted from the map in the meanwhile, so we
                 // cannot continue.
-                if (this.index !== -1 && this.originalIteratoKeys !== this.shimMap.currentIteratoKeys) {
+                if (this.index !== -1 && this.originalIteratorKeys !== this.shimMap.currentIteratorKeys) {
                     throw new Error("Cannot continue iteration because a map element has been deleted.");
                 }
 
-                const iteratorKeys = this.originalIteratoKeys;
+                const iteratorKeys = this.originalIteratorKeys;
                 if (this.index !== -1 && this.index < iteratorKeys.length) {
                     const index = this.index++;
                     return { value: this.selector(this.shimMap.data, iteratorKeys[index]), done: false };
@@ -169,7 +169,7 @@ namespace ts {
 
             data = createDictionaryObject<T>();
 
-            currentIteratoKeys?: string[];
+            currentIteratorKeys?: string[];
 
             get(key: string): T | undefined {
                 return this.data[key];
@@ -179,9 +179,9 @@ namespace ts {
                 if (!this.has(key)) {
                     this.size++;
 
-                    if (this.currentIteratoKeys) {
+                    if (this.currentIteratorKeys) {
                         // Add the new entry.
-                        this.currentIteratoKeys.push(key);
+                        this.currentIteratorKeys.push(key);
                     }
                 }
 
@@ -199,10 +199,10 @@ namespace ts {
                     this.size--;
                     delete this.data[key];
 
-                    if (this.currentIteratoKeys) {
+                    if (this.currentIteratorKeys) {
                         // Clear the iteratorKeys array. This means if iterators are still active
                         // they will throw on the next() call.
-                        this.currentIteratoKeys = undefined;
+                        this.currentIteratorKeys = undefined;
                     }
 
                     return true;
@@ -214,10 +214,10 @@ namespace ts {
                 this.data = createDictionaryObject<T>();
                 this.size = 0;
 
-                if (this.currentIteratoKeys) {
+                if (this.currentIteratorKeys) {
                     // Clear the iteratorKeys array. This means if iterators are still active
                     // they will throw on their next() call.
-                    this.currentIteratoKeys = undefined;
+                    this.currentIteratorKeys = undefined;
                 }
             }
 

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -260,7 +260,7 @@ namespace ts {
             }
 
             clear(): void {
-                this.data = createDictionaryObject<T>();
+                this.data = createDictionaryObject<MapEntry<T>>();
                 this.size = 0;
 
                 // Reset the linked list. Note that we must adjust the forward

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -58,6 +58,7 @@
         "unittests/publicApi.ts",
         "unittests/reuseProgramStructure.ts",
         "unittests/semver.ts",
+        "unittests/shimMap.ts",
         "unittests/transform.ts",
         "unittests/tsbuild.ts",
         "unittests/tsbuildWatchMode.ts",

--- a/src/testRunner/unittests/shimMap.ts
+++ b/src/testRunner/unittests/shimMap.ts
@@ -1,0 +1,103 @@
+namespace ts {
+    describe("unittests:: shimMap", () => {
+
+        function testMapIterationAddedValues(map: Map<string>, useForEach: boolean): string {
+            let resultString = "";
+
+            map.set("1", "1");
+            map.set("3", "3");
+            map.set("2", "2");
+            map.set("4", "4");
+
+            let addedThree = false;
+            const doForEach = (value: string, key: string) => {
+                resultString += `${key}:${value};`;
+
+                // Add a new key ("0") - the map should provide this
+                // one in the next iteration.
+                if (key === "1") {
+                    map.set("1", "X1");
+                    map.set("0", "X0");
+                    map.set("4", "X4");
+                }
+                else if (key === "3") {
+                    if (!addedThree) {
+                        addedThree = true;
+
+                        // Remove and re-add key "3"; the map should
+                        // visit it after "0".
+                        map.delete("3");
+                        map.set("3", "Y3");
+
+                        // Change the value of "2"; the map should provide
+                        // it when visiting the key.
+                        map.set("2", "Y2");
+                    }
+                    else {
+                        // Check that an entry added when we visit the
+                        // currently last entry will still be visited.
+                        map.set("999", "999");
+                    }
+                }
+                else if (key === "999") {
+                    // Ensure that clear() behaves correctly same as removing all keys.
+                    map.set("A", "A");
+                    map.set("B", "B");
+                    map.set("C", "C");
+                }
+                else if (key === "A") {
+                    map.clear();
+                    map.set("Z", "Z");
+                }
+                else if (key === "Z") {
+                    // Check that the map behaves correctly when an item is
+                    // added and removed immediately.
+                    map.set("X", "X");
+                    map.delete("X");
+                    map.set("Y", "Y");
+                }
+            };
+
+            if (useForEach) {
+                map.forEach(doForEach);
+            }
+            else {
+                // Use an iterator.
+                const iterator = map.entries();
+                while (true) {
+                    const { value: tuple, done } = iterator.next();
+                    if (done) {
+                        break;
+                    }
+
+                    doForEach(tuple[1], tuple[0]);
+                }
+            }
+
+            return resultString;
+        }
+
+        it("iterates values in insertion order and handles changes", () => {
+            const expectedResult = "1:1;3:3;2:Y2;4:X4;0:X0;3:Y3;999:999;A:A;Z:Z;Y:Y;";
+
+            // First, ensure the test actually has the same behavior as a native Map.
+            let nativeMap = createMap<string>();
+            const nativeMapForEachResult = testMapIterationAddedValues(nativeMap, /* useForEach */ true);
+            assert.equal(nativeMapForEachResult, expectedResult, "nativeMap-forEach");
+
+            nativeMap = createMap<string>();
+            const nativeMapIteratorResult = testMapIterationAddedValues(nativeMap, /* useForEach */ false);
+            assert.equal(nativeMapIteratorResult, expectedResult, "nativeMap-iterator");
+
+            // Then, test the shimMap.
+            let localShimMap = new (shimMap())<string>();
+            const shimMapForEachResult = testMapIterationAddedValues(localShimMap, /* useForEach */ true);
+            assert.equal(shimMapForEachResult, expectedResult, "shimMap-forEach");
+
+            localShimMap = new (shimMap())<string>();
+            const shimMapIteratorResult = testMapIterationAddedValues(localShimMap, /* useForEach */ false);
+            assert.equal(shimMapIteratorResult, expectedResult, "shimMap-iterator");
+
+        });
+    });
+}

--- a/src/testRunner/unittests/shimMap.ts
+++ b/src/testRunner/unittests/shimMap.ts
@@ -50,10 +50,13 @@ namespace ts {
                     map.set("Z", "Z");
                 }
                 else if (key === "Z") {
-                    // Check that the map behaves correctly when an item is
+                    // Check that the map behaves correctly when two items are
                     // added and removed immediately.
                     map.set("X", "X");
-                    map.delete("X");
+                    map.set("X1", "X1");
+                    map.set("X2", "X2");
+                    map.delete("X1");
+                    map.delete("X2");
                     map.set("Y", "Y");
                 }
             };
@@ -78,7 +81,7 @@ namespace ts {
         }
 
         it("iterates values in insertion order and handles changes", () => {
-            const expectedResult = "1:1;3:3;2:Y2;4:X4;0:X0;3:Y3;999:999;A:A;Z:Z;Y:Y;";
+            const expectedResult = "1:1;3:3;2:Y2;4:X4;0:X0;3:Y3;999:999;A:A;Z:Z;X:X;Y:Y;";
 
             // First, ensure the test actually has the same behavior as a native Map.
             let nativeMap = createMap<string>();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
Hi,

this PR adjusts the [`shimMap`](https://github.com/Microsoft/TypeScript/blob/5fb39769ada9ff72d905c62069aab136c93f38a8/src/compiler/core.ts#L117) that is used by `createMap<T>()` for IE 11/ES 5 environments (instead of a native `Map`) to visit values that are added while an iteration or `forEach()` is running (which is documented for a native `Map`). Previously, new values during iteration would not be visited, causing problems in **IE 11** as described in #26090.
I used the same mechanism for both the `forEach` call and iterators created with `.entries()`.

<del>**Note:** With this PR, the `shimMap` does not support deleting values while an iteration is still running - in this case, when the iterator/forEach loop continues after the delete operation, it will throw an error.</del>

<del>I think it is possible to also support deleting values while an iteration is active using a linked list, but with the caveat that a memory leak could occur if you keep a reference to an non-finished iterator, and then continuously add and delete values from the map. Additionally, as long as there are unfinished iterators (that may or may not be reachable), delete operations on the map would be slow, as they would need to search the iterator key elements.</del>

**Update:** I have reworked the implementation so that the `shimMap` should now have the same behavior as a native map for iterators and `forEach()` loops (see comment below). This means that entries are iterated in insertion order, values added during iteration will be visited, and values removed during iteration (before they were visited) will not be visited.

- [x] Add a test that verifies the new behavior of the `shimMap`.

Fixes #26090
Fixes #29193
