### PR TITLE
Fix crash in convert to ES6 module for files containing uninitialised variables

### DIFF
--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -82,7 +82,7 @@ namespace ts {
             switch (statement.kind) {
                 case SyntaxKind.VariableStatement:
                     return (statement as VariableStatement).declarationList.declarations.some(decl =>
-                        isRequireCall(propertyAccessLeftHandSide(decl.initializer!), /*checkArgumentIsStringLiteralLike*/ true)); // TODO: GH#18217
+                        !!decl.initializer && isRequireCall(propertyAccessLeftHandSide(decl.initializer), /*checkArgumentIsStringLiteralLike*/ true));
                 case SyntaxKind.ExpressionStatement: {
                     const { expression } = statement as ExpressionStatement;
                     if (!isBinaryExpression(expression)) return isRequireCall(expression, /*checkArgumentIsStringLiteralLike*/ true);

--- a/tests/cases/fourslash/refactorConvertToEs6Module_unexported_uninitialized_var.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_unexported_uninitialized_var.ts
@@ -1,0 +1,24 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @target: esnext
+
+// @Filename: /a.js
+////var privateUnrelated;
+////[|exports.f|] = function() {};
+////privateUnrelated = 1;
+////console.log(privateUnrelated);
+
+verify.getSuggestionDiagnostics([{
+    message: "File is a CommonJS module; it may be converted to an ES6 module.",
+    code: 80001,
+}]);
+
+verify.codeFix({
+    description: "Convert to ES6 module",
+    newFileContent:
+`var privateUnrelated;
+export function f() {}
+privateUnrelated = 1;
+console.log(privateUnrelated);`,
+});


### PR DESCRIPTION
containsTopLevelCommonjs previously assumed that all variable declarations had an initialiser,
which is not correct.

Found in bluebird's async.js while trying to get codefixes for it.