### PR TITLE
Add codefix for 'convert to unknown' diagnostic

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4724,5 +4724,13 @@
     "Generate types for all packages without types": {
         "category": "Message",
         "code": 95068
+    },
+    "Add 'unknown' conversion for non-overlapping types": {
+        "category": "Message",
+        "code": 95069
+    },
+    "Add 'unknown' to all conversions of non-overlapping types": {
+        "category": "Message",
+        "code": 95070
     }
 }

--- a/src/services/codefixes/addConvertToUnknownForNonOverlappingTypes.ts
+++ b/src/services/codefixes/addConvertToUnknownForNonOverlappingTypes.ts
@@ -1,0 +1,42 @@
+/* @internal */
+namespace ts.codefix {
+    const fixId = "addConvertToUnknownForNonOverlappingTypes";
+    const errorCodes = [Diagnostics.Conversion_of_type_0_to_type_1_may_be_a_mistake_because_neither_type_sufficiently_overlaps_with_the_other_If_this_was_intentional_convert_the_expression_to_unknown_first.code];
+    registerCodeFix({
+        errorCodes,
+        getCodeActions: (context) => {
+            const changes = textChanges.ChangeTracker.with(context, t => makeChange(t, context.sourceFile, context.span.start));
+            return [createCodeFixAction(fixId, changes, Diagnostics.Add_unknown_conversion_for_non_overlapping_types, fixId, Diagnostics.Add_unknown_to_all_conversions_of_non_overlapping_types)];
+        },
+        fixIds: [fixId],
+        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => makeChange(changes, diag.file, diag.start)),
+    });
+
+    function makeChange(changeTracker: textChanges.ChangeTracker, sourceFile: SourceFile, pos: number) {
+        const token = getTokenAtPosition(sourceFile, pos);
+
+        const asExpression = findAncestor<AsExpression>(token, isAsExpression)!;
+        if (!!asExpression) {
+            Debug.assert(!!asExpression, "Expected position to be owned by an as-expression.");
+
+            const nodeBeingCast = asExpression.getChildAt(0);
+            const expressionBeingCast = findAncestor<Expression>(nodeBeingCast, isExpression)!;
+            Debug.assert(!!expressionBeingCast, "Expected position to be owned by an expression.");
+
+            const replacement = createAsExpression(expressionBeingCast, createKeywordTypeNode(SyntaxKind.UnknownKeyword));
+            changeTracker.replaceNode(sourceFile, expressionBeingCast, replacement);
+        }
+
+        const typeAssertion = findAncestor<TypeAssertion>(token, isTypeAssertion)!;
+        if (!!typeAssertion) {
+            Debug.assert(!!typeAssertion, "Expected position to be owned by a type assertion.");
+
+            const nodeBeingCast = typeAssertion.getLastToken();
+            const expressionBeingCast = findAncestor<Expression>(nodeBeingCast, isExpression)!;
+            Debug.assert(!!expressionBeingCast, "Expected position to be owned by an expression.");
+
+            const replacement = createTypeAssertion(createKeywordTypeNode(SyntaxKind.UnknownKeyword), expressionBeingCast);
+            changeTracker.replaceNode(sourceFile, expressionBeingCast, replacement);
+        }
+    }
+}

