### PR TITLE
Dont explicitly get declaration diagnostics in --build mode, instead get them as part of emit

### DIFF
--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -1050,14 +1050,6 @@ namespace ts {
                 return buildErrors(syntaxDiagnostics, BuildResultFlags.SyntaxErrors, "Syntactic");
             }
 
-            // Don't emit .d.ts if there are decl file errors
-            if (getEmitDeclarations(program.getCompilerOptions())) {
-                const declDiagnostics = program.getDeclarationDiagnostics();
-                if (declDiagnostics.length) {
-                    return buildErrors(declDiagnostics, BuildResultFlags.DeclarationEmitErrors, "Declaration file");
-                }
-            }
-
             // Same as above but now for semantic diagnostics
             const semanticDiagnostics = program.getSemanticDiagnostics();
             if (semanticDiagnostics.length) {
@@ -1066,14 +1058,23 @@ namespace ts {
 
             let newestDeclarationFileContentChangedTime = minimumDate;
             let anyDtsChanged = false;
-            let emitDiagnostics: Diagnostic[] | undefined;
-            const reportEmitDiagnostic = (d: Diagnostic) => (emitDiagnostics || (emitDiagnostics = [])).push(d);
-            emitFilesAndReportErrors(program, reportEmitDiagnostic, writeFileName, /*reportSummary*/ undefined, (fileName, content, writeBom, onError) => {
+            let declDiagnostics: Diagnostic[] | undefined;
+            const reportDeclarationDiagnostics = (d: Diagnostic) => (declDiagnostics || (declDiagnostics = [])).push(d);
+            const outputFiles: OutputFile[] = [];
+            emitFilesAndReportErrors(program, reportDeclarationDiagnostics, writeFileName, /*reportSummary*/ undefined, (name, text, writeByteOrderMark) => outputFiles.push({ name, text, writeByteOrderMark }));
+            // Don't emit .d.ts if there are decl file errors
+            if (declDiagnostics) {
+                return buildErrors(declDiagnostics, BuildResultFlags.DeclarationEmitErrors, "Declaration file");
+            }
+
+            // Actual Emit
+            const emitterDiagnostics = createDiagnosticCollection();
+            outputFiles.forEach(({ name, text, writeByteOrderMark }) => {
                 let priorChangeTime: Date | undefined;
-                if (!anyDtsChanged && isDeclarationFile(fileName)) {
+                if (!anyDtsChanged && isDeclarationFile(name)) {
                     // Check for unchanged .d.ts files
-                    if (host.fileExists(fileName) && host.readFile(fileName) === content) {
-                        priorChangeTime = host.getModifiedTime(fileName);
+                    if (host.fileExists(name) && host.readFile(name) === text) {
+                        priorChangeTime = host.getModifiedTime(name);
                     }
                     else {
                         resultFlags &= ~BuildResultFlags.DeclarationOutputUnchanged;
@@ -1081,14 +1082,15 @@ namespace ts {
                     }
                 }
 
-                host.writeFile(fileName, content, writeBom, onError, emptyArray);
+                writeFile(host, emitterDiagnostics, name, text, writeByteOrderMark);
                 if (priorChangeTime !== undefined) {
                     newestDeclarationFileContentChangedTime = newer(priorChangeTime, newestDeclarationFileContentChangedTime);
-                    unchangedOutputs.setValue(fileName, priorChangeTime);
+                    unchangedOutputs.setValue(name, priorChangeTime);
                 }
             });
 
-            if (emitDiagnostics) {
+            const emitDiagnostics = emitterDiagnostics.getDiagnostics();
+            if (emitDiagnostics.length) {
                 return buildErrors(emitDiagnostics, BuildResultFlags.EmitErrors, "Emit");
             }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3402,7 +3402,7 @@ namespace ts {
         return combinePaths(newDirPath, sourceFilePath);
     }
 
-    export function writeFile(host: EmitHost, diagnostics: DiagnosticCollection, fileName: string, data: string, writeByteOrderMark: boolean, sourceFiles?: ReadonlyArray<SourceFile>) {
+    export function writeFile(host: { writeFile: WriteFileCallback; }, diagnostics: DiagnosticCollection, fileName: string, data: string, writeByteOrderMark: boolean, sourceFiles?: ReadonlyArray<SourceFile>) {
         host.writeFile(fileName, data, writeByteOrderMark, hostErrorMessage => {
             diagnostics.add(createCompilerDiagnostic(Diagnostics.Could_not_write_file_0_Colon_1, fileName, hostErrorMessage));
         }, sourceFiles);


### PR DESCRIPTION
The result running this against [branch](https://github.com/Microsoft/TypeScript/tree/noExplicitDeclarationDiagnostics31):

```
SubProj: 1

Before                         After

Files:                  691    Files:                  691
Lines:               151530    Lines:               151530
Nodes:               464264    Nodes:               464264
Identifiers:         156379    Identifiers:         156379
Symbols:             102129    Symbols:             102093
Types:                 8255    Types:                 8253
Memory used:        220852K    Memory used:        227634K
I/O Read time:        0.36s    I/O Read time:        0.34s
Parse time:           0.97s    Parse time:           0.87s
Program time:         2.33s    Program time:         2.13s
Bind time:            0.54s    Bind time:            0.52s
Check time:           0.62s    Check time:           0.59s
transformTime time:   0.67s    transformTime time:   0.35s
commentTime time:     0.07s    commentTime time:     0.04s
Source Map time:      0.06s    Source Map time:      0.05s
I/O Write time:       1.29s    printTime time:       0.88s
printTime time:       2.54s    Emit time:            0.88s
Emit time:            2.54s    I/O Write time:       1.23s
Total time:           6.03s    Total time:           4.12s


SubProj: 2

Before                         After

Files:                 1798    Files:                 1798
Lines:               196503    Lines:               196503
Nodes:               613506    Nodes:               613506
Identifiers:         200977    Identifiers:         200977
Symbols:             151499    Symbols:             151460
Types:                20812    Types:                20736
Memory used:        379835K    Memory used:        396170K
I/O Read time:        0.65s    I/O Read time:        0.76s
Parse time:           0.37s    Parse time:           0.40s
Program time:         2.80s    Program time:         3.19s
Bind time:            0.23s    Bind time:            0.23s
Check time:           1.40s    Check time:           1.39s
transformTime time:   1.01s    transformTime time:   0.66s
commentTime time:     0.13s    commentTime time:     0.10s
Source Map time:      0.17s    Source Map time:      0.14s
I/O Write time:       3.11s    printTime time:       1.80s
printTime time:       5.58s    Emit time:            1.80s
Emit time:            5.58s    I/O Write time:       2.47s
Total time:          10.01s    Total time:           6.61s


SubProj: 3

Before                         After

Files:                  7532    Files:                  7532
Lines:                484560    Lines:                484560
Nodes:               1671393    Nodes:               1671393
Identifiers:          535514    Identifiers:          535514
Symbols:              544664    Symbols:              543399
Types:                178410    Types:                177418
Memory used:        1224491K    Memory used:        1026740K
I/O Read time:         3.28s    I/O Read time:         3.70s
Parse time:            1.80s    Parse time:            1.76s
Program time:         16.03s    Program time:         17.01s
Bind time:             0.85s    Bind time:             1.27s
Check time:            9.61s    Check time:            9.47s
transformTime time:   10.96s    transformTime time:    8.89s
commentTime time:      1.00s    commentTime time:      0.98s
I/O Write time:       24.09s    Source Map time:       1.80s
Source Map time:       1.87s    printTime time:       20.96s
printTime time:       45.65s    Emit time:            20.96s
Emit time:            45.65s    I/O Write time:       17.99s
Total time:           72.14s    Total time:           48.70s


SubProj: 4

Before                         After

Files:                  2279    Files:                  2279
Lines:                217646    Lines:                217646
Nodes:                666632    Nodes:                666632
Identifiers:          217008    Identifiers:          217008
Symbols:              182741    Symbols:              182725
Types:                 28149    Types:                 28135
Memory used:        1405059K    Memory used:        1216589K
I/O Read time:         1.06s    I/O Read time:         0.73s
Parse time:            0.64s    Parse time:            0.46s
Program time:          8.01s    Program time:          6.05s
Bind time:             0.48s    Bind time:             0.26s
Check time:            6.34s    Check time:            3.23s
transformTime time:    1.73s    transformTime time:    0.72s
commentTime time:      0.12s    commentTime time:      0.10s
Source Map time:       0.36s    Source Map time:       0.23s
I/O Write time:        2.89s    printTime time:        2.10s
printTime time:        5.74s    Emit time:             2.10s
Emit time:             5.74s    I/O Write time:        1.84s
Total time:           20.57s    Total time:           11.64s


SubProj: 5

Before                         After

Files:                 1788    Files:                  1788
Lines:               203217    Lines:                203217
Nodes:               625553    Nodes:                625553
Identifiers:         207437    Identifiers:          207437
Symbols:             157661    Symbols:              157615
Types:                21297    Types:                 21220
Memory used:        419655K    Memory used:        1402991K
I/O Read time:        1.04s    I/O Read time:         0.53s
Parse time:           0.57s    Parse time:            0.32s
Program time:         6.69s    Program time:          4.42s
Bind time:            0.24s    Bind time:             0.18s
Check time:           3.72s    Check time:            2.26s
transformTime time:   0.95s    transformTime time:    0.94s
commentTime time:     0.13s    commentTime time:      0.14s
Source Map time:      0.24s    Source Map time:       0.27s
I/O Write time:       3.04s    printTime time:        2.72s
printTime time:       5.61s    Emit time:             2.72s
Emit time:            5.61s    I/O Write time:        2.54s
Total time:          16.26s    Total time:            9.58s


SubProj: 6

Before                         After

Files:                 8825    Files:                  8825
Lines:               523559    Lines:                523559
Nodes:              1808872    Nodes:               1808872
Identifiers:         574875    Identifiers:          574875
Symbols:             592580    Symbols:              589930
Types:               176342    Types:                173989
Memory used:        988967K    Memory used:        1297742K
I/O Read time:        5.02s    I/O Read time:         3.72s
Parse time:           1.83s    Parse time:            1.74s
Program time:        23.88s    Program time:         22.16s
Bind time:            0.80s    Bind time:             0.81s
Check time:          10.11s    Check time:           10.46s
transformTime time:  10.38s    transformTime time:    8.16s
commentTime time:     1.16s    commentTime time:      1.03s
Source Map time:      1.92s    Source Map time:       1.93s
I/O Write time:      21.25s    printTime time:       20.47s
printTime time:      41.76s    Emit time:            20.47s
Emit time:           41.76s    I/O Write time:       15.38s
Total time:          76.54s    Total time:           53.90s


SubProj: 7

Before                         After

Files:                 5994    Files:                 5994
Lines:               375981    Lines:               375981
Nodes:              1250166    Nodes:              1250166
Identifiers:         399975    Identifiers:         399975
Symbols:             414247    Symbols:             413803
Types:                95908    Types:                95440
Memory used:        892468K    Memory used:        912933K
I/O Read time:        2.65s    I/O Read time:        2.05s
Parse time:           1.12s    Parse time:           1.28s
Program time:        16.60s    Program time:        18.82s
Bind time:            0.44s    Bind time:            0.73s
Check time:           6.66s    Check time:           9.93s
transformTime time:   5.26s    transformTime time:   5.12s
commentTime time:     0.55s    commentTime time:     0.56s
Source Map time:      0.95s    Source Map time:      1.06s
I/O Write time:      11.17s    printTime time:      11.21s
printTime time:      21.26s    Emit time:           11.21s
Emit time:           21.26s    I/O Write time:       8.14s
Total time:          44.96s    Total time:          40.70s


SubProj: 8

Before                         After

Files:                  3585    Files:                  3585
Lines:                258607    Lines:                258607
Nodes:                823001    Nodes:                823001
Identifiers:          270975    Identifiers:          270975
Symbols:              251610    Symbols:              251608
Types:                 49876    Types:                 49874
Memory used:        1162755K    Memory used:        1207865K
I/O Read time:         0.78s    I/O Read time:         0.51s
Parse time:            0.33s    Parse time:            0.32s
Program time:          8.81s    Program time:          8.07s
Bind time:             0.31s    Bind time:             0.23s
Check time:            3.83s    Check time:            3.46s
transformTime time:    4.81s    transformTime time:    3.14s
commentTime time:      0.17s    commentTime time:      0.18s
Source Map time:       0.28s    Source Map time:       0.51s
I/O Write time:        3.10s    printTime time:        5.36s
printTime time:        7.55s    Emit time:             5.36s
Emit time:             7.55s    I/O Write time:        2.21s
Total time:           20.51s    Total time:           17.13s

Total Approximately::
Before: 267.02s
After:  192.38s
```