### PR TITLE
infer from usage JSDoc:Don't emit nested comments

### DIFF
--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -219,7 +219,9 @@ namespace ts.codefix {
             if (param.initializer || getJSDocType(param) || !isIdentifier(param.name)) return;
 
             const typeNode = inference.type && getTypeNodeIfAccessible(inference.type, param, program, host);
-            return typeNode && createJSDocParamTag(param.name, !!inference.isOptional, createJSDocTypeExpression(typeNode), "");
+            const name = getSynthesizedClone(param.name);
+            setEmitFlags(name, EmitFlags.NoComments | EmitFlags.NoNestedComments);
+            return typeNode && createJSDocParamTag(name, !!inference.isOptional, createJSDocTypeExpression(typeNode), "");
         });
         addJSDocTags(changes, sourceFile, signature, paramTags);
     }

--- a/tests/cases/fourslash/codeFixInferFromUsageCommentAfterParameter.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageCommentAfterParameter.ts
@@ -8,7 +8,6 @@
 
 
 ////function coll(callback /*, name1, name2, ... */) {
-//function coll(callback) {
 ////    return callback(this);
 ////}
 

--- a/tests/cases/fourslash/codeFixInferFromUsageCommentAfterParameter.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageCommentAfterParameter.ts
@@ -1,0 +1,25 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @noImplicitAny: true
+// @Filename: important.js
+
+
+////function coll(callback /*, name1, name2, ... */) {
+//function coll(callback) {
+////    return callback(this);
+////}
+
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 2,
+    newFileContent:
+`/**
+ * @param {(arg0: any) => void} callback
+ */
+function coll(callback /*, name1, name2, ... */) {
+    return callback(this);
+}`,
+});


### PR DESCRIPTION
Previously, the trivia on a parameter name would show up inside the
emitted JSDoc comment. If the trivia contained a C-style comment, the
emitted JSDoc comment would be invalid. For example:

```js
function call(callback /*oh no*/) {
  return callback(this)
}
```

Emitted this comment:

```js
/**
 * @param {(arg0: any) => void} callback /*oh no*/
 */
```

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #28143 