### PR TITLE
Enable statistics reporting per program through temporary build api

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -119,6 +119,18 @@ namespace ts {
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Enable_tracing_of_the_name_resolution_process
         },
+        {
+            name: "diagnostics",
+            type: "boolean",
+            category: Diagnostics.Advanced_Options,
+            description: Diagnostics.Show_diagnostic_information
+        },
+        {
+            name: "extendedDiagnostics",
+            type: "boolean",
+            category: Diagnostics.Advanced_Options,
+            description: Diagnostics.Show_verbose_diagnostic_information
+        },
     ];
 
     /* @internal */
@@ -591,18 +603,6 @@ namespace ts {
             type: "string",
             category: Diagnostics.Advanced_Options,
             description: Diagnostics.Specify_the_JSX_factory_function_to_use_when_targeting_react_JSX_emit_e_g_React_createElement_or_h
-        },
-        {
-            name: "diagnostics",
-            type: "boolean",
-            category: Diagnostics.Advanced_Options,
-            description: Diagnostics.Show_diagnostic_information
-        },
-        {
-            name: "extendedDiagnostics",
-            type: "boolean",
-            category: Diagnostics.Advanced_Options,
-            description: Diagnostics.Show_verbose_diagnostic_information
         },
         {
             name: "resolveJsonModule",

--- a/src/tsc/tsc.ts
+++ b/src/tsc/tsc.ts
@@ -199,11 +199,14 @@ namespace ts {
             reportWatchModeWithoutSysSupport();
         }
 
-        // TODO: change this to host if watch => watchHost otherwiue without wathc
-        const builder = createSolutionBuilder(buildOptions.watch ?
+        // TODO: change this to host if watch => watchHost otherwiue without watch
+        const buildHost = buildOptions.watch ?
             createSolutionBuilderWithWatchHost(sys, reportDiagnostic, createBuilderStatusReporter(sys, shouldBePretty()), createWatchStatusReporter()) :
-            createSolutionBuilderHost(sys, reportDiagnostic, createBuilderStatusReporter(sys, shouldBePretty()), createReportErrorSummary(buildOptions)),
-            projects, buildOptions);
+            createSolutionBuilderHost(sys, reportDiagnostic, createBuilderStatusReporter(sys, shouldBePretty()), createReportErrorSummary(buildOptions));
+        buildHost.beforeCreateProgram = enableStatistics;
+        buildHost.afterProgramEmitAndDiagnostics = reportStatistics;
+
+        const builder = createSolutionBuilder(buildHost, projects, buildOptions);
         if (buildOptions.clean) {
             return sys.exit(builder.cleanAllProjects());
         }


### PR DESCRIPTION
This helps investigate perf issues. Since build API is yet to be finalized just create make-shift api to enable and disable statistics from tsc

