### PR TITLE
Ensure all default type params are mapped to some default even in circular scenarios

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7663,8 +7663,10 @@ namespace ts {
                 // Map an unsatisfied type parameter with a default type.
                 // If a type parameter does not have a default type, or if the default type
                 // is a forward reference, the empty object type is used.
+                const baseDefaultType = getDefaultTypeArgumentType(isJavaScriptImplicitAny);
+                const cicrularityMapper = createTypeMapper(typeParameters!, map(typeParameters!, () => baseDefaultType));
                 for (let i = numTypeArguments; i < numTypeParameters; i++) {
-                    result[i] = getConstraintFromTypeParameter(typeParameters![i]) || getDefaultTypeArgumentType(isJavaScriptImplicitAny);
+                    result[i] = instantiateType(getConstraintFromTypeParameter(typeParameters![i]) || baseDefaultType, cicrularityMapper);
                 }
                 for (let i = numTypeArguments; i < numTypeParameters; i++) {
                     const mapper = createTypeMapper(typeParameters!, result);
@@ -7672,7 +7674,7 @@ namespace ts {
                     if (isJavaScriptImplicitAny && defaultType && isTypeIdenticalTo(defaultType, emptyObjectType)) {
                         defaultType = anyType;
                     }
-                    result[i] = defaultType ? instantiateType(defaultType, mapper) : getDefaultTypeArgumentType(isJavaScriptImplicitAny);
+                    result[i] = defaultType ? instantiateType(defaultType, mapper) : baseDefaultType;
                 }
                 result.length = typeParameters!.length;
                 return result;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7664,9 +7664,9 @@ namespace ts {
                 // If a type parameter does not have a default type, or if the default type
                 // is a forward reference, the empty object type is used.
                 const baseDefaultType = getDefaultTypeArgumentType(isJavaScriptImplicitAny);
-                const cicrularityMapper = createTypeMapper(typeParameters!, map(typeParameters!, () => baseDefaultType));
+                const circularityMapper = createTypeMapper(typeParameters!, map(typeParameters!, () => baseDefaultType));
                 for (let i = numTypeArguments; i < numTypeParameters; i++) {
-                    result[i] = instantiateType(getConstraintFromTypeParameter(typeParameters![i]) || baseDefaultType, cicrularityMapper);
+                    result[i] = instantiateType(getConstraintFromTypeParameter(typeParameters![i]) || baseDefaultType, circularityMapper);
                 }
                 for (let i = numTypeArguments; i < numTypeParameters; i++) {
                     const mapper = createTypeMapper(typeParameters!, result);

--- a/tests/baselines/reference/subclassThisTypeAssignable.js
+++ b/tests/baselines/reference/subclassThisTypeAssignable.js
@@ -1,0 +1,34 @@
+//// [subclassThisTypeAssignable.ts]
+interface Lifecycle<Attrs, State> {
+	oninit?(vnode: Vnode<Attrs, State>): number;
+	[_: number]: any;
+}
+
+interface Vnode<Attrs, State extends Lifecycle<Attrs, State> = Lifecycle<Attrs, State>> {
+	tag: Component<Attrs, State>;
+}
+
+interface Component<Attrs, State> {
+	view(this: State, vnode: Vnode<Attrs, State>): number;
+}
+
+interface ClassComponent<A> extends Lifecycle<A, ClassComponent<A>> {
+	oninit?(vnode: Vnode<A, this>): number;
+	view(vnode: Vnode<A, this>): number;
+}
+
+interface MyAttrs { id: number }
+class C implements ClassComponent<MyAttrs> {
+	view(v: Vnode<MyAttrs>) { return 0; }
+}
+
+const test8: ClassComponent<any> = new C();
+
+//// [subclassThisTypeAssignable.js]
+var C = /** @class */ (function () {
+    function C() {
+    }
+    C.prototype.view = function (v) { return 0; };
+    return C;
+}());
+var test8 = new C();

--- a/tests/baselines/reference/subclassThisTypeAssignable.js
+++ b/tests/baselines/reference/subclassThisTypeAssignable.js
@@ -1,4 +1,6 @@
-//// [subclassThisTypeAssignable.ts]
+//// [tests/cases/compiler/subclassThisTypeAssignable.ts] ////
+
+//// [tile1.ts]
 interface Lifecycle<Attrs, State> {
 	oninit?(vnode: Vnode<Attrs, State>): number;
 	[_: number]: any;
@@ -23,8 +25,12 @@ class C implements ClassComponent<MyAttrs> {
 }
 
 const test8: ClassComponent<any> = new C();
+//// [file1.js]
+/** @type {ClassComponent<any>} */
+const test9 = new C();
 
-//// [subclassThisTypeAssignable.js]
+
+//// [tile1.js]
 var C = /** @class */ (function () {
     function C() {
     }
@@ -32,3 +38,6 @@ var C = /** @class */ (function () {
     return C;
 }());
 var test8 = new C();
+//// [file1.js]
+/** @type {ClassComponent<any>} */
+var test9 = new C();

--- a/tests/baselines/reference/subclassThisTypeAssignable.symbols
+++ b/tests/baselines/reference/subclassThisTypeAssignable.symbols
@@ -1,92 +1,98 @@
-=== tests/cases/compiler/subclassThisTypeAssignable.ts ===
+=== tests/cases/compiler/tile1.ts ===
 interface Lifecycle<Attrs, State> {
->Lifecycle : Symbol(Lifecycle, Decl(subclassThisTypeAssignable.ts, 0, 0))
->Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 0, 20))
->State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 0, 26))
+>Lifecycle : Symbol(Lifecycle, Decl(tile1.ts, 0, 0))
+>Attrs : Symbol(Attrs, Decl(tile1.ts, 0, 20))
+>State : Symbol(State, Decl(tile1.ts, 0, 26))
 
 	oninit?(vnode: Vnode<Attrs, State>): number;
->oninit : Symbol(Lifecycle.oninit, Decl(subclassThisTypeAssignable.ts, 0, 35))
->vnode : Symbol(vnode, Decl(subclassThisTypeAssignable.ts, 1, 9))
->Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
->Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 0, 20))
->State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 0, 26))
+>oninit : Symbol(Lifecycle.oninit, Decl(tile1.ts, 0, 35))
+>vnode : Symbol(vnode, Decl(tile1.ts, 1, 9))
+>Vnode : Symbol(Vnode, Decl(tile1.ts, 3, 1))
+>Attrs : Symbol(Attrs, Decl(tile1.ts, 0, 20))
+>State : Symbol(State, Decl(tile1.ts, 0, 26))
 
 	[_: number]: any;
