### PR TITLE
Check for reentrancy in fillMissingTypeArguments and use defaults instead if so

### DIFF
--- a/tests/baselines/reference/selfRecrusiveTypeParameterWithDefault.js
+++ b/tests/baselines/reference/selfRecrusiveTypeParameterWithDefault.js
@@ -1,0 +1,7 @@
+//// [selfRecrusiveTypeParameterWithDefault.ts]
+interface JoiObject {}
+
+interface AbstractSchema<Schema extends AbstractSchema = any, Value = any> extends JoiObject { x; }
+
+
+//// [selfRecrusiveTypeParameterWithDefault.js]

--- a/tests/baselines/reference/selfRecrusiveTypeParameterWithDefault.symbols
+++ b/tests/baselines/reference/selfRecrusiveTypeParameterWithDefault.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/selfRecrusiveTypeParameterWithDefault.ts ===
+interface JoiObject {}
+>JoiObject : Symbol(JoiObject, Decl(selfRecrusiveTypeParameterWithDefault.ts, 0, 0))
+
+interface AbstractSchema<Schema extends AbstractSchema = any, Value = any> extends JoiObject { x; }
+>AbstractSchema : Symbol(AbstractSchema, Decl(selfRecrusiveTypeParameterWithDefault.ts, 0, 22))
+>Schema : Symbol(Schema, Decl(selfRecrusiveTypeParameterWithDefault.ts, 2, 25))
+>AbstractSchema : Symbol(AbstractSchema, Decl(selfRecrusiveTypeParameterWithDefault.ts, 0, 22))
+>Value : Symbol(Value, Decl(selfRecrusiveTypeParameterWithDefault.ts, 2, 61))
+>JoiObject : Symbol(JoiObject, Decl(selfRecrusiveTypeParameterWithDefault.ts, 0, 0))
+>x : Symbol(AbstractSchema.x, Decl(selfRecrusiveTypeParameterWithDefault.ts, 2, 94))
+

--- a/tests/baselines/reference/selfRecrusiveTypeParameterWithDefault.types
+++ b/tests/baselines/reference/selfRecrusiveTypeParameterWithDefault.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/selfRecrusiveTypeParameterWithDefault.ts ===
+interface JoiObject {}
+
+interface AbstractSchema<Schema extends AbstractSchema = any, Value = any> extends JoiObject { x; }
+>x : any
+

--- a/tests/cases/compiler/selfRecrusiveTypeParameterWithDefault.ts
+++ b/tests/cases/compiler/selfRecrusiveTypeParameterWithDefault.ts
@@ -1,0 +1,3 @@
+interface JoiObject {}
+
+interface AbstractSchema<Schema extends AbstractSchema = any, Value = any> extends JoiObject { x; }


### PR DESCRIPTION
Fixes #28873

`fillMissingTypeArguments` uses the constraint to allow the default itself to reference the parent type circularly (and use defaults), however when the constraint itself references the parent type and uses defaults, ofc we can't safely renter and just need to use the base default type.
