### PR TITLE
Remove JSDocTag#atToken

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2225,7 +2225,6 @@ namespace ts {
     /* @internal */
     function createJSDocTag<T extends JSDocTag>(kind: T["kind"], tagName: string): T {
         const node = createSynthesizedNode(kind) as T;
-        node.atToken = createToken(SyntaxKind.AtToken);
         node.tagName = createIdentifier(tagName);
         return node;
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -719,7 +719,6 @@ namespace ts {
     export type AsteriskToken = Token<SyntaxKind.AsteriskToken>;
     export type EqualsGreaterThanToken = Token<SyntaxKind.EqualsGreaterThanToken>;
     export type EndOfFileToken = Token<SyntaxKind.EndOfFileToken> & JSDocContainer;
-    export type AtToken = Token<SyntaxKind.AtToken>;
     export type ReadonlyToken = Token<SyntaxKind.ReadonlyKeyword>;
     export type AwaitKeywordToken = Token<SyntaxKind.AwaitKeyword>;
     export type PlusToken = Token<SyntaxKind.PlusToken>;
@@ -2421,7 +2420,6 @@ namespace ts {
 
     export interface JSDocTag extends Node {
         parent: JSDoc | JSDocTypeLiteral;
-        atToken: AtToken;
         tagName: Identifier;
         comment?: string;
     }

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -703,7 +703,7 @@ namespace ts {
                         pushCommentRange(pos, tag.pos - pos);
                     }
 
-                    pushClassification(tag.atToken.pos, tag.atToken.end - tag.atToken.pos, ClassificationType.punctuation); // "@"
+                    pushClassification(tag.pos, 1, ClassificationType.punctuation); // "@"
                     pushClassification(tag.tagName.pos, tag.tagName.end - tag.tagName.pos, ClassificationType.docCommentTagName); // e.g. "param"
 
                     pos = tag.tagName.end;

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@link tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@link tags.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTag",
             "pos": 63,
             "end": 68,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 63,
-                "end": 64
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 64,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 6,
             "end": 64,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 6,
-                "end": 7
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 7,
@@ -31,11 +26,6 @@
                             "kind": "JSDocParameterTag",
                             "pos": 34,
                             "end": 64,
-                            "atToken": {
-                                "kind": "AtToken",
-                                "pos": 34,
-                                "end": 35
-                            },
                             "tagName": {
                                 "kind": "Identifier",
                                 "pos": 35,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 42,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 47,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.leadingAsterisk.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.leadingAsterisk.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTypeTag",
             "pos": 8,
             "end": 22,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 7,
             "end": 59,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 7,
-                "end": 8
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 8,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noLeadingAsterisk.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noLeadingAsterisk.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTypeTag",
             "pos": 8,
             "end": 22,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noReturnType.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noReturnType.json
@@ -7,11 +7,6 @@
             "kind": "JSDocReturnTag",
             "pos": 8,
             "end": 15,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.oneParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.oneParamTag.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 32,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 57,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 59,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 64,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType1.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 29,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 44,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramWithoutType.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramWithoutType.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 21,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag1.json
@@ -7,11 +7,6 @@
             "kind": "JSDocReturnTag",
             "pos": 8,
             "end": 24,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
@@ -7,11 +7,6 @@
             "kind": "JSDocReturnTag",
             "pos": 8,
             "end": 24,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnsTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnsTag1.json
@@ -7,11 +7,6 @@
             "kind": "JSDocReturnTag",
             "pos": 8,
             "end": 25,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTemplateTag",
             "pos": 8,
             "end": 19,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag2.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTemplateTag",
             "pos": 8,
             "end": 21,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag3.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag3.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTemplateTag",
             "pos": 8,
             "end": 22,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag4.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag4.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTemplateTag",
             "pos": 8,
             "end": 22,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag5.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag5.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTemplateTag",
             "pos": 8,
             "end": 23,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTemplateTag",
             "pos": 8,
             "end": 24,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTag2.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 34,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,
@@ -41,11 +36,6 @@
             "kind": "JSDocParameterTag",
             "pos": 34,
             "end": 58,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 34,
-                "end": 35
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 35,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTagOnSameLine.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTagOnSameLine.json
@@ -7,11 +7,6 @@
             "kind": "JSDocParameterTag",
             "pos": 8,
             "end": 30,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,
@@ -41,11 +36,6 @@
             "kind": "JSDocParameterTag",
             "pos": 30,
             "end": 54,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 30,
-                "end": 31
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 31,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typeTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typeTag.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTypeTag",
             "pos": 8,
             "end": 22,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
@@ -7,11 +7,6 @@
             "kind": "JSDocTypedefTag",
             "pos": 8,
             "end": 100,
-            "atToken": {
-                "kind": "AtToken",
-                "pos": 8,
-                "end": 9
-            },
             "tagName": {
                 "kind": "Identifier",
                 "pos": 9,
@@ -39,11 +34,6 @@
                         "kind": "JSDocPropertyTag",
                         "pos": 47,
                         "end": 74,
-                        "atToken": {
-                            "kind": "AtToken",
-                            "pos": 47,
-                            "end": 48
-                        },
                         "tagName": {
                             "kind": "Identifier",
                             "pos": 48,
@@ -73,11 +63,6 @@
                         "kind": "JSDocPropertyTag",
                         "pos": 74,
                         "end": 100,
-                        "atToken": {
-                            "kind": "AtToken",
-                            "pos": 74,
-                            "end": 75
-                        },
                         "tagName": {
                             "kind": "Identifier",
                             "pos": 75,

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -504,7 +504,6 @@ declare namespace ts {
     type AsteriskToken = Token<SyntaxKind.AsteriskToken>;
     type EqualsGreaterThanToken = Token<SyntaxKind.EqualsGreaterThanToken>;
     type EndOfFileToken = Token<SyntaxKind.EndOfFileToken> & JSDocContainer;
-    type AtToken = Token<SyntaxKind.AtToken>;
     type ReadonlyToken = Token<SyntaxKind.ReadonlyKeyword>;
     type AwaitKeywordToken = Token<SyntaxKind.AwaitKeyword>;
     type PlusToken = Token<SyntaxKind.PlusToken>;
@@ -1551,7 +1550,6 @@ declare namespace ts {
     }
     interface JSDocTag extends Node {
         parent: JSDoc | JSDocTypeLiteral;
-        atToken: AtToken;
         tagName: Identifier;
         comment?: string;
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -504,7 +504,6 @@ declare namespace ts {
     type AsteriskToken = Token<SyntaxKind.AsteriskToken>;
     type EqualsGreaterThanToken = Token<SyntaxKind.EqualsGreaterThanToken>;
     type EndOfFileToken = Token<SyntaxKind.EndOfFileToken> & JSDocContainer;
-    type AtToken = Token<SyntaxKind.AtToken>;
     type ReadonlyToken = Token<SyntaxKind.ReadonlyKeyword>;
     type AwaitKeywordToken = Token<SyntaxKind.AwaitKeyword>;
     type PlusToken = Token<SyntaxKind.PlusToken>;
@@ -1551,7 +1550,6 @@ declare namespace ts {
     }
     interface JSDocTag extends Node {
         parent: JSDoc | JSDocTypeLiteral;
-        atToken: AtToken;
         tagName: Identifier;
         comment?: string;
     }


### PR DESCRIPTION
We don't really have a good reason for adding these in the parser. We don't typically add non-optional tokens to the parse tree, preferring to do so in services if necessary (see `function createChildren` in `services.ts`).