### PR TITLE
Add assignability rules for when the target is a conditional type

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3894,6 +3894,8 @@ namespace ts {
         wildcardInstantiation?: Type;    // Instantiation with type parameters mapped to wildcard type
         /* @internal */
         immediateBaseConstraint?: Type;  // Immediate base constraint cache
+        /* @internal */
+        instantiableToNever?: boolean;   // Flag set by `canBeNever`
     }
 
     /* @internal */

--- a/tests/baselines/reference/conditionalTypes2.errors.txt
+++ b/tests/baselines/reference/conditionalTypes2.errors.txt
@@ -24,9 +24,13 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(74,12): error TS2
 tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2345: Argument of type 'Extract2<T, Foo, Bar>' is not assignable to parameter of type '{ foo: string; bat: string; }'.
   Type 'T extends Bar ? T : never' is not assignable to type '{ foo: string; bat: string; }'.
     Type 'Bar & Foo & T' is not assignable to type '{ foo: string; bat: string; }'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(161,11): error TS2322: Type '{ a: number; b: number; }' is not assignable to type '[T] extends [[infer U]] ? U : { b: number; }'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(163,11): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<T>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(165,11): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<T & string>'.
+tests/cases/conformance/types/conditional/conditionalTypes2.ts(169,11): error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<[T] extends [never] ? { a: number; } : never>'.
 
 
-==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (7 errors) ====
+==== tests/cases/conformance/types/conditional/conditionalTypes2.ts (11 errors) ====
     interface Covariant<T> {
         foo: T extends string ? T : number;
     }
@@ -206,4 +210,36 @@ tests/cases/conformance/types/conditional/conditionalTypes2.ts(75,12): error TS2
     
     type C2<T, V, E> =
         T extends object ? { [Q in keyof T]: C2<T[Q], V, E>; } : T;
+    
+    // #26933
+    type Distributive<T> = T extends { a: number } ? { a: number } : { b: number };
+    function testAssignabilityToConditionalType<T>() {
+        const o = { a: 1, b: 2 };
+        const x: [T] extends [string] ? { y: number } : { a: number, b: number } = undefined!;
+        // Simple case: OK
+        const o1: [T] extends [number] ? { a: number } : { b: number } = o;
+        // Simple case where source happens to be a conditional type: also OK
+        const x1: [T] extends [number]
+            ? ([T] extends [string] ? { y: number } : { a: number })
+            : ([T] extends [string] ? { y: number } : { b: number })
+            = x;
+        // Infer type parameters: no good
+        const o2: [T] extends [[infer U]] ? U : { b: number } = o;
+              ~~
+!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type '[T] extends [[infer U]] ? U : { b: number; }'.
+        // Distributive where T might instantiate to never: no good
+        const o3: Distributive<T> = o;
+              ~~
+!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<T>'.
+        // Distributive where T & string might instantiate to never: also no good
+        const o4: Distributive<T & string> = o;
+              ~~
+!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<T & string>'.
+        // Distributive where {a: T} cannot instantiate to never: OK
+        const o5: Distributive<{ a: T }> = o;
+        // Distributive where check type is a conditional which returns a non-never type upon instantiation with `never` but can still return never otherwise: no good
+        const o6: Distributive<[T] extends [never] ? { a: number } : never> = o;
+              ~~
+!!! error TS2322: Type '{ a: number; b: number; }' is not assignable to type 'Distributive<[T] extends [never] ? { a: number; } : never>'.
+    }
     

--- a/tests/baselines/reference/conditionalTypes2.js
+++ b/tests/baselines/reference/conditionalTypes2.js
@@ -146,6 +146,30 @@ type B2<T, V> =
 type C2<T, V, E> =
     T extends object ? { [Q in keyof T]: C2<T[Q], V, E>; } : T;
 
+// #26933
+type Distributive<T> = T extends { a: number } ? { a: number } : { b: number };
+function testAssignabilityToConditionalType<T>() {
+    const o = { a: 1, b: 2 };
+    const x: [T] extends [string] ? { y: number } : { a: number, b: number } = undefined!;
+    // Simple case: OK
+    const o1: [T] extends [number] ? { a: number } : { b: number } = o;
+    // Simple case where source happens to be a conditional type: also OK
+    const x1: [T] extends [number]
+        ? ([T] extends [string] ? { y: number } : { a: number })
+        : ([T] extends [string] ? { y: number } : { b: number })
+        = x;
+    // Infer type parameters: no good
+    const o2: [T] extends [[infer U]] ? U : { b: number } = o;
+    // Distributive where T might instantiate to never: no good
+    const o3: Distributive<T> = o;
+    // Distributive where T & string might instantiate to never: also no good
+    const o4: Distributive<T & string> = o;
+    // Distributive where {a: T} cannot instantiate to never: OK
+    const o5: Distributive<{ a: T }> = o;
+    // Distributive where check type is a conditional which returns a non-never type upon instantiation with `never` but can still return never otherwise: no good
+    const o6: Distributive<[T] extends [never] ? { a: number } : never> = o;
+}
+
 
 //// [conditionalTypes2.js]
 "use strict";
