### PR TITLE
Insert async keyword as last modifier in async refactor

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -68,7 +68,7 @@ namespace ts.codefix {
         }
 
         // add the async keyword
-        changes.insertModifierBefore(sourceFile, SyntaxKind.AsyncKeyword, functionToConvert);
+        changes.insertLastModifierBefore(sourceFile, SyntaxKind.AsyncKeyword, functionToConvert);
 
         function startTransformation(node: CallExpression, nodeToReplace: Node) {
             const newNodes = transformExpression(node, transformer, node);

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -315,6 +315,16 @@ namespace ts.textChanges {
             this.replaceRange(sourceFile, { pos, end: pos }, createToken(modifier), { suffix: " " });
         }
 
+        public insertLastModifierBefore(sourceFile: SourceFile, modifier: SyntaxKind, before: Node): void {
+            if (!before.modifiers) {
+                this.insertModifierBefore(sourceFile, modifier, before);
+                return;
+            }
+
+            const pos = before.modifiers.end;
+            this.replaceRange(sourceFile, { pos, end: pos }, createToken(modifier), { prefix: " " });
+        }
+
         public insertCommentBeforeLine(sourceFile: SourceFile, lineNumber: number, position: number, commentText: string): void {
             const lineStartPosition = getStartPositionOfLine(lineNumber, sourceFile);
             const startPosition = getFirstNonSpaceCharacterPosition(sourceFile.text, lineStartPosition);

--- a/src/testRunner/unittests/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/convertToAsyncFunction.ts
@@ -1255,6 +1255,11 @@ function [#|main2|]() {
         .then(() => { console.log("."); return delay(500); })
 }
 `);
+_testConvertToAsyncFunction("convertToAsyncFunction_exportModifier", `
+export function [#|foo|]() {
+    return fetch('https://typescriptlang.org').then(s => console.log(s));
+}
+`);
     });
 
     function _testConvertToAsyncFunction(caption: string, text: string) {

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_exportModifier.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_exportModifier.js
@@ -1,0 +1,12 @@
+// ==ORIGINAL==
+
+export function /*[#|*/foo/*|]*/() {
+    return fetch('https://typescriptlang.org').then(s => console.log(s));
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+export async function foo() {
+    const s = await fetch('https://typescriptlang.org');
+    return console.log(s);
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_exportModifier.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_exportModifier.ts
@@ -1,0 +1,12 @@
+// ==ORIGINAL==
+
+export function /*[#|*/foo/*|]*/() {
+    return fetch('https://typescriptlang.org').then(s => console.log(s));
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+export async function foo() {
+    const s = await fetch('https://typescriptlang.org');
+    return console.log(s);
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #27429.
Currently, the async refactor inserts the `async` keyword as the first modifier. However, whereas it's incorrect to put it before an `export` modifier, it's [always correct](https://www.ecma-international.org/ecma-262/9.0/index.html#sec-async-function-definitions) to put it as the last modifier.