### PR TITLE
Enhancements to SourceMap decoder from tsserver

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -337,17 +337,14 @@ namespace ts {
         return result;
     }
 
-    export function getPositionOfLineAndCharacter(sourceFile: SourceFileLike, line: number, character: number): number {
-        return sourceFile.getPositionOfLineAndCharacter ?
-            sourceFile.getPositionOfLineAndCharacter(line, character) :
-            computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text);
-    }
-
+    export function getPositionOfLineAndCharacter(sourceFile: SourceFileLike, line: number, character: number): number;
     /* @internal */
-    export function getPositionOfLineAndCharacterWithEdits(sourceFile: SourceFileLike, line: number, character: number): number {
+    // tslint:disable-next-line:unified-signatures
+    export function getPositionOfLineAndCharacter(sourceFile: SourceFileLike, line: number, character: number, allowEdits?: true): number;
+    export function getPositionOfLineAndCharacter(sourceFile: SourceFileLike, line: number, character: number, allowEdits?: true): number {
         return sourceFile.getPositionOfLineAndCharacter ?
-            sourceFile.getPositionOfLineAndCharacter(line, character) :
-            computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text, /*allowEdits*/ true);
+            sourceFile.getPositionOfLineAndCharacter(line, character, allowEdits) :
+            computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text, allowEdits);
     }
 
     /* @internal */

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -338,12 +338,16 @@ namespace ts {
     }
 
     export function getPositionOfLineAndCharacter(sourceFile: SourceFileLike, line: number, character: number): number {
-        return computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text);
+        return sourceFile.getPositionOfLineAndCharacter ?
+            sourceFile.getPositionOfLineAndCharacter(line, character) :
+            computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text);
     }
 
     /* @internal */
     export function getPositionOfLineAndCharacterWithEdits(sourceFile: SourceFileLike, line: number, character: number): number {
-        return computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text, /*allowEdits*/ true);
+        return sourceFile.getPositionOfLineAndCharacter ?
+            sourceFile.getPositionOfLineAndCharacter(line, character) :
+            computePositionOfLineAndCharacter(getLineStarts(sourceFile), line, character, sourceFile.text, /*allowEdits*/ true);
     }
 
     /* @internal */

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -592,11 +592,9 @@ namespace ts {
         const mapDirectory = getDirectoryPath(mapPath);
         const sourceRoot = map.sourceRoot ? getNormalizedAbsolutePath(map.sourceRoot, mapDirectory) : mapDirectory;
         const generatedAbsoluteFilePath = getNormalizedAbsolutePath(map.file, mapDirectory);
-        const generatedCanonicalFilePath = host.getCanonicalFileName(generatedAbsoluteFilePath) as Path;
-        const generatedFile = host.getSourceFileLike(generatedCanonicalFilePath);
+        const generatedFile = host.getSourceFileLike(generatedAbsoluteFilePath);
         const sourceFileAbsolutePaths = map.sources.map(source => getNormalizedAbsolutePath(source, sourceRoot));
-        const sourceFileCanonicalPaths = sourceFileAbsolutePaths.map(source => host.getCanonicalFileName(source) as Path);
-        const sourceToSourceIndexMap = createMapFromEntries(sourceFileCanonicalPaths.map((source, i) => [source, i] as [string, number]));
+        const sourceToSourceIndexMap = createMapFromEntries(sourceFileAbsolutePaths.map((source, i) => [host.getCanonicalFileName(source), i] as [string, number]));
         let decodedMappings: ReadonlyArray<MappedPosition> | undefined;
         let generatedMappings: SortedReadonlyArray<MappedPosition> | undefined;
         let sourceMappings: ReadonlyArray<SortedReadonlyArray<SourceMappedPosition>> | undefined;
@@ -613,8 +611,7 @@ namespace ts {
             let source: string | undefined;
             let sourcePosition: number | undefined;
             if (isSourceMapping(mapping)) {
-                const sourceFilePath = sourceFileCanonicalPaths[mapping.sourceIndex];
-                const sourceFile = host.getSourceFileLike(sourceFilePath);
+                const sourceFile = host.getSourceFileLike(sourceFileAbsolutePaths[mapping.sourceIndex]);
                 source = map.sources[mapping.sourceIndex];
                 sourcePosition = sourceFile !== undefined
                     ? getPositionOfLineAndCharacterWithEdits(sourceFile, mapping.sourceLine, mapping.sourceCharacter)

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -266,14 +266,24 @@ namespace ts {
     const sourceMapCommentRegExp = /^\/\/[@#] source[M]appingURL=(.+)\s*$/;
     const whitespaceOrMapCommentRegExp = /^\s*(\/\/[@#] .*)?$/;
 
+    export interface LineInfo {
+        getLineCount(): number;
+        getLineText(line: number): string;
+    }
+
+    export function getLineInfo(text: string, lineStarts: ReadonlyArray<number>): LineInfo {
+        return {
+            getLineCount: () => lineStarts.length,
+            getLineText: line => text.substring(lineStarts[line], lineStarts[line + 1])
+        };
+    }
+
     /**
      * Tries to find the sourceMappingURL comment at the end of a file.
-     * @param text The source text of the file.
-     * @param lineStarts The line starts of the file.
      */
-    export function tryGetSourceMappingURL(text: string, lineStarts: ReadonlyArray<number> = computeLineStarts(text)) {
-        for (let index = lineStarts.length - 1; index >= 0; index--) {
-            const line = text.substring(lineStarts[index], lineStarts[index + 1]);
+    export function tryGetSourceMappingURL(lineInfo: LineInfo) {
+        for (let index = lineInfo.getLineCount() - 1; index >= 0; index--) {
+            const line = lineInfo.getLineText(index);
             const comment = sourceMapCommentRegExp.exec(line);
             if (comment) {
                 return comment[1];

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -616,7 +616,7 @@ namespace ts {
 
         function processMapping(mapping: Mapping): MappedPosition {
             const generatedPosition = generatedFile !== undefined
-                ? getPositionOfLineAndCharacterWithEdits(generatedFile, mapping.generatedLine, mapping.generatedCharacter)
+                ? getPositionOfLineAndCharacter(generatedFile, mapping.generatedLine, mapping.generatedCharacter, /*allowEdits*/ true)
                 : -1;
             let source: string | undefined;
             let sourcePosition: number | undefined;
@@ -624,7 +624,7 @@ namespace ts {
                 const sourceFile = host.getSourceFileLike(sourceFileAbsolutePaths[mapping.sourceIndex]);
                 source = map.sources[mapping.sourceIndex];
                 sourcePosition = sourceFile !== undefined
-                    ? getPositionOfLineAndCharacterWithEdits(sourceFile, mapping.sourceLine, mapping.sourceCharacter)
+                    ? getPositionOfLineAndCharacter(sourceFile, mapping.sourceLine, mapping.sourceCharacter, /*allowEdits*/ true)
                     : -1;
             }
             return {

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -583,6 +583,8 @@ namespace ts {
     }
 
     function compareSourcePositions(left: SourceMappedPosition, right: SourceMappedPosition) {
+        // Compares sourcePosition without comparing sourceIndex
+        // since the mappings are grouped by sourceIndex
         Debug.assert(left.sourceIndex === right.sourceIndex);
         return compareValues(left.sourcePosition, right.sourcePosition);
     }

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -583,7 +583,8 @@ namespace ts {
     }
 
     function compareSourcePositions(left: SourceMappedPosition, right: SourceMappedPosition) {
-        return compareValues(left.sourceIndex, right.sourceIndex);
+        Debug.assert(left.sourceIndex === right.sourceIndex);
+        return compareValues(left.sourcePosition, right.sourcePosition);
     }
 
     function compareGeneratedPositions(left: MappedPosition, right: MappedPosition) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5528,7 +5528,7 @@ namespace ts {
 
     /* @internal */
     export interface DocumentPositionMapperHost {
-        getSourceFileLike(path: Path): SourceFileLike | undefined;
+        getSourceFileLike(fileName: string): SourceFileLike | undefined;
         getCanonicalFileName(path: string): string;
         log(text: string): void;
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2615,7 +2615,7 @@ namespace ts {
         readonly text: string;
         lineMap?: ReadonlyArray<number>;
         /* @internal */
-        getPositionOfLineAndCharacter?(line: number, character: number): number;
+        getPositionOfLineAndCharacter?(line: number, character: number, allowEdits?: true): number;
     }
 
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5530,7 +5530,7 @@ namespace ts {
     export interface DocumentPositionMapperHost {
         getSourceFileLike(path: Path): SourceFileLike | undefined;
         getCanonicalFileName(path: string): string;
-        log?(text: string): void;
+        log(text: string): void;
     }
 
     /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2614,6 +2614,8 @@ namespace ts {
     export interface SourceFileLike {
         readonly text: string;
         lineMap?: ReadonlyArray<number>;
+        /* @internal */
+        getPositionOfLineAndCharacter?(line: number, character: number): number;
     }
 
 

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -69,7 +69,7 @@ namespace Harness.SourceMapRecorder {
             SourceMapDecoder.initializeSourceMapDecoding(sourceMapData);
             sourceMapRecorder.WriteLine("===================================================================");
             sourceMapRecorder.WriteLine("JsFile: " + sourceMapData.sourceMap.file);
-            sourceMapRecorder.WriteLine("mapUrl: " + ts.tryGetSourceMappingURL(jsFile.text, jsLineMap));
+            sourceMapRecorder.WriteLine("mapUrl: " + ts.tryGetSourceMappingURL(ts.getLineInfo(jsFile.text, jsLineMap)));
             sourceMapRecorder.WriteLine("sourceRoot: " + sourceMapData.sourceMap.sourceRoot);
             sourceMapRecorder.WriteLine("sources: " + sourceMapData.sourceMap.sources);
             if (sourceMapData.sourceMap.sourcesContent) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2316,7 +2316,7 @@ namespace ts.server {
                         const lineOffset = info.positionToLineOffset(pos);
                         return { line: lineOffset.line - 1, character: lineOffset.offset - 1 };
                     },
-                    getPositionOfLineAndCharacter: (line, character) => info.lineOffsetToPosition(line + 1, character + 1)
+                    getPositionOfLineAndCharacter: (line, character, allowEdits) => info.lineOffsetToPosition(line + 1, character + 1, allowEdits)
                 };
             }
             return info.sourceFileLike;

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2298,7 +2298,6 @@ namespace ts.server {
             }
             else if (mapFileNameFromDeclarationInfo) {
                 declarationInfo.sourceMapFilePath = {
-                    declarationInfoPath: declarationInfo.path,
                     watcher: this.addMissingSourceMapFile(
                         project.currentDirectory === this.currentDirectory ?
                             mapFileNameFromDeclarationInfo :

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2604,7 +2604,7 @@ namespace ts.server {
 
         /** @internal */
         fileExists(fileName: NormalizedPath): boolean {
-            return this.filenameToScriptInfo.has(fileName) || this.host.fileExists(fileName);
+            return !!this.getScriptInfoForNormalizedPath(fileName) || this.host.fileExists(fileName);
         }
 
         private findExternalProjectContainingOpenScriptInfo(info: ScriptInfo): ExternalProject | undefined {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -504,8 +504,8 @@ namespace ts.server {
         }
 
         /*@internal*/
-        getDocumentPositionMapper(fileName: string): DocumentPositionMapper | undefined {
-            return this.projectService.getDocumentPositionMapper(fileName, this);
+        getDocumentPositionMapper(generatedFileName: string, sourceFileName?: string): DocumentPositionMapper | undefined {
+            return this.projectService.getDocumentPositionMapper(this, generatedFileName, sourceFileName);
         }
 
         /*@internal*/

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -505,62 +505,12 @@ namespace ts.server {
 
         /*@internal*/
         getDocumentPositionMapper(fileName: string): DocumentPositionMapper | undefined {
-            const declarationInfo = this.projectService.getOrCreateScriptInfoNotOpenedByClient(fileName, this.currentDirectory, this.directoryStructureHost);
-            if (!declarationInfo) return undefined;
-
-            declarationInfo.getSnapshot(); // Ensure synchronized
-            const existingMapper = declarationInfo.textStorage.mapper;
-            if (existingMapper !== undefined) {
-                return existingMapper ? existingMapper : undefined;
-            }
-
-            // Create the mapper
-            declarationInfo.mapInfo = undefined;
-
-            const mapper = getDocumentPositionMapper({
-                getCanonicalFileName: this.projectService.toCanonicalFileName,
-                log: s => this.log(s),
-                readMapFile: f => this.readMapFile(f, declarationInfo),
-                getSourceFileLike: f => this.getSourceFileLike(f)
-            }, declarationInfo.fileName, declarationInfo.textStorage.getLineInfo());
-            declarationInfo.textStorage.mapper = mapper || false;
-            return mapper;
-        }
-
-        private readMapFile(fileName: string, declarationInfo: ScriptInfo) {
-            const mapInfo = this.projectService.getOrCreateScriptInfoNotOpenedByClient(fileName, this.currentDirectory, this.directoryStructureHost);
-            if (!mapInfo) return undefined;
-            declarationInfo.mapInfo = mapInfo;
-            const snap = mapInfo.getSnapshot();
-            return snap.getText(0, snap.getLength());
+            return this.projectService.getDocumentPositionMapper(fileName, this);
         }
 
         /*@internal*/
         getSourceFileLike(fileName: string) {
-            const path = this.toPath(fileName);
-            const sourceFile = this.getSourceFile(path);
-            if (sourceFile && sourceFile.resolvedPath === path) return sourceFile;
-
-            // Need to look for other files.
-            const info = this.projectService.getOrCreateScriptInfoNotOpenedByClient(fileName, this.currentDirectory, this.directoryStructureHost);
-            if (!info) return undefined;
-
-            // Key doesnt matter since its only for text and lines
-            if (info.cacheSourceFile) return info.cacheSourceFile.sourceFile;
-            if (info.textStorage.sourceFileLike) return info.textStorage.sourceFileLike;
-
-            info.textStorage.sourceFileLike = {
-                get text() {
-                    Debug.fail("shouldnt need text");
-                    return "";
-                },
-                getLineAndCharacterOfPosition: pos => {
-                    const lineOffset = info.positionToLineOffset(pos);
-                    return { line: lineOffset.line - 1, character: lineOffset.offset - 1 };
-                },
-                getPositionOfLineAndCharacter: (line, character) => info.lineOffsetToPosition(line + 1, character + 1)
-            };
-            return info.textStorage.sourceFileLike;
+            return this.projectService.getSourceFileLike(fileName, this);
         }
 
         private shouldEmitFile(scriptInfo: ScriptInfo) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -759,7 +759,10 @@ namespace ts.server {
         }
 
         containsScriptInfo(info: ScriptInfo): boolean {
-            return this.isRoot(info) || (!!this.program && this.program.getSourceFileByPath(info.path) !== undefined);
+            if (this.isRoot(info)) return true;
+            if (!this.program) return false;
+            const file = this.program.getSourceFileByPath(info.path);
+            return !!file && file.resolvedPath === info.path;
         }
 
         containsFile(filename: NormalizedPath, requireOpen?: boolean): boolean {

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -69,7 +69,7 @@ namespace ts.server {
             this.info.sourceMapFilePath = undefined;
             this.info.declarationInfoPath = undefined;
             this.info.sourceInfos = undefined;
-            this.info.mapper = undefined;
+            this.info.documentPositionMapper = undefined;
         }
 
         /** Public for testing */
@@ -317,7 +317,7 @@ namespace ts.server {
         /*@internal*/
         sourceInfos?: Map<true>;
         /*@internal*/
-        mapper?: DocumentPositionMapper | false;
+        documentPositionMapper?: DocumentPositionMapper | false;
 
         constructor(
             private readonly host: ServerHost,

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -186,9 +186,9 @@ namespace ts.server {
          * @param line 1 based index
          * @param offset 1 based index
          */
-        lineOffsetToPosition(line: number, offset: number): number {
+        lineOffsetToPosition(line: number, offset: number, allowEdits?: true): number {
             if (!this.useScriptVersionCacheIfValidOrOpen()) {
-                return computePositionOfLineAndCharacter(this.getLineMap(), line - 1, offset - 1, this.text);
+                return computePositionOfLineAndCharacter(this.getLineMap(), line - 1, offset - 1, this.text, allowEdits);
             }
 
             // TODO: assert this offset is actually on the line
@@ -586,8 +586,12 @@ namespace ts.server {
          * @param line 1 based index
          * @param offset 1 based index
          */
-        lineOffsetToPosition(line: number, offset: number): number {
-            return this.textStorage.lineOffsetToPosition(line, offset);
+        lineOffsetToPosition(line: number, offset: number): number;
+        /*@internal*/
+        // tslint:disable-next-line:unified-signatures
+        lineOffsetToPosition(line: number, offset: number, allowEdits?: true): number;
+        lineOffsetToPosition(line: number, offset: number, allowEdits?: true): number {
+            return this.textStorage.lineOffsetToPosition(line, offset, allowEdits);
         }
 
         positionToLineOffset(position: number): protocol.Location {

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -64,14 +64,20 @@ namespace ts.server {
             this.switchToScriptVersionCache();
         }
 
+        private resetSourceMapInfo() {
+            this.info.mapper = undefined;
+            this.info.sourceFileLike = undefined;
+            this.info.mapInfo = undefined;
+            this.info.sourceInfos = undefined;
+        }
+
         /** Public for testing */
         public useText(newText?: string) {
             this.svc = undefined;
             this.text = newText;
             this.lineMap = undefined;
             this.fileSize = undefined;
-            this.info.mapper = undefined;
-            this.info.sourceFileLike = undefined;
+            this.resetSourceMapInfo();
             this.version.text++;
         }
 
@@ -81,8 +87,7 @@ namespace ts.server {
             this.text = undefined;
             this.lineMap = undefined;
             this.fileSize = undefined;
-            this.info.mapper = undefined;
-            this.info.sourceFileLike = undefined;
+            this.resetSourceMapInfo();
         }
 
         /**
@@ -304,7 +309,7 @@ namespace ts.server {
         /*@internal*/
         sourceInfos?: Map<true>;
         /*@internal*/
-        mapper: DocumentPositionMapper | false | undefined = false;
+        mapper?: DocumentPositionMapper | false;
         /*@internal*/
         sourceFileLike: SourceFileLike | undefined;
 

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -302,6 +302,8 @@ namespace ts.server {
         /*@internal*/
         mapInfo?: ScriptInfo;
         /*@internal*/
+        sourceInfos?: Map<true>;
+        /*@internal*/
         mapper: DocumentPositionMapper | false | undefined = false;
         /*@internal*/
         sourceFileLike: SourceFileLike | undefined;

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -65,10 +65,11 @@ namespace ts.server {
         }
 
         private resetSourceMapInfo() {
-            this.info.mapper = undefined;
             this.info.sourceFileLike = undefined;
-            this.info.mapInfo = undefined;
+            this.info.sourceMapFilePath = undefined;
+            this.info.declarationInfoPath = undefined;
             this.info.sourceInfos = undefined;
+            this.info.mapper = undefined;
         }
 
         /** Public for testing */
@@ -305,13 +306,18 @@ namespace ts.server {
         mTime?: number;
 
         /*@internal*/
-        mapInfo?: ScriptInfo;
+        sourceFileLike?: SourceFileLike;
+
+        /*@internal*/
+        sourceMapFilePath?: Path | false;
+
+        // Present on sourceMapFile info
+        /*@internal*/
+        declarationInfoPath?: Path;
         /*@internal*/
         sourceInfos?: Map<true>;
         /*@internal*/
         mapper?: DocumentPositionMapper | false;
-        /*@internal*/
-        sourceFileLike: SourceFileLike | undefined;
 
         constructor(
             private readonly host: ServerHost,

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -46,9 +46,6 @@ namespace ts.server {
          */
         private pendingReloadFromDisk = false;
 
-        mapper: DocumentPositionMapper | false | undefined = false;
-        sourceFileLike: SourceFileLike | undefined;
-
         constructor(private readonly host: ServerHost, private readonly fileName: NormalizedPath, initialVersion: ScriptInfoVersion | undefined, private readonly info: ScriptInfo) {
             this.version = initialVersion || { svc: 0, text: 0 };
         }
@@ -73,8 +70,8 @@ namespace ts.server {
             this.text = newText;
             this.lineMap = undefined;
             this.fileSize = undefined;
-            this.mapper = undefined;
-            this.sourceFileLike = undefined;
+            this.info.mapper = undefined;
+            this.info.sourceFileLike = undefined;
             this.version.text++;
         }
 
@@ -84,8 +81,8 @@ namespace ts.server {
             this.text = undefined;
             this.lineMap = undefined;
             this.fileSize = undefined;
-            this.mapper = undefined;
-            this.sourceFileLike = undefined;
+            this.info.mapper = undefined;
+            this.info.sourceFileLike = undefined;
         }
 
         /**
@@ -287,7 +284,7 @@ namespace ts.server {
 
         /* @internal */
         fileWatcher: FileWatcher | undefined;
-        /* @internal */ textStorage: TextStorage;
+        private textStorage: TextStorage;
 
         /*@internal*/
         readonly isDynamic: boolean;
@@ -304,6 +301,10 @@ namespace ts.server {
 
         /*@internal*/
         mapInfo?: ScriptInfo;
+        /*@internal*/
+        mapper: DocumentPositionMapper | false | undefined = false;
+        /*@internal*/
+        sourceFileLike: SourceFileLike | undefined;
 
         constructor(
             private readonly host: ServerHost,
@@ -582,6 +583,11 @@ namespace ts.server {
 
         public isJavaScript() {
             return this.scriptKind === ScriptKind.JS || this.scriptKind === ScriptKind.JSX;
+        }
+
+        /*@internal*/
+        getLineInfo(): LineInfo {
+            return this.textStorage.getLineInfo();
         }
     }
 }

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -66,6 +66,7 @@ namespace ts.server {
 
         private resetSourceMapInfo() {
             this.info.sourceFileLike = undefined;
+            this.info.closeSourceMapFileWatcher();
             this.info.sourceMapFilePath = undefined;
             this.info.declarationInfoPath = undefined;
             this.info.sourceInfos = undefined;
@@ -280,6 +281,13 @@ namespace ts.server {
         sourceFile: SourceFile;
     }
 
+    /*@internal*/
+    export interface SourceMapFileWatcher {
+        declarationInfoPath: Path;
+        watcher: FileWatcher;
+        sourceInfos?: Map<true>;
+    }
+
     export class ScriptInfo {
         /**
          * All projects that include this file
@@ -309,7 +317,7 @@ namespace ts.server {
         sourceFileLike?: SourceFileLike;
 
         /*@internal*/
-        sourceMapFilePath?: Path | false;
+        sourceMapFilePath?: Path | SourceMapFileWatcher | false;
 
         // Present on sourceMapFile info
         /*@internal*/
@@ -605,6 +613,14 @@ namespace ts.server {
         /*@internal*/
         getLineInfo(): LineInfo {
             return this.textStorage.getLineInfo();
+        }
+
+        /*@internal*/
+        closeSourceMapFileWatcher() {
+            if (this.sourceMapFilePath && !isString(this.sourceMapFilePath)) {
+                closeFileWatcherOf(this.sourceMapFilePath);
+                this.sourceMapFilePath = undefined;
+            }
         }
     }
 }

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -283,7 +283,6 @@ namespace ts.server {
 
     /*@internal*/
     export interface SourceMapFileWatcher {
-        declarationInfoPath: Path;
         watcher: FileWatcher;
         sourceInfos?: Map<true>;
     }

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -308,8 +308,8 @@ namespace ts.server {
             return this._getSnapshot().version;
         }
 
-        getLineInfo(line: number): AbsolutePositionAndLineText {
-            return this._getSnapshot().index.lineNumberToInfo(line);
+        getAbsolutePositionAndLineText(oneBasedLine: number): AbsolutePositionAndLineText {
+            return this._getSnapshot().index.lineNumberToInfo(oneBasedLine);
         }
 
         lineOffsetToPosition(line: number, column: number): number {
@@ -346,6 +346,10 @@ namespace ts.server {
             else {
                 return unchangedTextChangeRange;
             }
+        }
+
+        getLineCount() {
+            return this._getSnapshot().index.getLineCount();
         }
 
         static fromString(script: string) {
@@ -400,8 +404,12 @@ namespace ts.server {
             return this.root.charOffsetToLineInfo(1, position);
         }
 
+        getLineCount() {
+            return this.root.lineCount();
+        }
+
         lineNumberToInfo(oneBasedLine: number): AbsolutePositionAndLineText {
-            const lineCount = this.root.lineCount();
+            const lineCount = this.getLineCount();
             if (oneBasedLine <= lineCount) {
                 const { position, leaf } = this.root.lineNumberToInfo(oneBasedLine, 0);
                 return { absolutePosition: position, lineText: leaf && leaf.text };

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1474,7 +1474,7 @@ namespace ts.server {
             // only to the previous line.  If all this is true, then
             // add edits necessary to properly indent the current line.
             if ((args.key === "\n") && ((!edits) || (edits.length === 0) || allEditsBeforePos(edits, position))) {
-                const { lineText, absolutePosition } = scriptInfo.getLineInfo(args.line);
+                const { lineText, absolutePosition } = scriptInfo.getAbsolutePositionAndLineText(args.line);
                 if (lineText && lineText.search("\\S") < 0) {
                     const preferredIndent = languageService.getIndentationAtPosition(file, position, formatOptions);
                     let hasIndent = 0;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1145,7 +1145,7 @@ namespace ts {
             getProgram,
             fileExists: host.fileExists && (f => host.fileExists!(f)),
             readFile: host.readFile && ((f, encoding) => host.readFile!(f, encoding)),
-            getDocumentPositionMapper: host.getDocumentPositionMapper && (f => host.getDocumentPositionMapper!(f)),
+            getDocumentPositionMapper: host.getDocumentPositionMapper && ((generatedFileName, sourceFileName) => host.getDocumentPositionMapper!(generatedFileName, sourceFileName)),
             getSourceFileLike: host.getSourceFileLike && (f => host.getSourceFileLike!(f)),
             log
         });

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -602,8 +602,8 @@ namespace ts {
             return getLineStarts(this);
         }
 
-        public getPositionOfLineAndCharacter(line: number, character: number): number {
-            return computePositionOfLineAndCharacter(getLineStarts(this), line, character, this.text);
+        public getPositionOfLineAndCharacter(line: number, character: number, allowEdits?: true): number {
+            return computePositionOfLineAndCharacter(getLineStarts(this), line, character, this.text, allowEdits);
         }
 
         public getLineEndOfPosition(pos: number): number {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -603,7 +603,7 @@ namespace ts {
         }
 
         public getPositionOfLineAndCharacter(line: number, character: number): number {
-            return getPositionOfLineAndCharacter(this, line, character);
+            return computePositionOfLineAndCharacter(getLineStarts(this), line, character, this.text);
         }
 
         public getLineEndOfPosition(pos: number): number {
@@ -1143,8 +1143,10 @@ namespace ts {
             useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
             getCurrentDirectory: () => currentDirectory,
             getProgram,
-            fileExists: host.fileExists ? f => host.fileExists!(f) : returnFalse,
-            readFile: host.readFile ? (f, encoding) => host.readFile!(f, encoding) : () => undefined,
+            fileExists: host.fileExists && (f => host.fileExists!(f)),
+            readFile: host.readFile && ((f, encoding) => host.readFile!(f, encoding)),
+            getDocumentPositionMapper: host.getDocumentPositionMapper && (f => host.getDocumentPositionMapper!(f)),
+            getSourceFileLike: host.getSourceFileLike && (f => host.getSourceFileLike!(f)),
             log
         });
 

--- a/src/services/sourcemaps.ts
+++ b/src/services/sourcemaps.ts
@@ -39,9 +39,10 @@ namespace ts {
                 // obviously invalid map
                 return file.sourceMapper = identitySourceMapConsumer;
             }
-            const program = getProgram();
+
             return file.sourceMapper = createDocumentPositionMapper({
                 getSourceFileLike: s => {
+                    const program = getProgram();
                     // Lookup file in program, if provided
                     const file = program && program.getSourceFileByPath(s);
                     // file returned here could be .d.ts when asked for .ts file if projectReferences and module resolution created this source file

--- a/src/services/sourcemaps.ts
+++ b/src/services/sourcemaps.ts
@@ -127,11 +127,17 @@ namespace ts {
         }
     }
 
+    /**
+     * string | undefined to contents of map file to create DocumentPositionMapper from it
+     * DocumentPositionMapper | false to give back cached DocumentPositionMapper
+     */
+    export type ReadMapFile = (mapFileName: string) => string | undefined | DocumentPositionMapper | false;
+
     export function getDocumentPositionMapper(
         host: DocumentPositionMapperHost,
         generatedFileName: string,
         generatedFileLineInfo: LineInfo,
-        readMapFile: (fileName: string) => string | undefined) {
+        readMapFile: ReadMapFile) {
         let mapFileName = tryGetSourceMappingURL(generatedFileLineInfo);
         if (mapFileName) {
             const match = base64UrlRegExp.exec(mapFileName);
@@ -152,8 +158,11 @@ namespace ts {
         for (const location of possibleMapLocations) {
             const mapFileName = getNormalizedAbsolutePath(location, getDirectoryPath(generatedFileName));
             const mapFileContents = readMapFile(mapFileName);
-            if (mapFileContents) {
+            if (isString(mapFileContents)) {
                 return convertDocumentToSourceMapper(host, mapFileContents, mapFileName);
+            }
+            if (mapFileContents !== undefined) {
+                return mapFileContents || undefined;
             }
         }
         return undefined;

--- a/src/services/sourcemaps.ts
+++ b/src/services/sourcemaps.ts
@@ -131,7 +131,7 @@ namespace ts {
      * string | undefined to contents of map file to create DocumentPositionMapper from it
      * DocumentPositionMapper | false to give back cached DocumentPositionMapper
      */
-    export type ReadMapFile = (mapFileName: string) => string | undefined | DocumentPositionMapper | false;
+    export type ReadMapFile = (mapFileName: string, mapFileNameFromDts: string | undefined) => string | undefined | DocumentPositionMapper | false;
 
     export function getDocumentPositionMapper(
         host: DocumentPositionMapperHost,
@@ -155,9 +155,10 @@ namespace ts {
             possibleMapLocations.push(mapFileName);
         }
         possibleMapLocations.push(generatedFileName + ".map");
+        const originalMapFileName = mapFileName && getNormalizedAbsolutePath(mapFileName, getDirectoryPath(generatedFileName));
         for (const location of possibleMapLocations) {
             const mapFileName = getNormalizedAbsolutePath(location, getDirectoryPath(generatedFileName));
-            const mapFileContents = readMapFile(mapFileName);
+            const mapFileContents = readMapFile(mapFileName, originalMapFileName);
             if (isString(mapFileContents)) {
                 return convertDocumentToSourceMapper(host, mapFileContents, mapFileName);
             }

--- a/src/services/sourcemaps.ts
+++ b/src/services/sourcemaps.ts
@@ -97,7 +97,6 @@ namespace ts {
             const fileFromCache = sourceFileLike.get(path);
             if (fileFromCache !== undefined) return fileFromCache ? fileFromCache : undefined;
 
-            // TODO: should ask host instead?
             if (!host.readFile || host.fileExists && !host.fileExists(path)) {
                 sourceFileLike.set(path, false);
                 return undefined;

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -234,7 +234,7 @@ namespace ts {
         writeFile?(fileName: string, content: string): void;
 
         /* @internal */
-        getDocumentPositionMapper?(fileName: string): DocumentPositionMapper | undefined;
+        getDocumentPositionMapper?(generatedFileName: string, sourceFileName?: string): DocumentPositionMapper | undefined;
         /* @internal */
         getSourceFileLike?(fileName: string): SourceFileLike | undefined;
     }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -91,7 +91,6 @@ namespace ts {
 
     export interface SourceFileLike {
         getLineAndCharacterOfPosition(pos: number): LineAndCharacter;
-        /*@internal*/ sourceMapper?: DocumentPositionMapper;
     }
 
     export interface SourceMapSource {
@@ -233,6 +232,11 @@ namespace ts {
         installPackage?(options: InstallPackageOptions): Promise<ApplyCodeActionCommandResult>;
         /* @internal */ inspectValue?(options: InspectValueOptions): Promise<ValueInfo>;
         writeFile?(fileName: string, content: string): void;
+
+        /* @internal */
+        getDocumentPositionMapper?(fileName: string): DocumentPositionMapper | undefined;
+        /* @internal */
+        getSourceFileLike?(fileName: string): SourceFileLike | undefined;
     }
 
     /* @internal */

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1282,11 +1282,11 @@ namespace ts {
         return !!compilerOptions.module || compilerOptions.target! >= ScriptTarget.ES2015 || !!compilerOptions.noEmit;
     }
 
-    export function hostUsesCaseSensitiveFileNames(host: LanguageServiceHost): boolean {
+    export function hostUsesCaseSensitiveFileNames(host: { useCaseSensitiveFileNames?(): boolean; }): boolean {
         return host.useCaseSensitiveFileNames ? host.useCaseSensitiveFileNames() : false;
     }
 
-    export function hostGetCanonicalFileName(host: LanguageServiceHost): GetCanonicalFileName {
+    export function hostGetCanonicalFileName(host: { useCaseSensitiveFileNames?(): boolean; }): GetCanonicalFileName {
         return createGetCanonicalFileName(hostUsesCaseSensitiveFileNames(host));
     }
 

--- a/src/testRunner/unittests/textStorage.ts
+++ b/src/testRunner/unittests/textStorage.ts
@@ -60,7 +60,7 @@ namespace ts.textStorage {
             ts1.useText();
             assert.isFalse(ts1.hasScriptVersionCache_TestOnly(), "should not have script version cache - 2");
 
-            ts1.getLineInfo(0);
+            ts1.getAbsolutePositionAndLineText(0);
             assert.isTrue(ts1.hasScriptVersionCache_TestOnly(), "have script version cache - 2");
         });
 

--- a/src/testRunner/unittests/textStorage.ts
+++ b/src/testRunner/unittests/textStorage.ts
@@ -14,8 +14,8 @@ namespace ts.textStorage {
 
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, /*info*/undefined!);
-            const ts2 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, /*info*/undefined!);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
+            const ts2 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
 
             ts1.useScriptVersionCache_TestOnly();
             ts2.useText();
@@ -49,7 +49,7 @@ namespace ts.textStorage {
         it("should switch to script version cache if necessary", () => {
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, /*info*/undefined!);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
 
             ts1.getSnapshot();
             assert.isFalse(ts1.hasScriptVersionCache_TestOnly(), "should not have script version cache - 1");
@@ -67,7 +67,7 @@ namespace ts.textStorage {
         it("should be able to return the file size immediately after construction", () => {
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, /*info*/undefined!);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
 
             assert.strictEqual(f.content.length, ts1.getTelemetryFileSize());
         });
@@ -75,7 +75,7 @@ namespace ts.textStorage {
         it("should be able to return the file size when backed by text", () => {
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, /*info*/undefined!);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
 
             ts1.useText(f.content);
             assert.isFalse(ts1.hasScriptVersionCache_TestOnly());
@@ -86,7 +86,7 @@ namespace ts.textStorage {
         it("should be able to return the file size when backed by a script version cache", () => {
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, /*info*/undefined!);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
 
             ts1.useScriptVersionCache_TestOnly();
             assert.isTrue(ts1.hasScriptVersionCache_TestOnly());
@@ -126,7 +126,7 @@ namespace ts.textStorage {
 
             const host = projectSystem.createServerHost([changingFile]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(changingFile.path), /*initialVersion*/ undefined, /*info*/undefined!);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(changingFile.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
 
             assert.isTrue(ts1.reloadFromDisk());
 

--- a/src/testRunner/unittests/textStorage.ts
+++ b/src/testRunner/unittests/textStorage.ts
@@ -10,12 +10,16 @@ namespace ts.textStorage {
                 }`
         };
 
+        function getDummyScriptInfo() {
+            return { closeSourceMapFileWatcher: noop } as server.ScriptInfo;
+        }
+
         it("text based storage should be have exactly the same as script version cache", () => {
 
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
-            const ts2 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, getDummyScriptInfo());
+            const ts2 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, getDummyScriptInfo());
 
             ts1.useScriptVersionCache_TestOnly();
             ts2.useText();
@@ -49,7 +53,7 @@ namespace ts.textStorage {
         it("should switch to script version cache if necessary", () => {
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, getDummyScriptInfo());
 
             ts1.getSnapshot();
             assert.isFalse(ts1.hasScriptVersionCache_TestOnly(), "should not have script version cache - 1");
@@ -67,7 +71,7 @@ namespace ts.textStorage {
         it("should be able to return the file size immediately after construction", () => {
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, getDummyScriptInfo());
 
             assert.strictEqual(f.content.length, ts1.getTelemetryFileSize());
         });
@@ -75,7 +79,7 @@ namespace ts.textStorage {
         it("should be able to return the file size when backed by text", () => {
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, getDummyScriptInfo());
 
             ts1.useText(f.content);
             assert.isFalse(ts1.hasScriptVersionCache_TestOnly());
@@ -86,7 +90,7 @@ namespace ts.textStorage {
         it("should be able to return the file size when backed by a script version cache", () => {
             const host = projectSystem.createServerHost([f]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path), /*initialVersion*/ undefined, getDummyScriptInfo());
 
             ts1.useScriptVersionCache_TestOnly();
             assert.isTrue(ts1.hasScriptVersionCache_TestOnly());
@@ -126,7 +130,7 @@ namespace ts.textStorage {
 
             const host = projectSystem.createServerHost([changingFile]);
             // Since script info is not used in these tests, just cheat by passing undefined
-            const ts1 = new server.TextStorage(host, server.asNormalizedPath(changingFile.path), /*initialVersion*/ undefined, {} as server.ScriptInfo);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(changingFile.path), /*initialVersion*/ undefined, getDummyScriptInfo());
 
             assert.isTrue(ts1.reloadFromDisk());
 

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -10757,7 +10757,6 @@ fn5();`
                 openFilesForSession([dependencyTs, randomFile], session);
                 checkNumberOfProjects(service, { configuredProjects: 2 });
                 checkProjectActualFiles(service.configuredProjects.get(dependencyConfig.path)!, [dependencyTs.path, libFile.path, dependencyConfig.path]);
-                debugger;
                 for (let i = 0; i < 5; i++) {
                     const startSpan = { line: i + 1, offset: 17 };
                     const response = session.executeCommandSeq<protocol.RenameRequest>({

--- a/src/testRunner/unittests/tsserverProjectSystem.ts
+++ b/src/testRunner/unittests/tsserverProjectSystem.ts
@@ -10899,6 +10899,9 @@ fn5();
                     /*openFileLastLine*/ 6
                 );
             });
+
+            // TODO: test project changes when both projects are open
+            // TODO: project change when dependency is not built
         });
     });
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8210,7 +8210,6 @@ declare namespace ts.server {
         getGlobalProjectErrors(): ReadonlyArray<Diagnostic>;
         getAllProjectErrors(): ReadonlyArray<Diagnostic>;
         getLanguageService(ensureSynchronized?: boolean): LanguageService;
-        private readMapFile;
         private shouldEmitFile;
         getCompileOnSaveAffectedFileList(scriptInfo: ScriptInfo): string[];
         /**

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8497,10 +8497,6 @@ declare namespace ts.server {
         syntaxOnly?: boolean;
     }
     class ProjectService {
-        /**
-         * Container of all known scripts
-         */
-        private readonly filenameToScriptInfo;
         private readonly scriptInfoInNodeModulesWatchers;
         /**
          * Contains all the deleted script info's version information so that

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8046,6 +8046,7 @@ declare namespace ts.server {
         readonly containingProjects: Project[];
         private formatSettings;
         private preferences;
+        private textStorage;
         constructor(host: ServerHost, fileName: NormalizedPath, scriptKind: ScriptKind, hasMixedContent: boolean, path: Path, initialVersion?: ScriptInfoVersion);
         isScriptOpen(): boolean;
         open(newText: string): void;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8046,7 +8046,6 @@ declare namespace ts.server {
         readonly containingProjects: Project[];
         private formatSettings;
         private preferences;
-        private textStorage;
         constructor(host: ServerHost, fileName: NormalizedPath, scriptKind: ScriptKind, hasMixedContent: boolean, path: Path, initialVersion?: ScriptInfoVersion);
         isScriptOpen(): boolean;
         open(newText: string): void;
@@ -8211,6 +8210,7 @@ declare namespace ts.server {
         getGlobalProjectErrors(): ReadonlyArray<Diagnostic>;
         getAllProjectErrors(): ReadonlyArray<Diagnostic>;
         getLanguageService(ensureSynchronized?: boolean): LanguageService;
+        private readMapFile;
         private shouldEmitFile;
         getCompileOnSaveAffectedFileList(scriptInfo: ScriptInfo): string[];
         /**

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8595,6 +8595,9 @@ declare namespace ts.server {
         getHostFormatCodeOptions(): FormatCodeSettings;
         getHostPreferences(): protocol.UserPreferences;
         private onSourceFileChanged;
+        private handleSourceMapProjects;
+        private delayUpdateSourceInfoProjects;
+        private delayUpdateProjectsOfScriptInfoPath;
         private handleDeletedFile;
         private onConfigChangedForConfiguredProject;
         /**
@@ -8722,6 +8725,7 @@ declare namespace ts.server {
         private findExternalProjectContainingOpenScriptInfo;
         openClientFileWithNormalizedPath(fileName: NormalizedPath, fileContent?: string, scriptKind?: ScriptKind, hasMixedContent?: boolean, projectRootPath?: NormalizedPath): OpenConfiguredProjectResult;
         private removeOrphanConfiguredProjects;
+        private removeOrphanScriptInfos;
         private telemetryOnOpenFile;
         /**
          * Close file whose contents is managed by the client

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -8688,6 +8688,8 @@ declare namespace ts.server {
          */
         getScriptInfoForNormalizedPath(fileName: NormalizedPath): ScriptInfo | undefined;
         getScriptInfoForPath(fileName: Path): ScriptInfo | undefined;
+        private addSourceInfoToSourceMap;
+        private addMissingSourceMapFile;
         setHostConfiguration(args: protocol.ConfigureRequestArguments): void;
         closeLog(): void;
         /**


### PR DESCRIPTION
Current design for creation of source map decoder per project isn't efficient for tsserver. It could be referencing multiple projects for same declaration source map's and each project creates its own source map decoder. Apart from that each source map decoder reads for files and caches them in the decoder for files that aren't present in the program corresponding to the project.

With this approach, it adds a method on `LanguageServiceHost` as
- `getDocumentPositionMapper`: When provided it uses this method to get the document position mapper instead of creating one on its own.
- `getDocumentPositionMapper`: When provided it gets the `SourceFileLike` subset to `SourceFile` that offers text or optionally methods to map line character to absolute position and  other way around. (This helps with us just using snapshots when created to transform these instead of recomputing line starts and doing custom operation.

With this new API, tsserver project now implements these apis to create and cache the Document position mapper on the declaration file's script info. This is maintained till there is change in map file/declaration file. Apart from document position mapper, it maintains the list of source script infos associated with it to update the projects from whenever map file changes.

Apart from this change, it also fixes few existing issues found during additional test writing:
- File presence detection in the project where the sourceFile(ts file) is assumed to be part of project and its locations are used in generated file (d.ts) file because program.getSourceFile on both path gives the same file (.d.ts).
- There was also the issue of sourceIndex being compared instead of sourcePosition to sort the sourceMappings based on source location which is fixed in this.
- Missing path included path for source  (.ts) file when the project references the generated file(.d.ts) and file is not found.


