### PR TITLE
Like #27964 but for JSX

### DIFF
--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -1378,6 +1378,7 @@ namespace ts {
             case SyntaxKind.JsxSelfClosingElement:
             case SyntaxKind.JsxOpeningElement:
                 result = reduceNode((<JsxSelfClosingElement | JsxOpeningElement>node).tagName, cbNode, result);
+                result = reduceNodes((<JsxSelfClosingElement | JsxOpeningElement>node).typeArguments, cbNode, result);
                 result = reduceNode((<JsxSelfClosingElement | JsxOpeningElement>node).attributes, cbNode, result);
                 break;
 


### PR DESCRIPTION
Probably fixes #27854 but where you replace all instances of "tagged template" with "jsx element".