@@ -221,6 +245,24 @@ function foo(value) {
         toString1(value);
         toString2(value);
     }
+}
+function testAssignabilityToConditionalType() {
+    var o = { a: 1, b: 2 };
+    var x = undefined;
+    // Simple case: OK
+    var o1 = o;
+    // Simple case where source happens to be a conditional type: also OK
+    var x1 = x;
+    // Infer type parameters: no good
+    var o2 = o;
+    // Distributive where T might instantiate to never: no good
+    var o3 = o;
+    // Distributive where T & string might instantiate to never: also no good
+    var o4 = o;
+    // Distributive where {a: T} cannot instantiate to never: OK
+    var o5 = o;
+    // Distributive where check type is a conditional which returns a non-never type upon instantiation with `never` but can still return never otherwise: no good
+    var o6 = o;
 }
 
 
@@ -304,3 +346,11 @@ declare type B2<T, V> = T extends object ? T extends any[] ? T : {
 declare type C2<T, V, E> = T extends object ? {
     [Q in keyof T]: C2<T[Q], V, E>;
 } : T;
+declare type Distributive<T> = T extends {
+    a: number;
+} ? {
+    a: number;
+} : {
+    b: number;
+};
+declare function testAssignabilityToConditionalType<T>(): void;

--- a/tests/baselines/reference/conditionalTypes2.symbols
+++ b/tests/baselines/reference/conditionalTypes2.symbols
@@ -551,3 +551,95 @@ type C2<T, V, E> =
 >E : Symbol(E, Decl(conditionalTypes2.ts, 144, 13))
 >T : Symbol(T, Decl(conditionalTypes2.ts, 144, 8))
 
+// #26933
+type Distributive<T> = T extends { a: number } ? { a: number } : { b: number };
+>Distributive : Symbol(Distributive, Decl(conditionalTypes2.ts, 145, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 148, 18))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 148, 18))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 148, 34))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 148, 50))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 148, 66))
+
+function testAssignabilityToConditionalType<T>() {
+>testAssignabilityToConditionalType : Symbol(testAssignabilityToConditionalType, Decl(conditionalTypes2.ts, 148, 79))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+
+    const o = { a: 1, b: 2 };
+>o : Symbol(o, Decl(conditionalTypes2.ts, 150, 9))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 150, 15))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 150, 21))
+
+    const x: [T] extends [string] ? { y: number } : { a: number, b: number } = undefined!;
+>x : Symbol(x, Decl(conditionalTypes2.ts, 151, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 151, 37))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 151, 53))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 151, 64))
+>undefined : Symbol(undefined)
+
+    // Simple case: OK
+    const o1: [T] extends [number] ? { a: number } : { b: number } = o;
+>o1 : Symbol(o1, Decl(conditionalTypes2.ts, 153, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 153, 38))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 153, 54))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 150, 9))
+
+    // Simple case where source happens to be a conditional type: also OK
+    const x1: [T] extends [number]
+>x1 : Symbol(x1, Decl(conditionalTypes2.ts, 155, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+
+        ? ([T] extends [string] ? { y: number } : { a: number })
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 156, 35))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 156, 51))
+
+        : ([T] extends [string] ? { y: number } : { b: number })
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+>y : Symbol(y, Decl(conditionalTypes2.ts, 157, 35))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 157, 51))
+
+        = x;
+>x : Symbol(x, Decl(conditionalTypes2.ts, 151, 9))
+
+    // Infer type parameters: no good
+    const o2: [T] extends [[infer U]] ? U : { b: number } = o;
+>o2 : Symbol(o2, Decl(conditionalTypes2.ts, 160, 9))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 160, 33))
+>U : Symbol(U, Decl(conditionalTypes2.ts, 160, 33))
+>b : Symbol(b, Decl(conditionalTypes2.ts, 160, 45))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 150, 9))
+
+    // Distributive where T might instantiate to never: no good
+    const o3: Distributive<T> = o;
+>o3 : Symbol(o3, Decl(conditionalTypes2.ts, 162, 9))
+>Distributive : Symbol(Distributive, Decl(conditionalTypes2.ts, 145, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 150, 9))
+
+    // Distributive where T & string might instantiate to never: also no good
+    const o4: Distributive<T & string> = o;
+>o4 : Symbol(o4, Decl(conditionalTypes2.ts, 164, 9))
+>Distributive : Symbol(Distributive, Decl(conditionalTypes2.ts, 145, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 150, 9))
+
+    // Distributive where {a: T} cannot instantiate to never: OK
+    const o5: Distributive<{ a: T }> = o;
+>o5 : Symbol(o5, Decl(conditionalTypes2.ts, 166, 9))
+>Distributive : Symbol(Distributive, Decl(conditionalTypes2.ts, 145, 63))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 166, 28))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 150, 9))
+
+    // Distributive where check type is a conditional which returns a non-never type upon instantiation with `never` but can still return never otherwise: no good
+    const o6: Distributive<[T] extends [never] ? { a: number } : never> = o;
+>o6 : Symbol(o6, Decl(conditionalTypes2.ts, 168, 9))
+>Distributive : Symbol(Distributive, Decl(conditionalTypes2.ts, 145, 63))
+>T : Symbol(T, Decl(conditionalTypes2.ts, 149, 44))
+>a : Symbol(a, Decl(conditionalTypes2.ts, 168, 50))
+>o : Symbol(o, Decl(conditionalTypes2.ts, 150, 9))
+}
+

