### PR TITLE
Set default "jsx" mode to react

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -234,9 +234,9 @@ namespace ts {
         {
             name: "jsx",
             type: createMapFromTemplate({
+                "react": JsxEmit.React,
                 "preserve": JsxEmit.Preserve,
                 "react-native": JsxEmit.ReactNative,
-                "react": JsxEmit.React
             }),
             affectsSourceFile: true,
             paramType: Diagnostics.KIND,

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -25,7 +25,8 @@ namespace ts {
     }
 
     export function getTransformers(compilerOptions: CompilerOptions, customTransformers?: CustomTransformers) {
-        const jsx = compilerOptions.jsx;
+        const jsx = compilerOptions.jsx || JsxEmit.React;
+
         const languageVersion = getEmitScriptTarget(compilerOptions);
         const moduleKind = getEmitModuleKind(compilerOptions);
         const transformers: TransformerFactory<SourceFile | Bundle>[] = [];


### PR DESCRIPTION
### Checklist:
* [X] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [x] You've signed the CLA
* [X] Ask if this is actually needed
* [X] Run `jake runtests` locally -- they fail.
* [ ] Fix failing unit tests
* [ ] Update default value in the docs -- currently it's "Preserve"
  * https://www.typescriptlang.org/docs/handbook/compiler-options.html
* [ ] Follow [documentation section](https://github.com/Microsoft/TypeScript-wiki/blob/master/Contributing-to-TypeScript.md#documentation) in contributing wiki.
  * This PR is a breaking change for people that ignore the error and depend on current default behavior. 

### Description
If `compilerOptions.jsx` is `undefined` we treat it like if it were `JSXEmit.React`.

I don't feel like this is the right and the most elegant solution and I didn't fix tests yet so this is **WIP**.
I feel I need some more stepping around the code to find a place to actually set default config values.

Compiler still logs error when JSX flag is not explicitly set.
IMO is not too pretty so I have a fix for it in separate PR (https://github.com/hasparus/TypeScript/pull/1) I'd like to merge into this branch.

Solves #8529 