### PR TITLE
Simplify indexed access types applied to mapped types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -67,7 +67,6 @@ namespace ts {
         let enumCount = 0;
         let instantiationDepth = 0;
         let constraintDepth = 0;
-        let simplificationDepth = 0;
 
         const emptySymbols = createSymbolTable();
         const identityMapper: (type: Type) => Type = identity;
@@ -9687,29 +9686,13 @@ namespace ts {
 
             // If the object type is a mapped type { [P in K]: E }, where K is generic, instantiate E using a mapper
             // that substitutes the index type for P. For example, for an index access { [P in K]: Box<T[P]> }[X], we
-            // construct the type Box<T[X]>. Mapped types can be recursive so to guard against infinite recursion we
-            // only perform this simplification up to five levels deep.
-            if (simplificationDepth < 5) {
-                if (isGenericMappedType(objectType)) {
-                    return type.simplified = substituteIndexedMappedType(objectType, type);
-                }
-                if (objectType.flags & TypeFlags.TypeParameter) {
-                    const constraint = getConstraintOfTypeParameter(objectType as TypeParameter);
-                    if (constraint && isGenericMappedType(constraint)) {
-                        return type.simplified = substituteIndexedMappedType(constraint, type);
-                    }
-                }
+            // construct the type Box<T[X]>.
+            if (isGenericMappedType(objectType)) {
+                const mapper = createTypeMapper([getTypeParameterFromMappedType(objectType)], [type.indexType]);
+                const templateMapper = combineTypeMappers(objectType.mapper, mapper);
+                return type.simplified = mapType(instantiateType(getTemplateTypeFromMappedType(objectType), templateMapper), getSimplifiedType);
             }
             return type.simplified = type;
-        }
-
-        function substituteIndexedMappedType(objectType: MappedType, type: IndexedAccessType) {
-            simplificationDepth++;
-            const mapper = createTypeMapper([getTypeParameterFromMappedType(objectType)], [type.indexType]);
-            const templateMapper = combineTypeMappers(objectType.mapper, mapper);
-            const result = mapType(instantiateType(getTemplateTypeFromMappedType(objectType), templateMapper), getSimplifiedType);
-            simplificationDepth--;
-            return result;
         }
 
         function getIndexedAccessType(objectType: Type, indexType: Type, accessNode?: ElementAccessExpression | IndexedAccessTypeNode | PropertyName, missingType = accessNode ? errorType : unknownType): Type {

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -484,10 +484,10 @@ function onChangeGenericFunction<T>(handler: Handler<T & {preset: number}>) {
 function updateIds<T extends Record<K, string>, K extends string>(
     obj: T,
     idFields: K[],
-    idMapping: { [oldId: string]: string }
+    idMapping: Partial<Record<T[K], T[K]>>
 ): Record<K, string> {
     for (const idField of idFields) {
-        const newId = idMapping[obj[idField]];
+        const newId: T[K] | undefined = idMapping[obj[idField]];
         if (newId) {
             obj[idField] = newId;
         }
@@ -1312,9 +1312,7 @@ declare type Handler<T> = {
 declare function onChangeGenericFunction<T>(handler: Handler<T & {
     preset: number;
 }>): void;
-declare function updateIds<T extends Record<K, string>, K extends string>(obj: T, idFields: K[], idMapping: {
-    [oldId: string]: string;
-}): Record<K, string>;
+declare function updateIds<T extends Record<K, string>, K extends string>(obj: T, idFields: K[], idMapping: Partial<Record<T[K], T[K]>>): Record<K, string>;
 declare function updateIds2<T extends {
     [x: string]: string;
 }, K extends keyof T>(obj: T, key: K, stringMap: {

--- a/tests/baselines/reference/keyofAndIndexedAccess.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess.symbols
@@ -1767,9 +1767,14 @@ function updateIds<T extends Record<K, string>, K extends string>(
 >idFields : Symbol(idFields, Decl(keyofAndIndexedAccess.ts, 483, 11))
 >K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 482, 47))
 
-    idMapping: { [oldId: string]: string }
+    idMapping: Partial<Record<T[K], T[K]>>
 >idMapping : Symbol(idMapping, Decl(keyofAndIndexedAccess.ts, 484, 18))
->oldId : Symbol(oldId, Decl(keyofAndIndexedAccess.ts, 485, 18))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 482, 19))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 482, 47))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 482, 19))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 482, 47))
 
 ): Record<K, string> {
 >Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
@@ -1779,8 +1784,10 @@ function updateIds<T extends Record<K, string>, K extends string>(
 >idField : Symbol(idField, Decl(keyofAndIndexedAccess.ts, 487, 14))
 >idFields : Symbol(idFields, Decl(keyofAndIndexedAccess.ts, 483, 11))
 
-        const newId = idMapping[obj[idField]];
+        const newId: T[K] | undefined = idMapping[obj[idField]];
 >newId : Symbol(newId, Decl(keyofAndIndexedAccess.ts, 488, 13))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 482, 19))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 482, 47))
 >idMapping : Symbol(idMapping, Decl(keyofAndIndexedAccess.ts, 484, 18))
 >obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 482, 66))
 >idField : Symbol(idField, Decl(keyofAndIndexedAccess.ts, 487, 14))

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -1731,7 +1731,7 @@ function onChangeGenericFunction<T>(handler: Handler<T & {preset: number}>) {
 // Repro from #13285
 
 function updateIds<T extends Record<K, string>, K extends string>(
->updateIds : <T extends Record<K, string>, K extends string>(obj: T, idFields: K[], idMapping: { [oldId: string]: string; }) => Record<K, string>
+>updateIds : <T extends Record<K, string>, K extends string>(obj: T, idFields: K[], idMapping: Partial<Record<T[K], T[K]>>) => Record<K, string>
 
     obj: T,
 >obj : T
@@ -1739,32 +1739,31 @@ function updateIds<T extends Record<K, string>, K extends string>(
     idFields: K[],
 >idFields : K[]
 
-    idMapping: { [oldId: string]: string }
->idMapping : { [oldId: string]: string; }
->oldId : string
+    idMapping: Partial<Record<T[K], T[K]>>
+>idMapping : Partial<Record<T[K], T[K]>>
 
 ): Record<K, string> {
     for (const idField of idFields) {
 >idField : K
 >idFields : K[]
 
-        const newId = idMapping[obj[idField]];
->newId : { [oldId: string]: string; }[T[K]]
->idMapping[obj[idField]] : { [oldId: string]: string; }[T[K]]
->idMapping : { [oldId: string]: string; }
+        const newId: T[K] | undefined = idMapping[obj[idField]];
+>newId : T[K] | undefined
+>idMapping[obj[idField]] : Partial<Record<T[K], T[K]>>[T[K]]
+>idMapping : Partial<Record<T[K], T[K]>>
 >obj[idField] : T[K]
 >obj : T
 >idField : K
 
         if (newId) {
->newId : { [oldId: string]: string; }[T[K]]
+>newId : T[K] | undefined
 
             obj[idField] = newId;
->obj[idField] = newId : { [oldId: string]: string; }[T[K]]
+>obj[idField] = newId : T[K]
 >obj[idField] : T[K]
 >obj : T
 >idField : K
->newId : { [oldId: string]: string; }[T[K]]
+>newId : T[K]
         }
     }
     return obj;

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
@@ -66,10 +66,9 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(123,5): error
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(140,5): error TS2322: Type '42' is not assignable to type 'T[K]'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(141,5): error TS2322: Type '"hello"' is not assignable to type 'T[K]'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(142,5): error TS2322: Type 'number[]' is not assignable to type 'T[K]'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(158,9): error TS2322: Type '"hello"' is not assignable to type 'Record<keyof T, string>[K]'.
 
 
-==== tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts (42 errors) ====
+==== tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts (41 errors) ====
     class Shape {
         name: string;
         width: number;
@@ -329,15 +328,7 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(158,9): error
         let x: Partial<Record<keyof T, string>>[K] = "hello";
     }
     
-    // We simplify indexed accesses applied to mapped types up to five levels deep
-    
     function f31<T, K extends keyof T>() {
-        let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
-    }
-    
-    function f32<T, K extends keyof T>() {
-        let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
-            ~
-!!! error TS2322: Type '"hello"' is not assignable to type 'Record<keyof T, string>[K]'.
+        let x: Partial<Partial<Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>>>[K] = "hello";
     }
     

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.errors.txt
@@ -66,9 +66,10 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(123,5): error
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(140,5): error TS2322: Type '42' is not assignable to type 'T[K]'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(141,5): error TS2322: Type '"hello"' is not assignable to type 'T[K]'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(142,5): error TS2322: Type 'number[]' is not assignable to type 'T[K]'.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(158,9): error TS2322: Type '"hello"' is not assignable to type 'Record<keyof T, string>[K]'.
 
 
-==== tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts (41 errors) ====
+==== tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts (42 errors) ====
     class Shape {
         name: string;
         width: number;
@@ -320,5 +321,23 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts(142,5): error
         t[k] = [10, 20];  // Error
         ~~~~
 !!! error TS2322: Type 'number[]' is not assignable to type 'T[K]'.
+    }
+    
+    // Repro from #28839
+    
+    function f30<T, K extends keyof T>() {
+        let x: Partial<Record<keyof T, string>>[K] = "hello";
+    }
+    
+    // We simplify indexed accesses applied to mapped types up to five levels deep
+    
+    function f31<T, K extends keyof T>() {
+        let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
+    }
+    
+    function f32<T, K extends keyof T>() {
+        let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
+            ~
+!!! error TS2322: Type '"hello"' is not assignable to type 'Record<keyof T, string>[K]'.
     }
     

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.js
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.js
@@ -143,6 +143,22 @@ function test1<T extends Record<string, any>, K extends keyof T>(t: T, k: K) {
     t[k] = [10, 20];  // Error
 }
 
+// Repro from #28839
+
+function f30<T, K extends keyof T>() {
+    let x: Partial<Record<keyof T, string>>[K] = "hello";
+}
+
+// We simplify indexed accesses applied to mapped types up to five levels deep
+
+function f31<T, K extends keyof T>() {
+    let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
+}
+
+function f32<T, K extends keyof T>() {
+    let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
+}
+
 
 //// [keyofAndIndexedAccessErrors.js]
 var Shape = /** @class */ (function () {
@@ -214,4 +230,15 @@ function test1(t, k) {
     t[k] = 42; // Error
     t[k] = "hello"; // Error
     t[k] = [10, 20]; // Error
+}
+// Repro from #28839
+function f30() {
+    var x = "hello";
+}
+// We simplify indexed accesses applied to mapped types up to five levels deep
+function f31() {
+    var x = "hello";
+}
+function f32() {
+    var x = "hello";
 }

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.js
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.js
@@ -149,14 +149,8 @@ function f30<T, K extends keyof T>() {
     let x: Partial<Record<keyof T, string>>[K] = "hello";
 }
 
-// We simplify indexed accesses applied to mapped types up to five levels deep
-
 function f31<T, K extends keyof T>() {
-    let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
-}
-
-function f32<T, K extends keyof T>() {
-    let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
+    let x: Partial<Partial<Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>>>[K] = "hello";
 }
 
 
@@ -235,10 +229,6 @@ function test1(t, k) {
 function f30() {
     var x = "hello";
 }
-// We simplify indexed accesses applied to mapped types up to five levels deep
 function f31() {
-    var x = "hello";
-}
-function f32() {
     var x = "hello";
 }

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.symbols
@@ -486,3 +486,56 @@ function test1<T extends Record<string, any>, K extends keyof T>(t: T, k: K) {
 >k : Symbol(k, Decl(keyofAndIndexedAccessErrors.ts, 138, 70))
 }
 
+// Repro from #28839
+
+function f30<T, K extends keyof T>() {
+>f30 : Symbol(f30, Decl(keyofAndIndexedAccessErrors.ts, 142, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 146, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 146, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 146, 13))
+
+    let x: Partial<Record<keyof T, string>>[K] = "hello";
+>x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 147, 7))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 146, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 146, 15))
+}
+
+// We simplify indexed accesses applied to mapped types up to five levels deep
+
+function f31<T, K extends keyof T>() {
+>f31 : Symbol(f31, Decl(keyofAndIndexedAccessErrors.ts, 148, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 152, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 152, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 152, 13))
+
+    let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
+>x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 153, 7))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 152, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 152, 15))
+}
+
+function f32<T, K extends keyof T>() {
+>f32 : Symbol(f32, Decl(keyofAndIndexedAccessErrors.ts, 154, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 156, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 156, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 156, 13))
+
+    let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
+>x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 157, 7))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 156, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 156, 15))
+}
+

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.symbols
@@ -502,40 +502,23 @@ function f30<T, K extends keyof T>() {
 >K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 146, 15))
 }
 
