### PR TITLE
Improve error message when scriptInfo is missing in mapTextChangeToCodeEdit

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -867,7 +867,13 @@ namespace ts.server {
         private doEnsureDefaultProjectForFile(fileName: NormalizedPath): Project {
             this.ensureProjectStructuresUptoDate();
             const scriptInfo = this.getScriptInfoForNormalizedPath(fileName);
-            return scriptInfo ? scriptInfo.getDefaultProject() : Errors.ThrowNoProject();
+            if (scriptInfo) {
+                return scriptInfo.getDefaultProject();
+            }
+            else {
+                this.logger.msg(`Cannot find ${fileName} in ${JSON.stringify(this.allScriptInfoFileNamesForDebug)}`, Msg.Err);
+                return Errors.ThrowNoProject();
+            }
         }
 
         getScriptInfoEnsuringProjectsUptoDate(uncheckedFileName: string) {
@@ -1967,8 +1973,12 @@ namespace ts.server {
         }
 
         /* @internal */
-        allScriptInfoFileNamesForDebug(): ReadonlyArray<string> {
-            return arrayFrom(this.filenameToScriptInfo.keys());
+        allScriptInfoFileNamesForDebug(): ReadonlyArray<{ readonly path: string, readonly fileName: string }> {
+            const out: { readonly path: string, readonly fileName: string }[] = [];
+            this.filenameToScriptInfo.forEach((scriptInfo, path) => {
+                out.push({ path, fileName: scriptInfo.fileName });
+            });
+            return out;
         }
 
         /**

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1966,6 +1966,11 @@ namespace ts.server {
             return configProject && configProject.getCompilerOptions().configFile;
         }
 
+        /* @internal */
+        allScriptInfoFileNamesForDebug(): ReadonlyArray<string> {
+            return arrayFrom(this.filenameToScriptInfo.keys());
+        }
+
         /**
          * Returns the projects that contain script info through SymLink
          * Note that this does not return projects in info.containingProjects

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -867,13 +867,7 @@ namespace ts.server {
         private doEnsureDefaultProjectForFile(fileName: NormalizedPath): Project {
             this.ensureProjectStructuresUptoDate();
             const scriptInfo = this.getScriptInfoForNormalizedPath(fileName);
-            if (scriptInfo) {
-                return scriptInfo.getDefaultProject();
-            }
-            else {
-                this.logger.msg(`Cannot find ${fileName} in ${JSON.stringify(this.allScriptInfoFileNamesForDebug)}`, Msg.Err);
-                return Errors.ThrowNoProject();
-            }
+            return scriptInfo ? scriptInfo.getDefaultProject() : (this.logErrorForScriptInfoNotFound(fileName), Errors.ThrowNoProject());
         }
 
         getScriptInfoEnsuringProjectsUptoDate(uncheckedFileName: string) {
@@ -1973,12 +1967,9 @@ namespace ts.server {
         }
 
         /* @internal */
-        allScriptInfoFileNamesForDebug(): ReadonlyArray<{ readonly path: string, readonly fileName: string }> {
-            const out: { readonly path: string, readonly fileName: string }[] = [];
-            this.filenameToScriptInfo.forEach((scriptInfo, path) => {
-                out.push({ path, fileName: scriptInfo.fileName });
-            });
-            return out;
+        logErrorForScriptInfoNotFound(fileName: string): void {
+            const names = arrayFrom(this.filenameToScriptInfo.entries()).map(([path, scriptInfo]) => ({ path, fileName: scriptInfo.fileName }));
+            this.logger.msg(`Could not find file ${JSON.stringify(fileName)}.\nAll files are: ${JSON.stringify(names)}`, Msg.Err);
         }
 
         /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1158,7 +1158,7 @@ namespace ts.server {
                     this.projectService.getScriptInfo(args.file);
                 if (!scriptInfo) {
                     if (ignoreNoProjectError) return emptyArray;
-                    this.logErrorForScriptInfoNotFound(args.file);
+                    this.projectService.logErrorForScriptInfoNotFound(args.file);
                     return Errors.ThrowNoProject();
                 }
                 projects = scriptInfo.containingProjects;
@@ -1167,15 +1167,10 @@ namespace ts.server {
             // filter handles case when 'projects' is undefined
             projects = filter(projects, p => p.languageServiceEnabled && !p.isOrphan());
             if (!ignoreNoProjectError && (!projects || !projects.length) && !symLinkedProjects) {
-                this.logErrorForScriptInfoNotFound(args.file);
+                this.projectService.logErrorForScriptInfoNotFound(args.file);
                 return Errors.ThrowNoProject();
             }
             return symLinkedProjects ? { projects: projects!, symLinkedProjects } : projects!; // TODO: GH#18217
-        }
-
-        private logErrorForScriptInfoNotFound(fileName: string): void {
-            this.logger.msg(`Could not find file ${JSON.stringify(fileName)}.\n` +
-                `All files are: ${JSON.stringify(this.projectService.allScriptInfoFileNamesForDebug())}`, Msg.Err);
         }
 
         private getDefaultProject(args: protocol.FileRequestArgs) {
@@ -1920,7 +1915,7 @@ namespace ts.server {
             const scriptInfo = this.projectService.getScriptInfoOrConfig(textChanges.fileName);
             if (!!textChanges.isNewFile === !!scriptInfo) {
                 if (!scriptInfo) { // and !isNewFile
-                    this.logErrorForScriptInfoNotFound(textChanges.fileName);
+                    this.projectService.logErrorForScriptInfoNotFound(textChanges.fileName);
                 }
                 Debug.fail("Expected isNewFile for (only) new files. " + JSON.stringify({ isNewFile: !!textChanges.isNewFile, hasScriptInfo: !!scriptInfo }));
             }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8826,6 +8826,7 @@ declare namespace ts.server {
         private getProjectInfoWorker;
         private getRenameInfo;
         private getProjects;
+        private logErrorForScriptInfoNotFound;
         private getDefaultProject;
         private getRenameLocations;
         private mapRenameInfo;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8826,7 +8826,6 @@ declare namespace ts.server {
         private getProjectInfoWorker;
         private getRenameInfo;
         private getProjects;
-        private logErrorForScriptInfoNotFound;
         private getDefaultProject;
         private getRenameLocations;
         private mapRenameInfo;


### PR DESCRIPTION
Should help diagnose #28233
Putting the text in a log message instead of in the exception text to avoid putting PII in exception text.