### PR TITLE
Fix bug in reduceEachChild for tagged template expressions

### DIFF
--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -1111,6 +1111,7 @@ namespace ts {
 
             case SyntaxKind.TaggedTemplateExpression:
                 result = reduceNode((<TaggedTemplateExpression>node).tag, cbNode, result);
+                result = reduceNodes((<NewExpression>node).typeArguments, cbNodes, result);
                 result = reduceNode((<TaggedTemplateExpression>node).template, cbNode, result);
                 break;
 

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -1111,7 +1111,7 @@ namespace ts {
 
             case SyntaxKind.TaggedTemplateExpression:
                 result = reduceNode((<TaggedTemplateExpression>node).tag, cbNode, result);
-                result = reduceNodes((<NewExpression>node).typeArguments, cbNodes, result);
+                result = reduceNodes((<TaggedTemplateExpression>node).typeArguments, cbNodes, result);
                 result = reduceNode((<TaggedTemplateExpression>node).template, cbNode, result);
                 break;
 

--- a/src/testRunner/unittests/transform.ts
+++ b/src/testRunner/unittests/transform.ts
@@ -45,9 +45,8 @@ namespace ts {
                 if (isIdentifier(node) && node.text === "oldName") {
                     return createIdentifier("newName");
                 }
-        
                 return visitEachChild(node, visitor, context);
-            }
+            };
             return (node: SourceFile) => visitNode(node, visitor);
         }
 
@@ -99,7 +98,7 @@ namespace ts {
                 },
                 compilerOptions: {
                     newLine: NewLineKind.CarriageReturnLineFeed,
-                    target: ts.ScriptTarget.Latest
+                    target: ScriptTarget.Latest
                 }
             }).outputText;
         });

--- a/tests/baselines/reference/transformApi/transformsCorrectly.issue27854.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.issue27854.js
@@ -1,0 +1,3 @@
+newName<{
+    a: string;
+}> ` ... `;

--- a/tests/baselines/reference/transformApi/transformsCorrectly.issue27854.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.issue27854.js
@@ -1,3 +1,1 @@
-newName<{
-    a: string;
-}> ` ... `;
+newName ` ... `;


### PR DESCRIPTION
Fixes #27854

The bug was in `reduceEachChild` where it was not reducing type arguments (recently introduced) of tagged template expressions.

Added a test case from the bug report.
/cc @DanielRosenwasser 