### PR TITLE
Add rule that a type is assignable to `A extends B ? C : D` if it is assignable to both C and D.

### DIFF
--- a/tests/baselines/reference/conditionalTypes1.errors.txt
+++ b/tests/baselines/reference/conditionalTypes1.errors.txt
@@ -18,23 +18,35 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(104,5): error TS2
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(106,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>'.
   Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
     Type 'keyof T' is not assignable to type 'never'.
-      Type 'string | number | symbol' is not assignable to type 'never'.
-        Type 'string' is not assignable to type 'never'.
+      Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'never'.
+        Type 'keyof T' is not assignable to type 'never'.
+          Type 'string | number | symbol' is not assignable to type 'never'.
+            Type 'string' is not assignable to type 'never'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(108,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
   Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
     Type 'keyof T' is not assignable to type 'never'.
+      Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'never'.
+        Type 'keyof T' is not assignable to type 'never'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(114,5): error TS2322: Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
   Type 'string | number | symbol' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
     Type 'string' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+      Type 'string' is not assignable to type 'keyof T'.
+        Type 'keyof T' is not assignable to type 'never'.
+          Type 'string | number | symbol' is not assignable to type 'never'.
+            Type 'string' is not assignable to type 'never'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(115,5): error TS2322: Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
   Type 'keyof T' is not assignable to type 'never'.
-    Type 'string | number | symbol' is not assignable to type 'never'.
-      Type 'string' is not assignable to type 'never'.
+    Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'never'.
+      Type 'keyof T' is not assignable to type 'never'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(116,5): error TS2322: Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
   Type 'string | number | symbol' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
     Type 'string' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+      Type 'string' is not assignable to type 'never'.
+        Type 'keyof T' is not assignable to type 'never'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(117,5): error TS2322: Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
   Type 'keyof T' is not assignable to type 'never'.
+    Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'never'.
+      Type 'keyof T' is not assignable to type 'never'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(134,10): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(135,5): error TS2542: Index signature in type 'DeepReadonlyArray<Part>' only permits reading.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(136,22): error TS2540: Cannot assign to 'id' because it is a constant or a read-only property.
@@ -188,14 +200,18 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(288,43): error TS
 !!! error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>'.
 !!! error TS2322:   Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
 !!! error TS2322:     Type 'keyof T' is not assignable to type 'never'.
-!!! error TS2322:       Type 'string | number | symbol' is not assignable to type 'never'.
-!!! error TS2322:         Type 'string' is not assignable to type 'never'.
+!!! error TS2322:       Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'never'.
+!!! error TS2322:         Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322:           Type 'string | number | symbol' is not assignable to type 'never'.
+!!! error TS2322:             Type 'string' is not assignable to type 'never'.
         z = x;
         z = y;  // Error
         ~
 !!! error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
 !!! error TS2322:   Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
 !!! error TS2322:     Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322:       Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'never'.
+!!! error TS2322:         Type 'keyof T' is not assignable to type 'never'.
     }
     
     function f8<T>(x: keyof T, y: FunctionPropertyNames<T>, z: NonFunctionPropertyNames<T>) {
@@ -206,21 +222,29 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(288,43): error TS
 !!! error TS2322: Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
 !!! error TS2322:   Type 'string | number | symbol' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
 !!! error TS2322:     Type 'string' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
+!!! error TS2322:       Type 'string' is not assignable to type 'keyof T'.
+!!! error TS2322:         Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322:           Type 'string | number | symbol' is not assignable to type 'never'.
+!!! error TS2322:             Type 'string' is not assignable to type 'never'.
         y = z;  // Error
         ~
 !!! error TS2322: Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
 !!! error TS2322:   Type 'keyof T' is not assignable to type 'never'.
-!!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'never'.
-!!! error TS2322:       Type 'string' is not assignable to type 'never'.
+!!! error TS2322:     Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'never'.
+!!! error TS2322:       Type 'keyof T' is not assignable to type 'never'.
         z = x;  // Error
         ~
 !!! error TS2322: Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
 !!! error TS2322:   Type 'string | number | symbol' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
 !!! error TS2322:     Type 'string' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
+!!! error TS2322:       Type 'string' is not assignable to type 'never'.
+!!! error TS2322:         Type 'keyof T' is not assignable to type 'never'.
         z = y;  // Error
         ~
 !!! error TS2322: Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'T[keyof T] extends Function ? never : keyof T'.
 !!! error TS2322:   Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322:     Type 'T[keyof T] extends Function ? keyof T : never' is not assignable to type 'never'.
+!!! error TS2322:       Type 'keyof T' is not assignable to type 'never'.
     }
     
     type DeepReadonly<T> =

--- a/tests/baselines/reference/conditionalTypes2.errors.txt
+++ b/tests/baselines/reference/conditionalTypes2.errors.txt
@@ -24,9 +24,12 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(74,12): error TS2
 tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2345: Argument of type 'Extract2<T, Foo, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
   Type 'T extends Bar ? T : never' is not assignable to type '{ foo: string; bat: string; }'.
     Type 'Bar & Foo & T' is not assignable to type '{ foo: string; bat: string; }'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(163,11): error TS2322: Type '{ a: number; b: number; }' is not assignable to type '[T] extends [[infer U]] ? U : { b: number; }'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(165,11): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<T>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(167,11): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<T & string>'.
 
 
-==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (7 errors) ====
+==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (10 errors) ====
     interface Covariant<T> {
         foo: T extends string ? T : number;
     }
@@ -206,4 +209,34 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2
     
     type C2<T, V, E> =
         T extends object ? { [Q in keyof T]: C2<T[Q], V, E>; } : T;
+    
+    // #26933
+    
+    type Distributive<T> = T extends {a: number} ? { a: number } : { b: number };
+    
+    function testAssignabilityToConditionalType<T>() {
+        const o = { a: 1, b: 2 };
+        const x: [T] extends [string] ? { y: number } : { a: number, b: number } = undefined!;
+        // Simple case: OK
+        const o1: [T] extends [number] ? { a: number } : { b: number } = o;
+        // Simple case where source happens to be a conditional type: also OK
+        const x1: [T] extends [number]
+            ? ([T] extends [string] ? { y: number } : { a: number })
+            : ([T] extends [string] ? { y: number } : { b: number })
+            = x;
+        // Infer type parameters: no good
+        const o2: [T] extends [[infer U]] ? U : { b: number } = o;
+              ~~
+!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type '[T] extends [[infer U]] ? U : { b: number; }'.
+        // Distributive where T might instantiate to never: no good
+        const o3: Distributive<T> = o;
+              ~~
+!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<T>'.
+        // Distributive where T & string might instantiate to never: also no good
+        const o4: Distributive<T & string> = o;
+              ~~
+!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<T & string>'.
+        // Distributive where {a: T} cannot instantiate to never: OK
+        const o5: Distributive<{a: T}> = o;
+    }
     

--- a/tests/baselines/reference/conditionalTypes2.js
+++ b/tests/baselines/reference/conditionalTypes2.js
@@ -146,6 +146,30 @@ type B2<T, V> =
 type C2<T, V, E> =
     T extends object ? { [Q in keyof T]: C2<T[Q], V, E>; } : T;
 
+// #26933
+
+type Distributive<T> = T extends {a: number} ? { a: number } : { b: number };
+
+function testAssignabilityToConditionalType<T>() {
+    const o = { a: 1, b: 2 };
+    const x: [T] extends [string] ? { y: number } : { a: number, b: number } = undefined!;
+    // Simple case: OK
+    const o1: [T] extends [number] ? { a: number } : { b: number } = o;
+    // Simple case where source happens to be a conditional type: also OK
+    const x1: [T] extends [number]
+        ? ([T] extends [string] ? { y: number } : { a: number })
+        : ([T] extends [string] ? { y: number } : { b: number })
+        = x;
+    // Infer type parameters: no good
+    const o2: [T] extends [[infer U]] ? U : { b: number } = o;
+    // Distributive where T might instantiate to never: no good
+    const o3: Distributive<T> = o;
+    // Distributive where T & string might instantiate to never: also no good
+    const o4: Distributive<T & string> = o;
+    // Distributive where {a: T} cannot instantiate to never: OK
+    const o5: Distributive<{a: T}> = o;
+}
+
 
 //// [conditionalTypes2.js]
 "use strict";
@@ -221,6 +245,22 @@ function foo(value) {
         toString1(value);
         toString2(value);
     }
+}
+function testAssignabilityToConditionalType() {
+    var o = { a: 1, b: 2 };
+    var x = undefined;
+    // Simple case: OK
+    var o1 = o;
+    // Simple case where source happens to be a conditional type: also OK
+    var x1 = x;
+    // Infer type parameters: no good
+    var o2 = o;
+    // Distributive where T might instantiate to never: no good
+    var o3 = o;
+    // Distributive where T & string might instantiate to never: also no good
+    var o4 = o;
+    // Distributive where {a: T} cannot instantiate to never: OK
+    var o5 = o;
 }
 
 
