### PR TITLE
Make the assignability rule for conditional types require the check types and distributivity to be identical.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12693,10 +12693,11 @@ namespace ts {
                 else if (source.flags & TypeFlags.Conditional) {
                     if (target.flags & TypeFlags.Conditional) {
                         // Two conditional types 'T1 extends U1 ? X1 : Y1' and 'T2 extends U2 ? X2 : Y2' are related if
-                        // one of T1 and T2 is related to the other, U1 and U2 are identical types, X1 is related to X2,
-                        // and Y1 is related to Y2.
-                        if (isTypeIdenticalTo((<ConditionalType>source).extendsType, (<ConditionalType>target).extendsType) &&
-                            (isRelatedTo((<ConditionalType>source).checkType, (<ConditionalType>target).checkType) || isRelatedTo((<ConditionalType>target).checkType, (<ConditionalType>source).checkType))) {
+                        // they have the same distributivity, T1 and T2 are identical types, U1 and U2 are identical
+                        // types, X1 is related to X2, and Y1 is related to Y2.
+                        if ((<ConditionalType>source).root.isDistributive === (<ConditionalType>target).root.isDistributive &&
+                            isTypeIdenticalTo((<ConditionalType>source).extendsType, (<ConditionalType>target).extendsType) &&
+                            isTypeIdenticalTo((<ConditionalType>source).checkType, (<ConditionalType>target).checkType)) {
                             if (result = isRelatedTo(getTrueTypeFromConditionalType(<ConditionalType>source), getTrueTypeFromConditionalType(<ConditionalType>target), reportErrors)) {
                                 result &= isRelatedTo(getFalseTypeFromConditionalType(<ConditionalType>source), getFalseTypeFromConditionalType(<ConditionalType>target), reportErrors);
                             }

--- a/tests/baselines/reference/conditionalTypes2.errors.txt
+++ b/tests/baselines/reference/conditionalTypes2.errors.txt
@@ -1,29 +1,38 @@
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(15,5): error TS2322: Type 'Covariant<A>' is not assignable to type 'Covariant<B>'.
-  Type 'A' is not assignable to type 'B'.
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(19,5): error TS2322: Type 'Contravariant<B>' is not assignable to type 'Contravariant<A>'.
-  Type 'A' is not assignable to type 'B'.
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(24,5): error TS2322: Type 'Invariant<B>' is not assignable to type 'Invariant<A>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(16,5): error TS2322: Type 'Covariant<B>' is not assignable to type 'Covariant<A>'.
+  Types of property 'foo' are incompatible.
+    Type 'B extends string ? B : number' is not assignable to type 'A extends string ? A : number'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(17,5): error TS2322: Type 'Covariant<A>' is not assignable to type 'Covariant<B>'.
+  Types of property 'foo' are incompatible.
+    Type 'A extends string ? A : number' is not assignable to type 'B extends string ? B : number'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(21,5): error TS2322: Type 'Contravariant<B>' is not assignable to type 'Contravariant<A>'.
+  Types of property 'foo' are incompatible.
+    Type 'B extends string ? keyof B : number' is not assignable to type 'A extends string ? keyof A : number'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(22,5): error TS2322: Type 'Contravariant<A>' is not assignable to type 'Contravariant<B>'.
+  Types of property 'foo' are incompatible.
+    Type 'A extends string ? keyof A : number' is not assignable to type 'B extends string ? keyof B : number'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(26,5): error TS2322: Type 'Invariant<B>' is not assignable to type 'Invariant<A>'.
   Types of property 'foo' are incompatible.
     Type 'B extends string ? keyof B : B' is not assignable to type 'A extends string ? keyof A : A'.
-      Type 'keyof B' is not assignable to type 'keyof A'.
-        Type 'string | number | symbol' is not assignable to type 'keyof A'.
-          Type 'string' is not assignable to type 'keyof A'.
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(25,5): error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(27,5): error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
   Types of property 'foo' are incompatible.
     Type 'A extends string ? keyof A : A' is not assignable to type 'B extends string ? keyof B : B'.
-      Type 'A' is not assignable to type 'B'.
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(73,12): error TS2345: Argument of type 'Extract<Extract<T, Foo>, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2345: Argument of type 'Extract<Extract<T, Foo>, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
   Property 'bat' is missing in type 'Bar & Foo' but required in type '{ foo: string; bat: string; }'.
     Type 'Extract<Foo & T, Bar>' is not assignable to type '{ foo: string; bat: string; }'.
       Property 'bat' is missing in type 'Bar & Foo' but required in type '{ foo: string; bat: string; }'.
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(74,12): error TS2345: Argument of type 'Extract<T, Foo & Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(76,12): error TS2345: Argument of type 'Extract<T, Foo & Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
   Property 'bat' is missing in type 'Foo & Bar' but required in type '{ foo: string; bat: string; }'.
-tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2345: Argument of type 'Extract2<T, Foo, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(77,12): error TS2345: Argument of type 'Extract2<T, Foo, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
   Type 'T extends Bar ? T : never' is not assignable to type '{ foo: string; bat: string; }'.
     Type 'Bar & Foo & T' is not assignable to type '{ foo: string; bat: string; }'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(165,5): error TS2322: Type 'MyElement<A>' is not assignable to type 'MyElement<B>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(170,5): error TS2322: Type 'MyAcceptor<B>' is not assignable to type 'MyAcceptor<A>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(177,5): error TS2322: Type 'Dist<T>' is not assignable to type 'Aux<{ a: T; }>'.
 
 
-==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (7 errors) ====
+==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (12 errors) ====
+    // #27118: Conditional types are now invariant in the check type.
+    
     interface Covariant<T> {
         foo: T extends string ? T : number;
     }
@@ -37,19 +46,29 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2
     }
     
     function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
-        a = b;
+        a = b;  // Error
+        ~
+!!! error TS2322: Type 'Covariant<B>' is not assignable to type 'Covariant<A>'.
+!!! error TS2322:   Types of property 'foo' are incompatible.
+!!! error TS2322:     Type 'B extends string ? B : number' is not assignable to type 'A extends string ? A : number'.
         b = a;  // Error
         ~
 !!! error TS2322: Type 'Covariant<A>' is not assignable to type 'Covariant<B>'.
-!!! error TS2322:   Type 'A' is not assignable to type 'B'.
+!!! error TS2322:   Types of property 'foo' are incompatible.
+!!! error TS2322:     Type 'A extends string ? A : number' is not assignable to type 'B extends string ? B : number'.
     }
     
     function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
         a = b;  // Error
         ~
 !!! error TS2322: Type 'Contravariant<B>' is not assignable to type 'Contravariant<A>'.
-!!! error TS2322:   Type 'A' is not assignable to type 'B'.
-        b = a;
+!!! error TS2322:   Types of property 'foo' are incompatible.
+!!! error TS2322:     Type 'B extends string ? keyof B : number' is not assignable to type 'A extends string ? keyof A : number'.
+        b = a;  // Error
+        ~
+!!! error TS2322: Type 'Contravariant<A>' is not assignable to type 'Contravariant<B>'.
+!!! error TS2322:   Types of property 'foo' are incompatible.
+!!! error TS2322:     Type 'A extends string ? keyof A : number' is not assignable to type 'B extends string ? keyof B : number'.
     }
     
     function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
@@ -58,15 +77,11 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2
 !!! error TS2322: Type 'Invariant<B>' is not assignable to type 'Invariant<A>'.
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type 'B extends string ? keyof B : B' is not assignable to type 'A extends string ? keyof A : A'.
-!!! error TS2322:       Type 'keyof B' is not assignable to type 'keyof A'.
-!!! error TS2322:         Type 'string | number | symbol' is not assignable to type 'keyof A'.
-!!! error TS2322:           Type 'string' is not assignable to type 'keyof A'.
         b = a;  // Error
         ~
 !!! error TS2322: Type 'Invariant<A>' is not assignable to type 'Invariant<B>'.
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type 'A extends string ? keyof A : A' is not assignable to type 'B extends string ? keyof B : B'.
-!!! error TS2322:       Type 'A' is not assignable to type 'B'.
     }
     
     // Extract<T, Function> is a T that is known to be a Function
@@ -120,50 +135,18 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2
 !!! error TS2345:   Property 'bat' is missing in type 'Bar & Foo' but required in type '{ foo: string; bat: string; }'.
 !!! error TS2345:     Type 'Extract<Foo & T, Bar>' is not assignable to type '{ foo: string; bat: string; }'.
 !!! error TS2345:       Property 'bat' is missing in type 'Bar & Foo' but required in type '{ foo: string; bat: string; }'.
-!!! related TS2728 tests/cases/conformance/types/conditional/conditionalTypes2.ts:62:43: 'bat' is declared here.
-!!! related TS2728 tests/cases/conformance/types/conditional/conditionalTypes2.ts:62:43: 'bat' is declared here.
+!!! related TS2728 tests/cases/conformance/types/conditional/conditionalTypes2.ts:64:43: 'bat' is declared here.
+!!! related TS2728 tests/cases/conformance/types/conditional/conditionalTypes2.ts:64:43: 'bat' is declared here.
         fooBat(y);  // Error
                ~
 !!! error TS2345: Argument of type 'Extract<T, Foo & Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
 !!! error TS2345:   Property 'bat' is missing in type 'Foo & Bar' but required in type '{ foo: string; bat: string; }'.
-!!! related TS2728 tests/cases/conformance/types/conditional/conditionalTypes2.ts:62:43: 'bat' is declared here.
+!!! related TS2728 tests/cases/conformance/types/conditional/conditionalTypes2.ts:64:43: 'bat' is declared here.
         fooBat(z);  // Error
                ~
 !!! error TS2345: Argument of type 'Extract2<T, Foo, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
 !!! error TS2345:   Type 'T extends Bar ? T : never' is not assignable to type '{ foo: string; bat: string; }'.
 !!! error TS2345:     Type 'Bar & Foo & T' is not assignable to type '{ foo: string; bat: string; }'.
-    }
-    
-    // Repros from #22860
-    
-    class Opt<T> {
-        toVector(): Vector<T> {
-            return <any>undefined;
-        }
-    }
-    
-    interface Seq<T> {
-        tail(): Opt<Seq<T>>;
-    }
-    
-    class Vector<T> implements Seq<T> {
-        tail(): Opt<Vector<T>> {
-            return <any>undefined;
-        }
-        partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
-        partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
-        partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
-            return <any>undefined;
-        }
-    }
-    
-    interface A1<T> {
-        bat: B1<A1<T>>;
-    }
-    
-    interface B1<T> extends A1<T> {
-        bat: B1<B1<T>>;
-        boom: T extends any ? true : true
     }
     
     // Repro from #22899
