### PR TITLE
Error when destructuring private property in a parameter

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19022,7 +19022,7 @@ namespace ts {
         }
 
         function markPropertyAsReferenced(prop: Symbol, nodeForCheckWriteOnly: Node | undefined, isThisAccess: boolean) {
-            if (!prop || !(prop.flags & SymbolFlags.ClassMember) || !prop.valueDeclaration || !hasModifier(prop.valueDeclaration, ModifierFlags.Private)) {
+            if (!(prop.flags & SymbolFlags.ClassMember) || !prop.valueDeclaration || !hasModifier(prop.valueDeclaration, ModifierFlags.Private)) {
                 return;
             }
             if (nodeForCheckWriteOnly && isWriteOnlyAccess(nodeForCheckWriteOnly) && !(prop.flags & SymbolFlags.SetAccessor && !(prop.flags & SymbolFlags.GetAccessor))) {
@@ -25280,10 +25280,10 @@ namespace ts {
                 if (!isBindingPattern(name)) {
                     const nameText = getTextOfPropertyName(name);
                     if (nameText) {
-                        const property = getPropertyOfType(parentType!, nameText)!; // TODO: GH#18217
-                        markPropertyAsReferenced(property, /*nodeForCheckWriteOnly*/ undefined, /*isThisAccess*/ false); // A destructuring is never a write-only reference.
-                        if (parent.initializer && property) {
-                            checkPropertyAccessibility(parent, parent.initializer.kind === SyntaxKind.SuperKeyword, parentType!, property);
+                        const property = getPropertyOfType(parentType!, nameText); // TODO: GH#18217
+                        if (property) {
+                            markPropertyAsReferenced(property, /*nodeForCheckWriteOnly*/ undefined, /*isThisAccess*/ false); // A destructuring is never a write-only reference.
+                            checkPropertyAccessibility(parent, !!parent.initializer && parent.initializer.kind === SyntaxKind.SuperKeyword, parentType!, property);
                         }
                     }
                 }

--- a/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.errors.txt
+++ b/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.errors.txt
@@ -5,9 +5,12 @@ tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAre
 tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(20,5): error TS2341: Property 'priv' is private and only accessible within class 'K'.
 tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(20,5): error TS2341: Property 'privateMethod' is private and only accessible within class 'K'.
 tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(20,5): error TS2445: Property 'prot' is protected and only accessible within class 'K' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(21,12): error TS2341: Property 'priv' is private and only accessible within class 'K'.
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(21,12): error TS2341: Property 'privateMethod' is private and only accessible within class 'K'.
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(21,12): error TS2445: Property 'prot' is protected and only accessible within class 'K' and its subclasses.
 
 
-==== tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts (7 errors) ====
+==== tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts (10 errors) ====
     class K {
         private priv;
         protected prot;
@@ -26,7 +29,7 @@ tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAre
         }
     }
     let k = new K();
-    let { priv } = k; // error 
+    let { priv } = k; // error
         ~~~~~~~~
 !!! error TS2341: Property 'priv' is private and only accessible within class 'K'.
     let { prot } = k; // error
@@ -35,11 +38,20 @@ tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAre
     let { privateMethod } = k; // error
         ~~~~~~~~~~~~~~~~~
 !!! error TS2341: Property 'privateMethod' is private and only accessible within class 'K'.
-    let { priv: a, prot: b, privateMethod: f } = k; // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    let { priv: a, prot: b, privateMethod: pm } = k; // error
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2341: Property 'priv' is private and only accessible within class 'K'.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2341: Property 'privateMethod' is private and only accessible within class 'K'.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2445: Property 'prot' is protected and only accessible within class 'K' and its subclasses.
+    function f({ priv, prot, privateMethod }: K) {
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2341: Property 'priv' is private and only accessible within class 'K'.
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2341: Property 'privateMethod' is private and only accessible within class 'K'.
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2445: Property 'prot' is protected and only accessible within class 'K' and its subclasses.
+    
+    }
     

--- a/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.js
+++ b/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.js
@@ -15,10 +15,13 @@ class C extends K {
     }
 }
 let k = new K();
-let { priv } = k; // error 
+let { priv } = k; // error
 let { prot } = k; // error
 let { privateMethod } = k; // error
-let { priv: a, prot: b, privateMethod: f } = k; // error
+let { priv: a, prot: b, privateMethod: pm } = k; // error
+function f({ priv, prot, privateMethod }: K) {
+
+}
 
 
 //// [privateProtectedMembersAreNotAccessibleDestructuring.js]
@@ -57,7 +60,10 @@ var C = /** @class */ (function (_super) {
     return C;
 }(K));
 var k = new K();
-var priv = k.priv; // error 
+var priv = k.priv; // error
 var prot = k.prot; // error
 var privateMethod = k.privateMethod; // error
-var a = k.priv, b = k.prot, f = k.privateMethod; // error
+var a = k.priv, b = k.prot, pm = k.privateMethod; // error
+function f(_a) {
+    var priv = _a.priv, prot = _a.prot, privateMethod = _a.privateMethod;
+}

--- a/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.symbols
+++ b/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.symbols
@@ -49,7 +49,7 @@ let k = new K();
 >k : Symbol(k, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 15, 3))
 >K : Symbol(K, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 0, 0))
 
-let { priv } = k; // error 
+let { priv } = k; // error
 >priv : Symbol(priv, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 16, 5))
 >k : Symbol(k, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 15, 3))
 
