### PR TITLE
Flag non-any/number/string operands on either side of comparison as errors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22698,8 +22698,10 @@ namespace ts {
                     if (checkForDisallowedESSymbolOperand(operator)) {
                         leftType = getBaseTypeOfLiteralType(checkNonNullType(leftType, left));
                         rightType = getBaseTypeOfLiteralType(checkNonNullType(rightType, right));
-                        if (!(isTypeComparableTo(leftType, rightType) || isTypeComparableTo(rightType, leftType) ||
-                            (isTypeAssignableTo(leftType, numberOrBigIntType) && isTypeAssignableTo(rightType, numberOrBigIntType))
+                        if (!checkTypeComparableWithLessOrGreaterThanOperator(leftType) &&
+                            !checkTypeComparableWithLessOrGreaterThanOperator(rightType) ||
+                            !(isTypeComparableTo(leftType, rightType) || isTypeComparableTo(rightType, leftType) ||
+                             (isTypeAssignableTo(leftType, numberOrBigIntType) && isTypeAssignableTo(rightType, numberOrBigIntType))
                         )) {
                             reportOperatorError();
                         }
@@ -22758,6 +22760,19 @@ namespace ts {
 
                 default:
                     return Debug.fail();
+            }
+
+            function checkTypeComparableWithLessOrGreaterThanOperator(valueType: Type): boolean {
+                const t = valueType.flags;
+                return (t === TypeFlags.String) ||
+                    (t === TypeFlags.Number) ||
+                    (t === TypeFlags.Any) ||
+                    (t === TypeFlags.TypeParameter) ||
+                    (t === TypeFlags.Enum) ||
+                    (t === TypeFlags.Object) ||
+                    (t === TypeFlags.Intersection) ||
+                    (t === (TypeFlags.EnumLiteral | TypeFlags.Union)) ||
+                    (t === (TypeFlags.Union));
             }
 
             function checkAssignmentDeclaration(kind: AssignmentDeclarationKind, rightType: Type) {

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
@@ -1,22 +1,30 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(11,11): error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(13,11): error TS2365: Operator '<' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(15,11): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(15,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(16,11): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(16,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(20,11): error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(22,11): error TS2365: Operator '>' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(24,11): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(24,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(25,11): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(25,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(29,11): error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(31,11): error TS2365: Operator '<=' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(33,11): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(33,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(34,11): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(34,24): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(38,11): error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(40,11): error TS2365: Operator '>=' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(42,11): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(42,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(43,11): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS2532: Object is possibly 'undefined'.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts (16 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts (24 errors) ====
     enum E { a, b, c }
     
     var a: number;
@@ -28,8 +36,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator <
     var ra1 = a < a;
     var ra2 = b < b;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'boolean'.
     var ra3 = c < c;
     var ra4 = d < d;
+              ~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'void' and 'void'.
     var ra5 = e < e;
     var ra6 = null < null;
               ~~~~
@@ -45,8 +57,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator >
     var rb1 = a > a;
     var rb2 = b > b;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'boolean' and 'boolean'.
     var rb3 = c > c;
     var rb4 = d > d;
+              ~~~~~
+!!! error TS2365: Operator '>' cannot be applied to types 'void' and 'void'.
     var rb5 = e > e;
     var rb6 = null > null;
               ~~~~
@@ -62,8 +78,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator <=
     var rc1 = a <= a;
     var rc2 = b <= b;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'boolean' and 'boolean'.
     var rc3 = c <= c;
     var rc4 = d <= d;
+              ~~~~~~
+!!! error TS2365: Operator '<=' cannot be applied to types 'void' and 'void'.
     var rc5 = e <= e;
     var rc6 = null <= null;
               ~~~~
@@ -79,8 +99,12 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
     // operator >=
     var rd1 = a >= a;
     var rd2 = b >= b;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'boolean' and 'boolean'.
     var rd3 = c >= c;
     var rd4 = d >= d;
+              ~~~~~~
+!!! error TS2365: Operator '>=' cannot be applied to types 'void' and 'void'.
     var rd5 = e >= e;
     var rd6 = null >= null;
               ~~~~


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `jake runtests` locally
* [x] You've signed the CLA
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #15506

