### PR TITLE
Add codefix to make non-reassignable variables reassignable

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4687,5 +4687,9 @@
     "Make all const or readonly expressions reassignable": {
         "category": "Message",
         "code": 95069
+    },
+    "Remove '{0}' modifier": {
+        "category": "Message",
+        "code": 95070
     }
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4683,5 +4683,9 @@
     "Generate types for all packages without types": {
         "category": "Message",
         "code": 95068
+    },
+    "Make all const or readonly expressions reassignable": {
+        "category": "Message",
+        "code": 95069
     }
 }

--- a/src/services/codefixes/fixConvertConstantVariableOrProperty.ts
+++ b/src/services/codefixes/fixConvertConstantVariableOrProperty.ts
@@ -8,7 +8,7 @@ namespace ts.codefix {
         errorCodes,
         getCodeActions(context) {
             const { sourceFile, span, program } = context;
-            const { declaration } = getDeclaration(sourceFile, span.start, program.getTypeChecker());
+            const declaration = getDeclaration(sourceFile, span.start, program.getTypeChecker());
             if (!declaration) return undefined;
             const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, declaration));
             const type = declaration.kind === SyntaxKind.VariableDeclaration ? "const" : "readonly";
@@ -16,18 +16,16 @@ namespace ts.codefix {
         },
         fixIds: [fixId],
         getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => {
-            const { declaration } = getDeclaration(diag.file, diag.start, context.program.getTypeChecker());
+            const declaration = getDeclaration(diag.file, diag.start, context.program.getTypeChecker());
             if (declaration) doChange(changes, context.sourceFile, declaration);
         }),
     });
-    function getDeclaration(sourceFile: SourceFile, pos: number, checker: TypeChecker): {declaration: Declaration | undefined} {
+    function getDeclaration(sourceFile: SourceFile, pos: number, checker: TypeChecker): Declaration | undefined {
         const node = getTokenAtPosition(sourceFile, pos);
-        let declaration: Declaration | undefined;
         const symbol = checker.getSymbolAtLocation(node);
         if (symbol) {
-            declaration = symbol.valueDeclaration;
+            return symbol.valueDeclaration;
         }
-        return { declaration };
     }
 
     function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, node: Declaration) {

--- a/src/services/codefixes/fixConvertConstantVariableOrProperty.ts
+++ b/src/services/codefixes/fixConvertConstantVariableOrProperty.ts
@@ -7,63 +7,47 @@ namespace ts.codefix {
     registerCodeFix({
         errorCodes,
         getCodeActions(context) {
-            const { sourceFile, span } = context;
-            const { declaration, kind } = getDeclaration(sourceFile, span.start);
-            if (!declaration || !kind) return undefined;
-
-            const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, declaration, kind));
-            const type = kind === SyntaxKind.ConstKeyword ? "const" : "readonly";
-            const changeTo = type === "const" ? "let" : "non-readonly";
-            return [createCodeFixAction(fixId, changes, [Diagnostics.Change_0_to_1, type, changeTo], fixId, Diagnostics.Make_all_const_or_readonly_expressions_reassignable)];
+            const { sourceFile, span, program } = context;
+            const { declaration } = getDeclaration(sourceFile, span.start, program.getTypeChecker());
+            if (!declaration) return undefined;
+            const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, declaration));
+            const type = declaration.kind === SyntaxKind.VariableDeclaration ? "const" : "readonly";
+            return [createCodeFixAction(fixId, changes, [Diagnostics.Remove_0_modifier, type], fixId, Diagnostics.Make_all_const_or_readonly_expressions_reassignable)];
         },
         fixIds: [fixId],
         getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => {
-            const { declaration, kind } = getDeclaration(diag.file, diag.start);
-            if (declaration && kind) doChange(changes, context.sourceFile, declaration, kind);
+            const { declaration } = getDeclaration(diag.file, diag.start, context.program.getTypeChecker());
+            if (declaration) doChange(changes, context.sourceFile, declaration);
         }),
     });
