### PR TITLE
Improved type inference for discriminated unions

### DIFF
--- a/tests/baselines/reference/discriminatedUnionInference.js
+++ b/tests/baselines/reference/discriminatedUnionInference.js
@@ -1,0 +1,27 @@
+//// [discriminatedUnionInference.ts]
+// Repro from #28862
+
+type Foo<A> = { type: "foo", (): A[] };
+type Bar<A> = { type: "bar", (): A };
+
+type FooBar<A> = Foo<A> | Bar<A>;
+
+type InferA<T> = T extends FooBar<infer A> ? A : never;
+
+type FooA = InferA<Foo<number>>;  // number
+
+// Repro from #28862
+
+type Item<T> = { kind: 'a', data: T } | { kind: 'b', data: T[] };
+
+declare function foo<T>(item: Item<T>): T;
+
+let x1 = foo({ kind: 'a', data: 42 });  // number
+let x2 = foo({ kind: 'b', data: [1, 2] });  // number
+
+
+//// [discriminatedUnionInference.js]
+"use strict";
+// Repro from #28862
+var x1 = foo({ kind: 'a', data: 42 }); // number
+var x2 = foo({ kind: 'b', data: [1, 2] }); // number

--- a/tests/baselines/reference/discriminatedUnionInference.symbols
+++ b/tests/baselines/reference/discriminatedUnionInference.symbols
@@ -1,0 +1,68 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts ===
+// Repro from #28862
+
+type Foo<A> = { type: "foo", (): A[] };
+>Foo : Symbol(Foo, Decl(discriminatedUnionInference.ts, 0, 0))
+>A : Symbol(A, Decl(discriminatedUnionInference.ts, 2, 9))
+>type : Symbol(type, Decl(discriminatedUnionInference.ts, 2, 15))
+>A : Symbol(A, Decl(discriminatedUnionInference.ts, 2, 9))
+
+type Bar<A> = { type: "bar", (): A };
+>Bar : Symbol(Bar, Decl(discriminatedUnionInference.ts, 2, 39))
+>A : Symbol(A, Decl(discriminatedUnionInference.ts, 3, 9))
+>type : Symbol(type, Decl(discriminatedUnionInference.ts, 3, 15))
+>A : Symbol(A, Decl(discriminatedUnionInference.ts, 3, 9))
+
+type FooBar<A> = Foo<A> | Bar<A>;
+>FooBar : Symbol(FooBar, Decl(discriminatedUnionInference.ts, 3, 37))
+>A : Symbol(A, Decl(discriminatedUnionInference.ts, 5, 12))
+>Foo : Symbol(Foo, Decl(discriminatedUnionInference.ts, 0, 0))
+>A : Symbol(A, Decl(discriminatedUnionInference.ts, 5, 12))
+>Bar : Symbol(Bar, Decl(discriminatedUnionInference.ts, 2, 39))
+>A : Symbol(A, Decl(discriminatedUnionInference.ts, 5, 12))
+
+type InferA<T> = T extends FooBar<infer A> ? A : never;
+>InferA : Symbol(InferA, Decl(discriminatedUnionInference.ts, 5, 33))
+>T : Symbol(T, Decl(discriminatedUnionInference.ts, 7, 12))
+>T : Symbol(T, Decl(discriminatedUnionInference.ts, 7, 12))
+>FooBar : Symbol(FooBar, Decl(discriminatedUnionInference.ts, 3, 37))
+>A : Symbol(A, Decl(discriminatedUnionInference.ts, 7, 39))
+>A : Symbol(A, Decl(discriminatedUnionInference.ts, 7, 39))
+
+type FooA = InferA<Foo<number>>;  // number
+>FooA : Symbol(FooA, Decl(discriminatedUnionInference.ts, 7, 55))
+>InferA : Symbol(InferA, Decl(discriminatedUnionInference.ts, 5, 33))
+>Foo : Symbol(Foo, Decl(discriminatedUnionInference.ts, 0, 0))
+
+// Repro from #28862
+
+type Item<T> = { kind: 'a', data: T } | { kind: 'b', data: T[] };
+>Item : Symbol(Item, Decl(discriminatedUnionInference.ts, 9, 32))
+>T : Symbol(T, Decl(discriminatedUnionInference.ts, 13, 10))
+>kind : Symbol(kind, Decl(discriminatedUnionInference.ts, 13, 16))
+>data : Symbol(data, Decl(discriminatedUnionInference.ts, 13, 27))
+>T : Symbol(T, Decl(discriminatedUnionInference.ts, 13, 10))
+>kind : Symbol(kind, Decl(discriminatedUnionInference.ts, 13, 41))
+>data : Symbol(data, Decl(discriminatedUnionInference.ts, 13, 52))
+>T : Symbol(T, Decl(discriminatedUnionInference.ts, 13, 10))
+
+declare function foo<T>(item: Item<T>): T;
+>foo : Symbol(foo, Decl(discriminatedUnionInference.ts, 13, 65))
+>T : Symbol(T, Decl(discriminatedUnionInference.ts, 15, 21))
+>item : Symbol(item, Decl(discriminatedUnionInference.ts, 15, 24))
+>Item : Symbol(Item, Decl(discriminatedUnionInference.ts, 9, 32))
+>T : Symbol(T, Decl(discriminatedUnionInference.ts, 15, 21))
+>T : Symbol(T, Decl(discriminatedUnionInference.ts, 15, 21))
+
+let x1 = foo({ kind: 'a', data: 42 });  // number
+>x1 : Symbol(x1, Decl(discriminatedUnionInference.ts, 17, 3))
+>foo : Symbol(foo, Decl(discriminatedUnionInference.ts, 13, 65))
+>kind : Symbol(kind, Decl(discriminatedUnionInference.ts, 17, 14))
+>data : Symbol(data, Decl(discriminatedUnionInference.ts, 17, 25))
+
+let x2 = foo({ kind: 'b', data: [1, 2] });  // number
+>x2 : Symbol(x2, Decl(discriminatedUnionInference.ts, 18, 3))
+>foo : Symbol(foo, Decl(discriminatedUnionInference.ts, 13, 65))
+>kind : Symbol(kind, Decl(discriminatedUnionInference.ts, 18, 14))
+>data : Symbol(data, Decl(discriminatedUnionInference.ts, 18, 25))
+

