### PR TITLE
Fixes duplicated comment when executing code fix to add missing enum …

### DIFF
--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -297,6 +297,6 @@ namespace ts.codefix {
             enumDeclaration.modifiers,
             enumDeclaration.name,
             concatenate(enumDeclaration.members, singleElementArray(enumMember))
-        ));
+        ), { useNonAdjustedStartPosition: false, useNonAdjustedEndPosition: true });
     }
 }

--- a/tests/cases/fourslash/codeFixAddMissingEnumMember12.ts
+++ b/tests/cases/fourslash/codeFixAddMissingEnumMember12.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+////const x; // this is x
+////
+////// this is E
+////enum E {
+////}
+////E.a
+
+verify.codeFix({
+    description: "Add missing enum member 'a'",
+    newFileContent: `const x; // this is x
+
+// this is E
+enum E {
+    a
+}
+E.a`
+});
+
+


### PR DESCRIPTION
…member

Resolves issue #28031 by overriding default value of
`useNonAdjustedStartPosition` option to replaceNode. Test case included
that confirms intended behaviour.

Here's a checklist you might find useful.
* [x] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `jake runtests` locally
* [x] You've signed the CLA
* [x] There are new or updated unit tests validating the change

Fixes #28031