-    function getDeclaration(sourceFile: SourceFile, pos: number): {declaration: VariableStatement | PropertyDeclaration | undefined, kind: SyntaxKind | undefined } {
+    function getDeclaration(sourceFile: SourceFile, pos: number, checker: TypeChecker): {declaration: Declaration | undefined} {
         const node = getTokenAtPosition(sourceFile, pos);
-        const tokenName = node.getText();
-        let declaration: VariableStatement | PropertyDeclaration | undefined;
-        let kind: SyntaxKind | undefined;
-        // The first parent of the property reassignment has [class].[prop]
-        if (node.parent.getText().includes(".")) {
-            declaration = findChild(sourceFile, (node) => node.kind === SyntaxKind.PropertyDeclaration
-                && node.getText().includes(tokenName));
-            kind = SyntaxKind.PropertyDeclaration;
+        let declaration: Declaration | undefined;
+        const symbol = checker.getSymbolAtLocation(node);
+        if (symbol) {
+            declaration = symbol.valueDeclaration;
         }
-        // The first parent with const reaassignment has [variable] = [value]
-        else if (node.parent.getText().includes("=")) {
-            declaration = findChild(sourceFile, (node) => node.kind === SyntaxKind.VariableStatement
-                && node.getText().includes("const") && node.getText().includes(tokenName));
-            kind = SyntaxKind.ConstKeyword;
-        }
-        return { declaration, kind };
+        return { declaration };
     }
 
-    function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, node: VariableStatement | PropertyDeclaration, kind: SyntaxKind) {
-        if (kind === SyntaxKind.ConstKeyword) {
-            const constToken = findChild(node, node => node.kind === SyntaxKind.ConstKeyword);
-            if (constToken) {
-                const letToken = createToken(SyntaxKind.LetKeyword);
-                changes.replaceNode(sourceFile, constToken, letToken);
-            }
+    function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, node: Declaration) {
+        if (node.kind === SyntaxKind.VariableDeclaration) {
+            const oldDeclarationList = node.parent as VariableDeclarationList;
+            const declarationList = createVariableDeclarationList(oldDeclarationList.declarations, NodeFlags.Let);
+            changes.replaceNode(sourceFile, oldDeclarationList, declarationList);
         }
-        else if (kind === SyntaxKind.PropertyDeclaration) {
-            const readonlyToken = findChild(node, node => node.kind === SyntaxKind.ReadonlyKeyword);
+        else if (node.kind === SyntaxKind.PropertyDeclaration) {
+            const readonlyToken = findAnyChildOfKind(node, SyntaxKind.ReadonlyKeyword);
             if (readonlyToken) {
                 changes.delete(sourceFile, readonlyToken);
             }
         }
     }
 
-    export function findChild<T extends Node>(
-        n: Node,
-        test: (node: T) => boolean
-    ): T | undefined {
-        const child = find(n.getChildren(), (c): c is T => test(c as T));
-        if (child) return child;
-        return n.getChildren().map((c) => findChild(c, test)).filter(Boolean)[0];
+    function findAnyChildOfKind(node: Node, kind: SyntaxKind): Node | undefined {
+        return node.forEachChild(child => {
+            if (child.kind === kind) return child;
+            else findAnyChildOfKind(child, kind);
+        });
     }
 }

--- a/src/services/codefixes/fixConvertConstantVariableOrProperty.ts
+++ b/src/services/codefixes/fixConvertConstantVariableOrProperty.ts
@@ -1,0 +1,69 @@
+/* @internal */
+namespace ts.codefix {
+    const fixId = "fixConvertConstantVariableOrProperty";
+    const errorCodes = [
+        Diagnostics.Cannot_assign_to_0_because_it_is_a_constant_or_a_read_only_property.code
+    ];
+    registerCodeFix({
+        errorCodes,
+        getCodeActions(context) {
+            const { sourceFile, span } = context;
+            const { declaration, kind } = getDeclaration(sourceFile, span.start);
+            if (!declaration || !kind) return undefined;
+
+            const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, declaration, kind));
+            const type = kind === SyntaxKind.ConstKeyword ? "const" : "readonly";
+            const changeTo = type === "const" ? "let" : "non-readonly";
+            return [createCodeFixAction(fixId, changes, [Diagnostics.Change_0_to_1, type, changeTo], fixId, Diagnostics.Make_all_const_or_readonly_expressions_reassignable)];
+        },
+        fixIds: [fixId],
+        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => {
+            const { declaration, kind } = getDeclaration(diag.file, diag.start);
+            if (declaration && kind) doChange(changes, context.sourceFile, declaration, kind);
+        }),
+    });
+    function getDeclaration(sourceFile: SourceFile, pos: number): {declaration: VariableStatement | PropertyDeclaration | undefined, kind: SyntaxKind | undefined } {
+        const node = getTokenAtPosition(sourceFile, pos);
+        const tokenName = node.getText();
+        let declaration: VariableStatement | PropertyDeclaration | undefined;
+        let kind: SyntaxKind | undefined;
+        // The first parent of the property reassignment has [class].[prop]
+        if (node.parent.getText().includes(".")) {
+            declaration = findChild(sourceFile, (node) => node.kind === SyntaxKind.PropertyDeclaration
+                && node.getText().includes(tokenName));
+            kind = SyntaxKind.PropertyDeclaration;
+        }
+        // The first parent with const reaassignment has [variable] = [value]
+        else if (node.parent.getText().includes("=")) {
+            declaration = findChild(sourceFile, (node) => node.kind === SyntaxKind.VariableStatement
+                && node.getText().includes("const") && node.getText().includes(tokenName));
+            kind = SyntaxKind.ConstKeyword;
+        }
+        return { declaration, kind };
+    }
+
+    function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, node: VariableStatement | PropertyDeclaration, kind: SyntaxKind) {
+        if (kind === SyntaxKind.ConstKeyword) {
+            const constToken = findChild(node, node => node.kind === SyntaxKind.ConstKeyword);
+            if (constToken) {
+                const letToken = createToken(SyntaxKind.LetKeyword);
+                changes.replaceNode(sourceFile, constToken, letToken);
+            }
+        }
+        else if (kind === SyntaxKind.PropertyDeclaration) {
+            const readonlyToken = findChild(node, node => node.kind === SyntaxKind.ReadonlyKeyword);
+            if (readonlyToken) {
+                changes.delete(sourceFile, readonlyToken);
+            }
+        }
+    }
+
+    export function findChild<T extends Node>(
+        n: Node,
+        test: (node: T) => boolean
+    ): T | undefined {
+        const child = find(n.getChildren(), (c): c is T => test(c as T));
+        if (child) return child;
+        return n.getChildren().map((c) => findChild(c, test)).filter(Boolean)[0];
+    }
+}

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -57,6 +57,7 @@
         "codefixes/fixClassDoesntImplementInheritedAbstractMember.ts",
         "codefixes/fixClassSuperMustPrecedeThisAccess.ts",
         "codefixes/fixConstructorForDerivedNeedSuperCall.ts",
