### PR TITLE
Support synthesized SourceFile parent in getOrCreateEmitNode (#24709)

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2819,7 +2819,7 @@ namespace ts {
                     return node.emitNode = { annotatedNodes: [node] } as EmitNode;
                 }
 
-                const sourceFile = getSourceFileOfNode(node);
+                const sourceFile = getSourceFileOfNode(getParseTreeNode(getSourceFileOfNode(node)));
                 getOrCreateEmitNode(sourceFile).annotatedNodes!.push(node);
             }
 

--- a/tests/baselines/reference/transformApi/transformsCorrectly.issue24709.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.issue24709.js
@@ -1,0 +1,6 @@
+var X = /** @class */ (function () {
+    function X() {
+    }
+    X.prototype.foobar = function (x) { return x; };
+    return X;
+}());


### PR DESCRIPTION
getOrCreateEmitNode() assumes that the SourceFile of node that is
part of a parse tree will also be a parse tree node. This assumption is
not valid for a transformed SourceFile. disposeEmitNodes() already handles
this case by getting the original SourceFile node if the provided node
is synthesized, so do the same in getOrCreateEmitNode().

This results in the test case in #24709 to run without error.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #24709

