### PR TITLE
Fix crash on property assignment of unresolved module

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2608,7 +2608,7 @@ namespace ts {
                 return true;
             }
             const node = symbol.valueDeclaration;
-            if (isCallExpression(node)) {
+            if (node && isCallExpression(node)) {
                 return !!getAssignedExpandoInitializer(node);
             }
             let init = !node ? undefined :

--- a/tests/baselines/reference/propertyAssignmentOnUnresolvedImportedSymbol.errors.txt
+++ b/tests/baselines/reference/propertyAssignmentOnUnresolvedImportedSymbol.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/salsa/bug28576.js(1,15): error TS2307: Cannot find module 'arglebaz'.
+
+
+==== tests/cases/conformance/salsa/bug28576.js (1 errors) ====
+    import x from 'arglebaz'
+                  ~~~~~~~~~~
+!!! error TS2307: Cannot find module 'arglebaz'.
+    {
+        x.bar = 1
+    }
+    

--- a/tests/baselines/reference/propertyAssignmentOnUnresolvedImportedSymbol.symbols
+++ b/tests/baselines/reference/propertyAssignmentOnUnresolvedImportedSymbol.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/salsa/bug28576.js ===
+import x from 'arglebaz'
+>x : Symbol(x, Decl(bug28576.js, 0, 6))
+{
+    x.bar = 1
+>x : Symbol(x, Decl(bug28576.js, 0, 6))
+}
+

--- a/tests/baselines/reference/propertyAssignmentOnUnresolvedImportedSymbol.types
+++ b/tests/baselines/reference/propertyAssignmentOnUnresolvedImportedSymbol.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/salsa/bug28576.js ===
+import x from 'arglebaz'
+>x : any
+{
+    x.bar = 1
+>x.bar = 1 : 1
+>x.bar : any
+>x : any
+>bar : any
+>1 : 1
+}
+

--- a/tests/cases/conformance/salsa/propertyAssignmentOnUnresolvedImportedSymbol.ts
+++ b/tests/cases/conformance/salsa/propertyAssignmentOnUnresolvedImportedSymbol.ts
@@ -1,0 +1,8 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: bug28576.js
+import x from 'arglebaz'
+{
+    x.bar = 1
+}


### PR DESCRIPTION
Previously, the compiler would crash when binding a non-top-level property assignment on the symbol of an unresolved module:

```js
import x from 'arglebaz'
{
    x.bar = 1
}
```

That's because `x` looks like an alias but doesn't have a valueDeclaration (since there is no file named 'arglebaz'), and the new code for binding Object.defineProperty calls forgot to check for an undefined valueDeclaration.

This change adds the checks for an undefined valueDeclaration.

Fixes #28576 