### PR TITLE
Infer tuples for jsx children if contextually typed by a tuple

### DIFF
--- a/tests/baselines/reference/checkJsxChildrenCanBeTupleType.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenCanBeTupleType.errors.txt
@@ -1,0 +1,35 @@
+tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx(17,18): error TS2322: Type '{ children: [Element, Element, Element]; }' is not assignable to type 'Readonly<ResizablePanelProps>'.
+  Types of property 'children' are incompatible.
+    Type '[Element, Element, Element]' is not assignable to type '[ReactNode, ReactNode]'.
+      Types of property 'length' are incompatible.
+        Type '3' is not assignable to type '2'.
+
+
+==== tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    
+    import React from 'react'
+    
+    interface ResizablePanelProps {
+      children: [React.ReactNode, React.ReactNode]
+    }
+    
+    class ResizablePanel extends React.Component<
+      ResizablePanelProps, any> {}
+    
+    const test = <ResizablePanel>
+      <div />
+      <div />
+    </ResizablePanel>
+    
+    const testErr = <ResizablePanel>
+                     ~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ children: [Element, Element, Element]; }' is not assignable to type 'Readonly<ResizablePanelProps>'.
+!!! error TS2322:   Types of property 'children' are incompatible.
+!!! error TS2322:     Type '[Element, Element, Element]' is not assignable to type '[ReactNode, ReactNode]'.
+!!! error TS2322:       Types of property 'length' are incompatible.
+!!! error TS2322:         Type '3' is not assignable to type '2'.
+      <div />
+      <div />
+      <div />
+    </ResizablePanel>

--- a/tests/baselines/reference/checkJsxChildrenCanBeTupleType.js
+++ b/tests/baselines/reference/checkJsxChildrenCanBeTupleType.js
@@ -1,0 +1,58 @@
+//// [checkJsxChildrenCanBeTupleType.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+
+import React from 'react'
+
+interface ResizablePanelProps {
+  children: [React.ReactNode, React.ReactNode]
+}
+
+class ResizablePanel extends React.Component<
+  ResizablePanelProps, any> {}
+
+const test = <ResizablePanel>
+  <div />
+  <div />
+</ResizablePanel>
+
+const testErr = <ResizablePanel>
+  <div />
+  <div />
+  <div />
+</ResizablePanel>
+
+//// [checkJsxChildrenCanBeTupleType.js]
+"use strict";
+/// <reference path="react16.d.ts" />
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+exports.__esModule = true;
+var react_1 = __importDefault(require("react"));
+var ResizablePanel = /** @class */ (function (_super) {
+    __extends(ResizablePanel, _super);
+    function ResizablePanel() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return ResizablePanel;
+}(react_1["default"].Component));
+var test = react_1["default"].createElement(ResizablePanel, null,
+    react_1["default"].createElement("div", null),
+    react_1["default"].createElement("div", null));
+var testErr = react_1["default"].createElement(ResizablePanel, null,
+    react_1["default"].createElement("div", null),
+    react_1["default"].createElement("div", null),
+    react_1["default"].createElement("div", null));

