### PR TITLE
Dont emit module resolution errors when looking up specifiers for container symbols

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2238,8 +2238,8 @@ namespace ts {
             return initializer || decl;
         }
 
-        function resolveExternalModuleName(location: Node, moduleReferenceExpression: Expression): Symbol | undefined {
-            return resolveExternalModuleNameWorker(location, moduleReferenceExpression, Diagnostics.Cannot_find_module_0);
+        function resolveExternalModuleName(location: Node, moduleReferenceExpression: Expression, ignoreErrors?: boolean): Symbol | undefined {
+            return resolveExternalModuleNameWorker(location, moduleReferenceExpression, ignoreErrors ? undefined : Diagnostics.Cannot_find_module_0);
         }
 
         function resolveExternalModuleNameWorker(location: Node, moduleReferenceExpression: Expression, moduleNotFoundError: DiagnosticMessage | undefined, isForAugmentation = false): Symbol | undefined {
@@ -2601,7 +2601,7 @@ namespace ts {
                 // Try to make an import using an import already in the enclosing file, if possible
                 for (const importRef of containingFile.imports) {
                     if (nodeIsSynthesized(importRef)) continue; // Synthetic names can't be resolved by `resolveExternalModuleName` - they'll cause a debug assert if they error
-                    const resolvedModule = resolveExternalModuleName(enclosingDeclaration, importRef);
+                    const resolvedModule = resolveExternalModuleName(enclosingDeclaration, importRef, /*ignoreErrors*/ true);
                     if (!resolvedModule) continue;
                     const ref = getAliasForSymbolInContainer(resolvedModule, symbol);
                     if (!ref) continue;

--- a/tests/baselines/reference/jsxImportForSideEffectsNonExtantNoError.js
+++ b/tests/baselines/reference/jsxImportForSideEffectsNonExtantNoError.js
@@ -1,0 +1,16 @@
+//// [jsxImportForSideEffectsNonExtantNoError.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+import * as React from "react";
+
+import "./App.css"; // doesn't actually exist
+
+const tag = <div></div>;
+
+
+//// [jsxImportForSideEffectsNonExtantNoError.js]
+"use strict";
+exports.__esModule = true;
+/// <reference path="react16.d.ts" />
+var React = require("react");
+require("./App.css"); // doesn't actually exist
+var tag = React.createElement("div", null);

--- a/tests/baselines/reference/jsxImportForSideEffectsNonExtantNoError.symbols
+++ b/tests/baselines/reference/jsxImportForSideEffectsNonExtantNoError.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/jsxImportForSideEffectsNonExtantNoError.tsx ===
+/// <reference path="react16.d.ts" />
+import * as React from "react";
+>React : Symbol(React, Decl(jsxImportForSideEffectsNonExtantNoError.tsx, 1, 6))
+
+import "./App.css"; // doesn't actually exist
+
+const tag = <div></div>;
+>tag : Symbol(tag, Decl(jsxImportForSideEffectsNonExtantNoError.tsx, 5, 5))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react16.d.ts, 2420, 114))
+

--- a/tests/baselines/reference/jsxImportForSideEffectsNonExtantNoError.types
+++ b/tests/baselines/reference/jsxImportForSideEffectsNonExtantNoError.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/jsxImportForSideEffectsNonExtantNoError.tsx ===
+/// <reference path="react16.d.ts" />
+import * as React from "react";
+>React : typeof React
+
+import "./App.css"; // doesn't actually exist
+
+const tag = <div></div>;
+>tag : JSX.Element
+><div></div> : JSX.Element
+>div : any
+>div : any
+

--- a/tests/cases/compiler/jsxImportForSideEffectsNonExtantNoError.tsx
+++ b/tests/cases/compiler/jsxImportForSideEffectsNonExtantNoError.tsx
@@ -1,0 +1,7 @@
+// @jsx: react
+/// <reference path="/.lib/react16.d.ts" />
+import * as React from "react";
+
+import "./App.css"; // doesn't actually exist
+
+const tag = <div></div>;


### PR DESCRIPTION
Fixes #28538

Although I really do think it's strange we don't error on these kinds of imports.