### PR TITLE
Add exports of current module to getSymbolsInScope

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27698,8 +27698,11 @@ namespace ts {
                     }
 
                     switch (location.kind) {
+                        case SyntaxKind.SourceFile:
+                            if (!isExternalOrCommonJsModule(<SourceFile>location)) break;
+                            // falls through
                         case SyntaxKind.ModuleDeclaration:
-                            copySymbols(getSymbolOfNode(location as ModuleDeclaration).exports!, meaning & SymbolFlags.ModuleMember);
+                            copySymbols(getSymbolOfNode(location as ModuleDeclaration | SourceFile).exports!, meaning & SymbolFlags.ModuleMember);
                             break;
                         case SyntaxKind.EnumDeclaration:
                             copySymbols(getSymbolOfNode(location as EnumDeclaration).exports!, meaning & SymbolFlags.EnumMember);

--- a/tests/cases/fourslash/completionsExportImport.ts
+++ b/tests/cases/fourslash/completionsExportImport.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+////declare global {
+////    namespace N {
+////        const foo: number;
+////    }
+////}
+////export import foo = N.foo;
+/////**/
+
+verify.completions({
+    marker: "",
+    exact: [
+        { name: "foo", kind: "alias", kindModifiers: "export", text: "(alias) const foo: number\nimport foo = N.foo" },
+        ...completion.globalsPlus([{ name: "N", kind: "module", kindModifiers: "declare", text: "namespace N" }]),
+    ],
+});


### PR DESCRIPTION
Fixes #26540
Now matches the behavior of `resolveNameHelper`.