@@ -61,12 +61,21 @@ let { privateMethod } = k; // error
 >privateMethod : Symbol(privateMethod, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 18, 5))
 >k : Symbol(k, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 15, 3))
 
-let { priv: a, prot: b, privateMethod: f } = k; // error
+let { priv: a, prot: b, privateMethod: pm } = k; // error
 >priv : Symbol(K.priv, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 0, 9))
 >a : Symbol(a, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 19, 5))
 >prot : Symbol(K.prot, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 1, 17))
 >b : Symbol(b, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 19, 14))
 >privateMethod : Symbol(K.privateMethod, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 2, 19))
->f : Symbol(f, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 19, 23))
+>pm : Symbol(pm, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 19, 23))
 >k : Symbol(k, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 15, 3))
+
+function f({ priv, prot, privateMethod }: K) {
+>f : Symbol(f, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 19, 48))
+>priv : Symbol(priv, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 20, 12))
+>prot : Symbol(prot, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 20, 18))
+>privateMethod : Symbol(privateMethod, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 20, 24))
+>K : Symbol(K, Decl(privateProtectedMembersAreNotAccessibleDestructuring.ts, 0, 0))
+
+}
 

--- a/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.types
+++ b/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.types
@@ -51,7 +51,7 @@ let k = new K();
 >new K() : K
 >K : typeof K
 
-let { priv } = k; // error 
+let { priv } = k; // error
 >priv : any
 >k : K
 
@@ -63,12 +63,20 @@ let { privateMethod } = k; // error
 >privateMethod : () => void
 >k : K
 
-let { priv: a, prot: b, privateMethod: f } = k; // error
+let { priv: a, prot: b, privateMethod: pm } = k; // error
 >priv : any
 >a : any
 >prot : any
 >b : any
 >privateMethod : any
->f : () => void
+>pm : () => void
 >k : K
+
+function f({ priv, prot, privateMethod }: K) {
+>f : ({ priv, prot, privateMethod }: K) => void
+>priv : any
+>prot : any
+>privateMethod : () => void
+
+}
 

--- a/tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts
+++ b/tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts
@@ -14,7 +14,10 @@ class C extends K {
     }
 }
 let k = new K();
-let { priv } = k; // error 
+let { priv } = k; // error
 let { prot } = k; // error
 let { privateMethod } = k; // error
-let { priv: a, prot: b, privateMethod: f } = k; // error
+let { priv: a, prot: b, privateMethod: pm } = k; // error
+function f({ priv, prot, privateMethod }: K) {
+
+}


### PR DESCRIPTION
Previously the check was only done if `parent.initializer` existed, which meant it worked for variable declarations but not for parameters.