--- a/tests/baselines/reference/conditionalTypes2.types
+++ b/tests/baselines/reference/conditionalTypes2.types
@@ -341,3 +341,80 @@ type C2<T, V, E> =
 
     T extends object ? { [Q in keyof T]: C2<T[Q], V, E>; } : T;
 
+// #26933
+type Distributive<T> = T extends { a: number } ? { a: number } : { b: number };
+>Distributive : Distributive<T>
+>a : number
+>a : number
+>b : number
+
+function testAssignabilityToConditionalType<T>() {
+>testAssignabilityToConditionalType : <T>() => void
+
+    const o = { a: 1, b: 2 };
+>o : { a: number; b: number; }
+>{ a: 1, b: 2 } : { a: number; b: number; }
+>a : number
+>1 : 1
+>b : number
+>2 : 2
+
+    const x: [T] extends [string] ? { y: number } : { a: number, b: number } = undefined!;
+>x : [T] extends [string] ? { y: number; } : { a: number; b: number; }
+>y : number
+>a : number
+>b : number
+>undefined! : never
+>undefined : undefined
+
+    // Simple case: OK
+    const o1: [T] extends [number] ? { a: number } : { b: number } = o;
+>o1 : [T] extends [number] ? { a: number; } : { b: number; }
+>a : number
+>b : number
+>o : { a: number; b: number; }
+
+    // Simple case where source happens to be a conditional type: also OK
+    const x1: [T] extends [number]
+>x1 : [T] extends [number] ? [T] extends [string] ? { y: number; } : { a: number; } : [T] extends [string] ? { y: number; } : { b: number; }
+
+        ? ([T] extends [string] ? { y: number } : { a: number })
+>y : number
+>a : number
+
+        : ([T] extends [string] ? { y: number } : { b: number })
+>y : number
+>b : number
+
+        = x;
+>x : [T] extends [string] ? { y: number; } : { a: number; b: number; }
+
+    // Infer type parameters: no good
+    const o2: [T] extends [[infer U]] ? U : { b: number } = o;
+>o2 : [T] extends [[infer U]] ? U : { b: number; }
+>b : number
+>o : { a: number; b: number; }
+
+    // Distributive where T might instantiate to never: no good
+    const o3: Distributive<T> = o;
+>o3 : Distributive<T>
+>o : { a: number; b: number; }
+
+    // Distributive where T & string might instantiate to never: also no good
+    const o4: Distributive<T & string> = o;
+>o4 : Distributive<T & string>
+>o : { a: number; b: number; }
+
+    // Distributive where {a: T} cannot instantiate to never: OK
+    const o5: Distributive<{ a: T }> = o;
+>o5 : Distributive<{ a: T; }>
+>a : T
+>o : { a: number; b: number; }
+
+    // Distributive where check type is a conditional which returns a non-never type upon instantiation with `never` but can still return never otherwise: no good
+    const o6: Distributive<[T] extends [never] ? { a: number } : never> = o;
+>o6 : Distributive<[T] extends [never] ? { a: number; } : never>
+>a : number
+>o : { a: number; b: number; }
+}
+

