### PR TITLE
Let assignability checking of generic mapped types decompose intersections on both the source and the target.

### DIFF
--- a/tests/baselines/reference/conditionalTypes1.errors.txt
+++ b/tests/baselines/reference/conditionalTypes1.errors.txt
@@ -20,9 +20,11 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(106,5): error TS2
     Type 'keyof T' is not assignable to type 'never'.
       Type 'string | number | symbol' is not assignable to type 'never'.
         Type 'string' is not assignable to type 'never'.
+          Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'T'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(108,5): error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
   Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
     Type 'keyof T' is not assignable to type 'never'.
+      Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'T'.
 tests/cases/conformance/types/conditional/conditionalTypes1.ts(114,5): error TS2322: Type 'keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
   Type 'string | number | symbol' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
     Type 'string' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
@@ -190,12 +192,14 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(288,43): error TS
 !!! error TS2322:     Type 'keyof T' is not assignable to type 'never'.
 !!! error TS2322:       Type 'string | number | symbol' is not assignable to type 'never'.
 !!! error TS2322:         Type 'string' is not assignable to type 'never'.
+!!! error TS2322:           Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>' is not assignable to type 'T'.
         z = x;
         z = y;  // Error
         ~
 !!! error TS2322: Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'Pick<T, { [K in keyof T]: T[K] extends Function ? never : K; }[keyof T]>'.
 !!! error TS2322:   Type 'T[keyof T] extends Function ? never : keyof T' is not assignable to type 'T[keyof T] extends Function ? keyof T : never'.
 !!! error TS2322:     Type 'keyof T' is not assignable to type 'never'.
