### PR TITLE
Make RenameInfo a union

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -3,12 +3,15 @@ namespace ts.server {
         writeMessage(message: string): void;
     }
 
-    interface RenameEntry extends RenameInfo {
-        fileName: string;
-        position: number;
-        locations: RenameLocation[];
-        findInStrings: boolean;
-        findInComments: boolean;
+    interface RenameEntry {
+        readonly renameInfo: RenameInfo;
+        readonly inputs: {
+            readonly fileName: string;
+            readonly position: number;
+            readonly findInStrings: boolean;
+            readonly findInComments: boolean;
+        };
+        readonly locations: RenameLocation[];
     }
 
     /* @internal */
@@ -395,29 +398,36 @@ namespace ts.server {
                 }
             }
 
-            return this.lastRenameEntry = {
-                canRename: body.info.canRename,
-                fileToRename: body.info.fileToRename,
-                displayName: body.info.displayName,
-                fullDisplayName: body.info.fullDisplayName,
-                kind: body.info.kind,
-                kindModifiers: body.info.kindModifiers,
-                localizedErrorMessage: body.info.localizedErrorMessage,
-                triggerSpan: createTextSpanFromBounds(position, position),
-                fileName,
-                position,
-                findInStrings: !!findInStrings,
-                findInComments: !!findInComments,
+            const renameInfo = body.info.canRename
+                ? identity<RenameInfoSuccess>({
+                    canRename: body.info.canRename,
+                    fileToRename: body.info.fileToRename,
+                    displayName: body.info.displayName,
+                    fullDisplayName: body.info.fullDisplayName,
+                    kind: body.info.kind,
+                    kindModifiers: body.info.kindModifiers,
+                    triggerSpan: createTextSpanFromBounds(position, position),
+                })
+                : identity<RenameInfoFailure>({ canRename: false, localizedErrorMessage: body.info.localizedErrorMessage });
+            this.lastRenameEntry = {
+                renameInfo,
+                inputs: {
+                    fileName,
+                    position,
+                    findInStrings: !!findInStrings,
+                    findInComments: !!findInComments,
+                },
                 locations,
             };
+            return renameInfo;
         }
 
         findRenameLocations(fileName: string, position: number, findInStrings: boolean, findInComments: boolean): RenameLocation[] {
             if (!this.lastRenameEntry ||
-                this.lastRenameEntry.fileName !== fileName ||
-                this.lastRenameEntry.position !== position ||
-                this.lastRenameEntry.findInStrings !== findInStrings ||
-                this.lastRenameEntry.findInComments !== findInComments) {
+                this.lastRenameEntry.inputs.fileName !== fileName ||
+                this.lastRenameEntry.inputs.position !== position ||
+                this.lastRenameEntry.inputs.findInStrings !== findInStrings ||
+                this.lastRenameEntry.inputs.findInComments !== findInComments) {
                 this.getRenameInfo(fileName, position, findInStrings, findInComments);
             }
 

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1537,7 +1537,7 @@ Actual: ${stringify(fullActual)}`);
         public verifyRenameInfoSucceeded(displayName: string | undefined, fullDisplayName: string | undefined, kind: string | undefined, kindModifiers: string | undefined, fileToRename: string | undefined, expectedRange: Range | undefined): void {
             const renameInfo = this.languageService.getRenameInfo(this.activeFile.fileName, this.currentCaretPosition);
             if (!renameInfo.canRename) {
-                this.raiseError("Rename did not succeed");
+                throw this.raiseError("Rename did not succeed");
             }
 
             this.validate("displayName", displayName, renameInfo.displayName);
@@ -1563,9 +1563,8 @@ Actual: ${stringify(fullActual)}`);
         public verifyRenameInfoFailed(message?: string) {
             const renameInfo = this.languageService.getRenameInfo(this.activeFile.fileName, this.currentCaretPosition);
             if (renameInfo.canRename) {
-                this.raiseError("Rename was expected to fail");
+                throw this.raiseError("Rename was expected to fail");
             }
-
             this.validate("error", message, renameInfo.localizedErrorMessage);
         }
 

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1087,22 +1087,17 @@ namespace ts.server.protocol {
     /**
      * Information about the item to be renamed.
      */
-    export interface RenameInfo {
+    export type RenameInfo = RenameInfoSuccess | RenameInfoFailure;
+    export interface RenameInfoSuccess {
         /**
          * True if item can be renamed.
          */
-        canRename: boolean;
-
+        canRename: true;
         /**
          * File or directory to rename.
          * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
          */
         fileToRename?: string;
-
-        /**
-         * Error message if item can not be renamed.
-         */
-        localizedErrorMessage?: string;
 
         /**
          * Display name of the item to be renamed.
@@ -1126,6 +1121,13 @@ namespace ts.server.protocol {
 
         /** Span of text to rename. */
         triggerSpan: TextSpan;
+    }
+    export interface RenameInfoFailure {
+        canRename: false;
+        /**
+         * Error message if item can not be renamed.
+         */
+        localizedErrorMessage: string;
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1184,8 +1184,15 @@ namespace ts.server {
             return { info: renameInfo, locs: this.toSpanGroups(locations) };
         }
 
-        private mapRenameInfo({ canRename, fileToRename, localizedErrorMessage, displayName, fullDisplayName, kind, kindModifiers, triggerSpan }: RenameInfo, scriptInfo: ScriptInfo): protocol.RenameInfo {
-            return { canRename, fileToRename, localizedErrorMessage, displayName, fullDisplayName, kind, kindModifiers, triggerSpan: this.toLocationTextSpan(triggerSpan, scriptInfo) };
+        private mapRenameInfo(info: RenameInfo, scriptInfo: ScriptInfo): protocol.RenameInfo {
+            if (info.canRename) {
+                const { canRename, fileToRename, displayName, fullDisplayName, kind, kindModifiers, triggerSpan } = info;
+                return identity<protocol.RenameInfoSuccess>(
+                    { canRename, fileToRename, displayName, fullDisplayName, kind, kindModifiers, triggerSpan: this.toLocationTextSpan(triggerSpan, scriptInfo) });
+            }
+            else {
+                return info;
+            }
         }
 
         private toSpanGroups(locations: ReadonlyArray<RenameLocation>): ReadonlyArray<protocol.SpanGroup> {

--- a/src/services/rename.ts
+++ b/src/services/rename.ts
@@ -56,37 +56,26 @@ namespace ts.Rename {
             fileToRename: name,
             kind,
             displayName: name,
-            localizedErrorMessage: undefined,
             fullDisplayName: name,
             kindModifiers: ScriptElementKindModifier.none,
             triggerSpan,
         };
     }
 
-    function getRenameInfoSuccess(displayName: string, fullDisplayName: string, kind: ScriptElementKind, kindModifiers: string, node: Node, sourceFile: SourceFile): RenameInfo {
+    function getRenameInfoSuccess(displayName: string, fullDisplayName: string, kind: ScriptElementKind, kindModifiers: string, node: Node, sourceFile: SourceFile): RenameInfoSuccess {
         return {
             canRename: true,
             fileToRename: undefined,
             kind,
             displayName,
-            localizedErrorMessage: undefined,
             fullDisplayName,
             kindModifiers,
             triggerSpan: createTriggerSpanForNode(node, sourceFile)
         };
     }
 
-    function getRenameInfoError(diagnostic: DiagnosticMessage): RenameInfo {
-        // TODO: GH#18217
-        return {
-            canRename: false,
-            localizedErrorMessage: getLocaleSpecificMessage(diagnostic),
-            displayName: undefined!,
-            fullDisplayName: undefined!,
-            kind: undefined!,
-            kindModifiers: undefined!,
-            triggerSpan: undefined!
-        };
+    function getRenameInfoError(diagnostic: DiagnosticMessage): RenameInfoFailure {
+        return { canRename: false, localizedErrorMessage: getLocaleSpecificMessage(diagnostic) };
     }
 
     function createTriggerSpanForNode(node: Node, sourceFile: SourceFile) {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -821,19 +821,23 @@ namespace ts {
         tags?: JSDocTagInfo[];
     }
 
-    export interface RenameInfo {
-        canRename: boolean;
+    export type RenameInfo = RenameInfoSuccess | RenameInfoFailure;
+    export interface RenameInfoSuccess {
+        canRename: true;
         /**
          * File or directory to rename.
          * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
          */
         fileToRename?: string;
-        localizedErrorMessage?: string;
         displayName: string;
         fullDisplayName: string;
         kind: ScriptElementKind;
         kindModifiers: string;
         triggerSpan: TextSpan;
+    }
+    export interface RenameInfoFailure {
+        canRename: false;
+        localizedErrorMessage: string;
     }
 
     export interface SignatureHelpParameter {

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -8309,7 +8309,6 @@ namespace ts.projectSystem {
                     fullDisplayName: '"/users/username/projects/a/c/fc".C',
                     kind: ScriptElementKind.constElement,
                     kindModifiers: ScriptElementKindModifier.exportedModifier,
-                    localizedErrorMessage: undefined,
                     triggerSpan: protocolTextSpanFromSubstring(cFile.content, "C"),
                 },
                 locs: [
@@ -9597,7 +9596,6 @@ export function Test2() {
                     fullDisplayName: aTs.path,
                     kind: ScriptElementKind.moduleElement,
                     kindModifiers: "",
-                    localizedErrorMessage: undefined,
                     triggerSpan: protocolTextSpanFromSubstring(bTs.content, "a", { index: 1 }),
                 },
                 locs: [{ file: bTs.path, locs: [protocolRenameSpanFromSubstring(bTs.content, "./a")] }],
@@ -9618,7 +9616,6 @@ export function Test2() {
                     fullDisplayName: "x",
                     kind: ScriptElementKind.constElement,
                     kindModifiers: ScriptElementKindModifier.none,
-                    localizedErrorMessage: undefined,
                     triggerSpan: protocolTextSpanFromSubstring(aTs.content, "x"),
                 },
                 locs: [
@@ -10131,7 +10128,6 @@ declare class TestLib {
                     fullDisplayName: "fnA",
                     kind: ScriptElementKind.alias,
                     kindModifiers: ScriptElementKindModifier.none,
-                    localizedErrorMessage: undefined,
                     triggerSpan: protocolTextSpanFromSubstring(userTs.content, "fnA", { index: 1 }),
                 },
                 locs: [renameUserTs(userTs), renameATs(aTs)],
@@ -10151,7 +10147,6 @@ declare class TestLib {
                     fullDisplayName: '"/a/a".fnA',
                     kind: ScriptElementKind.functionElement,
                     kindModifiers: ScriptElementKindModifier.exportedModifier,
-                    localizedErrorMessage: undefined,
                     triggerSpan: protocolTextSpanFromSubstring(aTs.content, "fnA"),
                 },
                 locs: [renameATs(aTs), renameUserTs(userTs)],
@@ -10181,7 +10176,6 @@ declare class TestLib {
                     fullDisplayName: "fnB",
                     kind: ScriptElementKind.alias,
                     kindModifiers: ScriptElementKindModifier.none,
-                    localizedErrorMessage: undefined,
                     triggerSpan: protocolTextSpanFromSubstring(userTs.content, "fnB", { index: 1 }),
                 },
                 locs: [

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5114,19 +5114,23 @@ declare namespace ts {
         documentation?: SymbolDisplayPart[];
         tags?: JSDocTagInfo[];
     }
-    interface RenameInfo {
-        canRename: boolean;
+    type RenameInfo = RenameInfoSuccess | RenameInfoFailure;
+    interface RenameInfoSuccess {
+        canRename: true;
         /**
          * File or directory to rename.
          * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
          */
         fileToRename?: string;
-        localizedErrorMessage?: string;
         displayName: string;
         fullDisplayName: string;
         kind: ScriptElementKind;
         kindModifiers: string;
         triggerSpan: TextSpan;
+    }
+    interface RenameInfoFailure {
+        canRename: false;
+        localizedErrorMessage: string;
     }
     interface SignatureHelpParameter {
         name: string;
@@ -6437,20 +6441,17 @@ declare namespace ts.server.protocol {
     /**
      * Information about the item to be renamed.
      */
-    interface RenameInfo {
+    type RenameInfo = RenameInfoSuccess | RenameInfoFailure;
+    interface RenameInfoSuccess {
         /**
          * True if item can be renamed.
          */
-        canRename: boolean;
+        canRename: true;
         /**
          * File or directory to rename.
          * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
          */
         fileToRename?: string;
-        /**
-         * Error message if item can not be renamed.
-         */
-        localizedErrorMessage?: string;
         /**
          * Display name of the item to be renamed.
          */
@@ -6469,6 +6470,13 @@ declare namespace ts.server.protocol {
         kindModifiers: string;
         /** Span of text to rename. */
         triggerSpan: TextSpan;
+    }
+    interface RenameInfoFailure {
+        canRename: false;
+        /**
+         * Error message if item can not be renamed.
+         */
+        localizedErrorMessage: string;
     }
     /**
      *  A group of text spans, all in 'file'.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5114,19 +5114,23 @@ declare namespace ts {
         documentation?: SymbolDisplayPart[];
         tags?: JSDocTagInfo[];
     }
-    interface RenameInfo {
-        canRename: boolean;
+    type RenameInfo = RenameInfoSuccess | RenameInfoFailure;
+    interface RenameInfoSuccess {
+        canRename: true;
         /**
          * File or directory to rename.
          * If set, `getEditsForFileRename` should be called instead of `findRenameLocations`.
          */
         fileToRename?: string;
-        localizedErrorMessage?: string;
         displayName: string;
         fullDisplayName: string;
         kind: ScriptElementKind;
         kindModifiers: string;
         triggerSpan: TextSpan;
+    }
+    interface RenameInfoFailure {
+        canRename: false;
+        localizedErrorMessage: string;
     }
     interface SignatureHelpParameter {
         name: string;


### PR DESCRIPTION
Fixes #27373

Separates `RenameInfoSuccess` and `RenameInfoFailure`. Previously `RenameInfo` contained their combined properties -- marked non-optional but we were passing `undefined!` to them (was a TODO for #18217).
This will technically be a type-level breaking change, but shouldn't be a breaking change at runtime.