### PR TITLE
Unify semantic differences between produceDiagnostics and non-producing checkers

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4281,6 +4281,8 @@ namespace ts {
         isolatedSignatureType?: ObjectType; // A manufactured type that just contains the signature for purposes of signature comparison
         /* @internal */
         instantiations?: Map<Signature>;    // Generic signature instantiation cache
+        /* @internal */
+        getFailureCandidate?: undefined;    // Make discriminable with the `FailedSignature` sentinel inside the checker
     }
 
     export const enum IndexKind {

--- a/tests/baselines/reference/argumentExpressionContextualTyping.types
+++ b/tests/baselines/reference/argumentExpressionContextualTyping.types
@@ -122,7 +122,7 @@ baz(array);                          // Error
 baz(["string", 1, true, ...array]);  // Error
 >baz(["string", 1, true, ...array]) : void
 >baz : (x: [string, number, boolean]) => void
->["string", 1, true, ...array] : (string | number | boolean)[]
+>["string", 1, true, ...array] : [string, number, true, ...(string | number | boolean)[]]
 >"string" : "string"
 >1 : 1
 >true : true

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.types
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.types
@@ -36,11 +36,11 @@ const FooComponent = (props: { foo: "A" | "B" | "C" }) => <span>{props.foo}</spa
 <FooComponent foo={"f"} />;
 ><FooComponent foo={"f"} /> : JSX.Element
 >FooComponent : (props: { foo: "A" | "B" | "C"; }) => JSX.Element
->foo : string
+>foo : "f"
 >"f" : "f"
 
 <FooComponent foo="f"   />;
 ><FooComponent foo="f"   /> : JSX.Element
 >FooComponent : (props: { foo: "A" | "B" | "C"; }) => JSX.Element
->foo : string
+>foo : "f"
 

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.types
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.types
@@ -95,8 +95,8 @@ const b3 = <MainButton {...{goTo:"home"}} extra />;  // goTo has type"home" | "c
 >b3 : JSX.Element
 ><MainButton {...{goTo:"home"}} extra /> : JSX.Element
 >MainButton : { (buttonProps: ButtonProps): JSX.Element; (linkProps: LinkProps): JSX.Element; }
->{goTo:"home"} : { goTo: string; }
->goTo : string
+>{goTo:"home"} : { goTo: "home"; }
+>goTo : "home"
 >"home" : "home"
 >extra : true
 
@@ -104,7 +104,7 @@ const b4 = <MainButton goTo="home" extra />;  // goTo has type "home" | "contact
 >b4 : JSX.Element
 ><MainButton goTo="home" extra /> : JSX.Element
 >MainButton : { (buttonProps: ButtonProps): JSX.Element; (linkProps: LinkProps): JSX.Element; }
->goTo : string
+>goTo : "home"
 >extra : true
 
 export function NoOverload(buttonProps: ButtonProps): JSX.Element { return undefined }
@@ -138,8 +138,8 @@ const d1 = <NoOverload1 {...{goTo:"home"}} extra  />;  // goTo has type "home" |
 >d1 : JSX.Element
 ><NoOverload1 {...{goTo:"home"}} extra  /> : JSX.Element
 >NoOverload1 : (linkProps: LinkProps) => JSX.Element
->{goTo:"home"} : { goTo: string; }
->goTo : string
+>{goTo:"home"} : { goTo: "home"; }
+>goTo : "home"
 >"home" : "home"
 >extra : true
 

--- a/tests/baselines/reference/declarationsAndAssignments.types
+++ b/tests/baselines/reference/declarationsAndAssignments.types
@@ -463,12 +463,12 @@ f14([2, ["abc", { x: 0 }]]);
 f14([2, ["abc", { y: false }]]);  // Error, no x
 >f14([2, ["abc", { y: false }]]) : void
 >f14 : ([a, [b, { x, y: c }]]: [number, [string, { x: any; y?: boolean; }]]) => void
->[2, ["abc", { y: false }]] : (number | (string | { y: boolean; })[])[]
+>[2, ["abc", { y: false }]] : [number, [string, { y: false; }]]
 >2 : 2
->["abc", { y: false }] : (string | { y: boolean; })[]
+>["abc", { y: false }] : [string, { y: false; }]
 >"abc" : "abc"
->{ y: false } : { y: boolean; }
->y : boolean
+>{ y: false } : { y: false; }
+>y : false
 >false : false
 
 module M {

--- a/tests/baselines/reference/destructuringParameterDeclaration1ES5.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration1ES5.types
@@ -54,7 +54,7 @@ a1([1, 2, [["world"]]]);
 a1([1, 2, [["world"]], 3]);
 >a1([1, 2, [["world"]], 3]) : void
 >a1 : ([a, b, [[c]]]: [number, number, string[][]]) => void
->[1, 2, [["world"]], 3] : (number | string[][])[]
+>[1, 2, [["world"]], 3] : [number, number, string[][], number]
 >1 : 1
 >2 : 2
 >[["world"]] : string[][]
@@ -302,11 +302,11 @@ c5([1, 2, [["string"]]]);               // Implied type is is [any, any, [[any]]
 c5([1, 2, [["string"]], false, true]);  // Implied type is is [any, any, [[any]]]
 >c5([1, 2, [["string"]], false, true]) : void
 >c5 : ([a, b, [[c]]]: [any, any, [[any]]]) => void
->[1, 2, [["string"]], false, true] : (number | boolean | string[][])[]
+>[1, 2, [["string"]], false, true] : [number, number, [[string]], boolean, boolean]
 >1 : 1
 >2 : 2
->[["string"]] : string[][]
->["string"] : string[]
+>[["string"]] : [[string]]
+>["string"] : [string]
 >"string" : "string"
 >false : false
 >true : true

--- a/tests/baselines/reference/destructuringParameterDeclaration1ES5iterable.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration1ES5iterable.types
@@ -54,7 +54,7 @@ a1([1, 2, [["world"]]]);
 a1([1, 2, [["world"]], 3]);
 >a1([1, 2, [["world"]], 3]) : void
 >a1 : ([a, b, [[c]]]: [number, number, string[][]]) => void
->[1, 2, [["world"]], 3] : (number | string[][])[]
+>[1, 2, [["world"]], 3] : [number, number, string[][], number]
 >1 : 1
 >2 : 2
 >[["world"]] : string[][]
@@ -302,11 +302,11 @@ c5([1, 2, [["string"]]]);               // Implied type is is [any, any, [[any]]
 c5([1, 2, [["string"]], false, true]);  // Implied type is is [any, any, [[any]]]
 >c5([1, 2, [["string"]], false, true]) : void
 >c5 : ([a, b, [[c]]]: [any, any, [[any]]]) => void
->[1, 2, [["string"]], false, true] : (number | boolean | string[][])[]
+>[1, 2, [["string"]], false, true] : [number, number, [[string]], boolean, boolean]
 >1 : 1
 >2 : 2
->[["string"]] : string[][]
->["string"] : string[]
+>[["string"]] : [[string]]
+>["string"] : [string]
 >"string" : "string"
 >false : false
 >true : true

--- a/tests/baselines/reference/destructuringParameterDeclaration1ES6.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration1ES6.types
@@ -56,7 +56,7 @@ a1([1, 2, [["world"]]]);
 a1([1, 2, [["world"]], 3]);
 >a1([1, 2, [["world"]], 3]) : void
 >a1 : ([a, b, [[c]]]: [number, number, string[][]]) => void
->[1, 2, [["world"]], 3] : (number | string[][])[]
+>[1, 2, [["world"]], 3] : [number, number, string[][], number]
 >1 : 1
 >2 : 2
 >[["world"]] : string[][]
@@ -285,11 +285,11 @@ c5([1, 2, [["string"]]]);               // Implied type is is [any, any, [[any]]
 c5([1, 2, [["string"]], false, true]);  // Implied type is is [any, any, [[any]]]
 >c5([1, 2, [["string"]], false, true]) : void
 >c5 : ([a, b, [[c]]]: [any, any, [[any]]]) => void
->[1, 2, [["string"]], false, true] : (number | boolean | string[][])[]
+>[1, 2, [["string"]], false, true] : [number, number, [[string]], boolean, boolean]
 >1 : 1
 >2 : 2
->[["string"]] : string[][]
->["string"] : string[]
+>[["string"]] : [[string]]
+>["string"] : [string]
 >"string" : "string"
 >false : false
 >true : true

--- a/tests/baselines/reference/destructuringParameterDeclaration2.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration2.types
@@ -13,7 +13,7 @@ function a0([a, b, [[c]]]: [number, number, string[][]]) { }
 a0([1, "string", [["world"]]);      // Error
 >a0([1, "string", [["world"]]) : void
 >a0 : ([a, b, [[c]]]: [number, number, string[][]]) => void
->[1, "string", [["world"]] : (string | number | string[][])[]
+>[1, "string", [["world"]] : [number, string, string[][]]
 >1 : 1
 >"string" : "string"
 >[["world"]] : string[][]
@@ -23,7 +23,7 @@ a0([1, "string", [["world"]]);      // Error
 a0([1, 2, [["world"]], "string"]);  // Error
 >a0([1, 2, [["world"]], "string"]) : void
 >a0 : ([a, b, [[c]]]: [number, number, string[][]]) => void
->[1, 2, [["world"]], "string"] : (string | number | string[][])[]
+>[1, 2, [["world"]], "string"] : [number, number, string[][], string]
 >1 : 1
 >2 : 2
 >[["world"]] : string[][]
@@ -183,7 +183,7 @@ c3({ b: true });   // Error, implied type is { b: number|string }.
 c5([1, 2, false, true]);   // Error, implied type is [any, any, [[any]]]
 >c5([1, 2, false, true]) : void
 >c5 : ([a, b, [[c]]]: [any, any, [[any]]]) => void
->[1, 2, false, true] : (number | boolean)[]
+>[1, 2, false, true] : [number, number, boolean, boolean]
 >1 : 1
 >2 : 2
 >false : false
@@ -192,11 +192,11 @@ c5([1, 2, false, true]);   // Error, implied type is [any, any, [[any]]]
 c6([1, 2, [["string"]]]);  // Error, implied type is [any, any, [[number]]]  // Use initializer
 >c6([1, 2, [["string"]]]) : void
 >c6 : ([a, b, [[c]]]: [any, any, [[number?]]]) => void
->[1, 2, [["string"]]] : (number | string[][])[]
+>[1, 2, [["string"]]] : [number, number, [[string]]]
 >1 : 1
 >2 : 2
->[["string"]] : string[][]
->["string"] : string[]
+>[["string"]] : [[string]]
+>["string"] : [string]
 >"string" : "string"
 
 // A parameter can be marked optional by following its name or binding pattern with a question mark (?)

--- a/tests/baselines/reference/destructuringParameterDeclaration3ES5.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration3ES5.types
@@ -85,11 +85,11 @@ a1(...array);
 a9([1, 2, [["string"]], false, true]);   // Parameter type is [any, any, [[any]]]
 >a9([1, 2, [["string"]], false, true]) : void
 >a9 : ([a, b, [[c]]]: [any, any, [[any]]]) => void
->[1, 2, [["string"]], false, true] : (number | boolean | string[][])[]
+>[1, 2, [["string"]], false, true] : [number, number, [[string]], boolean, boolean]
 >1 : 1
 >2 : 2
->[["string"]] : string[][]
->["string"] : string[]
+>[["string"]] : [[string]]
+>["string"] : [string]
 >"string" : "string"
 >false : false
 >true : true
@@ -109,7 +109,7 @@ a10([1, 2, [["string"]], false, true]);   // Parameter type is any[]
 a10([1, 2, 3, false, true]);              // Parameter type is any[]
 >a10([1, 2, 3, false, true]) : void
 >a10 : ([a, b, [[c]], ...x]: [any, any, [[any]], ...any[]]) => void
->[1, 2, 3, false, true] : (number | boolean)[]
+>[1, 2, 3, false, true] : [number, number, number, boolean, boolean]
 >1 : 1
 >2 : 2
 >3 : 3
@@ -119,7 +119,7 @@ a10([1, 2, 3, false, true]);              // Parameter type is any[]
 a10([1, 2]);                              // Parameter type is any[]
 >a10([1, 2]) : void
 >a10 : ([a, b, [[c]], ...x]: [any, any, [[any]], ...any[]]) => void
->[1, 2] : number[]
+>[1, 2] : [number, number]
 >1 : 1
 >2 : 2
 

--- a/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration3ES5iterable.types
@@ -85,11 +85,11 @@ a1(...array);
 a9([1, 2, [["string"]], false, true]);   // Parameter type is [any, any, [[any]]]
 >a9([1, 2, [["string"]], false, true]) : void
 >a9 : ([a, b, [[c]]]: [any, any, [[any]]]) => void
->[1, 2, [["string"]], false, true] : (number | boolean | string[][])[]
+>[1, 2, [["string"]], false, true] : [number, number, [[string]], boolean, boolean]
 >1 : 1
 >2 : 2
->[["string"]] : string[][]
->["string"] : string[]
+>[["string"]] : [[string]]
+>["string"] : [string]
 >"string" : "string"
 >false : false
 >true : true
@@ -109,7 +109,7 @@ a10([1, 2, [["string"]], false, true]);   // Parameter type is any[]
 a10([1, 2, 3, false, true]);              // Parameter type is any[]
 >a10([1, 2, 3, false, true]) : void
 >a10 : ([a, b, [[c]], ...x]: [any, any, [[any]], ...any[]]) => void
->[1, 2, 3, false, true] : (number | boolean)[]
+>[1, 2, 3, false, true] : [number, number, number, boolean, boolean]
 >1 : 1
 >2 : 2
 >3 : 3
@@ -119,7 +119,7 @@ a10([1, 2, 3, false, true]);              // Parameter type is any[]
 a10([1, 2]);                              // Parameter type is any[]
 >a10([1, 2]) : void
 >a10 : ([a, b, [[c]], ...x]: [any, any, [[any]], ...any[]]) => void
->[1, 2] : number[]
+>[1, 2] : [number, number]
 >1 : 1
 >2 : 2
 

--- a/tests/baselines/reference/destructuringParameterDeclaration3ES6.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration3ES6.types
@@ -85,11 +85,11 @@ a1(...array);
 a9([1, 2, [["string"]], false, true]);   // Parameter type is [any, any, [[any]]]
 >a9([1, 2, [["string"]], false, true]) : void
 >a9 : ([a, b, [[c]]]: [any, any, [[any]]]) => void
->[1, 2, [["string"]], false, true] : (number | boolean | string[][])[]
+>[1, 2, [["string"]], false, true] : [number, number, [[string]], boolean, boolean]
 >1 : 1
 >2 : 2
->[["string"]] : string[][]
->["string"] : string[]
+>[["string"]] : [[string]]
+>["string"] : [string]
 >"string" : "string"
 >false : false
 >true : true
@@ -109,7 +109,7 @@ a10([1, 2, [["string"]], false, true]);   // Parameter type is any[]
 a10([1, 2, 3, false, true]);              // Parameter type is any[]
 >a10([1, 2, 3, false, true]) : void
 >a10 : ([a, b, [[c]], ...x]: [any, any, [[any]], ...any[]]) => void
->[1, 2, 3, false, true] : (number | boolean)[]
+>[1, 2, 3, false, true] : [number, number, number, boolean, boolean]
 >1 : 1
 >2 : 2
 >3 : 3
@@ -119,7 +119,7 @@ a10([1, 2, 3, false, true]);              // Parameter type is any[]
 a10([1, 2]);                              // Parameter type is any[]
 >a10([1, 2]) : void
 >a10 : ([a, b, [[c]], ...x]: [any, any, [[any]], ...any[]]) => void
->[1, 2] : number[]
+>[1, 2] : [number, number]
 >1 : 1
 >2 : 2
 

--- a/tests/baselines/reference/destructuringParameterDeclaration4.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration4.types
@@ -69,7 +69,7 @@ a1(...array2);            // Error parameter type is (number|string)[]
 a5([1, 2, "string", false, true]);       // Error, parameter type is [any, any, [[any]]]
 >a5([1, 2, "string", false, true]) : void
 >a5 : ([a, b, [[c]]]: [any, any, [[any]]]) => void
->[1, 2, "string", false, true] : (string | number | boolean)[]
+>[1, 2, "string", false, true] : [number, number, string, boolean, boolean]
 >1 : 1
 >2 : 2
 >"string" : "string"
@@ -79,7 +79,7 @@ a5([1, 2, "string", false, true]);       // Error, parameter type is [any, any, 
 a5([1, 2]);                              // Error, parameter type is [any, any, [[any]]]
 >a5([1, 2]) : void
 >a5 : ([a, b, [[c]]]: [any, any, [[any]]]) => void
->[1, 2] : number[]
+>[1, 2] : [number, number]
 >1 : 1
 >2 : 2
 

--- a/tests/baselines/reference/destructuringParameterDeclaration8.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration8.types
@@ -49,22 +49,22 @@ test({ method: 'x', nested: { p: 'a' } })
 test({ method: 'z', nested: { p: 'b' } })
 >test({ method: 'z', nested: { p: 'b' } }) : void
 >test : ({ method, nested: { p } }: { method?: "x" | "y"; nested?: { p: "a" | "b"; }; }) => void
->{ method: 'z', nested: { p: 'b' } } : { method: string; nested: { p: string; }; }
->method : string
+>{ method: 'z', nested: { p: 'b' } } : { method: "z"; nested: { p: "b"; }; }
+>method : "z"
 >'z' : "z"
->nested : { p: string; }
->{ p: 'b' } : { p: string; }
->p : string
+>nested : { p: "b"; }
+>{ p: 'b' } : { p: "b"; }
+>p : "b"
 >'b' : "b"
 
 test({ method: 'one', nested: { p: 'a' } })
 >test({ method: 'one', nested: { p: 'a' } }) : void
 >test : ({ method, nested: { p } }: { method?: "x" | "y"; nested?: { p: "a" | "b"; }; }) => void
->{ method: 'one', nested: { p: 'a' } } : { method: string; nested: { p: string; }; }
->method : string
+>{ method: 'one', nested: { p: 'a' } } : { method: "one"; nested: { p: "a"; }; }
+>method : "one"
 >'one' : "one"
->nested : { p: string; }
->{ p: 'a' } : { p: string; }
->p : string
+>nested : { p: "a"; }
+>{ p: 'a' } : { p: "a"; }
+>p : "a"
 >'a' : "a"
 

--- a/tests/baselines/reference/destructuringParameterProperties2.types
+++ b/tests/baselines/reference/destructuringParameterProperties2.types
@@ -75,7 +75,7 @@ var x = new C1(undefined, [0, undefined, ""]);
 >new C1(undefined, [0, undefined, ""]) : any
 >C1 : typeof C1
 >undefined : undefined
->[0, undefined, ""] : (string | number)[]
+>[0, undefined, ""] : [number, undefined, string]
 >0 : 0
 >undefined : undefined
 >"" : ""

--- a/tests/baselines/reference/destructuringParameterProperties5.types
+++ b/tests/baselines/reference/destructuringParameterProperties5.types
@@ -58,7 +58,7 @@ var a = new C1([{ x1: 10, x2: "", x3: true }, "", false]);
 >a : any
 >new C1([{ x1: 10, x2: "", x3: true }, "", false]) : any
 >C1 : typeof C1
->[{ x1: 10, x2: "", x3: true }, "", false] : (string | boolean | { x1: number; x2: string; x3: boolean; })[]
+>[{ x1: 10, x2: "", x3: true }, "", false] : [{ x1: number; x2: string; x3: boolean; }, string, boolean]
 >{ x1: 10, x2: "", x3: true } : { x1: number; x2: string; x3: boolean; }
 >x1 : number
 >10 : 10

--- a/tests/baselines/reference/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.types
+++ b/tests/baselines/reference/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.types
@@ -71,7 +71,7 @@ foo({
 }, getNum(), [
 >getNum() : number
 >getNum : () => number
->[    1,    2,    getNum] : (number | (() => number))[]
+>[    1,    2,    getNum] : [number, number, () => number]
 
     1,
 >1 : 1

--- a/tests/baselines/reference/for-of39.types
+++ b/tests/baselines/reference/for-of39.types
@@ -3,11 +3,11 @@ var map = new Map([["", true], ["", 0]]);
 >map : any
 >new Map([["", true], ["", 0]]) : any
 >Map : MapConstructor
->[["", true], ["", 0]] : ((string | boolean)[] | (string | number)[])[]
->["", true] : (string | boolean)[]
+>[["", true], ["", 0]] : ([string, boolean] | [string, number])[]
+>["", true] : [string, boolean]
 >"" : ""
 >true : true
->["", 0] : (string | number)[]
+>["", 0] : [string, number]
 >"" : ""
 >0 : 0
 

--- a/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.types
+++ b/tests/baselines/reference/genericArgumentCallSigAssignmentCompat.types
@@ -31,7 +31,7 @@ _.all([true, 1, null, 'yes'], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => boolean
->[true, 1, null, 'yes'] : (string | number | boolean)[]
+>[true, 1, null, 'yes'] : (string | number | true)[]
 >true : true
 >1 : 1
 >null : null

--- a/tests/baselines/reference/genericTypeArgumentInference1.types
+++ b/tests/baselines/reference/genericTypeArgumentInference1.types
@@ -28,7 +28,7 @@ var r = _.all([true, 1, null, 'yes'], _.identity);
 >_.all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
 >_ : Underscore.Static
 >all : <T>(list: T[], iterator?: Underscore.Iterator<T, boolean>, context?: any) => T
->[true, 1, null, 'yes'] : (string | number | boolean)[]
+>[true, 1, null, 'yes'] : (string | number | true)[]
 >true : true
 >1 : 1
 >null : null

--- a/tests/baselines/reference/iterableArrayPattern28.types
+++ b/tests/baselines/reference/iterableArrayPattern28.types
@@ -12,11 +12,11 @@ takeFirstTwoEntries(...new Map([["", 0], ["hello", true]]));
 >...new Map([["", 0], ["hello", true]]) : any
 >new Map([["", 0], ["hello", true]]) : any
 >Map : MapConstructor
->[["", 0], ["hello", true]] : ((string | number)[] | (string | boolean)[])[]
->["", 0] : (string | number)[]
+>[["", 0], ["hello", true]] : ([string, number] | [string, boolean])[]
+>["", 0] : [string, number]
 >"" : ""
 >0 : 0
->["hello", true] : (string | boolean)[]
+>["hello", true] : [string, boolean]
 >"hello" : "hello"
 >true : true
 

--- a/tests/baselines/reference/jsxChildrenGenericContextualTypes.types
+++ b/tests/baselines/reference/jsxChildrenGenericContextualTypes.types
@@ -116,7 +116,7 @@ const arg = <ElemLit prop="x" children={p => "y"} />
 >arg : JSX.Element
 ><ElemLit prop="x" children={p => "y"} /> : JSX.Element
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
->prop : string
+>prop : "x"
 >children : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "y"
 >p => "y" : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "y"
 >p : JSX.IntrinsicAttributes & LitProps<"x">
@@ -126,7 +126,7 @@ const argchild = <ElemLit prop="x">{p => "y"}</ElemLit>
 >argchild : JSX.Element
 ><ElemLit prop="x">{p => "y"}</ElemLit> : JSX.Element
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
->prop : string
+>prop : "x"
 >p => "y" : (p: JSX.IntrinsicAttributes & LitProps<"x">) => "y"
 >p : JSX.IntrinsicAttributes & LitProps<"x">
 >"y" : "y"
@@ -136,7 +136,7 @@ const mismatched = <ElemLit prop="x">{() => 12}</ElemLit>
 >mismatched : JSX.Element
 ><ElemLit prop="x">{() => 12}</ElemLit> : JSX.Element
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element
->prop : string
+>prop : "x"
 >() => 12 : () => number
 >12 : 12
 >ElemLit : <T extends string>(p: LitProps<T>) => JSX.Element

--- a/tests/baselines/reference/mappedTypeInferenceErrors.errors.txt
+++ b/tests/baselines/reference/mappedTypeInferenceErrors.errors.txt
@@ -1,7 +1,8 @@
+tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts(13,26): error TS2339: Property 'bar' does not exist on type '{ x: number; y: number; }'.
 tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts(16,9): error TS2322: Type 'number' is not assignable to type '() => {}'.
 
 
-==== tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts (1 errors) ====
+==== tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts (2 errors) ====
     // Repro from #19316
     
     type ComputedOf<T> = {
@@ -15,6 +16,8 @@ tests/cases/conformance/types/mapped/mappedTypeInferenceErrors.ts(16,9): error T
         computed: {
             bar(): number {
                 let z = this.bar;
+                             ~~~
+!!! error TS2339: Property 'bar' does not exist on type '{ x: number; y: number; }'.
                 return 42;
             },
             baz: 42

--- a/tests/baselines/reference/mappedTypeInferenceErrors.symbols
+++ b/tests/baselines/reference/mappedTypeInferenceErrors.symbols
@@ -42,9 +42,7 @@ foo({
 
             let z = this.bar;
 >z : Symbol(z, Decl(mappedTypeInferenceErrors.ts, 12, 15))
->this.bar : Symbol(bar, Decl(mappedTypeInferenceErrors.ts, 10, 15))
->this : Symbol(__object, Decl(mappedTypeInferenceErrors.ts, 10, 13))
->bar : Symbol(bar, Decl(mappedTypeInferenceErrors.ts, 10, 15))
+>this : Symbol(__object, Decl(mappedTypeInferenceErrors.ts, 9, 10))
 
             return 42;
         },

--- a/tests/baselines/reference/mappedTypeInferenceErrors.types
+++ b/tests/baselines/reference/mappedTypeInferenceErrors.types
@@ -34,10 +34,10 @@ foo({
 >bar : () => number
 
             let z = this.bar;
->z : () => number
->this.bar : () => number
->this : { bar(): number; baz: number; }
->bar : () => number
+>z : any
+>this.bar : any
+>this : { x: number; y: number; }
+>bar : any
 
             return 42;
 >42 : 42

--- a/tests/baselines/reference/optionalBindingParameters1.types
+++ b/tests/baselines/reference/optionalBindingParameters1.types
@@ -18,7 +18,7 @@ foo(["", 0, false]);
 foo([false, 0, ""]);
 >foo([false, 0, ""]) : void
 >foo : ([x, y, z]?: [string, number, boolean]) => void
->[false, 0, ""] : (string | number | boolean)[]
+>[false, 0, ""] : [boolean, number, string]
 >false : false
 >0 : 0
 >"" : ""

--- a/tests/baselines/reference/optionalBindingParametersInOverloads1.types
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads1.types
@@ -22,7 +22,7 @@ foo(["", 0, false]);
 foo([false, 0, ""]);
 >foo([false, 0, ""]) : any
 >foo : ([x, y, z]?: [string, number, boolean]) => any
->[false, 0, ""] : (string | number | boolean)[]
+>[false, 0, ""] : [boolean, number, string]
 >false : false
 >0 : 0
 >"" : ""

--- a/tests/baselines/reference/restTupleElements1.types
+++ b/tests/baselines/reference/restTupleElements1.types
@@ -170,7 +170,7 @@ declare function f0<T, U>(x: [T, ...U[]]): [T, U];
 f0([]);  // Error
 >f0([]) : any
 >f0 : <T, U>(x: [T, ...U[]]) => [T, U]
->[] : never[]
+>[] : []
 
 f0([1]);
 >f0([1]) : [number, {}]

--- a/tests/baselines/reference/strictBindCallApply1.types
+++ b/tests/baselines/reference/strictBindCallApply1.types
@@ -99,7 +99,7 @@ let a01 = foo.apply(undefined, [10]);  // Error
 >foo : (a: number, b: string) => string
 >apply : { <T, R>(this: (this: T) => R, thisArg: T): R; <T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R; }
 >undefined : undefined
->[10] : number[]
+>[10] : [number]
 >10 : 10
 
 let a02 = foo.apply(undefined, [10, 20]);  // Error
@@ -109,7 +109,7 @@ let a02 = foo.apply(undefined, [10, 20]);  // Error
 >foo : (a: number, b: string) => string
 >apply : { <T, R>(this: (this: T) => R, thisArg: T): R; <T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R; }
 >undefined : undefined
->[10, 20] : number[]
+>[10, 20] : [number, number]
 >10 : 10
 >20 : 20
 
@@ -120,7 +120,7 @@ let a03 = foo.apply(undefined, [10, "hello", 30]);  // Error
 >foo : (a: number, b: string) => string
 >apply : { <T, R>(this: (this: T) => R, thisArg: T): R; <T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R; }
 >undefined : undefined
->[10, "hello", 30] : (string | number)[]
+>[10, "hello", 30] : [number, string, number]
 >10 : 10
 >"hello" : "hello"
 >30 : 30
@@ -283,7 +283,7 @@ let a11 = c.foo.apply(c, [10]);  // Error
 >foo : (this: C, a: number, b: string) => string
 >apply : { <T, R>(this: (this: T) => R, thisArg: T): R; <T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R; }
 >c : C
->[10] : number[]
+>[10] : [number]
 >10 : 10
 
 let a12 = c.foo.apply(c, [10, 20]);  // Error
@@ -295,7 +295,7 @@ let a12 = c.foo.apply(c, [10, 20]);  // Error
 >foo : (this: C, a: number, b: string) => string
 >apply : { <T, R>(this: (this: T) => R, thisArg: T): R; <T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R; }
 >c : C
->[10, 20] : number[]
+>[10, 20] : [number, number]
 >10 : 10
 >20 : 20
 
@@ -308,7 +308,7 @@ let a13 = c.foo.apply(c, [10, "hello", 30]);  // Error
 >foo : (this: C, a: number, b: string) => string
 >apply : { <T, R>(this: (this: T) => R, thisArg: T): R; <T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R; }
 >c : C
->[10, "hello", 30] : (string | number)[]
+>[10, "hello", 30] : [number, string, number]
 >10 : 10
 >"hello" : "hello"
 >30 : 30
@@ -322,7 +322,7 @@ let a14 = c.foo.apply(undefined, [10, "hello"]);  // Error
 >foo : (this: C, a: number, b: string) => string
 >apply : { <T, R>(this: (this: T) => R, thisArg: T): R; <T, A extends any[], R>(this: (this: T, ...args: A) => R, thisArg: T, args: A): R; }
 >undefined : undefined
->[10, "hello"] : (string | number)[]
+>[10, "hello"] : [number, string]
 >10 : 10
 >"hello" : "hello"
 
@@ -415,7 +415,7 @@ C.apply(c, [10]);  // Error
 >C : typeof C
 >apply : { <T>(this: new () => T, thisArg: T): void; <T, A extends any[]>(this: new (...args: A) => T, thisArg: T, args: A): void; }
 >c : C
->[10] : number[]
+>[10] : [number]
 >10 : 10
 
 C.apply(c, [10, 20]);  // Error
@@ -424,7 +424,7 @@ C.apply(c, [10, 20]);  // Error
 >C : typeof C
 >apply : { <T>(this: new () => T, thisArg: T): void; <T, A extends any[]>(this: new (...args: A) => T, thisArg: T, args: A): void; }
 >c : C
->[10, 20] : number[]
+>[10, 20] : [number, number]
 >10 : 10
 >20 : 20
 
@@ -434,7 +434,7 @@ C.apply(c, [10, "hello", 30]);  // Error
 >C : typeof C
 >apply : { <T>(this: new () => T, thisArg: T): void; <T, A extends any[]>(this: new (...args: A) => T, thisArg: T, args: A): void; }
 >c : C
->[10, "hello", 30] : (string | number)[]
+>[10, "hello", 30] : [number, string, number]
 >10 : 10
 >"hello" : "hello"
 >30 : 30

--- a/tests/baselines/reference/symbolProperty21.types
+++ b/tests/baselines/reference/symbolProperty21.types
@@ -22,7 +22,7 @@ declare function foo<T, U>(p: I<T, U>): { t: T; u: U };
 foo({
 >foo({    [Symbol.isConcatSpreadable]: "",    [Symbol.toPrimitive]: 0,    [Symbol.unscopables]: true}) : any
 >foo : <T, U>(p: I<T, U>) => { t: T; u: U; }
->{    [Symbol.isConcatSpreadable]: "",    [Symbol.toPrimitive]: 0,    [Symbol.unscopables]: true} : { [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }
+>{    [Symbol.isConcatSpreadable]: "",    [Symbol.toPrimitive]: 0,    [Symbol.unscopables]: true} : { [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }
 
     [Symbol.isConcatSpreadable]: "",
 >[Symbol.isConcatSpreadable] : string
@@ -39,7 +39,7 @@ foo({
 >0 : 0
 
     [Symbol.unscopables]: true
->[Symbol.unscopables] : boolean
+>[Symbol.unscopables] : true
 >Symbol.unscopables : symbol
 >Symbol : SymbolConstructor
 >unscopables : symbol

--- a/tests/baselines/reference/tsxSpreadAttributesResolution10.types
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution10.types
@@ -42,7 +42,7 @@ let y = <Opt {...obj} x={3}/>;
 ><Opt {...obj} x={3}/> : JSX.Element
 >Opt : typeof Opt
 >obj : OptionProp
->x : number
+>x : 3
 >3 : 3
 
 let y1 = <Opt {...obj1} x="Hi"/>;
@@ -57,7 +57,7 @@ let y2 = <Opt {...obj1} x={3}/>;
 ><Opt {...obj1} x={3}/> : JSX.Element
 >Opt : typeof Opt
 >obj1 : OptionProp
->x : number
+>x : 3
 >3 : 3
 
 let y3 = <Opt x />;

--- a/tests/baselines/reference/tsxSpreadAttributesResolution12.types
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution12.types
@@ -78,10 +78,10 @@ let x1 = <OverWriteAttr overwrite="hi" {...obj1} x={3} {...{y: true}} />
 >OverWriteAttr : typeof OverWriteAttr
 >overwrite : string
 >obj1 : { x: 2; }
->x : number
+>x : 3
 >3 : 3
->{y: true} : { y: boolean; }
->y : boolean
+>{y: true} : { y: true; }
+>y : true
 >true : true
 
 let x2 = <OverWriteAttr {...anyobj} x={3} />
@@ -98,8 +98,8 @@ let x3 = <OverWriteAttr overwrite="hi" {...obj1} {...{y: true}} />
 >OverWriteAttr : typeof OverWriteAttr
 >overwrite : string
 >obj1 : { x: 2; }
->{y: true} : { y: boolean; }
->y : boolean
+>{y: true} : { y: true; }
+>y : true
 >true : true
 
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.types
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.types
@@ -63,20 +63,20 @@ let w = <Poisoned {...{x: 5, y: "2"}}/>;
 >w : JSX.Element
 ><Poisoned {...{x: 5, y: "2"}}/> : JSX.Element
 >Poisoned : typeof Poisoned
->{x: 5, y: "2"} : { x: number; y: string; }
+>{x: 5, y: "2"} : { x: number; y: "2"; }
 >x : number
 >5 : 5
->y : string
+>y : "2"
 >"2" : "2"
 
 let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
 >w1 : JSX.Element
 ><Poisoned {...{x: 5, y: "2"}} X="hi" /> : JSX.Element
 >Poisoned : typeof Poisoned
->{x: 5, y: "2"} : { x: number; y: string; }
+>{x: 5, y: "2"} : { x: number; y: "2"; }
 >x : number
 >5 : 5
->y : string
+>y : "2"
 >"2" : "2"
 >X : string
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution6.types
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution6.types
@@ -34,7 +34,7 @@ let x = <TextComponent editable={true} />
 >x : JSX.Element
 ><TextComponent editable={true} /> : JSX.Element
 >TextComponent : typeof TextComponent
->editable : boolean
+>editable : true
 >true : true
 
 const textProps: TextProps = {

--- a/tests/baselines/reference/underscoreTest1.types
+++ b/tests/baselines/reference/underscoreTest1.types
@@ -235,7 +235,7 @@ _.all([true, 1, null, 'yes'], _.identity);
 >_.all : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
 >_ : Underscore.Static
 >all : { <T>(list: T[], iterator?: Iterator_<T, boolean>, context?: any): boolean; <T>(list: Dictionary<T>, iterator?: Iterator_<T, boolean>, context?: any): boolean; }
->[true, 1, null, 'yes'] : (string | number | boolean)[]
+>[true, 1, null, 'yes'] : (string | number | true)[]
 >true : true
 >1 : 1
 >null : null

--- a/tests/cases/fourslash/completionsCombineOverloads_returnType.ts
+++ b/tests/cases/fourslash/completionsCombineOverloads_returnType.ts
@@ -6,4 +6,4 @@
 ////declare function f(s: string): B;
 ////f()./**/
 
-verify.completions({ marker: "", exact: ["a", "b"] });
+verify.completions({ marker: "", exact: undefined });

--- a/tests/cases/fourslash/genericCombinators2.ts
+++ b/tests/cases/fourslash/genericCombinators2.ts
@@ -63,8 +63,8 @@ verify.quickInfos({
     "3b": "(parameter) y: A",
     "4a": "(parameter) x: number",
     "4b": "(parameter) y: B<any>",
-    "5a": "(parameter) x: number",
-    "5b": "(parameter) y: string",
+    "5a": "(parameter) x: any",
+    "5b": "(parameter) y: any",
     "6a": "(parameter) x: Collection<number, number>",
     "6b": "(parameter) y: string",
     "7a": "(parameter) x: number",
@@ -78,12 +78,12 @@ verify.quickInfos({
     13: "var r3a: Collection<number, {}>",
     14: "var r3b: Collection<number, {}>",
     15: "var r4a: Collection<number, any>",
-    17: "var r5a: Collection<number, Date>",
+    17: "var r5a: any",
     18: "var r5b: Collection<number, Date>",
     19: "var r6a: Collection<Collection<number, number>, Date>",
     20: "var r6b: Collection<Collection<number, number>, Date>",
     21: "var r7a: Collection<number, string>",
-    22: "var r7b: Collection<number, string>",
+    22: "var r7b: any",
     23: "var r8a: Collection<number, string>"
 });
 

--- a/tests/cases/fourslash/goToDefinitionFunctionOverloads.ts
+++ b/tests/cases/fourslash/goToDefinitionFunctionOverloads.ts
@@ -11,6 +11,6 @@
 verify.goToDefinition({
     functionOverloadReference1: "functionOverload1",
     functionOverloadReference2: "functionOverload2",
-    brokenOverload: "functionOverload1",
+    brokenOverload: "functionOverloadDefinition",
     functionOverload1: "functionOverloadDefinition"
 });

--- a/tests/cases/fourslash/quickInfo_errorSignatureFillsInTypeParameter.ts
+++ b/tests/cases/fourslash/quickInfo_errorSignatureFillsInTypeParameter.ts
@@ -3,4 +3,4 @@
 ////declare function f<T>(x: number): T;
 ////const x/**/ = f();
 
-verify.quickInfoAt("", "const x: {}");
+verify.quickInfoAt("", "const x: any");

--- a/tests/cases/fourslash/signatureHelpWithTriggers02.ts
+++ b/tests/cases/fourslash/signatureHelpWithTriggers02.ts
@@ -9,7 +9,7 @@ goTo.marker("1");
 
 edit.insert("(");
 verify.signatureHelp({
-    text: "bar(x: {}, y: {}): {}",
+    text: "bar(x: any, y: any): any",
     triggerReason: {
         kind: "characterTyped",
         triggerCharacter: "(",

--- a/tests/cases/fourslash/tsxGoToDefinitionStatelessFunction2.ts
+++ b/tests/cases/fourslash/tsxGoToDefinitionStatelessFunction2.ts
@@ -31,10 +31,10 @@
 //// let opt = <[|Main/*sixthTarget*/Button|] wrong />;
 
 verify.goToDefinition({
-    firstTarget: "firstSource",
-    secondTarget: "firstSource",
+    firstTarget: ["firstSource", "secondSource", "thirdSource"],
+    secondTarget: ["firstSource", "secondSource", "thirdSource"],
     thirdTarget: "firstSource",
     fourthTarget: "firstSource",
     fifthTarget: "secondSource",
-    sixthTarget: "firstSource"
+    sixthTarget: ["firstSource", "secondSource", "thirdSource"]
 });


### PR DESCRIPTION
To allow them do be able to be used interchangeably for equivalent API results. The core of the change is making it to that we always resolve to an `unknownSignature` on call resolution failure, but also making it possible for the services and `getContextualType` APIs to recover data on what the "best" signatures were (without letting the types from those signatures leak into the type heirarchy of the program).

The biggest changes are that now when a call has an error quick info shows its return type and arguments as `any`, rather than the return type of the "best" signature.