### PR TITLE
Infer over each mapped type constraint member if it is a union

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3682,6 +3682,7 @@ namespace ts {
     export interface ReverseMappedSymbol extends TransientSymbol {
         propertyType: Type;
         mappedType: MappedType;
+        constraintType: IndexType;
     }
 
     export const enum InternalSymbolName {
@@ -4090,6 +4091,7 @@ namespace ts {
     export interface ReverseMappedType extends ObjectType {
         source: Type;
         mappedType: MappedType;
+        constraintType: IndexType;
     }
 
     /* @internal */

--- a/tests/baselines/reference/checkJsxIntersectionElementPropsType.js
+++ b/tests/baselines/reference/checkJsxIntersectionElementPropsType.js
@@ -1,0 +1,38 @@
+//// [checkJsxIntersectionElementPropsType.tsx]
+declare namespace JSX {
+    interface ElementAttributesProperty { props: {}; }
+}
+
+declare class Component<P> {
+  constructor(props: Readonly<P>);
+  readonly props: Readonly<P>;
+}
+
+class C<T> extends Component<{ x?: boolean; } & T> {}
+const y = new C({foobar: "example"});
+const x = <C foobar="example" />
+
+//// [checkJsxIntersectionElementPropsType.jsx]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var C = /** @class */ (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C;
+}(Component));
+var y = new C({ foobar: "example" });
+var x = <C foobar="example"/>;

--- a/tests/baselines/reference/checkJsxIntersectionElementPropsType.symbols
+++ b/tests/baselines/reference/checkJsxIntersectionElementPropsType.symbols
@@ -1,0 +1,41 @@
+=== tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx ===
+declare namespace JSX {
+>JSX : Symbol(JSX, Decl(checkJsxIntersectionElementPropsType.tsx, 0, 0))
+
+    interface ElementAttributesProperty { props: {}; }
+>ElementAttributesProperty : Symbol(ElementAttributesProperty, Decl(checkJsxIntersectionElementPropsType.tsx, 0, 23))
+>props : Symbol(ElementAttributesProperty.props, Decl(checkJsxIntersectionElementPropsType.tsx, 1, 41))
+}
+
+declare class Component<P> {
+>Component : Symbol(Component, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 1))
+>P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 4, 24))
+
+  constructor(props: Readonly<P>);
+>props : Symbol(props, Decl(checkJsxIntersectionElementPropsType.tsx, 5, 14))
+>Readonly : Symbol(Readonly, Decl(lib.es5.d.ts, --, --))
+>P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 4, 24))
+
+  readonly props: Readonly<P>;
+>props : Symbol(Component.props, Decl(checkJsxIntersectionElementPropsType.tsx, 5, 34))
+>Readonly : Symbol(Readonly, Decl(lib.es5.d.ts, --, --))
+>P : Symbol(P, Decl(checkJsxIntersectionElementPropsType.tsx, 4, 24))
+}
+
+class C<T> extends Component<{ x?: boolean; } & T> {}
+>C : Symbol(C, Decl(checkJsxIntersectionElementPropsType.tsx, 7, 1))
+>T : Symbol(T, Decl(checkJsxIntersectionElementPropsType.tsx, 9, 8))
+>Component : Symbol(Component, Decl(checkJsxIntersectionElementPropsType.tsx, 2, 1))
+>x : Symbol(x, Decl(checkJsxIntersectionElementPropsType.tsx, 9, 30))
+>T : Symbol(T, Decl(checkJsxIntersectionElementPropsType.tsx, 9, 8))
+
+const y = new C({foobar: "example"});
+>y : Symbol(y, Decl(checkJsxIntersectionElementPropsType.tsx, 10, 5))
+>C : Symbol(C, Decl(checkJsxIntersectionElementPropsType.tsx, 7, 1))
+>foobar : Symbol(foobar, Decl(checkJsxIntersectionElementPropsType.tsx, 10, 17))
+
+const x = <C foobar="example" />
+>x : Symbol(x, Decl(checkJsxIntersectionElementPropsType.tsx, 11, 5))
+>C : Symbol(C, Decl(checkJsxIntersectionElementPropsType.tsx, 7, 1))
+>foobar : Symbol(foobar, Decl(checkJsxIntersectionElementPropsType.tsx, 11, 12))
+

--- a/tests/baselines/reference/checkJsxIntersectionElementPropsType.types
+++ b/tests/baselines/reference/checkJsxIntersectionElementPropsType.types
@@ -1,0 +1,35 @@
+=== tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx ===
+declare namespace JSX {
+    interface ElementAttributesProperty { props: {}; }
+>props : {}
+}
+
+declare class Component<P> {
+>Component : Component<P>
+
+  constructor(props: Readonly<P>);
+>props : Readonly<P>
+
+  readonly props: Readonly<P>;
+>props : Readonly<P>
+}
+
+class C<T> extends Component<{ x?: boolean; } & T> {}
+>C : C<T>
+>Component : Component<{ x?: boolean | undefined; } & T>
+>x : boolean | undefined
+
+const y = new C({foobar: "example"});
+>y : C<{ foobar: {}; }>
+>new C({foobar: "example"}) : C<{ foobar: {}; }>
+>C : typeof C
+>{foobar: "example"} : { foobar: string; }
+>foobar : string
+>"example" : "example"
+
+const x = <C foobar="example" />
+>x : error
+><C foobar="example" /> : error
+>C : typeof C
+>foobar : string
+

--- a/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
+++ b/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
@@ -1,0 +1,14 @@
+// @jsx: preserve
+// @strict: true
+declare namespace JSX {
+    interface ElementAttributesProperty { props: {}; }
+}
+
+declare class Component<P> {
+  constructor(props: Readonly<P>);
+  readonly props: Readonly<P>;
+}
+
+class C<T> extends Component<{ x?: boolean; } & T> {}
+const y = new C({foobar: "example"});
+const x = <C foobar="example" />


### PR DESCRIPTION
Fixes #28001
(There might be another prior report about the non-JSX case with someone assigned to it or with some other kind of resolution marked on it; I'm not sure)