--- a/src/services/codefixes/addConvertToUnknownForNonOverlappingTypes.ts
+++ b/src/services/codefixes/addConvertToUnknownForNonOverlappingTypes.ts
@@ -17,26 +17,22 @@ namespace ts.codefix {
 
         const asExpression = findAncestor<AsExpression>(token, isAsExpression)!;
         if (!!asExpression) {
-            Debug.assert(!!asExpression, "Expected position to be owned by an as-expression.");
+            const nodeBeingConverted = asExpression.getChildAt(0);
+            const expressionBeingConverted = findAncestor<Expression>(nodeBeingConverted, isExpression)!;
+            Debug.assert(!!expressionBeingConverted, "Expected position to be owned by an expression.");
 
-            const nodeBeingCast = asExpression.getChildAt(0);
-            const expressionBeingCast = findAncestor<Expression>(nodeBeingCast, isExpression)!;
-            Debug.assert(!!expressionBeingCast, "Expected position to be owned by an expression.");
-
-            const replacement = createAsExpression(expressionBeingCast, createKeywordTypeNode(SyntaxKind.UnknownKeyword));
-            changeTracker.replaceNode(sourceFile, expressionBeingCast, replacement);
+            const replacement = createAsExpression(expressionBeingConverted, createKeywordTypeNode(SyntaxKind.UnknownKeyword));
+            changeTracker.replaceNode(sourceFile, expressionBeingConverted, replacement);
         }
 
         const typeAssertion = findAncestor<TypeAssertion>(token, isTypeAssertion)!;
         if (!!typeAssertion) {
-            Debug.assert(!!typeAssertion, "Expected position to be owned by a type assertion.");
+            const nodeBeingConverted = typeAssertion.getLastToken();
+            const expressionBeingConverted = findAncestor<Expression>(nodeBeingConverted, isExpression)!;
+            Debug.assert(!!expressionBeingConverted, "Expected position to be owned by an expression.");
 
-            const nodeBeingCast = typeAssertion.getLastToken();
-            const expressionBeingCast = findAncestor<Expression>(nodeBeingCast, isExpression)!;
-            Debug.assert(!!expressionBeingCast, "Expected position to be owned by an expression.");
-
-            const replacement = createTypeAssertion(createKeywordTypeNode(SyntaxKind.UnknownKeyword), expressionBeingCast);
-            changeTracker.replaceNode(sourceFile, expressionBeingCast, replacement);
+            const replacement = createTypeAssertion(createKeywordTypeNode(SyntaxKind.UnknownKeyword), expressionBeingConverted);
+            changeTracker.replaceNode(sourceFile, expressionBeingConverted, replacement);
         }
     }
 }

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -43,6 +43,7 @@
         "textChanges.ts",
         "codeFixProvider.ts",
         "refactorProvider.ts",
