### PR TITLE
Use safe some function to handle undefined declarations (fixes #27338)

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1397,7 +1397,7 @@ namespace ts.Completions {
                 if (resolvedModuleSymbol !== moduleSymbol &&
                     // Don't add another completion for `export =` of a symbol that's already global.
                     // So in `declare namespace foo {} declare module "foo" { export = foo; }`, there will just be the global completion for `foo`.
-                    resolvedModuleSymbol.declarations.some(d => !!d.getSourceFile().externalModuleIndicator)) {
+                    some(resolvedModuleSymbol.declarations, d => !!d.getSourceFile().externalModuleIndicator)) {
                     symbols.push(resolvedModuleSymbol);
                     symbolToOriginInfoMap[getSymbolId(resolvedModuleSymbol)] = { kind: SymbolOriginInfoKind.Export, moduleSymbol, isDefaultExport: false };
                 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #27338

This fix uses safe variant of `some` implementation, that will skip cases where `resolvedModuleSymbol.declarations` is `undefined`. After applying this fix and using built TS version in VS Code I can see adequate suggestions when I call for completion info.

This fix uses similar approach as [code few lined below](https://github.com/Microsoft/TypeScript/blob/master/src/services/completions.ts#L1413) so I'm not sure if I need to add unit tests here. If unit tests are must have in this case - would be grateful for suggest how to achieve `undefined` `declarations`.