@@ -304,3 +344,11 @@ declare type B2<T, V> = T extends object ? T extends any[] ? T : {
 declare type C2<T, V, E> = T extends object ? {
     [Q in keyof T]: C2<T[Q], V, E>;
 } : T;
+declare type Distributive<T> = T extends {
+    a: number;
+} ? {
+    a: number;
+} : {
+    b: number;
+};
+declare function testAssignabilityToConditionalType<T>(): void;

--- a/tests/baselines/reference/conditionalTypes2.symbols
+++ b/tests/baselines/reference/conditionalTypes2.symbols
@@ -551,3 +551,88 @@ type C2<T, V, E> =
 >E : Symbol(E, Decl(conditionalTypes2.ts, 144, 13))
 >T : Symbol(T, Decl(conditionalTypes2.ts, 144, 8))
 
+// #26933
+
+type Distributive<T> = T extends {a: number} ? { a: number } : { b: number };
+>Distributive : Symbol(Distributive, Decl(conditionalTypes2.ts, 145, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 18))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 18))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 149, 34))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 149, 48))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 149, 64))
+
+function testAssignabilityToConditionalType<T>() {
+>testAssignabilityToConditionalType : Symbol(testAssignabilityToConditionalType, Decl(conditionalTypes2.ts, 149, 77))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+
+    const o = { a: 1, b: 2 };
+>o : Symbol(o, Decl(conditionalTypes2.ts, 152, 9))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 152, 15))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 152, 21))
+
+    const x: [T] extends [string] ? { y: number } : { a: number, b: number } = undefined!;
+>x : Symbol(x, Decl(conditionalTypes2.ts, 153, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 153, 37))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 153, 53))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 153, 64))
+>undefined : Symbol(undefined)
+
+    // Simple case: OK
+    const o1: [T] extends [number] ? { a: number } : { b: number } = o;
+>o1 : Symbol(o1, Decl(conditionalTypes2.ts, 155, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 155, 38))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 155, 54))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 152, 9))
+
+    // Simple case where source happens to be a conditional type: also OK
+    const x1: [T] extends [number]
+>x1 : Symbol(x1, Decl(conditionalTypes2.ts, 157, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+
+        ? ([T] extends [string] ? { y: number } : { a: number })
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 158, 35))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 158, 51))
+
+        : ([T] extends [string] ? { y: number } : { b: number })
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 159, 35))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 159, 51))
+
+        = x;
+>x : Symbol(x, Decl(conditionalTypes2.ts, 153, 9))
+
+    // Infer type parameters: no good
+    const o2: [T] extends [[infer U]] ? U : { b: number } = o;
+>o2 : Symbol(o2, Decl(conditionalTypes2.ts, 162, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 162, 33))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 162, 33))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 162, 45))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 152, 9))
+
+    // Distributive where T might instantiate to never: no good
+    const o3: Distributive<T> = o;
+>o3 : Symbol(o3, Decl(conditionalTypes2.ts, 164, 9))
+>Distributive : Symbol(Distributive, Decl(conditionalTypes2.ts, 145, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 152, 9))
+
+    // Distributive where T & string might instantiate to never: also no good
+    const o4: Distributive<T & string> = o;
+>o4 : Symbol(o4, Decl(conditionalTypes2.ts, 166, 9))
+>Distributive : Symbol(Distributive, Decl(conditionalTypes2.ts, 145, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 152, 9))
+
+    // Distributive where {a: T} cannot instantiate to never: OK
+    const o5: Distributive<{a: T}> = o;
+>o5 : Symbol(o5, Decl(conditionalTypes2.ts, 168, 9))
+>Distributive : Symbol(Distributive, Decl(conditionalTypes2.ts, 145, 63))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 168, 28))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 151, 44))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 152, 9))
+}
+

