### PR TITLE
Exclude keywords from import completions

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2585,6 +2585,10 @@ namespace ts {
         return token !== undefined && isNonContextualKeyword(token);
     }
 
+    export function isIdentifierANonContextualKeyword({ originalKeywordKind }: Identifier): boolean {
+        return !!originalKeywordKind && !isContextualKeyword(originalKeywordKind);
+    }
+
     export type TriviaKind = SyntaxKind.SingleLineCommentTrivia
         | SyntaxKind.MultiLineCommentTrivia
         | SyntaxKind.NewLineTrivia

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1412,7 +1412,7 @@ namespace ts.Completions {
                         || some(symbol.declarations, d =>
                             // If `!!d.name.originalKeywordKind`, this is `export { _break as break };` -- skip this and prefer the keyword completion.
                             // If `!!d.parent.parent.moduleSpecifier`, this is `export { foo } from "foo"` re-export, which creates a new symbol (thus isn't caught by the first check).
-                            isExportSpecifier(d) && (d.propertyName ? !!d.name.originalKeywordKind : !!d.parent.parent.moduleSpecifier))) {
+                            isExportSpecifier(d) && (d.propertyName ? isIdentifierANonContextualKeyword(d.name) : !!d.parent.parent.moduleSpecifier))) {
                         continue;
                     }
 

--- a/tests/cases/fourslash/completionsImport_keywords.ts
+++ b/tests/cases/fourslash/completionsImport_keywords.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.ts
+////const _break = 0;
+////export { _break as break };
+
+// @Filename: /b.ts
+////br/**/
+
+verify.completions({
+    marker: "",
+    excludes: { name: "break", source: "/a" },
+    preferences: { includeCompletionsForModuleExports: true },
+});

--- a/tests/cases/fourslash/completionsImport_keywords.ts
+++ b/tests/cases/fourslash/completionsImport_keywords.ts
@@ -3,12 +3,37 @@
 // @Filename: /a.ts
 ////const _break = 0;
 ////export { _break as break };
+////const _implements = 0;
+////export { _implements as implements };
+////const _unique = 0;
+////export { _unique as unique };
+
+// Note: `export const unique = 0;` is legal,
+// but we want to test that we don't block an import completion of 'unique' just because it appears in an ExportSpecifier.
 
 // @Filename: /b.ts
-////br/**/
+////br/*break*/
+////im/*implements*/
+////un/*unique*/
 
-verify.completions({
-    marker: "",
-    excludes: { name: "break", source: "/a" },
-    preferences: { includeCompletionsForModuleExports: true },
-});
+const preferences: FourSlashInterface.UserPreferences = { includeCompletionsForModuleExports: true };
+verify.completions(
+    // no reserved words
+    {
+        marker: "break",
+        excludes: [{ name: "break", source: "/a" }],
+        preferences,
+    },
+    // no strict mode reserved words
+    {
+        marker: "implements",
+        excludes: [{ name: "implements", source: "/a" }],
+        preferences,
+    },
+    // yes contextual keywords
+    {
+        marker: "unique",
+        includes: { name: "unique", source: "/a", sourceDisplay: "./a", text: "(alias) const unique: 0\nexport unique", hasAction: true },
+        preferences,
+    },
+);

--- a/tests/cases/fourslash/completionsImport_keywords.ts
+++ b/tests/cases/fourslash/completionsImport_keywords.ts
@@ -21,19 +21,22 @@ verify.completions(
     // no reserved words
     {
         marker: "break",
-        excludes: [{ name: "break", source: "/a" }],
+        includes: { name: "break", text: "break", kind: "keyword" },
+        excludes: { name: "break", source: "/a" },
         preferences,
     },
     // no strict mode reserved words
     {
         marker: "implements",
-        excludes: [{ name: "implements", source: "/a" }],
+        includes: { name: "implements", text: "implements", kind: "keyword" },
+        excludes: { name: "implements", source: "/a" },
         preferences,
     },
     // yes contextual keywords
     {
         marker: "unique",
         includes: { name: "unique", source: "/a", sourceDisplay: "./a", text: "(alias) const unique: 0\nexport unique", hasAction: true },
+        excludes: { name: "unique", source: undefined },
         preferences,
     },
 );


### PR DESCRIPTION
Fixes an issue where some module exporting `break` would cause us to add it as an import every time `break` was typed.