### PR TITLE
Fix commonjs export= merging (#27368)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2344,7 +2344,7 @@ namespace ts {
         }
 
         function getCommonJsExportEquals(exported: Symbol | undefined, moduleSymbol: Symbol): Symbol | undefined {
-            if (!exported || moduleSymbol.exports!.size === 1) {
+            if (!exported || exported === unknownSymbol || moduleSymbol.exports!.size === 1) {
                 return exported;
             }
             const merged = cloneSymbol(exported);

--- a/tests/baselines/reference/moduleExportAliasUnknown.errors.txt
+++ b/tests/baselines/reference/moduleExportAliasUnknown.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/salsa/bug27025.js(1,25): error TS2339: Property 'nonprop' does not exist on type 'Window'.
+tests/cases/conformance/salsa/bug27025.js(2,15): error TS2304: Cannot find name 'bar'.
+
+
+==== tests/cases/conformance/salsa/bug27025.js (2 errors) ====
+    module.exports = window.nonprop;
+                            ~~~~~~~
+!!! error TS2339: Property 'nonprop' does not exist on type 'Window'.
+    exports.foo = bar;
+                  ~~~
+!!! error TS2304: Cannot find name 'bar'.
+    

--- a/tests/baselines/reference/moduleExportAliasUnknown.symbols
+++ b/tests/baselines/reference/moduleExportAliasUnknown.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/salsa/bug27025.js ===
+module.exports = window.nonprop;
+>module.exports : Symbol("tests/cases/conformance/salsa/bug27025", Decl(bug27025.js, 0, 0))
+>module : Symbol(export=, Decl(bug27025.js, 0, 0))
+>exports : Symbol(export=, Decl(bug27025.js, 0, 0))
+>window : Symbol(window, Decl(lib.dom.d.ts, --, --))
+
+exports.foo = bar;
+>exports : Symbol(foo, Decl(bug27025.js, 0, 32))
+>foo : Symbol(foo, Decl(bug27025.js, 0, 32))
+

--- a/tests/baselines/reference/moduleExportAliasUnknown.types
+++ b/tests/baselines/reference/moduleExportAliasUnknown.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/salsa/bug27025.js ===
+module.exports = window.nonprop;
+>module.exports = window.nonprop : any
+>module.exports : any
+>module : { "tests/cases/conformance/salsa/bug27025": any; }
+>exports : any
+>window.nonprop : any
+>window : Window
+>nonprop : any
+
+exports.foo = bar;
+>exports.foo = bar : any
+>exports.foo : any
+>exports : any
+>foo : any
+>bar : any
+

--- a/tests/cases/conformance/salsa/moduleExportAliasUnknown.ts
+++ b/tests/cases/conformance/salsa/moduleExportAliasUnknown.ts
@@ -1,0 +1,6 @@
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+// @Filename: bug27025.js
+module.exports = window.nonprop;
+exports.foo = bar;


### PR DESCRIPTION
I'm surprised we haven't seen more of this; I suspect it's because the
mixed `module.exports=` + `export.foo=` pattern isn't that common.
However, it'll happen any time that the exported symbol is unknown;
getCommonJsExportEquals blithely clones unknownSymbol and proceeds to
stick the `exports.foo=` properties onto it.

This causes problems later, because the compiler checks for
unknownSymbol with `===`. The fix is to not stick properties onto a
clone of unknownSymbol. This makes the correct errors appear and removes
the crash.

Port of #27368 to master
