### PR TITLE
Bad callsite inferences fall back to body usage

### DIFF
--- a/tests/cases/fourslash/codeFixInferFromUsageCallBodyPriority.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageCallBodyPriority.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+// based on acorn
+
+////function isIdentifierStart([|code, astral |]) {
+////  if (code < 65) { return code === 36 }
+////  if (code < 91) { return true }
+////  if (code < 97) { return code === 95 }
+////  if (code < 123) { return true }
+////  if (code <= 0xffff) { return code >= 0xaa }
+////  if (astral === false) { return false }
+////}
+////
+////function isLet(nextCh: any) {
+////    return isIdentifierStart(nextCh, true)
+////};
+
+
+verify.rangeAfterCodeFix("code: number, astral: boolean",/*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);


### PR DESCRIPTION
For parameters, the infer-from-usage codefix uses a substantially different codepath that previously only looked at call site uses. When this resulted in no inferences, or bad inferences, for a single parameter, the codefix would just use any. Only if no usages of a function were found would the codefix use the body-inference code.

This commit makes parameter inference fall back to body-inference code for individual parameters when there is no inference or inference to any.
