### PR TITLE
Parameters infer from body and call sites

### DIFF
--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -194,7 +194,8 @@ namespace ts.codefix {
             case SyntaxKind.Constructor:
                 return true;
             case SyntaxKind.FunctionExpression:
-                return !!declaration.name;
+                const parent = declaration.parent;
+                return isVariableDeclaration(parent) && isIdentifier(parent.name) || !!declaration.name;
         }
         return false;
     }

--- a/tests/cases/fourslash/annotateWithTypeFromJSDoc8.ts
+++ b/tests/cases/fourslash/annotateWithTypeFromJSDoc8.ts
@@ -10,6 +10,7 @@
 
 verify.codeFix({
     description: "Annotate with type from JSDoc",
+    index: 0,
     newFileContent:
 `/**
  * @param {number} x

--- a/tests/cases/fourslash/codeFixInferFromUsageCallBodyBoth.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageCallBodyBoth.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+////class C {
+////
+////}
+////var c = new C()
+////function f([|x, y |]) {
+////    if (y) {
+////        x = 1
+////    }
+////    return x
+////}
+////f(new C())
+
+
+verify.rangeAfterCodeFix("x: number | C, y: undefined",/*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);

--- a/tests/cases/fourslash/codeFixInferFromUsageFunctionExpression.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageFunctionExpression.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-////var f = function f([|x |]) {
+////var f = function ([|x |]) {
 ////    return x
 ////}
 ////f(1)

--- a/tests/cases/fourslash/codeFixInferFromUsageFunctionExpression.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageFunctionExpression.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+////var f = function f([|x |]) {
+////    return x
+////}
+////f(1)
+
+verify.rangeAfterCodeFix("x: number",/*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);
+

--- a/tests/cases/fourslash/codeFixInferFromUsageUnifyAnonymousType.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageUnifyAnonymousType.ts
@@ -16,4 +16,4 @@
 ////kw("6", { beforeExpr: true, prefix: true, startsExpr: true })
 
 
-verify.rangeAfterCodeFix("name: string, options: { startsExpr?: boolean; beforeExpr?: boolean; isLoop?: boolean; prefix?: boolean; } | undefined",/*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);
+verify.rangeAfterCodeFix("name: string | number, options: { startsExpr?: boolean; beforeExpr?: boolean; isLoop?: boolean; prefix?: boolean; keyword?: any; } | undefined",/*includeWhiteSpace*/ undefined, /*errorCode*/ undefined, 0);


### PR DESCRIPTION
1. Function expressions check their parent for an applicable name. Currently the only applicable name is a a declaration name that must be an identifier. This is a small change that I will follow up with a comprehensive change to support JS-style assignment declarations.
2. Parameters use inferences both from usage in their function body and from call sites. Previously inferences from call sites would be the only ones used if any were present, and the algorithm would fall back to body-usage inferences. Now they are combined upfront and then unified.

The latter change decreases coverage about 0.5% (the number of previously-any sites that are now annotated), but decreases the introduced error rate by more than 5%.