### PR TITLE
Always generate lowercase locale directory names

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -117,7 +117,8 @@ const generatedLCGFile = "built/local/enu/diagnosticMessages.generated.json.lcg"
  *    2. 'src\compiler\diagnosticMessages.generated.json' => 'built\local\ENU\diagnosticMessages.generated.json.lcg'
  *       generate the lcg file (source of messages to localize) from the diagnosticMessages.generated.json
  */
-const localizationTargets = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"]
+const localizationTargets = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"]
+    .map(f => f.toLowerCase())
     .map(f => `built/local/${f}/diagnosticMessages.generated.json`)
     .concat(generatedLCGFile);
 

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -24,8 +24,6 @@ else if (process.env.PATH !== undefined) {
 
 const host = process.env.TYPESCRIPT_HOST || process.env.host || "node";
 
-const locales = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-BR", "ru", "tr", "zh-CN", "zh-TW"];
-
 const defaultTestTimeout = 40000;
 
 let useDebugMode = true;
@@ -708,19 +706,6 @@ const Travis = {
         console.log("travis_time:end:" + marker.id + ":start=" + toNs(marker.stamp) + ",finish=" + toNs(total) + ",duration=" + toNs(diff) + "\r");
     }
 };
-
-function buildLocalizedTargets() {
-    /**
-     * The localization target produces the two following transformations:
-     *    1. 'src\loc\lcl\<locale>\diagnosticMessages.generated.json.lcl' => 'built\local\<locale>\diagnosticMessages.generated.json'
-     *       convert localized resources into a .json file the compiler can understand
-     *    2. 'src\compiler\diagnosticMessages.generated.json' => 'built\local\ENU\diagnosticMessages.generated.json.lcg'
-     *       generate the lcg file (source of messages to localize) from the diagnosticMessages.generated.json
-     */
-    const localizationTargets = ["cs", "de", "es", "fr", "it", "ja", "ko", "pl", "pt-br", "ru", "tr", "zh-cn", "zh-tw"]
-        .map(f => path.join(Paths.builtLocal,f))
-        .concat(path.dirname(Paths.generatedLCGFile));
-}
 
 function toNs(diff) {
     return diff[0] * 1e9 + diff[1];

--- a/scripts/generateLocalizedDiagnosticMessages.ts
+++ b/scripts/generateLocalizedDiagnosticMessages.ts
@@ -36,7 +36,7 @@ function main(): void {
                     console.error("Unexpected XML file structure. Expected to find result.LCX.$.TgtCul.");
                     process.exit(1);
                 }
-                const outputDirectoryName = getPreferedLocaleName(result.LCX.$.TgtCul);
+                const outputDirectoryName = getPreferedLocaleName(result.LCX.$.TgtCul).toLowerCase();
                 if (!outputDirectoryName) {
                     console.error(`Invalid output locale name for '${result.LCX.$.TgtCul}'.`);
                     process.exit(1);


### PR DESCRIPTION
Always generate lowercase locale directory names so 'LKG's produce identical results on case-sensitive file systems.

Fixes #28945.