->_ : Symbol(_, Decl(subclassThisTypeAssignable.ts, 2, 2))
+>_ : Symbol(_, Decl(tile1.ts, 2, 2))
 }
 
 interface Vnode<Attrs, State extends Lifecycle<Attrs, State> = Lifecycle<Attrs, State>> {
->Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
->Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 5, 16))
->State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 5, 22))
->Lifecycle : Symbol(Lifecycle, Decl(subclassThisTypeAssignable.ts, 0, 0))
->Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 5, 16))
->State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 5, 22))
->Lifecycle : Symbol(Lifecycle, Decl(subclassThisTypeAssignable.ts, 0, 0))
->Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 5, 16))
->State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 5, 22))
+>Vnode : Symbol(Vnode, Decl(tile1.ts, 3, 1))
+>Attrs : Symbol(Attrs, Decl(tile1.ts, 5, 16))
+>State : Symbol(State, Decl(tile1.ts, 5, 22))
+>Lifecycle : Symbol(Lifecycle, Decl(tile1.ts, 0, 0))
+>Attrs : Symbol(Attrs, Decl(tile1.ts, 5, 16))
+>State : Symbol(State, Decl(tile1.ts, 5, 22))
+>Lifecycle : Symbol(Lifecycle, Decl(tile1.ts, 0, 0))
+>Attrs : Symbol(Attrs, Decl(tile1.ts, 5, 16))
+>State : Symbol(State, Decl(tile1.ts, 5, 22))
 
 	tag: Component<Attrs, State>;