@@ -246,4 +229,29 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2
     };
     type PCCA = ProductComplementComplement['a'];
     type PCCB = ProductComplementComplement['b'];
+    
+    // Repros from #27118
+    
+    type MyElement<A> = [A] extends [[infer E]] ? E : never;
+    function oops<A, B extends A>(arg: MyElement<A>): MyElement<B> {
+        return arg;  // Unsound, should be error
+        ~~~~~~~~~~~
+!!! error TS2322: Type 'MyElement<A>' is not assignable to type 'MyElement<B>'.
+    }
+    
+    type MyAcceptor<A> = [A] extends [[infer E]] ? (arg: E) => void : never;
+    function oops2<A, B extends A>(arg: MyAcceptor<B>): MyAcceptor<A> {
+        return arg;  // Unsound, should be error
+        ~~~~~~~~~~~
+!!! error TS2322: Type 'MyAcceptor<B>' is not assignable to type 'MyAcceptor<A>'.
+    }
+    
+    type Dist<T> = T extends number ? number : string;
+    type Aux<A extends { a: unknown }> = A["a"] extends number ? number : string;
+    type Nondist<T> = Aux<{a: T}>;
+    function oops3<T>(arg: Dist<T>): Nondist<T> {
+        return arg;  // Unsound, should be error
+        ~~~~~~~~~~~
+!!! error TS2322: Type 'Dist<T>' is not assignable to type 'Aux<{ a: T; }>'.
+    }
     

--- a/tests/baselines/reference/conditionalTypes2.js
+++ b/tests/baselines/reference/conditionalTypes2.js
@@ -1,4 +1,6 @@
 //// [conditionalTypes2.ts]
+// #27118: Conditional types are now invariant in the check type.
+
 interface Covariant<T> {
     foo: T extends string ? T : number;
 }
@@ -12,13 +14,13 @@ interface Invariant<T> {
 }
 
 function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
-    a = b;
+    a = b;  // Error
     b = a;  // Error
 }
 
 function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
     a = b;  // Error
-    b = a;
+    b = a;  // Error
 }
 
 function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
@@ -74,38 +76,6 @@ function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: E
     fooBat(x);  // Error
     fooBat(y);  // Error
     fooBat(z);  // Error
-}
-
-// Repros from #22860
-
-class Opt<T> {
-    toVector(): Vector<T> {
-        return <any>undefined;
-    }
-}
-
-interface Seq<T> {
-    tail(): Opt<Seq<T>>;
-}
-
-class Vector<T> implements Seq<T> {
-    tail(): Opt<Vector<T>> {
-        return <any>undefined;
-    }
-    partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
-    partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
-    partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
-        return <any>undefined;
-    }
-}
-
-interface A1<T> {
-    bat: B1<A1<T>>;
-}
-
-interface B1<T> extends A1<T> {
-    bat: B1<B1<T>>;
-    boom: T extends any ? true : true
 }
 
 // Repro from #22899
@@ -189,16 +159,36 @@ type ProductComplementComplement = {
 type PCCA = ProductComplementComplement['a'];
 type PCCB = ProductComplementComplement['b'];
 
+// Repros from #27118
+
+type MyElement<A> = [A] extends [[infer E]] ? E : never;
+function oops<A, B extends A>(arg: MyElement<A>): MyElement<B> {
+    return arg;  // Unsound, should be error
+}
+
+type MyAcceptor<A> = [A] extends [[infer E]] ? (arg: E) => void : never;
+function oops2<A, B extends A>(arg: MyAcceptor<B>): MyAcceptor<A> {
+    return arg;  // Unsound, should be error
+}
+
+type Dist<T> = T extends number ? number : string;
+type Aux<A extends { a: unknown }> = A["a"] extends number ? number : string;
+type Nondist<T> = Aux<{a: T}>;
+function oops3<T>(arg: Dist<T>): Nondist<T> {
+    return arg;  // Unsound, should be error
+}
+
 
 //// [conditionalTypes2.js]
 "use strict";
+// #27118: Conditional types are now invariant in the check type.
 function f1(a, b) {
-    a = b;
+    a = b; // Error
     b = a; // Error
 }
 function f2(a, b) {
     a = b; // Error
-    b = a;
+    b = a; // Error
 }
 function f3(a, b) {
     a = b; // Error
@@ -239,31 +229,20 @@ function f21(x, y, z) {
     fooBat(y); // Error
     fooBat(z); // Error
 }
-// Repros from #22860
-var Opt = /** @class */ (function () {
-    function Opt() {
-    }
-    Opt.prototype.toVector = function () {
-        return undefined;
-    };
-    return Opt;
-}());
-var Vector = /** @class */ (function () {
-    function Vector() {
-    }
-    Vector.prototype.tail = function () {
-        return undefined;
-    };
-    Vector.prototype.partition2 = function (predicate) {
-        return undefined;
-    };
-    return Vector;
-}());
 function foo(value) {
     if (isFunction(value)) {
         toString1(value);
         toString2(value);
     }
+}
+function oops(arg) {
+    return arg; // Unsound, should be error
+}
+function oops2(arg) {
+    return arg; // Unsound, should be error
+}
+function oops3(arg) {
+    return arg; // Unsound, should be error
 }
 
 
@@ -302,24 +281,6 @@ declare function fooBat(x: {
 declare type Extract2<T, U, V> = T extends U ? T extends V ? T : never : never;
 declare function f20<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>): void;
 declare function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>): void;
-declare class Opt<T> {
-    toVector(): Vector<T>;
-}
-interface Seq<T> {
-    tail(): Opt<Seq<T>>;
-}
-declare class Vector<T> implements Seq<T> {
-    tail(): Opt<Vector<T>>;
-    partition2<U extends T>(predicate: (v: T) => v is U): [Vector<U>, Vector<Exclude<T, U>>];
-    partition2(predicate: (x: T) => boolean): [Vector<T>, Vector<T>];
-}
-interface A1<T> {
-    bat: B1<A1<T>>;
-}
-interface B1<T> extends A1<T> {
-    bat: B1<B1<T>>;
-    boom: T extends any ? true : true;
-}
 declare function toString1(value: object | Function): string;
 declare function toString2(value: Function): string;
 declare function foo<T>(value: T): void;
@@ -392,3 +353,15 @@ declare type ProductComplementComplement = {
 };
 declare type PCCA = ProductComplementComplement['a'];
 declare type PCCB = ProductComplementComplement['b'];
+declare type MyElement<A> = [A] extends [[infer E]] ? E : never;
+declare function oops<A, B extends A>(arg: MyElement<A>): MyElement<B>;
+declare type MyAcceptor<A> = [A] extends [[infer E]] ? (arg: E) => void : never;
+declare function oops2<A, B extends A>(arg: MyAcceptor<B>): MyAcceptor<A>;
+declare type Dist<T> = T extends number ? number : string;
+declare type Aux<A extends {
+    a: unknown;
+}> = A["a"] extends number ? number : string;
+declare type Nondist<T> = Aux<{
+    a: T;
+}>;
+declare function oops3<T>(arg: Dist<T>): Nondist<T>;

--- a/tests/baselines/reference/conditionalTypes2.symbols
+++ b/tests/baselines/reference/conditionalTypes2.symbols
@@ -1,687 +1,655 @@
 === tests/cases/conformance/types/conditional/conditionalTypes2.ts ===
+// #27118: Conditional types are now invariant in the check type.
+
 interface Covariant<T> {
 >Covariant : Symbol(Covariant, Decl(conditionalTypes2.ts, 0, 0))
->T : Symbol(T, Decl(conditionalTypes2.ts, 0, 20))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 2, 20))
 
     foo: T extends string ? T : number;
->foo : Symbol(Covariant.foo, Decl(conditionalTypes2.ts, 0, 24))
->T : Symbol(T, Decl(conditionalTypes2.ts, 0, 20))
->T : Symbol(T, Decl(conditionalTypes2.ts, 0, 20))
+>foo : Symbol(Covariant.foo, Decl(conditionalTypes2.ts, 2, 24))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 2, 20))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 2, 20))
 }
 
 interface Contravariant<T> {
->Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 2, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 4, 24))
+>Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 4, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 6, 24))
 
     foo: T extends string ? keyof T : number;
->foo : Symbol(Contravariant.foo, Decl(conditionalTypes2.ts, 4, 28))
->T : Symbol(T, Decl(conditionalTypes2.ts, 4, 24))
->T : Symbol(T, Decl(conditionalTypes2.ts, 4, 24))
+>foo : Symbol(Contravariant.foo, Decl(conditionalTypes2.ts, 6, 28))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 6, 24))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 6, 24))
 }
 
 interface Invariant<T> {
->Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 6, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 8, 20))
+>Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 8, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 10, 20))
 
     foo: T extends string ? keyof T : T;
