### PR TITLE
Properly set symbolMeanings when calling getSymbolsInScope

### DIFF
--- a/tests/cases/fourslash/completionsIsTypeOnlyCompletion.ts
+++ b/tests/cases/fourslash/completionsIsTypeOnlyCompletion.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts'/>
+
+// @noLib: true
+
+// @Filename: /abc.ts
+////export type Abc = number;
+
+// @Filename: /user.ts
+//// import { Abc } from "./abc";
+////function f(Abc: Ab/**/) {}
+
+verify.completions({
+    marker: "",
+    // Should not have an import completion for 'Abc', should use the local one
+    exact: ["Abc", ...completion.typeKeywords],
+    preferences: {
+        includeCompletionsForModuleExports: true,
+    },
+});


### PR DESCRIPTION
Fixes #28324

