### PR TITLE
Cache completion validity, remove too-precise completion this inference

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3802,6 +3802,7 @@ namespace ts {
         contextFreeType?: Type;          // Cached context-free type used by the first pass of inference; used when a function's return is partially contextually sensitive
         deferredNodes?: Map<Node>; // Set of nodes whose checking has been deferred
         capturedBlockScopeBindings?: Symbol[]; // Block-scoped bindings captured beneath this part of an IterationStatement
+        propertyAccessValidity?: Map<boolean>; // Tracks if a property access is valid for some given type
     }
 
     export const enum TypeFlags {


### PR DESCRIPTION
Fixes #23285 some. Could still stand to be better.

From my comment in the other thread
> Hm, you're right, Opened it up and tried it again and saw the problem. Anyway, I have a change that cuts it from around 8s to 3s on my machine; but the core of the issue is what isValidPropertyAccessForCompletions is doing right now - it's essentially doing a (partial) call resolution, which is fairly expensive. My change caches the result, so it can be reused if encountered again, which seems to help, since completions is always followed by a completion entry details request which currently repeats the work.

This fixes the obvious deficiencies we had with respect to repeated work and mostly unnecessary work - something in lodash is still hideously expensive to compare, however, which probably merits looking into separately.