->tag : Symbol(Vnode.tag, Decl(subclassThisTypeAssignable.ts, 5, 89))
->Component : Symbol(Component, Decl(subclassThisTypeAssignable.ts, 7, 1))
->Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 5, 16))
->State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 5, 22))
+>tag : Symbol(Vnode.tag, Decl(tile1.ts, 5, 89))
+>Component : Symbol(Component, Decl(tile1.ts, 7, 1))
+>Attrs : Symbol(Attrs, Decl(tile1.ts, 5, 16))
+>State : Symbol(State, Decl(tile1.ts, 5, 22))
 }
 
 interface Component<Attrs, State> {
->Component : Symbol(Component, Decl(subclassThisTypeAssignable.ts, 7, 1))
->Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 9, 20))
->State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 9, 26))
+>Component : Symbol(Component, Decl(tile1.ts, 7, 1))
+>Attrs : Symbol(Attrs, Decl(tile1.ts, 9, 20))
+>State : Symbol(State, Decl(tile1.ts, 9, 26))
 
 	view(this: State, vnode: Vnode<Attrs, State>): number;
->view : Symbol(Component.view, Decl(subclassThisTypeAssignable.ts, 9, 35))
->this : Symbol(this, Decl(subclassThisTypeAssignable.ts, 10, 6))
->State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 9, 26))
->vnode : Symbol(vnode, Decl(subclassThisTypeAssignable.ts, 10, 18))
->Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
->Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 9, 20))
->State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 9, 26))
+>view : Symbol(Component.view, Decl(tile1.ts, 9, 35))
+>this : Symbol(this, Decl(tile1.ts, 10, 6))
+>State : Symbol(State, Decl(tile1.ts, 9, 26))
+>vnode : Symbol(vnode, Decl(tile1.ts, 10, 18))
+>Vnode : Symbol(Vnode, Decl(tile1.ts, 3, 1))
+>Attrs : Symbol(Attrs, Decl(tile1.ts, 9, 20))
+>State : Symbol(State, Decl(tile1.ts, 9, 26))
 }
 
 interface ClassComponent<A> extends Lifecycle<A, ClassComponent<A>> {
->ClassComponent : Symbol(ClassComponent, Decl(subclassThisTypeAssignable.ts, 11, 1))
->A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
->Lifecycle : Symbol(Lifecycle, Decl(subclassThisTypeAssignable.ts, 0, 0))
->A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
->ClassComponent : Symbol(ClassComponent, Decl(subclassThisTypeAssignable.ts, 11, 1))
->A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
+>ClassComponent : Symbol(ClassComponent, Decl(tile1.ts, 11, 1))
+>A : Symbol(A, Decl(tile1.ts, 13, 25))
+>Lifecycle : Symbol(Lifecycle, Decl(tile1.ts, 0, 0))
+>A : Symbol(A, Decl(tile1.ts, 13, 25))
+>ClassComponent : Symbol(ClassComponent, Decl(tile1.ts, 11, 1))
+>A : Symbol(A, Decl(tile1.ts, 13, 25))
 
 	oninit?(vnode: Vnode<A, this>): number;
->oninit : Symbol(ClassComponent.oninit, Decl(subclassThisTypeAssignable.ts, 13, 69))
->vnode : Symbol(vnode, Decl(subclassThisTypeAssignable.ts, 14, 9))
->Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
->A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
+>oninit : Symbol(ClassComponent.oninit, Decl(tile1.ts, 13, 69))
+>vnode : Symbol(vnode, Decl(tile1.ts, 14, 9))
+>Vnode : Symbol(Vnode, Decl(tile1.ts, 3, 1))
+>A : Symbol(A, Decl(tile1.ts, 13, 25))
 
 	view(vnode: Vnode<A, this>): number;
->view : Symbol(ClassComponent.view, Decl(subclassThisTypeAssignable.ts, 14, 40))
->vnode : Symbol(vnode, Decl(subclassThisTypeAssignable.ts, 15, 6))
->Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
->A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
+>view : Symbol(ClassComponent.view, Decl(tile1.ts, 14, 40))
+>vnode : Symbol(vnode, Decl(tile1.ts, 15, 6))
+>Vnode : Symbol(Vnode, Decl(tile1.ts, 3, 1))
+>A : Symbol(A, Decl(tile1.ts, 13, 25))
 }
 
 interface MyAttrs { id: number }