--- a/tests/baselines/reference/conditionalTypes2.types
+++ b/tests/baselines/reference/conditionalTypes2.types
@@ -341,3 +341,75 @@ type C2<T, V, E> =
 
     T extends object ? { [Q in keyof T]: C2<T[Q], V, E>; } : T;
 
+// #26933
+
+type Distributive<T> = T extends {a: number} ? { a: number } : { b: number };
+>Distributive : Distributive<T>
+>a : number
+>a : number
+>b : number
+
+function testAssignabilityToConditionalType<T>() {
+>testAssignabilityToConditionalType : <T>() => void
+
+    const o = { a: 1, b: 2 };
+>o : { a: number; b: number; }
+>{ a: 1, b: 2 } : { a: number; b: number; }
+>a : number
+>1 : 1
+>b : number
+>2 : 2
+
+    const x: [T] extends [string] ? { y: number } : { a: number, b: number } = undefined!;
+>x : [T] extends [string] ? { y: number; } : { a: number; b: number; }
+>y : number
+>a : number
+>b : number
+>undefined! : never
+>undefined : undefined
+
+    // Simple case: OK
+    const o1: [T] extends [number] ? { a: number } : { b: number } = o;
+>o1 : [T] extends [number] ? { a: number; } : { b: number; }
+>a : number
+>b : number
+>o : { a: number; b: number; }
+
+    // Simple case where source happens to be a conditional type: also OK
+    const x1: [T] extends [number]
+>x1 : [T] extends [number] ? [T] extends [string] ? { y: number; } : { a: number; } : [T] extends [string] ? { y: number; } : { b: number; }
+
+        ? ([T] extends [string] ? { y: number } : { a: number })
+>y : number
+>a : number
+
+        : ([T] extends [string] ? { y: number } : { b: number })
+>y : number
+>b : number
+
+        = x;
+>x : [T] extends [string] ? { y: number; } : { a: number; b: number; }
+
+    // Infer type parameters: no good
+    const o2: [T] extends [[infer U]] ? U : { b: number } = o;
+>o2 : [T] extends [[infer U]] ? U : { b: number; }
+>b : number
+>o : { a: number; b: number; }
+
+    // Distributive where T might instantiate to never: no good
+    const o3: Distributive<T> = o;
+>o3 : Distributive<T>
+>o : { a: number; b: number; }
+
+    // Distributive where T & string might instantiate to never: also no good
+    const o4: Distributive<T & string> = o;
+>o4 : Distributive<T & string>
+>o : { a: number; b: number; }
+
+    // Distributive where {a: T} cannot instantiate to never: OK
+    const o5: Distributive<{a: T}> = o;
+>o5 : Distributive<{ a: T; }>
+>a : T
+>o : { a: number; b: number; }
+}
+

