### PR TITLE
Small refactoring of getTransformationBody

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -410,7 +410,7 @@ namespace ts.codefix {
                     break;
                 }
 
-                const synthCall = createCall(getSynthesizedDeepClone(func as Identifier), /*typeArguments*/ undefined, argName ? [argName.identifier] : emptyArray);
+                const synthCall = createCall(getSynthesizedDeepClone(func as Identifier), /*typeArguments*/ undefined, [argName.identifier]);
                 if (shouldReturn) {
                     return [createReturn(synthCall)];
                 }


### PR DESCRIPTION
This PR has no associated issue because it's a very small refactoring aiming to simplify the code and is not a bug or a feature. I was reading `TypeScript` source code and noticed it and I don't think it's worth opening an issue for it.

Remove unneeded `argName` check, because it always evaluates to `true` (the `false` case is handled just before the modified line)
