### PR TITLE
LanguageService: add getSupportedCodeFixes to make it proxyable

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -741,5 +741,9 @@ namespace ts.server {
         dispose(): void {
             throw new Error("dispose is not available through the server layer.");
         }
+
+        getSupportedCodeFixes() {
+            return getSupportedCodeFixes();
+        }
     }
 }

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -578,6 +578,9 @@ namespace Harness.LanguageService {
             return ts.notImplemented();
         }
         dispose(): void { this.shim.dispose({}); }
+        getSupportedCodeFixes(): ReadonlyArray<string> {
+            throw new Error("Not supported on the shim.");
+        }
     }
 
     export class ShimLanguageServiceAdapter implements LanguageServiceAdapter {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -748,6 +748,7 @@ namespace ts.server.protocol {
      */
     export interface GetSupportedCodeFixesRequest extends Request {
         command: CommandTypes.GetSupportedCodeFixes;
+        arguments?: Partial<FileRequestArgs>;
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1805,8 +1805,8 @@ namespace ts.server {
 
         private getSupportedCodeFixes(args?: protocol.FileRequestArgs): ReadonlyArray<string> {
             if (args && args.file) {
-                const {project} = this.getFileAndProject(args);
-                return project.getLanguageService(/*ensureSynchronized*/ false).getSupportedCodeFixes();
+                const {file, project} = this.getFileAndProject(args);
+                return project.getLanguageService().getSupportedCodeFixes(file);
             }
             return getSupportedCodeFixes();
         }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1803,9 +1803,9 @@ namespace ts.server {
             }
         }
 
-        private getSupportedCodeFixes(args?: protocol.FileRequestArgs): ReadonlyArray<string> {
+        private getSupportedCodeFixes(args?: Partial<protocol.FileRequestArgs>): ReadonlyArray<string> {
             if (args && args.file) {
-                const {file, project} = this.getFileAndProject(args);
+                const {file, project} = this.getFileAndProject(<protocol.FileRequestArgs>args);
                 return project.getLanguageService().getSupportedCodeFixes(file);
             }
             return getSupportedCodeFixes();
@@ -2346,8 +2346,8 @@ namespace ts.server {
             [CommandNames.ApplyCodeActionCommand]: (request: protocol.ApplyCodeActionCommandRequest) => {
                 return this.requiredResponse(this.applyCodeActionCommand(request.arguments));
             },
-            [CommandNames.GetSupportedCodeFixes]: () => {
-                return this.requiredResponse(this.getSupportedCodeFixes());
+            [CommandNames.GetSupportedCodeFixes]: (request: protocol.GetSupportedCodeFixesRequest) => {
+                return this.requiredResponse(this.getSupportedCodeFixes(request.arguments));
             },
             [CommandNames.GetApplicableRefactors]: (request: protocol.GetApplicableRefactorsRequest) => {
                 return this.requiredResponse(this.getApplicableRefactors(request.arguments));

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1803,7 +1803,11 @@ namespace ts.server {
             }
         }
 
-        private getSupportedCodeFixes(): string[] {
+        private getSupportedCodeFixes(args?: protocol.FileRequestArgs): ReadonlyArray<string> {
+            if (args && args.file) {
+                const {project} = this.getFileAndProject(args);
+                return project.getLanguageService(/*ensureSynchronized*/ false).getSupportedCodeFixes();
+            }
             return getSupportedCodeFixes();
         }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2143,6 +2143,7 @@ namespace ts {
             getEditsForRefactor,
             toLineColumnOffset: sourceMapper.toLineColumnOffset,
             getSourceMapper: () => sourceMapper,
+            getSupportedCodeFixes,
         };
     }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -356,7 +356,7 @@ namespace ts {
         /* @internal */ getNonBoundSourceFile(fileName: string): SourceFile;
 
         dispose(): void;
-        getSupportedCodeFixes(): ReadonlyArray<string>;
+        getSupportedCodeFixes(fileName: string): ReadonlyArray<string>;
     }
 
     export interface JsxClosingTagInfo {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -356,6 +356,7 @@ namespace ts {
         /* @internal */ getNonBoundSourceFile(fileName: string): SourceFile;
 
         dispose(): void;
+        getSupportedCodeFixes(): ReadonlyArray<string>;
     }
 
     export interface JsxClosingTagInfo {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4754,7 +4754,7 @@ declare namespace ts {
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
         getProgram(): Program | undefined;
         dispose(): void;
-        getSupportedCodeFixes(): ReadonlyArray<string>;
+        getSupportedCodeFixes(fileName: string): ReadonlyArray<string>;
     }
     interface JsxClosingTagInfo {
         readonly newText: string;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4754,6 +4754,7 @@ declare namespace ts {
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
         getProgram(): Program | undefined;
         dispose(): void;
+        getSupportedCodeFixes(): ReadonlyArray<string>;
     }
     interface JsxClosingTagInfo {
         readonly newText: string;
@@ -6199,6 +6200,7 @@ declare namespace ts.server.protocol {
      */
     interface GetSupportedCodeFixesRequest extends Request {
         command: CommandTypes.GetSupportedCodeFixes;
+        arguments?: Partial<FileRequestArgs>;
     }
     /**
      * A response for GetSupportedCodeFixesRequest request.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4754,7 +4754,7 @@ declare namespace ts {
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
         getProgram(): Program | undefined;
         dispose(): void;
-        getSupportedCodeFixes(): ReadonlyArray<string>;
+        getSupportedCodeFixes(fileName: string): ReadonlyArray<string>;
     }
     interface JsxClosingTagInfo {
         readonly newText: string;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4754,6 +4754,7 @@ declare namespace ts {
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
         getProgram(): Program | undefined;
         dispose(): void;
+        getSupportedCodeFixes(): ReadonlyArray<string>;
     }
     interface JsxClosingTagInfo {
         readonly newText: string;


### PR DESCRIPTION
Fixes: #28966

I'd highly appreciate some pointers on how to test this change. (@sheetalkamat?)

Is the change to the protocol what @DanielRosenwasser meant in https://github.com/Microsoft/TypeScript/issues/28966#issuecomment-447087185?