### PR TITLE
Fix bug: Ensure JSDoc type range is valid

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6308,7 +6308,7 @@ namespace ts {
 
             // Parses out a JSDoc type expression.
             export function parseJSDocTypeExpression(mayOmitBraces?: boolean): JSDocTypeExpression {
-                const result = <JSDocTypeExpression>createNode(SyntaxKind.JSDocTypeExpression, scanner.getTokenPos());
+                const result = <JSDocTypeExpression>createNode(SyntaxKind.JSDocTypeExpression);
 
                 const hasBrace = (mayOmitBraces ? parseOptional : parseExpected)(SyntaxKind.OpenBraceToken);
                 result.type = doInsideOfContext(NodeFlags.JSDoc, parseJSDocType);

--- a/tests/cases/fourslash/editJsdocType.ts
+++ b/tests/cases/fourslash/editJsdocType.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @noLib: true
+
+// @Filename: /a.js
+/////** @type/**/ */
+////const x = 0;
+
+goTo.marker();
+verify.quickInfoIs("");
+edit.insert(" ");
+verify.quickInfoIs("");


### PR DESCRIPTION
Fixes a crash that occurred in updateTokenPositionsAndMarkElements when there was no type after `@type` as in `/** @type */` and the document was then edited. (Similar to #26283)

This branch is based on #27162 and will be rebased after that is in.