### PR TITLE
Handle when advancing past , of call expression moves past endPos of formatting

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -753,17 +753,17 @@ namespace ts.formatting {
 
                 const listEndToken = getCloseTokenForOpenToken(listStartToken);
                 if (listEndToken !== SyntaxKind.Unknown && formattingScanner.isOnToken()) {
-                    let tokenInfo = formattingScanner.readTokenInfo(parent);
+                    let tokenInfo: TokenInfo | undefined = formattingScanner.readTokenInfo(parent);
                     if (tokenInfo.token.kind === SyntaxKind.CommaToken && isCallLikeExpression(parent)) {
                         formattingScanner.advance();
-                        tokenInfo = formattingScanner.readTokenInfo(parent);
+                        tokenInfo = formattingScanner.isOnToken() ? formattingScanner.readTokenInfo(parent) : undefined;
                     }
 
                     // consume the list end token only if it is still belong to the parent
                     // there might be the case when current token matches end token but does not considered as one
                     // function (x: function) <--
                     // without this check close paren will be interpreted as list end token for function expression which is wrong
-                    if (tokenInfo.token.kind === listEndToken && rangeContainsRange(parent, tokenInfo.token)) {
+                    if (tokenInfo && tokenInfo.token.kind === listEndToken && rangeContainsRange(parent, tokenInfo.token)) {
                         // consume list end token
                         consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation, parent);
                     }

--- a/tests/cases/fourslash/formatRangeEndingAfterCommaOfCall.ts
+++ b/tests/cases/fourslash/formatRangeEndingAfterCommaOfCall.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts"/>
+////export const strong: StrongParser = verify(fmap(build(() =>
+////    /*start*/surround('**', compress(some(union([inline]), '**')), '**')),/*end*/
+////    ns => [html('strong', ns)]
+////), ([el]) => hasTightStartText(el));
+
+format.selection("start", "end");

--- a/tests/cases/fourslash/formatRangeEndingAfterCommaOfCall.ts
+++ b/tests/cases/fourslash/formatRangeEndingAfterCommaOfCall.ts
@@ -1,7 +1,7 @@
 /// <reference path="fourslash.ts"/>
-////export const strong: StrongParser = verify(fmap(build(() =>
-////    /*start*/surround('**', compress(some(union([inline]), '**')), '**')),/*end*/
-////    ns => [html('strong', ns)]
-////), ([el]) => hasTightStartText(el));
+////someCall(
+////    /*start*/"firstParameter",/*end*/
+////    "something else"
+////);
 
 format.selection("start", "end");


### PR DESCRIPTION
Fixes #26513