### PR TITLE
Parse an object literal property as shorthand unless followed by '(' or ':'

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4736,8 +4736,7 @@ namespace ts {
             // CoverInitializedName[Yield] :
             //     IdentifierReference[?Yield] Initializer[In, ?Yield]
             // this is necessary because ObjectLiteral productions are also used to cover grammar for ObjectAssignmentPattern
-            const isShorthandPropertyAssignment =
-                tokenIsIdentifier && (token() === SyntaxKind.CommaToken || token() === SyntaxKind.CloseBraceToken || token() === SyntaxKind.EqualsToken);
+            const isShorthandPropertyAssignment = tokenIsIdentifier && (token() !== SyntaxKind.ColonToken);
             if (isShorthandPropertyAssignment) {
                 node.kind = SyntaxKind.ShorthandPropertyAssignment;
                 const equalsToken = parseOptionalToken(SyntaxKind.EqualsToken);

--- a/src/testRunner/unittests/convertCompilerOptionsFromJson.ts
+++ b/src/testRunner/unittests/convertCompilerOptionsFromJson.ts
@@ -596,7 +596,8 @@ namespace ts {
                 {
                     compilerOptions: {
                         target: undefined,
-                        module: ModuleKind.ESNext
+                        module: ModuleKind.ESNext,
+                        experimentalDecorators: true,
                     },
                     hasParseErrors: true
                 }

--- a/src/testRunner/unittests/tsconfigParsing.ts
+++ b/src/testRunner/unittests/tsconfigParsing.ts
@@ -141,7 +141,7 @@ namespace ts {
 
         it("returns object with error when json is invalid", () => {
             const parsed = parseConfigFileTextToJson("/apath/tsconfig.json", "invalid");
-            assert.deepEqual(parsed.config, { invalid: undefined });
+            assert.deepEqual(parsed.config, {});
             const expected = createCompilerDiagnostic(Diagnostics._0_expected, "{");
             const error = parsed.error!;
             assert.equal(error.messageText, expected.messageText);

--- a/tests/baselines/reference/incompleteObjectLiteral1.errors.txt
+++ b/tests/baselines/reference/incompleteObjectLiteral1.errors.txt
@@ -1,8 +1,11 @@
-tests/cases/compiler/incompleteObjectLiteral1.ts(1,14): error TS1005: ':' expected.
+tests/cases/compiler/incompleteObjectLiteral1.ts(1,12): error TS2304: Cannot find name 'aa'.
+tests/cases/compiler/incompleteObjectLiteral1.ts(1,14): error TS1005: ',' expected.
 
 
-==== tests/cases/compiler/incompleteObjectLiteral1.ts (1 errors) ====
+==== tests/cases/compiler/incompleteObjectLiteral1.ts (2 errors) ====
     var tt = { aa; }
+               ~~
+!!! error TS2304: Cannot find name 'aa'.
                  ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
     var x = tt;

--- a/tests/baselines/reference/incompleteObjectLiteral1.js
+++ b/tests/baselines/reference/incompleteObjectLiteral1.js
@@ -3,5 +3,5 @@ var tt = { aa; }
 var x = tt;
 
 //// [incompleteObjectLiteral1.js]
-var tt = { aa:  };
+var tt = { aa: aa };
 var x = tt;

--- a/tests/baselines/reference/incompleteObjectLiteral1.types
+++ b/tests/baselines/reference/incompleteObjectLiteral1.types
@@ -3,7 +3,6 @@ var tt = { aa; }
 >tt : { aa: any; }
 >{ aa; } : { aa: any; }
 >aa : any
-> : any
 
 var x = tt;
 >x : { aa: any; }

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.errors.txt
@@ -7,13 +7,18 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(9,8): error TS1005: ':' expected.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(10,10): error TS1005: ':' expected.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(12,1): error TS1005: ':' expected.
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(15,6): error TS1005: ':' expected.
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(16,6): error TS1005: ':' expected.
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(17,6): error TS1005: ':' expected.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(15,5): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(15,6): error TS1005: ',' expected.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(16,5): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(16,6): error TS1005: ',' expected.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(16,12): error TS1005: ':' expected.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(17,5): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(17,6): error TS1005: ',' expected.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(17,9): error TS1005: ':' expected.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts(20,17): error TS1005: ':' expected.
 
 
-==== tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts (13 errors) ====
+==== tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts (18 errors) ====
     // errors
     var y = {
         "stringLiteral",
@@ -47,13 +52,23 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
     
     var x = {
         a.b,
+        ~
+!!! error TS2304: Cannot find name 'a'.
          ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
         a["ss"],
+        ~
+!!! error TS2304: Cannot find name 'a'.
          ~
+!!! error TS1005: ',' expected.
+               ~
 !!! error TS1005: ':' expected.
         a[1],
+        ~
+!!! error TS2304: Cannot find name 'a'.
          ~
+!!! error TS1005: ',' expected.
+            ~
 !!! error TS1005: ':' expected.
     };
     

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.js
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.js
@@ -21,6 +21,7 @@ var x = {
 var v = { class };  // error
 
 //// [objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.js]
+var _a;
 // errors
 var y = {
     "stringLiteral": ,
@@ -33,9 +34,12 @@ var y = {
     "class": ,
     "typeof": 
 };
-var x = {
-    a: .b,
-    a: ["ss"],
-    a: [1]
-};
+var x = (_a = {
+        a: a, : .b,
+        a: a
+    },
+    _a["ss"] = ,
+    _a.a = a,
+    _a[1] = ,
+    _a);
 var v = { "class":  }; // error

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.symbols
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.symbols
@@ -37,12 +37,17 @@ var x = {
 
     a.b,
 >a : Symbol(a, Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 13, 9), Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 14, 8), Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 15, 12))
+> : Symbol((Missing), Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 14, 5))
 
     a["ss"],
 >a : Symbol(a, Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 13, 9), Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 14, 8), Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 15, 12))
+>["ss"] : Symbol(["ss"], Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 15, 5))
+>"ss" : Symbol(["ss"], Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 15, 5))
 
     a[1],
 >a : Symbol(a, Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 13, 9), Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 14, 8), Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 15, 12))