+        "codefixes/addConvertToUnknownForNonOverlappingTypes.ts",
         "codefixes/addMissingInvocationForDecorator.ts",
         "codefixes/annotateWithTypeFromJSDoc.ts",
         "codefixes/convertFunctionToEs6Class.ts",

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes1.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes1.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+////[|0 as string|]
+
+verify.codeFix({
+    description: "Add 'unknown' conversion for non-overlapping types",
+    newRangeContent: `0 as unknown as string`
+});

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes1.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes1.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-////[|0 as string|]
+////0 as string
 
 verify.codeFix({
     description: "Add 'unknown' conversion for non-overlapping types",
-    newRangeContent: `0 as unknown as string`
+    newFileContent: `0 as unknown as string`
 });

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes2.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes2.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+////[|0 * (4 + 3) / 100 as string|]
+
+verify.codeFix({
+    description: "Add 'unknown' conversion for non-overlapping types",
+    newRangeContent: `0 * (4 + 3) / 100 as unknown as string`
+});

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes2.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes2.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-////[|0 * (4 + 3) / 100 as string|]
+////0 * (4 + 3) / 100 as string
 
 verify.codeFix({
     description: "Add 'unknown' conversion for non-overlapping types",
-    newRangeContent: `0 * (4 + 3) / 100 as unknown as string`
+    newFileContent: `0 * (4 + 3) / 100 as unknown as string`
 });

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes3.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes3.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+////[|["words"] as string|]
+
+verify.codeFix({
+    description: "Add 'unknown' conversion for non-overlapping types",
+    newRangeContent: `["words"] as unknown as string`
+});

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes3.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes3.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-////[|["words"] as string|]
+////["words"] as string
 
 verify.codeFix({
     description: "Add 'unknown' conversion for non-overlapping types",
-    newRangeContent: `["words"] as unknown as string`
+    newFileContent: `["words"] as unknown as string`
 });

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes4.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes4.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+////[|"words" as object|]
+
+verify.codeFix({
+    description: "Add 'unknown' conversion for non-overlapping types",
+    newRangeContent: `"words" as unknown as object`
+});

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes4.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes4.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-////[|"words" as object|]
+////"words" as object
 
 verify.codeFix({
     description: "Add 'unknown' conversion for non-overlapping types",
-    newRangeContent: `"words" as unknown as object`
+    newFileContent: `"words" as unknown as object`
 });

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes5.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes5.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+////[|<string>0|]
+
+verify.codeFix({
+    description: "Add 'unknown' conversion for non-overlapping types",
+    newRangeContent: `<string><unknown>0`
+});

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes5.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes5.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-////[|<string>0|]
+////<string>0
 
 verify.codeFix({
     description: "Add 'unknown' conversion for non-overlapping types",
-    newRangeContent: `<string><unknown>0`
+    newFileContent: `<string><unknown>0`
 });

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes6.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes6.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+////[|<string>0 * (4 + 3) / 100|]
+
+verify.codeFix({
+    description: "Add 'unknown' conversion for non-overlapping types",
+    newRangeContent: `<string><unknown>0 * (4 + 3) / 100`
+});

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes6.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes6.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-////[|<string>0 * (4 + 3) / 100|]
+////<string>0 * (4 + 3) / 100
 
 verify.codeFix({
     description: "Add 'unknown' conversion for non-overlapping types",
-    newRangeContent: `<string><unknown>0 * (4 + 3) / 100`
+    newFileContent: `<string><unknown>0 * (4 + 3) / 100`
 });

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes7.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes7.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+////[|<string>["words"]|]
+
+verify.codeFix({
+    description: "Add 'unknown' conversion for non-overlapping types",
+    newRangeContent: `<string><unknown>["words"]`
+});

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes7.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes7.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-////[|<string>["words"]|]
+////<string>["words"]
 
 verify.codeFix({
     description: "Add 'unknown' conversion for non-overlapping types",
-    newRangeContent: `<string><unknown>["words"]`
+    newFileContent: `<string><unknown>["words"]`
 });

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes8.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes8.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+
+////[|<object>"words"|]
+
+verify.codeFix({
+    description: "Add 'unknown' conversion for non-overlapping types",
+    newRangeContent: `<object><unknown>"words"`
+});

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes8.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes8.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-////[|<object>"words"|]
+////<object>"words"
 
 verify.codeFix({
     description: "Add 'unknown' conversion for non-overlapping types",
-    newRangeContent: `<object><unknown>"words"`
+    newFileContent: `<object><unknown>"words"`
 });

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes_all.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes_all.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+////class C {
+////    const s1 = 1 as string;
+////    const o1 = s + " word" as object;
+////
+////    const s2 = <string>2;
+////    const o2 = <object>s2;
+////}
+
+verify.codeFixAll({
+    fixId: "addConvertToUnknownForNonOverlappingTypes",
+    fixAllDescription: "Add 'unknown' to all conversions of non-overlapping types",
+    newFileContent:
+`class C {
+    const s1 = 1 as unknown as string;
+    const o1 = s + " word" as unknown as object;
+
+    const s2 = <string><unknown>2;
+    const o2 = <object>s2;
+}`
+});

--- a/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes_all.ts
+++ b/tests/cases/fourslash/codeFixAddConvertToUnknownForNonOverlappingTypes_all.ts
@@ -1,22 +1,18 @@
 /// <reference path='fourslash.ts' />
 
-////class C {
-////    const s1 = 1 as string;
-////    const o1 = s + " word" as object;
+////const s1 = 1 as string;
+////const o1 = s + " word" as object;
 ////
-////    const s2 = <string>2;
-////    const o2 = <object>s2;
-////}
+////const s2 = <string>2;
+////const o2 = <object>s2;
 
 verify.codeFixAll({
     fixId: "addConvertToUnknownForNonOverlappingTypes",
     fixAllDescription: "Add 'unknown' to all conversions of non-overlapping types",
     newFileContent:
-`class C {
-    const s1 = 1 as unknown as string;
-    const o1 = s + " word" as unknown as object;
+`const s1 = 1 as unknown as string;
+const o1 = s + " word" as unknown as object;
 
-    const s2 = <string><unknown>2;
-    const o2 = <object>s2;
-}`
+const s2 = <string><unknown>2;
+const o2 = <object><unknown>s2;`
 });


### PR DESCRIPTION
Codefix for diagnostic error 2352: "Conversion of type '{0}' to type '{1}' may be
a mistake because neither type sufficiently overlaps with the other. If this was
intentional, convert the expression to 'unknown' first."

Add codefix for both AsExpressions and TypeAssertions

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #28067

