### PR TITLE
Better nameless parameter implicit any error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13629,6 +13629,13 @@ namespace ts {
                     diagnostic = noImplicitAny ? Diagnostics.Member_0_implicitly_has_an_1_type : Diagnostics.Member_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage;
                     break;
                 case SyntaxKind.Parameter:
+                    const param = declaration as ParameterDeclaration;
+                    if (isIdentifier(param.name) &&
+                        (isCallSignatureDeclaration(param.parent) || isMethodSignature(param.parent) || isFunctionTypeNode(param.parent)) &&
+                        resolveName(param, param.name.escapedText, SymbolFlags.Type, undefined, param.name.escapedText, /*isUse*/ true)) {
+                        errorOrSuggestion(noImplicitAny, declaration, Diagnostics.Parameter_0_has_no_declared_type_but_is_itself_a_type_so_should_have_a_parameter_name_x_Colon_0, declarationNameToString(param.name));
+                        return;
+                    }
                     diagnostic = (<ParameterDeclaration>declaration).dotDotDotToken ?
                         noImplicitAny ? Diagnostics.Rest_parameter_0_implicitly_has_an_any_type : Diagnostics.Rest_parameter_0_implicitly_has_an_any_type_but_a_better_type_may_be_inferred_from_usage :
                         noImplicitAny ? Diagnostics.Parameter_0_implicitly_has_an_1_type : Diagnostics.Parameter_0_implicitly_has_an_1_type_but_a_better_type_may_be_inferred_from_usage;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13634,7 +13634,7 @@ namespace ts {
                         (isCallSignatureDeclaration(param.parent) || isMethodSignature(param.parent) || isFunctionTypeNode(param.parent)) &&
                         (resolveName(param, param.name.escapedText, SymbolFlags.Type, undefined, param.name.escapedText, /*isUse*/ true) ||
                          param.name.originalKeywordKind && isTypeNodeKind(param.name.originalKeywordKind))) {
-                        errorOrSuggestion(noImplicitAny, declaration, Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_x_Colon_0, declarationNameToString(param.name));
+                        errorOrSuggestion(noImplicitAny, declaration, Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_arg_Colon_0, declarationNameToString(param.name));
                         return;
                     }
                     diagnostic = (<ParameterDeclaration>declaration).dotDotDotToken ?

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13632,8 +13632,9 @@ namespace ts {
                     const param = declaration as ParameterDeclaration;
                     if (isIdentifier(param.name) &&
                         (isCallSignatureDeclaration(param.parent) || isMethodSignature(param.parent) || isFunctionTypeNode(param.parent)) &&
-                        resolveName(param, param.name.escapedText, SymbolFlags.Type, undefined, param.name.escapedText, /*isUse*/ true)) {
-                        errorOrSuggestion(noImplicitAny, declaration, Diagnostics.Parameter_0_has_no_declared_type_but_is_itself_a_type_so_should_have_a_parameter_name_x_Colon_0, declarationNameToString(param.name));
+                        (resolveName(param, param.name.escapedText, SymbolFlags.Type, undefined, param.name.escapedText, /*isUse*/ true) ||
+                         param.name.originalKeywordKind && isTypeNodeKind(param.name.originalKeywordKind))) {
+                        errorOrSuggestion(noImplicitAny, declaration, Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_x_Colon_0, declarationNameToString(param.name));
                         return;
                     }
                     diagnostic = (<ParameterDeclaration>declaration).dotDotDotToken ?

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13632,9 +13632,11 @@ namespace ts {
                     const param = declaration as ParameterDeclaration;
                     if (isIdentifier(param.name) &&
                         (isCallSignatureDeclaration(param.parent) || isMethodSignature(param.parent) || isFunctionTypeNode(param.parent)) &&
+                        param.parent.parameters.indexOf(param) > -1 &&
                         (resolveName(param, param.name.escapedText, SymbolFlags.Type, undefined, param.name.escapedText, /*isUse*/ true) ||
                          param.name.originalKeywordKind && isTypeNodeKind(param.name.originalKeywordKind))) {
-                        errorOrSuggestion(noImplicitAny, declaration, Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_arg_Colon_0, declarationNameToString(param.name));
+                        const newName = "arg" + param.parent.parameters.indexOf(param);
+                        errorOrSuggestion(noImplicitAny, declaration, Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_0_Colon_1, newName, declarationNameToString(param.name));
                         return;
                     }
                     diagnostic = (<ParameterDeclaration>declaration).dotDotDotToken ?

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4125,7 +4125,7 @@
         "category": "Suggestion",
         "code": 7050
     },
-    "Parameter has a name but no type. Did you mean 'x: {0}'?": {
+    "Parameter has a name but no type. Did you mean 'arg: {0}'?": {
         "category": "Error",
         "code": 7051
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4512,6 +4512,10 @@
         "category": "Message",
         "code": 90033
     },
+    "Add parameter name": {
+        "category": "Message",
+        "code": 90034
+    },
     "Convert function to an ES2015 class": {
         "category": "Message",
         "code": 95001
@@ -4752,7 +4756,6 @@
         "category": "Message",
         "code": 95062
     },
-
     "Add missing enum member '{0}'": {
         "category": "Message",
         "code": 95063
@@ -4784,5 +4787,9 @@
     "Add 'unknown' to all conversions of non-overlapping types": {
         "category": "Message",
         "code": 95070
+    },
+    "Add names to all parameters without names": {
+        "category": "Message",
+        "code": 95071
     }
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4125,7 +4125,7 @@
         "category": "Suggestion",
         "code": 7050
     },
-    "Parameter has a name but no type. Did you mean 'arg: {0}'?": {
+    "Parameter has a name but no type. Did you mean '{0}: {1}'?": {
         "category": "Error",
         "code": 7051
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4125,6 +4125,10 @@
         "category": "Suggestion",
         "code": 7050
     },
+    "Parameter '{0}' has no declared type, but is itself a type, so should have a parameter name 'x: {0}'.": {
+        "category": "Error",
+        "code": 7051
+    },
 
     "You cannot rename this element.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4125,7 +4125,7 @@
         "category": "Suggestion",
         "code": 7050
     },
-    "Parameter '{0}' has no declared type, but is itself a type, so should have a parameter name 'x: {0}'.": {
+    "Parameter has a name but no type. Did you mean 'x: {0}'?": {
         "category": "Error",
         "code": 7051
     },

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4566,6 +4566,31 @@ namespace ts {
     export function isObjectTypeDeclaration(node: Node): node is ObjectTypeDeclaration {
         return isClassLike(node) || isInterfaceDeclaration(node) || isTypeLiteralNode(node);
     }
+
+    export function isTypeNodeKind(kind: SyntaxKind) {
+        return (kind >= SyntaxKind.FirstTypeNode && kind <= SyntaxKind.LastTypeNode)
+            || kind === SyntaxKind.AnyKeyword
+            || kind === SyntaxKind.UnknownKeyword
+            || kind === SyntaxKind.NumberKeyword
+            || kind === SyntaxKind.BigIntKeyword
+            || kind === SyntaxKind.ObjectKeyword
+            || kind === SyntaxKind.BooleanKeyword
+            || kind === SyntaxKind.StringKeyword
+            || kind === SyntaxKind.SymbolKeyword
+            || kind === SyntaxKind.ThisKeyword
+            || kind === SyntaxKind.VoidKeyword
+            || kind === SyntaxKind.UndefinedKeyword
+            || kind === SyntaxKind.NullKeyword
+            || kind === SyntaxKind.NeverKeyword
+            || kind === SyntaxKind.ExpressionWithTypeArguments
+            || kind === SyntaxKind.JSDocAllType
+            || kind === SyntaxKind.JSDocUnknownType
+            || kind === SyntaxKind.JSDocNullableType
+            || kind === SyntaxKind.JSDocNonNullableType
+            || kind === SyntaxKind.JSDocOptionalType
+            || kind === SyntaxKind.JSDocFunctionType
+            || kind === SyntaxKind.JSDocVariadicType;
+    }
 }
 
 namespace ts {
@@ -6288,31 +6313,6 @@ namespace ts {
     }
 
     // Type
-
-    function isTypeNodeKind(kind: SyntaxKind) {
-        return (kind >= SyntaxKind.FirstTypeNode && kind <= SyntaxKind.LastTypeNode)
-            || kind === SyntaxKind.AnyKeyword
-            || kind === SyntaxKind.UnknownKeyword
-            || kind === SyntaxKind.NumberKeyword
-            || kind === SyntaxKind.BigIntKeyword
-            || kind === SyntaxKind.ObjectKeyword
-            || kind === SyntaxKind.BooleanKeyword
-            || kind === SyntaxKind.StringKeyword
-            || kind === SyntaxKind.SymbolKeyword
-            || kind === SyntaxKind.ThisKeyword
-            || kind === SyntaxKind.VoidKeyword
-            || kind === SyntaxKind.UndefinedKeyword
-            || kind === SyntaxKind.NullKeyword
-            || kind === SyntaxKind.NeverKeyword
-            || kind === SyntaxKind.ExpressionWithTypeArguments
-            || kind === SyntaxKind.JSDocAllType
-            || kind === SyntaxKind.JSDocUnknownType
-            || kind === SyntaxKind.JSDocNullableType
-            || kind === SyntaxKind.JSDocNonNullableType
-            || kind === SyntaxKind.JSDocOptionalType
-            || kind === SyntaxKind.JSDocFunctionType
-            || kind === SyntaxKind.JSDocVariadicType;
-    }
 
     /**
      * Node test that determines whether a node is a valid type node.

--- a/src/services/codefixes/addNameToNamelessParameter.ts
+++ b/src/services/codefixes/addNameToNamelessParameter.ts
@@ -1,7 +1,7 @@
 /* @internal */
 namespace ts.codefix {
     const fixId = "addNameToNamelessParameter";
-    const errorCodes = [Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_arg_Colon_0.code];
+    const errorCodes = [Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_0_Colon_1.code];
     registerCodeFix({
         errorCodes,
         getCodeActions: (context) => {

--- a/src/services/codefixes/addNameToNamelessParameter.ts
+++ b/src/services/codefixes/addNameToNamelessParameter.ts
@@ -1,7 +1,7 @@
 /* @internal */
 namespace ts.codefix {
     const fixId = "addNameToNamelessParameter";
-    const errorCodes = [Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_x_Colon_0.code];
+    const errorCodes = [Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_arg_Colon_0.code];
     registerCodeFix({
         errorCodes,
         getCodeActions: (context) => {

--- a/src/services/codefixes/addNameToNamelessParameter.ts
+++ b/src/services/codefixes/addNameToNamelessParameter.ts
@@ -1,0 +1,37 @@
+/* @internal */
+namespace ts.codefix {
+    const fixId = "addNameToNamelessParameter";
+    const errorCodes = [Diagnostics.Parameter_has_a_name_but_no_type_Did_you_mean_x_Colon_0.code];
+    registerCodeFix({
+        errorCodes,
+        getCodeActions: (context) => {
+            const changes = textChanges.ChangeTracker.with(context, t => makeChange(t, context.sourceFile, context.span.start));
+            return [createCodeFixAction(fixId, changes, Diagnostics.Add_parameter_name, fixId, Diagnostics.Add_names_to_all_parameters_without_names)];
+        },
+        fixIds: [fixId],
+        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => makeChange(changes, diag.file, diag.start)),
+    });
+
+    function makeChange(changeTracker: textChanges.ChangeTracker, sourceFile: SourceFile, pos: number) {
+        const token = getTokenAtPosition(sourceFile, pos);
+        if (!isIdentifier(token)) {
+            return Debug.fail("add-name-to-nameless-parameter operates on identifiers, but got a " + formatSyntaxKind(token.kind));
+        }
+        const param = token.parent;
+        if (!isParameter(param)) {
+            return Debug.fail("Tried to add a parameter name to a non-parameter: " + formatSyntaxKind(token.kind));
+        }
+        const i = param.parent.parameters.indexOf(param);
+        Debug.assert(!param.type, "Tried to add a parameter name to a parameter that already had one.");
+        Debug.assert(i > -1, "Parameter not found in parent parameter list.");
+        const replacement = createParameter(
+            /*decorators*/ undefined,
+            param.modifiers,
+            param.dotDotDotToken,
+            "arg" + i,
+            param.questionToken,
+            createTypeReferenceNode(token, /*typeArguments*/ undefined),
+            param.initializer);
+        changeTracker.replaceNode(sourceFile, token, replacement);
+    }
+}

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -45,6 +45,7 @@
         "refactorProvider.ts",
         "codefixes/addConvertToUnknownForNonOverlappingTypes.ts",
         "codefixes/addMissingInvocationForDecorator.ts",
+        "codefixes/addNameToNamelessParameter.ts",
         "codefixes/annotateWithTypeFromJSDoc.ts",
         "codefixes/inferFromUsage.ts",
         "codefixes/convertFunctionToEs6Class.ts",

--- a/tests/baselines/reference/noImplicitAnyNamelessParameter.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyNamelessParameter.errors.txt
@@ -1,33 +1,33 @@
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,17): error TS7051: Parameter has a name but no type. Did you mean 'arg: string'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,25): error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,19): error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,22): error TS7051: Parameter has a name but no type. Did you mean 'arg: number'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,20): error TS7051: Parameter has a name but no type. Did you mean 'arg: boolean'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,29): error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,32): error TS7051: Parameter has a name but no type. Did you mean 'arg: object'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,40): error TS7051: Parameter has a name but no type. Did you mean 'arg: undefined'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,17): error TS7051: Parameter has a name but no type. Did you mean 'arg0: string'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,25): error TS7051: Parameter has a name but no type. Did you mean 'arg1: C'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,19): error TS7051: Parameter has a name but no type. Did you mean 'arg0: C'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,22): error TS7051: Parameter has a name but no type. Did you mean 'arg1: number'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,20): error TS7051: Parameter has a name but no type. Did you mean 'arg0: boolean'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,29): error TS7051: Parameter has a name but no type. Did you mean 'arg1: C'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,32): error TS7051: Parameter has a name but no type. Did you mean 'arg2: object'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,40): error TS7051: Parameter has a name but no type. Did you mean 'arg3: undefined'?
 
 
 ==== tests/cases/compiler/noImplicitAnyNamelessParameter.ts (8 errors) ====
     class C { }
     declare var x: (string, C) => void;
                     ~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: string'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg0: string'?
                             ~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg1: C'?
     declare var y: { (C, number): void };
                       ~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg0: C'?
                          ~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: number'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg1: number'?
     declare var z: { m(boolean, C, object, undefined): void }
                        ~~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: boolean'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg0: boolean'?
                                 ~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg1: C'?
                                    ~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: object'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg2: object'?
                                            ~~~~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: undefined'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg3: undefined'?
     // note: null and void do not parse correctly without a preceding parameter name
     

