### PR TITLE
Correct codefix by removing private modifier

### DIFF
--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -200,11 +200,10 @@ namespace ts.codefix {
 
     function tryDeleteParameter(changes: textChanges.ChangeTracker, sourceFile: SourceFile, p: ParameterDeclaration, checker: TypeChecker, sourceFiles: ReadonlyArray<SourceFile>, isFixAll: boolean): void {
         if (mayDeleteParameter(p, checker, isFixAll)) {
-            const modifiers: Modifier["kind"][] = [SyntaxKind.PrivateKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.PublicKeyword, SyntaxKind.ReadonlyKeyword];
-            const foundModifiers = modifiers.map(modifier => findModifier(p, modifier)).filter(modifier => modifier !== undefined);
-            if (foundModifiers.length > 0) {
-                foundModifiers.forEach(modifier => {
-                    changes.deleteModifier(sourceFile, modifier!);
+            if (p.modifiers && p.modifiers.length > 0
+                && (!isIdentifier(p.name) || FindAllReferences.Core.isSymbolReferencedInFile(p.name, checker, sourceFile))) {
+                p.modifiers.forEach(modifier => {
+                    changes.deleteModifier(sourceFile, modifier);
                 });
             }
             else {

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -181,8 +181,8 @@ namespace ts.codefix {
 
     function deleteAssignments(changes: textChanges.ChangeTracker, sourceFile: SourceFile, token: Identifier, checker: TypeChecker) {
         FindAllReferences.Core.eachSymbolReferenceInFile(token, checker, sourceFile, (ref: Node) => {
-            if (ref.parent.kind === SyntaxKind.PropertyAccessExpression) ref = ref.parent;
-            if (ref.parent.kind === SyntaxKind.BinaryExpression && ref.parent.parent.kind === SyntaxKind.ExpressionStatement) {
+            if (isPropertyAccessExpression(ref.parent) && ref.parent.name === ref) ref = ref.parent;
+            if (isBinaryExpression(ref.parent) && isExpressionStatement(ref.parent.parent) && ref.parent.left === ref) {
                 changes.delete(sourceFile, ref.parent.parent);
             }
         });
@@ -201,7 +201,7 @@ namespace ts.codefix {
     function tryDeleteParameter(changes: textChanges.ChangeTracker, sourceFile: SourceFile, p: ParameterDeclaration, checker: TypeChecker, sourceFiles: ReadonlyArray<SourceFile>, isFixAll: boolean): void {
         if (mayDeleteParameter(p, checker, isFixAll)) {
             if (p.modifiers && p.modifiers.length > 0
-                && (!isIdentifier(p.name) || FindAllReferences.Core.isSymbolReferencedInFile(p.name, checker, sourceFile))) {
+                    && (!isIdentifier(p.name) || FindAllReferences.Core.isSymbolReferencedInFile(p.name, checker, sourceFile))) {
                 p.modifiers.forEach(modifier => {
                     changes.deleteModifier(sourceFile, modifier);
                 });

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -200,7 +200,7 @@ namespace ts.codefix {
 
     function tryDeleteParameter(changes: textChanges.ChangeTracker, sourceFile: SourceFile, p: ParameterDeclaration, checker: TypeChecker, sourceFiles: ReadonlyArray<SourceFile>, isFixAll: boolean): void {
         if (mayDeleteParameter(p, checker, isFixAll)) {
-            const privateModifier = ts.findModifier(p, ts.SyntaxKind.PrivateKeyword);
+            const privateModifier = findModifier(p, SyntaxKind.PrivateKeyword);
             if (privateModifier) {
                 changes.deleteModifier(sourceFile, p.modifiers![0]);
             }

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -200,8 +200,14 @@ namespace ts.codefix {
 
     function tryDeleteParameter(changes: textChanges.ChangeTracker, sourceFile: SourceFile, p: ParameterDeclaration, checker: TypeChecker, sourceFiles: ReadonlyArray<SourceFile>, isFixAll: boolean): void {
         if (mayDeleteParameter(p, checker, isFixAll)) {
-            changes.delete(sourceFile, p);
-            deleteUnusedArguments(changes, sourceFile, p, sourceFiles, checker);
+            const privateModifier = ts.findModifier(p, ts.SyntaxKind.PrivateKeyword);
+            if (privateModifier) {
+                changes.deleteModifier(sourceFile, p.modifiers![0]);
+            }
+            else {
+                changes.delete(sourceFile, p);
+                deleteUnusedArguments(changes, sourceFile, p, sourceFiles, checker);
+            }
         }
     }
 

--- a/src/services/codefixes/fixUnusedIdentifier.ts
+++ b/src/services/codefixes/fixUnusedIdentifier.ts
@@ -200,9 +200,12 @@ namespace ts.codefix {
 
     function tryDeleteParameter(changes: textChanges.ChangeTracker, sourceFile: SourceFile, p: ParameterDeclaration, checker: TypeChecker, sourceFiles: ReadonlyArray<SourceFile>, isFixAll: boolean): void {
         if (mayDeleteParameter(p, checker, isFixAll)) {
-            const privateModifier = findModifier(p, SyntaxKind.PrivateKeyword);
-            if (privateModifier) {
-                changes.deleteModifier(sourceFile, p.modifiers![0]);
+            const modifiers: Modifier["kind"][] = [SyntaxKind.PrivateKeyword, SyntaxKind.ProtectedKeyword, SyntaxKind.PublicKeyword, SyntaxKind.ReadonlyKeyword];
+            const foundModifiers = modifiers.map(modifier => findModifier(p, modifier)).filter(modifier => modifier !== undefined);
+            if (foundModifiers.length > 0) {
+                foundModifiers.forEach(modifier => {
+                    changes.deleteModifier(sourceFile, modifier!);
+                });
             }
             else {
                 changes.delete(sourceFile, p);

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -839,7 +839,9 @@ namespace ts.FindAllReferences.Core {
     }
 
     export function eachSymbolReferenceInFile<T>(definition: Identifier, checker: TypeChecker, sourceFile: SourceFile, cb: (token: Identifier) => T): T | undefined {
-        const symbol = checker.getSymbolAtLocation(definition);
+        const symbol = isParameterPropertyDeclaration(definition.parent)
+            ? first(checker.getSymbolsOfParameterPropertyDeclaration(definition.parent, definition.text))
+            : checker.getSymbolAtLocation(definition);
         if (!symbol) return undefined;
         for (const token of getPossibleSymbolReferenceNodes(sourceFile, symbol.name)) {
             if (!isIdentifier(token) || token === definition || token.escapedText !== definition.escapedText) continue;

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_parameter_modifier.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_parameter_modifier.ts
@@ -5,7 +5,7 @@
 
 ////export class Example {
 ////    prop: any;
-////    constructor(private arg: any) {
+////    constructor(private readonly arg: any) {
 ////        this.prop = arg;
 ////    }
 ////}

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_parameter_modifier.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_parameter_modifier.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @noUnusedLocals: true
+// @noUnusedParameters: true
+
+////export class Example {
+////    prop: any;
+////    constructor(private arg: any) {
+////        this.prop = arg;
+////    }
+////}
+
+verify.codeFix({
+    description: "Remove declaration for: 'arg'",
+    newFileContent:
+`export class Example {
+    prop: any;
+    constructor(arg: any) {
+        this.prop = arg;
+    }
+}`,
+});

--- a/tests/cases/fourslash/codeFixUnusedIdentifier_parameter_modifier_and_arg.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_parameter_modifier_and_arg.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+// @noUnusedLocals: true
+// @noUnusedParameters: true
+
+////export class Example {
+////    constructor(private readonly arg: any) {
+////    }
+////}
+
+verify.codeFix({
+    description: "Remove declaration for: 'arg'",
+    newFileContent:
+`export class Example {
+    constructor() {
+    }
+}`,
+});


### PR DESCRIPTION
In case of private attribute and private constructor parameter with
assignment in the constructor body, the parameter is flagged as unused.
This is caused by the private modifier which is shadowed by the
explicity assignment in the body.
This commit updates the codefix to just remove the private modifier in
this cases.

Status:
* [x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `jake runtests` locally
* [x] You've signed the CLA
* [x] There are new or updated unit tests validating the change

Fixes #24931