### PR TITLE
generateGetAccessorAndSetAccessor: Don't use FindAllReferences

### DIFF
--- a/src/services/refactors/generateGetAccessorAndSetAccessor.ts
+++ b/src/services/refactors/generateGetAccessorAndSetAccessor.ts
@@ -16,7 +16,7 @@ namespace ts.refactor.generateGetAccessorAndSetAccessor {
         readonly declaration: AcceptedDeclaration;
         readonly fieldName: AcceptedNameType;
         readonly accessorName: AcceptedNameType;
-        readonly originalName: AcceptedNameType;
+        readonly originalName: string;
         readonly renameAccessor: boolean;
     }
 
@@ -69,7 +69,7 @@ namespace ts.refactor.generateGetAccessorAndSetAccessor {
             // readonly modifier only existed in classLikeDeclaration
             const constructor = getFirstConstructorWithBody(<ClassLikeDeclaration>container);
             if (constructor) {
-                updateReadonlyPropertyInitializerStatementConstructor(changeTracker, context, constructor, fieldName, originalName);
+                updateReadonlyPropertyInitializerStatementConstructor(changeTracker, file, constructor, fieldName.text, originalName);
             }
         }
         else {
@@ -135,7 +135,7 @@ namespace ts.refactor.generateGetAccessorAndSetAccessor {
             isReadonly: hasReadonlyModifier(declaration),
             type: getTypeAnnotationNode(declaration),
             container: declaration.kind === SyntaxKind.Parameter ? declaration.parent.parent : declaration.parent,
-            originalName: <AcceptedNameType>declaration.name,
+            originalName: (<AcceptedNameType>declaration.name).text,
             declaration,
             fieldName,
             accessorName,
@@ -221,22 +221,22 @@ namespace ts.refactor.generateGetAccessorAndSetAccessor {
                 : changeTracker.insertNodeAfter(file, declaration, accessor);
     }
 
-    function updateReadonlyPropertyInitializerStatementConstructor(changeTracker: textChanges.ChangeTracker, context: RefactorContext, constructor: ConstructorDeclaration, fieldName: AcceptedNameType, originalName: AcceptedNameType) {
+    function updateReadonlyPropertyInitializerStatementConstructor(changeTracker: textChanges.ChangeTracker, file: SourceFile, constructor: ConstructorDeclaration, fieldName: string, originalName: string) {
         if (!constructor.body) return;
-        const { file, program, cancellationToken } = context;
-
-        const referenceEntries = mapDefined(FindAllReferences.getReferenceEntriesForNode(originalName.parent.pos, originalName, program, [file], cancellationToken!), entry => // TODO: GH#18217
-            (entry.kind !== FindAllReferences.EntryKind.Span && rangeContainsRange(constructor, entry.node) && isIdentifier(entry.node) && isWriteAccess(entry.node)) ? entry.node : undefined);
-
-        forEach(referenceEntries, entry => {
-            const parent = entry.parent;
-            const accessorName = createIdentifier(fieldName.text);
-            const node = isBinaryExpression(parent)
-                ? updateBinary(parent, accessorName, parent.right, parent.operatorToken)
-                : isPropertyAccessExpression(parent)
-                    ? updatePropertyAccess(parent, parent.expression, accessorName)
-                    : Debug.fail("Unexpected write access token");
-            changeTracker.replaceNode(file, parent, node);
+        constructor.body.forEachChild(function recur(node) {
+            if (isElementAccessExpression(node) &&
+                node.expression.kind === SyntaxKind.ThisKeyword &&
+                isStringLiteral(node.argumentExpression) &&
+                node.argumentExpression.text === originalName &&
+                isWriteAccess(node)) {
+                changeTracker.replaceNode(file, node.argumentExpression, createStringLiteral(fieldName));
+            }
+            if (isPropertyAccessExpression(node) && node.expression.kind === SyntaxKind.ThisKeyword && node.name.text === originalName && isWriteAccess(node)) {
+                changeTracker.replaceNode(file, node.name, createIdentifier(fieldName));
+            }
+            if (!isFunctionLike(node) && !isClassLike(node)) {
+                node.forEachChild(recur);
+            }
         });
     }
 }

--- a/tests/cases/fourslash/refactorConvertToGetAccessAndSetAccess33.ts
+++ b/tests/cases/fourslash/refactorConvertToGetAccessAndSetAccess33.ts
@@ -5,7 +5,7 @@
 ////     public b: number;
 ////     constructor () {
 ////         this.a = 1; // convert
-////         this.a++; // convert
+////         this["a"]++; // convert
 ////         ++this.a; // convert
 ////         if (Math.random()) {
 ////             this.a = 2; // convert
@@ -29,7 +29,7 @@ edit.applyRefactor({
     public b: number;
     constructor () {
         this._a = 1; // convert
-        this._a++; // convert
+        this["_a"]++; // convert
         ++this._a; // convert
         if (Math.random()) {
             this._a = 2; // convert


### PR DESCRIPTION
Previously this found *all* references to the property, then filtered out the ones that happened to appear in the constructor -- simpler to just walk the constructor.