->foo : Symbol(Invariant.foo, Decl(conditionalTypes2.ts, 8, 24))
->T : Symbol(T, Decl(conditionalTypes2.ts, 8, 20))
->T : Symbol(T, Decl(conditionalTypes2.ts, 8, 20))
->T : Symbol(T, Decl(conditionalTypes2.ts, 8, 20))
+>foo : Symbol(Invariant.foo, Decl(conditionalTypes2.ts, 10, 24))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 10, 20))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 10, 20))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 10, 20))
 }
 
 function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
->f1 : Symbol(f1, Decl(conditionalTypes2.ts, 10, 1))
->A : Symbol(A, Decl(conditionalTypes2.ts, 12, 12))
->B : Symbol(B, Decl(conditionalTypes2.ts, 12, 14))
->A : Symbol(A, Decl(conditionalTypes2.ts, 12, 12))
->a : Symbol(a, Decl(conditionalTypes2.ts, 12, 28))
+>f1 : Symbol(f1, Decl(conditionalTypes2.ts, 12, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 14, 12))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 14, 14))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 14, 12))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 14, 28))
 >Covariant : Symbol(Covariant, Decl(conditionalTypes2.ts, 0, 0))
->A : Symbol(A, Decl(conditionalTypes2.ts, 12, 12))
->b : Symbol(b, Decl(conditionalTypes2.ts, 12, 44))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 14, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 14, 44))
 >Covariant : Symbol(Covariant, Decl(conditionalTypes2.ts, 0, 0))
->B : Symbol(B, Decl(conditionalTypes2.ts, 12, 14))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 14, 14))
 
-    a = b;
->a : Symbol(a, Decl(conditionalTypes2.ts, 12, 28))
->b : Symbol(b, Decl(conditionalTypes2.ts, 12, 44))
+    a = b;  // Error
+>a : Symbol(a, Decl(conditionalTypes2.ts, 14, 28))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 14, 44))
 
     b = a;  // Error
->b : Symbol(b, Decl(conditionalTypes2.ts, 12, 44))
->a : Symbol(a, Decl(conditionalTypes2.ts, 12, 28))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 14, 44))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 14, 28))
 }
 
 function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
->f2 : Symbol(f2, Decl(conditionalTypes2.ts, 15, 1))
->A : Symbol(A, Decl(conditionalTypes2.ts, 17, 12))
->B : Symbol(B, Decl(conditionalTypes2.ts, 17, 14))
->A : Symbol(A, Decl(conditionalTypes2.ts, 17, 12))
->a : Symbol(a, Decl(conditionalTypes2.ts, 17, 28))
->Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 2, 1))
->A : Symbol(A, Decl(conditionalTypes2.ts, 17, 12))
->b : Symbol(b, Decl(conditionalTypes2.ts, 17, 48))
->Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 2, 1))
->B : Symbol(B, Decl(conditionalTypes2.ts, 17, 14))
+>f2 : Symbol(f2, Decl(conditionalTypes2.ts, 17, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 19, 12))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 19, 14))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 19, 12))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 19, 28))
+>Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 4, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 19, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 19, 48))
+>Contravariant : Symbol(Contravariant, Decl(conditionalTypes2.ts, 4, 1))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 19, 14))
 
     a = b;  // Error
->a : Symbol(a, Decl(conditionalTypes2.ts, 17, 28))
->b : Symbol(b, Decl(conditionalTypes2.ts, 17, 48))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 19, 28))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 19, 48))
 
-    b = a;
->b : Symbol(b, Decl(conditionalTypes2.ts, 17, 48))
->a : Symbol(a, Decl(conditionalTypes2.ts, 17, 28))
+    b = a;  // Error
+>b : Symbol(b, Decl(conditionalTypes2.ts, 19, 48))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 19, 28))
 }
 
 function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
->f3 : Symbol(f3, Decl(conditionalTypes2.ts, 20, 1))
->A : Symbol(A, Decl(conditionalTypes2.ts, 22, 12))
->B : Symbol(B, Decl(conditionalTypes2.ts, 22, 14))
->A : Symbol(A, Decl(conditionalTypes2.ts, 22, 12))
->a : Symbol(a, Decl(conditionalTypes2.ts, 22, 28))
->Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 6, 1))
->A : Symbol(A, Decl(conditionalTypes2.ts, 22, 12))
->b : Symbol(b, Decl(conditionalTypes2.ts, 22, 44))
->Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 6, 1))
->B : Symbol(B, Decl(conditionalTypes2.ts, 22, 14))
+>f3 : Symbol(f3, Decl(conditionalTypes2.ts, 22, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 24, 12))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 24, 14))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 24, 12))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 24, 28))
+>Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 8, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 24, 12))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 24, 44))
+>Invariant : Symbol(Invariant, Decl(conditionalTypes2.ts, 8, 1))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 24, 14))
 
     a = b;  // Error
->a : Symbol(a, Decl(conditionalTypes2.ts, 22, 28))
->b : Symbol(b, Decl(conditionalTypes2.ts, 22, 44))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 24, 28))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 24, 44))
 
     b = a;  // Error
->b : Symbol(b, Decl(conditionalTypes2.ts, 22, 44))
->a : Symbol(a, Decl(conditionalTypes2.ts, 22, 28))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 24, 44))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 24, 28))
 }
 
 // Extract<T, Function> is a T that is known to be a Function
 function isFunction<T>(value: T): value is Extract<T, Function> {
->isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 28, 20))
->value : Symbol(value, Decl(conditionalTypes2.ts, 28, 23))
->T : Symbol(T, Decl(conditionalTypes2.ts, 28, 20))
->value : Symbol(value, Decl(conditionalTypes2.ts, 28, 23))
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 27, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 30, 20))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 30, 23))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 30, 20))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 30, 23))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes2.ts, 28, 20))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 30, 20))
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
     return typeof value === "function";
->value : Symbol(value, Decl(conditionalTypes2.ts, 28, 23))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 30, 23))
 }
 
 function getFunction<T>(item: T) {
->getFunction : Symbol(getFunction, Decl(conditionalTypes2.ts, 30, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 32, 21))
->item : Symbol(item, Decl(conditionalTypes2.ts, 32, 24))
->T : Symbol(T, Decl(conditionalTypes2.ts, 32, 21))
+>getFunction : Symbol(getFunction, Decl(conditionalTypes2.ts, 32, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 34, 21))
+>item : Symbol(item, Decl(conditionalTypes2.ts, 34, 24))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 34, 21))
 
     if (isFunction(item)) {
->isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
->item : Symbol(item, Decl(conditionalTypes2.ts, 32, 24))
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 27, 1))
+>item : Symbol(item, Decl(conditionalTypes2.ts, 34, 24))
 
         return item;
->item : Symbol(item, Decl(conditionalTypes2.ts, 32, 24))
+>item : Symbol(item, Decl(conditionalTypes2.ts, 34, 24))
     }
     throw new Error();
 >Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 }
 
 function f10<T>(x: T) {
->f10 : Symbol(f10, Decl(conditionalTypes2.ts, 37, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->x : Symbol(x, Decl(conditionalTypes2.ts, 39, 16))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
+>f10 : Symbol(f10, Decl(conditionalTypes2.ts, 39, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 41, 13))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 41, 16))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 41, 13))
 
     if (isFunction(x)) {
->isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
->x : Symbol(x, Decl(conditionalTypes2.ts, 39, 16))
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 27, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 41, 16))
 
         const f: Function = x;
->f : Symbol(f, Decl(conditionalTypes2.ts, 41, 13))
+>f : Symbol(f, Decl(conditionalTypes2.ts, 43, 13))
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->x : Symbol(x, Decl(conditionalTypes2.ts, 39, 16))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 41, 16))
 
         const t: T = x;
->t : Symbol(t, Decl(conditionalTypes2.ts, 42, 13))
->T : Symbol(T, Decl(conditionalTypes2.ts, 39, 13))
->x : Symbol(x, Decl(conditionalTypes2.ts, 39, 16))
+>t : Symbol(t, Decl(conditionalTypes2.ts, 44, 13))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 41, 13))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 41, 16))
     }
 }
 
 function f11(x: string | (() => string) | undefined) {
->f11 : Symbol(f11, Decl(conditionalTypes2.ts, 44, 1))
->x : Symbol(x, Decl(conditionalTypes2.ts, 46, 13))
+>f11 : Symbol(f11, Decl(conditionalTypes2.ts, 46, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 48, 13))
 
     if (isFunction(x)) {
->isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
->x : Symbol(x, Decl(conditionalTypes2.ts, 46, 13))
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 27, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 48, 13))
 
         x();
->x : Symbol(x, Decl(conditionalTypes2.ts, 46, 13))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 48, 13))
     }
 }
 
 function f12(x: string | (() => string) | undefined) {
->f12 : Symbol(f12, Decl(conditionalTypes2.ts, 50, 1))
->x : Symbol(x, Decl(conditionalTypes2.ts, 52, 13))
+>f12 : Symbol(f12, Decl(conditionalTypes2.ts, 52, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 54, 13))
 
     const f = getFunction(x);  // () => string
->f : Symbol(f, Decl(conditionalTypes2.ts, 53, 9))
->getFunction : Symbol(getFunction, Decl(conditionalTypes2.ts, 30, 1))
->x : Symbol(x, Decl(conditionalTypes2.ts, 52, 13))
+>f : Symbol(f, Decl(conditionalTypes2.ts, 55, 9))
+>getFunction : Symbol(getFunction, Decl(conditionalTypes2.ts, 32, 1))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 54, 13))
 
     f();
->f : Symbol(f, Decl(conditionalTypes2.ts, 53, 9))
+>f : Symbol(f, Decl(conditionalTypes2.ts, 55, 9))
 }
 
 type Foo = { foo: string };
->Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
->foo : Symbol(foo, Decl(conditionalTypes2.ts, 57, 12))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 57, 1))
+>foo : Symbol(foo, Decl(conditionalTypes2.ts, 59, 12))
 
 type Bar = { bar: string };
->Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
->bar : Symbol(bar, Decl(conditionalTypes2.ts, 58, 12))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 59, 27))
+>bar : Symbol(bar, Decl(conditionalTypes2.ts, 60, 12))
 
 declare function fooBar(x: { foo: string, bar: string }): void;
->fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 58, 27))
->x : Symbol(x, Decl(conditionalTypes2.ts, 60, 24))
->foo : Symbol(foo, Decl(conditionalTypes2.ts, 60, 28))
->bar : Symbol(bar, Decl(conditionalTypes2.ts, 60, 41))
+>fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 60, 27))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 62, 24))
+>foo : Symbol(foo, Decl(conditionalTypes2.ts, 62, 28))
+>bar : Symbol(bar, Decl(conditionalTypes2.ts, 62, 41))
 
 declare function fooBat(x: { foo: string, bat: string }): void;
->fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 60, 63))
->x : Symbol(x, Decl(conditionalTypes2.ts, 61, 24))
->foo : Symbol(foo, Decl(conditionalTypes2.ts, 61, 28))
->bat : Symbol(bat, Decl(conditionalTypes2.ts, 61, 41))
+>fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 62, 63))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 63, 24))
+>foo : Symbol(foo, Decl(conditionalTypes2.ts, 63, 28))
+>bat : Symbol(bat, Decl(conditionalTypes2.ts, 63, 41))
 
 type Extract2<T, U, V> = T extends U ? T extends V ? T : never : never;
->Extract2 : Symbol(Extract2, Decl(conditionalTypes2.ts, 61, 63))
->T : Symbol(T, Decl(conditionalTypes2.ts, 63, 14))
->U : Symbol(U, Decl(conditionalTypes2.ts, 63, 16))
->V : Symbol(V, Decl(conditionalTypes2.ts, 63, 19))
->T : Symbol(T, Decl(conditionalTypes2.ts, 63, 14))
->U : Symbol(U, Decl(conditionalTypes2.ts, 63, 16))
->T : Symbol(T, Decl(conditionalTypes2.ts, 63, 14))
->V : Symbol(V, Decl(conditionalTypes2.ts, 63, 19))
->T : Symbol(T, Decl(conditionalTypes2.ts, 63, 14))
+>Extract2 : Symbol(Extract2, Decl(conditionalTypes2.ts, 63, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 65, 14))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 65, 16))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 65, 19))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 65, 14))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 65, 16))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 65, 14))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 65, 19))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 65, 14))
 
 function f20<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
->f20 : Symbol(f20, Decl(conditionalTypes2.ts, 63, 71))
->T : Symbol(T, Decl(conditionalTypes2.ts, 65, 13))
->x : Symbol(x, Decl(conditionalTypes2.ts, 65, 16))
+>f20 : Symbol(f20, Decl(conditionalTypes2.ts, 65, 71))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 67, 13))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 67, 16))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes2.ts, 65, 13))
->Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
->Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
->y : Symbol(y, Decl(conditionalTypes2.ts, 65, 49))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 67, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 57, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 59, 27))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 67, 49))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes2.ts, 65, 13))
->Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
->Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
->z : Symbol(z, Decl(conditionalTypes2.ts, 65, 75))
->Extract2 : Symbol(Extract2, Decl(conditionalTypes2.ts, 61, 63))
->T : Symbol(T, Decl(conditionalTypes2.ts, 65, 13))
->Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
->Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 67, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 57, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 59, 27))
+>z : Symbol(z, Decl(conditionalTypes2.ts, 67, 75))
+>Extract2 : Symbol(Extract2, Decl(conditionalTypes2.ts, 63, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 67, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 57, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 59, 27))
 
     fooBar(x);
->fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 58, 27))
->x : Symbol(x, Decl(conditionalTypes2.ts, 65, 16))
+>fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 60, 27))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 67, 16))
 
     fooBar(y);
->fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 58, 27))
->y : Symbol(y, Decl(conditionalTypes2.ts, 65, 49))
+>fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 60, 27))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 67, 49))
 
     fooBar(z);
->fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 58, 27))
->z : Symbol(z, Decl(conditionalTypes2.ts, 65, 75))
+>fooBar : Symbol(fooBar, Decl(conditionalTypes2.ts, 60, 27))
+>z : Symbol(z, Decl(conditionalTypes2.ts, 67, 75))
 }
 
 function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: Extract2<T, Foo, Bar>) {
->f21 : Symbol(f21, Decl(conditionalTypes2.ts, 69, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 71, 13))
->x : Symbol(x, Decl(conditionalTypes2.ts, 71, 16))
+>f21 : Symbol(f21, Decl(conditionalTypes2.ts, 71, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 73, 13))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 73, 16))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes2.ts, 71, 13))
->Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
->Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
->y : Symbol(y, Decl(conditionalTypes2.ts, 71, 49))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 73, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 57, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 59, 27))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 73, 49))
 >Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes2.ts, 71, 13))
->Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
->Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
->z : Symbol(z, Decl(conditionalTypes2.ts, 71, 75))
->Extract2 : Symbol(Extract2, Decl(conditionalTypes2.ts, 61, 63))
->T : Symbol(T, Decl(conditionalTypes2.ts, 71, 13))
->Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 55, 1))
->Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 57, 27))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 73, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 57, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 59, 27))
+>z : Symbol(z, Decl(conditionalTypes2.ts, 73, 75))
+>Extract2 : Symbol(Extract2, Decl(conditionalTypes2.ts, 63, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 73, 13))
+>Foo : Symbol(Foo, Decl(conditionalTypes2.ts, 57, 1))
+>Bar : Symbol(Bar, Decl(conditionalTypes2.ts, 59, 27))
 
     fooBat(x);  // Error
->fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 60, 63))
->x : Symbol(x, Decl(conditionalTypes2.ts, 71, 16))
+>fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 62, 63))
+>x : Symbol(x, Decl(conditionalTypes2.ts, 73, 16))
 
     fooBat(y);  // Error
->fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 60, 63))
->y : Symbol(y, Decl(conditionalTypes2.ts, 71, 49))
+>fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 62, 63))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 73, 49))
 
     fooBat(z);  // Error
->fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 60, 63))
->z : Symbol(z, Decl(conditionalTypes2.ts, 71, 75))
-}
-
-// Repros from #22860
-
-class Opt<T> {
->Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 75, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 79, 10))
-
-    toVector(): Vector<T> {
->toVector : Symbol(Opt.toVector, Decl(conditionalTypes2.ts, 79, 14))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 79, 10))
-
-        return <any>undefined;
->undefined : Symbol(undefined)
-    }
-}
-
-interface Seq<T> {
->Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 83, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 85, 14))
-
-    tail(): Opt<Seq<T>>;
->tail : Symbol(Seq.tail, Decl(conditionalTypes2.ts, 85, 18))
->Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 75, 1))
->Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 83, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 85, 14))
-}
-
-class Vector<T> implements Seq<T> {
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
->Seq : Symbol(Seq, Decl(conditionalTypes2.ts, 83, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
-
-    tail(): Opt<Vector<T>> {
->tail : Symbol(Vector.tail, Decl(conditionalTypes2.ts, 89, 35))
->Opt : Symbol(Opt, Decl(conditionalTypes2.ts, 75, 1))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
-
-        return <any>undefined;
->undefined : Symbol(undefined)
-    }
-    partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
->partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 92, 5), Decl(conditionalTypes2.ts, 93, 88), Decl(conditionalTypes2.ts, 94, 64))
->U : Symbol(U, Decl(conditionalTypes2.ts, 93, 15))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
->predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 93, 28))
->v : Symbol(v, Decl(conditionalTypes2.ts, 93, 39))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
->v : Symbol(v, Decl(conditionalTypes2.ts, 93, 39))
->U : Symbol(U, Decl(conditionalTypes2.ts, 93, 15))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
->U : Symbol(U, Decl(conditionalTypes2.ts, 93, 15))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
->Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
->U : Symbol(U, Decl(conditionalTypes2.ts, 93, 15))
-
-    partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
->partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 92, 5), Decl(conditionalTypes2.ts, 93, 88), Decl(conditionalTypes2.ts, 94, 64))
->predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 94, 15))
->x : Symbol(x, Decl(conditionalTypes2.ts, 94, 26))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
-
-    partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
->partition2 : Symbol(Vector.partition2, Decl(conditionalTypes2.ts, 92, 5), Decl(conditionalTypes2.ts, 93, 88), Decl(conditionalTypes2.ts, 94, 64))
->U : Symbol(U, Decl(conditionalTypes2.ts, 95, 15))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
->predicate : Symbol(predicate, Decl(conditionalTypes2.ts, 95, 28))
->v : Symbol(v, Decl(conditionalTypes2.ts, 95, 39))
->T : Symbol(T, Decl(conditionalTypes2.ts, 89, 13))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
->U : Symbol(U, Decl(conditionalTypes2.ts, 95, 15))
->Vector : Symbol(Vector, Decl(conditionalTypes2.ts, 87, 1))
-
-        return <any>undefined;
->undefined : Symbol(undefined)
-    }
-}
-
-interface A1<T> {
->A1 : Symbol(A1, Decl(conditionalTypes2.ts, 98, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 100, 13))
-
-    bat: B1<A1<T>>;
->bat : Symbol(A1.bat, Decl(conditionalTypes2.ts, 100, 17))
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 102, 1))
->A1 : Symbol(A1, Decl(conditionalTypes2.ts, 98, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 100, 13))
-}
-
-interface B1<T> extends A1<T> {
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 102, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 104, 13))
->A1 : Symbol(A1, Decl(conditionalTypes2.ts, 98, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 104, 13))
-
-    bat: B1<B1<T>>;
->bat : Symbol(B1.bat, Decl(conditionalTypes2.ts, 104, 31))
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 102, 1))
->B1 : Symbol(B1, Decl(conditionalTypes2.ts, 102, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 104, 13))
-
-    boom: T extends any ? true : true
->boom : Symbol(B1.boom, Decl(conditionalTypes2.ts, 105, 19))
->T : Symbol(T, Decl(conditionalTypes2.ts, 104, 13))
+>fooBat : Symbol(fooBat, Decl(conditionalTypes2.ts, 62, 63))
+>z : Symbol(z, Decl(conditionalTypes2.ts, 73, 75))
 }
 
 // Repro from #22899
 
 declare function toString1(value: object | Function): string ;
