### PR TITLE
Prefer getValidSourceFile over Debug.assertDefined(program.getSourceFile(*))

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1533,7 +1533,7 @@ namespace ts {
             const normalizedFileName = normalizePath(fileName);
             Debug.assert(filesToSearch.some(f => normalizePath(f) === normalizedFileName));
             synchronizeHostData();
-            const sourceFilesToSearch = map(filesToSearch, f => Debug.assertDefined(program.getSourceFile(f)));
+            const sourceFilesToSearch = filesToSearch.map(getValidSourceFile);
             const sourceFile = getValidSourceFile(fileName);
             return DocumentHighlights.getDocumentHighlights(program, cancellationToken, sourceFile, position, sourceFilesToSearch);
         }


### PR DESCRIPTION
Inspired by #27879. Won't fix it but should have a less cryptic stack trace.

