### PR TITLE
Support parameter types for mixin constructors

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1960,7 +1960,7 @@
         "category": "Error",
         "code": 2544
     },
-    "A mixin class must have a constructor with a single rest parameter of type 'any[]'.": {
+    "A mixin class must have a constructor with the same parameter types as the base class.": {
         "category": "Error",
         "code": 2545
     },

--- a/tests/baselines/reference/genericWildcardBaseClass.errors.txt
+++ b/tests/baselines/reference/genericWildcardBaseClass.errors.txt
@@ -1,0 +1,73 @@
+tests/cases/compiler/genericWildcardBaseClass.ts(23,18): error TS2545: A mixin class must have a constructor with the same parameter types as the base class.
+tests/cases/compiler/genericWildcardBaseClass.ts(42,49): error TS2345: Argument of type 'typeof BadClass' is not assignable to parameter of type 'typeof BaseClass'.
+  Types of parameters 'n' and 's' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/genericWildcardBaseClass.ts(46,30): error TS2345: Argument of type '2' is not assignable to parameter of type 'string'.
+
+
+==== tests/cases/compiler/genericWildcardBaseClass.ts (3 errors) ====
+    abstract class BaseClass {
+        constructor(s: string = '', ...args: any[]) { }
+        base() { return 0; }
+        static staticBase() { return ''; }
+    }
+    
+    function extendNoConstructor<T extends typeof BaseClass>(Base: T) {
+        return class ExN extends Base {
+            ext() { return 0; }
+            static staticExt() { return ''; }
+        };
+    }
+    
+    function extendCompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+        return class ExC extends Base {
+            constructor(x?: string, ...args: any[]) {
+                super(x, args);
+            }
+        };
+    }
+    
+    function fails_IncompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+        return class Fail extends Base {
+                     ~~~~
+!!! error TS2545: A mixin class must have a constructor with the same parameter types as the base class.
+            constructor(x?: string, ...args: string[]) {
+                super(x, args);
+            }
+        };
+    }
+    
+    abstract class ExtClass extends BaseClass {
+        thing() { return 0; }
+        static staticThing() { return ''; }
+    }
+    
+    abstract class BadClass extends BaseClass {
+        constructor(n: number) {
+            super();
+        }
+    }
+    
+    const Thing2 = extendCompatibleConstructor(extendNoConstructor(ExtClass));
+    extendCompatibleConstructor(extendNoConstructor(BadClass));
+                                                    ~~~~~~~~
+!!! error TS2345: Argument of type 'typeof BadClass' is not assignable to parameter of type 'typeof BaseClass'.
+!!! error TS2345:   Types of parameters 'n' and 's' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    
+    const thing2 = new Thing2();
+    const thing2arg = new Thing2('');
+    const fails_arg = new Thing2(2);
+                                 ~
+!!! error TS2345: Argument of type '2' is not assignable to parameter of type 'string'.
+    
+    const str2 = Thing2.staticExt() + Thing2.staticThing() + Thing2.staticBase();
+    const num2 = thing2.ext() + thing2.thing() + thing2.base();
+    
+    class Thing3 extends Thing2 {
+        constructor() {
+            super('', 1, 2);
+            Math.round(this.base() + this.thing() + this.ext());
+        }
+    }
+    

