### PR TITLE
Fix tests for node 11

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -3846,7 +3846,7 @@ ${code}
         }
 
         // put ranges in the correct order
-        localRanges = localRanges.sort((a, b) => a.pos < b.pos ? -1 : 1);
+        localRanges = localRanges.sort((a, b) => a.pos < b.pos ? -1 : a.pos === b.pos && a.end > b.end ? -1 : 1);
         localRanges.forEach((r) => { ranges.push(r); });
 
         return {

--- a/tests/cases/fourslash/generateTypes_baselines.ts
+++ b/tests/cases/fourslash/generateTypes_baselines.ts
@@ -6,14 +6,14 @@ verify.generateTypes(
     // would like to test against the real "global" but that may vary between node versions.
     {
         value: {
-            Array: ignore(Array, ["values"]),
+            Array: ignore(Array, ["values", "flat", "flatMap"]),
             Boolean,
             Date,
             Math,
             Number,
             RegExp,
             String: ignore(String, ["padStart", "padEnd", "trimStart", "trimEnd"]),
-            Symbol: ignore(Symbol, ["asyncIterator"]),
+            Symbol: ignore(Symbol, ["asyncIterator", "description"]),
         },
         outputBaseline: "global",
     },


### PR DESCRIPTION
1. Sort is now stable in node 11, which exposed a lack in the sorting of nested ranges. Ranges now sort based on last ending if the start positions are the same. This means nested ranges sort the containing range first, even if a range contains another range that starts at the same position.
2. Symbol has a new member, `description`, which can't be accessed through the prototype. In addition, Array now has `flat` and `flatMap`, which I excluded to keep baselines the same between Node 6-11.

Fixes the build break on Node 11.