--- a/tests/baselines/reference/checkJsxChildrenCanBeTupleType.symbols
+++ b/tests/baselines/reference/checkJsxChildrenCanBeTupleType.symbols
@@ -1,0 +1,55 @@
+=== tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx ===
+/// <reference path="react16.d.ts" />
+
+import React from 'react'
+>React : Symbol(React, Decl(checkJsxChildrenCanBeTupleType.tsx, 2, 6))
+
+interface ResizablePanelProps {
+>ResizablePanelProps : Symbol(ResizablePanelProps, Decl(checkJsxChildrenCanBeTupleType.tsx, 2, 25))
+
+  children: [React.ReactNode, React.ReactNode]
+>children : Symbol(ResizablePanelProps.children, Decl(checkJsxChildrenCanBeTupleType.tsx, 4, 31))
+>React : Symbol(React, Decl(checkJsxChildrenCanBeTupleType.tsx, 2, 6))
+>ReactNode : Symbol(React.ReactNode, Decl(react16.d.ts, 216, 49))
+>React : Symbol(React, Decl(checkJsxChildrenCanBeTupleType.tsx, 2, 6))
+>ReactNode : Symbol(React.ReactNode, Decl(react16.d.ts, 216, 49))
+}
+
+class ResizablePanel extends React.Component<
+>ResizablePanel : Symbol(ResizablePanel, Decl(checkJsxChildrenCanBeTupleType.tsx, 6, 1))
+>React.Component : Symbol(React.Component, Decl(react16.d.ts, 345, 54), Decl(react16.d.ts, 349, 94))
+>React : Symbol(React, Decl(checkJsxChildrenCanBeTupleType.tsx, 2, 6))
+>Component : Symbol(React.Component, Decl(react16.d.ts, 345, 54), Decl(react16.d.ts, 349, 94))
+
+  ResizablePanelProps, any> {}
+>ResizablePanelProps : Symbol(ResizablePanelProps, Decl(checkJsxChildrenCanBeTupleType.tsx, 2, 25))
+
+const test = <ResizablePanel>
+>test : Symbol(test, Decl(checkJsxChildrenCanBeTupleType.tsx, 11, 5))
+>ResizablePanel : Symbol(ResizablePanel, Decl(checkJsxChildrenCanBeTupleType.tsx, 6, 1))
+
+  <div />
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+
+  <div />
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+
+</ResizablePanel>
+>ResizablePanel : Symbol(ResizablePanel, Decl(checkJsxChildrenCanBeTupleType.tsx, 6, 1))
+
+const testErr = <ResizablePanel>
+>testErr : Symbol(testErr, Decl(checkJsxChildrenCanBeTupleType.tsx, 16, 5))
+>ResizablePanel : Symbol(ResizablePanel, Decl(checkJsxChildrenCanBeTupleType.tsx, 6, 1))
+
+  <div />
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+
+  <div />
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+
+  <div />
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+
+</ResizablePanel>
+>ResizablePanel : Symbol(ResizablePanel, Decl(checkJsxChildrenCanBeTupleType.tsx, 6, 1))
+

--- a/tests/baselines/reference/checkJsxChildrenCanBeTupleType.types
+++ b/tests/baselines/reference/checkJsxChildrenCanBeTupleType.types
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx ===
+/// <reference path="react16.d.ts" />
+
+import React from 'react'
+>React : typeof React
+
+interface ResizablePanelProps {
+  children: [React.ReactNode, React.ReactNode]
+>children : [React.ReactNode, React.ReactNode]
+>React : any
+>React : any
+}
+
+class ResizablePanel extends React.Component<
+>ResizablePanel : ResizablePanel
+>React.Component : React.Component<ResizablePanelProps, any, any>
+>React : typeof React
+>Component : typeof React.Component
+
+  ResizablePanelProps, any> {}
+
+const test = <ResizablePanel>
+>test : JSX.Element
+><ResizablePanel>  <div />  <div /></ResizablePanel> : JSX.Element
+>ResizablePanel : typeof ResizablePanel
+
+  <div />
+><div /> : JSX.Element
+>div : any
+
+  <div />
+><div /> : JSX.Element
+>div : any
+
+</ResizablePanel>
+>ResizablePanel : typeof ResizablePanel
+
+const testErr = <ResizablePanel>
+>testErr : JSX.Element
+><ResizablePanel>  <div />  <div />  <div /></ResizablePanel> : JSX.Element
+>ResizablePanel : typeof ResizablePanel
+
+  <div />
+><div /> : JSX.Element
+>div : any
+
+  <div />
+><div /> : JSX.Element
+>div : any
+
+  <div />
+><div /> : JSX.Element
+>div : any
+
+</ResizablePanel>
+>ResizablePanel : typeof ResizablePanel
+

--- a/tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx
+++ b/tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx
@@ -1,0 +1,24 @@
+// @jsx: react
+// @strict: true
+// @esModuleInterop: true
+/// <reference path="/.lib/react16.d.ts" />
+
+import React from 'react'
+
+interface ResizablePanelProps {
+  children: [React.ReactNode, React.ReactNode]
+}
+
+class ResizablePanel extends React.Component<
+  ResizablePanelProps, any> {}
+
+const test = <ResizablePanel>
+  <div />
+  <div />
+</ResizablePanel>
+
+const testErr = <ResizablePanel>
+  <div />
+  <div />
+  <div />
+</ResizablePanel>


### PR DESCRIPTION
Fixes #22759

