### PR TITLE
Revert over-eager bailout when trimming trailing whitespace

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -1106,10 +1106,7 @@ namespace ts.formatting {
          * Trimming will be done for lines after the previous range
          */
         function trimTrailingWhitespacesForRemainingRange() {
-            if (!previousRange) {
-                return;
-            }
-            const startPosition = previousRange.end;
+            const startPosition = previousRange ? previousRange.end : originalRange.pos;
 
             const startLine = sourceFile.getLineAndCharacterOfPosition(startPosition).line;
             const endLine = sourceFile.getLineAndCharacterOfPosition(originalRange.end).line;

--- a/tests/cases/fourslash/formatAfterWhitespace.ts
+++ b/tests/cases/fourslash/formatAfterWhitespace.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+////function foo()
+////{
+////    var bar;
+////    /*1*/
+////}
+goTo.marker('1')
+edit.insertLine("");
+verify.currentFileContentIs(`function foo()
+{
+    var bar;
+
+
+}`);


### PR DESCRIPTION
Broken by #27978, which removed the fallback. Before that change, if formatting processed *no* ranges, then trimTrailingWhitespacesForRemainingRange would instead use the original range. During the development of #27978, I thought it was necessary to instead skip trimming when no ranges were processed. This turns out to be wrong, so this PR reinstates the original behaviour.

Fixes #28781
