### PR TITLE
Skip method this type validity filter for objects with more than 20 members

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -230,9 +230,9 @@ namespace ts {
                 const node = getParseTreeNode(nodeIn, isPropertyAccessOrQualifiedNameOrImportTypeNode);
                 return !!node && isValidPropertyAccess(node, escapeLeadingUnderscores(propertyName));
             },
-            isValidPropertyAccessForCompletions: (nodeIn, type, property) => {
+            isValidPropertyAccessForCompletions: (nodeIn, type, property, skipMethodCheck) => {
                 const node = getParseTreeNode(nodeIn, isPropertyAccessExpression);
-                return !!node && isValidPropertyAccessForCompletions(node, type, property);
+                return !!node && isValidPropertyAccessForCompletions(node, type, property, skipMethodCheck);
             },
             getSignatureFromDeclaration: declarationIn => {
                 const declaration = getParseTreeNode(declarationIn, isFunctionLike);
@@ -19083,9 +19083,9 @@ namespace ts {
             }
         }
 
-        function isValidPropertyAccessForCompletions(node: PropertyAccessExpression | ImportTypeNode, type: Type, property: Symbol): boolean {
+        function isValidPropertyAccessForCompletions(node: PropertyAccessExpression | ImportTypeNode, type: Type, property: Symbol, skipMethodCheck: boolean): boolean {
             return isValidPropertyAccessWithType(node, node.kind !== SyntaxKind.ImportType && node.expression.kind === SyntaxKind.SuperKeyword, property.escapedName, type)
-                && (!(property.flags & SymbolFlags.Method) || isValidMethodAccess(property, type));
+                && (!(property.flags & SymbolFlags.Method) || (skipMethodCheck || isValidMethodAccess(property, type)));
         }
         function isValidMethodAccess(method: Symbol, actualThisType: Type): boolean {
             const propType = getTypeOfPropertyOfType(actualThisType, method.escapedName)!;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3103,7 +3103,7 @@ namespace ts {
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): string | number | undefined;
         isValidPropertyAccess(node: PropertyAccessExpression | QualifiedName | ImportTypeNode, propertyName: string): boolean;
         /** Exclude accesses to private properties or methods with a `this` parameter that `type` doesn't satisfy. */
-        /* @internal */ isValidPropertyAccessForCompletions(node: PropertyAccessExpression | ImportTypeNode, type: Type, property: Symbol): boolean;
+        /* @internal */ isValidPropertyAccessForCompletions(node: PropertyAccessExpression | ImportTypeNode, type: Type, property: Symbol, skipMethodCheck: boolean): boolean;
         /** Follow all aliases to get the original symbol. */
         getAliasedSymbol(symbol: Symbol): Symbol;
         /** Follow a *single* alias to get the immediately aliased symbol. */

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -912,8 +912,9 @@ namespace ts.Completions {
                 symbols.push(...getPropertiesForCompletion(type, typeChecker));
             }
             else {
-                for (const symbol of type.getApparentProperties()) {
-                    if (typeChecker.isValidPropertyAccessForCompletions(node.kind === SyntaxKind.ImportType ? <ImportTypeNode>node : <PropertyAccessExpression>node.parent, type, symbol)) {
+                const props = type.getApparentProperties();
+                for (const symbol of props) {
+                    if (typeChecker.isValidPropertyAccessForCompletions(node.kind === SyntaxKind.ImportType ? <ImportTypeNode>node : <PropertyAccessExpression>node.parent, type, symbol, props.length > 20)) {
                         addPropertySymbol(symbol);
                     }
                 }


### PR DESCRIPTION
Fixes #23285 specifically by limiting the number of properties we filter methods on to 20 (so if an object has > 20 members, we no longer filter invalid method calls from the completion list), though the underlying issue remains. It's also questionable if the filtering is even really correct, since using the member in a non-calling fashion is still acceptable - the choice to filter methods at all feels somewhat pragmatic.

That underlying issue is that every anonymous type instantiation is unique - so even though we're querying similar types across the ~300 this-type comparisons we perform, since the input anonymous types are differing identities, we repeat a lot of very similar work. Caching on signatures doesn't help here, since each comparison is triggered for a different signature. The issue is simply that if I have 200 methods with `this: {item: T}`, then every time we infer from `{item: string}` to `{item: T}` and instantiate `T` with `string`, we get a new overall type identity and need to perform a structural comparison, even though it's still just `{item: string}`.

