### PR TITLE
Fix bug when augmenting parent-less symbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26751,7 +26751,7 @@ namespace ts {
                         let reportError = !(symbol.flags & SymbolFlags.Transient);
                         if (!reportError) {
                             // symbol should not originate in augmentation
-                            reportError = isExternalModuleAugmentation(symbol.parent!.declarations[0]);
+                            reportError = !!symbol.parent && isExternalModuleAugmentation(symbol.parent.declarations[0]);
                         }
                     }
                     break;

--- a/tests/baselines/reference/moduleAugmentationOfAlias.js
+++ b/tests/baselines/reference/moduleAugmentationOfAlias.js
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/moduleAugmentationOfAlias.ts] ////
+
+//// [a.ts]
+interface I {}
+export default I;
+
+//// [b.ts]
+export {};
+declare module './a' {
+    export default interface I { x: number; }
+}
+
+//// [c.ts]
+import I from "./a";
+function f(i: I) {
+    i.x;
+}
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+//// [c.js]
+"use strict";
+exports.__esModule = true;
+function f(i) {
+    i.x;
+}

--- a/tests/baselines/reference/moduleAugmentationOfAlias.symbols
+++ b/tests/baselines/reference/moduleAugmentationOfAlias.symbols
@@ -1,0 +1,32 @@
+=== /a.ts ===
+interface I {}
+>I : Symbol(I, Decl(a.ts, 0, 0), Decl(b.ts, 1, 22))
+
+export default I;
+>I : Symbol(I, Decl(a.ts, 0, 0))
+
+=== /b.ts ===
+export {};
+declare module './a' {
+>'./a' : Symbol("/a", Decl(a.ts, 0, 0), Decl(b.ts, 0, 10))
+
+    export default interface I { x: number; }
+>I : Symbol(I, Decl(a.ts, 0, 0), Decl(b.ts, 1, 22))
+>x : Symbol(I.x, Decl(b.ts, 2, 32))
+}
+
+=== /c.ts ===
+import I from "./a";
+>I : Symbol(I, Decl(c.ts, 0, 6))
+
+function f(i: I) {
+>f : Symbol(f, Decl(c.ts, 0, 20))
+>i : Symbol(i, Decl(c.ts, 1, 11))
+>I : Symbol(I, Decl(c.ts, 0, 6))
+
+    i.x;
+>i.x : Symbol(I.x, Decl(b.ts, 2, 32))
+>i : Symbol(i, Decl(c.ts, 1, 11))
+>x : Symbol(I.x, Decl(b.ts, 2, 32))
+}
+

--- a/tests/baselines/reference/moduleAugmentationOfAlias.types
+++ b/tests/baselines/reference/moduleAugmentationOfAlias.types
@@ -1,0 +1,28 @@
+=== /a.ts ===
+interface I {}
+export default I;
+>I : I
+
+=== /b.ts ===
+export {};
+declare module './a' {
+>'./a' : typeof import("/a")
+
+    export default interface I { x: number; }
+>x : number
+}
+
+=== /c.ts ===
+import I from "./a";
+>I : any
+
+function f(i: I) {
+>f : (i: I) => void
+>i : I
+
+    i.x;
+>i.x : number
+>i : I
+>x : number
+}
+

--- a/tests/cases/compiler/moduleAugmentationOfAlias.ts
+++ b/tests/cases/compiler/moduleAugmentationOfAlias.ts
@@ -1,0 +1,15 @@
+// @Filename: /a.ts
+interface I {}
+export default I;
+
+// @Filename: /b.ts
+export {};
+declare module './a' {
+    export default interface I { x: number; }
+}
+
+// @Filename: /c.ts
+import I from "./a";
+function f(i: I) {
+    i.x;
+}


### PR DESCRIPTION
Bug was discovered in `ember-data` on DefinitelyTyped.