### PR TITLE
Fix crash in use-before-def checking of enum tag (#27350)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1711,7 +1711,9 @@ namespace ts {
         function checkResolvedBlockScopedVariable(result: Symbol, errorLocation: Node): void {
             Debug.assert(!!(result.flags & SymbolFlags.BlockScopedVariable || result.flags & SymbolFlags.Class || result.flags & SymbolFlags.Enum));
             // Block-scoped variables cannot be used before their definition
-            const declaration = forEach(result.declarations, d => isBlockOrCatchScoped(d) || isClassLike(d) || (d.kind === SyntaxKind.EnumDeclaration) ? d : undefined);
+            const declaration = find(
+                result.declarations,
+                d => isBlockOrCatchScoped(d) || isClassLike(d) || (d.kind === SyntaxKind.EnumDeclaration) || isInJSFile(d) && !!getJSDocEnumTag(d));
 
             if (declaration === undefined) return Debug.fail("Declaration to checkResolvedBlockScopedVariable is undefined");
 

--- a/tests/baselines/reference/enumTagUseBeforeDefCrash.symbols
+++ b/tests/baselines/reference/enumTagUseBeforeDefCrash.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/jsdoc/bug27134.js ===
+/**
+ * @enum {number}
+ */
+var foo = { };
+>foo : Symbol(foo, Decl(bug27134.js, 3, 3))
+
+/**
+ * @type {foo}
+ */
+var s;
+>s : Symbol(s, Decl(bug27134.js, 8, 3))
+

--- a/tests/baselines/reference/enumTagUseBeforeDefCrash.types
+++ b/tests/baselines/reference/enumTagUseBeforeDefCrash.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/bug27134.js ===
+/**
+ * @enum {number}
+ */
+var foo = { };
+>foo : typeof foo
+>{ } : {}
+
+/**
+ * @type {foo}
+ */
+var s;
+>s : number
+

--- a/tests/cases/conformance/jsdoc/enumTagUseBeforeDefCrash.ts
+++ b/tests/cases/conformance/jsdoc/enumTagUseBeforeDefCrash.ts
@@ -1,0 +1,13 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: bug27134.js
+/**
+ * @enum {number}
+ */
+var foo = { };
+
+/**
+ * @type {foo}
+ */
+var s;


### PR DESCRIPTION
Port of #27350 from 3.1 to master.
Fixes #27134 