### PR TITLE
Cache results for readFile, fileExists, directory exists, sourceFiles for .d.ts files across the build (only first time)

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -203,6 +203,114 @@ namespace ts {
         return compilerHost;
     }
 
+    /*@internal*/
+    export function changeCompilerHostToUseCache(
+        host: CompilerHost,
+        toPath: (fileName: string) => Path,
+        useCacheForSourceFile: boolean
+    ) {
+        const originalReadFile = host.readFile;
+        const originalFileExists = host.fileExists;
+        const originalDirectoryExists = host.directoryExists;
+        const originalCreateDirectory = host.createDirectory;
+        const originalWriteFile = host.writeFile;
+        const originalGetSourceFile = host.getSourceFile;
+        const readFileCache = createMap<string | false>();
+        const fileExistsCache = createMap<boolean>();
+        const directoryExistsCache = createMap<boolean>();
+        const sourceFileCache = createMap<SourceFile>();
+
+        const readFileWithCache = (fileName: string): string | undefined => {
+            const key = toPath(fileName);
+            const value = readFileCache.get(key);
+            if (value !== undefined) return value || undefined;
+            return setReadFileCache(key, fileName);
+        };
+        const setReadFileCache = (key: Path, fileName: string) => {
+            const newValue = originalReadFile.call(host, fileName);
+            readFileCache.set(key, newValue || false);
+            return newValue;
+        };
+        host.readFile = fileName => {
+            const key = toPath(fileName);
+            const value = readFileCache.get(key);
+            if (value !== undefined) return value; // could be .d.ts from output
+            if (!fileExtensionIs(fileName, Extension.Json)) {
+                return originalReadFile.call(host, fileName);
+            }
+
+            return setReadFileCache(key, fileName);
+        };
+
+        if (useCacheForSourceFile) {
+            host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+                const key = toPath(fileName);
+                const value = sourceFileCache.get(key);
+                if (value) return value;
+
+                const sourceFile = originalGetSourceFile.call(host, fileName, languageVersion, onError, shouldCreateNewSourceFile);
+                if (sourceFile && (isDeclarationFileName(fileName) || fileExtensionIs(fileName, Extension.Json))) {
+                    sourceFileCache.set(key, sourceFile);
+                }
+                return sourceFile;
+            };
+        }
+
+        // fileExists for any kind of extension
+        host.fileExists = fileName => {
+            const key = toPath(fileName);
+            const value = fileExistsCache.get(key);
+            if (value !== undefined) return value;
+            const newValue = originalFileExists.call(host, fileName);
+            fileExistsCache.set(key, !!newValue);
+            return newValue;
+        };
+        host.writeFile = (fileName, data, writeByteOrderMark, onError, sourceFiles) => {
+            const key = toPath(fileName);
+            fileExistsCache.delete(key);
+
+            const value = readFileCache.get(key);
+            if (value && value !== data) {
+                readFileCache.delete(key);
+                sourceFileCache.delete(key);
+            }
+            else if (useCacheForSourceFile) {
+                const sourceFile = sourceFileCache.get(key);
+                if (sourceFile && sourceFile.text !== data) {
+                    sourceFileCache.delete(key);
+                }
+            }
+            originalWriteFile.call(host, fileName, data, writeByteOrderMark, onError, sourceFiles);
+        };
+
+        // directoryExists
+        if (originalDirectoryExists && originalCreateDirectory) {
+            host.directoryExists = directory => {
+                const key = toPath(directory);
+                const value = directoryExistsCache.get(key);
+                if (value !== undefined) return value;
+                const newValue = originalDirectoryExists.call(host, directory);
+                directoryExistsCache.set(key, !!newValue);
+                return newValue;
+            };
+            host.createDirectory = directory => {
+                const key = toPath(directory);
+                directoryExistsCache.delete(key);
+                originalCreateDirectory.call(host, directory);
+            };
+        }
+
+        return {
+            originalReadFile,
+            originalFileExists,
+            originalDirectoryExists,
+            originalCreateDirectory,
+            originalWriteFile,
+            originalGetSourceFile,
+            readFileWithCache
+        };
+    }
+
     export function getPreEmitDiagnostics(program: Program, sourceFile?: SourceFile, cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic> {
         const diagnostics = [
             ...program.getConfigFileParsingDiagnostics(),

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -83,7 +83,7 @@ namespace ts {
             let text: string | undefined;
             try {
                 performance.mark("beforeIORead");
-                text = host.readFile(fileName);
+                text = compilerHost.readFile(fileName);
                 performance.mark("afterIORead");
                 performance.measure("I/O Read", "beforeIORead", "afterIORead");
             }
@@ -112,8 +112,8 @@ namespace ts {
             if (directoryPath.length > getRootLength(directoryPath) && !directoryExists(directoryPath)) {
                 const parentDirectory = getDirectoryPath(directoryPath);
                 ensureDirectoriesExist(parentDirectory);
-                if (host.createDirectory) {
-                    host.createDirectory(directoryPath);
+                if (compilerHost.createDirectory) {
+                    compilerHost.createDirectory(directoryPath);
                 }
                 else {
                     system.createDirectory(directoryPath);
@@ -181,7 +181,7 @@ namespace ts {
 
         const newLine = getNewLineCharacter(options, () => system.newLine);
         const realpath = system.realpath && ((path: string) => system.realpath!(path));
-        const host: CompilerHost = {
+        const compilerHost: CompilerHost = {
             getSourceFile,
             getDefaultLibLocation,
             getDefaultLibFileName: options => combinePaths(getDefaultLibLocation(), getDefaultLibFileName(options)),
@@ -200,7 +200,7 @@ namespace ts {
             readDirectory: (path, extensions, include, exclude, depth) => system.readDirectory(path, extensions, include, exclude, depth),
             createDirectory: d => system.createDirectory(d)
         };
-        return host;
+        return compilerHost;
     }
 
     export function getPreEmitDiagnostics(program: Program, sourceFile?: SourceFile, cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic> {

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -1230,7 +1230,7 @@ namespace ts {
                 return sourceFile;
             };
 
-            // fileExits for any kind of extension
+            // fileExists for any kind of extension
             host.fileExists = fileName => {
                 const key = toPath(fileName);
                 const value = fileExistsCache.get(key);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5014,6 +5014,9 @@ namespace ts {
         /* @internal */ hasInvalidatedResolution?: HasInvalidatedResolution;
         /* @internal */ hasChangedAutomaticTypeDirectiveNames?: boolean;
         createHash?(data: string): string;
+
+        // TODO: later handle this in better way in builder host instead once the ap
+        /*@internal*/createDirectory?(directory: string): void;
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5015,7 +5015,7 @@ namespace ts {
         /* @internal */ hasChangedAutomaticTypeDirectiveNames?: boolean;
         createHash?(data: string): string;
 
-        // TODO: later handle this in better way in builder host instead once the ap
+        // TODO: later handle this in better way in builder host instead once the api for tsbuild finalizes and doesnt use compilerHost as base
         /*@internal*/createDirectory?(directory: string): void;
     }
 

--- a/src/tsc/tsc.ts
+++ b/src/tsc/tsc.ts
@@ -227,6 +227,9 @@ namespace ts {
 
     function performCompilation(rootNames: string[], projectReferences: ReadonlyArray<ProjectReference> | undefined, options: CompilerOptions, configFileParsingDiagnostics?: ReadonlyArray<Diagnostic>) {
         const host = createCompilerHost(options);
+        const currentDirectory = host.getCurrentDirectory();
+        const getCanonicalFileName = createGetCanonicalFileName(host.useCaseSensitiveFileNames());
+        changeCompilerHostToUseCache(host, fileName => toPath(fileName, currentDirectory, getCanonicalFileName), /*useCacheForSourceFile*/ false);
         enableStatistics(options);
 
         const programOptions: CreateProgramOptions = {


### PR DESCRIPTION
This PR adds support to cache fileExists, directoryExists, readFile(.json files) and getSourceFile (for .d.ts). Currently this is done only in --build mode (and only first build in --watch mode but not incremental build) since that needs to be handled separately with invalidating files/directories as per watch. 

The result running this against [branch](https://github.com/Microsoft/TypeScript/tree/cacheHostResults31):

```
SubProj1:
Before                         After
Files:                  691    Files:                  691
Lines:               151530    Lines:               151530
Nodes:               464264    Nodes:               464264
Identifiers:         156379    Identifiers:         156379
Symbols:             102129    Symbols:             102129
Types:                 8255    Types:                 8255
Memory used:        225607K    Memory used:        224866K
I/O Read time:        0.32s    I/O Read time:        0.38s
Parse time:           0.79s    Parse time:           0.89s
Program time:         2.41s    Program time:         2.20s
Bind time:            0.52s    Bind time:            0.51s
Check time:           0.57s    Check time:           0.61s
transformTime time:   0.47s    transformTime time:   0.55s
commentTime time:     0.05s    commentTime time:     0.05s
Source Map time:      0.05s    Source Map time:      0.07s
I/O Write time:       1.06s    I/O Write time:       1.26s
printTime time:       1.95s    printTime time:       2.37s
Emit time:            1.95s    Emit time:            2.37s
Total time:           5.45s    Total time:           5.68s

SubProj2:
Before                         After
Files:                 1798    Files:                 1798
Lines:               196503    Lines:               196503
Nodes:               613506    Nodes:               613506
Identifiers:         200977    Identifiers:         200977
Symbols:             151499    Symbols:             151499
Types:                20812    Types:                20812
Memory used:        501871K    Memory used:        382104K
I/O Read time:        0.77s    I/O Read time:        0.76s
Parse time:           0.89s    Parse time:           0.40s
Program time:         5.24s    Program time:         3.04s
Bind time:            0.58s    Bind time:            0.24s
Check time:           1.31s    Check time:           1.39s
transformTime time:   0.83s    transformTime time:   0.93s
commentTime time:     0.12s    commentTime time:     0.12s
Source Map time:      0.14s    Source Map time:      0.15s
I/O Write time:       2.57s    I/O Write time:       2.96s
printTime time:       4.52s    printTime time:       5.11s
Emit time:            4.52s    Emit time:            5.11s
Total time:          11.65s    Total time:           9.78s

SubProj3:
Before                         After
Files:                 7532    Files:                 7532
Lines:               484560    Lines:               484560
Nodes:              1671393    Nodes:              1671393
Identifiers:         535514    Identifiers:         535514
Symbols:             544664    Symbols:             544664
Types:               178410    Types:               178410
Memory used:        913549K    Memory used:        898701K
I/O Read time:        3.56s    I/O Read time:        3.52s
Parse time:           2.26s    Parse time:           1.56s
Program time:        23.65s    Program time:        15.65s
Bind time:            1.33s    Bind time:            0.88s
Check time:           9.44s    Check time:           9.65s
transformTime time:  10.26s    transformTime time:   9.95s
commentTime time:     0.99s    commentTime time:     0.87s
I/O Write time:      23.28s    I/O Write time:      22.81s
Source Map time:      1.82s    Source Map time:      1.63s
printTime time:      42.80s    printTime time:      41.98s
Emit time:           42.80s    Emit time:           41.98s
Total time:          77.21s    Total time:          68.16s

SubProj4:
Before                         After
Files:                 2279    Files:                 2279
Lines:               217646    Lines:               217646
Nodes:               666632    Nodes:               666632
Identifiers:         217008    Identifiers:         217008
Symbols:             182741    Symbols:             182741
Types:                28149    Types:                28149
Memory used:        377728K    Memory used:        929302K
I/O Read time:        1.10s    I/O Read time:        0.73s
Parse time:           1.19s    Parse time:           0.39s
Program time:         9.17s    Program time:         5.97s
Bind time:            0.38s    Bind time:            0.28s
Check time:           1.35s    Check time:           2.95s
transformTime time:   0.68s    transformTime time:   0.82s
commentTime time:     0.08s    commentTime time:     0.10s
Source Map time:      0.11s    Source Map time:      0.14s
I/O Write time:       1.97s    I/O Write time:       2.23s
printTime time:       3.47s    printTime time:       4.04s
Emit time:            3.47s    Emit time:            4.04s
Total time:          14.37s    Total time:          13.25s

SubProj5:
Before                         After
Files:                 1788    Files:                  1788
Lines:               203217    Lines:                203217
Nodes:               625553    Nodes:                625553
Identifiers:         207437    Identifiers:          207437
Symbols:             157661    Symbols:              157661
Types:                21297    Types:                 21297
Memory used:        354200K    Memory used:        1084183K
I/O Read time:        0.76s    I/O Read time:         0.45s
Parse time:           0.85s    Parse time:            0.24s
Program time:         5.61s    Program time:          3.56s
Bind time:            0.29s    Bind time:             0.11s
Check time:           1.16s    Check time:            1.48s
transformTime time:   0.59s    transformTime time:    0.81s
commentTime time:     0.11s    commentTime time:      0.13s
Source Map time:      0.15s    Source Map time:       0.20s
I/O Write time:       2.44s    I/O Write time:        2.94s
printTime time:       4.25s    printTime time:        5.17s
Emit time:            4.25s    Emit time:             5.17s
Total time:          11.31s    Total time:           10.31s

SubProj6:
Before                         After
Files:                  8825    Files:                  8825
Lines:                523559    Lines:                523559
Nodes:               1808872    Nodes:               1808872
Identifiers:          574875    Identifiers:          574875
Symbols:              592580    Symbols:              592580
Types:                176342    Types:                176342
Memory used:        1235392K    Memory used:        1295707K
I/O Read time:         3.87s    I/O Read time:         3.65s
Parse time:            2.52s    Parse time:            1.79s
Program time:         27.89s    Program time:         22.86s
Bind time:             1.00s    Bind time:             0.79s
Check time:            8.35s    Check time:           10.37s
transformTime time:    9.62s    transformTime time:   10.16s
commentTime time:      0.98s    commentTime time:      0.94s
Source Map time:       1.83s    Source Map time:       1.74s
I/O Write time:       19.03s    I/O Write time:       19.89s
printTime time:       36.52s    printTime time:       39.22s
Emit time:            36.52s    Emit time:            39.22s
Total time:           73.77s    Total time:           73.24s

SubProj7:
Before                         After
Files:                  5994    Files:                 5994
Lines:                375981    Lines:               375981
Nodes:               1250166    Nodes:              1250166
Identifiers:          399975    Identifiers:         399975
Symbols:              414247    Symbols:             414247
Types:                 95908    Types:                95908
Memory used:        2003453K    Memory used:        892452K
I/O Read time:         3.30s    I/O Read time:        1.73s
Parse time:            3.51s    Parse time:           0.84s
Program time:         30.55s    Program time:        14.54s
Bind time:             1.40s    Bind time:            0.42s
Check time:           14.79s    Check time:           6.67s
transformTime time:    9.25s    transformTime time:   4.76s
commentTime time:      0.89s    commentTime time:     0.52s
Source Map time:       1.52s    Source Map time:      0.90s
I/O Write time:       11.50s    I/O Write time:       9.91s
printTime time:       24.97s    printTime time:      19.19s
Emit time:            24.97s    Emit time:           19.19s
Total time:           71.70s    Total time:          40.81s

SubProj8:
Before                         After
Files:                 3585    Files:                  3585
Lines:               258607    Lines:                258607
Nodes:               823001    Nodes:                823001
Identifiers:         270975    Identifiers:          270975
Symbols:             251610    Symbols:              251610
Types:                49876    Types:                 49876
Memory used:        504267K    Memory used:        1166429K
I/O Read time:        1.68s    I/O Read time:         0.43s
Parse time:           1.60s    Parse time:            0.38s
Program time:        13.87s    Program time:          7.89s
Bind time:            0.69s    Bind time:             0.25s
Check time:           2.65s    Check time:            3.64s
transformTime time:   3.02s    transformTime time:    4.51s
commentTime time:     0.18s    commentTime time:      0.22s
Source Map time:      0.25s    Source Map time:       0.28s
I/O Write time:       3.08s    I/O Write time:        2.96s
printTime time:       6.52s    printTime time:        7.30s
Emit time:            6.52s    Emit time:             7.30s
Total time:          23.72s    Total time:           19.07s

Total Approximately::
Before: 282s
After:  234s
```
