### PR TITLE
[release-3.2] Use compilerOptionsIndicateEs6Modules over program contains es6 modules for determining auto import offering. Also dont depend on uncheck js file for this.

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1050,12 +1050,10 @@ namespace ts.Completions {
             if (sourceFile.externalModuleIndicator) return true;
             // If already using commonjs, don't introduce ES6.
             if (sourceFile.commonJsModuleIndicator) return false;
-            // For JS, stay on the safe side.
-            if (isUncheckedFile) return false;
-            // If some file is using ES6 modules, assume that it's OK to add more.
-            if (programContainsEs6Modules(program)) return true;
             // If module transpilation is enabled or we're targeting es6 or above, or not emitting, OK.
-            return compilerOptionsIndicateEs6Modules(program.getCompilerOptions());
+            if (compilerOptionsIndicateEs6Modules(program.getCompilerOptions())) return true;
+            // If some file is using ES6 modules, assume that it's OK to add more.
+            return programContainsEs6Modules(program);
         }
 
         function isSnippetScope(scopeNode: Node): boolean {

--- a/tests/cases/fourslash/completionsImport_compilerOptionsModule.ts
+++ b/tests/cases/fourslash/completionsImport_compilerOptionsModule.ts
@@ -11,22 +11,31 @@
 ////fo/*b*/
 
 // @Filename: /c.js
-////const x = 0;/*c*/ // Off for JS files (unless a non-declaration external module exists in the project)
+////const x = 0;/*c*/
+
+// @Filename: /c1.js
+////// @ts-check
+////const x = 0;/*ccheck*/
 
 // @Filename: /c2.ts
-////const x = 0;/*c2*/
+////const x = 0;/*cts*/
 
 // @Filename: /d.js
 ////const a = import("./a"); // Does not make this an external module
 ////fo/*d*/
 
+// @Filename: /d1.js
+////// @ts-check
+////const a = import("./a"); // Does not make this an external module
+////fo/*dcheck*/
+
 // @Filename: /d2.ts
 ////const a = import("./a"); // Does not make this an external module
-////fo/*d2*/
+////fo/*dts*/
 
-verify.completions({ marker: ["b", "c", "d"], excludes: "foo", preferences: { includeCompletionsForModuleExports: true } });
+verify.completions({ marker: ["b"], excludes: "foo", preferences: { includeCompletionsForModuleExports: true } });
 verify.completions({
-    marker: ["c2", "d2"],
+    marker: ["c", "ccheck", "cts", "d", "dcheck", "dts"],
     includes: [{ name: "foo", source: "/node_modules/a/index", text: "const foo: 0", kind: "const", kindModifiers: "export,declare", hasAction: true, sourceDisplay: "a" }],
     preferences: { includeCompletionsForModuleExports: true },
 });

--- a/tests/cases/fourslash/noImportCompletionsInOtherJavaScriptFile.ts
+++ b/tests/cases/fourslash/noImportCompletionsInOtherJavaScriptFile.ts
@@ -12,19 +12,40 @@
 ////
 
 // @Filename: /b.js
-//// /**/
+//// /*1*/
 
-verify.completions({ marker: "", excludes: "fail", preferences: { includeCompletionsForModuleExports: true } });
-edit.insert("export const k = 10;\r\nf");
-verify.completions({
-    includes: {
-        name: "fail",
-        source: "/node_modules/foo/index",
-        sourceDisplay: "./node_modules/foo/index",
-        text: "const fail: number",
-        kind: "const",
-        kindModifiers: "export,declare",
-        hasAction: true,
-    },
-    preferences: { includeCompletionsForModuleExports: true },
+// @Filename: /b2.js
+//////@ts-check
+/////*2*/
+
+// @Filename: /b3.ts
+/////*3*/
+
+// In esnext js files are assumed to be modules
+goTo.eachMarker(() => {
+    verify.completions({
+        includes: {
+            name: "fail",
+            source: "/node_modules/foo/index",
+            sourceDisplay: "./node_modules/foo/index",
+            text: "const fail: number",
+            kind: "const",
+            kindModifiers: "export,declare",
+            hasAction: true,
+        },
+        preferences: { includeCompletionsForModuleExports: true },
+    });
+    edit.insert("export const k = 10;\r\nf");
+    verify.completions({
+        includes: {
+            name: "fail",
+            source: "/node_modules/foo/index",
+            sourceDisplay: "./node_modules/foo/index",
+            text: "const fail: number",
+            kind: "const",
+            kindModifiers: "export,declare",
+            hasAction: true,
+        },
+        preferences: { includeCompletionsForModuleExports: true },
+    });
 });


### PR DESCRIPTION
Fixes #28696
Port of #28745 to release-3.2