+>[1] : Symbol([1], Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 16, 5))
+>1 : Symbol([1], Decl(objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.ts, 16, 5))
 
 };
 

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorFromNotUsingIdentifier.types
@@ -41,24 +41,27 @@ var y = {
 > : any
 
 var x = {
->x : { a: number[]; }
->{    a.b,    a["ss"],    a[1],} : { a: number[]; }
+>x : { a: any; (Missing): any; ["ss"]: any; [1]: any; }
+>{    a.b,    a["ss"],    a[1],} : { a: any; (Missing): any; ["ss"]: any; [1]: any; }
 
     a.b,
 >a : any
+> : any
 >.b : any
 > : any
 >b : any
 
     a["ss"],
 >a : any
->["ss"] : string[]
+>["ss"] : any
 >"ss" : "ss"
+> : any
 
     a[1],
 >a : any
->[1] : number[]
+>[1] : any
 >1 : 1
+> : any
 
 };
 

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorWithModule.ts(10,10): error TS1005: ':' expected.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorWithModule.ts(10,10): error TS1005: ',' expected.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorWithModule.ts(14,3): error TS2339: Property 'y' does not exist on type 'typeof m'.
 
 
@@ -14,7 +14,7 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
         export var y = {
             m.x  // error
              ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
         };
     }
     

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.js
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.js
@@ -25,7 +25,7 @@ var n;
 (function (n) {
     var z = 10000;
     n.y = {
-        m: .x // error
+        m: m, : .x // error
     };
 })(n || (n = {}));
 m.y.x;

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.symbols
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.symbols
@@ -21,6 +21,7 @@ module n {
 
         m.x  // error
 >m : Symbol(m, Decl(objectLiteralShorthandPropertiesErrorWithModule.ts, 8, 20))
+> : Symbol((Missing), Decl(objectLiteralShorthandPropertiesErrorWithModule.ts, 9, 9))
 
     };
 }

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.types
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesErrorWithModule.types
@@ -19,11 +19,12 @@ module n {
 >10000 : 10000
 
     export var y = {
->y : { m: any; }
->{        m.x  // error    } : { m: any; }
+>y : { m: typeof m; (Missing): any; }
+>{        m.x  // error    } : { m: typeof m; (Missing): any; }
 
         m.x  // error
->m : any
+>m : typeof m
+> : any
 >.x : any
 > : any
 >x : any

--- a/tests/baselines/reference/objectLiteralWithSemicolons1.errors.txt
+++ b/tests/baselines/reference/objectLiteralWithSemicolons1.errors.txt
@@ -1,13 +1,19 @@
-tests/cases/compiler/objectLiteralWithSemicolons1.ts(1,12): error TS1005: ':' expected.
-tests/cases/compiler/objectLiteralWithSemicolons1.ts(1,15): error TS1005: ':' expected.
+tests/cases/compiler/objectLiteralWithSemicolons1.ts(1,11): error TS2304: Cannot find name 'a'.
+tests/cases/compiler/objectLiteralWithSemicolons1.ts(1,12): error TS1005: ',' expected.
+tests/cases/compiler/objectLiteralWithSemicolons1.ts(1,14): error TS2304: Cannot find name 'b'.
+tests/cases/compiler/objectLiteralWithSemicolons1.ts(1,15): error TS1005: ',' expected.
 tests/cases/compiler/objectLiteralWithSemicolons1.ts(1,17): error TS2304: Cannot find name 'c'.
 
 
-==== tests/cases/compiler/objectLiteralWithSemicolons1.ts (3 errors) ====
+==== tests/cases/compiler/objectLiteralWithSemicolons1.ts (5 errors) ====
     var v = { a; b; c }
+              ~
+!!! error TS2304: Cannot find name 'a'.
                ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
+                 ~
+!!! error TS2304: Cannot find name 'b'.
                   ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
                     ~
 !!! error TS2304: Cannot find name 'c'.

--- a/tests/baselines/reference/objectLiteralWithSemicolons1.js
+++ b/tests/baselines/reference/objectLiteralWithSemicolons1.js
@@ -2,4 +2,4 @@
 var v = { a; b; c }
 
 //// [objectLiteralWithSemicolons1.js]
-var v = { a: , b: , c: c };
+var v = { a: a, b: b, c: c };

--- a/tests/baselines/reference/objectLiteralWithSemicolons1.types
+++ b/tests/baselines/reference/objectLiteralWithSemicolons1.types
@@ -3,8 +3,6 @@ var v = { a; b; c }
 >v : { a: any; b: any; c: any; }
 >{ a; b; c } : { a: any; b: any; c: any; }
 >a : any
-> : any
 >b : any
-> : any
 >c : any
 

--- a/tests/baselines/reference/objectLiteralWithSemicolons2.errors.txt
+++ b/tests/baselines/reference/objectLiteralWithSemicolons2.errors.txt
@@ -1,16 +1,22 @@
-tests/cases/compiler/objectLiteralWithSemicolons2.ts(2,4): error TS1005: ':' expected.
-tests/cases/compiler/objectLiteralWithSemicolons2.ts(3,4): error TS1005: ':' expected.
+tests/cases/compiler/objectLiteralWithSemicolons2.ts(2,3): error TS2304: Cannot find name 'a'.
+tests/cases/compiler/objectLiteralWithSemicolons2.ts(2,4): error TS1005: ',' expected.
+tests/cases/compiler/objectLiteralWithSemicolons2.ts(3,3): error TS2304: Cannot find name 'b'.
+tests/cases/compiler/objectLiteralWithSemicolons2.ts(3,4): error TS1005: ',' expected.
 tests/cases/compiler/objectLiteralWithSemicolons2.ts(4,3): error TS2304: Cannot find name 'c'.
 
 
-==== tests/cases/compiler/objectLiteralWithSemicolons2.ts (3 errors) ====
+==== tests/cases/compiler/objectLiteralWithSemicolons2.ts (5 errors) ====
     var v = {
       a;
+      ~
+!!! error TS2304: Cannot find name 'a'.
        ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
       b;
+      ~
+!!! error TS2304: Cannot find name 'b'.
        ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
       c
       ~
 !!! error TS2304: Cannot find name 'c'.

--- a/tests/baselines/reference/objectLiteralWithSemicolons2.js
+++ b/tests/baselines/reference/objectLiteralWithSemicolons2.js
@@ -7,7 +7,7 @@ var v = {
 
 //// [objectLiteralWithSemicolons2.js]
 var v = {
-    a: ,
-    b: ,
+    a: a,
+    b: b,
     c: c
 };

--- a/tests/baselines/reference/objectLiteralWithSemicolons2.types
+++ b/tests/baselines/reference/objectLiteralWithSemicolons2.types
@@ -5,11 +5,9 @@ var v = {
 
   a;
 >a : any
-> : any
 
   b;
 >b : any
-> : any
 
   c
 >c : any

--- a/tests/baselines/reference/objectLiteralWithSemicolons3.errors.txt
+++ b/tests/baselines/reference/objectLiteralWithSemicolons3.errors.txt
@@ -1,17 +1,26 @@
-tests/cases/compiler/objectLiteralWithSemicolons3.ts(2,4): error TS1005: ':' expected.
-tests/cases/compiler/objectLiteralWithSemicolons3.ts(3,4): error TS1005: ':' expected.
-tests/cases/compiler/objectLiteralWithSemicolons3.ts(4,4): error TS1005: ':' expected.
+tests/cases/compiler/objectLiteralWithSemicolons3.ts(2,3): error TS2304: Cannot find name 'a'.
+tests/cases/compiler/objectLiteralWithSemicolons3.ts(2,4): error TS1005: ',' expected.
+tests/cases/compiler/objectLiteralWithSemicolons3.ts(3,3): error TS2304: Cannot find name 'b'.
+tests/cases/compiler/objectLiteralWithSemicolons3.ts(3,4): error TS1005: ',' expected.
+tests/cases/compiler/objectLiteralWithSemicolons3.ts(4,3): error TS2304: Cannot find name 'c'.
+tests/cases/compiler/objectLiteralWithSemicolons3.ts(4,4): error TS1005: ',' expected.
 
 
-==== tests/cases/compiler/objectLiteralWithSemicolons3.ts (3 errors) ====
+==== tests/cases/compiler/objectLiteralWithSemicolons3.ts (6 errors) ====
     var v = {
       a;
+      ~
+!!! error TS2304: Cannot find name 'a'.
        ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
       b;
+      ~
+!!! error TS2304: Cannot find name 'b'.
        ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
       c;
+      ~
+!!! error TS2304: Cannot find name 'c'.
        ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
     }

--- a/tests/baselines/reference/objectLiteralWithSemicolons3.js
+++ b/tests/baselines/reference/objectLiteralWithSemicolons3.js
@@ -7,7 +7,7 @@ var v = {
 
 //// [objectLiteralWithSemicolons3.js]
 var v = {
-    a: ,
-    b: ,
-    c: 
+    a: a,
+    b: b,
+    c: c
 };

--- a/tests/baselines/reference/objectLiteralWithSemicolons3.types
+++ b/tests/baselines/reference/objectLiteralWithSemicolons3.types
@@ -5,13 +5,10 @@ var v = {
 
   a;
 >a : any
-> : any
 
   b;
 >b : any
-> : any
 
   c;
 >c : any
-> : any
 }

--- a/tests/baselines/reference/objectLiteralWithSemicolons4.errors.txt
+++ b/tests/baselines/reference/objectLiteralWithSemicolons4.errors.txt
@@ -1,9 +1,12 @@
-tests/cases/compiler/objectLiteralWithSemicolons4.ts(3,1): error TS1005: ':' expected.
+tests/cases/compiler/objectLiteralWithSemicolons4.ts(2,3): error TS2304: Cannot find name 'a'.
+tests/cases/compiler/objectLiteralWithSemicolons4.ts(3,1): error TS1005: ',' expected.
 
 
-==== tests/cases/compiler/objectLiteralWithSemicolons4.ts (1 errors) ====
+==== tests/cases/compiler/objectLiteralWithSemicolons4.ts (2 errors) ====
     var v = {
       a
+      ~
+!!! error TS2304: Cannot find name 'a'.
     ;
     ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.

--- a/tests/baselines/reference/objectLiteralWithSemicolons4.js
+++ b/tests/baselines/reference/objectLiteralWithSemicolons4.js
@@ -5,5 +5,5 @@ var v = {
 
 //// [objectLiteralWithSemicolons4.js]
 var v = {
-    a: 
+    a: a
 };

--- a/tests/baselines/reference/objectLiteralWithSemicolons4.types
+++ b/tests/baselines/reference/objectLiteralWithSemicolons4.types
@@ -7,5 +7,3 @@ var v = {
 >a : any
 
 ;
-> : any
-

--- a/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.esnext.errors.txt
+++ b/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.esnext.errors.txt
@@ -4,7 +4,8 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/asyncGeneratorSetA
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitInParameterInitializerIsError.ts(2,19): error TS2524: 'await' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitMissingValueIsError.ts(3,14): error TS1109: Expression expected.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts(2,15): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts(2,20): error TS1005: ':' expected.
+tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts(2,15): error TS2693: 'await' only refers to a type, but is being used as a value here.
+tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts(2,20): error TS1005: ',' expected.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts(2,22): error TS1136: Property assignment expected.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts(4,1): error TS1128: Declaration or statement expected.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/nestedFunctionDeclarationNamedAwaitIsError.ts(3,18): error TS1003: Identifier expected.
@@ -19,7 +20,8 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/nestedFunctionExpr
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/nestedFunctionExpressionNamedYieldIsError.ts(3,36): error TS1005: '=>' expected.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldInParameterInitializerIsError.ts(2,19): error TS2523: 'yield' expressions cannot be used in a parameter initializer.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts(2,15): error TS1138: Parameter declaration expected.
-tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts(2,20): error TS1005: ':' expected.
+tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts(2,15): error TS2693: 'yield' only refers to a type, but is being used as a value here.
+tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts(2,20): error TS1005: ',' expected.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts(2,22): error TS1136: Property assignment expected.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts(4,1): error TS1128: Declaration or statement expected.
 tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingValueIsError.ts(3,16): error TS1109: Expression expected.
@@ -40,26 +42,30 @@ tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldStarMissingVa
         async * yield() {
         }
     };
-==== tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts (4 errors) ====
+==== tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitParameterIsError.ts (5 errors) ====
     const o4 = {
         async * f(await) {
                   ~~~~~
 !!! error TS1138: Parameter declaration expected.
+                  ~~~~~
+!!! error TS2693: 'await' only refers to a type, but is being used as a value here.
                        ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
                          ~
 !!! error TS1136: Property assignment expected.
         }
     };
     ~
 !!! error TS1128: Declaration or statement expected.
-==== tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts (4 errors) ====
+==== tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts (5 errors) ====
     const o5 = {
         async * f(yield) {
                   ~~~~~
 !!! error TS1138: Parameter declaration expected.
+                  ~~~~~
+!!! error TS2693: 'yield' only refers to a type, but is being used as a value here.
                        ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
                          ~
 !!! error TS1136: Property assignment expected.
         }

--- a/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.esnext.types
+++ b/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.esnext.types
@@ -33,7 +33,6 @@ const o4 = {
     async * f(await) {
 >f : () => any
 >await : any
-> : any
     }
 };
 === tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/yieldParameterIsError.ts ===
@@ -44,7 +43,6 @@ const o5 = {
     async * f(yield) {
 >f : () => any
 >yield : any
-> : any
     }
 };
 === tests/cases/conformance/parser/ecmascriptnext/asyncGenerators/awaitInParameterInitializerIsError.ts ===

--- a/tests/baselines/reference/parser512097.errors.txt
+++ b/tests/baselines/reference/parser512097.errors.txt
@@ -1,10 +1,13 @@
-tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512097.ts(1,14): error TS1005: ':' expected.
+tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512097.ts(1,12): error TS2304: Cannot find name 'aa'.
+tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512097.ts(1,14): error TS1005: ',' expected.
 
 
-==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512097.ts (1 errors) ====
-    var tt = { aa; } // After this point, no useful parsing occurs in the entire file
+==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512097.ts (2 errors) ====
+    var tt = { aa; }
+               ~~
+!!! error TS2304: Cannot find name 'aa'.
                  ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
     
     if (true) {
     }

--- a/tests/baselines/reference/parser512097.js
+++ b/tests/baselines/reference/parser512097.js
@@ -1,10 +1,10 @@
 //// [parser512097.ts]
-var tt = { aa; } // After this point, no useful parsing occurs in the entire file
+var tt = { aa; }
 
 if (true) {
 }
 
 //// [parser512097.js]
-var tt = { aa:  }; // After this point, no useful parsing occurs in the entire file
+var tt = { aa: aa };
 if (true) {
 }

--- a/tests/baselines/reference/parser512097.symbols
+++ b/tests/baselines/reference/parser512097.symbols
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512097.ts ===
-var tt = { aa; } // After this point, no useful parsing occurs in the entire file
+var tt = { aa; }
 >tt : Symbol(tt, Decl(parser512097.ts, 0, 3))
 >aa : Symbol(aa, Decl(parser512097.ts, 0, 10))
 

--- a/tests/baselines/reference/parser512097.types
+++ b/tests/baselines/reference/parser512097.types
@@ -1,9 +1,8 @@
 === tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512097.ts ===
-var tt = { aa; } // After this point, no useful parsing occurs in the entire file
+var tt = { aa; }
 >tt : { aa: any; }
 >{ aa; } : { aa: any; }
 >aa : any
-> : any
 
 if (true) {
 >true : true

--- a/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.errors.txt
+++ b/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.errors.txt
@@ -1,13 +1,16 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ObjectLiterals/parserErrorRecovery_ObjectLiteral2.ts(2,1): error TS1005: ':' expected.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ObjectLiterals/parserErrorRecovery_ObjectLiteral2.ts(1,11): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ObjectLiterals/parserErrorRecovery_ObjectLiteral2.ts(2,1): error TS1005: ',' expected.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ObjectLiterals/parserErrorRecovery_ObjectLiteral2.ts(2,7): error TS1005: ':' expected.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ObjectLiterals/parserErrorRecovery_ObjectLiteral2.ts(2,8): error TS1005: '}' expected.
 
 
-==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ObjectLiterals/parserErrorRecovery_ObjectLiteral2.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ObjectLiterals/parserErrorRecovery_ObjectLiteral2.ts (4 errors) ====
     var v = { a
+              ~
+!!! error TS2304: Cannot find name 'a'.
     return;
     ~~~~~~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
           ~
 !!! error TS1005: ':' expected.
            

--- a/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.js
+++ b/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.js
@@ -3,5 +3,5 @@ var v = { a
 return;
 
 //// [parserErrorRecovery_ObjectLiteral2.js]
-var v = { a: ,
+var v = { a: a,
     "return":  };

--- a/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.types
+++ b/tests/baselines/reference/parserErrorRecovery_ObjectLiteral2.types
@@ -5,7 +5,6 @@ var v = { a
 >a : any
 
 return;
-> : any
 >return : any
 > : any
 

--- a/tests/baselines/reference/privateIndexer2.errors.txt
+++ b/tests/baselines/reference/privateIndexer2.errors.txt
@@ -2,10 +2,11 @@ tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts(4,15)
 tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts(4,17): error TS2693: 'string' only refers to a type, but is being used as a value here.
 tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts(4,23): error TS1005: ',' expected.
 tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts(4,24): error TS1136: Property assignment expected.
-tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts(4,32): error TS1005: ':' expected.
+tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts(4,26): error TS2693: 'string' only refers to a type, but is being used as a value here.
+tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts(4,32): error TS1005: ',' expected.
 
 
-==== tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts (5 errors) ====
+==== tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts (6 errors) ====
     // private indexers not allowed
     
     var x = {
@@ -18,8 +19,10 @@ tests/cases/conformance/classes/indexMemberDeclarations/privateIndexer2.ts(4,32)
 !!! error TS1005: ',' expected.
                            ~
 !!! error TS1136: Property assignment expected.
+                             ~~~~~~
+!!! error TS2693: 'string' only refers to a type, but is being used as a value here.
                                    ~
-!!! error TS1005: ':' expected.
+!!! error TS1005: ',' expected.
     }
     
     var y: {

--- a/tests/baselines/reference/privateIndexer2.js
+++ b/tests/baselines/reference/privateIndexer2.js
@@ -14,6 +14,6 @@ var y: {
 var _a;
 var x = (_a = {},
     _a[x] = string,
-    _a.string = ,
+    _a.string = string,
     _a);
 var y;

--- a/tests/baselines/reference/privateIndexer2.types
+++ b/tests/baselines/reference/privateIndexer2.types
@@ -10,7 +10,6 @@ var x = {
 >x : any
 >string : any
 >string : any
-> : any
 }
 
 var y: {

--- a/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512097.ts
+++ b/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512097.ts
@@ -1,4 +1,4 @@
-var tt = { aa; } // After this point, no useful parsing occurs in the entire file
+var tt = { aa; }
 
 if (true) {
 }

--- a/tests/cases/fourslash/completionsAtIncompleteObjectLiteralProperty.ts
+++ b/tests/cases/fourslash/completionsAtIncompleteObjectLiteralProperty.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @noLib: true
+
+////f({
+////    a/**/
+////    xyz: ``,
+////});
+////declare function f(options: { abc?: number, xyz?: string }): void;
+
+verify.completions({
+    marker: "",
+    exact: ["abc"],
+});


### PR DESCRIPTION
Fixes #28107

Previously at `{ x y: 3 }` we would try parsing `y` as the initializer of `x`. Now we will make `x` a shorthand property, preserving `y: 3` as its own property.
Updates many baselines but they were all error cases already.