--- a/tests/baselines/reference/genericRestTypes.types
+++ b/tests/baselines/reference/genericRestTypes.types
@@ -22,7 +22,7 @@ type Bind1<T extends (head: any, ...tail: any[]) => any> = (...args: Tail<Parame
 >Bind1 : Bind1<T>
 >head : any
 >tail : any[]
->args : any[]
+>args : Tail<Parameters<T>>
 
 type Generic = Bind1<MyFunctionType>; // (bar: string) => boolean
 >Generic : Bind1<MyFunctionType>

--- a/tests/baselines/reference/genericRestTypes.types
+++ b/tests/baselines/reference/genericRestTypes.types
@@ -22,7 +22,7 @@ type Bind1<T extends (head: any, ...tail: any[]) => any> = (...args: Tail<Parame
 >Bind1 : Bind1<T>
 >head : any
 >tail : any[]
->args : Tail<Parameters<T>>
+>args : any[]
 
 type Generic = Bind1<MyFunctionType>; // (bar: string) => boolean
 >Generic : Bind1<MyFunctionType>

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.errors.txt
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/thisConditionalInferenceInClassBody.ts(10,27): error TS2345: Argument of type '"hi"' is not assignable to parameter of type 'Unwrap<this["prop"]>'.
-  Type '"hi"' is not assignable to type 'string & U'.
-    Type '"hi"' is not assignable to type 'U'.
+tests/cases/compiler/thisConditionalInferenceInClassBody.ts(25,5): error TS2322: Type 'Q' is not assignable to type 'InferBecauseWhyNotDistributive<Q>'.
+  Type '(arg: any) => any' is not assignable to type 'InferBecauseWhyNotDistributive<Q>'.
 
 
-==== tests/cases/compiler/thisConditionalInferenceInClassBody.ts (1 errors) ====
+==== tests/cases/compiler/thisConditionalInferenceInClassBody.ts (2 errors) ====
     type Wrapped<T> = { ___secret: T };
     type Unwrap<T> = T extends Wrapped<infer U> ? U : T;
     
@@ -16,16 +16,23 @@ tests/cases/compiler/thisConditionalInferenceInClassBody.ts(10,27): error TS2345
             set(this, 'prop', 'hi'); // <-- type error
                               ~~~~
 !!! error TS2345: Argument of type '"hi"' is not assignable to parameter of type 'Unwrap<this["prop"]>'.
-!!! error TS2345:   Type '"hi"' is not assignable to type 'string & U'.
-!!! error TS2345:     Type '"hi"' is not assignable to type 'U'.
         }
     }
     
     set(new Foo(), 'prop', 'hi'); // <-- typechecks
     
-    type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+    type InferBecauseWhyNot<T> = [T] extends [(p: infer P1) => any] ? P1 | T : never;
     
     function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
         return x;
+    }
+    
+    type InferBecauseWhyNotDistributive<T> = T extends (p: infer P1) => any ? P1 | T : never;
+    
+    function f2<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNotDistributive<Q> {
+        return x; // should fail, as when Q = never, InferBecauseWhyNotDistributive<Q> = never,
+        ~~~~~~~~~
+!!! error TS2322: Type 'Q' is not assignable to type 'InferBecauseWhyNotDistributive<Q>'.
+!!! error TS2322:   Type '(arg: any) => any' is not assignable to type 'InferBecauseWhyNotDistributive<Q>'.
     }
     

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.errors.txt
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.errors.txt
@@ -1,0 +1,31 @@
+tests/cases/compiler/thisConditionalInferenceInClassBody.ts(10,27): error TS2345: Argument of type '"hi"' is not assignable to parameter of type 'Unwrap<this["prop"]>'.
+  Type '"hi"' is not assignable to type 'string & U'.
+    Type '"hi"' is not assignable to type 'U'.
+
+
+==== tests/cases/compiler/thisConditionalInferenceInClassBody.ts (1 errors) ====
+    type Wrapped<T> = { ___secret: T };
+    type Unwrap<T> = T extends Wrapped<infer U> ? U : T;
+    
+    declare function set<T, K extends keyof T>(obj: T, key: K, value: Unwrap<T[K]>): Unwrap<T[K]>;
+    
+    class Foo {
+        prop: Wrapped<string>;
+    
+        method() {
+            set(this, 'prop', 'hi'); // <-- type error
+                              ~~~~
+!!! error TS2345: Argument of type '"hi"' is not assignable to parameter of type 'Unwrap<this["prop"]>'.
+!!! error TS2345:   Type '"hi"' is not assignable to type 'string & U'.
+!!! error TS2345:     Type '"hi"' is not assignable to type 'U'.
+        }
+    }
+    
+    set(new Foo(), 'prop', 'hi'); // <-- typechecks
+    
+    type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+    
+    function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
+        return x;
+    }
+    

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.js
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.js
@@ -14,10 +14,16 @@ class Foo {
 
 set(new Foo(), 'prop', 'hi'); // <-- typechecks
 
-type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+type InferBecauseWhyNot<T> = [T] extends [(p: infer P1) => any] ? P1 | T : never;
 
 function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
     return x;
+}
+
+type InferBecauseWhyNotDistributive<T> = T extends (p: infer P1) => any ? P1 | T : never;
+
+function f2<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNotDistributive<Q> {
+    return x; // should fail, as when Q = never, InferBecauseWhyNotDistributive<Q> = never,
 }
 
 