->toString1 : Symbol(toString1, Decl(conditionalTypes2.ts, 107, 1))
->value : Symbol(value, Decl(conditionalTypes2.ts, 111, 27))
+>toString1 : Symbol(toString1, Decl(conditionalTypes2.ts, 77, 1))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 81, 27))
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 declare function toString2(value: Function): string ;
->toString2 : Symbol(toString2, Decl(conditionalTypes2.ts, 111, 62))
->value : Symbol(value, Decl(conditionalTypes2.ts, 112, 27))
+>toString2 : Symbol(toString2, Decl(conditionalTypes2.ts, 81, 62))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 82, 27))
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 
 function foo<T>(value: T) {
->foo : Symbol(foo, Decl(conditionalTypes2.ts, 112, 53))
->T : Symbol(T, Decl(conditionalTypes2.ts, 114, 13))
->value : Symbol(value, Decl(conditionalTypes2.ts, 114, 16))
->T : Symbol(T, Decl(conditionalTypes2.ts, 114, 13))
+>foo : Symbol(foo, Decl(conditionalTypes2.ts, 82, 53))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 84, 13))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 84, 16))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 84, 13))
 
     if (isFunction(value)) {
->isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 25, 1))
->value : Symbol(value, Decl(conditionalTypes2.ts, 114, 16))
+>isFunction : Symbol(isFunction, Decl(conditionalTypes2.ts, 27, 1))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 84, 16))
 
         toString1(value);
->toString1 : Symbol(toString1, Decl(conditionalTypes2.ts, 107, 1))
->value : Symbol(value, Decl(conditionalTypes2.ts, 114, 16))
+>toString1 : Symbol(toString1, Decl(conditionalTypes2.ts, 77, 1))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 84, 16))
 
         toString2(value);
->toString2 : Symbol(toString2, Decl(conditionalTypes2.ts, 111, 62))
->value : Symbol(value, Decl(conditionalTypes2.ts, 114, 16))
+>toString2 : Symbol(toString2, Decl(conditionalTypes2.ts, 81, 62))
+>value : Symbol(value, Decl(conditionalTypes2.ts, 84, 16))
     }
 }
 
 // Repro from #23052
 
 type A<T, V, E> =
->A : Symbol(A, Decl(conditionalTypes2.ts, 119, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 123, 7))
->V : Symbol(V, Decl(conditionalTypes2.ts, 123, 9))
->E : Symbol(E, Decl(conditionalTypes2.ts, 123, 12))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 89, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 93, 7))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 93, 9))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 93, 12))
 
   T extends object
->T : Symbol(T, Decl(conditionalTypes2.ts, 123, 7))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 93, 7))
 
     ? { [Q in { [P in keyof T]: T[P] extends V ? P : P; }[keyof T]]: A<T[Q], V, E>; }
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 125, 9))
->P : Symbol(P, Decl(conditionalTypes2.ts, 125, 17))
->T : Symbol(T, Decl(conditionalTypes2.ts, 123, 7))
->T : Symbol(T, Decl(conditionalTypes2.ts, 123, 7))
->P : Symbol(P, Decl(conditionalTypes2.ts, 125, 17))
->V : Symbol(V, Decl(conditionalTypes2.ts, 123, 9))
->P : Symbol(P, Decl(conditionalTypes2.ts, 125, 17))
->P : Symbol(P, Decl(conditionalTypes2.ts, 125, 17))
->T : Symbol(T, Decl(conditionalTypes2.ts, 123, 7))
->A : Symbol(A, Decl(conditionalTypes2.ts, 119, 1))
->T : Symbol(T, Decl(conditionalTypes2.ts, 123, 7))
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 125, 9))
->V : Symbol(V, Decl(conditionalTypes2.ts, 123, 9))
->E : Symbol(E, Decl(conditionalTypes2.ts, 123, 12))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 95, 9))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 95, 17))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 93, 7))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 93, 7))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 95, 17))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 93, 9))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 95, 17))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 95, 17))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 93, 7))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 89, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 93, 7))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 95, 9))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 93, 9))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 93, 12))
 
     : T extends V ? T : never;
->T : Symbol(T, Decl(conditionalTypes2.ts, 123, 7))
->V : Symbol(V, Decl(conditionalTypes2.ts, 123, 9))
->T : Symbol(T, Decl(conditionalTypes2.ts, 123, 7))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 93, 7))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 93, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 93, 7))
 
 type B<T, V> =
->B : Symbol(B, Decl(conditionalTypes2.ts, 126, 30))
->T : Symbol(T, Decl(conditionalTypes2.ts, 128, 7))
->V : Symbol(V, Decl(conditionalTypes2.ts, 128, 9))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 96, 30))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 98, 7))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 98, 9))
 
   T extends object
->T : Symbol(T, Decl(conditionalTypes2.ts, 128, 7))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 98, 7))
 
     ? { [Q in { [P in keyof T]: T[P] extends V ? P : P; }[keyof T]]: B<T[Q], V>; }
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 130, 9))
->P : Symbol(P, Decl(conditionalTypes2.ts, 130, 17))
->T : Symbol(T, Decl(conditionalTypes2.ts, 128, 7))
->T : Symbol(T, Decl(conditionalTypes2.ts, 128, 7))
->P : Symbol(P, Decl(conditionalTypes2.ts, 130, 17))
->V : Symbol(V, Decl(conditionalTypes2.ts, 128, 9))
->P : Symbol(P, Decl(conditionalTypes2.ts, 130, 17))
->P : Symbol(P, Decl(conditionalTypes2.ts, 130, 17))
->T : Symbol(T, Decl(conditionalTypes2.ts, 128, 7))
->B : Symbol(B, Decl(conditionalTypes2.ts, 126, 30))
->T : Symbol(T, Decl(conditionalTypes2.ts, 128, 7))
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 130, 9))
->V : Symbol(V, Decl(conditionalTypes2.ts, 128, 9))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 100, 9))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 100, 17))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 98, 7))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 98, 7))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 100, 17))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 98, 9))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 100, 17))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 100, 17))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 98, 7))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 96, 30))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 98, 7))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 100, 9))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 98, 9))
 
     : T extends V ? T : never;
->T : Symbol(T, Decl(conditionalTypes2.ts, 128, 7))
->V : Symbol(V, Decl(conditionalTypes2.ts, 128, 9))
->T : Symbol(T, Decl(conditionalTypes2.ts, 128, 7))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 98, 7))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 98, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 98, 7))
 
 type C<T, V, E> =
->C : Symbol(C, Decl(conditionalTypes2.ts, 131, 30))
->T : Symbol(T, Decl(conditionalTypes2.ts, 133, 7))
->V : Symbol(V, Decl(conditionalTypes2.ts, 133, 9))
->E : Symbol(E, Decl(conditionalTypes2.ts, 133, 12))
+>C : Symbol(C, Decl(conditionalTypes2.ts, 101, 30))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 103, 7))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 103, 9))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 103, 12))
 
   { [Q in { [P in keyof T]: T[P] extends V ? P : P; }[keyof T]]: C<T[Q], V, E>; };
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 134, 5))
->P : Symbol(P, Decl(conditionalTypes2.ts, 134, 13))
->T : Symbol(T, Decl(conditionalTypes2.ts, 133, 7))
->T : Symbol(T, Decl(conditionalTypes2.ts, 133, 7))
->P : Symbol(P, Decl(conditionalTypes2.ts, 134, 13))
->V : Symbol(V, Decl(conditionalTypes2.ts, 133, 9))
->P : Symbol(P, Decl(conditionalTypes2.ts, 134, 13))
->P : Symbol(P, Decl(conditionalTypes2.ts, 134, 13))
->T : Symbol(T, Decl(conditionalTypes2.ts, 133, 7))
->C : Symbol(C, Decl(conditionalTypes2.ts, 131, 30))
->T : Symbol(T, Decl(conditionalTypes2.ts, 133, 7))
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 134, 5))
->V : Symbol(V, Decl(conditionalTypes2.ts, 133, 9))
->E : Symbol(E, Decl(conditionalTypes2.ts, 133, 12))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 104, 5))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 104, 13))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 103, 7))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 103, 7))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 104, 13))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 103, 9))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 104, 13))
+>P : Symbol(P, Decl(conditionalTypes2.ts, 104, 13))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 103, 7))
+>C : Symbol(C, Decl(conditionalTypes2.ts, 101, 30))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 103, 7))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 104, 5))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 103, 9))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 103, 12))
 
 // Repro from #23100
 
 type A2<T, V, E> =
->A2 : Symbol(A2, Decl(conditionalTypes2.ts, 134, 82))
->T : Symbol(T, Decl(conditionalTypes2.ts, 138, 8))
->V : Symbol(V, Decl(conditionalTypes2.ts, 138, 10))
->E : Symbol(E, Decl(conditionalTypes2.ts, 138, 13))
+>A2 : Symbol(A2, Decl(conditionalTypes2.ts, 104, 82))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 108, 8))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 108, 10))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 108, 13))
 
     T extends object ? T extends any[] ? T : { [Q in keyof T]: A2<T[Q], V, E>; } : T;
