### PR TITLE
Always infer JSDoc for parameters

### DIFF
--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -215,10 +215,10 @@ namespace ts.codefix {
         }
         const paramTags = mapDefined(parameterInferences, inference => {
             const param = inference.declaration;
-            // only infer parameters that have (1) no type and (2) an accessible inferred type
+            // only infer parameters that have (1) no type
             if (param.initializer || getJSDocType(param) || !isIdentifier(param.name)) return;
 
-            const typeNode = inference.type && getTypeNodeIfAccessible(inference.type, param, program, host);
+            const typeNode = getTypeNodeIfAccessible(inference.type || program.getTypeChecker().getAnyType(), param, program, host);
             return typeNode && createJSDocParamTag(param.name, !!inference.isOptional, createJSDocTypeExpression(typeNode), "");
         });
         addJSDocTags(changes, sourceFile, signature, paramTags);

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -215,8 +215,7 @@ namespace ts.codefix {
         }
         const paramTags = mapDefined(parameterInferences, inference => {
             const param = inference.declaration;
-            // only infer parameters that have (1) no type
-            if (param.initializer || getJSDocType(param) || !isIdentifier(param.name)) return;
+            if (!isIdentifier(param.name)) return;
 
             const typeNode = getTypeNodeIfAccessible(inference.type || program.getTypeChecker().getAnyType(), param, program, host);
             const name = getSynthesizedClone(param.name);

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -215,7 +215,8 @@ namespace ts.codefix {
         }
         const paramTags = mapDefined(parameterInferences, inference => {
             const param = inference.declaration;
-            if (!isIdentifier(param.name)) return;
+            // only infer parameters that have no type
+            if (param.initializer || getJSDocType(param) || !isIdentifier(param.name)) return;
 
             const typeNode = getTypeNodeIfAccessible(inference.type || program.getTypeChecker().getAnyType(), param, program, host);
             const name = getSynthesizedClone(param.name);

--- a/tests/cases/fourslash/codeFixInferFromUsageAlwaysInferJSDoc.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageAlwaysInferJSDoc.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @noImplicitAny: true
+// @Filename: important.js
+
+
+////function coll(callback) {
+////}
+
+verify.codeFix({
+    description: "Infer parameter types from usage",
+    index: 2,
+    newFileContent:
+`/**
+ * @param {any} callback
+ */
+function coll(callback) {
+}`,
+});


### PR DESCRIPTION
If there are no inferences found, use `any`.

I only do this for parameters because I couldn't come up with any uses of variables or class members that didn't already succeed using (1) the type of the initialiser or (2) control flow analysis (for variables).

Based on our discussion with VS Code.