+!!! error TS2322:       Type 'Pick<T, { [K in keyof T]: T[K] extends Function ? K : never; }[keyof T]>' is not assignable to type 'T'.
     }
     
     function f8<T>(x: keyof T, y: FunctionPropertyNames<T>, z: NonFunctionPropertyNames<T>) {

--- a/tests/baselines/reference/genericMappedTypeIntersections.js
+++ b/tests/baselines/reference/genericMappedTypeIntersections.js
@@ -1,0 +1,14 @@
+//// [genericMappedTypeIntersections.ts]
+// Repro for #27484
+function makePropsForWrappedComponent<PassthroughProps, ExternalProps, InjectedProps>(
+    outerProps: Readonly<PassthroughProps & ExternalProps>,
+    injectedProps: Readonly<InjectedProps>): Readonly<PassthroughProps & InjectedProps> {
+    return Object.assign({}, injectedProps, outerProps);
+}
+
+
+//// [genericMappedTypeIntersections.js]
+// Repro for #27484
+function makePropsForWrappedComponent(outerProps, injectedProps) {
+    return Object.assign({}, injectedProps, outerProps);
+}

--- a/tests/baselines/reference/genericMappedTypeIntersections.symbols
+++ b/tests/baselines/reference/genericMappedTypeIntersections.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/genericMappedTypeIntersections.ts ===
+// Repro for #27484
+function makePropsForWrappedComponent<PassthroughProps, ExternalProps, InjectedProps>(
+>makePropsForWrappedComponent : Symbol(makePropsForWrappedComponent, Decl(genericMappedTypeIntersections.ts, 0, 0))
+>PassthroughProps : Symbol(PassthroughProps, Decl(genericMappedTypeIntersections.ts, 1, 38))
+>ExternalProps : Symbol(ExternalProps, Decl(genericMappedTypeIntersections.ts, 1, 55))
+>InjectedProps : Symbol(InjectedProps, Decl(genericMappedTypeIntersections.ts, 1, 70))
+
+    outerProps: Readonly<PassthroughProps & ExternalProps>,
+>outerProps : Symbol(outerProps, Decl(genericMappedTypeIntersections.ts, 1, 86))
+>Readonly : Symbol(Readonly, Decl(lib.es5.d.ts, --, --))
+>PassthroughProps : Symbol(PassthroughProps, Decl(genericMappedTypeIntersections.ts, 1, 38))
+>ExternalProps : Symbol(ExternalProps, Decl(genericMappedTypeIntersections.ts, 1, 55))
+
+    injectedProps: Readonly<InjectedProps>): Readonly<PassthroughProps & InjectedProps> {
+>injectedProps : Symbol(injectedProps, Decl(genericMappedTypeIntersections.ts, 2, 59))
+>Readonly : Symbol(Readonly, Decl(lib.es5.d.ts, --, --))
+>InjectedProps : Symbol(InjectedProps, Decl(genericMappedTypeIntersections.ts, 1, 70))
+>Readonly : Symbol(Readonly, Decl(lib.es5.d.ts, --, --))
+>PassthroughProps : Symbol(PassthroughProps, Decl(genericMappedTypeIntersections.ts, 1, 38))
+>InjectedProps : Symbol(InjectedProps, Decl(genericMappedTypeIntersections.ts, 1, 70))
+
+    return Object.assign({}, injectedProps, outerProps);
+>Object.assign : Symbol(ObjectConstructor.assign, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>assign : Symbol(ObjectConstructor.assign, Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>injectedProps : Symbol(injectedProps, Decl(genericMappedTypeIntersections.ts, 2, 59))
+>outerProps : Symbol(outerProps, Decl(genericMappedTypeIntersections.ts, 1, 86))
+}
+

--- a/tests/baselines/reference/genericMappedTypeIntersections.types
+++ b/tests/baselines/reference/genericMappedTypeIntersections.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/genericMappedTypeIntersections.ts ===
+// Repro for #27484
+function makePropsForWrappedComponent<PassthroughProps, ExternalProps, InjectedProps>(
+>makePropsForWrappedComponent : <PassthroughProps, ExternalProps, InjectedProps>(outerProps: Readonly<PassthroughProps & ExternalProps>, injectedProps: Readonly<InjectedProps>) => Readonly<PassthroughProps & InjectedProps>
+
+    outerProps: Readonly<PassthroughProps & ExternalProps>,
+>outerProps : Readonly<PassthroughProps & ExternalProps>
+
+    injectedProps: Readonly<InjectedProps>): Readonly<PassthroughProps & InjectedProps> {
+>injectedProps : Readonly<InjectedProps>
+
+    return Object.assign({}, injectedProps, outerProps);
+>Object.assign({}, injectedProps, outerProps) : Readonly<InjectedProps> & Readonly<PassthroughProps & ExternalProps>
+>Object.assign : { <T, U>(target: T, source: U): T & U; <T, U, V>(target: T, source1: U, source2: V): T & U & V; <T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W; (target: object, ...sources: any[]): any; }
+>Object : ObjectConstructor
+>assign : { <T, U>(target: T, source: U): T & U; <T, U, V>(target: T, source1: U, source2: V): T & U & V; <T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W; (target: object, ...sources: any[]): any; }
+>{} : {}
+>injectedProps : Readonly<InjectedProps>
+>outerProps : Readonly<PassthroughProps & ExternalProps>
+}
+

--- a/tests/baselines/reference/mappedTypeRelationships.errors.txt
+++ b/tests/baselines/reference/mappedTypeRelationships.errors.txt
@@ -35,29 +35,37 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(66,5): error TS2
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(72,5): error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(78,5): error TS2322: Type 'Partial<Thing>' is not assignable to type 'Partial<T>'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(88,5): error TS2322: Type 'Readonly<Thing>' is not assignable to type 'Readonly<T>'.
+  Type 'Readonly<Thing>' is not assignable to type 'T'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(127,5): error TS2322: Type 'Partial<U>' is not assignable to type 'Identity<U>'.
+  Type 'Partial<U>' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(143,5): error TS2322: Type '{ [P in keyof T]: T[P]; }' is not assignable to type '{ [P in keyof T]: U[P]; }'.
   Type 'T[P]' is not assignable to type 'U[P]'.
     Type 'T' is not assignable to type 'U'.
+      Type '{ [P in keyof T]: T[P]; }' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(148,5): error TS2322: Type '{ [P in keyof T]: T[P]; }' is not assignable to type '{ [P in keyof U]: U[P]; }'.
   Type 'keyof U' is not assignable to type 'keyof T'.
     Type 'string | number | symbol' is not assignable to type 'keyof T'.
       Type 'string' is not assignable to type 'keyof T'.
+        Type '{ [P in keyof T]: T[P]; }' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(153,5): error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in keyof T]: T[P]; }'.
   Type 'keyof T' is not assignable to type 'K'.
     Type 'string | number | symbol' is not assignable to type 'K'.
       Type 'string' is not assignable to type 'K'.
+        Type '{ [P in K]: T[P]; }' is not assignable to type 'T'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(158,5): error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in keyof U]: U[P]; }'.
   Type 'keyof U' is not assignable to type 'K'.
     Type 'string | number | symbol' is not assignable to type 'K'.
       Type 'string' is not assignable to type 'K'.
