### PR TITLE
Fix isSourceFileFromExternalLibrary for file with redirect

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1330,7 +1330,7 @@ namespace ts {
         }
 
         function isSourceFileFromExternalLibrary(file: SourceFile): boolean {
-            return !!sourceFilesFoundSearchingNodeModules.get((file.redirectInfo ? file.redirectInfo.redirectTarget : file).path);
+            return !!sourceFilesFoundSearchingNodeModules.get(file.path);
         }
 
         function isSourceFileDefaultLibrary(file: SourceFile): boolean {
@@ -2031,6 +2031,7 @@ namespace ts {
             redirect.resolvedPath = resolvedPath;
             redirect.originalFileName = originalFileName;
             redirect.redirectInfo = { redirectTarget, unredirected };
+            sourceFilesFoundSearchingNodeModules.set(path, !!sourceFilesFoundSearchingNodeModules.get(redirectTarget.path));
             Object.defineProperties(redirect, {
                 id: {
                     get(this: SourceFile) { return this.redirectInfo!.redirectTarget.id; },

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2031,7 +2031,7 @@ namespace ts {
             redirect.resolvedPath = resolvedPath;
             redirect.originalFileName = originalFileName;
             redirect.redirectInfo = { redirectTarget, unredirected };
-            sourceFilesFoundSearchingNodeModules.set(path, !!sourceFilesFoundSearchingNodeModules.get(redirectTarget.path));
+            sourceFilesFoundSearchingNodeModules.set(path, currentNodeModulesDepth > 0);
             Object.defineProperties(redirect, {
                 id: {
                     get(this: SourceFile) { return this.redirectInfo!.redirectTarget.id; },

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1330,7 +1330,7 @@ namespace ts {
         }
 
         function isSourceFileFromExternalLibrary(file: SourceFile): boolean {
-            return !!sourceFilesFoundSearchingNodeModules.get(file.path);
+            return !!sourceFilesFoundSearchingNodeModules.get((file.redirectInfo ? file.redirectInfo.redirectTarget : file).path);
         }
 
         function isSourceFileDefaultLibrary(file: SourceFile): boolean {

--- a/src/testRunner/unittests/programMissingFiles.ts
+++ b/src/testRunner/unittests/programMissingFiles.ts
@@ -112,7 +112,7 @@ namespace ts {
             const fooIndex = new documents.TextDocument("/node_modules/foo/index.d.ts", fooIndexText);
 
             const fs = vfs.createFromFileSystem(Harness.IO, /*ignoreCase*/ false, { documents: [a, bar, barFooPackage, barFooIndex, fooPackage, fooIndex], cwd: "/" });
-            const program = createProgram(["/index.ts"], emptyOptions, new fakes.CompilerHost(fs, { newLine: NewLineKind.LineFeed }));
+            const program = createProgram(["/a.ts"], emptyOptions, new fakes.CompilerHost(fs, { newLine: NewLineKind.LineFeed }));
 
             for (const file of [a, bar, barFooIndex, fooIndex]) {
                 const isExternalExpected = file !== a;

--- a/src/testRunner/unittests/programMissingFiles.ts
+++ b/src/testRunner/unittests/programMissingFiles.ts
@@ -98,4 +98,27 @@ namespace ts {
             ]);
         });
     });
+
+    describe("Program.isSourceFileFromExternalLibrary", () => {
+        it("works on redirect files", () => {
+            // In this example '/node_modules/foo/index.d.ts' will redirect to '/node_modules/bar/node_modules/foo/index.d.ts'.
+            const a = new documents.TextDocument("/a.ts", 'import * as bar from "bar"; import * as foo from "foo";');
+            const bar = new documents.TextDocument("/node_modules/bar/index.d.ts", 'import * as foo from "foo";');
+            const fooPackageJsonText = '{ "name": "foo", "version": "1.2.3" }';
+            const fooIndexText = "export const x: number;";
+            const barFooPackage = new documents.TextDocument("/node_modules/bar/node_modules/foo/package.json", fooPackageJsonText);
+            const barFooIndex = new documents.TextDocument("/node_modules/bar/node_modules/foo/index.d.ts", fooIndexText);
+            const fooPackage = new documents.TextDocument("/node_modules/foo/package.json", fooPackageJsonText);
+            const fooIndex = new documents.TextDocument("/node_modules/foo/index.d.ts", fooIndexText);
+
+            const fs = vfs.createFromFileSystem(Harness.IO, /*ignoreCase*/ false, { documents: [a, bar, barFooPackage, barFooIndex, fooPackage, fooIndex], cwd: "/" });
+            const program = createProgram(["/index.ts"], emptyOptions, new fakes.CompilerHost(fs, { newLine: NewLineKind.LineFeed }));
+
+            for (const file of [a, bar, barFooIndex, fooIndex]) {
+                const isExternalExpected = file !== a;
+                const isExternalActual = program.isSourceFileFromExternalLibrary(program.getSourceFile(file.file)!);
+                assert.equal(isExternalActual, isExternalExpected, `Expected ${file.file} isSourceFileFromExternalLibrary to be ${isExternalExpected}, got ${isExternalActual}`);
+            }
+        });
+    });
 }


### PR DESCRIPTION
Fixes a bug where a redirecting file was never considered to be from an external library.
