### PR TITLE
Default logger for projectService has assert on exceptions being logged in tsserver

### DIFF
--- a/src/testRunner/unittests/compileOnSave.ts
+++ b/src/testRunner/unittests/compileOnSave.ts
@@ -36,7 +36,7 @@ namespace ts.projectSystem {
                 typingsInstaller: typingsInstaller || server.nullTypingsInstaller,
                 byteLength: Utils.byteLength,
                 hrtime: process.hrtime,
-                logger: nullLogger,
+                logger: createHasErrorMessageLogger().logger,
                 canUseEvents: false
             };
             return new server.Session(opts);

--- a/src/testRunner/unittests/session.ts
+++ b/src/testRunner/unittests/session.ts
@@ -502,7 +502,7 @@ namespace ts.server {
                     typingsInstaller: undefined!, // TODO: GH#18217
                     byteLength: Utils.byteLength,
                     hrtime: process.hrtime,
-                    logger: projectSystem.nullLogger,
+                    logger: projectSystem.createHasErrorMessageLogger().logger,
                     canUseEvents: true
                 });
                 this.addProtocolHandler(this.customHandler, () => {
@@ -570,7 +570,7 @@ namespace ts.server {
                     typingsInstaller: undefined!, // TODO: GH#18217
                     byteLength: Utils.byteLength,
                     hrtime: process.hrtime,
-                    logger: projectSystem.nullLogger,
+                    logger: projectSystem.createHasErrorMessageLogger().logger,
                     canUseEvents: true
                 });
                 this.addProtocolHandler("echo", (req: protocol.Request) => ({

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -58,12 +58,13 @@ namespace ts.projectSystem {
         getLogFileName: () => undefined,
     };
 
-    function createHasErrorMessageLogger() {
+    export function createHasErrorMessageLogger() {
         let hasErrorMsg = false;
         const { close, hasLevel, loggingEnabled, startGroup, endGroup, info, getLogFileName, perftrc } = nullLogger;
         const logger: server.Logger = {
             close, hasLevel, loggingEnabled, startGroup, endGroup, info, getLogFileName, perftrc,
-            msg: () => {
+            msg: (s, type) => {
+                Debug.fail(`Error: ${s}, type: ${type}`);
                 hasErrorMsg = true;
             }
         };
@@ -322,7 +323,7 @@ namespace ts.projectSystem {
             typingsInstaller: undefined!, // TODO: GH#18217
             byteLength: Utils.byteLength,
             hrtime: process.hrtime,
-            logger: opts.logger || nullLogger,
+            logger: opts.logger || createHasErrorMessageLogger().logger,
             canUseEvents: false
         };
 
@@ -359,7 +360,7 @@ namespace ts.projectSystem {
     }
     export function createProjectService(host: server.ServerHost, parameters: CreateProjectServiceParameters = {}, options?: Partial<server.ProjectServiceOptions>) {
         const cancellationToken = parameters.cancellationToken || server.nullCancellationToken;
-        const logger = parameters.logger || nullLogger;
+        const logger = parameters.logger || createHasErrorMessageLogger().logger;
         const useSingleInferredProject = parameters.useSingleInferredProject !== undefined ? parameters.useSingleInferredProject : false;
         return new TestProjectService(host, logger, cancellationToken, useSingleInferredProject, parameters.typingsInstaller!, parameters.eventHandler!, options); // TODO: GH#18217
     }


### PR DESCRIPTION
Helps catching exceptions when they are only logged in the logger (and aren't assert failures since they would anyways be caught)