### PR TITLE
Added ObjectKeyword check to isPartOfTypeNode

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -978,6 +978,7 @@ namespace ts {
             case SyntaxKind.StringKeyword:
             case SyntaxKind.BooleanKeyword:
             case SyntaxKind.SymbolKeyword:
+            case SyntaxKind.ObjectKeyword:
             case SyntaxKind.UndefinedKeyword:
             case SyntaxKind.NeverKeyword:
                 return true;


### PR DESCRIPTION
The check for ObjectKeyword which seemed to be missing while checking for type of node was added to isPartOfTypeNode

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `jake runtests` locally
* [x] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #27583 

Thanks to the detailed description given by the contributor who opened the issue, it was a straight forward fix. In case of any addition or changes, I would be happy to implement them as soon as possible.
Being new to open-source, I will highly value any advice you give me (^_^)
Thank You.

