### PR TITLE
FunctionDeclaration's name is required

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1039,7 +1039,7 @@ namespace ts {
 
     export interface FunctionDeclaration extends FunctionLikeDeclarationBase, DeclarationStatement {
         kind: SyntaxKind.FunctionDeclaration;
-        name?: Identifier;
+        name: Identifier;
         body?: FunctionBody;
     }
 


### PR DESCRIPTION


function declaration's name is required

see https://www.ecma-international.org/ecma-262/9.0/index.html#sec-function-definitions