### PR TITLE
fix to unlimited arguments

### DIFF
--- a/lib/lib.es2015.core.d.ts
+++ b/lib/lib.es2015.core.d.ts
@@ -280,9 +280,37 @@ interface ObjectConstructor {
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
      * target object. Returns the target object.
+     * @param target The target object to copy to.
+     * @param source The source object from which to copy properties.
+     */
+    assign<T, U>(target: T, source: U): T & U;
+
+    /**
+     * Copy the values of all of the enumerable own properties from one or more source objects to a
+     * target object. Returns the target object.
+     * @param target The target object to copy to.
+     * @param source1 The first source object from which to copy properties.
+     * @param source2 The second source object from which to copy properties.
+     */
+    assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
+
+    /**
+     * Copy the values of all of the enumerable own properties from one or more source objects to a
+     * target object. Returns the target object.
+     * @param target The target object to copy to.
+     * @param source1 The first source object from which to copy properties.
+     * @param source2 The second source object from which to copy properties.
+     * @param source3 The third source object from which to copy properties.
+     */
+    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+
+    /**
+     * Copy the values of all of the enumerable own properties from one or more source objects to a
+     * target object. Returns the target object.
+     * @param target The target object to copy to.
      * @param sources One or more source objects from which to copy properties
      */
-    assign<T extends any[]>(...sources: T): T extends (infer I)[] ? (I extends any ? (a: I) => void : never) extends (a: infer U) => void ? U : never : never;
+    assign(target: object, ...sources: any[]): any;
 
     /**
      * Returns an array of all symbol properties found directly on object o.

--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -260,37 +260,9 @@ interface ObjectConstructor {
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
      * target object. Returns the target object.
-     * @param target The target object to copy to.
-     * @param source The source object from which to copy properties.
-     */
-    assign<T, U>(target: T, source: U): T & U;
-
-    /**
-     * Copy the values of all of the enumerable own properties from one or more source objects to a
-     * target object. Returns the target object.
-     * @param target The target object to copy to.
-     * @param source1 The first source object from which to copy properties.
-     * @param source2 The second source object from which to copy properties.
-     */
-    assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
-
-    /**
-     * Copy the values of all of the enumerable own properties from one or more source objects to a
-     * target object. Returns the target object.
-     * @param target The target object to copy to.
-     * @param source1 The first source object from which to copy properties.
-     * @param source2 The second source object from which to copy properties.
-     * @param source3 The third source object from which to copy properties.
-     */
-    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
-
-    /**
-     * Copy the values of all of the enumerable own properties from one or more source objects to a
-     * target object. Returns the target object.
-     * @param target The target object to copy to.
      * @param sources One or more source objects from which to copy properties
      */
-    assign(target: object, ...sources: any[]): any;
+    assign<T extends any[]>(...sources: T): T extends (infer I)[] ? (I extends any ? (a: I) => void : never) extends (a: infer U) => void ? U : never : never;
 
     /**
      * Returns an array of all symbol properties found directly on object o.


### PR DESCRIPTION
We will be able to get variable length argument Intersection types with this PR.

```typescript
const ONE =   { type: 1 as 1 };
const TWO =   { type: 2 as 2 };
const THREE = { type: 3 as 3 };
const FOUR =  { type: 4 as 4 };
const FIVE =  { type: 5 as 5 };

const merged1 = Object.assign(ONE, TWO, THREE, FOUR);
const merged2 = Object.assign(ONE, TWO, THREE, FOUR, FIVE);
```
[before]
```typescript
const merged1: { type: 1 } & { type: 2 } & { type: 3 } & { type: 4 }
const merged2:　any
```
[after]
```typescript
const merged1: { type: 1 } & { type: 2 } & { type: 3 } & { type: 4 }
const merged2: { type: 1 } & { type: 2 } & { type: 3 } & { type: 4 } & { type: 5 }

```