### PR TITLE
Correct ErrorEventHandler param name.

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -17065,7 +17065,7 @@ interface DecodeSuccessCallback {
 }
 
 interface ErrorEventHandler {
-    (event: Event | string, source?: string, fileno?: number, columnNumber?: number, error?: Error): void;
+    (event: Event | string, source?: string, lineno?: number, columnNumber?: number, error?: Error): void;
 }
 
 interface EventHandlerNonNull {


### PR DESCRIPTION
The parameter name is lineno rather than fileno. Sending a PR since the parameter name is confusing.
https://html.spec.whatwg.org/multipage/webappapis.html#onerroreventhandler

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

