### PR TITLE
Fix performance regression when reusing old state

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -594,7 +594,7 @@ namespace ts {
         let diagnosticsProducingTypeChecker: TypeChecker;
         let noDiagnosticsTypeChecker: TypeChecker;
         let classifiableNames: UnderscoreEscapedMap<true>;
-        let unmodifiedSourceFilesWithAmbientModules: SourceFile[] | undefined;
+        const ambientModuleNameToUnmodifiedFileName = createMap<string>();
 
         const cachedSemanticDiagnosticsForFile: DiagnosticCache<Diagnostic> = {};
         const cachedDeclarationDiagnosticsForFile: DiagnosticCache<DiagnosticWithLocation> = {};
@@ -1006,16 +1006,14 @@ namespace ts {
                 }
 
                 // at least one of declarations should come from non-modified source file
-                const firstUnmodifiedFile = unmodifiedSourceFilesWithAmbientModules && unmodifiedSourceFilesWithAmbientModules.find(
-                    f => contains(f.ambientModuleNames, moduleName)
-                );
+                const unmodifiedFile = ambientModuleNameToUnmodifiedFileName.get(moduleName);
 
-                if (!firstUnmodifiedFile) {
+                if (!unmodifiedFile) {
                     return false;
                 }
 
                 if (isTraceEnabled(options, host)) {
-                    trace(host, Diagnostics.Module_0_was_resolved_as_ambient_module_declared_in_1_since_this_file_was_not_modified, moduleName, firstUnmodifiedFile.fileName);
+                    trace(host, Diagnostics.Module_0_was_resolved_as_ambient_module_declared_in_1_since_this_file_was_not_modified, moduleName, unmodifiedFile);
                 }
                 return true;
             }
@@ -1204,7 +1202,13 @@ namespace ts {
             }
 
             const modifiedFiles = modifiedSourceFiles.map(f => f.oldFile);
-            unmodifiedSourceFilesWithAmbientModules = oldSourceFiles.filter((f) => !!f.ambientModuleNames.length && !contains(modifiedFiles, f));
+            for (const oldFile of oldSourceFiles) {
+                if (!contains(modifiedFiles, oldFile)) {
+                    for (const moduleName of oldFile.ambientModuleNames) {
+                        ambientModuleNameToUnmodifiedFileName.set(moduleName, oldFile.fileName);
+                    }
+                }
+            }
             // try to verify results of module resolution
             for (const { oldFile: oldSourceFile, newFile: newSourceFile } of modifiedSourceFiles) {
                 const newSourceFilePath = getNormalizedAbsolutePath(newSourceFile.originalFileName, currentDirectory);


### PR DESCRIPTION
Fixes: #28025

This (hopefully) fixes the performance regression reported in #28025.
`moduleNameResolvesToAmbientModuleInNonModifiedFile` may be executed for each import (or type reference directive) in every file of the program.
Previously it would iterate through all files of the program where most of them are likely to have no ambient module names.
The new implementation stores a file of unmodified files that contain ambient module names. This list is typically a lot shorter than the list of all files.

Note that I removed some unnecessary parameters because their contents are already available in an enclosing scope.
Also note that the old implementation used `modifiedFilePaths` even if it was `undefined`. In that case it assumed all files to be unchanged. But in fact every file could have been changed because reusing the old program aborted before populating that variable.