### PR TITLE
Generate JSDoc @param comments from camelCase

### DIFF
--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -409,10 +409,11 @@ namespace ts.textChanges {
 
         private printJSDocParameter(indent: number, printed: string, name: Identifier, isOptionalParameter: boolean | undefined) {
             let printName = unescapeLeadingUnderscores(name.escapedText);
+            const documentation = printName.match(/[A-Z]/) ? (" " + printName.replace(/[A-Z]/g, m => " " + m.toLowerCase()).trim()) : "";
             if (isOptionalParameter) {
                 printName = `[${printName}]`;
             }
-            return repeatString(" ", indent) + ` * @param {${printed}} ${printName}\n`;
+            return repeatString(" ", indent) + ` * @param {${printed}} ${printName}${documentation}\n`;
         }
 
         public insertTypeParameters(sourceFile: SourceFile, node: SignatureDeclaration, typeParameters: ReadonlyArray<TypeParameterDeclaration>): void {

--- a/tests/cases/fourslash/codeFixInferFromUsageGenerateJSDoc.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageGenerateJSDoc.ts
@@ -1,0 +1,41 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @checkJs: true
+// @noImplicitAny: true
+// @strictNullChecks: true
+// @Filename: important.js
+
+////function f(whatAGreatIdea, optionalThing) {
+////    whatAGreatIdea += 0;
+////    optionalThing += "";
+////}
+////f(1);
+////f(1, 'hi');
+////
+////function g(InitialCaps) {
+////    return InitialCaps * 2;
+////}
+
+verify.codeFixAll({
+    fixId: "inferFromUsage",
+    fixAllDescription: "Infer all types from usage",
+    newFileContent:
+`/**
+ * @param {number} whatAGreatIdea what a great idea
+ * @param {string} [optionalThing] optional thing
+ */
+function f(whatAGreatIdea, optionalThing) {
+    whatAGreatIdea += 0;
+    optionalThing += "";
+}
+f(1);
+f(1, 'hi');
+
+/**
+ * @param {number} InitialCaps initial caps
+ */
+function g(InitialCaps) {
+    return InitialCaps * 2;
+}`,
+});


### PR DESCRIPTION
When you ask run the infer-from-usage codefix, it turns this:

```js
function f(whatAGreatIdea, optionalThing) {
    whatAGreatIdea += 0;
    optionalThing += "";
}
```

Into this:

```js
/**
 * @param {number} whatAGreatIdea what a great idea
 * @param {string} [optionalThing] optional thing
 */
function f(whatAGreatIdea, optionalThing) {
    whatAGreatIdea += 0;
    optionalThing += "";
}
```

Note the default JSDoc comment text that is generated for each parameter.