### PR TITLE
#17542 enabling forceConsistentCasingInFileNames by default

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2049,9 +2049,9 @@ namespace ts {
                 const file = filesByName.get(path);
                 // try to check if we've already seen this file but with a different casing in path
                 // NOTE: this only makes sense for case-insensitive file systems, and only on files which are not redirected
-                
-                //default to true
-                const forceCasing = options.forceConsistentCasingInFileNames || options.forceConsistentCasingInFileNames==null
+
+                // default to true
+                const forceCasing = options.forceConsistentCasingInFileNames || options.forceConsistentCasingInFileNames === null || options.forceConsistentCasingInFileNames === undefined;
 
                 if (file && forceCasing) {
                     let inputName = fileName;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2049,7 +2049,11 @@ namespace ts {
                 const file = filesByName.get(path);
                 // try to check if we've already seen this file but with a different casing in path
                 // NOTE: this only makes sense for case-insensitive file systems, and only on files which are not redirected
-                if (file && options.forceConsistentCasingInFileNames) {
+                
+                //default to true
+                const forceCasing = options.forceConsistentCasingInFileNames || options.forceConsistentCasingInFileNames==null
+
+                if (file && forceCasing) {
                     let inputName = fileName;
                     const checkedName = file.fileName;
                     const isRedirect = toPath(checkedName) !== toPath(inputName);

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2051,7 +2051,7 @@ namespace ts {
                 // NOTE: this only makes sense for case-insensitive file systems, and only on files which are not redirected
 
                 // default to true
-                const forceCasing = options.forceConsistentCasingInFileNames || options.forceConsistentCasingInFileNames === null || options.forceConsistentCasingInFileNames === undefined;
+                const forceCasing = options.forceConsistentCasingInFileNames || options.forceConsistentCasingInFileNames === undefined;
 
                 if (file && forceCasing) {
                     let inputName = fileName;

--- a/src/testRunner/unittests/moduleResolution.ts
+++ b/src/testRunner/unittests/moduleResolution.ts
@@ -588,7 +588,7 @@ export = C;
                 "/a/b/c.ts": `/// <reference path="D.ts"/>`,
                 "/a/b/d.ts": "var x"
             });
-            test(files, { module: ModuleKind.AMD, forceConsistentCasingInFileNames: true }, "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "d.ts"], [1149]);
+            test(files, { module: ModuleKind.AMD }, "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "d.ts"], [1149]);
         });
 
         it("should fail when two files used in program differ only in casing (imports)", () => {
@@ -596,7 +596,7 @@ export = C;
                 "/a/b/c.ts": `import {x} from "D"`,
                 "/a/b/d.ts": "export var x"
             });
-            test(files, { module: ModuleKind.AMD, forceConsistentCasingInFileNames: true }, "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "d.ts"], [1149]);
+            test(files, { module: ModuleKind.AMD }, "/a/b", /*useCaseSensitiveFileNames*/ false, ["c.ts", "d.ts"], [1149]);
         });
 
         it("should fail when two files used in program differ only in casing (imports, relative module names)", () => {
@@ -604,7 +604,7 @@ export = C;
                 "moduleA.ts": `import {x} from "./ModuleB"`,
                 "moduleB.ts": "export var x"
             });
-            test(files, { module: ModuleKind.CommonJS, forceConsistentCasingInFileNames: true }, "", /*useCaseSensitiveFileNames*/ false, ["moduleA.ts", "moduleB.ts"], [1149]);
+            test(files, { module: ModuleKind.CommonJS }, "", /*useCaseSensitiveFileNames*/ false, ["moduleA.ts", "moduleB.ts"], [1149]);
         });
 
         it("should fail when two files exist on disk that differs only in casing", () => {
@@ -622,7 +622,7 @@ export = C;
                 "moduleB.ts": `import a = require("./moduleC")`,
                 "moduleC.ts": "export var x"
             });
-            test(files, { module: ModuleKind.CommonJS, forceConsistentCasingInFileNames: true }, "", /*useCaseSensitiveFileNames*/ false, ["moduleA.ts", "moduleB.ts", "moduleC.ts"], [1149, 1149]);
+            test(files, { module: ModuleKind.CommonJS }, "", /*useCaseSensitiveFileNames*/ false, ["moduleA.ts", "moduleB.ts", "moduleC.ts"], [1149, 1149]);
         });
 
         it("should fail when module names in 'require' calls has inconsistent casing and current directory has uppercase chars", () => {
@@ -635,7 +635,7 @@ import a = require("./moduleA");
 import b = require("./moduleB");
                 `
             });
-            test(files, { module: ModuleKind.CommonJS, forceConsistentCasingInFileNames: true }, "/a/B/c", /*useCaseSensitiveFileNames*/ false, ["moduleD.ts"], [1149]);
+            test(files, { module: ModuleKind.CommonJS }, "/a/B/c", /*useCaseSensitiveFileNames*/ false, ["moduleD.ts"], [1149]);
         });
         it("should not fail when module names in 'require' calls has consistent casing and current directory has uppercase chars", () => {
             const files = createMapFromTemplate({
@@ -647,7 +647,7 @@ import a = require("./moduleA");
 import b = require("./moduleB");
                 `
             });
-            test(files, { module: ModuleKind.CommonJS, forceConsistentCasingInFileNames: true }, "/a/B/c", /*useCaseSensitiveFileNames*/ false, ["moduleD.ts"], []);
+            test(files, { module: ModuleKind.CommonJS }, "/a/B/c", /*useCaseSensitiveFileNames*/ false, ["moduleD.ts"], []);
         });
     });
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This implements #17542 enable forceConsistentCasingInFileNames by default which fixes cross-platform compatability issues due to typescript not reporting different cases as an error in windows.

This is my first time modifying the typescript sourcecode, so hopefully I made the change in the right spot. I thought the PR would be a simple false -> true change in a config but apparently there's no central file for compiler option defaults.

In addition to this change the documentation at https://www.typescriptlang.org/docs/handbook/compiler-options.html would need to be updated.

