### PR TITLE
Use elipses for reverse mapped types in nested positions

### DIFF
--- a/tests/cases/fourslash/quickInfoMappedTypeRecursiveInference.ts
+++ b/tests/cases/fourslash/quickInfoMappedTypeRecursiveInference.ts
@@ -18,53 +18,53 @@
 
 verify.quickInfoAt('1', `const out: {
     a: {
-        a: any;
+        a: ...;
     };
 }`);
 verify.quickInfoAt('2', `function foo<{
     a: {
-        a: any;
+        a: ...;
     };
 }>(deep: Deep<{
     a: {
-        a: any;
+        a: ...;
     };
 }>): {
     a: {
-        a: any;
+        a: ...;
     };
 }`);
 verify.quickInfoAt('3', `(property) a: {
     a: {
-        a: any;
+        a: ...;
     };
 }`);
 verify.quickInfoAt('4', `(property) a: {
     a: {
-        a: any;
+        a: ...;
     };
 }`);
 verify.quickInfoAt('5', `(property) a: {
     a: {
-        a: any;
+        a: ...;
     };
 }`);
 verify.quickInfoAt('6', `const oub: {
-    [x: string]: any;
+    [x: string]: ...;
 }`);
 verify.quickInfoAt('7', `function foo<{
-    [x: string]: any;
+    [x: string]: ...;
 }>(deep: Deep<{
-    [x: string]: any;
+    [x: string]: ...;
 }>): {
-    [x: string]: any;
+    [x: string]: ...;
 }`);
 verify.quickInfoAt('8', `{
-    [x: string]: any;
+    [x: string]: ...;
 }`);
 verify.quickInfoAt('9', `{
-    [x: string]: any;
+    [x: string]: ...;
 }`);
 verify.quickInfoAt('10', `{
-    [x: string]: any;
+    [x: string]: ...;
 }`);

--- a/tests/cases/fourslash/reverseMappedTypeQuickInfo.ts
+++ b/tests/cases/fourslash/reverseMappedTypeQuickInfo.ts
@@ -1,0 +1,36 @@
+/// <reference path="fourslash.ts" />
+
+////interface IAction {
+////    type: string;
+////}
+////
+////type Reducer<S> = (state: S, action: IAction) => S
+////
+////function combineReducers<S>(reducers: { [K in keyof S]: Reducer<S[K]> }): Reducer<S> {
+////    const dummy = {} as S;
+////    return () => dummy;
+////}
+////
+////const test_inner = (test: string, action: IAction) => {
+////    return 'dummy';
+////}
+////const test = combineReducers({
+////    test_inner
+////});
+////
+////const test_outer = combineReducers({
+////    test
+////});
+////
+////// '{test: { test_inner: any } }'
+////type FinalType/*1*/ = ReturnType<typeof test_outer>;
+////
+////var k: FinalType;
+////k.test.test_inner/*2*/
+
+verify.quickInfoAt("1", `type FinalType = {
+    test: {
+        test_inner: ...;
+    };
+}`);
+verify.quickInfoAt("2", `(property) test_inner: string`);


### PR DESCRIPTION
Doesn't fix #23897 per sey, but makes it more apparent that we're eliding information in quickinfo (and not typechecking things wrong).

This is similar to the change I made in #28490 to make self-recursion locations print as `...` instead of `any`.

There's still the issue of declaration emit for these types and such (and that today they emit as `any` without being an error) - having some way to alias a reverse mapped type in general would go a long way towards making these print better, I think.