### PR TITLE
At '.' in object literal, don't close the object

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1482,7 +1482,15 @@ namespace ts {
                     // which would be a candidate for improved error reporting.
                     return token() === SyntaxKind.OpenBracketToken || isLiteralPropertyName();
                 case ParsingContext.ObjectLiteralMembers:
-                    return token() === SyntaxKind.OpenBracketToken || token() === SyntaxKind.AsteriskToken || token() === SyntaxKind.DotDotDotToken || isLiteralPropertyName();
+                    switch (token()) {
+                        case SyntaxKind.OpenBracketToken:
+                        case SyntaxKind.AsteriskToken:
+                        case SyntaxKind.DotDotDotToken:
+                        case SyntaxKind.DotToken: // Not an object literal member, but don't want to close the object (see `tests/cases/fourslash/completionsDotInObjectLiteral.ts`)
+                            return true;
+                        default:
+                            return isLiteralPropertyName();
+                    }
                 case ParsingContext.RestProperties:
                     return isLiteralPropertyName();
                 case ParsingContext.ObjectBindingElements:

--- a/src/testRunner/unittests/convertCompilerOptionsFromJson.ts
+++ b/src/testRunner/unittests/convertCompilerOptionsFromJson.ts
@@ -596,8 +596,7 @@ namespace ts {
                 {
                     compilerOptions: {
                         target: undefined,
-                        module: ModuleKind.ESNext,
-                        types: []
+                        module: ModuleKind.ESNext
                     },
                     hasParseErrors: true
                 }

--- a/tests/cases/fourslash/completionsDotInObjectLiteral.ts
+++ b/tests/cases/fourslash/completionsDotInObjectLiteral.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+////const o = {
+////    a: 1,
+////    ./**/
+////};
+
+verify.completions({ marker: "", exact: undefined });

--- a/tests/cases/fourslash/completionsDotInObjectLiteral.ts
+++ b/tests/cases/fourslash/completionsDotInObjectLiteral.ts
@@ -2,7 +2,9 @@
 
 ////const o = {
 ////    a: 1,
-////    ./**/
-////};
+////    [|.|]/**/
+////[|}|];
 
+verify.getSyntacticDiagnostics(test.ranges().map((range): FourSlashInterface.Diagnostic =>
+    ({ code: 1003, message: "Identifier expected.", range })));
 verify.completions({ marker: "", exact: undefined });


### PR DESCRIPTION
Fixes #27742

