### PR TITLE
Only functions can be constructor functions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20272,18 +20272,20 @@ namespace ts {
          * file.
          */
         function isJSConstructor(node: Declaration | undefined): boolean {
-            if (node && isInJSFile(node)) {
+            if (!node || !isInJSFile(node)) {
+                return false;
+            }
+            const func = isFunctionDeclaration(node) || isFunctionExpression(node) ? node :
+                isVariableDeclaration(node) && node.initializer && isFunctionExpression(node.initializer) ? node.initializer :
+                undefined;
+            if (func) {
                 // If the node has a @class tag, treat it like a constructor.
                 if (getJSDocClassTag(node)) return true;
 
                 // If the symbol of the node has members, treat it like a constructor.
-                const symbol = isFunctionDeclaration(node) || isFunctionExpression(node) ? getSymbolOfNode(node) :
-                     isVariableDeclaration(node) && node.initializer && isFunctionExpression(node.initializer) ? getSymbolOfNode(node.initializer) :
-                     undefined;
-
+                const symbol = getSymbolOfNode(func);
                 return !!symbol && symbol.members !== undefined;
             }
-
             return false;
         }
 

--- a/tests/baselines/reference/constructorTagOnClassConstructor.symbols
+++ b/tests/baselines/reference/constructorTagOnClassConstructor.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/bug27025.js ===
+export class Alpha { }
+>Alpha : Symbol(Alpha, Decl(bug27025.js, 0, 0))
+
+export class Beta {
+>Beta : Symbol(Beta, Decl(bug27025.js, 0, 22))
+
+  /**
+   * @constructor
+   */
+  constructor() {
+  }
+}
+
+const arr = [Alpha, Beta];
+>arr : Symbol(arr, Decl(bug27025.js, 9, 5))
+>Alpha : Symbol(Alpha, Decl(bug27025.js, 0, 0))
+>Beta : Symbol(Beta, Decl(bug27025.js, 0, 22))
+

--- a/tests/baselines/reference/constructorTagOnClassConstructor.types
+++ b/tests/baselines/reference/constructorTagOnClassConstructor.types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/jsdoc/bug27025.js ===
+export class Alpha { }
+>Alpha : Alpha
+
+export class Beta {
+>Beta : Beta
+
+  /**
+   * @constructor
+   */
+  constructor() {
+  }
+}
+
+const arr = [Alpha, Beta];
+>arr : (typeof Alpha)[]
+>[Alpha, Beta] : (typeof Alpha)[]
+>Alpha : typeof Alpha
+>Beta : typeof Beta
+

--- a/tests/cases/conformance/jsdoc/constructorTagOnClassConstructor.ts
+++ b/tests/cases/conformance/jsdoc/constructorTagOnClassConstructor.ts
@@ -1,0 +1,14 @@
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+// @Filename: bug27025.js
+export class Alpha { }
+export class Beta {
+  /**
+   * @constructor
+   */
+  constructor() {
+  }
+}
+
+const arr = [Alpha, Beta];


### PR DESCRIPTION
`@constructor` put on anything incorrectly makes it a JS constructor. This is a problem for actual constructors, because getJSClassType doesn't work on actual classes. The fix is to make isJSConstructor require that its declaration is a function.

Fixes #27345

