### PR TITLE
Fix parent points in unreachable code (#27400)

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -640,6 +640,7 @@ namespace ts {
         function bindChildrenWorker(node: Node): void {
             if (checkUnreachable(node)) {
                 bindEachChild(node);
+                bindJSDoc(node);
                 return;
             }
             switch (node.kind) {

--- a/tests/baselines/reference/jsdocBindingInUnreachableCode.symbols
+++ b/tests/baselines/reference/jsdocBindingInUnreachableCode.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsdoc/bug27341.js ===
+if (false) {
+    /**
+     * @param {string} s
+     */
+    const x = function (s) {
+>x : Symbol(x, Decl(bug27341.js, 4, 9))
+>s : Symbol(s, Decl(bug27341.js, 4, 24))
+
+    };
+}
+

--- a/tests/baselines/reference/jsdocBindingInUnreachableCode.types
+++ b/tests/baselines/reference/jsdocBindingInUnreachableCode.types
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/jsdoc/bug27341.js ===
+if (false) {
+>false : false
+
+    /**
+     * @param {string} s
+     */
+    const x = function (s) {
+>x : (s: string) => void
+>function (s) {    } : (s: string) => void
+>s : string
+
+    };
+}
+

--- a/tests/cases/conformance/jsdoc/jsdocBindingInUnreachableCode.ts
+++ b/tests/cases/conformance/jsdoc/jsdocBindingInUnreachableCode.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @noEmit: true
+// @checkJs: true
+// @Filename: bug27341.js
+if (false) {
+    /**
+     * @param {string} s
+     */
+    const x = function (s) {
+    };
+}


### PR DESCRIPTION
In the binder, unreachable code mistakenly skips the `bindJSDoc` call in `bindChildrenWorker`, which sets parent pointers. The fix is to call `bindJSDoc` in the case of unreachable code as well.

Port of #27400