### PR TITLE
Don't implicit-any diagnostic for json module

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2241,7 +2241,7 @@ namespace ts {
             const sourceFile = resolvedModule && !resolutionDiagnostic && host.getSourceFile(resolvedModule.resolvedFileName);
             if (sourceFile) {
                 if (sourceFile.symbol) {
-                    if (resolvedModule.isExternalLibraryImport && !extensionIsTS(resolvedModule.extension)) {
+                    if (resolvedModule.isExternalLibraryImport && !resolutionExtensionIsTSOrJson(resolvedModule.extension)) {
                         errorOnImplicitAnyModule(/*isError*/ false, errorNode, resolvedModule, moduleReference);
                     }
                     // merged symbol is module declaration symbol combined with all augmentations

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -593,7 +593,8 @@ namespace FourSlash {
         public verifyNoErrors() {
             ts.forEachKey(this.inputFiles, fileName => {
                 if (!ts.isAnySupportedFileExtension(fileName)
-                    || !this.getProgram().getCompilerOptions().allowJs && !ts.extensionIsTS(ts.extensionFromPath(fileName))) return;
+                    || Harness.getConfigNameFromFileName(fileName)
+                    || !this.getProgram().getCompilerOptions().allowJs && !ts.resolutionExtensionIsTSOrJson(ts.extensionFromPath(fileName))) return;
                 const errors = this.getDiagnostics(fileName).filter(e => e.category !== ts.DiagnosticCategory.Suggestion);
                 if (errors.length) {
                     this.printErrorLog(/*expectErrors*/ false, errors);

--- a/tests/cases/fourslash/codeFixCannotFindModule_suggestion_falsePositive.ts
+++ b/tests/cases/fourslash/codeFixCannotFindModule_suggestion_falsePositive.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @moduleResolution: node
+// @resolveJsonModule: true
+// @strict: true
+
+// @Filename: /node_modules/foo/bar.json
+////export const x = 0;
+
+// @Filename: /a.ts
+////import abs = require([|"foo/bar.json"|]);
+////abs;
+
+verify.noErrors();
+goTo.file("/a.ts");
+verify.getSuggestionDiagnostics([]);

--- a/tests/cases/fourslash/codeFixCannotFindModule_suggestion_falsePositive.ts
+++ b/tests/cases/fourslash/codeFixCannotFindModule_suggestion_falsePositive.ts
@@ -5,7 +5,7 @@
 // @strict: true
 
 // @Filename: /node_modules/foo/bar.json
-////export const x = 0;
+////{ "a": 0 }
 
 // @Filename: /a.ts
 ////import abs = require([|"foo/bar.json"|]);


### PR DESCRIPTION
Previously we would wrongly issue a diagnostic saying the the module is implicitly `any`.