### PR TITLE
Object.assign return assigned type instead merged

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -256,6 +256,11 @@ interface NumberConstructor {
     parseInt(string: string, radix?: number): number;
 }
 
+/**
+ * Assign properties from U to T.
+ */
+type Assign<T, U> = Pick<T, Exclude<keyof T, keyof U>> & U
+
 interface ObjectConstructor {
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
@@ -263,7 +268,7 @@ interface ObjectConstructor {
      * @param target The target object to copy to.
      * @param source The source object from which to copy properties.
      */
-    assign<T, U>(target: T, source: U): T & U;
+    assign<T, U>(target: T, source: U): Assign<T, U>;
 
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
@@ -272,7 +277,7 @@ interface ObjectConstructor {
      * @param source1 The first source object from which to copy properties.
      * @param source2 The second source object from which to copy properties.
      */
-    assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
+    assign<T, U, V>(target: T, source1: U, source2: V): Assign<Assign<T, U>, V>;
 
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
@@ -282,7 +287,7 @@ interface ObjectConstructor {
      * @param source2 The second source object from which to copy properties.
      * @param source3 The third source object from which to copy properties.
      */
-    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): Assign<Assign<Assign<T, U>, V>, W>;
 
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a


### PR DESCRIPTION
Got 'assing' in my eyes. Found some old bugs created in 16 (#11100). So I made this quick PR.

Situation:

```
let a = {
  a: 'string',
  b: { c: 4 },
};
let b = {
  a: 5,
  b: { d: 3 },
}
Object.assign({ }, a, b);
```

Result of this operation is `{ a: 5, b: { d: 3 } }`, but TS says its of `{ a: string & number; b: { c: number; d: number; } }` type, which is obviously wrong (according to [mozilla's JS reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign)).