### PR TITLE
Avoid stack overflow in completions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1142,7 +1142,7 @@ namespace ts.Completions {
                 const exportedSymbols = typeChecker.getExportsOfModule(symbol);
                 // If the exported symbols contains type,
                 // symbol can be referenced at locations where type is allowed
-                return exportedSymbols.some(symbolCanBeReferencedAtTypeLocation);
+                return exportedSymbols.some(ex => ex !== symbol && symbolCanBeReferencedAtTypeLocation(ex));
             }
             return false;
         }


### PR DESCRIPTION
In symbolCanBeReferfencedAtTypeLocation, telemetry reports that 3.1.3 has a stack overflow in the recursive case that checks exportedSymbols. I believe that the cause is a commonjs module with both export assignment and export property assignments via an alias [1], but I haven't been able to repro the crash since telemetry only reports a stack. Nevertheless, I think the correct fix is just to not recur in the case that an exported symbol is identical to its containing module.

```js
// @Filename: module.js
exports.version = 'hi'
function alias() { }
module.exports = alias

// @Filename: use.js
var m = require('./module')
m.al/**/
```

I expected the overflow to happen when requesting completions at `/**/` but it didn't.

Fixes #27872