### PR TITLE
noImplicitAny as suggestion

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13266,7 +13266,7 @@ namespace ts {
 
         function reportImplicitAny(noImplicitAny: boolean, declaration: Declaration, type: Type) {
             const typeAsString = typeToString(getWidenedType(type));
-            if (isInJSFile(declaration) && !getSourceFileOfNode(declaration).pragmas.has("checkJSDirective") && !compilerOptions.checkJs) {
+            if (isInJSFile(declaration) && !isCheckJsEnabledForFile(getSourceFileOfNode(declaration), compilerOptions)) {
                 // Only report implicit any errors/suggestions in TS and ts-check JS files
                 return;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4915,7 +4915,7 @@ namespace ts {
             }
             const widened = getWidenedType(addOptionality(type, definedInMethod && !definedInConstructor));
             if (filterType(widened, t => !!(t.flags & ~TypeFlags.Nullable)) === neverType) {
-                reportImplicitAny(noImplicitAny, symbol.valueDeclaration, anyType);
+                reportImplicitAny(symbol.valueDeclaration, anyType);
                 return anyType;
             }
             return widened;
@@ -4990,7 +4990,7 @@ namespace ts {
                 return result;
             }
             if (isEmptyArrayLiteralType(type)) {
-                reportImplicitAny(noImplicitAny, expression, anyArrayType);
+                reportImplicitAny(expression, anyArrayType);
                 return anyArrayType;
             }
             return type;
@@ -5041,7 +5041,7 @@ namespace ts {
                 return getTypeFromBindingPattern(element.name, includePatternInType, reportErrors);
             }
             if (reportErrors && !declarationBelongsToPrivateAmbientMember(element)) {
-                reportImplicitAny(noImplicitAny, element, anyType);
+                reportImplicitAny(element, anyType);
             }
             return anyType;
         }
@@ -5143,7 +5143,7 @@ namespace ts {
             // Report implicit any errors unless this is a private property within an ambient declaration
             if (reportErrors) {
                 if (!declarationBelongsToPrivateAmbientMember(declaration)) {
-                    reportImplicitAny(noImplicitAny, declaration, type);
+                    reportImplicitAny(declaration, type);
                 }
             }
             return type;
@@ -13264,7 +13264,7 @@ namespace ts {
             return errorReported;
         }
 
-        function reportImplicitAny(noImplicitAny: boolean, declaration: Declaration, type: Type) {
+        function reportImplicitAny(declaration: Declaration, type: Type) {
             const typeAsString = typeToString(getWidenedType(type));
             if (isInJSFile(declaration) && !isCheckJsEnabledForFile(getSourceFileOfNode(declaration), compilerOptions)) {
                 // Only report implicit any errors/suggestions in TS and ts-check JS files
@@ -13313,7 +13313,7 @@ namespace ts {
             if (produceDiagnostics && noImplicitAny && type.flags & TypeFlags.ContainsWideningType) {
                 // Report implicit any error within type if possible, otherwise report error on declaration
                 if (!reportWideningErrorsInType(type)) {
-                    reportImplicitAny(/*noImplicitAny*/ true, declaration, type);
+                    reportImplicitAny(declaration, type);
                 }
             }
         }
@@ -22314,11 +22314,11 @@ namespace ts {
                 isTypeAssertion(initializer) ? type : getWidenedLiteralType(type);
             if (isInJSFile(declaration)) {
                 if (widened.flags & TypeFlags.Nullable) {
-                    reportImplicitAny(noImplicitAny, declaration, anyType);
+                    reportImplicitAny(declaration, anyType);
                     return anyType;
                 }
                 else if (isEmptyArrayLiteralType(widened)) {
-                    reportImplicitAny(noImplicitAny, declaration, anyArrayType);
+                    reportImplicitAny(declaration, anyArrayType);
                     return anyArrayType;
                 }
             }
@@ -23310,7 +23310,7 @@ namespace ts {
             checkSourceElement(node.type);
 
             if (!node.type) {
-                reportImplicitAny(noImplicitAny, node, anyType);
+                reportImplicitAny(node, anyType);
             }
 
             const type = <MappedType>getTypeFromMappedTypeNode(node);
@@ -24335,7 +24335,7 @@ namespace ts {
                 // Report an implicit any error if there is no body, no explicit return type, and node is not a private method
                 // in an ambient context
                 if (nodeIsMissing(body) && !isPrivateWithinAmbient(node)) {
-                    reportImplicitAny(noImplicitAny, node, anyType);
+                    reportImplicitAny(node, anyType);
                 }
 
                 if (functionFlags & FunctionFlags.Generator && nodeIsPresent(body)) {

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -4981,7 +4981,8 @@ namespace ts.projectSystem {
             checkErrorMessage(session, "suggestionDiag", {
                 file: file.path,
                 diagnostics: [
-                    createDiagnostic({ line: 1, offset: 12 }, { line: 1, offset: 13 }, Diagnostics._0_is_declared_but_its_value_is_never_read, ["p"], "suggestion", /*reportsUnnecssary*/ true)
+                    createDiagnostic({ line: 1, offset: 12 }, { line: 1, offset: 13 }, Diagnostics.Parameter_0_implicitly_has_an_1_type, ["p", "any"], "suggestion", /*reportsUnnecessary*/ undefined),
+                    createDiagnostic({ line: 1, offset: 12 }, { line: 1, offset: 13 }, Diagnostics._0_is_declared_but_its_value_is_never_read, ["p"], "suggestion", /*reportsUnnecessary*/ true),
                 ],
             });
             checkCompleteEvent(session, 2, expectedSequenceId);

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -4981,7 +4981,6 @@ namespace ts.projectSystem {
             checkErrorMessage(session, "suggestionDiag", {
                 file: file.path,
                 diagnostics: [
-                    createDiagnostic({ line: 1, offset: 12 }, { line: 1, offset: 13 }, Diagnostics.Parameter_0_implicitly_has_an_1_type, ["p", "any"], "suggestion", /*reportsUnnecessary*/ undefined),
                     createDiagnostic({ line: 1, offset: 12 }, { line: 1, offset: 13 }, Diagnostics._0_is_declared_but_its_value_is_never_read, ["p"], "suggestion", /*reportsUnnecessary*/ true),
                 ],
             });

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc1.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc1.ts
@@ -4,10 +4,9 @@
 /////** @type {number} */
 ////var [|x|];
 
-verify.getSuggestionDiagnostics([{
-    message: "JSDoc types may be moved to TypeScript types.",
-    code: 80004,
-}]);
+verify.getSuggestionDiagnostics([
+    { message: "JSDoc types may be moved to TypeScript types.", code: 80004 },
+    { message: "Variable 'x' implicitly has an 'any' type.", code: 7005 }]);
 
 verify.codeFix({
     description: "Annotate with type from JSDoc",

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc3.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc3.ts
@@ -6,14 +6,17 @@
 //// * @param alpha - the other best parameter
 //// * @param {*} beta - I have no idea how this got here
 //// */
-////function [|f|](x, y, z: string, alpha, beta) {
+////function [|f|]([|x|], [|y|], z: string, [|alpha|], [|beta|]) {
 ////    x; y; z; alpha; beta;
 ////}
 
-verify.getSuggestionDiagnostics([{
-    message: "JSDoc types may be moved to TypeScript types.",
-    code: 80004,
-}]);
+const [r0, r1, r2, r3, r4] = test.ranges();
+verify.getSuggestionDiagnostics([
+    {message: "JSDoc types may be moved to TypeScript types.", code: 80004, range: r0},
+    {message: "Parameter 'x' implicitly has an 'any' type.", code: 7006, range: r1 },
+    {message: "Parameter 'y' implicitly has an 'any' type.", code: 7006, range: r2 },
+    {message: "Parameter 'alpha' implicitly has an 'any' type.", code: 7006, range: r3 },
+    {message: "Parameter 'beta' implicitly has an 'any' type.", code: 7006, range: r4 }]);
 
 verify.codeFix({
     description: "Annotate with type from JSDoc",

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_suggestion.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_suggestion.ts
@@ -7,6 +7,11 @@
 const [r0, r1] = test.ranges();
 verify.getSuggestionDiagnostics([
     {
+        message: "Parameter 'p' implicitly has an 'any' type.",
+        range: r0,
+        code: 7006,
+    },
+    {
         message: "'p' is declared but its value is never read.",
         range: r0,
         code: 6133,

--- a/tests/cases/fourslash/noSuggestionDiagnosticsOnParseError.ts
+++ b/tests/cases/fourslash/noSuggestionDiagnosticsOnParseError.ts
@@ -4,4 +4,13 @@
 ////export {};
 ////const a = 1 d;
 
-verify.getSuggestionDiagnostics([]);
+// Only give suggestions for nodes that do NOT have parse errors
+verify.getSuggestionDiagnostics([{
+    message: "Variable 'd' implicitly has an 'any' type.",
+    code: 7005,
+    range: {
+        fileName: "/a.ts",
+        pos: 23,
+        end: 24,
+    }
+}]);

--- a/tests/cases/fourslash/refactorConvertToEs6Module_export_named.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_export_named.ts
@@ -9,13 +9,15 @@
 ////exports.x = 0;
 ////exports.a1 = () => {};
 ////exports.a2 = () => 0;
-////exports.a3 = x => { x; };
-////exports.a4 = x => x;
+////exports.a3 = [|x|] => { x; };
+////exports.a4 = [|x|] => x;
 
-verify.getSuggestionDiagnostics([{
-    message: "File is a CommonJS module; it may be converted to an ES6 module.",
-    code: 80001,
-}]);
+const [r0, r1, r2] = test.ranges();
+verify.getSuggestionDiagnostics([
+    { message: "File is a CommonJS module; it may be converted to an ES6 module.", code: 80001, range: r0 },
+    { message: "Parameter 'x' implicitly has an 'any' type.", code: 7006, range: r1 },
+    { message: "Parameter 'x' implicitly has an 'any' type.", code: 7006, range: r2 },
+]);
 
 verify.codeFix({
     description: "Convert to ES6 module",

--- a/tests/cases/fourslash/refactorConvertToEs6Module_export_named.ts
+++ b/tests/cases/fourslash/refactorConvertToEs6Module_export_named.ts
@@ -9,14 +9,12 @@
 ////exports.x = 0;
 ////exports.a1 = () => {};
 ////exports.a2 = () => 0;
-////exports.a3 = [|x|] => { x; };
-////exports.a4 = [|x|] => x;
+////exports.a3 = x => { x; };
+////exports.a4 = x => x;
 
 const [r0, r1, r2] = test.ranges();
 verify.getSuggestionDiagnostics([
     { message: "File is a CommonJS module; it may be converted to an ES6 module.", code: 80001, range: r0 },
-    { message: "Parameter 'x' implicitly has an 'any' type.", code: 7006, range: r1 },
-    { message: "Parameter 'x' implicitly has an 'any' type.", code: 7006, range: r2 },
 ]);
 
 verify.codeFix({

--- a/tests/cases/fourslash/unusedLocalsInFunction2.ts
+++ b/tests/cases/fourslash/unusedLocalsInFunction2.ts
@@ -6,4 +6,4 @@
 ////    x+1;
 ////}
 
-verify.rangeAfterCodeFix("var x;");
+verify.rangeAfterCodeFix("var x;", undefined, undefined, 0);


### PR DESCRIPTION
With noImplicitAny suggestions, people will see suggestions for the infer-from-usage codefix even with noImplicitAny turned off. This applies to JS users, who are otherwise unlikely to see that codefix.

Notes:

1. I want to evaluate performance before merging this.
2. I want to make sure the suggestions are mostly reliable and sensical before merging as well. I'm going to look over our user tests.
3. Not all noImplicitAny errors turn into suggestions. In
particular:

    1. reportErrorsFromWidening does not, because it doesn't log an error that infer-from-usage fixes, and fixing it would require otherwise-unnecessary code.
   2. auto types do not have implicit any suggestions, because that would require running control flow in noImplicitAny mode.

