### PR TITLE
Do not add source files to container only project

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -694,12 +694,14 @@ namespace ts {
                 if (!resolvedProjectReferences) {
                     resolvedProjectReferences = projectReferences.map(parseProjectReferenceConfigFile);
                 }
-                for (const parsedRef of resolvedProjectReferences) {
-                    if (parsedRef) {
-                        const out = parsedRef.commandLine.options.outFile || parsedRef.commandLine.options.out;
-                        if (out) {
-                            const dtsOutfile = changeExtension(out, ".d.ts");
-                            processSourceFile(dtsOutfile, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false, /*packageId*/ undefined);
+                if (rootNames.length) {
+                    for (const parsedRef of resolvedProjectReferences) {
+                        if (parsedRef) {
+                            const out = parsedRef.commandLine.options.outFile || parsedRef.commandLine.options.out;
+                            if (out) {
+                                const dtsOutfile = changeExtension(out, ".d.ts");
+                                processSourceFile(dtsOutfile, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false, /*packageId*/ undefined);
+                            }
                         }
                     }
                 }
@@ -708,7 +710,7 @@ namespace ts {
             forEach(rootNames, name => processRootFile(name, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false));
 
             // load type declarations specified via 'types' argument or implicitly from types/ and node_modules/@types folders
-            const typeReferences: string[] = getAutomaticTypeDirectiveNames(options, host);
+            const typeReferences: string[] = rootNames.length ? getAutomaticTypeDirectiveNames(options, host) : emptyArray;
 
             if (typeReferences.length) {
                 // This containingFilename needs to match with the one used in managed-side
@@ -724,7 +726,7 @@ namespace ts {
             //  - The '--noLib' flag is used.
             //  - A 'no-default-lib' reference comment is encountered in
             //      processing the root files.
-            if (!skipDefaultLib) {
+            if (rootNames.length && !skipDefaultLib) {
                 // If '--lib' is not specified, include default library file according to '--target'
                 // otherwise, using options specified in '--lib' instead of '--target' default library file
                 const defaultLibraryFileName = getDefaultLibraryFileName();

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -726,7 +726,7 @@ namespace ts {
             //  - The '--noLib' flag is used.
             //  - A 'no-default-lib' reference comment is encountered in
             //      processing the root files.
-            if (rootNames.length && !skipDefaultLib) {
+            if (!skipDefaultLib) {
                 // If '--lib' is not specified, include default library file according to '--target'
                 // otherwise, using options specified in '--lib' instead of '--target' default library file
                 const defaultLibraryFileName = getDefaultLibraryFileName();

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -726,7 +726,7 @@ namespace ts {
             //  - The '--noLib' flag is used.
             //  - A 'no-default-lib' reference comment is encountered in
             //      processing the root files.
-            if (!skipDefaultLib) {
+            if (rootNames.length && !skipDefaultLib) {
                 // If '--lib' is not specified, include default library file according to '--target'
                 // otherwise, using options specified in '--lib' instead of '--target' default library file
                 const defaultLibraryFileName = getDefaultLibraryFileName();
@@ -1841,7 +1841,7 @@ namespace ts {
         }
 
         function getGlobalDiagnostics(): SortedReadonlyArray<Diagnostic> {
-            return sortAndDeduplicateDiagnostics(getDiagnosticsProducingTypeChecker().getGlobalDiagnostics().slice());
+            return rootNames.length ? sortAndDeduplicateDiagnostics(getDiagnosticsProducingTypeChecker().getGlobalDiagnostics().slice()) : emptyArray as any as SortedReadonlyArray<Diagnostic>;
         }
 
         function getConfigFileParsingDiagnostics(): ReadonlyArray<Diagnostic> {

--- a/src/testRunner/unittests/tscWatchMode.ts
+++ b/src/testRunner/unittests/tscWatchMode.ts
@@ -1074,7 +1074,10 @@ namespace ts.tscWatch {
             const host = createWatchedSystem([file1, configFile, libFile]);
             const watch = createWatchOfConfigFile(configFile.path, host);
 
-            checkProgramActualFiles(watch(), [libFile.path]);
+            checkProgramActualFiles(watch(), emptyArray);
+            checkOutputErrorsInitial(host, [
+                "error TS18003: No inputs were found in config file '/a/b/tsconfig.json'. Specified 'include' paths were '[\"app/*\",\"test/**/*\",\"something\"]' and 'exclude' paths were '[]'.\n"
+            ]);
         });
 
         it("non-existing directories listed in config file input array should be able to handle @types if input file list is empty", () => {
@@ -1100,7 +1103,10 @@ namespace ts.tscWatch {
             const host = createWatchedSystem([f, config, t1, t2], { currentDirectory: getDirectoryPath(f.path) });
             const watch = createWatchOfConfigFile(config.path, host);
 
-            checkProgramActualFiles(watch(), [t1.path, t2.path]);
+            checkProgramActualFiles(watch(), emptyArray);
+            checkOutputErrorsInitial(host, [
+                "tsconfig.json(1,24): error TS18002: The 'files' list in config file '/a/tsconfig.json' is empty.\n"
+            ]);
         });
 
         it("should support files without extensions", () => {

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -3061,7 +3061,7 @@ namespace ts.projectSystem {
                 const configProject = configuredProjectAt(projectService, 0);
                 checkProjectActualFiles(configProject, lazyConfiguredProjectsFromExternalProject ?
                     emptyArray : // Since no files opened from this project, its not loaded
-                    [libFile.path, configFile.path]);
+                    [configFile.path]);
 
                 host.reloadFS([libFile, site]);
                 host.checkTimeoutQueueLengthAndRun(1);
@@ -10521,7 +10521,7 @@ declare class TestLib {
                 assert.deepEqual(semanticDiagnostics, []);
             });
             const containerProject = service.configuredProjects.get(containerConfig.path)!;
-            checkProjectActualFiles(containerProject, [containerConfig.path, libFile.path]);
+            checkProjectActualFiles(containerProject, [containerConfig.path]);
             const optionsDiagnostics = session.executeCommandSeq<protocol.CompilerOptionsDiagnosticsRequest>({
                 command: protocol.CommandTypes.CompilerOptionsDiagnosticsFull,
                 arguments: { projectFileName: containerProject.projectName }

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -10521,7 +10521,12 @@ declare class TestLib {
                 assert.deepEqual(semanticDiagnostics, []);
             });
             const containerProject = service.configuredProjects.get(containerConfig.path)!;
-            checkProjectActualFiles(containerProject, [containerConfig.path]);
+            checkProjectActualFiles(containerProject, [containerConfig.path, libFile.path]);
+            const optionsDiagnostics = session.executeCommandSeq<protocol.CompilerOptionsDiagnosticsRequest>({
+                command: protocol.CommandTypes.CompilerOptionsDiagnosticsFull,
+                arguments: { projectFileName: containerProject.projectName }
+            }).response;
+            assert.deepEqual(optionsDiagnostics, []);
         });
     });
 

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -10520,6 +10520,8 @@ declare class TestLib {
                 }).response;
                 assert.deepEqual(semanticDiagnostics, []);
             });
+            const containerProject = service.configuredProjects.get(containerConfig.path)!;
+            checkProjectActualFiles(containerProject, [containerConfig.path]);
         });
     });
 


### PR DESCRIPTION
This fixes issue that @amcasey reported about seeing errors about duplicate identifiers.

