### PR TITLE
Let ts-ignore ignore suggestions

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1568,7 +1568,7 @@ namespace ts {
 
         function getSuggestionDiagnostics(sourceFile: SourceFile, cancellationToken: CancellationToken): ReadonlyArray<DiagnosticWithLocation> {
             return runWithCancellationToken(() => {
-                return getDiagnosticsProducingTypeChecker().getSuggestionDiagnostics(sourceFile, cancellationToken);
+                return getDiagnosticsProducingTypeChecker().getSuggestionDiagnostics(sourceFile, cancellationToken).filter(shouldReportDiagnostic);
             });
         }
 

--- a/tests/cases/fourslash/codeFixInferFromUsageTsIgnoreSuggestions.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageTsIgnoreSuggestions.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts' />
+// @allowJs: true
+// @checkJs: true
+// @Filename: important.js
+
+/////** @param x no types here! */
+/////**
+//// * 1
+//// * @param x a duplicate!
+//// * @param y yy
+//// */
+/////**
+//// * 2
+//// * @param z zz
+//// */
+////// @ts-ignore
+////function f([|x|]) {
+////    return x * 1
+////}
+////
+
+verify.getSuggestionDiagnostics([]);
+


### PR DESCRIPTION
Having checkJs on a JS file can potentially create many suggestions. One of the suggested codefixes is "add `// @ts-ignore`", but this does nothing. Making ts-ignore work with suggestions is one fix.

Two others are
1. Do not suggest ts-ignore for suggestions.
2. Allow (VS Code?) users to selectively turn off specific errors.

Of course, there is

3. Do nothing. The small suggestion &hellip; isn't that intrusive and (currently) is explicitly requested by checkJs users, who will not be bothered by the bogus ts-ignore suggestion.
