### PR TITLE
Use constraint for type parameter default default value if possible

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7651,7 +7651,7 @@ namespace ts {
                 // If a type parameter does not have a default type, or if the default type
                 // is a forward reference, the empty object type is used.
                 for (let i = numTypeArguments; i < numTypeParameters; i++) {
-                    result[i] = getDefaultTypeArgumentType(isJavaScriptImplicitAny);
+                    result[i] = getConstraintFromTypeParameter(typeParameters![i]) || getDefaultTypeArgumentType(isJavaScriptImplicitAny);
                 }
                 for (let i = numTypeArguments; i < numTypeParameters; i++) {
                     const mapper = createTypeMapper(typeParameters!, result);

--- a/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.errors.txt
+++ b/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts(3,18): error TS2322: Type '{ foo: string; }' is not assignable to type 'Test<string>'.
+  Object literal may only specify known properties, and 'foo' does not exist in type 'Test<string>'.
+tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts(5,19): error TS2322: Type '{}' is not assignable to type 'string'.
+
+
+==== tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts (2 errors) ====
+    type Test<T extends string = T> = { value: T };
+    
+    let zz: Test = { foo: "abc" };  // should error on comparison with Test<string>
+                     ~~~~~~~~~~
+!!! error TS2322: Type '{ foo: string; }' is not assignable to type 'Test<string>'.
+!!! error TS2322:   Object literal may only specify known properties, and 'foo' does not exist in type 'Test<string>'.
+    
+    let zzy: Test = { value: {} };  // should error
+                      ~~~~~
+!!! error TS2322: Type '{}' is not assignable to type 'string'.
+!!! related TS6500 tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts:1:37: The expected type comes from property 'value' which is declared here on type 'Test<string>'
+    

--- a/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.js
+++ b/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.js
@@ -1,0 +1,11 @@
+//// [typeArgumentDefaultUsesConstraintOnCircularDefault.ts]
+type Test<T extends string = T> = { value: T };
+
+let zz: Test = { foo: "abc" };  // should error on comparison with Test<string>
+
+let zzy: Test = { value: {} };  // should error
+
+
+//// [typeArgumentDefaultUsesConstraintOnCircularDefault.js]
+var zz = { foo: "abc" }; // should error on comparison with Test<string>
+var zzy = { value: {} }; // should error

--- a/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.symbols
+++ b/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts ===
+type Test<T extends string = T> = { value: T };
+>Test : Symbol(Test, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 0, 0))
+>T : Symbol(T, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 0, 10))
+>T : Symbol(T, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 0, 10))
+>value : Symbol(value, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 0, 35))
+>T : Symbol(T, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 0, 10))
+
+let zz: Test = { foo: "abc" };  // should error on comparison with Test<string>
+>zz : Symbol(zz, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 2, 3))
+>Test : Symbol(Test, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 0, 0))
+>foo : Symbol(foo, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 2, 16))
+
+let zzy: Test = { value: {} };  // should error
+>zzy : Symbol(zzy, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 4, 3))
+>Test : Symbol(Test, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 0, 0))
+>value : Symbol(value, Decl(typeArgumentDefaultUsesConstraintOnCircularDefault.ts, 4, 17))
+

--- a/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.types
+++ b/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts ===
+type Test<T extends string = T> = { value: T };
+>Test : Test<T>
+>value : T
+
+let zz: Test = { foo: "abc" };  // should error on comparison with Test<string>
+>zz : Test<string>
+>{ foo: "abc" } : { foo: string; }
+>foo : string
+>"abc" : "abc"
+
+let zzy: Test = { value: {} };  // should error
+>zzy : Test<string>
+>{ value: {} } : { value: {}; }
+>value : {}
+>{} : {}
+

--- a/tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts
+++ b/tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts
@@ -1,0 +1,5 @@
+type Test<T extends string = T> = { value: T };
+
+let zz: Test = { foo: "abc" };  // should error on comparison with Test<string>
+
+let zzy: Test = { value: {} };  // should error


### PR DESCRIPTION
Fixes an issue reported by @ahejlsberg in #27427 (the original issue as reported is still broken for other reasons).

