### PR TITLE
Better checking of assignment declarations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22119,8 +22119,17 @@ namespace ts {
                         leftType;
                 case SyntaxKind.EqualsToken:
                     const declKind = isBinaryExpression(left.parent) ? getAssignmentDeclarationKind(left.parent) : AssignmentDeclarationKind.None;
-                    checkAssignmentDeclaration(declKind, right);
+                    checkAssignmentDeclaration(declKind, rightType);
                     if (isAssignmentDeclaration(declKind)) {
+                        if (!(rightType.flags & TypeFlags.Object) ||
+                            declKind !== AssignmentDeclarationKind.ModuleExports &&
+                            declKind !== AssignmentDeclarationKind.Prototype &&
+                            !isEmptyObjectType(rightType) &&
+                            !isFunctionObjectType(rightType as ObjectType) &&
+                            !(getObjectFlags(rightType) & ObjectFlags.Class)) {
+                            // don't check assignability of module.exports=, C.prototype=, or expando types because they will necessarily be incomplete
+                            checkAssignmentOperator(rightType);
+                        }
                         return leftType;
                     }
                     else {
@@ -22137,9 +22146,8 @@ namespace ts {
                     return Debug.fail();
             }
 
-            function checkAssignmentDeclaration(kind: AssignmentDeclarationKind, right: Expression) {
+            function checkAssignmentDeclaration(kind: AssignmentDeclarationKind, rightType: Type) {
                 if (kind === AssignmentDeclarationKind.ModuleExports) {
-                    const rightType = checkExpression(right, checkMode);
                     for (const prop of getPropertiesOfObjectType(rightType)) {
                         const propType = getTypeOfSymbol(prop);
                         if (propType.symbol && propType.symbol.flags & SymbolFlags.Class) {

--- a/tests/baselines/reference/typeTagModuleExports.errors.txt
+++ b/tests/baselines/reference/typeTagModuleExports.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/jsdoc/bug27327.js(2,1): error TS2322: Type '0' is not assignable to type 'string'.
+
+
+==== tests/cases/conformance/jsdoc/bug27327.js (1 errors) ====
+    /** @type {string} */
+    module.exports = 0;
+    ~~~~~~~~~~~~~~
+!!! error TS2322: Type '0' is not assignable to type 'string'.
+    

--- a/tests/baselines/reference/typeTagModuleExports.symbols
+++ b/tests/baselines/reference/typeTagModuleExports.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/jsdoc/bug27327.js ===
+/** @type {string} */
+module.exports = 0;
+>module.exports : Symbol("tests/cases/conformance/jsdoc/bug27327", Decl(bug27327.js, 0, 0))
+>module : Symbol(export=, Decl(bug27327.js, 0, 0))
+>exports : Symbol(export=, Decl(bug27327.js, 0, 0))
+

--- a/tests/baselines/reference/typeTagModuleExports.types
+++ b/tests/baselines/reference/typeTagModuleExports.types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsdoc/bug27327.js ===
+/** @type {string} */
+module.exports = 0;
+>module.exports = 0 : string
+>module.exports : string
+>module : { "tests/cases/conformance/jsdoc/bug27327": string; }
+>exports : string
+>0 : 0
+

--- a/tests/baselines/reference/typeTagPrototypeAssignment.errors.txt
+++ b/tests/baselines/reference/typeTagPrototypeAssignment.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/jsdoc/bug27327.js(4,1): error TS2322: Type '12' is not assignable to type 'string'.
+
+
+==== tests/cases/conformance/jsdoc/bug27327.js (1 errors) ====
+    function C() {
+    }
+    /** @type {string} */
+    C.prototype = 12
+    ~~~~~~~~~~~
+!!! error TS2322: Type '12' is not assignable to type 'string'.
+    

--- a/tests/baselines/reference/typeTagPrototypeAssignment.symbols
+++ b/tests/baselines/reference/typeTagPrototypeAssignment.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/jsdoc/bug27327.js ===
+function C() {
+>C : Symbol(C, Decl(bug27327.js, 0, 0), Decl(bug27327.js, 1, 1))
+}
+/** @type {string} */
+C.prototype = 12
+>C.prototype : Symbol(C.prototype, Decl(bug27327.js, 1, 1))
+>C : Symbol(C, Decl(bug27327.js, 0, 0), Decl(bug27327.js, 1, 1))
+>prototype : Symbol(C.prototype, Decl(bug27327.js, 1, 1))
+

--- a/tests/baselines/reference/typeTagPrototypeAssignment.types
+++ b/tests/baselines/reference/typeTagPrototypeAssignment.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsdoc/bug27327.js ===
+function C() {
+>C : typeof C
+}
+/** @type {string} */
+C.prototype = 12
+>C.prototype = 12 : 12
+>C.prototype : string
+>C : typeof C
+>prototype : string
+>12 : 12
+

--- a/tests/cases/conformance/jsdoc/typeTagModuleExports.ts
+++ b/tests/cases/conformance/jsdoc/typeTagModuleExports.ts
@@ -1,0 +1,6 @@
+// @Filename: bug27327.js
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+/** @type {string} */
+module.exports = 0;

--- a/tests/cases/conformance/jsdoc/typeTagPrototypeAssignment.ts
+++ b/tests/cases/conformance/jsdoc/typeTagPrototypeAssignment.ts
@@ -1,0 +1,8 @@
+// @Filename: bug27327.js
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+function C() {
+}
+/** @type {string} */
+C.prototype = 12


### PR DESCRIPTION
Previously, type checking was turned off for all assignment declarations. This is a problem when the declarations are annotated with jsdoc types:

```js
/** @type {string} */
module.exports = 0
```

As @DanielRosenwasser points out, this will become more common as people use checkJS more and more.

This PR checks assignment declarations, *except* for expando initialisers. Expando initialisers are

1. Empty object types.
2. Function types.
3. Class types.
4. Non-empty object types when the assignment declaration kind is
prototype assignment or module.exports assignment.

It's probably possible to write a reasonable ad-hoc check for expando initalisers too, but they are (I think) least likely to be annotated since it looks weird:

```js
/** @type { x: number, y: string } */
var ns = {}
ns.x = 1
ns.y = 'oh no'
```

Fixes #27327

