### PR TITLE
Change pathCompletions to stringCompletions, move more code there

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -37,18 +37,13 @@ namespace ts.Completions {
     export function getCompletionsAtPosition(host: LanguageServiceHost, program: Program, log: Log, sourceFile: SourceFile, position: number, preferences: UserPreferences, triggerCharacter: CompletionsTriggerCharacter | undefined): CompletionInfo | undefined {
         const typeChecker = program.getTypeChecker();
         const compilerOptions = program.getCompilerOptions();
-        if (isInReferenceComment(sourceFile, position)) {
-            const entries = PathCompletions.getTripleSlashReferenceCompletion(sourceFile, position, compilerOptions, host);
-            return entries && convertPathCompletions(entries);
-        }
 
         const contextToken = findPrecedingToken(position, sourceFile);
         if (triggerCharacter && !isValidTrigger(sourceFile, triggerCharacter, contextToken, position)) return undefined;
 
-        if (isInString(sourceFile, position, contextToken)) {
-            return !contextToken || !isStringLiteralLike(contextToken)
-                ? undefined
-                : convertStringLiteralCompletions(getStringLiteralCompletionEntries(sourceFile, contextToken, position, typeChecker, compilerOptions, host), sourceFile, typeChecker, log, preferences);
+        const stringCompletions = StringCompletions.getStringLiteralCompletions(sourceFile, position, contextToken, typeChecker, compilerOptions, host, log, preferences);
+        if (stringCompletions) {
+            return stringCompletions;
         }
 
         if (contextToken && isBreakOrContinueStatement(contextToken.parent)
@@ -74,48 +69,6 @@ namespace ts.Completions {
                 return jsdocCompletionInfo(JsDoc.getJSDocParameterNameCompletions(completionData.tag));
             default:
                 return Debug.assertNever(completionData);
-        }
-    }
-
-    function convertStringLiteralCompletions(completion: StringLiteralCompletion | undefined, sourceFile: SourceFile, checker: TypeChecker, log: Log, preferences: UserPreferences): CompletionInfo | undefined {
-        if (completion === undefined) {
-            return undefined;
-        }
-        switch (completion.kind) {
-            case StringLiteralCompletionKind.Paths:
-                return convertPathCompletions(completion.paths);
-            case StringLiteralCompletionKind.Properties: {
-                const entries: CompletionEntry[] = [];
-                getCompletionEntriesFromSymbols(completion.symbols, entries, sourceFile, sourceFile, checker, ScriptTarget.ESNext, log, CompletionKind.String, preferences); // Target will not be used, so arbitrary
-                return { isGlobalCompletion: false, isMemberCompletion: true, isNewIdentifierLocation: completion.hasIndexSignature, entries };
-            }
-            case StringLiteralCompletionKind.Types: {
-                const entries = completion.types.map(type => ({ name: type.value, kindModifiers: ScriptElementKindModifier.none, kind: ScriptElementKind.string, sortText: "0" }));
-                return { isGlobalCompletion: false, isMemberCompletion: false, isNewIdentifierLocation: completion.isNewIdentifier, entries };
-            }
-            default:
-                return Debug.assertNever(completion);
-        }
-    }
-
-    function convertPathCompletions(pathCompletions: ReadonlyArray<PathCompletions.PathCompletion>): CompletionInfo {
-        const isGlobalCompletion = false; // We don't want the editor to offer any other completions, such as snippets, inside a comment.
-        const isNewIdentifierLocation = true; // The user may type in a path that doesn't yet exist, creating a "new identifier" with respect to the collection of identifiers the server is aware of.
-        const entries = pathCompletions.map(({ name, kind, span, extension }): CompletionEntry =>
-            ({ name, kind, kindModifiers: kindModifiersFromExtension(extension), sortText: "0", replacementSpan: span }));
-        return { isGlobalCompletion, isMemberCompletion: false, isNewIdentifierLocation, entries };
-    }
-    function kindModifiersFromExtension(extension: Extension | undefined): ScriptElementKindModifier {
-        switch (extension) {
-            case Extension.Dts: return ScriptElementKindModifier.dtsModifier;
-            case Extension.Js: return ScriptElementKindModifier.jsModifier;
-            case Extension.Json: return ScriptElementKindModifier.jsonModifier;
-            case Extension.Jsx: return ScriptElementKindModifier.jsxModifier;
-            case Extension.Ts: return ScriptElementKindModifier.tsModifier;
-            case Extension.Tsx: return ScriptElementKindModifier.tsxModifier;
-            case undefined: return ScriptElementKindModifier.none;
-            default:
-                return Debug.assertNever(extension);
         }
     }
 
@@ -284,22 +237,6 @@ namespace ts.Completions {
         };
     }
 
-    function quote(text: string, preferences: UserPreferences): string {
-        if (/^\d+$/.test(text)) {
-            return text;
-        }
-        const quoted = JSON.stringify(text);
-        switch (preferences.quotePreference) {
-            case undefined:
-            case "double":
-                return quoted;
-            case "single":
-                return `'${stripQuotes(quoted).replace("'", "\\'").replace('\\"', '"')}'`;
-            default:
-                return Debug.assertNever(preferences.quotePreference);
-        }
-    }
-
     function isRecommendedCompletionMatch(localSymbol: Symbol, recommendedCompletion: Symbol | undefined, checker: TypeChecker): boolean {
         return localSymbol === recommendedCompletion ||
             !!(localSymbol.flags & SymbolFlags.ExportValue) && checker.getExportSymbolOfSymbol(localSymbol) === recommendedCompletion;
@@ -313,7 +250,7 @@ namespace ts.Completions {
         return origin && originIsExport(origin) ? stripQuotes(origin.moduleSymbol.name) : undefined;
     }
 
-    function getCompletionEntriesFromSymbols(
+    export function getCompletionEntriesFromSymbols(
         symbols: ReadonlyArray<Symbol>,
         entries: Push<CompletionEntry>,
         location: Node | undefined,
@@ -391,145 +328,6 @@ namespace ts.Completions {
         return entries;
     }
 
-    const enum StringLiteralCompletionKind { Paths, Properties, Types }
-    interface StringLiteralCompletionsFromProperties {
-        readonly kind: StringLiteralCompletionKind.Properties;
-        readonly symbols: ReadonlyArray<Symbol>;
-        readonly hasIndexSignature: boolean;
-    }
-    interface StringLiteralCompletionsFromTypes {
-        readonly kind: StringLiteralCompletionKind.Types;
-        readonly types: ReadonlyArray<StringLiteralType>;
-        readonly isNewIdentifier: boolean;
-    }
-    type StringLiteralCompletion = { readonly kind: StringLiteralCompletionKind.Paths, readonly paths: ReadonlyArray<PathCompletions.PathCompletion> } | StringLiteralCompletionsFromProperties | StringLiteralCompletionsFromTypes;
-    function getStringLiteralCompletionEntries(sourceFile: SourceFile, node: StringLiteralLike, position: number, typeChecker: TypeChecker, compilerOptions: CompilerOptions, host: LanguageServiceHost): StringLiteralCompletion | undefined {
-        const { parent } = node;
-        switch (parent.kind) {
-            case SyntaxKind.LiteralType:
-                switch (parent.parent.kind) {
-                    case SyntaxKind.TypeReference:
-                        return { kind: StringLiteralCompletionKind.Types, types: getStringLiteralTypes(typeChecker.getTypeArgumentConstraint(parent as LiteralTypeNode)), isNewIdentifier: false };
-                    case SyntaxKind.IndexedAccessType:
-                        // Get all apparent property names
-                        // i.e. interface Foo {
-                        //          foo: string;
-                        //          bar: string;
-                        //      }
-                        //      let x: Foo["/*completion position*/"]
-                        return stringLiteralCompletionsFromProperties(typeChecker.getTypeFromTypeNode((parent.parent as IndexedAccessTypeNode).objectType));
-                    case SyntaxKind.ImportType:
-                        return { kind: StringLiteralCompletionKind.Paths, paths: PathCompletions.getStringLiteralCompletionsFromModuleNames(sourceFile, node, compilerOptions, host, typeChecker) };
-                    case SyntaxKind.UnionType: {
-                        if (!isTypeReferenceNode(parent.parent.parent)) return undefined;
-                        const alreadyUsedTypes = getAlreadyUsedTypesInStringLiteralUnion(parent.parent as UnionTypeNode, parent as LiteralTypeNode);
-                        const types = getStringLiteralTypes(typeChecker.getTypeArgumentConstraint(parent.parent as UnionTypeNode)).filter(t => !contains(alreadyUsedTypes, t.value));
-                        return { kind: StringLiteralCompletionKind.Types, types, isNewIdentifier: false };
-                    }
-                    default:
-                        return undefined;
-                }
-
-            case SyntaxKind.PropertyAssignment:
-                if (isObjectLiteralExpression(parent.parent) && (<PropertyAssignment>parent).name === node) {
-                    // Get quoted name of properties of the object literal expression
-                    // i.e. interface ConfigFiles {
-                    //          'jspm:dev': string
-                    //      }
-                    //      let files: ConfigFiles = {
-                    //          '/*completion position*/'
-                    //      }
-                    //
-                    //      function foo(c: ConfigFiles) {}
-                    //      foo({
-                    //          '/*completion position*/'
-                    //      });
-                    return stringLiteralCompletionsFromProperties(typeChecker.getContextualType(parent.parent));
-                }
-                return fromContextualType();
-
-            case SyntaxKind.ElementAccessExpression: {
-                const { expression, argumentExpression } = parent as ElementAccessExpression;
-                if (node === argumentExpression) {
-                    // Get all names of properties on the expression
-                    // i.e. interface A {
-                    //      'prop1': string
-                    // }
-                    // let a: A;
-                    // a['/*completion position*/']
-                    return stringLiteralCompletionsFromProperties(typeChecker.getTypeAtLocation(expression));
-                }
-                return undefined;
-            }
-
-            case SyntaxKind.CallExpression:
-            case SyntaxKind.NewExpression:
-                if (!isRequireCall(parent, /*checkArgumentIsStringLiteralLike*/ false) && !isImportCall(parent)) {
-                    const argumentInfo = SignatureHelp.getArgumentInfoForCompletions(node, position, sourceFile);
-                    // Get string literal completions from specialized signatures of the target
-                    // i.e. declare function f(a: 'A');
-                    // f("/*completion position*/")
-                    return argumentInfo ? getStringLiteralCompletionsFromSignature(argumentInfo, typeChecker) : fromContextualType();
-                }
-                // falls through (is `require("")` or `import("")`)
-
-            case SyntaxKind.ImportDeclaration:
-            case SyntaxKind.ExportDeclaration:
-            case SyntaxKind.ExternalModuleReference:
-                // Get all known external module names or complete a path to a module
-                // i.e. import * as ns from "/*completion position*/";
-                //      var y = import("/*completion position*/");
-                //      import x = require("/*completion position*/");
-                //      var y = require("/*completion position*/");
-                //      export * from "/*completion position*/";
-                return { kind: StringLiteralCompletionKind.Paths, paths: PathCompletions.getStringLiteralCompletionsFromModuleNames(sourceFile, node, compilerOptions, host, typeChecker) };
-
-            default:
-                return fromContextualType();
-        }
-
-        function fromContextualType(): StringLiteralCompletion {
-            // Get completion for string literal from string literal type
-            // i.e. var x: "hi" | "hello" = "/*completion position*/"
-            return { kind: StringLiteralCompletionKind.Types, types: getStringLiteralTypes(getContextualTypeFromParent(node, typeChecker)), isNewIdentifier: false };
-        }
-    }
-
-    function getAlreadyUsedTypesInStringLiteralUnion(union: UnionTypeNode, current: LiteralTypeNode): ReadonlyArray<string> {
-        return mapDefined(union.types, type =>
-            type !== current && isLiteralTypeNode(type) && isStringLiteral(type.literal) ? type.literal.text : undefined);
-    }
-
-    function getStringLiteralCompletionsFromSignature(argumentInfo: SignatureHelp.ArgumentInfoForCompletions, checker: TypeChecker): StringLiteralCompletionsFromTypes {
-        let isNewIdentifier = false;
-
-        const uniques = createMap<true>();
-        const candidates: Signature[] = [];
-        checker.getResolvedSignature(argumentInfo.invocation, candidates, argumentInfo.argumentCount);
-        const types = flatMap(candidates, candidate => {
-            if (!candidate.hasRestParameter && argumentInfo.argumentCount > candidate.parameters.length) return;
-            const type = checker.getParameterType(candidate, argumentInfo.argumentIndex);
-            isNewIdentifier = isNewIdentifier || !!(type.flags & TypeFlags.String);
-            return getStringLiteralTypes(type, uniques);
-        });
-
-        return { kind: StringLiteralCompletionKind.Types, types, isNewIdentifier };
-    }
-
-    function stringLiteralCompletionsFromProperties(type: Type | undefined): StringLiteralCompletionsFromProperties | undefined {
-        return type && { kind: StringLiteralCompletionKind.Properties, symbols: type.getApparentProperties(), hasIndexSignature: hasIndexSignature(type) };
-    }
-
-    function getStringLiteralTypes(type: Type | undefined, uniques = createMap<true>()): ReadonlyArray<StringLiteralType> {
-        if (!type) return emptyArray;
-        type = skipConstraint(type);
-        return type.isUnion()
-            ? flatMap(type.types, t => getStringLiteralTypes(t, uniques))
-            : type.isStringLiteral() && !(type.flags & TypeFlags.EnumLiteral) && addToSeen(uniques, type.value)
-            ? [type]
-            : emptyArray;
-    }
-
     interface SymbolCompletion {
         type: "symbol";
         symbol: Symbol;
@@ -597,10 +395,7 @@ namespace ts.Completions {
 
         const contextToken = findPrecedingToken(position, sourceFile);
         if (isInString(sourceFile, position, contextToken)) {
-            const stringLiteralCompletions = !contextToken || !isStringLiteralLike(contextToken)
-                ? undefined
-                : getStringLiteralCompletionEntries(sourceFile, contextToken, position, typeChecker, compilerOptions, host);
-            return stringLiteralCompletions && stringLiteralCompletionDetails(name, contextToken!, stringLiteralCompletions, sourceFile, typeChecker, cancellationToken); // TODO: GH#18217
+            return StringCompletions.getStringLiteralCompletionDetails(name, sourceFile, position, contextToken, typeChecker, compilerOptions, host, cancellationToken);
         }
 
         // Compute all the completion symbols again.
@@ -640,7 +435,7 @@ namespace ts.Completions {
         return createCompletionDetails(name, ScriptElementKindModifier.none, kind, [displayPart(name, kind2)]);
     }
 
-    function createCompletionDetailsForSymbol(symbol: Symbol, checker: TypeChecker, sourceFile: SourceFile, location: Node, cancellationToken: CancellationToken, codeActions?: CodeAction[], sourceDisplay?: SymbolDisplayPart[]): CompletionEntryDetails {
+    export function createCompletionDetailsForSymbol(symbol: Symbol, checker: TypeChecker, sourceFile: SourceFile, location: Node, cancellationToken: CancellationToken, codeActions?: CodeAction[], sourceDisplay?: SymbolDisplayPart[]): CompletionEntryDetails {
         const { displayParts, documentation, symbolKind, tags } =
             checker.runWithCancellationToken(cancellationToken, checker =>
                 SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(checker, symbol, sourceFile, location, location, SemanticMeaning.All)
@@ -648,24 +443,7 @@ namespace ts.Completions {
         return createCompletionDetails(symbol.name, SymbolDisplay.getSymbolModifiers(symbol), symbolKind, displayParts, documentation, tags, codeActions, sourceDisplay);
     }
 
-    function stringLiteralCompletionDetails(name: string, location: Node, completion: StringLiteralCompletion, sourceFile: SourceFile, checker: TypeChecker, cancellationToken: CancellationToken): CompletionEntryDetails | undefined {
-        switch (completion.kind) {
-            case StringLiteralCompletionKind.Paths: {
-                const match = find(completion.paths, p => p.name === name);
-                return match && createCompletionDetails(name, kindModifiersFromExtension(match.extension), match.kind, [textPart(name)]);
-            }
-            case StringLiteralCompletionKind.Properties: {
-                const match = find(completion.symbols, s => s.name === name);
-                return match && createCompletionDetailsForSymbol(match, checker, sourceFile, location, cancellationToken);
-            }
-            case StringLiteralCompletionKind.Types:
-                return find(completion.types, t => t.value === name) ? createCompletionDetails(name, ScriptElementKindModifier.none, ScriptElementKind.typeElement, [textPart(name)]) : undefined;
-            default:
-                return Debug.assertNever(completion);
-        }
-    }
-
-    function createCompletionDetails(name: string, kindModifiers: string, kind: ScriptElementKind, displayParts: SymbolDisplayPart[], documentation?: SymbolDisplayPart[], tags?: JSDocTagInfo[], codeActions?: CodeAction[], source?: SymbolDisplayPart[]): CompletionEntryDetails {
+    export function createCompletionDetails(name: string, kindModifiers: string, kind: ScriptElementKind, displayParts: SymbolDisplayPart[], documentation?: SymbolDisplayPart[], tags?: JSDocTagInfo[], codeActions?: CodeAction[], source?: SymbolDisplayPart[]): CompletionEntryDetails {
         return { name, kindModifiers, kind, displayParts, documentation, tags, codeActions, source };
     }
 
@@ -732,7 +510,7 @@ namespace ts.Completions {
     }
     type Request = { readonly kind: CompletionDataKind.JsDocTagName | CompletionDataKind.JsDocTag } | { readonly kind: CompletionDataKind.JsDocParameterName, tag: JSDocParameterTag };
 
-    const enum CompletionKind {
+    export const enum CompletionKind {
         ObjectPropertyDeclaration,
         Global,
         PropertyAccess,
@@ -784,28 +562,6 @@ namespace ts.Completions {
                     ? checker.getTypeAtLocation(parent.left)
                     : checker.getContextualType(previousToken as Expression);
         }
-    }
-
-    function getContextualTypeFromParent(node: Expression, checker: TypeChecker): Type | undefined {
-        const { parent } = node;
-        switch (parent.kind) {
-            case SyntaxKind.NewExpression:
-                return checker.getContextualType(parent as NewExpression);
-            case SyntaxKind.BinaryExpression: {
-                const { left, operatorToken, right } = parent as BinaryExpression;
-                return isEqualityOperatorKind(operatorToken.kind)
-                    ? checker.getTypeAtLocation(node === right ? left : right)
-                    : checker.getContextualType(node);
-            }
-            case SyntaxKind.CaseClause:
-                return (parent as CaseClause).expression === node ? getSwitchedType(parent as CaseClause, checker) : undefined;
-            default:
-                return checker.getContextualType(node);
-        }
-    }
-
-    function getSwitchedType(caseClause: CaseClause, checker: TypeChecker): Type | undefined {
-        return checker.getTypeAtLocation(caseClause.parent.parent.expression);
     }
 
     function getFirstSymbolInChain(symbol: Symbol, enclosingDeclaration: Node, checker: TypeChecker): Symbol | undefined {
@@ -2207,18 +1963,6 @@ namespace ts.Completions {
         return isIdentifier(node) ? node.originalKeywordKind || SyntaxKind.Unknown : node.kind;
     }
 
-    function isEqualityOperatorKind(kind: SyntaxKind): kind is EqualityOperator {
-        switch (kind) {
-            case SyntaxKind.EqualsEqualsEqualsToken:
-            case SyntaxKind.EqualsEqualsToken:
-            case SyntaxKind.ExclamationEqualsEqualsToken:
-            case SyntaxKind.ExclamationEqualsToken:
-                return true;
-            default:
-                return false;
-        }
-    }
-
     /** Get the corresponding JSDocTag node if the position is in a jsDoc comment */
     function getJsDocTagAtPosition(node: Node, position: number): JSDocTag | undefined {
         const jsdoc = findAncestor(node, isJSDoc);
@@ -2286,10 +2030,6 @@ namespace ts.Completions {
         return node.parent && isClassOrTypeElement(node.parent) && isObjectTypeDeclaration(node.parent.parent);
     }
 
-    function hasIndexSignature(type: Type): boolean {
-        return !!type.getStringIndexType() || !!type.getNumberIndexType();
-    }
-
     function isValidTrigger(sourceFile: SourceFile, triggerCharacter: CompletionsTriggerCharacter, contextToken: Node | undefined, position: number): boolean {
         switch (triggerCharacter) {
             case ".":
@@ -2314,17 +2054,5 @@ namespace ts.Completions {
 
     function binaryExpressionMayBeOpenTag({ left }: BinaryExpression): boolean {
         return nodeIsMissing(left);
-    }
-
-    function isStringLiteralOrTemplate(node: Node): node is StringLiteralLike | TemplateExpression | TaggedTemplateExpression {
-        switch (node.kind) {
-            case SyntaxKind.StringLiteral:
-            case SyntaxKind.NoSubstitutionTemplateLiteral:
-            case SyntaxKind.TemplateExpression:
-            case SyntaxKind.TaggedTemplateExpression:
-                return true;
-            default:
-                return false;
-        }
     }
 }

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -11,7 +11,7 @@
         "types.ts",
         "utilities.ts",
         "classifier.ts",
-        "pathCompletions.ts",
+        "stringCompletions.ts",
         "completions.ts",
         "documentHighlights.ts",
         "documentRegistry.ts",


### PR DESCRIPTION
Renames `pathCompletions` to `stringCompletions` and moves string completions code to there.
This actually reduces the number of exports in that file, because the string completions code needs to communicate with path completions more than it needs to communicate with the rest of completions.