### PR TITLE
Improved 'nameless' JSDoc typedef support.

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1755,7 +1755,7 @@ namespace ts {
                 bind(typeAlias.typeExpression);
                 if (!typeAlias.fullName || typeAlias.fullName.kind === SyntaxKind.Identifier) {
                     parent = typeAlias.parent;
-                    bindBlockScopedDeclaration(typeAlias, SymbolFlags.TypeAlias, SymbolFlags.TypeAliasExcludes);
+                    bindBlockScopedDeclaration(typeAlias, SymbolFlags.TypeAlias, SymbolFlags.TypeAliasExcludes & ~SymbolFlags.TypeAlias);
                 }
                 else {
                     bind(typeAlias.fullName);
@@ -2713,7 +2713,11 @@ namespace ts {
                 const isEnum = isInJSFile(node) && !!getJSDocEnumTag(node);
                 const enumFlags = (isEnum ? SymbolFlags.RegularEnum : SymbolFlags.None);
                 const enumExcludes = (isEnum ? SymbolFlags.RegularEnumExcludes : SymbolFlags.None);
-                if (isBlockOrCatchScoped(node)) {
+                const jsdocTypeDef = isInJSFile(node) && getJSDocNamelessTypedefTag(node);
+                if (jsdocTypeDef && !jsdocTypeDef.name) {
+                    bindBlockScopedDeclaration(node, SymbolFlags.TypeAlias, SymbolFlags.TypeAliasExcludes);
+                }
+                else if (isBlockOrCatchScoped(node)) {
                     bindBlockScopedDeclaration(node, SymbolFlags.BlockScopedVariable | enumFlags, SymbolFlags.BlockScopedVariableExcludes | enumExcludes);
                 }
                 else if (isParameterDeclaration(node)) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1240,6 +1240,10 @@ namespace ts {
         return node && node.kind === SyntaxKind.MethodDeclaration && node.parent.kind === SyntaxKind.ObjectLiteralExpression;
     }
 
+    export function isNamelessJSDocTypeDef(node: Node): boolean {
+        return !!getJSDocNamelessTypedefTag(node);
+    }
+
     export function isObjectLiteralOrClassExpressionMethod(node: Node): node is MethodDeclaration {
         return node.kind === SyntaxKind.MethodDeclaration &&
             (node.parent.kind === SyntaxKind.ObjectLiteralExpression ||
@@ -5131,6 +5135,11 @@ namespace ts {
     /** Gets the JSDoc enum tag for the node if present */
     export function getJSDocEnumTag(node: Node): JSDocEnumTag | undefined {
         return getFirstJSDocTag(node, isJSDocEnumTag);
+    }
+
+    /** Gets the nameless JSDoc typedef tag for the node if present */
+    export function getJSDocNamelessTypedefTag(node: Node): JSDocTypedefTag | undefined {
+        return getFirstJSDocTag(node, (n): n is JSDocTypedefTag => isJSDocTypedefTag(n) && !n.name);
     }
 
     /** Gets the JSDoc this tag for the node if present */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3251,6 +3251,8 @@ declare namespace ts {
     function getJSDocClassTag(node: Node): JSDocClassTag | undefined;
     /** Gets the JSDoc enum tag for the node if present */
     function getJSDocEnumTag(node: Node): JSDocEnumTag | undefined;
+    /** Gets the nameless JSDoc typedef tag for the node if present */
+    function getJSDocNamelessTypedefTag(node: Node): JSDocTypedefTag | undefined;
     /** Gets the JSDoc this tag for the node if present */
     function getJSDocThisTag(node: Node): JSDocThisTag | undefined;
     /** Gets the JSDoc return tag for the node if present */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3251,6 +3251,8 @@ declare namespace ts {
     function getJSDocClassTag(node: Node): JSDocClassTag | undefined;
     /** Gets the JSDoc enum tag for the node if present */
     function getJSDocEnumTag(node: Node): JSDocEnumTag | undefined;
+    /** Gets the nameless JSDoc typedef tag for the node if present */
+    function getJSDocNamelessTypedefTag(node: Node): JSDocTypedefTag | undefined;
     /** Gets the JSDoc this tag for the node if present */
     function getJSDocThisTag(node: Node): JSDocThisTag | undefined;
     /** Gets the JSDoc return tag for the node if present */

--- a/tests/baselines/reference/jsdocTypedefNoCrash.types
+++ b/tests/baselines/reference/jsdocTypedefNoCrash.types
@@ -4,6 +4,6 @@
  * }}
  */
 export const foo = 5;
->foo : 5
+>foo : error
 >5 : 5
 

--- a/tests/baselines/reference/jsdocTypedefNoCrash2.symbols
+++ b/tests/baselines/reference/jsdocTypedefNoCrash2.symbols
@@ -1,11 +1,11 @@
 === tests/cases/compiler/export.js ===
 export type foo = 5;
->foo : Symbol(foo, Decl(export.js, 0, 0), Decl(export.js, 5, 12))
+>foo : Symbol(foo, Decl(export.js, 0, 0), Decl(export.js, 2, 3))
 
 /**
  * @typedef {{
  * }}
  */
 export const foo = 5;
->foo : Symbol(foo, Decl(export.js, 0, 0), Decl(export.js, 5, 12))
+>foo : Symbol(foo, Decl(export.js, 5, 12))
 

--- a/tests/baselines/reference/jsdocTypedefNoCrash2.types
+++ b/tests/baselines/reference/jsdocTypedefNoCrash2.types
@@ -7,6 +7,6 @@ export type foo = 5;
  * }}
  */
 export const foo = 5;
->foo : 5
+>foo : any
 >5 : 5
 

--- a/tests/baselines/reference/typedefNameless.errors.txt
+++ b/tests/baselines/reference/typedefNameless.errors.txt
@@ -1,0 +1,70 @@
+tests/cases/conformance/jsdoc/a.js(11,1): error TS2693: 'nameless' only refers to a type, but is being used as a value here.
+tests/cases/conformance/jsdoc/a.js(26,5): error TS2693: 'notOK' only refers to a type, but is being used as a value here.
+tests/cases/conformance/jsdoc/a.js(32,7): error TS1155: 'const' declarations must be initialized.
+
+
+==== tests/cases/conformance/jsdoc/a.js (3 errors) ====
+    /**
+     * @typedef {number}
+     */
+    var nameless;
+    
+    /**
+     * @typedef {number} named
+     */
+    var this_is_not_the_name = true;
+    
+    nameless = 123; // nameless is not a value
+    ~~~~~~~~
+!!! error TS2693: 'nameless' only refers to a type, but is being used as a value here.
+    
+    /**
+     * @param {named} p1
+     * @param {nameless} p2
+     */
+    function abc(p1, p2) {}
+    
+    /**
+     * @param {named} p1
+     * @param {nameless} p2
+     */
+    export function breakThings(p1, p2) {}
+    
+    /** @typedef {number} */
+    var notOK = 1;
+        ~~~~~
+!!! error TS2693: 'notOK' only refers to a type, but is being used as a value here.
+    
+    /** @typedef {string} */
+    let thisIsOK;
+    
+    /** @typedef {{L: number}} */
+    const notLegalButShouldBe;
+          ~~~~~~~~~~~~~~~~~~~
+!!! error TS1155: 'const' declarations must be initialized.
+    
+==== tests/cases/conformance/jsdoc/b.js (0 errors) ====
+    /**
+     * @typedef {{
+     *   p: string
+     * }}
+     */
+    export var type1;
+    
+==== tests/cases/conformance/jsdoc/c.js (0 errors) ====
+    import { type1 as aliased } from './b';
+    
+    /**
+     * @param {aliased} pt1
+     */
+    function f1(pt1) {}
+    
+    /** @type {{ p2?: any }} */
+    var k = {};
+    
+    /**
+     * @typedef {aliased}
+     */
+    k.p2;
+    
+    

--- a/tests/baselines/reference/typedefNameless.symbols
+++ b/tests/baselines/reference/typedefNameless.symbols
@@ -1,0 +1,79 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/**
+ * @typedef {number}
+ */
+var nameless;
+>nameless : Symbol(nameless, Decl(a.js, 3, 3), Decl(a.js, 1, 3))
+
+/**
+ * @typedef {number} named
+ */
+var this_is_not_the_name = true;
+>this_is_not_the_name : Symbol(this_is_not_the_name, Decl(a.js, 8, 3))
+
+nameless = 123; // nameless is not a value
+
+/**
+ * @param {named} p1
+ * @param {nameless} p2
+ */
+function abc(p1, p2) {}
+>abc : Symbol(abc, Decl(a.js, 10, 15))
+>p1 : Symbol(p1, Decl(a.js, 16, 13))
+>p2 : Symbol(p2, Decl(a.js, 16, 16))
+
+/**
+ * @param {named} p1
+ * @param {nameless} p2
+ */
+export function breakThings(p1, p2) {}
+>breakThings : Symbol(breakThings, Decl(a.js, 16, 23))
+>p1 : Symbol(p1, Decl(a.js, 22, 28))
+>p2 : Symbol(p2, Decl(a.js, 22, 31))
+
+/** @typedef {number} */
+var notOK = 1;
+>notOK : Symbol(notOK, Decl(a.js, 25, 3), Decl(a.js, 24, 4))
+
+/** @typedef {string} */
+let thisIsOK;
+>thisIsOK : Symbol(thisIsOK, Decl(a.js, 28, 3), Decl(a.js, 27, 4))
+
+/** @typedef {{L: number}} */
+const notLegalButShouldBe;
+>notLegalButShouldBe : Symbol(notLegalButShouldBe, Decl(a.js, 31, 5), Decl(a.js, 30, 4))
+
+=== tests/cases/conformance/jsdoc/b.js ===
+/**
+ * @typedef {{
+ *   p: string
+ * }}
+ */
+export var type1;
+>type1 : Symbol(type1, Decl(b.js, 5, 10), Decl(b.js, 1, 3))
+
+=== tests/cases/conformance/jsdoc/c.js ===
+import { type1 as aliased } from './b';
+>type1 : Symbol(aliased, Decl(c.js, 0, 8))
+>aliased : Symbol(aliased, Decl(c.js, 0, 8))
+
+/**
+ * @param {aliased} pt1
+ */
+function f1(pt1) {}
+>f1 : Symbol(f1, Decl(c.js, 0, 39))
+>pt1 : Symbol(pt1, Decl(c.js, 5, 12))
+
+/** @type {{ p2?: any }} */
+var k = {};
+>k : Symbol(k, Decl(c.js, 8, 3))
+
+/**
+ * @typedef {aliased}
+ */
+k.p2;
+>k.p2 : Symbol(p2, Decl(c.js, 7, 12))
+>k : Symbol(k, Decl(c.js, 8, 3))
+>p2 : Symbol(p2, Decl(c.js, 7, 12))
+
+

--- a/tests/baselines/reference/typedefNameless.types
+++ b/tests/baselines/reference/typedefNameless.types
@@ -1,0 +1,85 @@
+=== tests/cases/conformance/jsdoc/a.js ===
+/**
+ * @typedef {number}
+ */
+var nameless;
+>nameless : any
+
+/**
+ * @typedef {number} named
+ */
+var this_is_not_the_name = true;
+>this_is_not_the_name : boolean
+>true : true
+
+nameless = 123; // nameless is not a value
+>nameless = 123 : 123
+>nameless : any
+>123 : 123
+
+/**
+ * @param {named} p1
+ * @param {nameless} p2
+ */
+function abc(p1, p2) {}
+>abc : (p1: number, p2: number) => void
+>p1 : number
+>p2 : number
+
+/**
+ * @param {named} p1
+ * @param {nameless} p2
+ */
+export function breakThings(p1, p2) {}
+>breakThings : (p1: number, p2: number) => void
+>p1 : number
+>p2 : number
+
+/** @typedef {number} */
+var notOK = 1;
+>notOK : any
+>1 : 1
+
+/** @typedef {string} */
+let thisIsOK;
+>thisIsOK : any
+
+/** @typedef {{L: number}} */
+const notLegalButShouldBe;
+>notLegalButShouldBe : any
+
+=== tests/cases/conformance/jsdoc/b.js ===
+/**
+ * @typedef {{
+ *   p: string
+ * }}
+ */
+export var type1;
+>type1 : any
+
+=== tests/cases/conformance/jsdoc/c.js ===
+import { type1 as aliased } from './b';
+>type1 : any
+>aliased : any
+
+/**
+ * @param {aliased} pt1
+ */
+function f1(pt1) {}
+>f1 : (pt1: { p: string; }) => void
+>pt1 : { p: string; }
+
+/** @type {{ p2?: any }} */
+var k = {};
+>k : { p2?: any; }
+>{} : {}
+
+/**
+ * @typedef {aliased}
+ */
+k.p2;
+>k.p2 : any
+>k : { p2?: any; }
+>p2 : any
+
+

--- a/tests/cases/conformance/jsdoc/typedefNameless.ts
+++ b/tests/cases/conformance/jsdoc/typedefNameless.ts
@@ -1,0 +1,62 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @noImplicitAny: true
+// @Filename: a.js
+/**
+ * @typedef {number}
+ */
+var nameless;
+
+/**
+ * @typedef {number} named
+ */
+var this_is_not_the_name = true;
+
+nameless = 123; // nameless is not a value
+
+/**
+ * @param {named} p1
+ * @param {nameless} p2
+ */
+function abc(p1, p2) {}
+
+/**
+ * @param {named} p1
+ * @param {nameless} p2
+ */
+export function breakThings(p1, p2) {}
+
+/** @typedef {number} */
+var notOK = 1;
+
+/** @typedef {string} */
+let thisIsOK;
+
+/** @typedef {{L: number}} */
+const notLegalButShouldBe;
+
+// @Filename: b.js
+/**
+ * @typedef {{
+ *   p: string
+ * }}
+ */
+export var type1;
+
+// @Filename: c.js
+import { type1 as aliased } from './b';
+
+/**
+ * @param {aliased} pt1
+ */
+function f1(pt1) {}
+
+/** @type {{ p2?: any }} */
+var k = {};
+
+/**
+ * @typedef {aliased}
+ */
+k.p2;
+

--- a/tests/cases/fourslash/jsdocTypedefTagSemanticMeaning1.ts
+++ b/tests/cases/fourslash/jsdocTypedefTagSemanticMeaning1.ts
@@ -4,9 +4,9 @@
 // @Filename: a.js
 
 /////** @typedef {number} */
-////const [|{| "isWriteAccess": true, "isDefinition": true |}T|] = 1;
+////var [|{| "isWriteAccess": false, "isDefinition": true |}T|];
 
 /////** @type {[|T|]} */
-////const n = [|T|];
+////const n = 2;
 
-verify.singleReferenceGroup("type T = number\nconst T: 1");
+verify.singleReferenceGroup("type T = number");

--- a/tests/cases/fourslash/server/jsdocTypedefTagRename01.ts
+++ b/tests/cases/fourslash/server/jsdocTypedefTagRename01.ts
@@ -6,8 +6,6 @@
 //// /** @typedef {(string | number)} */
 //// var [|NumberLike|];
 ////
-//// [|NumberLike|] = 10;
-////
 //// /** @type {[|NumberLike|]} */
 //// var numberLike;
 


### PR DESCRIPTION
Being able to pass JSDoc `@typedef`s around as if they were values greatly reduces the need for a separate JSDoc import syntax (as in #22160 #26352 #22160). This commit improves upon the already existing nameless `@typedef` support, by:

 - Fixing a bug (#26626) in the binding of the type alias within external or CommonJS modules
 - Making nameless `@typedef`s have the same semantics as a native TypeAlias (i.e. `type ex = number`).
 - Adding error handling if trying to use a nameless (declared?) typedef as a value type, or with an initializer.
 - Adding a new conformance test case for the above mentioned features, and usage across modules.

Fixes #26626