### PR TITLE
Remove 'verify.fileAfterCodeFix', use 'verify.codeFix'

### DIFF
--- a/tests/cases/fourslash/codeFixInferFromUsageMemberJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageMemberJS.ts
@@ -14,10 +14,12 @@
 ////    }
 ////}
 
-
 // Note: Should be number[] | undefined, but inference currently privileges assignments
 // over usage (even when the only result is undefined) and infers only undefined.
-verify.fileAfterCodeFix(
+verify.codeFix({
+    description: "Infer type of 'p' from usage",
+    index: 2,
+    newFileContent:
 `class C {
     constructor() {
         /** @type {undefined} */
@@ -26,5 +28,5 @@ verify.fileAfterCodeFix(
     method() {
         this.p.push(1)
     }
-}
-`, undefined, 2);
+}`
+});

--- a/tests/cases/fourslash/codeFixInferFromUsageMultipleParametersJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageMultipleParametersJS.ts
@@ -9,8 +9,10 @@
 //// }
 //// f(1, "string", { a: 1 }, {shouldNotBeHere: 2}, {shouldNotBeHere: 2}, 3, "string");
 
-
-verify.fileAfterCodeFix(
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 6,
+    newFileContent:
 `/**
  * @param {number} a
  * @param {string} b
@@ -20,4 +22,5 @@ verify.fileAfterCodeFix(
  */
 function f(a, b, c, d, e = 0, ...d ) {
 }
-f(1, "string", { a: 1 }, {shouldNotBeHere: 2}, {shouldNotBeHere: 2}, 3, "string");`, undefined, 6);
+f(1, "string", { a: 1 }, {shouldNotBeHere: 2}, {shouldNotBeHere: 2}, 3, "string");`,
+});

--- a/tests/cases/fourslash/codeFixInferFromUsageNumberIndexSignatureJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageNumberIndexSignatureJS.ts
@@ -8,10 +8,14 @@
 ////    return a[0] + 1;
 ////}
 
-verify.fileAfterCodeFix(
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 2,
+    newFileContent:
 `/**
  * @param {number[]} a
  */
 function f(a) {
     return a[0] + 1;
-}`, undefined, 2);
+}`,
+});

--- a/tests/cases/fourslash/codeFixInferFromUsageOptionalParamJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageOptionalParamJS.ts
@@ -10,12 +10,16 @@
 ////f();
 ////f(1);
 
-verify.fileAfterCodeFix(
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 2,
+    newFileContent:
 `/**
  * @param {number} [a]
  */
-function f(a) {
+function f(a){
     a;
 }
 f();
-f(1);`, undefined, 2);
+f(1);`,
+});

--- a/tests/cases/fourslash/codeFixInferFromUsagePartialParameterListJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsagePartialParameterListJS.ts
@@ -13,9 +13,11 @@
 ////}
 ////f(1, 2, 3)
 
-verify.fileAfterCodeFix(
-`
-/**
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 2,
+    newFileContent:
+`/**
  * @param {*} y
  */
 /**
@@ -25,5 +27,5 @@ verify.fileAfterCodeFix(
 function f(x, y, z) {
     return x
 }
-f(1, 2, 3)
-`, undefined, 2);
+f(1, 2, 3)`,
+});

--- a/tests/cases/fourslash/codeFixInferFromUsagePropertyAccessJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsagePropertyAccessJS.ts
@@ -16,7 +16,10 @@
 ////    return x.y.z
 ////}
 
-verify.fileAfterCodeFix(
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 2,
+    newFileContent:
 `/**
  * @param {{ b: { c: any; }; }} a
  * @param {{ n: () => number; }} m
@@ -31,4 +34,5 @@ function foo(a, m, x) {
     x.y.z
     x.y.z.push(0);
     return x.y.z
-}`, undefined, 2);
+}`,
+});

--- a/tests/cases/fourslash/codeFixInferFromUsageRestParam2JS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageRestParam2JS.ts
@@ -13,7 +13,10 @@
 ////f(3, false, "s2");
 ////f(4, "s1", "s2", false, "s4");
 
-verify.fileAfterCodeFix(
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 2,
+    newFileContent:
 `/** @param {number} a */
 /**
  * @param {(string | boolean)[]} rest
@@ -24,4 +27,5 @@ function f(a, ...rest){
 f(1);
 f(2, "s1");
 f(3, false, "s2");
-f(4, "s1", "s2", false, "s4");`, undefined, 2);
+f(4, "s1", "s2", false, "s4");`,
+});

--- a/tests/cases/fourslash/codeFixInferFromUsageRestParam3JS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageRestParam3JS.ts
@@ -5,12 +5,15 @@
 // @noImplicitAny: true
 // @Filename: important.js
 /////** @param {number} a */
-////function f(a, [|...rest |]){
+////function f(a, [|...rest|]){
 ////    a;
 ////    rest.push(22);
 ////}
 
-verify.fileAfterCodeFix(
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 2,
+    newFileContent:
 `/** @param {number} a */
 /**
  * @param {number[]} rest
@@ -18,4 +21,5 @@ verify.fileAfterCodeFix(
 function f(a, ...rest){
     a;
     rest.push(22);
-}`, undefined, 2);
+}`,
+});

--- a/tests/cases/fourslash/codeFixInferFromUsageRestParamJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageRestParamJS.ts
@@ -13,7 +13,10 @@
 ////f(3, "s1", "s2");
 ////f(3, "s1", "s2", "s3", "s4");
 
-verify.fileAfterCodeFix(
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 4,
+    newFileContent:
 `/** @param {number} a */
 /**
  * @param {string[]} rest
@@ -24,4 +27,5 @@ function f(a: number, ...rest){
 f(1);
 f(2, "s1");
 f(3, "s1", "s2");
-f(3, "s1", "s2", "s3", "s4");`, undefined, 4);
+f(3, "s1", "s2", "s3", "s4");`,
+});

--- a/tests/cases/fourslash/codeFixInferFromUsageSetterJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageSetterJS.ts
@@ -11,9 +11,11 @@
 ////}
 ////(new C).x = 1;
 
-verify.fileAfterCodeFix(
-`
-class C {
+verify.codeFix({
+    description: "Infer type of \'x\' from usage",
+    index: 2,
+    newFileContent:
+`class C {
     /**
      * @param {number} v
      */
@@ -21,4 +23,5 @@ class C {
         v;
     }
 }
-(new C).x = 1;`, undefined, 2);
+(new C).x = 1;`,
+});

--- a/tests/cases/fourslash/codeFixInferFromUsageSingleLineClassJS.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageSingleLineClassJS.ts
@@ -9,11 +9,14 @@
 ////var c = new C()
 ////c.m(1)
 
-verify.fileAfterCodeFix(
-`
-class C {/**
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 2,
+    newFileContent:
+`class C {/**
           * @param {number} x
           */
          m(x) {return x;}}
 var c = new C()
-c.m(1)`, undefined, 2);
+c.m(1)`,
+});


### PR DESCRIPTION
There's no reason to have two separate methods for testing the same thing, and `verify.codeFix` strictly tests more, since it tests the description and whitespace.