--- a/tests/baselines/reference/noImplicitAnyNamelessParameter.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyNamelessParameter.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,17): error TS7051: Parameter has a name but no type. Did you mean 'x: string'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,25): error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,19): error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,22): error TS7051: Parameter has a name but no type. Did you mean 'x: number'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,20): error TS7051: Parameter has a name but no type. Did you mean 'x: boolean'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,29): error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,32): error TS7051: Parameter has a name but no type. Did you mean 'x: object'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,40): error TS7051: Parameter has a name but no type. Did you mean 'x: undefined'?
+
+
+==== tests/cases/compiler/noImplicitAnyNamelessParameter.ts (8 errors) ====
+    class C { }
+    declare var x: (string, C) => void;
+                    ~~~~~~
+!!! error TS7051: Parameter has a name but no type. Did you mean 'x: string'?
+                            ~
+!!! error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
+    declare var y: { (C, number): void };
+                      ~
+!!! error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
+                         ~~~~~~
+!!! error TS7051: Parameter has a name but no type. Did you mean 'x: number'?
+    declare var z: { m(boolean, C, object, undefined): void }
+                       ~~~~~~~
+!!! error TS7051: Parameter has a name but no type. Did you mean 'x: boolean'?
+                                ~
+!!! error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
+                                   ~~~~~~
+!!! error TS7051: Parameter has a name but no type. Did you mean 'x: object'?
+                                           ~~~~~~~~~
+!!! error TS7051: Parameter has a name but no type. Did you mean 'x: undefined'?
+    // note: null and void do not parse correctly without a preceding parameter name
+    

