### PR TITLE
Do not process library reference directives with noLib set.

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2227,8 +2227,9 @@ namespace ts {
                         processReferencedFiles(file, isDefaultLib);
                         processTypeReferenceDirectives(file);
                     }
-
-                    processLibReferenceDirectives(file);
+                    if (!options.noLib) {
+                        processLibReferenceDirectives(file);
+                    }
 
                     modulesWithElidedImports.set(file.path, false);
                     processImportedModules(file);
@@ -2315,8 +2316,10 @@ namespace ts {
                     processReferencedFiles(file, isDefaultLib);
                     processTypeReferenceDirectives(file);
                 }
+                if (!options.noLib) {
+                    processLibReferenceDirectives(file);
+                }
 
-                processLibReferenceDirectives(file);
 
                 // always process imported modules to record module name resolutions
                 processImportedModules(file);

--- a/tests/baselines/reference/libReferenceNoLib.js
+++ b/tests/baselines/reference/libReferenceNoLib.js
@@ -1,0 +1,51 @@
+//// [tests/cases/conformance/declarationEmit/libReferenceNoLib.ts] ////
+
+//// [fakelib.ts]
+// Test that passing noLib disables <reference lib> resolution.
+
+interface Object { }
+interface Array<T> { }
+interface String { }
+interface Boolean { }
+interface Number { }
+interface Function { }
+interface RegExp { }
+interface IArguments { }
+
+
+//// [file1.ts]
+/// <reference lib="dom" />
+export declare interface HTMLElement { field: string; }
+export const elem: HTMLElement = { field: 'a' };
+
+
+//// [fakelib.js]
+// Test that passing noLib disables <reference lib> resolution.
+//// [file1.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.elem = { field: 'a' };
+
+
+//// [fakelib.d.ts]
+interface Object {
+}
+interface Array<T> {
+}
+interface String {
+}
+interface Boolean {
+}
+interface Number {
+}
+interface Function {
+}
+interface RegExp {
+}
+interface IArguments {
+}
+//// [file1.d.ts]
+export declare interface HTMLElement {
+    field: string;
+}
+export declare const elem: HTMLElement;

--- a/tests/baselines/reference/libReferenceNoLib.symbols
+++ b/tests/baselines/reference/libReferenceNoLib.symbols
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/declarationEmit/fakelib.ts ===
+// Test that passing noLib disables <reference lib> resolution.
+
+interface Object { }
+>Object : Symbol(Object, Decl(fakelib.ts, 0, 0))
+
+interface Array<T> { }
+>Array : Symbol(Array, Decl(fakelib.ts, 2, 20))
+>T : Symbol(T, Decl(fakelib.ts, 3, 16))
+
+interface String { }
+>String : Symbol(String, Decl(fakelib.ts, 3, 22))
+
+interface Boolean { }
+>Boolean : Symbol(Boolean, Decl(fakelib.ts, 4, 20))
+
+interface Number { }
+>Number : Symbol(Number, Decl(fakelib.ts, 5, 21))
+
+interface Function { }
+>Function : Symbol(Function, Decl(fakelib.ts, 6, 20))
+
+interface RegExp { }
+>RegExp : Symbol(RegExp, Decl(fakelib.ts, 7, 22))
+
+interface IArguments { }
+>IArguments : Symbol(IArguments, Decl(fakelib.ts, 8, 20))
+
+
+=== tests/cases/conformance/declarationEmit/file1.ts ===
+/// <reference lib="dom" />
+export declare interface HTMLElement { field: string; }
+>HTMLElement : Symbol(HTMLElement, Decl(file1.ts, 0, 0))
+>field : Symbol(HTMLElement.field, Decl(file1.ts, 1, 38))
+
+export const elem: HTMLElement = { field: 'a' };
+>elem : Symbol(elem, Decl(file1.ts, 2, 12))
+>HTMLElement : Symbol(HTMLElement, Decl(file1.ts, 0, 0))
+>field : Symbol(field, Decl(file1.ts, 2, 34))
+

--- a/tests/baselines/reference/libReferenceNoLib.types
+++ b/tests/baselines/reference/libReferenceNoLib.types
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/declarationEmit/fakelib.ts ===
+// Test that passing noLib disables <reference lib> resolution.
+No type information for this code.
+No type information for this code.interface Object { }
+No type information for this code.interface Array<T> { }
+No type information for this code.interface String { }
+No type information for this code.interface Boolean { }
+No type information for this code.interface Number { }
+No type information for this code.interface Function { }
+No type information for this code.interface RegExp { }
+No type information for this code.interface IArguments { }
+No type information for this code.
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/declarationEmit/file1.ts ===
+/// <reference lib="dom" />
+export declare interface HTMLElement { field: string; }
+>field : string
+
+export const elem: HTMLElement = { field: 'a' };
+>elem : HTMLElement
+>{ field: 'a' } : { field: string; }
+>field : string
+>'a' : "a"
+