--- a/tests/baselines/reference/genericWildcardBaseClass.js
+++ b/tests/baselines/reference/genericWildcardBaseClass.js
@@ -1,0 +1,154 @@
+//// [genericWildcardBaseClass.ts]
+abstract class BaseClass {
+    constructor(s: string = '', ...args: any[]) { }
+    base() { return 0; }
+    static staticBase() { return ''; }
+}
+
+function extendNoConstructor<T extends typeof BaseClass>(Base: T) {
+    return class ExN extends Base {
+        ext() { return 0; }
+        static staticExt() { return ''; }
+    };
+}
+
+function extendCompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+    return class ExC extends Base {
+        constructor(x?: string, ...args: any[]) {
+            super(x, args);
+        }
+    };
+}
+
+function fails_IncompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+    return class Fail extends Base {
+        constructor(x?: string, ...args: string[]) {
+            super(x, args);
+        }
+    };
+}
+
+abstract class ExtClass extends BaseClass {
+    thing() { return 0; }
+    static staticThing() { return ''; }
+}
+
+abstract class BadClass extends BaseClass {
+    constructor(n: number) {
+        super();
+    }
+}
+
+const Thing2 = extendCompatibleConstructor(extendNoConstructor(ExtClass));
+extendCompatibleConstructor(extendNoConstructor(BadClass));
+
+const thing2 = new Thing2();
+const thing2arg = new Thing2('');
+const fails_arg = new Thing2(2);
+
+const str2 = Thing2.staticExt() + Thing2.staticThing() + Thing2.staticBase();
+const num2 = thing2.ext() + thing2.thing() + thing2.base();
+
+class Thing3 extends Thing2 {
+    constructor() {
+        super('', 1, 2);
+        Math.round(this.base() + this.thing() + this.ext());
+    }
+}
+
+
+//// [genericWildcardBaseClass.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var BaseClass = /** @class */ (function () {
+    function BaseClass(s) {
+        if (s === void 0) { s = ''; }
+        var args = [];
+        for (var _i = 1; _i < arguments.length; _i++) {
+            args[_i - 1] = arguments[_i];
+        }
+    }
+    BaseClass.prototype.base = function () { return 0; };
+    BaseClass.staticBase = function () { return ''; };
+    return BaseClass;
+}());
+function extendNoConstructor(Base) {
+    return /** @class */ (function (_super) {
+        __extends(ExN, _super);
+        function ExN() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        ExN.prototype.ext = function () { return 0; };
+        ExN.staticExt = function () { return ''; };
+        return ExN;
+    }(Base));
+}
+function extendCompatibleConstructor(Base) {
+    return /** @class */ (function (_super) {
+        __extends(ExC, _super);
+        function ExC(x) {
+            var args = [];
+            for (var _i = 1; _i < arguments.length; _i++) {
+                args[_i - 1] = arguments[_i];
+            }
+            return _super.call(this, x, args) || this;
+        }
+        return ExC;
+    }(Base));
+}
+function fails_IncompatibleConstructor(Base) {
+    return /** @class */ (function (_super) {
+        __extends(Fail, _super);
+        function Fail(x) {
+            var args = [];
+            for (var _i = 1; _i < arguments.length; _i++) {
+                args[_i - 1] = arguments[_i];
+            }
+            return _super.call(this, x, args) || this;
+        }
+        return Fail;
+    }(Base));
+}
+var ExtClass = /** @class */ (function (_super) {
+    __extends(ExtClass, _super);
+    function ExtClass() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    ExtClass.prototype.thing = function () { return 0; };
+    ExtClass.staticThing = function () { return ''; };
+    return ExtClass;
+}(BaseClass));
+var BadClass = /** @class */ (function (_super) {
+    __extends(BadClass, _super);
+    function BadClass(n) {
+        return _super.call(this) || this;
+    }
+    return BadClass;
+}(BaseClass));
+var Thing2 = extendCompatibleConstructor(extendNoConstructor(ExtClass));
+extendCompatibleConstructor(extendNoConstructor(BadClass));
+var thing2 = new Thing2();
+var thing2arg = new Thing2('');
+var fails_arg = new Thing2(2);
+var str2 = Thing2.staticExt() + Thing2.staticThing() + Thing2.staticBase();
+var num2 = thing2.ext() + thing2.thing() + thing2.base();
+var Thing3 = /** @class */ (function (_super) {
+    __extends(Thing3, _super);
+    function Thing3() {
+        var _this = _super.call(this, '', 1, 2) || this;
+        Math.round(_this.base() + _this.thing() + _this.ext());
+        return _this;
+    }
+    return Thing3;
+}(Thing2));