->MyAttrs : Symbol(MyAttrs, Decl(subclassThisTypeAssignable.ts, 16, 1))
->id : Symbol(MyAttrs.id, Decl(subclassThisTypeAssignable.ts, 18, 19))
+>MyAttrs : Symbol(MyAttrs, Decl(tile1.ts, 16, 1))
+>id : Symbol(MyAttrs.id, Decl(tile1.ts, 18, 19))
 
 class C implements ClassComponent<MyAttrs> {
->C : Symbol(C, Decl(subclassThisTypeAssignable.ts, 18, 32))
->ClassComponent : Symbol(ClassComponent, Decl(subclassThisTypeAssignable.ts, 11, 1))
->MyAttrs : Symbol(MyAttrs, Decl(subclassThisTypeAssignable.ts, 16, 1))
+>C : Symbol(C, Decl(tile1.ts, 18, 32))
+>ClassComponent : Symbol(ClassComponent, Decl(tile1.ts, 11, 1))
+>MyAttrs : Symbol(MyAttrs, Decl(tile1.ts, 16, 1))
 
 	view(v: Vnode<MyAttrs>) { return 0; }
->view : Symbol(C.view, Decl(subclassThisTypeAssignable.ts, 19, 44))
->v : Symbol(v, Decl(subclassThisTypeAssignable.ts, 20, 6))
->Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
->MyAttrs : Symbol(MyAttrs, Decl(subclassThisTypeAssignable.ts, 16, 1))
+>view : Symbol(C.view, Decl(tile1.ts, 19, 44))
+>v : Symbol(v, Decl(tile1.ts, 20, 6))
+>Vnode : Symbol(Vnode, Decl(tile1.ts, 3, 1))
+>MyAttrs : Symbol(MyAttrs, Decl(tile1.ts, 16, 1))
 }
 
 const test8: ClassComponent<any> = new C();
->test8 : Symbol(test8, Decl(subclassThisTypeAssignable.ts, 23, 5))
->ClassComponent : Symbol(ClassComponent, Decl(subclassThisTypeAssignable.ts, 11, 1))
->C : Symbol(C, Decl(subclassThisTypeAssignable.ts, 18, 32))
+>test8 : Symbol(test8, Decl(tile1.ts, 23, 5))
+>ClassComponent : Symbol(ClassComponent, Decl(tile1.ts, 11, 1))
+>C : Symbol(C, Decl(tile1.ts, 18, 32))
+
+=== tests/cases/compiler/file1.js ===
+/** @type {ClassComponent<any>} */
+const test9 = new C();
+>test9 : Symbol(test9, Decl(file1.js, 1, 5))
+>C : Symbol(C, Decl(tile1.ts, 18, 32))
 