-// We simplify indexed accesses applied to mapped types up to five levels deep
-
 function f31<T, K extends keyof T>() {
 >f31 : Symbol(f31, Decl(keyofAndIndexedAccessErrors.ts, 148, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 152, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 152, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 152, 13))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 150, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 150, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 150, 13))
 
-    let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
->x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 153, 7))
+    let x: Partial<Partial<Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>>>[K] = "hello";
+>x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 151, 7))
 >Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
 >Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
->Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
->Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
->Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 152, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 152, 15))
-}
-
-function f32<T, K extends keyof T>() {
->f32 : Symbol(f32, Decl(keyofAndIndexedAccessErrors.ts, 154, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 156, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 156, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 156, 13))
-
-    let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
->x : Symbol(x, Decl(keyofAndIndexedAccessErrors.ts, 157, 7))
 >Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
 >Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
 >Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
 >Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
 >Partial : Symbol(Partial, Decl(lib.es5.d.ts, --, --))
 >Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 156, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 156, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccessErrors.ts, 150, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccessErrors.ts, 150, 15))
 }
 

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.types
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.types
@@ -465,3 +465,31 @@ function test1<T extends Record<string, any>, K extends keyof T>(t: T, k: K) {
 >20 : 20
 }
 
+// Repro from #28839
+
+function f30<T, K extends keyof T>() {
+>f30 : <T, K extends keyof T>() => void
+
+    let x: Partial<Record<keyof T, string>>[K] = "hello";
+>x : Partial<Record<keyof T, string>>[K]
+>"hello" : "hello"
+}
+
+// We simplify indexed accesses applied to mapped types up to five levels deep
+
+function f31<T, K extends keyof T>() {
+>f31 : <T, K extends keyof T>() => void
+
+    let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
+>x : Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K]
+>"hello" : "hello"
+}
+
+function f32<T, K extends keyof T>() {
+>f32 : <T, K extends keyof T>() => void
+
+    let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
+>x : Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K]
+>"hello" : "hello"
+}
+