--- a/tests/baselines/reference/noImplicitAnyNamelessParameter.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyNamelessParameter.errors.txt
@@ -1,33 +1,33 @@
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,17): error TS7051: Parameter has a name but no type. Did you mean 'x: string'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,25): error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,19): error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,22): error TS7051: Parameter has a name but no type. Did you mean 'x: number'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,20): error TS7051: Parameter has a name but no type. Did you mean 'x: boolean'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,29): error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,32): error TS7051: Parameter has a name but no type. Did you mean 'x: object'?
-tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,40): error TS7051: Parameter has a name but no type. Did you mean 'x: undefined'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,17): error TS7051: Parameter has a name but no type. Did you mean 'arg: string'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(2,25): error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,19): error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(3,22): error TS7051: Parameter has a name but no type. Did you mean 'arg: number'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,20): error TS7051: Parameter has a name but no type. Did you mean 'arg: boolean'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,29): error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,32): error TS7051: Parameter has a name but no type. Did you mean 'arg: object'?
+tests/cases/compiler/noImplicitAnyNamelessParameter.ts(4,40): error TS7051: Parameter has a name but no type. Did you mean 'arg: undefined'?
 
 
 ==== tests/cases/compiler/noImplicitAnyNamelessParameter.ts (8 errors) ====
     class C { }
     declare var x: (string, C) => void;
                     ~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'x: string'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: string'?
                             ~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
     declare var y: { (C, number): void };
                       ~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
                          ~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'x: number'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: number'?
     declare var z: { m(boolean, C, object, undefined): void }
                        ~~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'x: boolean'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: boolean'?
                                 ~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'x: C'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: C'?
                                    ~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'x: object'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: object'?
                                            ~~~~~~~~~