--- a/tests/baselines/reference/subclassThisTypeAssignable.symbols
+++ b/tests/baselines/reference/subclassThisTypeAssignable.symbols
@@ -1,0 +1,92 @@
+=== tests/cases/compiler/subclassThisTypeAssignable.ts ===
+interface Lifecycle<Attrs, State> {
+>Lifecycle : Symbol(Lifecycle, Decl(subclassThisTypeAssignable.ts, 0, 0))
+>Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 0, 20))
+>State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 0, 26))
+
+	oninit?(vnode: Vnode<Attrs, State>): number;
+>oninit : Symbol(Lifecycle.oninit, Decl(subclassThisTypeAssignable.ts, 0, 35))
+>vnode : Symbol(vnode, Decl(subclassThisTypeAssignable.ts, 1, 9))
+>Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
+>Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 0, 20))
+>State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 0, 26))
+
+	[_: number]: any;
+>_ : Symbol(_, Decl(subclassThisTypeAssignable.ts, 2, 2))
+}
+
+interface Vnode<Attrs, State extends Lifecycle<Attrs, State> = Lifecycle<Attrs, State>> {
+>Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
+>Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 5, 16))
+>State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 5, 22))
+>Lifecycle : Symbol(Lifecycle, Decl(subclassThisTypeAssignable.ts, 0, 0))
+>Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 5, 16))
+>State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 5, 22))
+>Lifecycle : Symbol(Lifecycle, Decl(subclassThisTypeAssignable.ts, 0, 0))
+>Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 5, 16))
+>State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 5, 22))
+
+	tag: Component<Attrs, State>;
+>tag : Symbol(Vnode.tag, Decl(subclassThisTypeAssignable.ts, 5, 89))
+>Component : Symbol(Component, Decl(subclassThisTypeAssignable.ts, 7, 1))
+>Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 5, 16))
+>State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 5, 22))
+}
+
+interface Component<Attrs, State> {
+>Component : Symbol(Component, Decl(subclassThisTypeAssignable.ts, 7, 1))
+>Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 9, 20))
+>State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 9, 26))
+
+	view(this: State, vnode: Vnode<Attrs, State>): number;
+>view : Symbol(Component.view, Decl(subclassThisTypeAssignable.ts, 9, 35))
+>this : Symbol(this, Decl(subclassThisTypeAssignable.ts, 10, 6))
+>State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 9, 26))
+>vnode : Symbol(vnode, Decl(subclassThisTypeAssignable.ts, 10, 18))
+>Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
+>Attrs : Symbol(Attrs, Decl(subclassThisTypeAssignable.ts, 9, 20))
+>State : Symbol(State, Decl(subclassThisTypeAssignable.ts, 9, 26))
+}
+
+interface ClassComponent<A> extends Lifecycle<A, ClassComponent<A>> {
+>ClassComponent : Symbol(ClassComponent, Decl(subclassThisTypeAssignable.ts, 11, 1))
+>A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
+>Lifecycle : Symbol(Lifecycle, Decl(subclassThisTypeAssignable.ts, 0, 0))
+>A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
+>ClassComponent : Symbol(ClassComponent, Decl(subclassThisTypeAssignable.ts, 11, 1))
+>A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
+
+	oninit?(vnode: Vnode<A, this>): number;
+>oninit : Symbol(ClassComponent.oninit, Decl(subclassThisTypeAssignable.ts, 13, 69))
+>vnode : Symbol(vnode, Decl(subclassThisTypeAssignable.ts, 14, 9))
+>Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
+>A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
+
+	view(vnode: Vnode<A, this>): number;
+>view : Symbol(ClassComponent.view, Decl(subclassThisTypeAssignable.ts, 14, 40))
+>vnode : Symbol(vnode, Decl(subclassThisTypeAssignable.ts, 15, 6))
+>Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
+>A : Symbol(A, Decl(subclassThisTypeAssignable.ts, 13, 25))
+}
+
+interface MyAttrs { id: number }
+>MyAttrs : Symbol(MyAttrs, Decl(subclassThisTypeAssignable.ts, 16, 1))
+>id : Symbol(MyAttrs.id, Decl(subclassThisTypeAssignable.ts, 18, 19))
+
+class C implements ClassComponent<MyAttrs> {
+>C : Symbol(C, Decl(subclassThisTypeAssignable.ts, 18, 32))
+>ClassComponent : Symbol(ClassComponent, Decl(subclassThisTypeAssignable.ts, 11, 1))
+>MyAttrs : Symbol(MyAttrs, Decl(subclassThisTypeAssignable.ts, 16, 1))
+
+	view(v: Vnode<MyAttrs>) { return 0; }
+>view : Symbol(C.view, Decl(subclassThisTypeAssignable.ts, 19, 44))
+>v : Symbol(v, Decl(subclassThisTypeAssignable.ts, 20, 6))
+>Vnode : Symbol(Vnode, Decl(subclassThisTypeAssignable.ts, 3, 1))
+>MyAttrs : Symbol(MyAttrs, Decl(subclassThisTypeAssignable.ts, 16, 1))
+}
+
+const test8: ClassComponent<any> = new C();
+>test8 : Symbol(test8, Decl(subclassThisTypeAssignable.ts, 23, 5))
+>ClassComponent : Symbol(ClassComponent, Decl(subclassThisTypeAssignable.ts, 11, 1))
+>C : Symbol(C, Decl(subclassThisTypeAssignable.ts, 18, 32))
+

