### PR TITLE
Introducing autoEmitAMDModuleNames compiler option

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -783,6 +783,13 @@ namespace ts {
             description: Diagnostics.Disable_strict_checking_of_generic_signatures_in_function_types,
         },
         {
+            name: "autoEmitAMDModuleNames",
+            type: "boolean",
+            affectsSemanticDiagnostics: true,
+            category: Diagnostics.Advanced_Options,
+            description: Diagnostics.Generates_AMD_module_names_regardless_even_when_outDir_option_is_provided,
+        },
+        {
             name: "keyofStringsOnly",
             type: "boolean",
             category: Diagnostics.Advanced_Options,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3815,6 +3815,10 @@
         "category": "Message",
         "code": 6217
     },
+    "Generates AMD module names regardless even when outDir option is provided.": {
+        "category": "Message",
+        "code": 6218
+    },
 
     "Projects to reference": {
         "category": "Message",

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -4622,7 +4622,7 @@ namespace ts {
         if (file.moduleName) {
             return createLiteral(file.moduleName);
         }
-        if (!file.isDeclarationFile && (options.out || options.outFile)) {
+        if (!file.isDeclarationFile && (options.out || options.outFile || options.autoEmitAMDModuleNames)) {
             return createLiteral(getExternalModuleNameFromPath(host, file.fileName));
         }
         return undefined;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4481,6 +4481,7 @@ namespace ts {
         allowUnreachableCode?: boolean;
         allowUnusedLabels?: boolean;
         alwaysStrict?: boolean;  // Always combine with strict property
+        autoEmitAMDModuleNames?: boolean;
         baseUrl?: string;
         /** An error if set - this should only go through the -b pipeline and not actually be observed */
         /*@internal*/

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2440,6 +2440,7 @@ declare namespace ts {
         allowUnreachableCode?: boolean;
         allowUnusedLabels?: boolean;
         alwaysStrict?: boolean;
+        autoEmitAMDModuleNames?: boolean;
         baseUrl?: string;
         charset?: string;
         checkJs?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2440,6 +2440,7 @@ declare namespace ts {
         allowUnreachableCode?: boolean;
         allowUnusedLabels?: boolean;
         alwaysStrict?: boolean;
+        autoEmitAMDModuleNames?: boolean;
         baseUrl?: string;
         charset?: string;
         checkJs?: boolean;

--- a/tests/baselines/reference/autoEmitAMDModuleNames1.js
+++ b/tests/baselines/reference/autoEmitAMDModuleNames1.js
@@ -1,0 +1,20 @@
+//// [autoEmitAMDModuleNames1.ts]
+class Foo {
+    x: number;
+    constructor() {
+        this.x = 5;
+    }
+}
+export = Foo;
+
+//// [autoEmitAMDModuleNames1.js]
+define("autoEmitAMDModuleNames1", ["require", "exports"], function (require, exports) {
+    "use strict";
+    var Foo = /** @class */ (function () {
+        function Foo() {
+            this.x = 5;
+        }
+        return Foo;
+    }());
+    return Foo;
+});

--- a/tests/baselines/reference/autoEmitAMDModuleNames1.symbols
+++ b/tests/baselines/reference/autoEmitAMDModuleNames1.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/autoEmitAMDModuleNames1.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(autoEmitAMDModuleNames1.ts, 0, 0))
+
+    x: number;
+>x : Symbol(Foo.x, Decl(autoEmitAMDModuleNames1.ts, 0, 11))
+
+    constructor() {
+        this.x = 5;
+>this.x : Symbol(Foo.x, Decl(autoEmitAMDModuleNames1.ts, 0, 11))
+>this : Symbol(Foo, Decl(autoEmitAMDModuleNames1.ts, 0, 0))
+>x : Symbol(Foo.x, Decl(autoEmitAMDModuleNames1.ts, 0, 11))
+    }
+}
+export = Foo;
+>Foo : Symbol(Foo, Decl(autoEmitAMDModuleNames1.ts, 0, 0))
+

--- a/tests/baselines/reference/autoEmitAMDModuleNames1.types
+++ b/tests/baselines/reference/autoEmitAMDModuleNames1.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/autoEmitAMDModuleNames1.ts ===
+class Foo {
+>Foo : Foo
+
+    x: number;
+>x : number
+
+    constructor() {
+        this.x = 5;
+>this.x = 5 : 5
+>this.x : number
+>this : this
+>x : number
+>5 : 5
+    }
+}
+export = Foo;
+>Foo : Foo
+

--- a/tests/cases/compiler/autoEmitAMDModuleNames1.ts
+++ b/tests/cases/compiler/autoEmitAMDModuleNames1.ts
@@ -1,0 +1,10 @@
+//@module: amd
+//@autoEmitAMDModuleNames: true
+//@outDir: out/
+class Foo {
+    x: number;
+    constructor() {
+        this.x = 5;
+    }
+}
+export = Foo;


### PR DESCRIPTION
This pull request adds support to a new `autoEmitAMDModuleNames` compiler option to avoid AMD anonymous modules declaration when `outDir` is used (we have a change in behaviour when we switch from `outFile` to `outDir` on this regard)

Fixes #27547 

