### PR TITLE
When instantiating a mapped type, clone the type parameter.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6828,7 +6828,7 @@ namespace ts {
 
         function getConstraintTypeFromMappedType(type: MappedType) {
             return type.constraintType ||
-                (type.constraintType = instantiateType(getConstraintOfTypeParameter(getTypeParameterFromMappedType(type)), type.mapper || identityMapper) || errorType);
+                (type.constraintType = getConstraintOfTypeParameter(getTypeParameterFromMappedType(type)) || errorType);
         }
 
         function getTemplateTypeFromMappedType(type: MappedType) {
@@ -10381,6 +10381,12 @@ namespace ts {
             const result = <AnonymousType>createObjectType(type.objectFlags | ObjectFlags.Instantiated, type.symbol);
             if (type.objectFlags & ObjectFlags.Mapped) {
                 (<MappedType>result).declaration = (<MappedType>type).declaration;
+                // C.f. instantiateSignature
+                const origTypeParameter = getTypeParameterFromMappedType(<MappedType>type);
+                const freshTypeParameter = cloneTypeParameter(origTypeParameter);
+                (<MappedType>result).typeParameter = freshTypeParameter;
+                mapper = combineTypeMappers(makeUnaryTypeMapper(origTypeParameter, freshTypeParameter), mapper);
+                freshTypeParameter.mapper = mapper;
             }
             result.target = type;
             result.mapper = mapper;

--- a/tests/baselines/reference/mappedTypeParameterConstraint.js
+++ b/tests/baselines/reference/mappedTypeParameterConstraint.js
@@ -1,0 +1,14 @@
+//// [mappedTypeParameterConstraint.ts]
+// Repro for #27596
+
+type MyMap<T> = {[P in keyof T]: T[keyof T]};
+function foo<U>(arg: U): MyMap<U> {
+    return arg;
+}
+
+
+//// [mappedTypeParameterConstraint.js]
+// Repro for #27596
+function foo(arg) {
+    return arg;
+}

--- a/tests/baselines/reference/mappedTypeParameterConstraint.symbols
+++ b/tests/baselines/reference/mappedTypeParameterConstraint.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/mappedTypeParameterConstraint.ts ===
+// Repro for #27596
+
+type MyMap<T> = {[P in keyof T]: T[keyof T]};
+>MyMap : Symbol(MyMap, Decl(mappedTypeParameterConstraint.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeParameterConstraint.ts, 2, 11))
+>P : Symbol(P, Decl(mappedTypeParameterConstraint.ts, 2, 18))
+>T : Symbol(T, Decl(mappedTypeParameterConstraint.ts, 2, 11))
+>T : Symbol(T, Decl(mappedTypeParameterConstraint.ts, 2, 11))
+>T : Symbol(T, Decl(mappedTypeParameterConstraint.ts, 2, 11))
+
+function foo<U>(arg: U): MyMap<U> {
+>foo : Symbol(foo, Decl(mappedTypeParameterConstraint.ts, 2, 45))
+>U : Symbol(U, Decl(mappedTypeParameterConstraint.ts, 3, 13))
+>arg : Symbol(arg, Decl(mappedTypeParameterConstraint.ts, 3, 16))
+>U : Symbol(U, Decl(mappedTypeParameterConstraint.ts, 3, 13))
+>MyMap : Symbol(MyMap, Decl(mappedTypeParameterConstraint.ts, 0, 0))
+>U : Symbol(U, Decl(mappedTypeParameterConstraint.ts, 3, 13))
+
+    return arg;
+>arg : Symbol(arg, Decl(mappedTypeParameterConstraint.ts, 3, 16))
+}
+

--- a/tests/baselines/reference/mappedTypeParameterConstraint.types
+++ b/tests/baselines/reference/mappedTypeParameterConstraint.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/mappedTypeParameterConstraint.ts ===
+// Repro for #27596
+
+type MyMap<T> = {[P in keyof T]: T[keyof T]};
+>MyMap : MyMap<T>
+
+function foo<U>(arg: U): MyMap<U> {
+>foo : <U>(arg: U) => MyMap<U>
+>arg : U
+
+    return arg;
+>arg : U
+}
+

--- a/tests/cases/compiler/mappedTypeParameterConstraint.ts
+++ b/tests/cases/compiler/mappedTypeParameterConstraint.ts
@@ -1,0 +1,6 @@
+// Repro for #27596
+
+type MyMap<T> = {[P in keyof T]: T[keyof T]};
+function foo<U>(arg: U): MyMap<U> {
+    return arg;
+}


### PR DESCRIPTION
This gives the type parameter returned by getTypeParameterFromMappedType
an accurate constraint.

Fixes #27596.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->