--- a/tests/baselines/reference/subclassThisTypeAssignable.types
+++ b/tests/baselines/reference/subclassThisTypeAssignable.types
@@ -1,0 +1,49 @@
+=== tests/cases/compiler/subclassThisTypeAssignable.ts ===
+interface Lifecycle<Attrs, State> {
+	oninit?(vnode: Vnode<Attrs, State>): number;
+>oninit : (vnode: Vnode<Attrs, State>) => number
+>vnode : Vnode<Attrs, State>
+
+	[_: number]: any;
+>_ : number
+}
+
+interface Vnode<Attrs, State extends Lifecycle<Attrs, State> = Lifecycle<Attrs, State>> {
+	tag: Component<Attrs, State>;
+>tag : Component<Attrs, State>
+}
+
+interface Component<Attrs, State> {
+	view(this: State, vnode: Vnode<Attrs, State>): number;
+>view : (this: State, vnode: Vnode<Attrs, State>) => number
+>this : State
+>vnode : Vnode<Attrs, State>
+}
+
+interface ClassComponent<A> extends Lifecycle<A, ClassComponent<A>> {
+	oninit?(vnode: Vnode<A, this>): number;
+>oninit : (vnode: Vnode<A, this>) => number
+>vnode : Vnode<A, this>
+
+	view(vnode: Vnode<A, this>): number;
+>view : (vnode: Vnode<A, this>) => number
+>vnode : Vnode<A, this>
+}
+
+interface MyAttrs { id: number }
+>id : number
+
+class C implements ClassComponent<MyAttrs> {
+>C : C
+
+	view(v: Vnode<MyAttrs>) { return 0; }
+>view : (v: Vnode<MyAttrs, Lifecycle<MyAttrs, Lifecycle<{}, {}>>>) => number
+>v : Vnode<MyAttrs, Lifecycle<MyAttrs, Lifecycle<{}, {}>>>
+>0 : 0
+}
+
+const test8: ClassComponent<any> = new C();
+>test8 : ClassComponent<any>
+>new C() : C
+>C : typeof C
+

--- a/tests/baselines/reference/subclassThisTypeAssignable.types
+++ b/tests/baselines/reference/subclassThisTypeAssignable.types
@@ -1,4 +1,4 @@
-=== tests/cases/compiler/subclassThisTypeAssignable.ts ===
+=== tests/cases/compiler/tile1.ts ===
 interface Lifecycle<Attrs, State> {
 	oninit?(vnode: Vnode<Attrs, State>): number;
 >oninit : (vnode: Vnode<Attrs, State>) => number
@@ -44,6 +44,13 @@ class C implements ClassComponent<MyAttrs> {
 
 const test8: ClassComponent<any> = new C();
 >test8 : ClassComponent<any>
+>new C() : C
+>C : typeof C
+
+=== tests/cases/compiler/file1.js ===
+/** @type {ClassComponent<any>} */
+const test9 = new C();
+>test9 : ClassComponent<any>
 >new C() : C
 >C : typeof C
 

--- a/tests/cases/compiler/subclassThisTypeAssignable.ts
+++ b/tests/cases/compiler/subclassThisTypeAssignable.ts
@@ -1,3 +1,7 @@
+// @allowJs: true
+// @checkJs: true
+// @outDir: ./out
+// @filename: tile1.ts
 interface Lifecycle<Attrs, State> {
 	oninit?(vnode: Vnode<Attrs, State>): number;
 	[_: number]: any;
@@ -22,3 +26,6 @@ class C implements ClassComponent<MyAttrs> {
 }
 
 const test8: ClassComponent<any> = new C();
+// @filename: file1.js
+/** @type {ClassComponent<any>} */
+const test9 = new C();

--- a/tests/cases/compiler/subclassThisTypeAssignable.ts
+++ b/tests/cases/compiler/subclassThisTypeAssignable.ts
@@ -1,0 +1,24 @@
+interface Lifecycle<Attrs, State> {
+	oninit?(vnode: Vnode<Attrs, State>): number;
+	[_: number]: any;
+}
+
+interface Vnode<Attrs, State extends Lifecycle<Attrs, State> = Lifecycle<Attrs, State>> {
+	tag: Component<Attrs, State>;
+}
+
+interface Component<Attrs, State> {
+	view(this: State, vnode: Vnode<Attrs, State>): number;
+}
+
+interface ClassComponent<A> extends Lifecycle<A, ClassComponent<A>> {
+	oninit?(vnode: Vnode<A, this>): number;
+	view(vnode: Vnode<A, this>): number;
+}
+
+interface MyAttrs { id: number }
+class C implements ClassComponent<MyAttrs> {
+	view(v: Vnode<MyAttrs>) { return 0; }
+}
+
+const test8: ClassComponent<any> = new C();


### PR DESCRIPTION
Fixes #28388

In  #28222 we started having type parameters have a "base default" of their constraint while we solve for their defaults - however when a type parameter is circularly constrained (we allow this) and circularly defaulted (that we allow this is what caused the last change), this caused uninstantiated parameters to leak into the default. Now we ensure that any references in the constraint to type parameters being default'ed are mapped to the base default type for the context (`{}` or `any` depending on JS-or-not).