### PR TITLE
Do not do any reduction (even if it contains any) to the union type when getting contextual type

### DIFF
--- a/tests/baselines/reference/unionTypeWithIndexAndTuple.js
+++ b/tests/baselines/reference/unionTypeWithIndexAndTuple.js
@@ -1,0 +1,11 @@
+//// [unionTypeWithIndexAndTuple.ts]
+interface I {
+    [index: number]: any;
+    someOtherProperty: number;
+}
+function f(args: ["a"] | I) { }
+f(["a"]);
+
+//// [unionTypeWithIndexAndTuple.js]
+function f(args) { }
+f(["a"]);

--- a/tests/baselines/reference/unionTypeWithIndexAndTuple.symbols
+++ b/tests/baselines/reference/unionTypeWithIndexAndTuple.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/unionTypeWithIndexAndTuple.ts ===
+interface I {
+>I : Symbol(I, Decl(unionTypeWithIndexAndTuple.ts, 0, 0))
+
+    [index: number]: any;
+>index : Symbol(index, Decl(unionTypeWithIndexAndTuple.ts, 1, 5))
+
+    someOtherProperty: number;
+>someOtherProperty : Symbol(I.someOtherProperty, Decl(unionTypeWithIndexAndTuple.ts, 1, 25))
+}
+function f(args: ["a"] | I) { }
+>f : Symbol(f, Decl(unionTypeWithIndexAndTuple.ts, 3, 1))
+>args : Symbol(args, Decl(unionTypeWithIndexAndTuple.ts, 4, 11))
+>I : Symbol(I, Decl(unionTypeWithIndexAndTuple.ts, 0, 0))
+
+f(["a"]);
+>f : Symbol(f, Decl(unionTypeWithIndexAndTuple.ts, 3, 1))
+

--- a/tests/baselines/reference/unionTypeWithIndexAndTuple.types
+++ b/tests/baselines/reference/unionTypeWithIndexAndTuple.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/unionTypeWithIndexAndTuple.ts ===
+interface I {
+    [index: number]: any;
+>index : number
+
+    someOtherProperty: number;
+>someOtherProperty : number
+}
+function f(args: ["a"] | I) { }
+>f : (args: I | ["a"]) => void
+>args : I | ["a"]
+
+f(["a"]);
+>f(["a"]) : void
+>f : (args: I | ["a"]) => void
+>["a"] : ["a"]
+>"a" : "a"
+

--- a/tests/cases/compiler/unionTypeWithIndexAndTuple.ts
+++ b/tests/cases/compiler/unionTypeWithIndexAndTuple.ts
@@ -1,0 +1,6 @@
+interface I {
+    [index: number]: any;
+    someOtherProperty: number;
+}
+function f(args: ["a"] | I) { }
+f(["a"]);


### PR DESCRIPTION
Fixes #27975
Thanks @weswigham for point to this.