### PR TITLE
Handle merging unknownSymbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -390,7 +390,7 @@ namespace ts {
         const evolvingArrayTypes: EvolvingArrayType[] = [];
         const undefinedProperties = createMap<Symbol>() as UnderscoreEscapedMap<Symbol>;
 
-        const unknownSymbol = createSymbol(SymbolFlags.Property, "<<unknown>>" as __String);
+        const unknownSymbol = createSymbol(SymbolFlags.Property, "unknown" as __String);
         const resolvingSymbol = createSymbol(0, InternalSymbolName.Resolving);
 
         const anyType = createIntrinsicType(TypeFlags.Any, "any");
@@ -879,7 +879,7 @@ namespace ts {
                 if (!(target.flags & SymbolFlags.Transient)) {
                     const resolvedTarget = resolveSymbol(target);
                     if (resolvedTarget === unknownSymbol) {
-                        return unknownSymbol;
+                        return source;
                     }
                     target = cloneSymbol(resolvedTarget);
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -390,7 +390,7 @@ namespace ts {
         const evolvingArrayTypes: EvolvingArrayType[] = [];
         const undefinedProperties = createMap<Symbol>() as UnderscoreEscapedMap<Symbol>;
 
-        const unknownSymbol = createSymbol(SymbolFlags.Property, "unknown" as __String);
+        const unknownSymbol = createSymbol(SymbolFlags.Property, "<<unknown>>" as __String);
         const resolvingSymbol = createSymbol(0, InternalSymbolName.Resolving);
 
         const anyType = createIntrinsicType(TypeFlags.Any, "any");
@@ -877,7 +877,11 @@ namespace ts {
                 (source.flags | target.flags) & SymbolFlags.Assignment) {
                 Debug.assert(source !== target);
                 if (!(target.flags & SymbolFlags.Transient)) {
-                    target = cloneSymbol(resolveSymbol(target));
+                    const resolvedTarget = resolveSymbol(target);
+                    if (resolvedTarget === unknownSymbol) {
+                        return unknownSymbol;
+                    }
+                    target = cloneSymbol(resolvedTarget);
                 }
                 // Javascript static-property-assignment declarations always merge, even though they are also values
                 if (source.flags & SymbolFlags.ValueModule && target.flags & SymbolFlags.ValueModule && target.constEnumOnlyModule && !source.constEnumOnlyModule) {

--- a/tests/baselines/reference/exportAsNamespaceConflict.errors.txt
+++ b/tests/baselines/reference/exportAsNamespaceConflict.errors.txt
@@ -1,0 +1,10 @@
+/a.d.ts(3,1): error TS2303: Circular definition of import alias 'N'.
+
+
+==== /a.d.ts (1 errors) ====
+    declare global { namespace N {} }
+    export = N;
+    export as namespace N;
+    ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2303: Circular definition of import alias 'N'.
+    

--- a/tests/baselines/reference/exportAsNamespaceConflict.errors.txt
+++ b/tests/baselines/reference/exportAsNamespaceConflict.errors.txt
@@ -1,9 +1,12 @@
+/a.d.ts(2,10): error TS2708: Cannot use namespace 'N' as a value.
 /a.d.ts(3,1): error TS2303: Circular definition of import alias 'N'.
 
 
-==== /a.d.ts (1 errors) ====
+==== /a.d.ts (2 errors) ====
     declare global { namespace N {} }
     export = N;
+             ~
+!!! error TS2708: Cannot use namespace 'N' as a value.
     export as namespace N;
     ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2303: Circular definition of import alias 'N'.

--- a/tests/baselines/reference/exportAsNamespaceConflict.symbols
+++ b/tests/baselines/reference/exportAsNamespaceConflict.symbols
@@ -4,6 +4,8 @@ declare global { namespace N {} }
 >N : Symbol(N, Decl(a.d.ts, 0, 16))
 
 export = N;
+>N : Symbol(N, Decl(a.d.ts, 0, 16))
+
 export as namespace N;
 >N : Symbol(N, Decl(a.d.ts, 1, 11))
 

--- a/tests/baselines/reference/exportAsNamespaceConflict.symbols
+++ b/tests/baselines/reference/exportAsNamespaceConflict.symbols
@@ -1,0 +1,9 @@
+=== /a.d.ts ===
+declare global { namespace N {} }
+>global : Symbol(global, Decl(a.d.ts, 0, 0))
+>N : Symbol(N, Decl(a.d.ts, 0, 16))
+
+export = N;
+export as namespace N;
+>N : Symbol(N, Decl(a.d.ts, 1, 11))
+

--- a/tests/baselines/reference/exportAsNamespaceConflict.types
+++ b/tests/baselines/reference/exportAsNamespaceConflict.types
@@ -1,0 +1,10 @@
+=== /a.d.ts ===
+declare global { namespace N {} }
+>global : any
+
+export = N;
+>N : any
+
+export as namespace N;
+>N : any
+

--- a/tests/cases/compiler/exportAsNamespaceConflict.ts
+++ b/tests/cases/compiler/exportAsNamespaceConflict.ts
@@ -1,0 +1,4 @@
+// @Filename: /a.d.ts
+declare global { namespace N {} }
+export = N;
+export as namespace N;


### PR DESCRIPTION
Fixes #28380

We handle `unknownSymbol` specially in many places. It looks like when we make a clone of it we undo some of that special handling, and end up crashing since its flags make it a `Property` but it has no `valueDeclaration` as expected.