### PR TITLE
Mark the parameter of `charCodeAt` as optional

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -333,9 +333,9 @@ interface String {
 
     /**
       * Returns the Unicode value of the character at the specified location.
-      * @param index The zero-based index of the desired character. If there is no character at the specified index, NaN is returned.
+      * @param index The zero-based index of the desired character (defaults to zero). If there is no character at the specified index, NaN is returned.
       */
-    charCodeAt(index: number): number;
+    charCodeAt(index?: number): number;
 
     /**
       * Returns a string that contains the concatenation of two or more strings.

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -373,9 +373,9 @@ interface String {
 
     /**
       * Returns the Unicode value of the character at the specified location.
-      * @param index The zero-based index of the desired character. If there is no character at the specified index, NaN is returned.
+      * @param index The zero-based index of the desired character (defaults to zero). If there is no character at the specified index, NaN is returned.
       */
-    charCodeAt(index: number): number;
+    charCodeAt(index?: number): number;
 
     /**
       * Returns a string that contains the concatenation of two or more strings.


### PR DESCRIPTION
According to [the specification](https://www.ecma-international.org/ecma-262/5.1/#sec-15.5.4.5), when `undefined` is passed as an argument, the function treats it as `0`. This is a useful shorthand when dealing with single-char strings. Example:
```
let ch = 'x';
let code = ch.charCodeAt();
code += 1;
ch = String.fromCharCode(ch);
```


From the specification:

> 15.5.4.5 String.prototype.charCodeAt(pos)
> [...]
> 3. Let position be ToInteger(pos).

> 9.4 ToInteger
> Let number be the result of calling ToNumber on the input argument.
> If number is NaN, return +0.

> 9.3 ToNumber
> Undefined	→	NaN

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
