### PR TITLE
#27428 Pretty time format does not use local time format

### DIFF
--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -62,7 +62,7 @@ namespace ts {
         return pretty ?
             (diagnostic, newLine, options) => {
                 clearScreenIfNotWatchingForFileChanges(system, diagnostic, options);
-                let output = `[${formatColorAndReset(new Date().toLocaleTimeString(), ForegroundColorEscapeSequences.Grey)}] `;
+                let output = `[${formatColorAndReset(new Date().toLocaleTimeString("en-US", { hour12: false }), ForegroundColorEscapeSequences.Grey)}] `;
                 output += `${flattenDiagnosticMessageText(diagnostic.messageText, system.newLine)}${newLine + newLine}`;
                 system.write(output);
             } :
@@ -73,7 +73,7 @@ namespace ts {
                     output += newLine;
                 }
 
-                output += `${new Date().toLocaleTimeString()} - `;
+                output += `${new Date().toLocaleTimeString("en-US", { hour12: false })} - `;
                 output += `${flattenDiagnosticMessageText(diagnostic.messageText, system.newLine)}${getPlainDiagnosticFollowingNewLines(diagnostic, newLine)}`;
 
                 system.write(output);


### PR DESCRIPTION
Fix the local time in output logs to show 24 hours format
This is my first #Hacktoberfest PR. Cheers.
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #27428 