+        "codefixes/fixConvertConstantVariableOrProperty.ts",
         "codefixes/fixExtendsInterfaceBecomesImplements.ts",
         "codefixes/fixForgottenThisPropertyAccess.ts",
         "codefixes/fixUnusedIdentifier.ts",

--- a/tests/cases/fourslash/codeFixConvertConstantVariableOrProperty_const.tsx
+++ b/tests/cases/fourslash/codeFixConvertConstantVariableOrProperty_const.tsx
@@ -4,7 +4,7 @@
 ////variable = 4;
 
 verify.codeFix({
-    description: "Change 'const' to 'let'",
+    description: "Remove 'const' modifier",
     newFileContent:
 `let variable = 5;
 variable = 4;`,

--- a/tests/cases/fourslash/codeFixConvertConstantVariableOrProperty_const.tsx
+++ b/tests/cases/fourslash/codeFixConvertConstantVariableOrProperty_const.tsx
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts' />
+
+////const variable = 5;
+////variable = 4;
+
+verify.codeFix({
+    description: "Change 'const' to 'let'",
+    newFileContent:
+`let variable = 5;
+variable = 4;`,
+});

--- a/tests/cases/fourslash/codeFixConvertConstantVariableOrProperty_readonly.tsx
+++ b/tests/cases/fourslash/codeFixConvertConstantVariableOrProperty_readonly.tsx
@@ -7,7 +7,7 @@
 ////testInstance.prop = 3;
 
 verify.codeFix({
-    description: "Change 'readonly' to 'non-readonly'",
+    description: "Remove 'readonly' modifier",
     newFileContent:
 `class Test {
  prop = 5;

--- a/tests/cases/fourslash/codeFixConvertConstantVariableOrProperty_readonly.tsx
+++ b/tests/cases/fourslash/codeFixConvertConstantVariableOrProperty_readonly.tsx
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+////class Test {
+////    readonly prop = 5;
+////}
+////let testInstance = new Test();
+////testInstance.prop = 3;
+
+verify.codeFix({
+    description: "Change 'readonly' to 'non-readonly'",
+    newFileContent:
+`class Test {
+ prop = 5;
+}
+let testInstance = new Test();
+testInstance.prop = 3;`,
+});


### PR DESCRIPTION
Adds a codefix for the scenarios where a user attempts to re-assign a variable that was declared as `const` or property that was declared `readonly`. In the former, it changes the initial declaration to type `let` and in the latter, it removes the `readonly` modifier.

Added one more diagnostic message as well since, I couldn't find one that fit well enough for the fix all option. 

Fixes #22473 

