### PR TITLE
Allow Document's evaluate to receive a method as the resolver

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -1,13 +1,13 @@
 /*! *****************************************************************************
-Copyright (c) Microsoft Corporation. All rights reserved. 
+Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the
-License at http://www.apache.org/licenses/LICENSE-2.0  
- 
+License at http://www.apache.org/licenses/LICENSE-2.0
+
 THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
-WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, 
-MERCHANTABLITY OR NON-INFRINGEMENT. 
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
  
 See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
@@ -4349,7 +4349,7 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
      */
     elementFromPoint(x: number, y: number): Element | null;
     elementsFromPoint(x: number, y: number): Element[];
-    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
+    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | XPathNSResolverAsMethod | null, type: number, result: XPathResult | null): XPathResult;
     /**
      * Executes a command on the current document, current selection, or the given range.
      * @param commandId String that specifies the command to execute. This command can be any of the command identifiers that can be executed in script.
@@ -16772,7 +16772,7 @@ declare var XMLSerializer: {
 interface XPathEvaluator {
     createExpression(expression: string, resolver: XPathNSResolver): XPathExpression;
     createNSResolver(nodeResolver?: Node): XPathNSResolver;
-    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
+    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | XPathNSResolverAsMethod | null, type: number, result: XPathResult | null): XPathResult;
 }
 
 declare var XPathEvaluator: {
@@ -16790,8 +16790,10 @@ declare var XPathExpression: {
 };
 
 interface XPathNSResolver {
-    lookupNamespaceURI(prefix: string): string;
+    lookupNamespaceURI(prefix: string): string | null;
 }
+
+type XPathNSResolverAsMethod = (prefix: string) => string | null;
 
 declare var XPathNSResolver: {
     prototype: XPathNSResolver;


### PR DESCRIPTION
From the template's checklist, this PR is still missing to check if there's a need to update or create new tests to validate changes (although I ran tests locally and it's all passing). I prefer to discuss upon the PR here before writing new or modifying existing tests.

Fixes #
As discussed in https://github.com/Microsoft/TypeScript/issues/26437 `document.evaluate`'s resolver should also accept a _function which returns a String and takes a String parameter_. Also for `lookupNamespaceURI` the spec says it _returns the associated namespace URI or null if none is found._ So the changes here include:
* `XPathNSResolverAsMethod` type was created to allow `document.evaluate` to accept also a method (included via union type)
* `lookupNamespaceURI` and the new type created can also return `null`
