### PR TITLE
Add missing apostrophe to codefix suggestion

### DIFF
--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -677,7 +677,7 @@ namespace ts.refactor.extractSymbol {
             case SyntaxKind.ArrowFunction:
                 return "arrow function";
             case SyntaxKind.MethodDeclaration:
-                return `method '${scope.name.getText()}`;
+                return `method '${scope.name.getText()}'`;
             case SyntaxKind.GetAccessor:
                 return `'get ${scope.name.getText()}'`;
             case SyntaxKind.SetAccessor:


### PR DESCRIPTION
Codefix suggestion for extracting a constant variable from a method is missing an apostrophe as can be seen in the following image:

<img width="556" alt="screen shot 2018-10-28 at 11 22 00 pm" src="https://user-images.githubusercontent.com/17405336/47622012-637a9780-db08-11e8-80d6-5c28f95e07d1.png">