->T : Symbol(T, Decl(conditionalTypes2.ts, 138, 8))
->T : Symbol(T, Decl(conditionalTypes2.ts, 138, 8))
->T : Symbol(T, Decl(conditionalTypes2.ts, 138, 8))
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 139, 48))
->T : Symbol(T, Decl(conditionalTypes2.ts, 138, 8))
->A2 : Symbol(A2, Decl(conditionalTypes2.ts, 134, 82))
->T : Symbol(T, Decl(conditionalTypes2.ts, 138, 8))
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 139, 48))
->V : Symbol(V, Decl(conditionalTypes2.ts, 138, 10))
->E : Symbol(E, Decl(conditionalTypes2.ts, 138, 13))
->T : Symbol(T, Decl(conditionalTypes2.ts, 138, 8))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 108, 8))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 108, 8))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 108, 8))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 109, 48))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 108, 8))
+>A2 : Symbol(A2, Decl(conditionalTypes2.ts, 104, 82))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 108, 8))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 109, 48))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 108, 10))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 108, 13))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 108, 8))
 
 type B2<T, V> =
->B2 : Symbol(B2, Decl(conditionalTypes2.ts, 139, 85))
->T : Symbol(T, Decl(conditionalTypes2.ts, 141, 8))
->V : Symbol(V, Decl(conditionalTypes2.ts, 141, 10))
+>B2 : Symbol(B2, Decl(conditionalTypes2.ts, 109, 85))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 111, 8))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 111, 10))
 
     T extends object ? T extends any[] ? T : { [Q in keyof T]: B2<T[Q], V>; } : T;
->T : Symbol(T, Decl(conditionalTypes2.ts, 141, 8))
->T : Symbol(T, Decl(conditionalTypes2.ts, 141, 8))
->T : Symbol(T, Decl(conditionalTypes2.ts, 141, 8))
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 142, 48))
->T : Symbol(T, Decl(conditionalTypes2.ts, 141, 8))
->B2 : Symbol(B2, Decl(conditionalTypes2.ts, 139, 85))
->T : Symbol(T, Decl(conditionalTypes2.ts, 141, 8))
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 142, 48))
->V : Symbol(V, Decl(conditionalTypes2.ts, 141, 10))
->T : Symbol(T, Decl(conditionalTypes2.ts, 141, 8))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 111, 8))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 111, 8))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 111, 8))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 112, 48))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 111, 8))
+>B2 : Symbol(B2, Decl(conditionalTypes2.ts, 109, 85))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 111, 8))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 112, 48))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 111, 10))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 111, 8))
 
 type C2<T, V, E> =
->C2 : Symbol(C2, Decl(conditionalTypes2.ts, 142, 82))
->T : Symbol(T, Decl(conditionalTypes2.ts, 144, 8))
->V : Symbol(V, Decl(conditionalTypes2.ts, 144, 10))
->E : Symbol(E, Decl(conditionalTypes2.ts, 144, 13))
+>C2 : Symbol(C2, Decl(conditionalTypes2.ts, 112, 82))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 114, 8))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 114, 10))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 114, 13))
 
     T extends object ? { [Q in keyof T]: C2<T[Q], V, E>; } : T;
->T : Symbol(T, Decl(conditionalTypes2.ts, 144, 8))
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 145, 26))
->T : Symbol(T, Decl(conditionalTypes2.ts, 144, 8))
->C2 : Symbol(C2, Decl(conditionalTypes2.ts, 142, 82))
->T : Symbol(T, Decl(conditionalTypes2.ts, 144, 8))
->Q : Symbol(Q, Decl(conditionalTypes2.ts, 145, 26))
->V : Symbol(V, Decl(conditionalTypes2.ts, 144, 10))
->E : Symbol(E, Decl(conditionalTypes2.ts, 144, 13))
->T : Symbol(T, Decl(conditionalTypes2.ts, 144, 8))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 114, 8))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 115, 26))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 114, 8))
+>C2 : Symbol(C2, Decl(conditionalTypes2.ts, 112, 82))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 114, 8))
+>Q : Symbol(Q, Decl(conditionalTypes2.ts, 115, 26))
+>V : Symbol(V, Decl(conditionalTypes2.ts, 114, 10))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 114, 13))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 114, 8))
 
 // Repro from #28654
 
 type MaybeTrue<T extends { b: boolean }> = true extends T["b"] ? "yes" : "no";
->MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 145, 63))
->T : Symbol(T, Decl(conditionalTypes2.ts, 149, 15))
->b : Symbol(b, Decl(conditionalTypes2.ts, 149, 26))
->T : Symbol(T, Decl(conditionalTypes2.ts, 149, 15))
+>MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 115, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 119, 15))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 119, 26))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 119, 15))
 
 type T0 = MaybeTrue<{ b: never }>     // "no"
->T0 : Symbol(T0, Decl(conditionalTypes2.ts, 149, 78))
->MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 145, 63))
->b : Symbol(b, Decl(conditionalTypes2.ts, 151, 21))
+>T0 : Symbol(T0, Decl(conditionalTypes2.ts, 119, 78))
+>MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 115, 63))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 121, 21))
 
 type T1 = MaybeTrue<{ b: false }>;    // "no"
->T1 : Symbol(T1, Decl(conditionalTypes2.ts, 151, 33))
->MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 145, 63))
->b : Symbol(b, Decl(conditionalTypes2.ts, 152, 21))
+>T1 : Symbol(T1, Decl(conditionalTypes2.ts, 121, 33))
+>MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 115, 63))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 122, 21))
 
 type T2 = MaybeTrue<{ b: true }>;     // "yes"
->T2 : Symbol(T2, Decl(conditionalTypes2.ts, 152, 34))
->MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 145, 63))
->b : Symbol(b, Decl(conditionalTypes2.ts, 153, 21))
+>T2 : Symbol(T2, Decl(conditionalTypes2.ts, 122, 34))
+>MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 115, 63))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 123, 21))
 
 type T3 = MaybeTrue<{ b: boolean }>;  // "yes"
->T3 : Symbol(T3, Decl(conditionalTypes2.ts, 153, 33))
->MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 145, 63))
->b : Symbol(b, Decl(conditionalTypes2.ts, 154, 21))
+>T3 : Symbol(T3, Decl(conditionalTypes2.ts, 123, 33))
+>MaybeTrue : Symbol(MaybeTrue, Decl(conditionalTypes2.ts, 115, 63))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 124, 21))
 
 // Repro from #28824
 
 type Union = 'a' | 'b';
->Union : Symbol(Union, Decl(conditionalTypes2.ts, 154, 36))
+>Union : Symbol(Union, Decl(conditionalTypes2.ts, 124, 36))
 
 type Product<A extends Union, B> = { f1: A, f2: B};
->Product : Symbol(Product, Decl(conditionalTypes2.ts, 158, 23))
->A : Symbol(A, Decl(conditionalTypes2.ts, 159, 13))
->Union : Symbol(Union, Decl(conditionalTypes2.ts, 154, 36))
->B : Symbol(B, Decl(conditionalTypes2.ts, 159, 29))
->f1 : Symbol(f1, Decl(conditionalTypes2.ts, 159, 36))
->A : Symbol(A, Decl(conditionalTypes2.ts, 159, 13))
->f2 : Symbol(f2, Decl(conditionalTypes2.ts, 159, 43))
->B : Symbol(B, Decl(conditionalTypes2.ts, 159, 29))
+>Product : Symbol(Product, Decl(conditionalTypes2.ts, 128, 23))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 129, 13))
+>Union : Symbol(Union, Decl(conditionalTypes2.ts, 124, 36))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 129, 29))
+>f1 : Symbol(f1, Decl(conditionalTypes2.ts, 129, 36))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 129, 13))
+>f2 : Symbol(f2, Decl(conditionalTypes2.ts, 129, 43))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 129, 29))
 
 type ProductUnion = Product<'a', 0> | Product<'b', 1>;
->ProductUnion : Symbol(ProductUnion, Decl(conditionalTypes2.ts, 159, 51))
->Product : Symbol(Product, Decl(conditionalTypes2.ts, 158, 23))
->Product : Symbol(Product, Decl(conditionalTypes2.ts, 158, 23))
+>ProductUnion : Symbol(ProductUnion, Decl(conditionalTypes2.ts, 129, 51))
+>Product : Symbol(Product, Decl(conditionalTypes2.ts, 128, 23))
+>Product : Symbol(Product, Decl(conditionalTypes2.ts, 128, 23))
 
 // {a: "b"; b: "a"}
 type UnionComplement = {
->UnionComplement : Symbol(UnionComplement, Decl(conditionalTypes2.ts, 160, 54))
+>UnionComplement : Symbol(UnionComplement, Decl(conditionalTypes2.ts, 130, 54))
 
   [K in Union]: Exclude<Union, K>
->K : Symbol(K, Decl(conditionalTypes2.ts, 164, 3))
->Union : Symbol(Union, Decl(conditionalTypes2.ts, 154, 36))
+>K : Symbol(K, Decl(conditionalTypes2.ts, 134, 3))
+>Union : Symbol(Union, Decl(conditionalTypes2.ts, 124, 36))
 >Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
->Union : Symbol(Union, Decl(conditionalTypes2.ts, 154, 36))
->K : Symbol(K, Decl(conditionalTypes2.ts, 164, 3))
+>Union : Symbol(Union, Decl(conditionalTypes2.ts, 124, 36))
+>K : Symbol(K, Decl(conditionalTypes2.ts, 134, 3))
 
 };
 type UCA = UnionComplement['a'];
