### PR TITLE
add index signature `[key:string]: any;` to Window

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -16445,6 +16445,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
 }
 
 declare var Window: {
+    [key:string]: any;
     prototype: Window;
     new(): Window;
 };


### PR DESCRIPTION
- https://stackoverflow.com/questions/42193262/element-implicitly-has-an-any-type-because-type-window-has-no-index-signatur#42193905
- https://basarat.gitbooks.io/typescript/docs/types/index-signatures.html

This is a pull request to fix a bug!

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

The reason for this pull request is to avoid having to set "suppressImplicitAnyIndexErrors":true in the tsconfig.json

Here's an example:
```
window[ 'VideoPlayer' ] = VideoPlayer
```

Fixes #27925 