--- a/tests/baselines/reference/libReferenceNoLibBundle.js
+++ b/tests/baselines/reference/libReferenceNoLibBundle.js
@@ -1,0 +1,53 @@
+//// [tests/cases/conformance/declarationEmit/libReferenceNoLibBundle.ts] ////
+
+//// [fakelib.ts]
+// Test that passing noLib disables <reference lib> resolution.
+
+interface Object { }
+interface Array<T> { }
+interface String { }
+interface Boolean { }
+interface Number { }
+interface Function { }
+interface RegExp { }
+interface IArguments { }
+
+
+//// [file1.ts]
+/// <reference lib="dom" />
+export declare interface HTMLElement { field: string; }
+export const elem: HTMLElement = { field: 'a' };
+
+
+//// [bundle.js]
+// Test that passing noLib disables <reference lib> resolution.
+define("file1", ["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.elem = { field: 'a' };
+});
+
+
+//// [bundle.d.ts]
+interface Object {
+}
+interface Array<T> {
+}
+interface String {
+}
+interface Boolean {
+}
+interface Number {
+}
+interface Function {
+}
+interface RegExp {
+}
+interface IArguments {
+}
+declare module "file1" {
+    export interface HTMLElement {
+        field: string;
+    }
+    export const elem: HTMLElement;
+}

--- a/tests/baselines/reference/libReferenceNoLibBundle.symbols
+++ b/tests/baselines/reference/libReferenceNoLibBundle.symbols
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/declarationEmit/fakelib.ts ===
+// Test that passing noLib disables <reference lib> resolution.
+
+interface Object { }
+>Object : Symbol(Object, Decl(fakelib.ts, 0, 0))
+
+interface Array<T> { }
+>Array : Symbol(Array, Decl(fakelib.ts, 2, 20))
+>T : Symbol(T, Decl(fakelib.ts, 3, 16))
+
+interface String { }
+>String : Symbol(String, Decl(fakelib.ts, 3, 22))
+
+interface Boolean { }
+>Boolean : Symbol(Boolean, Decl(fakelib.ts, 4, 20))
+
+interface Number { }
+>Number : Symbol(Number, Decl(fakelib.ts, 5, 21))
+
+interface Function { }
+>Function : Symbol(Function, Decl(fakelib.ts, 6, 20))
+
+interface RegExp { }
+>RegExp : Symbol(RegExp, Decl(fakelib.ts, 7, 22))
+
+interface IArguments { }
+>IArguments : Symbol(IArguments, Decl(fakelib.ts, 8, 20))
+
+
+=== tests/cases/conformance/declarationEmit/file1.ts ===
+/// <reference lib="dom" />
+export declare interface HTMLElement { field: string; }
+>HTMLElement : Symbol(HTMLElement, Decl(file1.ts, 0, 0))
+>field : Symbol(HTMLElement.field, Decl(file1.ts, 1, 38))
+
+export const elem: HTMLElement = { field: 'a' };
+>elem : Symbol(elem, Decl(file1.ts, 2, 12))
+>HTMLElement : Symbol(HTMLElement, Decl(file1.ts, 0, 0))
+>field : Symbol(field, Decl(file1.ts, 2, 34))
+

--- a/tests/baselines/reference/libReferenceNoLibBundle.types
+++ b/tests/baselines/reference/libReferenceNoLibBundle.types
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/declarationEmit/fakelib.ts ===
+// Test that passing noLib disables <reference lib> resolution.
+No type information for this code.
+No type information for this code.interface Object { }
+No type information for this code.interface Array<T> { }
+No type information for this code.interface String { }
+No type information for this code.interface Boolean { }
+No type information for this code.interface Number { }
+No type information for this code.interface Function { }
+No type information for this code.interface RegExp { }
+No type information for this code.interface IArguments { }
+No type information for this code.
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/declarationEmit/file1.ts ===
+/// <reference lib="dom" />
+export declare interface HTMLElement { field: string; }
+>field : string
+
+export const elem: HTMLElement = { field: 'a' };
+>elem : HTMLElement
+>{ field: 'a' } : { field: string; }
+>field : string
+>'a' : "a"
+

--- a/tests/cases/conformance/declarationEmit/libReferenceNoLib.ts
+++ b/tests/cases/conformance/declarationEmit/libReferenceNoLib.ts
@@ -1,0 +1,21 @@
+// @target: esnext
+// @module: commonjs
+// @noLib: true
+// @declaration: true
+// Test that passing noLib disables <reference lib> resolution.
+
+// @filename: fakelib.ts
+interface Object { }
+interface Array<T> { }
+interface String { }
+interface Boolean { }
+interface Number { }
+interface Function { }
+interface RegExp { }
+interface IArguments { }
+
+
+// @filename: file1.ts
+/// <reference lib="dom" />
+export declare interface HTMLElement { field: string; }
+export const elem: HTMLElement = { field: 'a' };

--- a/tests/cases/conformance/declarationEmit/libReferenceNoLibBundle.ts
+++ b/tests/cases/conformance/declarationEmit/libReferenceNoLibBundle.ts
@@ -1,0 +1,23 @@
+// @target: esnext
+// @module: amd
+// @noLib: true
+// @declaration: true
+// @outFile: bundle.js
+
+// Test that passing noLib disables <reference lib> resolution.
+
+// @filename: fakelib.ts
+interface Object { }
+interface Array<T> { }
+interface String { }
+interface Boolean { }
+interface Number { }
+interface Function { }
+interface RegExp { }
+interface IArguments { }
+
+
+// @filename: file1.ts
+/// <reference lib="dom" />
+export declare interface HTMLElement { field: string; }
+export const elem: HTMLElement = { field: 'a' };


### PR DESCRIPTION
When a user sets `noLib`, this indicates that they will supply their own
list of `lib*.d.ts` files as part of input sources. In this situation,
TypeScript should not try to resolve library reference directives.

This avoids a problem where TypeScript loads a file that e.g. contains
`/// <reference lib="es2015.symbol"/>`. Previously, TypeScript would use
its builtin ts.libMap and attempt to load builtin libraries from the
TypeScript installation, instead of respecting the user-supplied set of
libraries.

Fixes #29021