@@ -33,4 +39,7 @@ var Foo = /** @class */ (function () {
 set(new Foo(), 'prop', 'hi'); // <-- typechecks
 function f(x) {
     return x;
+}
+function f2(x) {
+    return x; // should fail, as when Q = never, InferBecauseWhyNotDistributive<Q> = never,
 }

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.js
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.js
@@ -14,6 +14,13 @@ class Foo {
 
 set(new Foo(), 'prop', 'hi'); // <-- typechecks
 
+type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+
+function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
+    return x;
+}
+
+
 //// [thisConditionalInferenceInClassBody.js]
 var Foo = /** @class */ (function () {
     function Foo() {
@@ -24,3 +31,6 @@ var Foo = /** @class */ (function () {
     return Foo;
 }());
 set(new Foo(), 'prop', 'hi'); // <-- typechecks
+function f(x) {
+    return x;
+}

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.js
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.js
@@ -1,0 +1,26 @@
+//// [thisConditionalInferenceInClassBody.ts]
+type Wrapped<T> = { ___secret: T };
+type Unwrap<T> = T extends Wrapped<infer U> ? U : T;
+
+declare function set<T, K extends keyof T>(obj: T, key: K, value: Unwrap<T[K]>): Unwrap<T[K]>;
+
+class Foo {
+    prop: Wrapped<string>;
+
+    method() {
+        set(this, 'prop', 'hi'); // <-- type error
+    }
+}
+
+set(new Foo(), 'prop', 'hi'); // <-- typechecks
+
+//// [thisConditionalInferenceInClassBody.js]
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    Foo.prototype.method = function () {
+        set(this, 'prop', 'hi'); // <-- type error
+    };
+    return Foo;
+}());
+set(new Foo(), 'prop', 'hi'); // <-- typechecks

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.symbols
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.symbols
@@ -1,0 +1,53 @@
+=== tests/cases/compiler/thisConditionalInferenceInClassBody.ts ===
+type Wrapped<T> = { ___secret: T };
+>Wrapped : Symbol(Wrapped, Decl(thisConditionalInferenceInClassBody.ts, 0, 0))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 0, 13))
+>___secret : Symbol(___secret, Decl(thisConditionalInferenceInClassBody.ts, 0, 19))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 0, 13))
+
+type Unwrap<T> = T extends Wrapped<infer U> ? U : T;
+>Unwrap : Symbol(Unwrap, Decl(thisConditionalInferenceInClassBody.ts, 0, 35))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 1, 12))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 1, 12))
+>Wrapped : Symbol(Wrapped, Decl(thisConditionalInferenceInClassBody.ts, 0, 0))
+>U : Symbol(U, Decl(thisConditionalInferenceInClassBody.ts, 1, 40))
+>U : Symbol(U, Decl(thisConditionalInferenceInClassBody.ts, 1, 40))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 1, 12))
+
+declare function set<T, K extends keyof T>(obj: T, key: K, value: Unwrap<T[K]>): Unwrap<T[K]>;
+>set : Symbol(set, Decl(thisConditionalInferenceInClassBody.ts, 1, 52))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 3, 21))
+>K : Symbol(K, Decl(thisConditionalInferenceInClassBody.ts, 3, 23))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 3, 21))
+>obj : Symbol(obj, Decl(thisConditionalInferenceInClassBody.ts, 3, 43))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 3, 21))
+>key : Symbol(key, Decl(thisConditionalInferenceInClassBody.ts, 3, 50))
+>K : Symbol(K, Decl(thisConditionalInferenceInClassBody.ts, 3, 23))
+>value : Symbol(value, Decl(thisConditionalInferenceInClassBody.ts, 3, 58))
+>Unwrap : Symbol(Unwrap, Decl(thisConditionalInferenceInClassBody.ts, 0, 35))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 3, 21))
+>K : Symbol(K, Decl(thisConditionalInferenceInClassBody.ts, 3, 23))
+>Unwrap : Symbol(Unwrap, Decl(thisConditionalInferenceInClassBody.ts, 0, 35))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 3, 21))
+>K : Symbol(K, Decl(thisConditionalInferenceInClassBody.ts, 3, 23))
+
+class Foo {
+>Foo : Symbol(Foo, Decl(thisConditionalInferenceInClassBody.ts, 3, 94))
+
+    prop: Wrapped<string>;
+>prop : Symbol(Foo.prop, Decl(thisConditionalInferenceInClassBody.ts, 5, 11))
+>Wrapped : Symbol(Wrapped, Decl(thisConditionalInferenceInClassBody.ts, 0, 0))
+
+    method() {
+>method : Symbol(Foo.method, Decl(thisConditionalInferenceInClassBody.ts, 6, 26))
+
+        set(this, 'prop', 'hi'); // <-- type error
+>set : Symbol(set, Decl(thisConditionalInferenceInClassBody.ts, 1, 52))
+>this : Symbol(Foo, Decl(thisConditionalInferenceInClassBody.ts, 3, 94))
+    }
+}
+
+set(new Foo(), 'prop', 'hi'); // <-- typechecks
+>set : Symbol(set, Decl(thisConditionalInferenceInClassBody.ts, 1, 52))
+>Foo : Symbol(Foo, Decl(thisConditionalInferenceInClassBody.ts, 3, 94))
+

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.symbols
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.symbols
@@ -51,3 +51,25 @@ set(new Foo(), 'prop', 'hi'); // <-- typechecks
 >set : Symbol(set, Decl(thisConditionalInferenceInClassBody.ts, 1, 52))
 >Foo : Symbol(Foo, Decl(thisConditionalInferenceInClassBody.ts, 3, 94))
 
