### PR TITLE
Widen export assignment types so they arent accidentally fresh

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5173,7 +5173,7 @@ namespace ts {
                 return type;
             }
             if (declaration.kind === SyntaxKind.ExportAssignment) {
-                return checkExpression((<ExportAssignment>declaration).expression);
+                return widenTypeForVariableLikeDeclaration(checkExpressionCached((<ExportAssignment>declaration).expression), declaration);
             }
 
             // Handle variable, parameter or property

--- a/tests/baselines/reference/exportDefaultStripsFreshness.errors.txt
+++ b/tests/baselines/reference/exportDefaultStripsFreshness.errors.txt
@@ -1,0 +1,34 @@
+tests/cases/compiler/index.ts(10,6): error TS2345: Argument of type '{ foob: string; }' is not assignable to parameter of type 'IFoo'.
+  Property 'foo' is missing in type '{ foob: string; }'.
+tests/cases/compiler/index.ts(12,6): error TS2345: Argument of type '{ foob: string; }' is not assignable to parameter of type 'IFoo'.
+  Property 'foo' is missing in type '{ foob: string; }'.
+
+
+==== tests/cases/compiler/items.ts (0 errors) ====
+    export default {
+        foob: "a"
+    }
+    
+    export const q = {
+        foob: "b"
+    }
+==== tests/cases/compiler/index.ts (2 errors) ====
+    import B, {q} from "./items";
+    
+    interface IFoo {
+        foo: string;
+    }
+    
+    function nFoo(x: IFoo) {}
+    
+    
+    nFoo(q); // for comparison
+         ~
+!!! error TS2345: Argument of type '{ foob: string; }' is not assignable to parameter of type 'IFoo'.
+!!! error TS2345:   Property 'foo' is missing in type '{ foob: string; }'.
+    
+    nFoo(B);
+         ~
+!!! error TS2345: Argument of type '{ foob: string; }' is not assignable to parameter of type 'IFoo'.
+!!! error TS2345:   Property 'foo' is missing in type '{ foob: string; }'.
+    

--- a/tests/baselines/reference/exportDefaultStripsFreshness.js
+++ b/tests/baselines/reference/exportDefaultStripsFreshness.js
@@ -1,0 +1,41 @@
+//// [tests/cases/compiler/exportDefaultStripsFreshness.ts] ////
+
+//// [items.ts]
+export default {
+    foob: "a"
+}
+
+export const q = {
+    foob: "b"
+}
+//// [index.ts]
+import B, {q} from "./items";
+
+interface IFoo {
+    foo: string;
+}
+
+function nFoo(x: IFoo) {}
+
+
+nFoo(q); // for comparison
+
+nFoo(B);
+
+
+//// [items.js]
+"use strict";
+exports.__esModule = true;
+exports["default"] = {
+    foob: "a"
+};
+exports.q = {
+    foob: "b"
+};
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var items_1 = require("./items");
+function nFoo(x) { }
+nFoo(items_1.q); // for comparison
+nFoo(items_1["default"]);

--- a/tests/baselines/reference/exportDefaultStripsFreshness.symbols
+++ b/tests/baselines/reference/exportDefaultStripsFreshness.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/items.ts ===
+export default {
+    foob: "a"
+>foob : Symbol(foob, Decl(items.ts, 0, 16))
+}
+
+export const q = {
+>q : Symbol(q, Decl(items.ts, 4, 12))
+
+    foob: "b"
+>foob : Symbol(foob, Decl(items.ts, 4, 18))
+}
+=== tests/cases/compiler/index.ts ===
+import B, {q} from "./items";
+>B : Symbol(B, Decl(index.ts, 0, 6))
+>q : Symbol(q, Decl(index.ts, 0, 11))
+
+interface IFoo {
+>IFoo : Symbol(IFoo, Decl(index.ts, 0, 29))
+
+    foo: string;
+>foo : Symbol(IFoo.foo, Decl(index.ts, 2, 16))
+}
+
+function nFoo(x: IFoo) {}
+>nFoo : Symbol(nFoo, Decl(index.ts, 4, 1))
+>x : Symbol(x, Decl(index.ts, 6, 14))
+>IFoo : Symbol(IFoo, Decl(index.ts, 0, 29))
+
+
+nFoo(q); // for comparison
+>nFoo : Symbol(nFoo, Decl(index.ts, 4, 1))
+>q : Symbol(q, Decl(index.ts, 0, 11))
+
+nFoo(B);
+>nFoo : Symbol(nFoo, Decl(index.ts, 4, 1))
+>B : Symbol(B, Decl(index.ts, 0, 6))
+

--- a/tests/baselines/reference/exportDefaultStripsFreshness.types
+++ b/tests/baselines/reference/exportDefaultStripsFreshness.types
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/items.ts ===
+export default {
+>{    foob: "a"} : { foob: string; }
+
+    foob: "a"
+>foob : string
+>"a" : "a"
+}
+
+export const q = {
+>q : { foob: string; }
+>{    foob: "b"} : { foob: string; }
+
+    foob: "b"
+>foob : string
+>"b" : "b"
+}
+=== tests/cases/compiler/index.ts ===
+import B, {q} from "./items";
+>B : { foob: string; }
+>q : { foob: string; }
+
+interface IFoo {
+    foo: string;
+>foo : string
+}
+
+function nFoo(x: IFoo) {}
+>nFoo : (x: IFoo) => void
+>x : IFoo
+
+
+nFoo(q); // for comparison
+>nFoo(q) : void
+>nFoo : (x: IFoo) => void
+>q : { foob: string; }
+
+nFoo(B);
+>nFoo(B) : void
+>nFoo : (x: IFoo) => void
+>B : { foob: string; }
+

--- a/tests/cases/compiler/exportDefaultStripsFreshness.ts
+++ b/tests/cases/compiler/exportDefaultStripsFreshness.ts
@@ -1,0 +1,21 @@
+// @filename: items.ts
+export default {
+    foob: "a"
+}
+
+export const q = {
+    foob: "b"
+}
+// @filename: index.ts
+import B, {q} from "./items";
+
+interface IFoo {
+    foo: string;
+}
+
+function nFoo(x: IFoo) {}
+
+
+nFoo(q); // for comparison
+
+nFoo(B);


### PR DESCRIPTION
Fixes #27091

Also use `checkExpressionCached` instead of `checkExpression` because export assignments aren't going to be able to be affected by any context and `checkExportAssignment` is already caching it.