-!!! error TS7051: Parameter has a name but no type. Did you mean 'x: undefined'?
+!!! error TS7051: Parameter has a name but no type. Did you mean 'arg: undefined'?
     // note: null and void do not parse correctly without a preceding parameter name
     

--- a/tests/baselines/reference/noImplicitAnyNamelessParameter.js
+++ b/tests/baselines/reference/noImplicitAnyNamelessParameter.js
@@ -1,0 +1,15 @@
+//// [noImplicitAnyNamelessParameter.ts]
+class C { }
+declare var x: (string, C) => void;
+declare var y: { (C, number): void };
+declare var z: { m(boolean, C, object, undefined): void }
+// note: null and void do not parse correctly without a preceding parameter name
+
+
+//// [noImplicitAnyNamelessParameter.js]
+var C = /** @class */ (function () {
+    function C() {
+    }
+    return C;
+}());
+// note: null and void do not parse correctly without a preceding parameter name

--- a/tests/baselines/reference/noImplicitAnyNamelessParameter.symbols
+++ b/tests/baselines/reference/noImplicitAnyNamelessParameter.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/noImplicitAnyNamelessParameter.ts ===
+class C { }
+>C : Symbol(C, Decl(noImplicitAnyNamelessParameter.ts, 0, 0))
+
+declare var x: (string, C) => void;
+>x : Symbol(x, Decl(noImplicitAnyNamelessParameter.ts, 1, 11))
+>string : Symbol(string, Decl(noImplicitAnyNamelessParameter.ts, 1, 16))
+>C : Symbol(C, Decl(noImplicitAnyNamelessParameter.ts, 1, 23))
+
+declare var y: { (C, number): void };
+>y : Symbol(y, Decl(noImplicitAnyNamelessParameter.ts, 2, 11))
+>C : Symbol(C, Decl(noImplicitAnyNamelessParameter.ts, 2, 18))
+>number : Symbol(number, Decl(noImplicitAnyNamelessParameter.ts, 2, 20))
+
+declare var z: { m(boolean, C, object, undefined): void }
+>z : Symbol(z, Decl(noImplicitAnyNamelessParameter.ts, 3, 11))
+>m : Symbol(m, Decl(noImplicitAnyNamelessParameter.ts, 3, 16))
+>boolean : Symbol(boolean, Decl(noImplicitAnyNamelessParameter.ts, 3, 19))
+>C : Symbol(C, Decl(noImplicitAnyNamelessParameter.ts, 3, 27))
+>object : Symbol(object, Decl(noImplicitAnyNamelessParameter.ts, 3, 30))
+>undefined : Symbol(undefined, Decl(noImplicitAnyNamelessParameter.ts, 3, 38))
+
+// note: null and void do not parse correctly without a preceding parameter name
+