+type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+>InferBecauseWhyNot : Symbol(InferBecauseWhyNot, Decl(thisConditionalInferenceInClassBody.ts, 13, 29))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 15, 24))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 15, 24))
+>p : Symbol(p, Decl(thisConditionalInferenceInClassBody.ts, 15, 40))
+>P1 : Symbol(P1, Decl(thisConditionalInferenceInClassBody.ts, 15, 48))
+>P1 : Symbol(P1, Decl(thisConditionalInferenceInClassBody.ts, 15, 48))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 15, 24))
+
+function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
+>f : Symbol(f, Decl(thisConditionalInferenceInClassBody.ts, 15, 77))
+>Q : Symbol(Q, Decl(thisConditionalInferenceInClassBody.ts, 17, 11))
+>arg : Symbol(arg, Decl(thisConditionalInferenceInClassBody.ts, 17, 22))
+>x : Symbol(x, Decl(thisConditionalInferenceInClassBody.ts, 17, 40))
+>Q : Symbol(Q, Decl(thisConditionalInferenceInClassBody.ts, 17, 11))
+>InferBecauseWhyNot : Symbol(InferBecauseWhyNot, Decl(thisConditionalInferenceInClassBody.ts, 13, 29))
+>Q : Symbol(Q, Decl(thisConditionalInferenceInClassBody.ts, 17, 11))
+
+    return x;
+>x : Symbol(x, Decl(thisConditionalInferenceInClassBody.ts, 17, 40))
+}
+

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.symbols
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.symbols
@@ -51,17 +51,17 @@ set(new Foo(), 'prop', 'hi'); // <-- typechecks
 >set : Symbol(set, Decl(thisConditionalInferenceInClassBody.ts, 1, 52))
 >Foo : Symbol(Foo, Decl(thisConditionalInferenceInClassBody.ts, 3, 94))
 
-type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+type InferBecauseWhyNot<T> = [T] extends [(p: infer P1) => any] ? P1 | T : never;
 >InferBecauseWhyNot : Symbol(InferBecauseWhyNot, Decl(thisConditionalInferenceInClassBody.ts, 13, 29))
 >T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 15, 24))
 >T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 15, 24))
->p : Symbol(p, Decl(thisConditionalInferenceInClassBody.ts, 15, 40))
->P1 : Symbol(P1, Decl(thisConditionalInferenceInClassBody.ts, 15, 48))
->P1 : Symbol(P1, Decl(thisConditionalInferenceInClassBody.ts, 15, 48))
+>p : Symbol(p, Decl(thisConditionalInferenceInClassBody.ts, 15, 43))
+>P1 : Symbol(P1, Decl(thisConditionalInferenceInClassBody.ts, 15, 51))
+>P1 : Symbol(P1, Decl(thisConditionalInferenceInClassBody.ts, 15, 51))
 >T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 15, 24))
 
 function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
