### PR TITLE
Count only unit types when counting overlapping keys

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11975,7 +11975,7 @@ namespace ts {
                         // Some subset overlap if we have only string literals.
                         // If we have a union of index types, it seems likely that we
                         // needed to elaborate between two generic mapped types anyway.
-                        const len = length((overlap as UnionType).types);
+                        const len = length(filter((overlap as UnionType).types, isUnitType));
                         if (len >= matchingCount) {
                             bestMatch = target;
                             matchingCount = len;

--- a/tests/baselines/reference/inferTypes1.errors.txt
+++ b/tests/baselines/reference/inferTypes1.errors.txt
@@ -18,7 +18,7 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(75,43): error TS4081: E
 tests/cases/conformance/types/conditional/inferTypes1.ts(82,44): error TS2344: Type 'U' does not satisfy the constraint 'string'.
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(144,40): error TS2322: Type 'T' is not assignable to type 'string | number | symbol'.
-  Type 'T' is not assignable to type 'string'.
+  Type 'T' is not assignable to type 'symbol'.
 
 
 ==== tests/cases/conformance/types/conditional/inferTypes1.ts (16 errors) ====
@@ -202,7 +202,7 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(144,40): error TS2322: 
     type B<T> = string extends T ? { [P in T]: void; } : T;  // Error
                                            ~
 !!! error TS2322: Type 'T' is not assignable to type 'string | number | symbol'.
-!!! error TS2322:   Type 'T' is not assignable to type 'string'.
+!!! error TS2322:   Type 'T' is not assignable to type 'symbol'.
     
     // Repro from #22302
     

--- a/tests/baselines/reference/intersectionWithUnionConstraint.errors.txt
+++ b/tests/baselines/reference/intersectionWithUnionConstraint.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts(7,9): error TS2322: Type 'T & U' is not assignable to type 'string | number'.
   Type 'string | undefined' is not assignable to type 'string | number'.
     Type 'undefined' is not assignable to type 'string | number'.
-      Type 'T & U' is not assignable to type 'string'.
+      Type 'T & U' is not assignable to type 'number'.
 tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts(8,9): error TS2322: Type 'T & U' is not assignable to type 'string | null'.
   Type 'string | undefined' is not assignable to type 'string | null'.
     Type 'undefined' is not assignable to type 'string | null'.
@@ -32,7 +32,7 @@ tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts(12
 !!! error TS2322: Type 'T & U' is not assignable to type 'string | number'.
 !!! error TS2322:   Type 'string | undefined' is not assignable to type 'string | number'.
 !!! error TS2322:     Type 'undefined' is not assignable to type 'string | number'.
-!!! error TS2322:       Type 'T & U' is not assignable to type 'string'.
+!!! error TS2322:       Type 'T & U' is not assignable to type 'number'.
         let y2: string | null = x;       // Error
             ~~
 !!! error TS2322: Type 'T & U' is not assignable to type 'string | null'.

--- a/tests/baselines/reference/mappedTypeErrors.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors.errors.txt
@@ -37,7 +37,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(128,16): error TS2322: 
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(129,25): error TS2322: Type 'string' is not assignable to type 'number | undefined'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(130,39): error TS2322: Type 'string' is not assignable to type 'number | undefined'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(136,16): error TS2322: Type 'T' is not assignable to type 'string | number | symbol'.
-  Type 'T' is not assignable to type 'string'.
+  Type 'T' is not assignable to type 'symbol'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(136,21): error TS2536: Type 'P' cannot be used to index type 'T'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(148,17): error TS2339: Property 'foo' does not exist on type 'Pick<T, K>'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(152,17): error TS2339: Property 'foo' does not exist on type 'Record<K, number>'.
@@ -249,7 +249,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(152,17): error TS2339: 
         pt: {[P in T]?: T[P]}, // note: should be in keyof T
                    ~
 !!! error TS2322: Type 'T' is not assignable to type 'string | number | symbol'.
-!!! error TS2322:   Type 'T' is not assignable to type 'string'.
+!!! error TS2322:   Type 'T' is not assignable to type 'symbol'.
                         ~~~~
 !!! error TS2536: Type 'P' cannot be used to index type 'T'.
     };

--- a/tests/baselines/reference/mappedTypeErrors2.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors2.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(9,30): error TS2536: T
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(13,30): error TS2536: Type 'K' cannot be used to index type 'T3'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(15,38): error TS2536: Type 'S' cannot be used to index type '{ [key in AB[S]]: true; }'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(15,47): error TS2322: Type 'AB[S]' is not assignable to type 'string | number | symbol'.
-  Type 'AB[S]' is not assignable to type 'string'.
+  Type 'AB[S]' is not assignable to type 'symbol'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(15,47): error TS2536: Type 'S' cannot be used to index type 'AB'.
 tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(17,49): error TS2536: Type 'L' cannot be used to index type '{ [key in AB[S]]: true; }'.
 
@@ -31,7 +31,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors2.ts(17,49): error TS2536: 
 !!! error TS2536: Type 'S' cannot be used to index type '{ [key in AB[S]]: true; }'.
                                                   ~~~~~
 !!! error TS2322: Type 'AB[S]' is not assignable to type 'string | number | symbol'.
-!!! error TS2322:   Type 'AB[S]' is not assignable to type 'string'.
+!!! error TS2322:   Type 'AB[S]' is not assignable to type 'symbol'.
                                                   ~~~~~
 !!! error TS2536: Type 'S' cannot be used to index type 'AB'.
     


### PR DESCRIPTION
This way an unconstrained `T` compared against `string | number | symbol` no longer chooses `string` over the last one, `symbol`, when they all equally do not have overlapping properties.