### PR TITLE
Make JSON.parse return a JSON value instead of any

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -1039,6 +1039,11 @@ interface URIErrorConstructor {
 
 declare const URIError: URIErrorConstructor;
 
+type JSONPrimitive = string | number | boolean | null;
+type JSONValue = JSONPrimitive | JSONObject | JSONArray;
+type JSONObject = { [member: string]: JSONValue };
+interface JSONArray extends Array<JSONValue> {}
+
 interface JSON {
     /**
       * Converts a JavaScript Object Notation (JSON) string into an object.
@@ -1046,7 +1051,7 @@ interface JSON {
       * @param reviver A function that transforms the results. This function is called for each member of the object.
       * If a member contains nested objects, the nested objects are transformed before the parent object is.
       */
-    parse(text: string, reviver?: (key: any, value: any) => any): any;
+    parse(text: string, reviver?: (key: any, value: any) => any): JSONValue;
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
       * @param value A JavaScript value, usually an object or array, to be converted.

--- a/scripts/configurePrerelease.ts
+++ b/scripts/configurePrerelease.ts
@@ -28,7 +28,7 @@ function main(): void {
 
     // Acquire the version from the package.json file and modify it appropriately.
     const packageJsonFilePath = normalize(args[1]);
-    const packageJsonValue: PackageJson = JSON.parse(readFileSync(packageJsonFilePath).toString());
+    const packageJsonValue = JSON.parse(readFileSync(packageJsonFilePath).toString()) as PackageJson;
 
     const { majorMinor, patch } = parsePackageJsonVersion(packageJsonValue.version);
     const prereleasePatch = getPrereleasePatch(tag, patch);

--- a/scripts/generateLocalizedDiagnosticMessages.ts
+++ b/scripts/generateLocalizedDiagnosticMessages.ts
@@ -136,7 +136,7 @@ function main(): void {
             writeFile(
                 path.join(outputPath, "enu", "diagnosticMessages.generated.json.lcg"),
                 getLCGFileXML(
-                    objectToList(JSON.parse(data.toString()))
+                    objectToList(JSON.parse(data.toString()) as Record<string, string>)
                         .sort((a, b) => a.key > b.key ? 1 : -1)  // lcg sorted by property keys
                         .reduce((s, { key, value }) => s + getItemXML(key, value), "")
                 ));

--- a/scripts/processDiagnosticMessages.ts
+++ b/scripts/processDiagnosticMessages.ts
@@ -27,7 +27,7 @@ function main(): void {
     console.log(`Reading diagnostics from ${inputFilePath}`);
     const inputStr = fs.readFileSync(inputFilePath, { encoding: "utf-8" });
 
-    const diagnosticMessagesJson: { [key: string]: DiagnosticDetails } = JSON.parse(inputStr);
+    const diagnosticMessagesJson = JSON.parse(inputStr) as { [key: string]: DiagnosticDetails };
 
     const diagnosticMessages: InputDiagnosticMessageTable = new Map();
     for (const key in diagnosticMessagesJson) {


### PR DESCRIPTION
This makes type checking of things hangling JSON responses much more accurate and useful.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