--- a/tests/cases/conformance/types/conditional/conditionalTypes2.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes2.ts
@@ -147,3 +147,27 @@ type B2<T, V> =
 
 type C2<T, V, E> =
     T extends object ? { [Q in keyof T]: C2<T[Q], V, E>; } : T;
+
+// #26933
+
+type Distributive<T> = T extends {a: number} ? { a: number } : { b: number };
+
+function testAssignabilityToConditionalType<T>() {
+    const o = { a: 1, b: 2 };
+    const x: [T] extends [string] ? { y: number } : { a: number, b: number } = undefined!;
+    // Simple case: OK
+    const o1: [T] extends [number] ? { a: number } : { b: number } = o;
+    // Simple case where source happens to be a conditional type: also OK
+    const x1: [T] extends [number]
+        ? ([T] extends [string] ? { y: number } : { a: number })
+        : ([T] extends [string] ? { y: number } : { b: number })
+        = x;
+    // Infer type parameters: no good
+    const o2: [T] extends [[infer U]] ? U : { b: number } = o;
+    // Distributive where T might instantiate to never: no good
+    const o3: Distributive<T> = o;
+    // Distributive where T & string might instantiate to never: also no good
+    const o4: Distributive<T & string> = o;
+    // Distributive where {a: T} cannot instantiate to never: OK
+    const o5: Distributive<{a: T}> = o;
+}


### PR DESCRIPTION
(With some restrictions.)

Fixes #26933.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->