### PR TITLE
Report circular JSDoc type references

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2116,6 +2116,10 @@
         "category": "Error",
         "code": 2586
     },
+    "JSDoc type '{0}' circularly references itself.": {
+        "category": "Error",
+        "code": 2587
+    },
     "JSX element attributes type '{0}' may not be a union type.": {
         "category": "Error",
         "code": 2600

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3535,6 +3535,7 @@ namespace ts {
         type?: Type;                        // Type of value symbol
         uniqueESSymbolType?: Type;          // UniqueESSymbol type for a symbol
         declaredType?: Type;                // Type of class, interface, enum, type alias, or type parameter
+        resolvedJSDocType?: Type;           // Resolved type of a JSDoc type reference
         typeParameters?: TypeParameter[];   // Type parameters of type alias (undefined if non-generic)
         outerTypeParameters?: TypeParameter[];  // Outer type parameters of anonymous object type
         inferredClassType?: Type;           // Type of an inferred ES5 class

--- a/tests/baselines/reference/typeTagCircularReferenceOnConstructorFunction.errors.txt
+++ b/tests/baselines/reference/typeTagCircularReferenceOnConstructorFunction.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/conformance/jsdoc/bug27346.js(2,4): error TS8030: The type of a function declaration must match the function's signature.
+tests/cases/conformance/jsdoc/bug27346.js(2,11): error TS2587: JSDoc type 'MyClass' circularly references itself.
+
+
+==== tests/cases/conformance/jsdoc/bug27346.js (2 errors) ====
+    /**
+     * @type {MyClass}
+       ~~~~~~~~~~~~~~~
+!!! error TS8030: The type of a function declaration must match the function's signature.
+              ~~~~~~~
+!!! error TS2587: JSDoc type 'MyClass' circularly references itself.
+     */
+    function MyClass() { }
+    MyClass.prototype = {};
+    

--- a/tests/baselines/reference/typeTagCircularReferenceOnConstructorFunction.symbols
+++ b/tests/baselines/reference/typeTagCircularReferenceOnConstructorFunction.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsdoc/bug27346.js ===
+/**
+ * @type {MyClass}
+ */
+function MyClass() { }
+>MyClass : Symbol(MyClass, Decl(bug27346.js, 0, 0), Decl(bug27346.js, 3, 22))
+
+MyClass.prototype = {};
+>MyClass.prototype : Symbol(MyClass.prototype, Decl(bug27346.js, 3, 22))
+>MyClass : Symbol(MyClass, Decl(bug27346.js, 0, 0), Decl(bug27346.js, 3, 22))
+>prototype : Symbol(MyClass.prototype, Decl(bug27346.js, 3, 22))
+

--- a/tests/baselines/reference/typeTagCircularReferenceOnConstructorFunction.types
+++ b/tests/baselines/reference/typeTagCircularReferenceOnConstructorFunction.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/bug27346.js ===
+/**
+ * @type {MyClass}
+ */
+function MyClass() { }
+>MyClass : typeof MyClass
+
+MyClass.prototype = {};
+>MyClass.prototype = {} : {}
+>MyClass.prototype : {}
+>MyClass : typeof MyClass
+>prototype : {}
+>{} : {}
+

--- a/tests/cases/conformance/jsdoc/typeTagCircularReferenceOnConstructorFunction.ts
+++ b/tests/cases/conformance/jsdoc/typeTagCircularReferenceOnConstructorFunction.ts
@@ -1,0 +1,9 @@
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+// @Filename: bug27346.js
+/**
+ * @type {MyClass}
+ */
+function MyClass() { }
+MyClass.prototype = {};


### PR DESCRIPTION
JSDoc types references can often be to values, which can often be circular in ways that types tied to declarations cannot. I decided to create a separate property on SymbolLinks rather than reusing declaredType, although I'm not sure that's strictly required.

Fixes #27346