### PR TITLE
Skip default lib checking in all tsbuild tests

### DIFF
--- a/tests/projects/empty-files/core/tsconfig.json
+++ b/tests/projects/empty-files/core/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "composite": true,
         "declaration": true,
-        "declarationMap": true
+        "declarationMap": true,
+        "skipDefaultLibCheck": true
     }
 }

--- a/tests/projects/empty-files/no-references/tsconfig.json
+++ b/tests/projects/empty-files/no-references/tsconfig.json
@@ -4,6 +4,7 @@
     "compilerOptions": {
         "composite": true,
         "declaration": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "skipDefaultLibCheck": true
     }
 }

--- a/tests/projects/empty-files/with-references/tsconfig.json
+++ b/tests/projects/empty-files/with-references/tsconfig.json
@@ -6,6 +6,7 @@
     "compilerOptions": {
         "composite": true,
         "declaration": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "skipDefaultLibCheck": true
     }
 }

--- a/tests/projects/outfile-concat/first/tsconfig.json
+++ b/tests/projects/outfile-concat/first/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": false,
     "sourceMap": true,
     "declarationMap": true,
-    "outFile": "./bin/first-output.js"
+    "outFile": "./bin/first-output.js",
+    "skipDefaultLibCheck": true
   },
   "files": [
     "first_PART1.ts",

--- a/tests/projects/outfile-concat/second/tsconfig.json
+++ b/tests/projects/outfile-concat/second/tsconfig.json
@@ -7,7 +7,8 @@
     "sourceMap": true,
     "declarationMap": true,
     "declaration": true,
-    "outFile": "../2/second-output.js"
+    "outFile": "../2/second-output.js",
+    "skipDefaultLibCheck": true
   },
   "references": [
   ]

--- a/tests/projects/outfile-concat/third/tsconfig.json
+++ b/tests/projects/outfile-concat/third/tsconfig.json
@@ -7,7 +7,8 @@
     "sourceMap": true,
     "declarationMap": true,
     "declaration": true,
-    "outFile": "./thirdjs/output/third-output.js"
+    "outFile": "./thirdjs/output/third-output.js",
+    "skipDefaultLibCheck": true
   },
   "files": [
     "third_part1.ts"

--- a/tests/projects/projectReferenceWithRootDirInParent/tsconfig.base.json
+++ b/tests/projects/projectReferenceWithRootDirInParent/tsconfig.base.json
@@ -3,7 +3,8 @@
     "composite": true,
     "declaration": true,
     "rootDir": "./src/",
-    "outDir": "./dist/"
+    "outDir": "./dist/",
+    "skipDefaultLibCheck": true
   },
   "exclude": [
     "node_modules"

--- a/tests/projects/resolveJsonModuleAndComposite/tests/tsconfig_withFiles.json
+++ b/tests/projects/resolveJsonModuleAndComposite/tests/tsconfig_withFiles.json
@@ -7,7 +7,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipDefaultLibCheck": true
   },
   "files": [
     "src/index.ts", "src/hello.json"

--- a/tests/projects/resolveJsonModuleAndComposite/tests/tsconfig_withInclude.json
+++ b/tests/projects/resolveJsonModuleAndComposite/tests/tsconfig_withInclude.json
@@ -7,7 +7,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipDefaultLibCheck": true
   },
   "include": [
     "src/**/*"

--- a/tests/projects/resolveJsonModuleAndComposite/tests/tsconfig_withIncludeAndFiles.json
+++ b/tests/projects/resolveJsonModuleAndComposite/tests/tsconfig_withIncludeAndFiles.json
@@ -7,7 +7,8 @@
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "skipDefaultLibCheck": true
   },
   "files": [
     "src/hello.json"

--- a/tests/projects/sample1/core/tsconfig.json
+++ b/tests/projects/sample1/core/tsconfig.json
@@ -2,6 +2,7 @@
     "compilerOptions": {
         "composite": true,
         "declaration": true,
-        "declarationMap": true
+        "declarationMap": true,
+        "skipDefaultLibCheck": true
     }
 }

--- a/tests/projects/sample1/logic/tsconfig.json
+++ b/tests/projects/sample1/logic/tsconfig.json
@@ -3,7 +3,8 @@
         "composite": true,
         "declaration": true,
         "sourceMap": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "skipDefaultLibCheck": true
     },
     "references": [
         { "path": "../core" }

--- a/tests/projects/sample1/tests/tsconfig.json
+++ b/tests/projects/sample1/tests/tsconfig.json
@@ -7,6 +7,7 @@
     "compilerOptions": {
         "composite": true,
         "declaration": true,
-        "forceConsistentCasingInFileNames": true
+        "forceConsistentCasingInFileNames": true,
+        "skipDefaultLibCheck": true
     }
 }

--- a/tests/projects/sample1/ui/tsconfig.json
+++ b/tests/projects/sample1/ui/tsconfig.json
@@ -1,4 +1,7 @@
 {
+    "compilerOptions": {
+        "skipDefaultLibCheck": true
+    },
     "references": [
         { "path": "../logic/index" }
     ]


### PR DESCRIPTION
tsbuild tests took forever because they all typechecked the lib repeatedly. This skips that, and consequently most tsbuild tests drop out of the "worst-performing tests" category.