### PR TITLE
Avoid reformatting body of arrow function with single unused parameter

### DIFF
--- a/tests/cases/fourslash/codeFixUnusedIdentifier_all_delete.ts
+++ b/tests/cases/fourslash/codeFixUnusedIdentifier_all_delete.ts
@@ -31,6 +31,10 @@
 ////takesCb((x, y) => { x; });
 ////takesCb((x, y) => { y; });
 ////
+////x => {
+////    const y = 0;
+////};
+////
 ////{
 ////    let a, b;
 ////}
@@ -71,6 +75,9 @@ declare function takesCb(cb: (x: number, y: string) => void): void;
 takesCb(() => {});
 takesCb((x) => { x; });
 takesCb((x, y) => { y; });
+
+() => {
+};
 
 {
 }

--- a/tests/cases/fourslash/unusedParameterInLambda1.ts
+++ b/tests/cases/fourslash/unusedParameterInLambda1.ts
@@ -4,9 +4,8 @@
 // @noUnusedParameters: true
 ////[|/*~a*/(/*~b*/x/*~c*/:/*~d*/number/*~e*/)/*~f*/ => /*~g*/{/*~h*/}/*~i*/|]
 
-// In a perfect world, /*~f*/ and /*~h*/ would probably be retained.
 verify.codeFix({
     description: "Remove declaration for: 'x'",
     index: 0,
-    newRangeContent: "/*~a*/() => /*~g*/ { }/*~i*/",
+    newRangeContent: "/*~a*/(/*~e*/)/*~f*/ => /*~g*/{/*~h*/}/*~i*/",
 });

--- a/tests/cases/fourslash/unusedParameterInLambda2.ts
+++ b/tests/cases/fourslash/unusedParameterInLambda2.ts
@@ -4,9 +4,8 @@
 // @noUnusedParameters: true
 ////[|/*~a*/x/*~b*/ /*~c*/=>/*~d*/ {/*~e*/}/*~f*/|]
 
-// In a perfect world, /*~c*/ and /*~e*/ would probably be retained.
 verify.codeFix({
     description: "Remove declaration for: 'x'",
     index: 0,
-    newRangeContent: "/*~a*/() => /*~d*/ { }/*~f*/",
+    newRangeContent: "/*~a*/()/*~b*/ /*~c*/=>/*~d*/ {/*~e*/}/*~f*/",
 });


### PR DESCRIPTION
Fixes #27700

