### PR TITLE
Disallows `async abstract` method declarations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28342,6 +28342,9 @@ namespace ts {
                             if (flags & ModifierFlags.Private) {
                                 return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_be_used_with_1_modifier, "private", "abstract");
                             }
+                            if (flags & ModifierFlags.Async) {
+                                return grammarErrorOnNode(modifier, Diagnostics._0_modifier_cannot_be_used_with_1_modifier, "async", "abstract");
+                            }
                         }
 
                         flags |= ModifierFlags.Abstract;

--- a/tests/baselines/reference/abstractAsync.errors.txt
+++ b/tests/baselines/reference/abstractAsync.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/compiler/abstractAsync.ts(2,9): error TS1243: 'async' modifier cannot be used with 'abstract' modifier.
+
+
+==== tests/cases/compiler/abstractAsync.ts (1 errors) ====
+    abstract class ShouldFailClass {
+      async abstract badMethod(): Promise<number>;
+            ~~~~~~~~
+!!! error TS1243: 'async' modifier cannot be used with 'abstract' modifier.
+    }

--- a/tests/baselines/reference/abstractAsync.js
+++ b/tests/baselines/reference/abstractAsync.js
@@ -1,0 +1,11 @@
+//// [abstractAsync.ts]
+abstract class ShouldFailClass {
+  async abstract badMethod(): Promise<number>;
+}
+
+//// [abstractAsync.js]
+var ShouldFailClass = /** @class */ (function () {
+    function ShouldFailClass() {
+    }
+    return ShouldFailClass;
+}());

--- a/tests/baselines/reference/abstractAsync.symbols
+++ b/tests/baselines/reference/abstractAsync.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/abstractAsync.ts ===
+abstract class ShouldFailClass {
+>ShouldFailClass : Symbol(ShouldFailClass, Decl(abstractAsync.ts, 0, 0))
+
+  async abstract badMethod(): Promise<number>;
+>badMethod : Symbol(ShouldFailClass.badMethod, Decl(abstractAsync.ts, 0, 32))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+}

--- a/tests/baselines/reference/abstractAsync.types
+++ b/tests/baselines/reference/abstractAsync.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/abstractAsync.ts ===
+abstract class ShouldFailClass {
+>ShouldFailClass : ShouldFailClass
+
+  async abstract badMethod(): Promise<number>;
+>badMethod : () => Promise<number>
+>Promise : Promise<T>
+}

--- a/tests/cases/compiler/abstractAsync.ts
+++ b/tests/cases/compiler/abstractAsync.ts
@@ -1,0 +1,4 @@
+// @lib: es2015
+abstract class ShouldFailClass {
+  async abstract badMethod(): Promise<number>;
+}


### PR DESCRIPTION
Since we do not allow `async` as a modifier on type members such as in an interface, it was decided that it should also not be allowed on abstract methods.

Submitting a PR for this had been discussed on the original issue (which was then concluded to not be an actual bug, whereas *this* scenario is). This PR addresses the issue discussed in the comments [here](https://github.com/Microsoft/TypeScript/issues/25710#issuecomment-408174195).

***Edit by @DanielRosenwasser***: Fixes #28516
