### PR TITLE
Change es2015 usages to existing ts functions

### DIFF
--- a/src/compiler/inspectValue.ts
+++ b/src/compiler/inspectValue.ts
@@ -148,7 +148,8 @@ namespace ts {
     }
 
     export function isJsPrivate(name: string): boolean {
-        return startsWith(name, "_");    }
+        return startsWith(name, "_");
+    }
 
     function tryRequire(fileNameToRequire: string): unknown {
         try {

--- a/src/compiler/inspectValue.ts
+++ b/src/compiler/inspectValue.ts
@@ -148,8 +148,7 @@ namespace ts {
     }
 
     export function isJsPrivate(name: string): boolean {
-        return name.startsWith("_");
-    }
+        return startsWith(name, "_");    }
 
     function tryRequire(fileNameToRequire: string): unknown {
         try {

--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -203,7 +203,7 @@ namespace ts.moduleSpecifiers {
                 return; // Don't want to a package to globally import from itself
             }
 
-            const target = targets.find(t => compareStrings(t.slice(0, resolved.length + 1), resolved + "/") === Comparison.EqualTo);
+            const target = find(targets, t => compareStrings(t.slice(0, resolved.length + 1), resolved + "/") === Comparison.EqualTo);
             if (target === undefined) return;
 
             const relative = getRelativePathFromDirectory(resolved, target, getCanonicalFileName);

--- a/src/services/rename.ts
+++ b/src/services/rename.ts
@@ -45,8 +45,7 @@ namespace ts.Rename {
 
         const moduleSourceFile = find(moduleSymbol.declarations, isSourceFile);
         if (!moduleSourceFile) return undefined;
-        const withoutIndex = node.text.endsWith("/index") || node.text.endsWith("/index.js") ? undefined : tryRemoveSuffix(removeFileExtension(moduleSourceFile.fileName), "/index");
-        const name = withoutIndex === undefined ? moduleSourceFile.fileName : withoutIndex;
+        const withoutIndex = endsWith(node.text, "/index") || endsWith(node.text, "/index.js") ? undefined : tryRemoveSuffix(removeFileExtension(moduleSourceFile.fileName), "/index");        const name = withoutIndex === undefined ? moduleSourceFile.fileName : withoutIndex;
         const kind = withoutIndex === undefined ? ScriptElementKind.moduleElement : ScriptElementKind.directory;
         const indexAfterLastSlash = node.text.lastIndexOf("/") + 1;
         // Span should only be the last component of the path. + 1 to account for the quote character.

--- a/src/services/rename.ts
+++ b/src/services/rename.ts
@@ -45,7 +45,8 @@ namespace ts.Rename {
 
         const moduleSourceFile = find(moduleSymbol.declarations, isSourceFile);
         if (!moduleSourceFile) return undefined;
-        const withoutIndex = endsWith(node.text, "/index") || endsWith(node.text, "/index.js") ? undefined : tryRemoveSuffix(removeFileExtension(moduleSourceFile.fileName), "/index");        const name = withoutIndex === undefined ? moduleSourceFile.fileName : withoutIndex;
+        const withoutIndex = endsWith(node.text, "/index") || endsWith(node.text, "/index.js") ? undefined : tryRemoveSuffix(removeFileExtension(moduleSourceFile.fileName), "/index");
+        const name = withoutIndex === undefined ? moduleSourceFile.fileName : withoutIndex;
         const kind = withoutIndex === undefined ? ScriptElementKind.moduleElement : ScriptElementKind.directory;
         const indexAfterLastSlash = node.text.lastIndexOf("/") + 1;
         // Span should only be the last component of the path. + 1 to account for the quote character.


### PR DESCRIPTION
Fixes #28918 and complements PR #28921.

Changes:
- Already reported on #28921, `String.prototype.startsWith` instead of `ts.startsWith`: [`src/compiler/inspectValue.ts` line 151](https://github.com/Microsoft/TypeScript/blob/c2898db9dd58c9b0681d6131ed6076d71d89e6b5/src/compiler/inspectValue.ts#L151).

- Two usages of `String.prototype.endsWith` instead of `ts.endsWith`: [`src/services/rename.ts` line 48](https://github.com/Microsoft/TypeScript/blob/c2898db9dd58c9b0681d6131ed6076d71d89e6b5/src/services/rename.ts#L48).

- `Array.prototype.find` instead of `ts.find`: [`src/compiler/moduleSpecifiers.ts` line 206](https://github.com/Microsoft/TypeScript/blob/c2898db9dd58c9b0681d6131ed6076d71d89e6b5/src/compiler/moduleSpecifiers.ts#L206).