->f : Symbol(f, Decl(thisConditionalInferenceInClassBody.ts, 15, 77))
+>f : Symbol(f, Decl(thisConditionalInferenceInClassBody.ts, 15, 81))
 >Q : Symbol(Q, Decl(thisConditionalInferenceInClassBody.ts, 17, 11))
 >arg : Symbol(arg, Decl(thisConditionalInferenceInClassBody.ts, 17, 22))
 >x : Symbol(x, Decl(thisConditionalInferenceInClassBody.ts, 17, 40))
@@ -71,5 +71,27 @@ function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
 
     return x;
 >x : Symbol(x, Decl(thisConditionalInferenceInClassBody.ts, 17, 40))
+}
+
+type InferBecauseWhyNotDistributive<T> = T extends (p: infer P1) => any ? P1 | T : never;
+>InferBecauseWhyNotDistributive : Symbol(InferBecauseWhyNotDistributive, Decl(thisConditionalInferenceInClassBody.ts, 19, 1))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 21, 36))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 21, 36))
+>p : Symbol(p, Decl(thisConditionalInferenceInClassBody.ts, 21, 52))
+>P1 : Symbol(P1, Decl(thisConditionalInferenceInClassBody.ts, 21, 60))
+>P1 : Symbol(P1, Decl(thisConditionalInferenceInClassBody.ts, 21, 60))
+>T : Symbol(T, Decl(thisConditionalInferenceInClassBody.ts, 21, 36))
+
+function f2<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNotDistributive<Q> {
+>f2 : Symbol(f2, Decl(thisConditionalInferenceInClassBody.ts, 21, 89))
+>Q : Symbol(Q, Decl(thisConditionalInferenceInClassBody.ts, 23, 12))
+>arg : Symbol(arg, Decl(thisConditionalInferenceInClassBody.ts, 23, 23))
+>x : Symbol(x, Decl(thisConditionalInferenceInClassBody.ts, 23, 41))
+>Q : Symbol(Q, Decl(thisConditionalInferenceInClassBody.ts, 23, 12))
+>InferBecauseWhyNotDistributive : Symbol(InferBecauseWhyNotDistributive, Decl(thisConditionalInferenceInClassBody.ts, 19, 1))
+>Q : Symbol(Q, Decl(thisConditionalInferenceInClassBody.ts, 23, 12))
+
+    return x; // should fail, as when Q = never, InferBecauseWhyNotDistributive<Q> = never,
+>x : Symbol(x, Decl(thisConditionalInferenceInClassBody.ts, 23, 41))
 }
 

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.types
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.types
@@ -38,3 +38,16 @@ set(new Foo(), 'prop', 'hi'); // <-- typechecks
 >'prop' : "prop"
 >'hi' : "hi"
 
+type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+>InferBecauseWhyNot : InferBecauseWhyNot<T>
+>p : P1
+
+function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
+>f : <Q extends (arg: any) => any>(x: Q) => InferBecauseWhyNot<Q>
+>arg : any
+>x : Q
+
+    return x;
+>x : Q
+}
+

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.types
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.types
@@ -38,7 +38,7 @@ set(new Foo(), 'prop', 'hi'); // <-- typechecks
 >'prop' : "prop"
 >'hi' : "hi"
 
-type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+type InferBecauseWhyNot<T> = [T] extends [(p: infer P1) => any] ? P1 | T : never;
 >InferBecauseWhyNot : InferBecauseWhyNot<T>
 >p : P1
 
@@ -48,6 +48,19 @@ function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
 >x : Q
 
     return x;
