### PR TITLE
Remove two flags from TypeFlags

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17807,9 +17807,7 @@ namespace ts {
                 if (inDestructuringPattern) {
                     result.pattern = node;
                 }
-                if (!(result.flags & TypeFlags.Nullable)) {
-                    propagatedFlags |= (result.flags & TypeFlags.PropagatingFlags);
-                }
+                propagatedFlags |= (result.flags & TypeFlags.PropagatingFlags);
                 return result;
             }
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3836,13 +3836,11 @@ namespace ts {
         Substitution            = 1 << 25,  // Type parameter substitution
         NonPrimitive            = 1 << 26,  // intrinsic object type
         /* @internal */
-        FreshLiteral            = 1 << 27,  // Fresh literal or unique type
+        ContainsWideningType    = 1 << 27,  // Type is or contains undefined or null widening type
         /* @internal */
-        ContainsWideningType    = 1 << 28,  // Type is or contains undefined or null widening type
+        ContainsObjectLiteral   = 1 << 28,  // Type is or contains object literal type
         /* @internal */
-        ContainsObjectLiteral   = 1 << 29,  // Type is or contains object literal type
-        /* @internal */
-        ContainsAnyFunctionType = 1 << 30,  // Type is or contains the anyFunctionType
+        ContainsAnyFunctionType = 1 << 29,  // Type is or contains the anyFunctionType
 
         /* @internal */
         AnyOrUnknown = Any | Unknown,
@@ -3980,6 +3978,7 @@ namespace ts {
         JsxAttributes    = 1 << 12, // Jsx attributes type
         MarkerType       = 1 << 13, // Marker type used for variance probing
         JSLiteral        = 1 << 14, // Object type declared in JS - disables errors on read/write of nonexisting members
+        FreshLiteral     = 1 << 15, // Fresh object literal
         ClassOrInterface = Class | Interface
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3838,13 +3838,11 @@ namespace ts {
         /* @internal */
         FreshLiteral            = 1 << 27,  // Fresh literal or unique type
         /* @internal */
-        UnionOfPrimitiveTypes   = 1 << 28,  // Type is union of primitive types
+        ContainsWideningType    = 1 << 28,  // Type is or contains undefined or null widening type
         /* @internal */
-        ContainsWideningType    = 1 << 29,  // Type is or contains undefined or null widening type
+        ContainsObjectLiteral   = 1 << 29,  // Type is or contains object literal type
         /* @internal */
-        ContainsObjectLiteral   = 1 << 30,  // Type is or contains object literal type
-        /* @internal */
-        ContainsAnyFunctionType = 1 << 31,  // Type is or contains the anyFunctionType
+        ContainsAnyFunctionType = 1 << 30,  // Type is or contains the anyFunctionType
 
         /* @internal */
         AnyOrUnknown = Any | Unknown,
@@ -4077,7 +4075,10 @@ namespace ts {
         couldContainTypeVariables: boolean;
     }
 
-    export interface UnionType extends UnionOrIntersectionType { }
+    export interface UnionType extends UnionOrIntersectionType {
+        /* @internal */
+        primitiveTypesOnly: boolean;
+    }
 
     export interface IntersectionType extends UnionOrIntersectionType {
         /* @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2254,6 +2254,7 @@ declare namespace ts {
         JsxAttributes = 4096,
         MarkerType = 8192,
         JSLiteral = 16384,
+        FreshLiteral = 32768,
         ClassOrInterface = 3
     }
     interface ObjectType extends Type {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2254,6 +2254,7 @@ declare namespace ts {
         JsxAttributes = 4096,
         MarkerType = 8192,
         JSLiteral = 16384,
+        FreshLiteral = 32768,
         ClassOrInterface = 3
     }
     interface ObjectType extends Type {


### PR DESCRIPTION
This PR removes two `TypeFlags` to bring us back to 30 bits. `TypeFlags.UnionOfPrimitiveTypes` becomes a discrete property on `UnionType`, and `TypeFlags.FreshLiteral` becomes `ObjectFlags.FreshLiteral`.

Fixes #28354.