->UCA : Symbol(UCA, Decl(conditionalTypes2.ts, 165, 2))
->UnionComplement : Symbol(UnionComplement, Decl(conditionalTypes2.ts, 160, 54))
+>UCA : Symbol(UCA, Decl(conditionalTypes2.ts, 135, 2))
+>UnionComplement : Symbol(UnionComplement, Decl(conditionalTypes2.ts, 130, 54))
 
 type UCB = UnionComplement['b'];
->UCB : Symbol(UCB, Decl(conditionalTypes2.ts, 166, 32))
->UnionComplement : Symbol(UnionComplement, Decl(conditionalTypes2.ts, 160, 54))
+>UCB : Symbol(UCB, Decl(conditionalTypes2.ts, 136, 32))
+>UnionComplement : Symbol(UnionComplement, Decl(conditionalTypes2.ts, 130, 54))
 
 // {a: "a"; b: "b"}
 type UnionComplementComplement = {
->UnionComplementComplement : Symbol(UnionComplementComplement, Decl(conditionalTypes2.ts, 167, 32))
+>UnionComplementComplement : Symbol(UnionComplementComplement, Decl(conditionalTypes2.ts, 137, 32))
 
   [K in Union]: Exclude<Union, Exclude<Union, K>>
->K : Symbol(K, Decl(conditionalTypes2.ts, 171, 3))
->Union : Symbol(Union, Decl(conditionalTypes2.ts, 154, 36))
+>K : Symbol(K, Decl(conditionalTypes2.ts, 141, 3))
+>Union : Symbol(Union, Decl(conditionalTypes2.ts, 124, 36))
 >Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
->Union : Symbol(Union, Decl(conditionalTypes2.ts, 154, 36))
+>Union : Symbol(Union, Decl(conditionalTypes2.ts, 124, 36))
 >Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
->Union : Symbol(Union, Decl(conditionalTypes2.ts, 154, 36))
->K : Symbol(K, Decl(conditionalTypes2.ts, 171, 3))
+>Union : Symbol(Union, Decl(conditionalTypes2.ts, 124, 36))
+>K : Symbol(K, Decl(conditionalTypes2.ts, 141, 3))
 
 };
 type UCCA = UnionComplementComplement['a'];
->UCCA : Symbol(UCCA, Decl(conditionalTypes2.ts, 172, 2))
->UnionComplementComplement : Symbol(UnionComplementComplement, Decl(conditionalTypes2.ts, 167, 32))
+>UCCA : Symbol(UCCA, Decl(conditionalTypes2.ts, 142, 2))
+>UnionComplementComplement : Symbol(UnionComplementComplement, Decl(conditionalTypes2.ts, 137, 32))
 
 type UCCB = UnionComplementComplement['b'];
->UCCB : Symbol(UCCB, Decl(conditionalTypes2.ts, 173, 43))
->UnionComplementComplement : Symbol(UnionComplementComplement, Decl(conditionalTypes2.ts, 167, 32))
+>UCCB : Symbol(UCCB, Decl(conditionalTypes2.ts, 143, 43))
+>UnionComplementComplement : Symbol(UnionComplementComplement, Decl(conditionalTypes2.ts, 137, 32))
 
 // {a: Product<'b', 1>; b: Product<'a', 0>}
 type ProductComplement = {
->ProductComplement : Symbol(ProductComplement, Decl(conditionalTypes2.ts, 174, 43))
+>ProductComplement : Symbol(ProductComplement, Decl(conditionalTypes2.ts, 144, 43))
 
   [K in Union]: Exclude<ProductUnion, { f1: K }>
->K : Symbol(K, Decl(conditionalTypes2.ts, 178, 3))
->Union : Symbol(Union, Decl(conditionalTypes2.ts, 154, 36))
+>K : Symbol(K, Decl(conditionalTypes2.ts, 148, 3))
+>Union : Symbol(Union, Decl(conditionalTypes2.ts, 124, 36))
 >Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
->ProductUnion : Symbol(ProductUnion, Decl(conditionalTypes2.ts, 159, 51))
->f1 : Symbol(f1, Decl(conditionalTypes2.ts, 178, 39))
->K : Symbol(K, Decl(conditionalTypes2.ts, 178, 3))
+>ProductUnion : Symbol(ProductUnion, Decl(conditionalTypes2.ts, 129, 51))
+>f1 : Symbol(f1, Decl(conditionalTypes2.ts, 148, 39))
+>K : Symbol(K, Decl(conditionalTypes2.ts, 148, 3))
 
 };
 type PCA = ProductComplement['a'];
->PCA : Symbol(PCA, Decl(conditionalTypes2.ts, 179, 2))
->ProductComplement : Symbol(ProductComplement, Decl(conditionalTypes2.ts, 174, 43))
+>PCA : Symbol(PCA, Decl(conditionalTypes2.ts, 149, 2))
+>ProductComplement : Symbol(ProductComplement, Decl(conditionalTypes2.ts, 144, 43))
 
 type PCB = ProductComplement['b'];
->PCB : Symbol(PCB, Decl(conditionalTypes2.ts, 180, 34))
->ProductComplement : Symbol(ProductComplement, Decl(conditionalTypes2.ts, 174, 43))
+>PCB : Symbol(PCB, Decl(conditionalTypes2.ts, 150, 34))
+>ProductComplement : Symbol(ProductComplement, Decl(conditionalTypes2.ts, 144, 43))
 
 // {a: Product<'a', 0>; b: Product<'b', 1>}
 type ProductComplementComplement = {
->ProductComplementComplement : Symbol(ProductComplementComplement, Decl(conditionalTypes2.ts, 181, 34))
+>ProductComplementComplement : Symbol(ProductComplementComplement, Decl(conditionalTypes2.ts, 151, 34))
 
   [K in Union]: Exclude<ProductUnion, Exclude<ProductUnion, { f1: K }>>
->K : Symbol(K, Decl(conditionalTypes2.ts, 185, 3))
->Union : Symbol(Union, Decl(conditionalTypes2.ts, 154, 36))
+>K : Symbol(K, Decl(conditionalTypes2.ts, 155, 3))
+>Union : Symbol(Union, Decl(conditionalTypes2.ts, 124, 36))
 >Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
->ProductUnion : Symbol(ProductUnion, Decl(conditionalTypes2.ts, 159, 51))
+>ProductUnion : Symbol(ProductUnion, Decl(conditionalTypes2.ts, 129, 51))
 >Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
->ProductUnion : Symbol(ProductUnion, Decl(conditionalTypes2.ts, 159, 51))
->f1 : Symbol(f1, Decl(conditionalTypes2.ts, 185, 61))
->K : Symbol(K, Decl(conditionalTypes2.ts, 185, 3))
+>ProductUnion : Symbol(ProductUnion, Decl(conditionalTypes2.ts, 129, 51))
+>f1 : Symbol(f1, Decl(conditionalTypes2.ts, 155, 61))
+>K : Symbol(K, Decl(conditionalTypes2.ts, 155, 3))
 
 };
 type PCCA = ProductComplementComplement['a'];
->PCCA : Symbol(PCCA, Decl(conditionalTypes2.ts, 186, 2))
->ProductComplementComplement : Symbol(ProductComplementComplement, Decl(conditionalTypes2.ts, 181, 34))
+>PCCA : Symbol(PCCA, Decl(conditionalTypes2.ts, 156, 2))
+>ProductComplementComplement : Symbol(ProductComplementComplement, Decl(conditionalTypes2.ts, 151, 34))
 
 type PCCB = ProductComplementComplement['b'];
->PCCB : Symbol(PCCB, Decl(conditionalTypes2.ts, 187, 45))
->ProductComplementComplement : Symbol(ProductComplementComplement, Decl(conditionalTypes2.ts, 181, 34))
+>PCCB : Symbol(PCCB, Decl(conditionalTypes2.ts, 157, 45))
+>ProductComplementComplement : Symbol(ProductComplementComplement, Decl(conditionalTypes2.ts, 151, 34))
+
+// Repros from #27118
+
+type MyElement<A> = [A] extends [[infer E]] ? E : never;
+>MyElement : Symbol(MyElement, Decl(conditionalTypes2.ts, 158, 45))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 162, 15))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 162, 15))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 162, 39))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 162, 39))
+
+function oops<A, B extends A>(arg: MyElement<A>): MyElement<B> {
+>oops : Symbol(oops, Decl(conditionalTypes2.ts, 162, 56))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 163, 14))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 163, 16))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 163, 14))
+>arg : Symbol(arg, Decl(conditionalTypes2.ts, 163, 30))
+>MyElement : Symbol(MyElement, Decl(conditionalTypes2.ts, 158, 45))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 163, 14))
+>MyElement : Symbol(MyElement, Decl(conditionalTypes2.ts, 158, 45))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 163, 16))
+
+    return arg;  // Unsound, should be error
+>arg : Symbol(arg, Decl(conditionalTypes2.ts, 163, 30))
+}
+
+type MyAcceptor<A> = [A] extends [[infer E]] ? (arg: E) => void : never;
+>MyAcceptor : Symbol(MyAcceptor, Decl(conditionalTypes2.ts, 165, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 167, 16))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 167, 16))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 167, 40))
+>arg : Symbol(arg, Decl(conditionalTypes2.ts, 167, 48))
+>E : Symbol(E, Decl(conditionalTypes2.ts, 167, 40))
+
+function oops2<A, B extends A>(arg: MyAcceptor<B>): MyAcceptor<A> {
+>oops2 : Symbol(oops2, Decl(conditionalTypes2.ts, 167, 72))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 168, 15))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 168, 17))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 168, 15))
+>arg : Symbol(arg, Decl(conditionalTypes2.ts, 168, 31))
+>MyAcceptor : Symbol(MyAcceptor, Decl(conditionalTypes2.ts, 165, 1))
+>B : Symbol(B, Decl(conditionalTypes2.ts, 168, 17))
+>MyAcceptor : Symbol(MyAcceptor, Decl(conditionalTypes2.ts, 165, 1))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 168, 15))
+
+    return arg;  // Unsound, should be error
+>arg : Symbol(arg, Decl(conditionalTypes2.ts, 168, 31))
+}
+
+type Dist<T> = T extends number ? number : string;
+>Dist : Symbol(Dist, Decl(conditionalTypes2.ts, 170, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 172, 10))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 172, 10))
+
+type Aux<A extends { a: unknown }> = A["a"] extends number ? number : string;
+>Aux : Symbol(Aux, Decl(conditionalTypes2.ts, 172, 50))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 173, 9))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 173, 20))
+>A : Symbol(A, Decl(conditionalTypes2.ts, 173, 9))
+
+type Nondist<T> = Aux<{a: T}>;
+>Nondist : Symbol(Nondist, Decl(conditionalTypes2.ts, 173, 77))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 174, 13))
+>Aux : Symbol(Aux, Decl(conditionalTypes2.ts, 172, 50))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 174, 23))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 174, 13))
+
+function oops3<T>(arg: Dist<T>): Nondist<T> {
+>oops3 : Symbol(oops3, Decl(conditionalTypes2.ts, 174, 30))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 175, 15))
+>arg : Symbol(arg, Decl(conditionalTypes2.ts, 175, 18))
+>Dist : Symbol(Dist, Decl(conditionalTypes2.ts, 170, 1))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 175, 15))
+>Nondist : Symbol(Nondist, Decl(conditionalTypes2.ts, 173, 77))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 175, 15))
+
+    return arg;  // Unsound, should be error
+>arg : Symbol(arg, Decl(conditionalTypes2.ts, 175, 18))
+}
 

