### PR TITLE
Delete the link which doesn't work in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,6 @@ to establish the new baselines as the desired behavior. This will change the fil
 ## Localization
 
 All strings the user may see are stored in [`diagnosticMessages.json`](./src/compiler/diagnosticMessages.json).
-If you make changes to it, run `jake generate-diagnostics` to push them to the `Diagnostic` interface in [`diagnosticInformationMap.generated.ts`](./src/compiler/diagnosticInformationMap.generated.ts).
+If you make changes to it, run `jake generate-diagnostics` to push them to the `Diagnostic` interface in `diagnosticInformationMap.generated.ts`.
 
 See [coding guidelines on diagnostic messages](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines#diagnostic-messages).


### PR DESCRIPTION
Hi!

I found the link which doesn't work in CONTRIBUTING.md.
`./src/compiler/diagnosticInformationMap.generated.ts` doesn't  exist in this repo, so i remove the link.

This is a first PR, so if you have some problem, please tell me 🙇 