--- a/tests/baselines/reference/noImplicitAnyNamelessParameter.types
+++ b/tests/baselines/reference/noImplicitAnyNamelessParameter.types
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/noImplicitAnyNamelessParameter.ts ===
+class C { }
+>C : C
+
+declare var x: (string, C) => void;
+>x : (string: any, C: any) => void
+>string : any
+>C : any
+
+declare var y: { (C, number): void };
+>y : (C: any, number: any) => void
+>C : any
+>number : any
+
+declare var z: { m(boolean, C, object, undefined): void }
+>z : { m(boolean: any, C: any, object: any, undefined: any): void; }
+>m : (boolean: any, C: any, object: any, undefined: any) => void
+>boolean : any
+>C : any
+>object : any
+>undefined : any
+
+// note: null and void do not parse correctly without a preceding parameter name
+

--- a/tests/cases/compiler/noImplicitAnyNamelessParameter.ts
+++ b/tests/cases/compiler/noImplicitAnyNamelessParameter.ts
@@ -1,0 +1,5 @@
+// @noImplicitAny: true
+class C { }
+declare var x: (string, C) => void;
+declare var y: { (C, number): void };
+declare var z: { m(boolean, C, object, void, null, undefined): void }

--- a/tests/cases/compiler/noImplicitAnyNamelessParameter.ts
+++ b/tests/cases/compiler/noImplicitAnyNamelessParameter.ts
@@ -2,4 +2,5 @@
 class C { }
 declare var x: (string, C) => void;
 declare var y: { (C, number): void };
