### PR TITLE
Add a type check to prevent assigning unrelated class hierarchies

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -78,6 +78,7 @@ namespace ts {
         const strictNullChecks = getStrictOptionValue(compilerOptions, "strictNullChecks");
         const strictFunctionTypes = getStrictOptionValue(compilerOptions, "strictFunctionTypes");
         const strictBindCallApply = getStrictOptionValue(compilerOptions, "strictBindCallApply");
+        const strictClassTypes = getStrictOptionValue(compilerOptions, "strictClassTypes");
         const strictPropertyInitialization = getStrictOptionValue(compilerOptions, "strictPropertyInitialization");
         const noImplicitAny = getStrictOptionValue(compilerOptions, "noImplicitAny");
         const noImplicitThis = getStrictOptionValue(compilerOptions, "noImplicitThis");
@@ -12035,6 +12036,9 @@ namespace ts {
                     // to X. Failing both of those we want to check if the aggregation of A and B's members structurally
                     // relates to X. Thus, we include intersection types on the source side here.
                     if (source.flags & (TypeFlags.Object | TypeFlags.Intersection) && target.flags & TypeFlags.Object) {
+                        if (strictClassTypes && (getObjectFlags(target) & ObjectFlags.Class) && !isTypeDerivedFrom(source, target)) {
+                            return Ternary.False;
+                        }
                         // Report structural errors only if we haven't reported any errors yet
                         const reportStructuralErrors = reportErrors && errorInfo === saveErrorInfo && !sourceIsPrimitive;
                         result = propertiesRelatedTo(source, target, reportStructuralErrors);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -382,6 +382,14 @@ namespace ts {
             description: Diagnostics.Enable_strict_bind_call_and_apply_methods_on_functions
         },
         {
+            name: "strictClassTypes",
+            type: "boolean",
+            strictFlag: true,
+            showInSimplifiedHelpView: true,
+            category: Diagnostics.Strict_Type_Checking_Options,
+            description: Diagnostics.Enable_strict_checking_of_class_types
+        },
+        {
             name: "strictPropertyInitialization",
             type: "boolean",
             affectsSemanticDiagnostics: true,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3763,6 +3763,10 @@
         "category": "Message",
         "code": 6214
     },
+    "Enable strict checking of class types.": {
+        "category": "Message",
+        "code": 6215
+    },
 
     "Projects to reference": {
         "category": "Message",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4431,6 +4431,7 @@ namespace ts {
         strict?: boolean;
         strictFunctionTypes?: boolean;  // Always combine with strict property
         strictBindCallApply?: boolean;  // Always combine with strict property
+        strictClassTypes?: boolean;  // Always combine with strict property
         strictNullChecks?: boolean;  // Always combine with strict property
         strictPropertyInitialization?: boolean;  // Always combine with strict property
         stripInternal?: boolean;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7085,7 +7085,7 @@ namespace ts {
         return !!(compilerOptions.declaration || compilerOptions.composite);
     }
 
-    export type StrictOptionName = "noImplicitAny" | "noImplicitThis" | "strictNullChecks" | "strictFunctionTypes" | "strictBindCallApply" | "strictPropertyInitialization" | "alwaysStrict";
+    export type StrictOptionName = "noImplicitAny" | "noImplicitThis" | "strictNullChecks" | "strictFunctionTypes" | "strictBindCallApply" | "strictClassTypes" | "strictPropertyInitialization" | "alwaysStrict";
 
     export function getStrictOptionValue(compilerOptions: CompilerOptions, flag: StrictOptionName): boolean {
         return compilerOptions[flag] === undefined ? !!compilerOptions.strict : !!compilerOptions[flag];

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2495,6 +2495,7 @@ declare namespace ts {
         strict?: boolean;
         strictFunctionTypes?: boolean;
         strictBindCallApply?: boolean;
+        strictClassTypes?: boolean;
         strictNullChecks?: boolean;
         strictPropertyInitialization?: boolean;
         stripInternal?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2495,6 +2495,7 @@ declare namespace ts {
         strict?: boolean;
         strictFunctionTypes?: boolean;
         strictBindCallApply?: boolean;
+        strictClassTypes?: boolean;
         strictNullChecks?: boolean;
         strictPropertyInitialization?: boolean;
         stripInternal?: boolean;

--- a/tests/baselines/reference/signatureInstantiationWithRecursiveConstraints.js
+++ b/tests/baselines/reference/signatureInstantiationWithRecursiveConstraints.js
@@ -13,7 +13,6 @@ const myVar: Foo = new Bar();
 
 
 //// [signatureInstantiationWithRecursiveConstraints.js]
-"use strict";
 // Repro from #17148
 var Foo = /** @class */ (function () {
     function Foo() {

--- a/tests/baselines/reference/strictClassTypes.errors.txt
+++ b/tests/baselines/reference/strictClassTypes.errors.txt
@@ -1,0 +1,29 @@
+tests/cases/compiler/strictClassTypes.ts(16,1): error TS2322: Type 'A' is not assignable to type 'B'.
+tests/cases/compiler/strictClassTypes.ts(19,1): error TS2322: Type 'I' is not assignable to type 'C'.
+
+
+==== tests/cases/compiler/strictClassTypes.ts (2 errors) ====
+    class A {}
+    class B extends A {}
+    class C extends A {
+        x: number;
+    }
+    interface I {
+        x: number;
+    }
+    
+    declare let a: A;
+    declare let b: B;
+    declare let c: C;
+    declare let i: I;
+    
+    a = b; // Ok
+    b = a; // Error
+    ~
+!!! error TS2322: Type 'A' is not assignable to type 'B'.
+    
+    i = c; // Ok
+    c = i; // Error
+    ~
+!!! error TS2322: Type 'I' is not assignable to type 'C'.
+    

--- a/tests/baselines/reference/strictClassTypes.js
+++ b/tests/baselines/reference/strictClassTypes.js
@@ -1,0 +1,59 @@
+//// [strictClassTypes.ts]
+class A {}
+class B extends A {}
+class C extends A {
+    x: number;
+}
+interface I {
+    x: number;
+}
+
+declare let a: A;
+declare let b: B;
+declare let c: C;
+declare let i: I;
+
+a = b; // Ok
+b = a; // Error
+
+i = c; // Ok
+c = i; // Error
+
+
+//// [strictClassTypes.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    }
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+var B = /** @class */ (function (_super) {
+    __extends(B, _super);
+    function B() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return B;
+}(A));
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(A));
+a = b; // Ok
+b = a; // Error
+i = c; // Ok
+c = i; // Error

--- a/tests/baselines/reference/strictClassTypes.symbols
+++ b/tests/baselines/reference/strictClassTypes.symbols
@@ -1,0 +1,54 @@
+=== tests/cases/compiler/strictClassTypes.ts ===
+class A {}
+>A : Symbol(A, Decl(strictClassTypes.ts, 0, 0))
+
+class B extends A {}
+>B : Symbol(B, Decl(strictClassTypes.ts, 0, 10))
+>A : Symbol(A, Decl(strictClassTypes.ts, 0, 0))
+
+class C extends A {
+>C : Symbol(C, Decl(strictClassTypes.ts, 1, 20))
+>A : Symbol(A, Decl(strictClassTypes.ts, 0, 0))
+
+    x: number;
+>x : Symbol(C.x, Decl(strictClassTypes.ts, 2, 19))
+}
+interface I {
+>I : Symbol(I, Decl(strictClassTypes.ts, 4, 1))
+
+    x: number;
+>x : Symbol(I.x, Decl(strictClassTypes.ts, 5, 13))
+}
+
+declare let a: A;
+>a : Symbol(a, Decl(strictClassTypes.ts, 9, 11))
+>A : Symbol(A, Decl(strictClassTypes.ts, 0, 0))
+
+declare let b: B;
+>b : Symbol(b, Decl(strictClassTypes.ts, 10, 11))
+>B : Symbol(B, Decl(strictClassTypes.ts, 0, 10))
+
+declare let c: C;
+>c : Symbol(c, Decl(strictClassTypes.ts, 11, 11))
+>C : Symbol(C, Decl(strictClassTypes.ts, 1, 20))
+
+declare let i: I;
+>i : Symbol(i, Decl(strictClassTypes.ts, 12, 11))
+>I : Symbol(I, Decl(strictClassTypes.ts, 4, 1))
+
+a = b; // Ok
+>a : Symbol(a, Decl(strictClassTypes.ts, 9, 11))
+>b : Symbol(b, Decl(strictClassTypes.ts, 10, 11))
+
+b = a; // Error
+>b : Symbol(b, Decl(strictClassTypes.ts, 10, 11))
+>a : Symbol(a, Decl(strictClassTypes.ts, 9, 11))
+
+i = c; // Ok
+>i : Symbol(i, Decl(strictClassTypes.ts, 12, 11))
+>c : Symbol(c, Decl(strictClassTypes.ts, 11, 11))
+
+c = i; // Error
+>c : Symbol(c, Decl(strictClassTypes.ts, 11, 11))
+>i : Symbol(i, Decl(strictClassTypes.ts, 12, 11))
+

--- a/tests/baselines/reference/strictClassTypes.types
+++ b/tests/baselines/reference/strictClassTypes.types
@@ -1,0 +1,52 @@
+=== tests/cases/compiler/strictClassTypes.ts ===
+class A {}
+>A : A
+
+class B extends A {}
+>B : B
+>A : A
+
+class C extends A {
+>C : C
+>A : A
+
+    x: number;
+>x : number
+}
+interface I {
+    x: number;
+>x : number
+}
+
+declare let a: A;
+>a : A
+
+declare let b: B;
+>b : B
+
+declare let c: C;
+>c : C
+
+declare let i: I;
+>i : I
+
+a = b; // Ok
+>a = b : B
+>a : A
+>b : B
+
+b = a; // Error
+>b = a : A
+>b : B
+>a : A
+
+i = c; // Ok
+>i = c : C
+>i : I
+>c : C
+
+c = i; // Error
+>c = i : I
+>c : C
+>i : I
+

--- a/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
@@ -26,6 +26,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictClassTypes": true,              /* Enable strict checking of class types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
@@ -26,6 +26,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictClassTypes": true,              /* Enable strict checking of class types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -26,6 +26,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictClassTypes": true,              /* Enable strict checking of class types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -26,6 +26,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictClassTypes": true,              /* Enable strict checking of class types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
@@ -26,6 +26,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictClassTypes": true,              /* Enable strict checking of class types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -26,6 +26,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictClassTypes": true,              /* Enable strict checking of class types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -26,6 +26,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictClassTypes": true,              /* Enable strict checking of class types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -26,6 +26,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictClassTypes": true,              /* Enable strict checking of class types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -26,6 +26,7 @@
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictClassTypes": true,              /* Enable strict checking of class types. */
     // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */

--- a/tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts
+++ b/tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts
@@ -1,5 +1,3 @@
-// @strict: true
-
 // Repro from #17148
 
 class Foo {

--- a/tests/cases/compiler/strictClassTypes.ts
+++ b/tests/cases/compiler/strictClassTypes.ts
@@ -1,0 +1,21 @@
+// @strictClassTypes: true
+
+class A {}
+class B extends A {}
+class C extends A {
+    x: number;
+}
+interface I {
+    x: number;
+}
+
+declare let a: A;
+declare let b: B;
+declare let c: C;
+declare let i: I;
+
+a = b; // Ok
+b = a; // Error
+
+i = c; // Ok
+c = i; // Error


### PR DESCRIPTION
The problem is in JS a class instance is a bigger concept than just a struct. And sometimes it's counterintuitive we can pass some plain JS object instead of a specific class instance:
```ts
class Duck { }

function duckConsumer(duck: Duck) {
  if (!(duck instanceof Duck)) {
    console.log(`Now, ducks aren't the same`);
  }
}


class Crocodile {}

duckConsumer(new Crocodile());
```
