### PR TITLE
findAllRefs: Fix bug when symbol.declarations is undefined

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -143,7 +143,7 @@ namespace ts.FindAllReferences {
 
     function getDefinitionKindAndDisplayParts(symbol: Symbol, checker: TypeChecker, node: Node): { displayParts: SymbolDisplayPart[], kind: ScriptElementKind } {
         const meaning = Core.getIntersectingMeaningFromDeclarations(node, symbol);
-        const enclosingDeclaration = firstOrUndefined(symbol.declarations) || node;
+        const enclosingDeclaration = symbol.declarations && firstOrUndefined(symbol.declarations) || node;
         const { displayParts, symbolKind } =
             SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(checker, symbol, enclosingDeclaration.getSourceFile(), enclosingDeclaration, enclosingDeclaration, meaning);
         return { displayParts, kind: symbolKind };

--- a/tests/cases/fourslash/findAllRefsMappedType_nonHomomorphic.ts
+++ b/tests/cases/fourslash/findAllRefsMappedType_nonHomomorphic.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+
+////function f(x: { [K in "m"]: number; }) {
+////    x.[|m|];
+////    x.[|m|]
+////}
+
+verify.singleReferenceGroup("(property) m: number");


### PR DESCRIPTION
Fixes a bug where references on a non-homomorphic mapped type crashed due to `symbol.declarations` being undefined.