### PR TITLE
When getting contextual type with property name for element access, do it without using index signature since we are anyways going to get it later by index signature if nothing matches.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16741,7 +16741,7 @@ namespace ts {
             }
         }
 
-        function getTypeOfPropertyOfContextualType(type: Type, name: __String) {
+        function getTypeOfPropertyOfContextualType(type: Type, name: __String, ignoreIndexSignatureWhenNoProp?: boolean) {
             return mapType(type, t => {
                 if (t.flags & TypeFlags.StructuredType) {
                     const prop = getPropertyOfType(t, name);
@@ -16754,8 +16754,10 @@ namespace ts {
                             return restType;
                         }
                     }
-                    return isNumericLiteralName(name) && getIndexTypeOfContextualType(t, IndexKind.Number) ||
-                        getIndexTypeOfContextualType(t, IndexKind.String);
+                    if (!ignoreIndexSignatureWhenNoProp) {
+                        return isNumericLiteralName(name) && getIndexTypeOfContextualType(t, IndexKind.Number) ||
+                            getIndexTypeOfContextualType(t, IndexKind.String);
+                    }
                 }
                 return undefined;
             }, /*noReductions*/ true);
@@ -16806,7 +16808,7 @@ namespace ts {
         // type of T.
         function getContextualTypeForElementExpression(arrayContextualType: Type | undefined, index: number): Type | undefined {
             return arrayContextualType && (
-                getTypeOfPropertyOfContextualType(arrayContextualType, "" + index as __String)
+                getTypeOfPropertyOfContextualType(arrayContextualType, "" + index as __String, /*ignoreIndexSignatureWhenNoProp*/ true)
                 || getIndexTypeOfContextualType(arrayContextualType, IndexKind.Number)
                 || getIteratedTypeOrElementType(arrayContextualType, /*errorNode*/ undefined, /*allowStringInput*/ false, /*allowAsyncIterables*/ false, /*checkAssignability*/ false));
         }

--- a/tests/baselines/reference/narrowingByTypeofInSwitch.types
+++ b/tests/baselines/reference/narrowingByTypeofInSwitch.types
@@ -543,7 +543,7 @@ function multipleGenericFuse<X extends L | number, Y extends R | number>(xy: X |
 
         case 'function': return [xy, 1];
 >'function' : "function"
->[xy, 1] : [X, 1]
+>[xy, 1] : [X, number]
 >xy : X
 >1 : 1
 

--- a/tests/baselines/reference/unionTypeWithIndexAndTuple.js
+++ b/tests/baselines/reference/unionTypeWithIndexAndTuple.js
@@ -1,0 +1,11 @@
+//// [unionTypeWithIndexAndTuple.ts]
+interface I {
+    [index: number]: any;
+    someOtherProperty: number;
+}
+function f(args: ["a"] | I) { }
+f(["a"]);
+
+//// [unionTypeWithIndexAndTuple.js]
+function f(args) { }
+f(["a"]);

--- a/tests/baselines/reference/unionTypeWithIndexAndTuple.symbols
+++ b/tests/baselines/reference/unionTypeWithIndexAndTuple.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/unionTypeWithIndexAndTuple.ts ===
+interface I {
+>I : Symbol(I, Decl(unionTypeWithIndexAndTuple.ts, 0, 0))
+
+    [index: number]: any;
+>index : Symbol(index, Decl(unionTypeWithIndexAndTuple.ts, 1, 5))
+
+    someOtherProperty: number;
+>someOtherProperty : Symbol(I.someOtherProperty, Decl(unionTypeWithIndexAndTuple.ts, 1, 25))
+}
+function f(args: ["a"] | I) { }
+>f : Symbol(f, Decl(unionTypeWithIndexAndTuple.ts, 3, 1))
+>args : Symbol(args, Decl(unionTypeWithIndexAndTuple.ts, 4, 11))
+>I : Symbol(I, Decl(unionTypeWithIndexAndTuple.ts, 0, 0))
+
+f(["a"]);
+>f : Symbol(f, Decl(unionTypeWithIndexAndTuple.ts, 3, 1))
+

--- a/tests/baselines/reference/unionTypeWithIndexAndTuple.types
+++ b/tests/baselines/reference/unionTypeWithIndexAndTuple.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/unionTypeWithIndexAndTuple.ts ===
+interface I {
+    [index: number]: any;
+>index : number
+
+    someOtherProperty: number;
+>someOtherProperty : number
+}
+function f(args: ["a"] | I) { }
+>f : (args: I | ["a"]) => void
+>args : I | ["a"]
+
+f(["a"]);
+>f(["a"]) : void
+>f : (args: I | ["a"]) => void
+>["a"] : ["a"]
+>"a" : "a"
+

--- a/tests/cases/compiler/unionTypeWithIndexAndTuple.ts
+++ b/tests/cases/compiler/unionTypeWithIndexAndTuple.ts
@@ -1,0 +1,6 @@
+interface I {
+    [index: number]: any;
+    someOtherProperty: number;
+}
+function f(args: ["a"] | I) { }
+f(["a"]);


### PR DESCRIPTION
Fixes #27975