+        Type '{ [P in K]: T[P]; }' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(163,5): error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in keyof T]: U[P]; }'.
   Type 'keyof T' is not assignable to type 'K'.
     Type 'string | number | symbol' is not assignable to type 'K'.
       Type 'string' is not assignable to type 'K'.
+        Type '{ [P in K]: T[P]; }' is not assignable to type 'U'.
 tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in K]: U[P]; }'.
   Type 'T[P]' is not assignable to type 'U[P]'.
     Type 'T' is not assignable to type 'U'.
+      Type '{ [P in K]: T[P]; }' is not assignable to type 'U'.
 
 
 ==== tests/cases/conformance/types/mapped/mappedTypeRelationships.ts (30 errors) ====
@@ -209,6 +217,7 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
         y = x;  // Error
         ~
 !!! error TS2322: Type 'Readonly<Thing>' is not assignable to type 'Readonly<T>'.
+!!! error TS2322:   Type 'Readonly<Thing>' is not assignable to type 'T'.
     }
     
     type Item = {
@@ -250,6 +259,7 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
         x = y;  // Error
         ~
 !!! error TS2322: Type 'Partial<U>' is not assignable to type 'Identity<U>'.
+!!! error TS2322:   Type 'Partial<U>' is not assignable to type 'U'.
         y = x;
     }
     
@@ -270,6 +280,7 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
 !!! error TS2322: Type '{ [P in keyof T]: T[P]; }' is not assignable to type '{ [P in keyof T]: U[P]; }'.
 !!! error TS2322:   Type 'T[P]' is not assignable to type 'U[P]'.
 !!! error TS2322:     Type 'T' is not assignable to type 'U'.
