### PR TITLE
Correcting the order of passing arguments to word2mdJs for the task generating spec.md

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -26,7 +26,7 @@ const exec = require("./scripts/build/exec");
 const browserify = require("./scripts/build/browserify");
 const prepend = require("./scripts/build/prepend");
 const { removeSourceMaps } = require("./scripts/build/sourcemaps");
-const { CancellationTokenSource, CancelError, delay, Semaphore } = require("prex"); 
+const { CancellationTokenSource, CancelError, delay, Semaphore } = require("prex");
 const { libraryTargets, generateLibs } = require("./scripts/build/lib");
 const { runConsoleTests, cleanTestDirs, writeTestConfigFile, refBaseline, localBaseline, refRwcBaseline, localRwcBaseline } = require("./scripts/build/tests");
 
@@ -273,7 +273,7 @@ gulp.task(
 // Generate Markdown spec
 const specMd = "doc/spec.md";
 gulp.task(specMd, /*help*/ false, [word2mdJs], () =>
-    exec("cscript", ["//nologo", word2mdJs, path.resolve(specMd), path.resolve("doc/TypeScript Language Specification.docx")]));
+    exec("cscript", ["//nologo", word2mdJs, path.resolve("doc/TypeScript Language Specification.docx"), path.resolve(specMd)]));
 
 gulp.task(
     "generate-spec",
@@ -585,7 +585,7 @@ gulp.task(
                         project.waitForWorkToStart().then(() => {
                             source.cancel();
                         });
-                    
+
                         if (cmdLineOptions.tests || cmdLineOptions.failed) {
                             await runConsoleTests(runJs, "mocha-fivemat-progress-reporter", /*runInParallel*/ false, /*watchMode*/ true, source.token);
                         }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This is to fix the task of generating spec.md from the word document using scripts/word2md.js. 

word2md.js expects the arguments in the order as 

`word2md <inputfile> <outputfile>`

However, as per current code in Gulpfile.js, spec.md is being passed as an input file and word document is passed as an output file. Due to this, this task does not work properly. This PR will fix that issue.
