### PR TITLE
Indent "compilerOptions"

### DIFF
--- a/tests/cases/fourslash/codeFixCannotFindModule_generateTypes_all.ts
+++ b/tests/cases/fourslash/codeFixCannotFindModule_generateTypes_all.ts
@@ -27,7 +27,7 @@ verify.codeFixAll({
     "compilerOptions": {
         "baseUrl": ".",
         "paths": { "*": ["types/*"] },
-}
+    }
 }`,
     },
     commands: [


### PR DESCRIPTION
Fixes #26618
 Adds minor indentation fix in the file `codeFixCannotFindModule_generateTypes_all.ts`.
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