-declare var z: { m(boolean, C, object, void, null, undefined): void }
+declare var z: { m(boolean, C, object, undefined): void }
+// note: null and void do not parse correctly without a preceding parameter name

--- a/tests/cases/fourslash/codeFixAddAllParameterNames.ts
+++ b/tests/cases/fourslash/codeFixAddAllParameterNames.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+////interface I { i: number }
+////class C { a = 1 }
+////var x: { (boolean, undefined, I, C): string };
+
+verify.codeFixAll({
+    fixId: "addNameToNamelessParameter",
+    fixAllDescription: "Add names to all parameters without names",
+    newFileContent:
+`interface I { i: number }
+class C { a = 1 }
+var x: { (arg0: boolean, arg1: undefined, arg2: I, arg3: C): string };`
+});

--- a/tests/cases/fourslash/codeFixAddParameterNames.ts
+++ b/tests/cases/fourslash/codeFixAddParameterNames.ts
@@ -1,0 +1,5 @@
+/// <reference path='fourslash.ts' />
+// @noImplicitAny: true
+////var x: ([|number |]) => string;
+
+verify.rangeAfterCodeFix("arg0: number");


### PR DESCRIPTION
Fixes the first error I encountered when learning typescript:

```ts
var add: (number, number) => number;
```

Expected: a type that takes two numbers and produces a number:
Actual: Error "Parameter 'number' is implicitly of type 'any'."

A few notes:

1. I had to move `isTypeNodeKind` to the internal ts namespace in order to access it in the checker.
2. I don't test `void` or `null` because they don't even parse without parameter names.
3. I'll add a codefix if it's easy. I expect it will be.
4. This shows up as an error with noImplicitAny and suggestion without, which is good, as long as there is a codefix to back it up.

Thanks to @sana-ajani @andy-ms @uniqueiniquity for help writing the error message.