--- a/tests/baselines/reference/conditionalTypes2.types
+++ b/tests/baselines/reference/conditionalTypes2.types
@@ -1,4 +1,6 @@
 === tests/cases/conformance/types/conditional/conditionalTypes2.ts ===
+// #27118: Conditional types are now invariant in the check type.
+
 interface Covariant<T> {
     foo: T extends string ? T : number;
 >foo : T extends string ? T : number
@@ -19,7 +21,7 @@ function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
 >a : Covariant<A>
 >b : Covariant<B>
 
-    a = b;
+    a = b;  // Error
 >a = b : Covariant<B>
 >a : Covariant<A>
 >b : Covariant<B>
@@ -40,7 +42,7 @@ function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
 >a : Contravariant<A>
 >b : Contravariant<B>
 
-    b = a;
+    b = a;  // Error
 >b = a : Contravariant<A>
 >b : Contravariant<B>
 >a : Contravariant<A>
@@ -207,71 +209,6 @@ function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: E
 >z : Extract2<T, Foo, Bar>
 }
 
-// Repros from #22860
-
-class Opt<T> {
->Opt : Opt<T>
-
-    toVector(): Vector<T> {
->toVector : () => Vector<T>
-
-        return <any>undefined;
-><any>undefined : any
->undefined : undefined
-    }
-}
-
-interface Seq<T> {
-    tail(): Opt<Seq<T>>;
->tail : () => Opt<Seq<T>>
-}
-
-class Vector<T> implements Seq<T> {
->Vector : Vector<T>
-
-    tail(): Opt<Vector<T>> {
->tail : () => Opt<Vector<T>>
-
-        return <any>undefined;
-><any>undefined : any
->undefined : undefined
-    }
-    partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
->partition2 : { <U extends T>(predicate: (v: T) => v is U): [Vector<U>, Vector<Exclude<T, U>>]; (predicate: (x: T) => boolean): [Vector<T>, Vector<T>]; }
->predicate : (v: T) => v is U
->v : T
-
-    partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
->partition2 : { <U extends T>(predicate: (v: T) => v is U): [Vector<U>, Vector<Exclude<T, U>>]; (predicate: (x: T) => boolean): [Vector<T>, Vector<T>]; }
->predicate : (x: T) => boolean
->x : T
-
-    partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
->partition2 : { <U extends T>(predicate: (v: T) => v is U): [Vector<U>, Vector<Exclude<T, U>>]; (predicate: (x: T) => boolean): [Vector<T>, Vector<T>]; }
->predicate : (v: T) => boolean
->v : T
-
-        return <any>undefined;
-><any>undefined : any
->undefined : undefined
-    }
-}
-
-interface A1<T> {
-    bat: B1<A1<T>>;
->bat : B1<A1<T>>
-}
-
-interface B1<T> extends A1<T> {
-    bat: B1<B1<T>>;
->bat : B1<B1<T>>
-
-    boom: T extends any ? true : true
->boom : T extends any ? true : true
->true : true
->true : true
-}
-
 // Repro from #22899
 
 declare function toString1(value: object | Function): string ;
@@ -430,4 +367,48 @@ type PCCA = ProductComplementComplement['a'];
 
 type PCCB = ProductComplementComplement['b'];
 >PCCB : Product<"b", 1>
+
+// Repros from #27118
+
+type MyElement<A> = [A] extends [[infer E]] ? E : never;
+>MyElement : MyElement<A>
+
+function oops<A, B extends A>(arg: MyElement<A>): MyElement<B> {
+>oops : <A, B extends A>(arg: MyElement<A>) => MyElement<B>
+>arg : MyElement<A>
+
+    return arg;  // Unsound, should be error
+>arg : MyElement<A>
+}
+
+type MyAcceptor<A> = [A] extends [[infer E]] ? (arg: E) => void : never;
+>MyAcceptor : MyAcceptor<A>
+>arg : E
+
+function oops2<A, B extends A>(arg: MyAcceptor<B>): MyAcceptor<A> {
+>oops2 : <A, B extends A>(arg: MyAcceptor<B>) => MyAcceptor<A>
+>arg : MyAcceptor<B>
+
+    return arg;  // Unsound, should be error
+>arg : MyAcceptor<B>
+}
+
+type Dist<T> = T extends number ? number : string;
+>Dist : Dist<T>
+
+type Aux<A extends { a: unknown }> = A["a"] extends number ? number : string;
+>Aux : Aux<A>
+>a : unknown
+
+type Nondist<T> = Aux<{a: T}>;
+>Nondist : Aux<{ a: T; }>
+>a : T
+
+function oops3<T>(arg: Dist<T>): Nondist<T> {
+>oops3 : <T>(arg: Dist<T>) => Aux<{ a: T; }>
+>arg : Dist<T>
+
+    return arg;  // Unsound, should be error
+>arg : Dist<T>
+}
 

--- a/tests/cases/conformance/types/conditional/conditionalTypes2.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes2.ts
@@ -1,6 +1,8 @@
 // @strict: true
 // @declaration: true
 
+// #27118: Conditional types are now invariant in the check type.
+
 interface Covariant<T> {
     foo: T extends string ? T : number;
 }
@@ -14,13 +16,13 @@ interface Invariant<T> {
 }
 
 function f1<A, B extends A>(a: Covariant<A>, b: Covariant<B>) {
-    a = b;
+    a = b;  // Error
     b = a;  // Error
 }
 
 function f2<A, B extends A>(a: Contravariant<A>, b: Contravariant<B>) {
     a = b;  // Error
-    b = a;
+    b = a;  // Error
 }
 
 function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>) {
@@ -76,38 +78,6 @@ function f21<T>(x: Extract<Extract<T, Foo>, Bar>, y: Extract<T, Foo & Bar>, z: E
     fooBat(x);  // Error
     fooBat(y);  // Error
     fooBat(z);  // Error
-}
-
-// Repros from #22860
-
-class Opt<T> {
-    toVector(): Vector<T> {
-        return <any>undefined;
-    }
-}
-
-interface Seq<T> {
-    tail(): Opt<Seq<T>>;
-}
-
-class Vector<T> implements Seq<T> {
-    tail(): Opt<Vector<T>> {
-        return <any>undefined;
-    }
-    partition2<U extends T>(predicate:(v:T)=>v is U): [Vector<U>,Vector<Exclude<T, U>>];
-    partition2(predicate:(x:T)=>boolean): [Vector<T>,Vector<T>];
-    partition2<U extends T>(predicate:(v:T)=>boolean): [Vector<U>,Vector<any>] {
-        return <any>undefined;
-    }
-}
-
-interface A1<T> {
-    bat: B1<A1<T>>;
-}
-
-interface B1<T> extends A1<T> {
-    bat: B1<B1<T>>;
-    boom: T extends any ? true : true
 }
 
 // Repro from #22899
@@ -190,3 +160,22 @@ type ProductComplementComplement = {
 };
 type PCCA = ProductComplementComplement['a'];
 type PCCB = ProductComplementComplement['b'];
+
+// Repros from #27118
+
+type MyElement<A> = [A] extends [[infer E]] ? E : never;
+function oops<A, B extends A>(arg: MyElement<A>): MyElement<B> {
+    return arg;  // Unsound, should be error
+}
+
+type MyAcceptor<A> = [A] extends [[infer E]] ? (arg: E) => void : never;
+function oops2<A, B extends A>(arg: MyAcceptor<B>): MyAcceptor<A> {
+    return arg;  // Unsound, should be error
+}
+
+type Dist<T> = T extends number ? number : string;
+type Aux<A extends { a: unknown }> = A["a"] extends number ? number : string;
+type Nondist<T> = Aux<{a: T}>;
+function oops3<T>(arg: Dist<T>): Nondist<T> {
+    return arg;  // Unsound, should be error
+}


### PR DESCRIPTION
Fixes #27118.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally
* [X] You've signed the CLA
* [X] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->