### PR TITLE
When contextual type doesnt find property in unit type, use the index signature from unit type(fix the incorrectly used union type to get the signature)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16732,8 +16732,8 @@ namespace ts {
                             return restType;
                         }
                     }
-                    return isNumericLiteralName(name) && getIndexTypeOfContextualType(type, IndexKind.Number) ||
-                        getIndexTypeOfContextualType(type, IndexKind.String);
+                    return isNumericLiteralName(name) && getIndexTypeOfContextualType(t, IndexKind.Number) ||
+                        getIndexTypeOfContextualType(t, IndexKind.String);
                 }
                 return undefined;
             }, /*noReductions*/ true);

--- a/tests/baselines/reference/unionTypeWithIndexAndMethodSignature.js
+++ b/tests/baselines/reference/unionTypeWithIndexAndMethodSignature.js
@@ -1,0 +1,15 @@
+//// [unionTypeWithIndexAndMethodSignature.ts]
+interface Options {
+    m(x: number): void;
+    [key: string]: unknown;
+}
+declare function f(options: number | Options): void;
+f({
+    m(x) { },
+});
+
+//// [unionTypeWithIndexAndMethodSignature.js]
+"use strict";
+f({
+    m: function (x) { }
+});

--- a/tests/baselines/reference/unionTypeWithIndexAndMethodSignature.symbols
+++ b/tests/baselines/reference/unionTypeWithIndexAndMethodSignature.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/unionTypeWithIndexAndMethodSignature.ts ===
+interface Options {
+>Options : Symbol(Options, Decl(unionTypeWithIndexAndMethodSignature.ts, 0, 0))
+
+    m(x: number): void;
+>m : Symbol(Options.m, Decl(unionTypeWithIndexAndMethodSignature.ts, 0, 19))
+>x : Symbol(x, Decl(unionTypeWithIndexAndMethodSignature.ts, 1, 6))
+
+    [key: string]: unknown;
+>key : Symbol(key, Decl(unionTypeWithIndexAndMethodSignature.ts, 2, 5))
+}
+declare function f(options: number | Options): void;
+>f : Symbol(f, Decl(unionTypeWithIndexAndMethodSignature.ts, 3, 1))
+>options : Symbol(options, Decl(unionTypeWithIndexAndMethodSignature.ts, 4, 19))
+>Options : Symbol(Options, Decl(unionTypeWithIndexAndMethodSignature.ts, 0, 0))
+
+f({
+>f : Symbol(f, Decl(unionTypeWithIndexAndMethodSignature.ts, 3, 1))
+
+    m(x) { },
+>m : Symbol(m, Decl(unionTypeWithIndexAndMethodSignature.ts, 5, 3))
+>x : Symbol(x, Decl(unionTypeWithIndexAndMethodSignature.ts, 6, 6))
+
+});

--- a/tests/baselines/reference/unionTypeWithIndexAndMethodSignature.types
+++ b/tests/baselines/reference/unionTypeWithIndexAndMethodSignature.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/unionTypeWithIndexAndMethodSignature.ts ===
+interface Options {
+    m(x: number): void;
+>m : (x: number) => void
+>x : number
+
+    [key: string]: unknown;
+>key : string
+}
+declare function f(options: number | Options): void;
+>f : (options: number | Options) => void
+>options : number | Options
+
+f({
+>f({    m(x) { },}) : void
+>f : (options: number | Options) => void
+>{    m(x) { },} : { m(x: number): void; }
+
+    m(x) { },
+>m : (x: number) => void
+>x : number
+
+});

--- a/tests/cases/compiler/unionTypeWithIndexAndMethodSignature.ts
+++ b/tests/cases/compiler/unionTypeWithIndexAndMethodSignature.ts
@@ -1,0 +1,9 @@
+// @strict: true
+interface Options {
+    m(x: number): void;
+    [key: string]: unknown;
+}
+declare function f(options: number | Options): void;
+f({
+    m(x) { },
+});


### PR DESCRIPTION
Fixes #27949
