### PR TITLE
[WIP] Make allowJs and declaration options work together

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2612,10 +2612,6 @@ namespace ts {
                 }
             }
 
-            if (!options.noEmit && options.allowJs && getEmitDeclarations(options)) {
-                createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "allowJs", getEmitDeclarationOptionName(options));
-            }
-
             if (options.checkJs && !options.allowJs) {
                 programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_without_specifying_option_1, "checkJs", "allowJs"));
             }


### PR DESCRIPTION
**Not ready for review yet!**

This is work in progress, and a follow-up on recently closed #21455. I'm pretty stuck already in early stages of this pull request, so if anyone is able and willing to help I'll be glad to give access to my branch and coordinate the effort.

I think the best way to address this is to add helper utilities to TypeScript that convert nodes from `*.js` files with JSDoc types to nodes that look exactly as if the types were defined in `*.ts` code. Any guidance or ideas about different approaches would be much appreciated.

* [x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [x] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Fixes #7546