--- a/tests/baselines/reference/discriminatedUnionInference.types
+++ b/tests/baselines/reference/discriminatedUnionInference.types
@@ -1,0 +1,55 @@
+=== tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts ===
+// Repro from #28862
+
+type Foo<A> = { type: "foo", (): A[] };
+>Foo : Foo<A>
+>type : "foo"
+
+type Bar<A> = { type: "bar", (): A };
+>Bar : Bar<A>
+>type : "bar"
+
+type FooBar<A> = Foo<A> | Bar<A>;
+>FooBar : FooBar<A>
+
+type InferA<T> = T extends FooBar<infer A> ? A : never;
+>InferA : InferA<T>
+
+type FooA = InferA<Foo<number>>;  // number
+>FooA : number
+
+// Repro from #28862
+
+type Item<T> = { kind: 'a', data: T } | { kind: 'b', data: T[] };
+>Item : Item<T>
+>kind : "a"
+>data : T
+>kind : "b"
+>data : T[]
+
+declare function foo<T>(item: Item<T>): T;
+>foo : <T>(item: Item<T>) => T
+>item : Item<T>
+
+let x1 = foo({ kind: 'a', data: 42 });  // number
+>x1 : number
+>foo({ kind: 'a', data: 42 }) : number
+>foo : <T>(item: Item<T>) => T
+>{ kind: 'a', data: 42 } : { kind: "a"; data: number; }
+>kind : "a"
+>'a' : "a"
+>data : number
+>42 : 42
+
+let x2 = foo({ kind: 'b', data: [1, 2] });  // number
+>x2 : number
+>foo({ kind: 'b', data: [1, 2] }) : number
+>foo : <T>(item: Item<T>) => T
+>{ kind: 'b', data: [1, 2] } : { kind: "b"; data: number[]; }
+>kind : "b"
+>'b' : "b"
+>data : number[]
+>[1, 2] : number[]
+>1 : 1
+>2 : 2
+

