### PR TITLE
At '.' in array literal, don't close the array

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1518,8 +1518,10 @@ namespace ts {
                 case ParsingContext.TypeParameters:
                     return isIdentifier();
                 case ParsingContext.ArrayLiteralMembers:
-                    if (token() === SyntaxKind.CommaToken) {
-                        return true;
+                    switch (token()) {
+                        case SyntaxKind.CommaToken:
+                        case SyntaxKind.DotToken: // Not an array literal member, but don't want to close the array (see `tests/cases/fourslash/completionsDotInArrayLiteralInObjectLiteral.ts`)
+                            return true;
                     }
                     // falls through
                 case ParsingContext.ArgumentExpressions:

--- a/tests/cases/fourslash/completionsDotInArrayLiteralInObjectLiteral.ts
+++ b/tests/cases/fourslash/completionsDotInArrayLiteralInObjectLiteral.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+////const o = { x: [[|.|][||]/**/
+
+const [r0, r1] = test.ranges();
+verify.getSyntacticDiagnostics([
+    { code: 1109, message: "Expression expected.", range: r0 },
+    { code: 1003, message: "Identifier expected.", range: r1 },
+]);
+
+verify.completions({ marker: "", exact: undefined });


### PR DESCRIPTION
This is basically the same problem/fix as for #27850, but for arrays instead of objects. For some reason the problem only happens when the array literal is inside an object literal.