### PR TITLE
Refactors can return ReadonlyArray<ApplicableRefactorInfo>

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -5021,7 +5021,7 @@ namespace FourSlashInterface {
     export interface VerifyRefactorOptions {
         name: string;
         actionName: string;
-        refactors: ts.ApplicableRefactorInfo[];
+        refactors: ReadonlyArray<ts.ApplicableRefactorInfo>;
     }
 
     export interface VerifyCompletionActionOptions extends NewContentOptions {

--- a/src/services/refactorProvider.ts
+++ b/src/services/refactorProvider.ts
@@ -5,7 +5,7 @@ namespace ts {
         getEditsForAction(context: RefactorContext, actionName: string): RefactorEditInfo | undefined;
 
         /** Compute (quickly) which actions are available here */
-        getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined;
+        getAvailableActions(context: RefactorContext): ReadonlyArray<ApplicableRefactorInfo>;
     }
 
     export interface RefactorContext extends textChanges.TextChangesContext {

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -15,10 +15,10 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
         addBraces: boolean;
     }
 
-    function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
+    function getAvailableActions(context: RefactorContext): ReadonlyArray<ApplicableRefactorInfo> {
         const { file, startPosition } = context;
         const info = getConvertibleArrowFunctionAtPosition(file, startPosition);
-        if (!info) return undefined;
+        if (!info) return emptyArray;
 
         return [{
             name: refactorName,

--- a/src/services/refactors/convertExport.ts
+++ b/src/services/refactors/convertExport.ts
@@ -4,9 +4,9 @@ namespace ts.refactor {
     const actionNameDefaultToNamed = "Convert default export to named export";
     const actionNameNamedToDefault = "Convert named export to default export";
     registerRefactor(refactorName, {
-        getAvailableActions(context): ApplicableRefactorInfo[] | undefined {
+        getAvailableActions(context): ReadonlyArray<ApplicableRefactorInfo> {
             const info = getInfo(context);
-            if (!info) return undefined;
+            if (!info) return emptyArray;
             const description = info.wasDefault ? Diagnostics.Convert_default_export_to_named_export.message : Diagnostics.Convert_named_export_to_default_export.message;
             const actionName = info.wasDefault ? actionNameDefaultToNamed : actionNameNamedToDefault;
             return [{ name: refactorName, description, actions: [{ name: actionName, description }] }];

--- a/src/services/refactors/convertImport.ts
+++ b/src/services/refactors/convertImport.ts
@@ -4,9 +4,9 @@ namespace ts.refactor {
     const actionNameNamespaceToNamed = "Convert namespace import to named imports";
     const actionNameNamedToNamespace = "Convert named imports to namespace import";
     registerRefactor(refactorName, {
-        getAvailableActions(context): ApplicableRefactorInfo[] | undefined {
+        getAvailableActions(context): ReadonlyArray<ApplicableRefactorInfo> {
             const i = getImportToConvert(context);
-            if (!i) return undefined;
+            if (!i) return emptyArray;
             const description = i.kind === SyntaxKind.NamespaceImport ? Diagnostics.Convert_namespace_import_to_named_imports.message : Diagnostics.Convert_named_imports_to_namespace_import.message;
             const actionName = i.kind === SyntaxKind.NamespaceImport ? actionNameNamespaceToNamed : actionNameNamedToNamespace;
             return [{ name: refactorName, description, actions: [{ name: actionName, description }] }];

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -7,18 +7,18 @@ namespace ts.refactor.extractSymbol {
      * Compute the associated code actions
      * Exported for tests.
      */
-    export function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
+    export function getAvailableActions(context: RefactorContext): ReadonlyArray<ApplicableRefactorInfo> {
         const rangeToExtract = getRangeToExtract(context.file, getRefactorContextSpan(context));
 
         const targetRange = rangeToExtract.targetRange;
         if (targetRange === undefined) {
-            return undefined;
+            return emptyArray;
         }
 
         const extractions = getPossibleExtractions(targetRange, context);
         if (extractions === undefined) {
             // No extractions possible
-            return undefined;
+            return emptyArray;
         }
 
         const functionActions: RefactorActionInfo[] = [];
@@ -82,7 +82,7 @@ namespace ts.refactor.extractSymbol {
             });
         }
 
-        return infos.length ? infos : undefined;
+        return infos.length ? infos : emptyArray;
     }
 
     /* Exported for tests */

--- a/src/services/refactors/generateGetAccessorAndSetAccessor.ts
+++ b/src/services/refactors/generateGetAccessorAndSetAccessor.ts
@@ -20,8 +20,8 @@ namespace ts.refactor.generateGetAccessorAndSetAccessor {
         readonly renameAccessor: boolean;
     }
 
-    function getAvailableActions(context: RefactorContext): ApplicableRefactorInfo[] | undefined {
-        if (!getConvertibleFieldAtPosition(context)) return undefined;
+    function getAvailableActions(context: RefactorContext): ReadonlyArray<ApplicableRefactorInfo> {
+        if (!getConvertibleFieldAtPosition(context)) return emptyArray;
 
         return [{
             name: actionName,

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -2,8 +2,8 @@
 namespace ts.refactor {
     const refactorName = "Move to a new file";
     registerRefactor(refactorName, {
-        getAvailableActions(context): ApplicableRefactorInfo[] | undefined {
-            if (!context.preferences.allowTextChangesInNewFiles || getStatementsToMove(context) === undefined) return undefined;
+        getAvailableActions(context): ReadonlyArray<ApplicableRefactorInfo> {
+            if (!context.preferences.allowTextChangesInNewFiles || getStatementsToMove(context) === undefined) return emptyArray;
             const description = getLocaleSpecificMessage(Diagnostics.Move_to_a_new_file);
             return [{ name: refactorName, description, actions: [{ name: refactorName, description }] }];
         },

--- a/src/testRunner/unittests/extractTestHelpers.ts
+++ b/src/testRunner/unittests/extractTestHelpers.ts
@@ -107,7 +107,7 @@ namespace ts {
             };
             const rangeToExtract = refactor.extractSymbol.getRangeToExtract(sourceFile, createTextSpanFromRange(selectionRange));
             assert.equal(rangeToExtract.errors, undefined, rangeToExtract.errors && "Range error: " + rangeToExtract.errors[0].messageText);
-            const infos = refactor.extractSymbol.getAvailableActions(context)!;
+            const infos = refactor.extractSymbol.getAvailableActions(context);
             const actions = find(infos, info => info.description === description.message)!.actions;
 
             const data: string[] = [];
@@ -169,7 +169,7 @@ namespace ts {
             };
             const rangeToExtract = refactor.extractSymbol.getRangeToExtract(sourceFile, createTextSpanFromRange(selectionRange));
             assert.isUndefined(rangeToExtract.errors, rangeToExtract.errors && "Range error: " + rangeToExtract.errors[0].messageText);
-            const infos = refactor.extractSymbol.getAvailableActions(context)!;
+            const infos = refactor.extractSymbol.getAvailableActions(context);
             assert.isUndefined(find(infos, info => info.description === description.message));
         });
     }


### PR DESCRIPTION
These outputs are accumulated using `flatMap`, so the arrays are never written to again. So it's safe to return a `ReadonlyArray`.

