### PR TITLE
Always await expression of promise type in return position

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -465,11 +465,11 @@ namespace ts.codefix {
                         return innerCbBody;
                     }
 
+                    const type = transformer.checker.getTypeAtLocation(func);
+                    const returnType = getLastCallSignature(type, transformer.checker)!.getReturnType();
+                    const rightHandSide = getSynthesizedDeepClone(funcBody);
+                    const possiblyAwaitedRightHandSide = !!transformer.checker.getPromisedTypeOfPromise(returnType) ? createAwait(rightHandSide) : rightHandSide;
                     if (!shouldReturn) {
-                        const type = transformer.checker.getTypeAtLocation(func);
-                        const returnType = getLastCallSignature(type, transformer.checker)!.getReturnType();
-                        const rightHandSide = getSynthesizedDeepClone(funcBody);
-                        const possiblyAwaitedRightHandSide = !!transformer.checker.getPromisedTypeOfPromise(returnType) ? createAwait(rightHandSide) : rightHandSide;
                         const transformedStatement = createTransformedStatement(prevArgName, possiblyAwaitedRightHandSide, transformer);
                         if (prevArgName) {
                             prevArgName.types.push(returnType);
@@ -477,7 +477,7 @@ namespace ts.codefix {
                         return transformedStatement;
                     }
                     else {
-                        return [createReturn(getSynthesizedDeepClone(funcBody))];
+                        return [createReturn(possiblyAwaitedRightHandSide)];
                     }
                 }
             }

--- a/src/testRunner/unittests/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/convertToAsyncFunction.ts
@@ -1236,6 +1236,13 @@ function [#|f|]() {
 }
 `);
 
+    _testConvertToAsyncFunction("convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock", `
+function [#|f|]() {
+    return Promise.resolve(1)
+        .then(x => Promise.reject(x))
+        .catch(err => console.log(err));
+}    
+`);
 
 _testConvertToAsyncFunction("convertToAsyncFunction_nestedPromises", `
 function [#|f|]() {

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsPromiseLastInChain.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsPromiseLastInChain.js
@@ -8,5 +8,5 @@ function /*[#|*/f/*|]*/() {
 
 async function f() {
     const s = await fetch('https://typescriptlang.org');
-    return Promise.resolve(s.statusText.length);
+    return await Promise.resolve(s.statusText.length);
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsPromiseLastInChain.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsPromiseLastInChain.ts
@@ -8,5 +8,5 @@ function /*[#|*/f/*|]*/() {
 
 async function f() {
     const s = await fetch('https://typescriptlang.org');
-    return Promise.resolve(s.statusText.length);
+    return await Promise.resolve(s.statusText.length);
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.js
@@ -1,0 +1,19 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/() {
+    return Promise.resolve(1)
+        .then(x => Promise.reject(x))
+        .catch(err => console.log(err));
+}    
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f() {
+    try {
+        const x = await Promise.resolve(1);
+        return await Promise.reject(x);
+    }
+    catch (err) {
+        return console.log(err);
+    }
+}    

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.ts
@@ -1,0 +1,19 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/() {
+    return Promise.resolve(1)
+        .then(x => Promise.reject(x))
+        .catch(err => console.log(err));
+}    
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f() {
+    try {
+        const x = await Promise.resolve(1);
+        return await Promise.reject(x);
+    }
+    catch (err) {
+        return console.log(err);
+    }
+}    

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_nestedPromises.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_nestedPromises.js
@@ -9,5 +9,5 @@ function /*[#|*/f/*|]*/() {
 async function f() {
     const x = await fetch('https://typescriptlang.org');
     const y = await Promise.resolve(3);
-    return Promise.resolve(x.statusText.length + y);
+    return await Promise.resolve(x.statusText.length + y);
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_nestedPromises.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_nestedPromises.ts
@@ -9,5 +9,5 @@ function /*[#|*/f/*|]*/() {
 async function f() {
     const x = await fetch('https://typescriptlang.org');
     const y = await Promise.resolve(3);
-    return Promise.resolve(x.statusText.length + y);
+    return await Promise.resolve(x.statusText.length + y);
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #27544 

Currently, if a promise handler that is itself returning a promise is changed to an async function using our code fix, that promise is not awaited if it will be in a return position in the resulting async function. This was done since the following are equivalent in evaluation:
```ts
async function f() {
  return Promise.resolve(3);
}

async function g() {
  return await Promise.resolve(3);
}
```

However, if a rejected promise is returned from within a `try` block, awaiting the promise will cause it to be caught by the `catch` block, whereas returning it without an await will pass the rejected promise to the caller.

This PR changes the code fix behavior so promises returned by promise handlers will always be awaited, regardless of whether they are in a return position or not. This does mean that "unnecessary" awaits will be added, but for promises that might potentially be rejected but are, at the time of the code fix, not caught, the extra await may avoid later issues if wrapped in a `catch` after the fact.

Thanks @bterlson for input!
