### PR TITLE
Don't consider 'typeof a' as using 'a'

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19001,7 +19001,7 @@ namespace ts {
         }
 
         function markPropertyAsReferenced(prop: Symbol, nodeForCheckWriteOnly: Node | undefined, isThisAccess: boolean) {
-            if (!prop || !(prop.flags & SymbolFlags.ClassMember) || !prop.valueDeclaration || !hasModifier(prop.valueDeclaration, ModifierFlags.Private)) {
+            if (isInTypeOf || !prop || !(prop.flags & SymbolFlags.ClassMember) || !prop.valueDeclaration || !hasModifier(prop.valueDeclaration, ModifierFlags.Private)) {
                 return;
             }
             if (nodeForCheckWriteOnly && isWriteOnlyAccess(nodeForCheckWriteOnly) && !(prop.flags & SymbolFlags.SetAccessor && !(prop.flags & SymbolFlags.GetAccessor))) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -55,6 +55,7 @@ namespace ts {
         let cancellationToken: CancellationToken | undefined;
         let requestedExternalEmitHelpers: ExternalEmitHelpers;
         let externalHelpersModule: Symbol;
+        let isInTypeOf = false;
 
         // tslint:disable variable-name
         const Symbol = objectAllocator.getSymbolConstructor();
@@ -1478,7 +1479,7 @@ namespace ts {
             // We just climbed up parents looking for the name, meaning that we started in a descendant node of `lastLocation`.
             // If `result === lastSelfReferenceLocation.symbol`, that means that we are somewhere inside `lastSelfReferenceLocation` looking up a name, and resolving to `lastLocation` itself.
             // That means that this is a self-reference of `lastLocation`, and shouldn't count this when considering whether `lastLocation` is used.
-            if (isUse && result && (!lastSelfReferenceLocation || result !== lastSelfReferenceLocation.symbol)) {
+            if (isUse && result && (!lastSelfReferenceLocation || result !== lastSelfReferenceLocation.symbol) && !isInTypeOf) {
                 result.isReferenced! |= meaning;
             }
 
@@ -8657,11 +8658,14 @@ namespace ts {
         function getTypeFromTypeQueryNode(node: TypeQueryNode): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
+                const saveIsInTypeOf = isInTypeOf;
+                isInTypeOf = true;
                 // TypeScript 1.0 spec (April 2014): 3.6.3
                 // The expression is processed as an identifier expression (section 4.3)
                 // or property access expression(section 4.10),
                 // the widened type(section 3.9) of which becomes the result.
                 links.resolvedType = getRegularTypeOfLiteralType(getWidenedType(checkExpression(node.exprName)));
+                isInTypeOf = saveIsInTypeOf;
             }
             return links.resolvedType;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -55,7 +55,6 @@ namespace ts {
         let cancellationToken: CancellationToken | undefined;
         let requestedExternalEmitHelpers: ExternalEmitHelpers;
         let externalHelpersModule: Symbol;
-        let isInTypeOf = false;
 
         // tslint:disable variable-name
         const Symbol = objectAllocator.getSymbolConstructor();
@@ -1479,7 +1478,7 @@ namespace ts {
             // We just climbed up parents looking for the name, meaning that we started in a descendant node of `lastLocation`.
             // If `result === lastSelfReferenceLocation.symbol`, that means that we are somewhere inside `lastSelfReferenceLocation` looking up a name, and resolving to `lastLocation` itself.
             // That means that this is a self-reference of `lastLocation`, and shouldn't count this when considering whether `lastLocation` is used.
-            if (isUse && result && (!lastSelfReferenceLocation || result !== lastSelfReferenceLocation.symbol) && !isInTypeOf) {
+            if (isUse && result && (!lastSelfReferenceLocation || result !== lastSelfReferenceLocation.symbol) && !isInTypeQuery(originalLocation!)) {
                 result.isReferenced! |= meaning;
             }
 
@@ -8658,14 +8657,11 @@ namespace ts {
         function getTypeFromTypeQueryNode(node: TypeQueryNode): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
-                const saveIsInTypeOf = isInTypeOf;
-                isInTypeOf = true;
                 // TypeScript 1.0 spec (April 2014): 3.6.3
                 // The expression is processed as an identifier expression (section 4.3)
                 // or property access expression(section 4.10),
                 // the widened type(section 3.9) of which becomes the result.
                 links.resolvedType = getRegularTypeOfLiteralType(getWidenedType(checkExpression(node.exprName)));
-                isInTypeOf = saveIsInTypeOf;
             }
             return links.resolvedType;
         }
@@ -19001,7 +18997,7 @@ namespace ts {
         }
 
         function markPropertyAsReferenced(prop: Symbol, nodeForCheckWriteOnly: Node | undefined, isThisAccess: boolean) {
-            if (isInTypeOf || !prop || !(prop.flags & SymbolFlags.ClassMember) || !prop.valueDeclaration || !hasModifier(prop.valueDeclaration, ModifierFlags.Private)) {
+            if (nodeForCheckWriteOnly && isInTypeQuery(nodeForCheckWriteOnly) || !prop || !(prop.flags & SymbolFlags.ClassMember) || !prop.valueDeclaration || !hasModifier(prop.valueDeclaration, ModifierFlags.Private)) {
                 return;
             }
             if (nodeForCheckWriteOnly && isWriteOnlyAccess(nodeForCheckWriteOnly) && !(prop.flags & SymbolFlags.SetAccessor && !(prop.flags & SymbolFlags.GetAccessor))) {

--- a/tests/baselines/reference/unusedParameterUsedInTypeOf.errors.txt
+++ b/tests/baselines/reference/unusedParameterUsedInTypeOf.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/compiler/unusedParameterUsedInTypeOf.ts(1,14): error TS6133: 'a' is declared but its value is never read.
+
+
+==== tests/cases/compiler/unusedParameterUsedInTypeOf.ts (1 errors) ====
+    function f1 (a: number, b: typeof a) {
+                 ~
+!!! error TS6133: 'a' is declared but its value is never read.
+        return b;
+    }

--- a/tests/baselines/reference/unusedPropertyUsedInTypeOf.errors.txt
+++ b/tests/baselines/reference/unusedPropertyUsedInTypeOf.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/unusedPropertyUsedInTypeOf.ts(2,29): error TS6133: 'x' is declared but its value is never read.
+
+
+==== tests/cases/compiler/unusedPropertyUsedInTypeOf.ts (1 errors) ====
+    class C {
+        private static readonly x: number;
+                                ~
+!!! error TS6133: 'x' is declared but its value is never read.
+        m(p: typeof C.x) { return p; }
+    }
+    

--- a/tests/baselines/reference/unusedPropertyUsedInTypeOf.js
+++ b/tests/baselines/reference/unusedPropertyUsedInTypeOf.js
@@ -1,0 +1,14 @@
+//// [unusedPropertyUsedInTypeOf.ts]
+class C {
+    private static readonly x: number;
+    m(p: typeof C.x) { return p; }
+}
+
+
+//// [unusedPropertyUsedInTypeOf.js]
+var C = /** @class */ (function () {
+    function C() {
+    }
+    C.prototype.m = function (p) { return p; };
+    return C;
+}());

--- a/tests/baselines/reference/unusedPropertyUsedInTypeOf.symbols
+++ b/tests/baselines/reference/unusedPropertyUsedInTypeOf.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/unusedPropertyUsedInTypeOf.ts ===
+class C {
+>C : Symbol(C, Decl(unusedPropertyUsedInTypeOf.ts, 0, 0))
+
+    private static readonly x: number;
+>x : Symbol(C.x, Decl(unusedPropertyUsedInTypeOf.ts, 0, 9))
+
+    m(p: typeof C.x) { return p; }
+>m : Symbol(C.m, Decl(unusedPropertyUsedInTypeOf.ts, 1, 38))
+>p : Symbol(p, Decl(unusedPropertyUsedInTypeOf.ts, 2, 6))
+>C.x : Symbol(C.x, Decl(unusedPropertyUsedInTypeOf.ts, 0, 9))
+>C : Symbol(C, Decl(unusedPropertyUsedInTypeOf.ts, 0, 0))
+>x : Symbol(C.x, Decl(unusedPropertyUsedInTypeOf.ts, 0, 9))
+>p : Symbol(p, Decl(unusedPropertyUsedInTypeOf.ts, 2, 6))
+}
+

--- a/tests/baselines/reference/unusedPropertyUsedInTypeOf.types
+++ b/tests/baselines/reference/unusedPropertyUsedInTypeOf.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/unusedPropertyUsedInTypeOf.ts ===
+class C {
+>C : C
+
+    private static readonly x: number;
+>x : number
+
+    m(p: typeof C.x) { return p; }
+>m : (p: number) => number
+>p : number
+>C.x : number
+>C : typeof C
+>x : number
+>p : number
+}
+

--- a/tests/cases/compiler/unusedPropertyUsedInTypeOf.ts
+++ b/tests/cases/compiler/unusedPropertyUsedInTypeOf.ts
@@ -1,0 +1,7 @@
+// @noUnusedLocals:true
+// @noUnusedParameters:true
+
+class C {
+    private static readonly x: number;
+    m(p: typeof C.x) { return p; }
+}


### PR DESCRIPTION
Fixes a bug where a variable that was only ever used in a `typeof` expression was still considered used.