### PR TITLE
Fix issue of program not being reused when host implements getSourceFileByPath

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2024,10 +2024,12 @@ namespace ts {
             }
         }
 
-        function createRedirectSourceFile(redirectTarget: SourceFile, unredirected: SourceFile, fileName: string, path: Path): SourceFile {
+        function createRedirectSourceFile(redirectTarget: SourceFile, unredirected: SourceFile, fileName: string, path: Path, resolvedPath: Path, originalFileName: string): SourceFile {
             const redirect: SourceFile = Object.create(redirectTarget);
             redirect.fileName = fileName;
             redirect.path = path;
+            redirect.resolvedPath = resolvedPath;
+            redirect.originalFileName = originalFileName;
             redirect.redirectInfo = { redirectTarget, unredirected };
             Object.defineProperties(redirect, {
                 id: {
@@ -2118,7 +2120,7 @@ namespace ts {
                 if (fileFromPackageId) {
                     // Some other SourceFile already exists with this package name and version.
                     // Instead of creating a duplicate, just redirect to the existing one.
-                    const dupFile = createRedirectSourceFile(fileFromPackageId, file!, fileName, path); // TODO: GH#18217
+                    const dupFile = createRedirectSourceFile(fileFromPackageId, file!, fileName, path, toPath(fileName), originalFileName); // TODO: GH#18217
                     redirectTargetsMap.add(fileFromPackageId.path, fileName);
                     filesByName.set(path, dupFile);
                     sourceFileToPackageName.set(path, packageId.name);

--- a/src/testRunner/unittests/reuseProgramStructure.ts
+++ b/src/testRunner/unittests/reuseProgramStructure.ts
@@ -119,7 +119,6 @@ namespace ts {
         });
         const useCaseSensitiveFileNames = sys && sys.useCaseSensitiveFileNames;
         const getCanonicalFileName = createGetCanonicalFileName(useCaseSensitiveFileNames);
-        const filesByPath = useGetSourceFileByPath ? mapEntries(files, (fileName, file) => [toPath(fileName, "", getCanonicalFileName), file]) : undefined;
         const trace: string[] = [];
         const result: TestCompilerHost = {
             trace: s => trace.push(s),
@@ -139,7 +138,8 @@ namespace ts {
             },
         };
         if (useGetSourceFileByPath) {
-            result.getSourceFileByPath = (_fileName, path) => filesByPath!.get(path);
+            const filesByPath = mapEntries(files, (fileName, file) => [toPath(fileName, "", getCanonicalFileName), file]);
+            result.getSourceFileByPath = (_fileName, path) => filesByPath.get(path);
         }
         return result;
     }


### PR DESCRIPTION
This was because redirect file didn't set `resolvedPath` which then would pick from redirected file. So when getting source file, instead of getting if for undirected path, we would end up getting source file for redirected file and then comparing wrong files together.
Fixes #27207