### PR TITLE
Skip implicit any suggestions with no codefix

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13683,6 +13683,10 @@ namespace ts {
                     break;
                 case SyntaxKind.BindingElement:
                     diagnostic = Diagnostics.Binding_element_0_implicitly_has_an_1_type;
+                    if (!noImplicitAny) {
+                        // Don't issue a suggestion for binding elements since the codefix doesn't yet support them.
+                        return;
+                    }
                     break;
                 case SyntaxKind.JSDocFunctionType:
                     error(declaration, Diagnostics.Function_type_which_lacks_return_type_annotation_implicitly_has_an_0_return_type, typeAsString);

--- a/tests/cases/fourslash/codeFixInferFromUsageBindingElement.ts
+++ b/tests/cases/fourslash/codeFixInferFromUsageBindingElement.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+////function f([car, cdr]) {
+////    return car + cdr + 1
+////}
+
+// When inferFromUsage supports it, it should infer number for both variables
+verify.getSuggestionDiagnostics([]);
+


### PR DESCRIPTION
The only unsupported one is binding patterns, which aren't supported by the codefix. The code was a lot faster to write without supporting them, but there's no real barrier besides that.

I'll port this change to 3.2 if we decide we want to ship it as part of 3.2.2.

Fixes #28750