+>x : Q
+}
+
+type InferBecauseWhyNotDistributive<T> = T extends (p: infer P1) => any ? P1 | T : never;
+>InferBecauseWhyNotDistributive : InferBecauseWhyNotDistributive<T>
+>p : P1
+
+function f2<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNotDistributive<Q> {
+>f2 : <Q extends (arg: any) => any>(x: Q) => InferBecauseWhyNotDistributive<Q>
+>arg : any
+>x : Q
+
+    return x; // should fail, as when Q = never, InferBecauseWhyNotDistributive<Q> = never,
 >x : Q
 }
 

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.types
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.types
@@ -22,7 +22,7 @@ class Foo {
 >method : () => void
 
         set(this, 'prop', 'hi'); // <-- type error
->set(this, 'prop', 'hi') : Unwrap<this["prop"]>
+>set(this, 'prop', 'hi') : any
 >set : <T, K extends keyof T>(obj: T, key: K, value: Unwrap<T[K]>) => Unwrap<T[K]>
 >this : this
 >'prop' : "prop"

--- a/tests/baselines/reference/thisConditionalInferenceInClassBody.types
+++ b/tests/baselines/reference/thisConditionalInferenceInClassBody.types
@@ -1,0 +1,40 @@
+=== tests/cases/compiler/thisConditionalInferenceInClassBody.ts ===
+type Wrapped<T> = { ___secret: T };
+>Wrapped : Wrapped<T>
+>___secret : T
+
+type Unwrap<T> = T extends Wrapped<infer U> ? U : T;
+>Unwrap : Unwrap<T>
+
+declare function set<T, K extends keyof T>(obj: T, key: K, value: Unwrap<T[K]>): Unwrap<T[K]>;
+>set : <T, K extends keyof T>(obj: T, key: K, value: Unwrap<T[K]>) => Unwrap<T[K]>
+>obj : T
+>key : K
+>value : Unwrap<T[K]>
+
+class Foo {
+>Foo : Foo
+
+    prop: Wrapped<string>;
+>prop : Wrapped<string>
+
+    method() {
+>method : () => void
+
+        set(this, 'prop', 'hi'); // <-- type error
+>set(this, 'prop', 'hi') : Unwrap<this["prop"]>
+>set : <T, K extends keyof T>(obj: T, key: K, value: Unwrap<T[K]>) => Unwrap<T[K]>
+>this : this
+>'prop' : "prop"
+>'hi' : "hi"
+    }
+}
+
+set(new Foo(), 'prop', 'hi'); // <-- typechecks
+>set(new Foo(), 'prop', 'hi') : string
+>set : <T, K extends keyof T>(obj: T, key: K, value: Unwrap<T[K]>) => Unwrap<T[K]>
+>new Foo() : Foo
+>Foo : typeof Foo
+>'prop' : "prop"
+>'hi' : "hi"
+

--- a/tests/cases/compiler/thisConditionalInferenceInClassBody.ts
+++ b/tests/cases/compiler/thisConditionalInferenceInClassBody.ts
@@ -12,3 +12,9 @@ class Foo {
 }
 
 set(new Foo(), 'prop', 'hi'); // <-- typechecks
+
+type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+
+function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
+    return x;
+}

--- a/tests/cases/compiler/thisConditionalInferenceInClassBody.ts
+++ b/tests/cases/compiler/thisConditionalInferenceInClassBody.ts
@@ -13,8 +13,14 @@ class Foo {
 
 set(new Foo(), 'prop', 'hi'); // <-- typechecks
 
-type InferBecauseWhyNot<T> = T extends (p: infer P1) => any ? P1 | T : never;
+type InferBecauseWhyNot<T> = [T] extends [(p: infer P1) => any] ? P1 | T : never;
 
 function f<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNot<Q> {
     return x;
+}
+
+type InferBecauseWhyNotDistributive<T> = T extends (p: infer P1) => any ? P1 | T : never;
+
+function f2<Q extends (arg: any) => any>(x: Q): InferBecauseWhyNotDistributive<Q> {
+    return x; // should fail, as when Q = never, InferBecauseWhyNotDistributive<Q> = never,
 }

--- a/tests/cases/compiler/thisConditionalInferenceInClassBody.ts
+++ b/tests/cases/compiler/thisConditionalInferenceInClassBody.ts
@@ -1,0 +1,14 @@
+type Wrapped<T> = { ___secret: T };
+type Unwrap<T> = T extends Wrapped<infer U> ? U : T;
+
+declare function set<T, K extends keyof T>(obj: T, key: K, value: Unwrap<T[K]>): Unwrap<T[K]>;
+
+class Foo {
+    prop: Wrapped<string>;
+
+    method() {
+        set(this, 'prop', 'hi'); // <-- type error
+    }
+}
+
+set(new Foo(), 'prop', 'hi'); // <-- typechecks


### PR DESCRIPTION
Inspired by looking into #27014
Fixes #26933
Steals from #27589


This adds assignability rules for relating types when the target is a conditional type. We only check for conditional type target assignability when:
* The target is not distributive or,
* The distributive conditional type's check type cannot be instantiated to `never`
Given these circumstances, a type is assignable to the conditional in question if 
* it is assignable to both branches of the conditional, or
* if the conditional type looks to be always `true` (yet has `infer` types, preventing simplification) and it is assignable to the intersection of the instantiated constraint of the `true` branch and the uninstantiated constraint (this allows for "independent" infer types to not interfere with true branch assignability, whilst still preserving the assignment-blocking part of the existential-like behavior of the `infer` types).