+!!! error TS2322:       Type '{ [P in keyof T]: T[P]; }' is not assignable to type 'U'.
     }
     
     function f72<T, U extends T>(x: { [P in keyof T]: T[P] }, y: { [P in keyof U]: U[P] }) {
@@ -280,6 +291,7 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
 !!! error TS2322:   Type 'keyof U' is not assignable to type 'keyof T'.
 !!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'keyof T'.
 !!! error TS2322:       Type 'string' is not assignable to type 'keyof T'.
+!!! error TS2322:         Type '{ [P in keyof T]: T[P]; }' is not assignable to type 'U'.
     }
     
     function f73<T, K extends keyof T>(x: { [P in K]: T[P] }, y: { [P in keyof T]: T[P] }) {
@@ -290,6 +302,7 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
 !!! error TS2322:   Type 'keyof T' is not assignable to type 'K'.
 !!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'K'.
 !!! error TS2322:       Type 'string' is not assignable to type 'K'.
+!!! error TS2322:         Type '{ [P in K]: T[P]; }' is not assignable to type 'T'.
     }
     
     function f74<T, U extends T, K extends keyof T>(x: { [P in K]: T[P] }, y: { [P in keyof U]: U[P] }) {
@@ -300,6 +313,7 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
 !!! error TS2322:   Type 'keyof U' is not assignable to type 'K'.
 !!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'K'.
 !!! error TS2322:       Type 'string' is not assignable to type 'K'.
+!!! error TS2322:         Type '{ [P in K]: T[P]; }' is not assignable to type 'U'.
     }
     
     function f75<T, U extends T, K extends keyof T>(x: { [P in K]: T[P] }, y: { [P in keyof T]: U[P] }) {
@@ -310,6 +324,7 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
 !!! error TS2322:   Type 'keyof T' is not assignable to type 'K'.
 !!! error TS2322:     Type 'string | number | symbol' is not assignable to type 'K'.
 !!! error TS2322:       Type 'string' is not assignable to type 'K'.
+!!! error TS2322:         Type '{ [P in K]: T[P]; }' is not assignable to type 'U'.
     }
     
     function f76<T, U extends T, K extends keyof T>(x: { [P in K]: T[P] }, y: { [P in K]: U[P] }) {
@@ -319,6 +334,7 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(168,5): error TS
 !!! error TS2322: Type '{ [P in K]: T[P]; }' is not assignable to type '{ [P in K]: U[P]; }'.
 !!! error TS2322:   Type 'T[P]' is not assignable to type 'U[P]'.
 !!! error TS2322:     Type 'T' is not assignable to type 'U'.
+!!! error TS2322:       Type '{ [P in K]: T[P]; }' is not assignable to type 'U'.
     }
     
     function f80<T>(t: T): Partial<T> {

--- a/tests/baselines/reference/mappedTypes5.errors.txt
+++ b/tests/baselines/reference/mappedTypes5.errors.txt
@@ -1,6 +1,11 @@
 tests/cases/conformance/types/mapped/mappedTypes5.ts(6,9): error TS2322: Type 'Partial<T>' is not assignable to type 'Readonly<T>'.
+  Type 'Partial<T>' is not assignable to type 'T'.
 tests/cases/conformance/types/mapped/mappedTypes5.ts(8,9): error TS2322: Type 'Partial<Readonly<T>>' is not assignable to type 'Readonly<T>'.
+  Type 'Partial<Readonly<T>>' is not assignable to type 'T'.
 tests/cases/conformance/types/mapped/mappedTypes5.ts(9,9): error TS2322: Type 'Readonly<Partial<T>>' is not assignable to type 'Readonly<T>'.
+  Type 'Readonly<Partial<T>>' is not assignable to type 'T'.
+    Type 'T[P] | undefined' is not assignable to type 'T[P]'.
+      Type 'undefined' is not assignable to type 'T[P]'.
 
 
 ==== tests/cases/conformance/types/mapped/mappedTypes5.ts (3 errors) ====
@@ -12,13 +17,18 @@ tests/cases/conformance/types/mapped/mappedTypes5.ts(9,9): error TS2322: Type 'R
         let b1: Readonly<T> = p;  // Error
             ~~
 !!! error TS2322: Type 'Partial<T>' is not assignable to type 'Readonly<T>'.
+!!! error TS2322:   Type 'Partial<T>' is not assignable to type 'T'.
         let b2: Readonly<T> = r;
         let b3: Readonly<T> = pr;  // Error
             ~~
 !!! error TS2322: Type 'Partial<Readonly<T>>' is not assignable to type 'Readonly<T>'.
+!!! error TS2322:   Type 'Partial<Readonly<T>>' is not assignable to type 'T'.
         let b4: Readonly<T> = rp;  // Error
             ~~
 !!! error TS2322: Type 'Readonly<Partial<T>>' is not assignable to type 'Readonly<T>'.
+!!! error TS2322:   Type 'Readonly<Partial<T>>' is not assignable to type 'T'.
+!!! error TS2322:     Type 'T[P] | undefined' is not assignable to type 'T[P]'.
+!!! error TS2322:       Type 'undefined' is not assignable to type 'T[P]'.
         let c1: Partial<Readonly<T>> = p;
         let c2: Partial<Readonly<T>> = r;
         let c3: Partial<Readonly<T>> = pr;

--- a/tests/cases/compiler/genericMappedTypeIntersections.ts
+++ b/tests/cases/compiler/genericMappedTypeIntersections.ts
@@ -1,0 +1,7 @@
+// Repro for #27484
+// @target: es6
+function makePropsForWrappedComponent<PassthroughProps, ExternalProps, InjectedProps>(
+    outerProps: Readonly<PassthroughProps & ExternalProps>,
+    injectedProps: Readonly<InjectedProps>): Readonly<PassthroughProps & InjectedProps> {
+    return Object.assign({}, injectedProps, outerProps);
+}


### PR DESCRIPTION
Fixes #27484.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->