--- a/tests/baselines/reference/genericRestParameters3.errors.txt
+++ b/tests/baselines/reference/genericRestParameters3.errors.txt
@@ -22,8 +22,8 @@ tests/cases/conformance/types/rest/genericRestParameters3.ts(31,21): error TS234
     Property '0' is missing in type 'CoolArray<any>' but required in type '[(...args: any[]) => void]'.
 tests/cases/conformance/types/rest/genericRestParameters3.ts(38,32): error TS2345: Argument of type '[10, 20]' is not assignable to parameter of type 'CoolArray<number>'.
   Property 'hello' is missing in type '[10, 20]' but required in type 'CoolArray<number>'.
-tests/cases/conformance/types/rest/genericRestParameters3.ts(43,1): error TS2345: Argument of type '[]' is not assignable to parameter of type 'CoolArray<never>'.
-  Property 'hello' is missing in type '[]' but required in type 'CoolArray<never>'.
+tests/cases/conformance/types/rest/genericRestParameters3.ts(43,1): error TS2345: Argument of type '[]' is not assignable to parameter of type 'CoolArray<{}>'.
+  Property 'hello' is missing in type '[]' but required in type 'CoolArray<{}>'.
 tests/cases/conformance/types/rest/genericRestParameters3.ts(44,5): error TS2345: Argument of type '[number]' is not assignable to parameter of type 'CoolArray<{}>'.
   Property 'hello' is missing in type '[number]' but required in type 'CoolArray<{}>'.
 tests/cases/conformance/types/rest/genericRestParameters3.ts(45,5): error TS2345: Argument of type '[number, number]' is not assignable to parameter of type 'CoolArray<{}>'.
@@ -115,8 +115,8 @@ tests/cases/conformance/types/rest/genericRestParameters3.ts(53,5): error TS2345
     
     baz();       // Error
     ~~~~~
-!!! error TS2345: Argument of type '[]' is not assignable to parameter of type 'CoolArray<never>'.
-!!! error TS2345:   Property 'hello' is missing in type '[]' but required in type 'CoolArray<never>'.
+!!! error TS2345: Argument of type '[]' is not assignable to parameter of type 'CoolArray<{}>'.
+!!! error TS2345:   Property 'hello' is missing in type '[]' but required in type 'CoolArray<{}>'.
 !!! related TS2728 tests/cases/conformance/types/rest/genericRestParameters3.ts:24:5: 'hello' is declared here.
     baz(1);      // Error
         ~

--- a/tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts
@@ -1,0 +1,21 @@
+// @strict: true
+
+// Repro from #28862
+
+type Foo<A> = { type: "foo", (): A[] };
+type Bar<A> = { type: "bar", (): A };
+
+type FooBar<A> = Foo<A> | Bar<A>;
+
+type InferA<T> = T extends FooBar<infer A> ? A : never;
+
+type FooA = InferA<Foo<number>>;  // number
+
+// Repro from #28862
+
+type Item<T> = { kind: 'a', data: T } | { kind: 'b', data: T[] };
+
+declare function foo<T>(item: Item<T>): T;
+
+let x1 = foo({ kind: 'a', data: 42 });  // number
+let x2 = foo({ kind: 'b', data: [1, 2] });  // number


### PR DESCRIPTION
With this PR we improve type inference for discriminated unions by only inferring between constituent object types with matching discriminants. For example:

```ts
type Item<T> = { kind: 'a', data: T } | { kind: 'b', data: T[] };

declare function foo<T>(item: Item<T>): T;

let x1 = foo({ kind: 'a', data: 42 });  // number
let x2 = foo({ kind: 'b', data: [1, 2] });  // number
```

Previously this example would fail on `x2` because we'd infer `number[]` for `T`. Now we only infer to the variant with a matching `kind` property.

Fixes #28862.