--- a/tests/baselines/reference/genericWildcardBaseClass.symbols
+++ b/tests/baselines/reference/genericWildcardBaseClass.symbols
@@ -1,0 +1,173 @@
+=== tests/cases/compiler/genericWildcardBaseClass.ts ===
+abstract class BaseClass {
+>BaseClass : Symbol(BaseClass, Decl(genericWildcardBaseClass.ts, 0, 0))
+
+    constructor(s: string = '', ...args: any[]) { }
+>s : Symbol(s, Decl(genericWildcardBaseClass.ts, 1, 16))
+>args : Symbol(args, Decl(genericWildcardBaseClass.ts, 1, 31))
+
+    base() { return 0; }
+>base : Symbol(BaseClass.base, Decl(genericWildcardBaseClass.ts, 1, 51))
+
+    static staticBase() { return ''; }
+>staticBase : Symbol(BaseClass.staticBase, Decl(genericWildcardBaseClass.ts, 2, 24))
+}
+
+function extendNoConstructor<T extends typeof BaseClass>(Base: T) {
+>extendNoConstructor : Symbol(extendNoConstructor, Decl(genericWildcardBaseClass.ts, 4, 1))
+>T : Symbol(T, Decl(genericWildcardBaseClass.ts, 6, 29))
+>BaseClass : Symbol(BaseClass, Decl(genericWildcardBaseClass.ts, 0, 0))
+>Base : Symbol(Base, Decl(genericWildcardBaseClass.ts, 6, 57))
+>T : Symbol(T, Decl(genericWildcardBaseClass.ts, 6, 29))
+
+    return class ExN extends Base {
+>ExN : Symbol(ExN, Decl(genericWildcardBaseClass.ts, 7, 10))
+>Base : Symbol(Base, Decl(genericWildcardBaseClass.ts, 6, 57))
+
+        ext() { return 0; }
+>ext : Symbol(ExN.ext, Decl(genericWildcardBaseClass.ts, 7, 35))
+
+        static staticExt() { return ''; }
+>staticExt : Symbol(ExN.staticExt, Decl(genericWildcardBaseClass.ts, 8, 27))
+
+    };
+}
+
+function extendCompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+>extendCompatibleConstructor : Symbol(extendCompatibleConstructor, Decl(genericWildcardBaseClass.ts, 11, 1))
+>T : Symbol(T, Decl(genericWildcardBaseClass.ts, 13, 37))
+>BaseClass : Symbol(BaseClass, Decl(genericWildcardBaseClass.ts, 0, 0))
+>Base : Symbol(Base, Decl(genericWildcardBaseClass.ts, 13, 65))
+>T : Symbol(T, Decl(genericWildcardBaseClass.ts, 13, 37))
+
+    return class ExC extends Base {
+>ExC : Symbol(ExC, Decl(genericWildcardBaseClass.ts, 14, 10))
+>Base : Symbol(Base, Decl(genericWildcardBaseClass.ts, 13, 65))
+
+        constructor(x?: string, ...args: any[]) {
+>x : Symbol(x, Decl(genericWildcardBaseClass.ts, 15, 20))
+>args : Symbol(args, Decl(genericWildcardBaseClass.ts, 15, 31))
+
+            super(x, args);
+>super : Symbol(T, Decl(genericWildcardBaseClass.ts, 13, 37))
+>x : Symbol(x, Decl(genericWildcardBaseClass.ts, 15, 20))
+>args : Symbol(args, Decl(genericWildcardBaseClass.ts, 15, 31))
+        }
+    };
+}
+
+function fails_IncompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+>fails_IncompatibleConstructor : Symbol(fails_IncompatibleConstructor, Decl(genericWildcardBaseClass.ts, 19, 1))
+>T : Symbol(T, Decl(genericWildcardBaseClass.ts, 21, 39))
+>BaseClass : Symbol(BaseClass, Decl(genericWildcardBaseClass.ts, 0, 0))
+>Base : Symbol(Base, Decl(genericWildcardBaseClass.ts, 21, 67))
+>T : Symbol(T, Decl(genericWildcardBaseClass.ts, 21, 39))
+
+    return class Fail extends Base {
+>Fail : Symbol(Fail, Decl(genericWildcardBaseClass.ts, 22, 10))
+>Base : Symbol(Base, Decl(genericWildcardBaseClass.ts, 21, 67))
+
+        constructor(x?: string, ...args: string[]) {
+>x : Symbol(x, Decl(genericWildcardBaseClass.ts, 23, 20))
+>args : Symbol(args, Decl(genericWildcardBaseClass.ts, 23, 31))
+
+            super(x, args);
+>super : Symbol(T, Decl(genericWildcardBaseClass.ts, 21, 39))
+>x : Symbol(x, Decl(genericWildcardBaseClass.ts, 23, 20))
+>args : Symbol(args, Decl(genericWildcardBaseClass.ts, 23, 31))
+        }
+    };
+}
+
+abstract class ExtClass extends BaseClass {
+>ExtClass : Symbol(ExtClass, Decl(genericWildcardBaseClass.ts, 27, 1))
+>BaseClass : Symbol(BaseClass, Decl(genericWildcardBaseClass.ts, 0, 0))
+
+    thing() { return 0; }
+>thing : Symbol(ExtClass.thing, Decl(genericWildcardBaseClass.ts, 29, 43))
+
+    static staticThing() { return ''; }
+>staticThing : Symbol(ExtClass.staticThing, Decl(genericWildcardBaseClass.ts, 30, 25))
+}
+
+abstract class BadClass extends BaseClass {
+>BadClass : Symbol(BadClass, Decl(genericWildcardBaseClass.ts, 32, 1))
+>BaseClass : Symbol(BaseClass, Decl(genericWildcardBaseClass.ts, 0, 0))
+
+    constructor(n: number) {
+>n : Symbol(n, Decl(genericWildcardBaseClass.ts, 35, 16))
+
+        super();
+>super : Symbol(BaseClass, Decl(genericWildcardBaseClass.ts, 0, 0))
+    }
+}
+
+const Thing2 = extendCompatibleConstructor(extendNoConstructor(ExtClass));
+>Thing2 : Symbol(Thing2, Decl(genericWildcardBaseClass.ts, 40, 5))
+>extendCompatibleConstructor : Symbol(extendCompatibleConstructor, Decl(genericWildcardBaseClass.ts, 11, 1))
+>extendNoConstructor : Symbol(extendNoConstructor, Decl(genericWildcardBaseClass.ts, 4, 1))
+>ExtClass : Symbol(ExtClass, Decl(genericWildcardBaseClass.ts, 27, 1))
+
+extendCompatibleConstructor(extendNoConstructor(BadClass));
+>extendCompatibleConstructor : Symbol(extendCompatibleConstructor, Decl(genericWildcardBaseClass.ts, 11, 1))
+>extendNoConstructor : Symbol(extendNoConstructor, Decl(genericWildcardBaseClass.ts, 4, 1))
+>BadClass : Symbol(BadClass, Decl(genericWildcardBaseClass.ts, 32, 1))
+
+const thing2 = new Thing2();
+>thing2 : Symbol(thing2, Decl(genericWildcardBaseClass.ts, 43, 5))
+>Thing2 : Symbol(Thing2, Decl(genericWildcardBaseClass.ts, 40, 5))
+
+const thing2arg = new Thing2('');
+>thing2arg : Symbol(thing2arg, Decl(genericWildcardBaseClass.ts, 44, 5))
+>Thing2 : Symbol(Thing2, Decl(genericWildcardBaseClass.ts, 40, 5))
+
+const fails_arg = new Thing2(2);
+>fails_arg : Symbol(fails_arg, Decl(genericWildcardBaseClass.ts, 45, 5))
+>Thing2 : Symbol(Thing2, Decl(genericWildcardBaseClass.ts, 40, 5))
+
+const str2 = Thing2.staticExt() + Thing2.staticThing() + Thing2.staticBase();
+>str2 : Symbol(str2, Decl(genericWildcardBaseClass.ts, 47, 5))
+>Thing2.staticExt : Symbol(ExN.staticExt, Decl(genericWildcardBaseClass.ts, 8, 27))
+>Thing2 : Symbol(Thing2, Decl(genericWildcardBaseClass.ts, 40, 5))
+>staticExt : Symbol(ExN.staticExt, Decl(genericWildcardBaseClass.ts, 8, 27))
+>Thing2.staticThing : Symbol(ExtClass.staticThing, Decl(genericWildcardBaseClass.ts, 30, 25))
+>Thing2 : Symbol(Thing2, Decl(genericWildcardBaseClass.ts, 40, 5))
+>staticThing : Symbol(ExtClass.staticThing, Decl(genericWildcardBaseClass.ts, 30, 25))
+>Thing2.staticBase : Symbol(staticBase, Decl(genericWildcardBaseClass.ts, 2, 24), Decl(genericWildcardBaseClass.ts, 2, 24), Decl(genericWildcardBaseClass.ts, 2, 24))
+>Thing2 : Symbol(Thing2, Decl(genericWildcardBaseClass.ts, 40, 5))
+>staticBase : Symbol(staticBase, Decl(genericWildcardBaseClass.ts, 2, 24), Decl(genericWildcardBaseClass.ts, 2, 24), Decl(genericWildcardBaseClass.ts, 2, 24))
+
+const num2 = thing2.ext() + thing2.thing() + thing2.base();
+>num2 : Symbol(num2, Decl(genericWildcardBaseClass.ts, 48, 5))
+>thing2.ext : Symbol(ExN.ext, Decl(genericWildcardBaseClass.ts, 7, 35))
+>thing2 : Symbol(thing2, Decl(genericWildcardBaseClass.ts, 43, 5))
+>ext : Symbol(ExN.ext, Decl(genericWildcardBaseClass.ts, 7, 35))
+>thing2.thing : Symbol(ExtClass.thing, Decl(genericWildcardBaseClass.ts, 29, 43))
+>thing2 : Symbol(thing2, Decl(genericWildcardBaseClass.ts, 43, 5))
+>thing : Symbol(ExtClass.thing, Decl(genericWildcardBaseClass.ts, 29, 43))
+>thing2.base : Symbol(BaseClass.base, Decl(genericWildcardBaseClass.ts, 1, 51))
+>thing2 : Symbol(thing2, Decl(genericWildcardBaseClass.ts, 43, 5))
+>base : Symbol(BaseClass.base, Decl(genericWildcardBaseClass.ts, 1, 51))
+
+class Thing3 extends Thing2 {
+>Thing3 : Symbol(Thing3, Decl(genericWildcardBaseClass.ts, 48, 59))
+>Thing2 : Symbol(Thing2, Decl(genericWildcardBaseClass.ts, 40, 5))
+
+    constructor() {
+        super('', 1, 2);
+        Math.round(this.base() + this.thing() + this.ext());
+>Math.round : Symbol(Math.round, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>round : Symbol(Math.round, Decl(lib.es5.d.ts, --, --))
+>this.base : Symbol(BaseClass.base, Decl(genericWildcardBaseClass.ts, 1, 51))
+>this : Symbol(Thing3, Decl(genericWildcardBaseClass.ts, 48, 59))
+>base : Symbol(BaseClass.base, Decl(genericWildcardBaseClass.ts, 1, 51))
+>this.thing : Symbol(ExtClass.thing, Decl(genericWildcardBaseClass.ts, 29, 43))
+>this : Symbol(Thing3, Decl(genericWildcardBaseClass.ts, 48, 59))
+>thing : Symbol(ExtClass.thing, Decl(genericWildcardBaseClass.ts, 29, 43))
+>this.ext : Symbol(ExN.ext, Decl(genericWildcardBaseClass.ts, 7, 35))
+>this : Symbol(Thing3, Decl(genericWildcardBaseClass.ts, 48, 59))
+>ext : Symbol(ExN.ext, Decl(genericWildcardBaseClass.ts, 7, 35))
+    }
+}
+

--- a/tests/baselines/reference/genericWildcardBaseClass.types
+++ b/tests/baselines/reference/genericWildcardBaseClass.types
@@ -1,0 +1,211 @@
+=== tests/cases/compiler/genericWildcardBaseClass.ts ===
+abstract class BaseClass {
+>BaseClass : BaseClass
+
+    constructor(s: string = '', ...args: any[]) { }
+>s : string
+>'' : ""
+>args : any[]
+
+    base() { return 0; }
+>base : () => number
+>0 : 0
+
+    static staticBase() { return ''; }
+>staticBase : () => string
+>'' : ""
+}
+
+function extendNoConstructor<T extends typeof BaseClass>(Base: T) {
+>extendNoConstructor : <T extends typeof BaseClass>(Base: T) => { new (s?: string, ...args: any[]): ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & T
+>BaseClass : typeof BaseClass
+>Base : T
+
+    return class ExN extends Base {
+>class ExN extends Base {        ext() { return 0; }        static staticExt() { return ''; }    } : { new (s?: string, ...args: any[]): ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & T
+>ExN : { new (s?: string, ...args: any[]): ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & T
+>Base : BaseClass
+
+        ext() { return 0; }
+>ext : () => number
+>0 : 0
+
+        static staticExt() { return ''; }
+>staticExt : () => string
+>'' : ""
+
+    };
+}
+
+function extendCompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+>extendCompatibleConstructor : <T extends typeof BaseClass>(Base: T) => { new (x?: string, ...args: any[]): ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & T
+>BaseClass : typeof BaseClass
+>Base : T
+
+    return class ExC extends Base {
+>class ExC extends Base {        constructor(x?: string, ...args: any[]) {            super(x, args);        }    } : { new (x?: string, ...args: any[]): ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & T
+>ExC : { new (x?: string, ...args: any[]): ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & T
+>Base : BaseClass
+
+        constructor(x?: string, ...args: any[]) {
+>x : string
+>args : any[]
+
+            super(x, args);
+>super(x, args) : void
+>super : T
+>x : string
+>args : any[]
+        }
+    };
+}
+
+function fails_IncompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+>fails_IncompatibleConstructor : <T extends typeof BaseClass>(Base: T) => { new (x?: string, ...args: string[]): Fail; prototype: fails_IncompatibleConstructor<any>.Fail; staticBase(): string; } & T
+>BaseClass : typeof BaseClass
+>Base : T
+
+    return class Fail extends Base {
+>class Fail extends Base {        constructor(x?: string, ...args: string[]) {            super(x, args);        }    } : { new (x?: string, ...args: string[]): Fail; prototype: fails_IncompatibleConstructor<any>.Fail; staticBase(): string; } & T
+>Fail : { new (x?: string, ...args: string[]): Fail; prototype: fails_IncompatibleConstructor<any>.Fail; staticBase(): string; } & T
+>Base : BaseClass
+
+        constructor(x?: string, ...args: string[]) {
+>x : string
+>args : string[]
+
+            super(x, args);
+>super(x, args) : void
+>super : T
+>x : string
+>args : string[]
+        }
+    };
+}
+
+abstract class ExtClass extends BaseClass {
+>ExtClass : ExtClass
+>BaseClass : BaseClass
+
+    thing() { return 0; }
+>thing : () => number
+>0 : 0
+
+    static staticThing() { return ''; }
+>staticThing : () => string
+>'' : ""
+}
+
+abstract class BadClass extends BaseClass {
+>BadClass : BadClass
+>BaseClass : BaseClass
+
+    constructor(n: number) {
+>n : number
+
+        super();
+>super() : void
+>super : typeof BaseClass
+    }
+}
+
+const Thing2 = extendCompatibleConstructor(extendNoConstructor(ExtClass));
+>Thing2 : { new (x?: string, ...args: any[]): extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+>extendCompatibleConstructor(extendNoConstructor(ExtClass)) : { new (x?: string, ...args: any[]): extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+>extendCompatibleConstructor : <T extends typeof BaseClass>(Base: T) => { new (x?: string, ...args: any[]): ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & T
+>extendNoConstructor(ExtClass) : { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+>extendNoConstructor : <T extends typeof BaseClass>(Base: T) => { new (s?: string, ...args: any[]): ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & T
+>ExtClass : typeof ExtClass
+
+extendCompatibleConstructor(extendNoConstructor(BadClass));
+>extendCompatibleConstructor(extendNoConstructor(BadClass)) : any
+>extendCompatibleConstructor : <T extends typeof BaseClass>(Base: T) => { new (x?: string, ...args: any[]): ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & T
+>extendNoConstructor(BadClass) : any
+>extendNoConstructor : <T extends typeof BaseClass>(Base: T) => { new (s?: string, ...args: any[]): ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & T
+>BadClass : typeof BadClass
+
+const thing2 = new Thing2();
+>thing2 : extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC & extendNoConstructor<typeof ExtClass>.ExN & ExtClass
+>new Thing2() : extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC & extendNoConstructor<typeof ExtClass>.ExN & ExtClass
+>Thing2 : { new (x?: string, ...args: any[]): extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+
+const thing2arg = new Thing2('');
+>thing2arg : extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC & extendNoConstructor<typeof ExtClass>.ExN & ExtClass
+>new Thing2('') : extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC & extendNoConstructor<typeof ExtClass>.ExN & ExtClass
+>Thing2 : { new (x?: string, ...args: any[]): extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+>'' : ""
+
+const fails_arg = new Thing2(2);
+>fails_arg : any
+>new Thing2(2) : any
+>Thing2 : { new (x?: string, ...args: any[]): extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+>2 : 2
+
+const str2 = Thing2.staticExt() + Thing2.staticThing() + Thing2.staticBase();
+>str2 : string
+>Thing2.staticExt() + Thing2.staticThing() + Thing2.staticBase() : string
+>Thing2.staticExt() + Thing2.staticThing() : string
+>Thing2.staticExt() : string
+>Thing2.staticExt : () => string
+>Thing2 : { new (x?: string, ...args: any[]): extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+>staticExt : () => string
+>Thing2.staticThing() : string
+>Thing2.staticThing : () => string
+>Thing2 : { new (x?: string, ...args: any[]): extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+>staticThing : () => string
+>Thing2.staticBase() : string
+>Thing2.staticBase : () => string
+>Thing2 : { new (x?: string, ...args: any[]): extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+>staticBase : () => string
+
+const num2 = thing2.ext() + thing2.thing() + thing2.base();
+>num2 : number
+>thing2.ext() + thing2.thing() + thing2.base() : number
+>thing2.ext() + thing2.thing() : number
+>thing2.ext() : number
+>thing2.ext : () => number
+>thing2 : extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC & extendNoConstructor<typeof ExtClass>.ExN & ExtClass
+>ext : () => number
+>thing2.thing() : number
+>thing2.thing : () => number
+>thing2 : extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC & extendNoConstructor<typeof ExtClass>.ExN & ExtClass
+>thing : () => number
+>thing2.base() : number
+>thing2.base : () => number
+>thing2 : extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC & extendNoConstructor<typeof ExtClass>.ExN & ExtClass
+>base : () => number
+
+class Thing3 extends Thing2 {
+>Thing3 : Thing3
+>Thing2 : extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC & extendNoConstructor<typeof ExtClass>.ExN & ExtClass
+
+    constructor() {
+        super('', 1, 2);
+>super('', 1, 2) : void
+>super : { new (x?: string, ...args: any[]): extendCompatibleConstructor<{ new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass>.ExC; prototype: extendCompatibleConstructor<any>.ExC; staticBase(): string; } & { new (s?: string, ...args: any[]): extendNoConstructor<typeof ExtClass>.ExN; prototype: extendNoConstructor<any>.ExN; staticExt(): string; staticBase(): string; } & typeof ExtClass
+>'' : ""
+>1 : 1
+>2 : 2
+
+        Math.round(this.base() + this.thing() + this.ext());
+>Math.round(this.base() + this.thing() + this.ext()) : number
+>Math.round : (x: number) => number
+>Math : Math
+>round : (x: number) => number
+>this.base() + this.thing() + this.ext() : number
+>this.base() + this.thing() : number
+>this.base() : number
+>this.base : () => number
+>this : this
+>base : () => number
+>this.thing() : number
+>this.thing : () => number
+>this : this
+>thing : () => number
+>this.ext() : number
+>this.ext : () => number
+>this : this
+>ext : () => number
+    }
+}
+

--- a/tests/cases/compiler/genericWildcardBaseClass.ts
+++ b/tests/cases/compiler/genericWildcardBaseClass.ts
@@ -1,0 +1,56 @@
+abstract class BaseClass {
+    constructor(s: string = '', ...args: any[]) { }
+    base() { return 0; }
+    static staticBase() { return ''; }
+}
+
+function extendNoConstructor<T extends typeof BaseClass>(Base: T) {
+    return class ExN extends Base {
+        ext() { return 0; }
+        static staticExt() { return ''; }
+    };
+}
+
+function extendCompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+    return class ExC extends Base {
+        constructor(x?: string, ...args: any[]) {
+            super(x, args);
+        }
+    };
+}
+
+function fails_IncompatibleConstructor<T extends typeof BaseClass>(Base: T) {
+    return class Fail extends Base {
+        constructor(x?: string, ...args: string[]) {
+            super(x, args);
+        }
+    };
+}
+
+abstract class ExtClass extends BaseClass {
+    thing() { return 0; }
+    static staticThing() { return ''; }
+}
+
+abstract class BadClass extends BaseClass {
+    constructor(n: number) {
+        super();
+    }
+}
+
+const Thing2 = extendCompatibleConstructor(extendNoConstructor(ExtClass));
+extendCompatibleConstructor(extendNoConstructor(BadClass));
+
+const thing2 = new Thing2();
+const thing2arg = new Thing2('');
+const fails_arg = new Thing2(2);
+
+const str2 = Thing2.staticExt() + Thing2.staticThing() + Thing2.staticBase();
+const num2 = thing2.ext() + thing2.thing() + thing2.base();
+
+class Thing3 extends Thing2 {
+    constructor() {
+        super('', 1, 2);
+        Math.round(this.base() + this.thing() + this.ext());
+    }
+}


### PR DESCRIPTION
This PR adds an ability to use strict constructor signatures on mixin classes for #13743 instead of saying just `constructor(...args: any[])`.

This feature will be useful if the mixin class needs some arguments from the overridden constructor, e.g.:
```ts
abstract class Base {
  constructor(s: string = '') {}
}
const mixin = <T extends typeof Base>(base: T) => class extends base {
  constructor(x?: string) {
    super(x);
    // use the "x"
  }
};

class Incompatible {
  constructor(n: number) {}
}
mixin(Incompatible); // Fails to extend from a class with an incompatible constructor
```

I researched for the reason of requiring the mixin constructor to be `constructor(...args: any[])` but didn't manage to find one which can be violated by this PR.