--- a/tests/baselines/reference/keyofAndIndexedAccessErrors.types
+++ b/tests/baselines/reference/keyofAndIndexedAccessErrors.types
@@ -475,21 +475,11 @@ function f30<T, K extends keyof T>() {
 >"hello" : "hello"
 }
 
-// We simplify indexed accesses applied to mapped types up to five levels deep
-
 function f31<T, K extends keyof T>() {
 >f31 : <T, K extends keyof T>() => void
 
-    let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
->x : Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K]
->"hello" : "hello"
-}
-
-function f32<T, K extends keyof T>() {
->f32 : <T, K extends keyof T>() => void
-
-    let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
->x : Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K]
+    let x: Partial<Partial<Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>>>[K] = "hello";
+>x : Partial<Partial<Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>>>[K]
 >"hello" : "hello"
 }
 

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
@@ -486,10 +486,10 @@ function onChangeGenericFunction<T>(handler: Handler<T & {preset: number}>) {
 function updateIds<T extends Record<K, string>, K extends string>(
     obj: T,
     idFields: K[],
-    idMapping: { [oldId: string]: string }
+    idMapping: Partial<Record<T[K], T[K]>>
 ): Record<K, string> {
     for (const idField of idFields) {
-        const newId = idMapping[obj[idField]];
+        const newId: T[K] | undefined = idMapping[obj[idField]];
         if (newId) {
             obj[idField] = newId;
         }

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
@@ -141,3 +141,19 @@ function test1<T extends Record<string, any>, K extends keyof T>(t: T, k: K) {
     t[k] = "hello";  // Error
     t[k] = [10, 20];  // Error
 }
+
+// Repro from #28839
+
+function f30<T, K extends keyof T>() {
+    let x: Partial<Record<keyof T, string>>[K] = "hello";
+}
+
+// We simplify indexed accesses applied to mapped types up to five levels deep
+
+function f31<T, K extends keyof T>() {
+    let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
+}
+
+function f32<T, K extends keyof T>() {
+    let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
+}

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
@@ -148,12 +148,6 @@ function f30<T, K extends keyof T>() {
     let x: Partial<Record<keyof T, string>>[K] = "hello";
 }
 
-// We simplify indexed accesses applied to mapped types up to five levels deep
-
 function f31<T, K extends keyof T>() {
-    let x: Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>[K] = "hello";
-}
-
-function f32<T, K extends keyof T>() {
-    let x: Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>[K] = "hello";
+    let x: Partial<Partial<Partial<Partial<Partial<Partial<Partial<Record<keyof T, string>>>>>>>>[K] = "hello";
 }


### PR DESCRIPTION
Previously we didn't simplify indexed access types applied to mapped types beyond one level because it could cause infinite recursion when mapped types circularly reference themselves. With this PR we now simplify to any number of levels, meaning that constructs such as the following are no longer errors:

```ts
function test<T, K extends keyof T>() {
    let x: Partial<Record<keyof T, string>>[K] = "hello";  // Was error, now ok
}
```

Fixes #28839.