### PR TITLE
Remove lib file errors from builder cache when global files are to be emitted

### DIFF
--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -368,7 +368,7 @@ namespace ts.BuilderState {
         }
 
         // If this is non module emit, or its a global file, it depends on all the source files
-        if (!state.referencedMap || (!isExternalModule(sourceFile) && !containsOnlyAmbientModules(sourceFile))) {
+        if (!state.referencedMap || isFileAffectingGlobalScope(sourceFile)) {
             return getAllFileNames(state, programOfThisState);
         }
 
@@ -431,6 +431,22 @@ namespace ts.BuilderState {
     }
 
     /**
+     * Return true if file contains anything that augments to global scope we need to build them as if
+     * they are global files as well as module
+     */
+    function containsGlobalScopeAugmentation(sourceFile: SourceFile) {
+        return some(sourceFile.moduleAugmentations, augmentation => isGlobalScopeAugmentation(augmentation.parent as ModuleDeclaration));
+    }
+
+    /**
+     * Return true if the file will invalidate all files because it affectes global scope
+     */
+    function isFileAffectingGlobalScope(sourceFile: SourceFile) {
+        return containsGlobalScopeAugmentation(sourceFile) ||
+            !isExternalModule(sourceFile) && !containsOnlyAmbientModules(sourceFile);
+    }
+
+    /**
      * Gets all files of the program excluding the default library file
      */
     function getAllFilesExcludingDefaultLibraryFile(state: BuilderState, programOfThisState: Program, firstSourceFile: SourceFile): ReadonlyArray<SourceFile> {
@@ -473,7 +489,7 @@ namespace ts.BuilderState {
      * When program emits modular code, gets the files affected by the sourceFile whose shape has changed
      */
     function getFilesAffectedByUpdatedShapeWhenModuleEmit(state: BuilderState, programOfThisState: Program, sourceFileWithUpdatedShape: SourceFile, cacheToUpdateSignature: Map<string>, cancellationToken: CancellationToken | undefined, computeHash: ComputeHash | undefined, exportedModulesMapCache: ComputingExportedModulesMap | undefined) {
-        if (!isExternalModule(sourceFileWithUpdatedShape) && !containsOnlyAmbientModules(sourceFileWithUpdatedShape)) {
+        if (isFileAffectingGlobalScope(sourceFileWithUpdatedShape)) {
             return getAllFilesExcludingDefaultLibraryFile(state, programOfThisState, sourceFileWithUpdatedShape);
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25111,7 +25111,7 @@ namespace ts {
                     }
                 }
                 if (symbol.declarations.length > 1) {
-                    if (some(symbol.declarations, d => d !== node && !areDeclarationFlagsIdentical(d, node))) {
+                    if (some(symbol.declarations, d => d !== node && isVariableLike(d) && !areDeclarationFlagsIdentical(d, node))) {
                         error(node.name, Diagnostics.All_declarations_of_0_must_have_identical_modifiers, declarationNameToString(node.name));
                     }
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25110,6 +25110,11 @@ namespace ts {
                         checkParameterInitializer(node);
                     }
                 }
+                if (symbol.declarations.length > 1) {
+                    if (some(symbol.declarations, d => d !== node && !areDeclarationFlagsIdentical(d, node))) {
+                        error(node.name, Diagnostics.All_declarations_of_0_must_have_identical_modifiers, declarationNameToString(node.name));
+                    }
+                }
             }
             else {
                 // Node is a secondary declaration, check that type is identical to primary declaration and check that
@@ -25125,7 +25130,6 @@ namespace ts {
                     checkTypeAssignableToAndOptionallyElaborate(checkExpressionCached(node.initializer), declarationType, node, node.initializer, /*headMessage*/ undefined);
                 }
                 if (!areDeclarationFlagsIdentical(node, symbol.valueDeclaration)) {
-                    error(getNameOfDeclaration(symbol.valueDeclaration), Diagnostics.All_declarations_of_0_must_have_identical_modifiers, declarationNameToString(node.name));
                     error(node.name, Diagnostics.All_declarations_of_0_must_have_identical_modifiers, declarationNameToString(node.name));
                 }
             }

--- a/src/testRunner/unittests/tscWatchMode.ts
+++ b/src/testRunner/unittests/tscWatchMode.ts
@@ -1564,6 +1564,125 @@ export class Data2 {
                 verifyTransitiveExports([libFile, app, lib2Public, lib2Data, lib2Data2, lib1Public, lib1ToolsPublic, lib1ToolsInterface]);
             });
         });
+
+        describe("updates errors in lib file when non module file changes", () => {
+            const currentDirectory = "/user/username/projects/myproject";
+            const field = "fullscreen";
+            const aFile: File = {
+                path: `${currentDirectory}/a.ts`,
+                content: `interface Document {
+	${field}: boolean;
+}`
+            };
+            const libFileWithDocument: File = {
+                path: libFile.path,
+                content: `${libFile.content}
+interface Document {
+    readonly ${field}: boolean;
+}`
+            };
+
+            function getDiagnostic(program: Program, file: File) {
+                return getDiagnosticOfFileFromProgram(program, file.path, file.content.indexOf(field), field.length, Diagnostics.All_declarations_of_0_must_have_identical_modifiers, field);
+            }
+
+            const files = [aFile, libFileWithDocument];
+
+            function verifyLibErrors(options: CompilerOptions) {
+                const host = createWatchedSystem(files, { currentDirectory });
+                const watch = createWatchOfFilesAndCompilerOptions([aFile.path], host, options);
+                checkProgramActualFiles(watch(), [aFile.path, libFile.path]);
+                checkOutputErrorsInitial(host, getErrors());
+
+                host.writeFile(aFile.path, "var x = 10;");
+                host.runQueuedTimeoutCallbacks();
+                checkProgramActualFiles(watch(), [aFile.path, libFile.path]);
+                checkOutputErrorsIncremental(host, emptyArray);
+
+                host.writeFile(aFile.path, aFile.content);
+                host.runQueuedTimeoutCallbacks();
+                checkProgramActualFiles(watch(), [aFile.path, libFile.path]);
+                checkOutputErrorsIncremental(host, getErrors());
+
+                function getErrors() {
+                    return [
+                        ...(options.skipLibCheck || options.skipDefaultLibCheck ? [] : [getDiagnostic(watch(), libFileWithDocument)]),
+                        getDiagnostic(watch(), aFile)
+                    ];
+                }
+            }
+
+            it("with default options", () => {
+                verifyLibErrors({});
+            });
+            it("with skipLibCheck", () => {
+                verifyLibErrors({ skipLibCheck: true });
+            });
+            it("with skipDefaultLibCheck", () => {
+                verifyLibErrors({ skipDefaultLibCheck: true });
+            });
+        });
+
+        it("when skipLibCheck and skipDefaultLibCheck changes", () => {
+            const currentDirectory = "/user/username/projects/myproject";
+            const field = "fullscreen";
+            const aFile: File = {
+                path: `${currentDirectory}/a.ts`,
+                content: `interface Document {
+	${field}: boolean;
+}`
+            };
+            const bFile: File = {
+                path: `${currentDirectory}/b.d.ts`,
+                content: `interface Document {
+	${field}: boolean;
+}`
+            };
+            const libFileWithDocument: File = {
+                path: libFile.path,
+                content: `${libFile.content}
+interface Document {
+    readonly ${field}: boolean;
+}`
+            };
+            const configFile: File = {
+                path: `${currentDirectory}/tsconfig.json`,
+                content: "{}"
+            };
+
+            const files = [aFile, bFile, configFile, libFileWithDocument];
+
+            const host = createWatchedSystem(files, { currentDirectory });
+            const watch = createWatchOfConfigFile("tsconfig.json", host);
+            verifyProgramFiles();
+            checkOutputErrorsInitial(host, [
+                getDiagnostic(libFileWithDocument),
+                getDiagnostic(aFile),
+                getDiagnostic(bFile)
+            ]);
+
+            verifyConfigChange({ skipLibCheck: true }, [aFile]);
+            verifyConfigChange({ skipDefaultLibCheck: true }, [aFile, bFile]);
+            verifyConfigChange({}, [libFileWithDocument, aFile, bFile]);
+            verifyConfigChange({ skipDefaultLibCheck: true }, [aFile, bFile]);
+            verifyConfigChange({ skipLibCheck: true }, [aFile]);
+            verifyConfigChange({}, [libFileWithDocument, aFile, bFile]);
+
+            function verifyConfigChange(compilerOptions: CompilerOptions, errorInFiles: ReadonlyArray<File>) {
+                host.writeFile(configFile.path, JSON.stringify({ compilerOptions }));
+                host.runQueuedTimeoutCallbacks();
+                verifyProgramFiles();
+                checkOutputErrorsIncremental(host, errorInFiles.map(getDiagnostic));
+            }
+
+            function getDiagnostic(file: File) {
+                return getDiagnosticOfFileFromProgram(watch(), file.path, file.content.indexOf(field), field.length, Diagnostics.All_declarations_of_0_must_have_identical_modifiers, field);
+            }
+
+            function verifyProgramFiles() {
+                checkProgramActualFiles(watch(), [aFile.path, bFile.path, libFile.path]);
+            }
+        });
     });
 
     describe("tsc-watch emit with outFile or out setting", () => {


### PR DESCRIPTION
Fixes #26389

