### PR TITLE
Fix checking for type parameter visibility when merged with a parameter

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1231,7 +1231,7 @@ namespace ts {
                                     // local types not visible outside the function body
                                     : false;
                             }
-                            if (meaning & SymbolFlags.Value && result.flags & SymbolFlags.FunctionScopedVariable) {
+                            if (meaning & result.flags & SymbolFlags.FunctionScopedVariable) {
                                 // parameters are visible only inside function body, parameter list and return type
                                 // technically for parameter list case here we might mix parameters and variables declared in function,
                                 // however it is detected separately when checking initializers of parameters

--- a/tests/baselines/reference/typeParameterDoesntBlockParameterLookup.js
+++ b/tests/baselines/reference/typeParameterDoesntBlockParameterLookup.js
@@ -1,0 +1,4 @@
+//// [typeParameterDoesntBlockParameterLookup.ts]
+declare function f<Foo extends Bar, Bar>(Bar: any): void
+
+//// [typeParameterDoesntBlockParameterLookup.js]

--- a/tests/baselines/reference/typeParameterDoesntBlockParameterLookup.symbols
+++ b/tests/baselines/reference/typeParameterDoesntBlockParameterLookup.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/typeParameterDoesntBlockParameterLookup.ts ===
+declare function f<Foo extends Bar, Bar>(Bar: any): void
+>f : Symbol(f, Decl(typeParameterDoesntBlockParameterLookup.ts, 0, 0))
+>Foo : Symbol(Foo, Decl(typeParameterDoesntBlockParameterLookup.ts, 0, 19))
+>Bar : Symbol(Bar, Decl(typeParameterDoesntBlockParameterLookup.ts, 0, 35), Decl(typeParameterDoesntBlockParameterLookup.ts, 0, 41))
+>Bar : Symbol(Bar, Decl(typeParameterDoesntBlockParameterLookup.ts, 0, 35), Decl(typeParameterDoesntBlockParameterLookup.ts, 0, 41))
+>Bar : Symbol(Bar, Decl(typeParameterDoesntBlockParameterLookup.ts, 0, 35), Decl(typeParameterDoesntBlockParameterLookup.ts, 0, 41))
+

--- a/tests/baselines/reference/typeParameterDoesntBlockParameterLookup.types
+++ b/tests/baselines/reference/typeParameterDoesntBlockParameterLookup.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/typeParameterDoesntBlockParameterLookup.ts ===
+declare function f<Foo extends Bar, Bar>(Bar: any): void
+>f : <Foo extends Bar, Bar>(Bar: any) => void
+>Bar : any
+

--- a/tests/cases/compiler/typeParameterDoesntBlockParameterLookup.ts
+++ b/tests/cases/compiler/typeParameterDoesntBlockParameterLookup.ts
@@ -1,0 +1,1 @@
+declare function f<Foo extends Bar, Bar>(Bar: any): void


### PR DESCRIPTION
Fixes #25672

A type parameter merged with a parameter has both type and value meanings, and both the `Type` and the `Value` masks contain some of the same meanings (`Class`, `Enum`, `EnumMember` and `Assignment`), so comparing a target `meaning` (and not a `flags` member) against just one of them almost always yields `true`. We really only want to limit the scope of the parameter meanings of the symbol to the function body, so we need to ensure that the meaning we're looking for is really just the value meanings we actually care about (in this case, `FunctionScopedVariable`).
