### PR TITLE
Non-latebound computed property names should print as their underlying name type

### DIFF
--- a/tests/baselines/reference/declarationEmitComputedNameConstEnumAlias.js
+++ b/tests/baselines/reference/declarationEmitComputedNameConstEnumAlias.js
@@ -1,0 +1,44 @@
+//// [tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts] ////
+
+//// [EnumExample.ts]
+enum EnumExample {
+    TEST = 'TEST',
+}
+
+export default EnumExample;
+
+//// [index.ts]
+import EnumExample from './EnumExample';
+
+export default {
+    [EnumExample.TEST]: {},
+};
+
+//// [EnumExample.js]
+"use strict";
+exports.__esModule = true;
+var EnumExample;
+(function (EnumExample) {
+    EnumExample["TEST"] = "TEST";
+})(EnumExample || (EnumExample = {}));
+exports["default"] = EnumExample;
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var _a;
+var EnumExample_1 = require("./EnumExample");
+exports["default"] = (_a = {},
+    _a[EnumExample_1["default"].TEST] = {},
+    _a);
+
+
+//// [EnumExample.d.ts]
+declare enum EnumExample {
+    TEST = "TEST"
+}
+export default EnumExample;
+//// [index.d.ts]
+declare const _default: {
+    TEST: {};
+};
+export default _default;

--- a/tests/baselines/reference/declarationEmitComputedNameConstEnumAlias.symbols
+++ b/tests/baselines/reference/declarationEmitComputedNameConstEnumAlias.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/EnumExample.ts ===
+enum EnumExample {
+>EnumExample : Symbol(EnumExample, Decl(EnumExample.ts, 0, 0))
+
+    TEST = 'TEST',
+>TEST : Symbol(EnumExample.TEST, Decl(EnumExample.ts, 0, 18))
+}
+
+export default EnumExample;
+>EnumExample : Symbol(EnumExample, Decl(EnumExample.ts, 0, 0))
+
+=== tests/cases/compiler/index.ts ===
+import EnumExample from './EnumExample';
+>EnumExample : Symbol(EnumExample, Decl(index.ts, 0, 6))
+
+export default {
+    [EnumExample.TEST]: {},
+>[EnumExample.TEST] : Symbol([EnumExample.TEST], Decl(index.ts, 2, 16))
+>EnumExample.TEST : Symbol(EnumExample.TEST, Decl(EnumExample.ts, 0, 18))
+>EnumExample : Symbol(EnumExample, Decl(index.ts, 0, 6))
+>TEST : Symbol(EnumExample.TEST, Decl(EnumExample.ts, 0, 18))
+
+};

--- a/tests/baselines/reference/declarationEmitComputedNameConstEnumAlias.types
+++ b/tests/baselines/reference/declarationEmitComputedNameConstEnumAlias.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/EnumExample.ts ===
+enum EnumExample {
+>EnumExample : EnumExample
+
+    TEST = 'TEST',
+>TEST : EnumExample.TEST
+>'TEST' : "TEST"
+}
+
+export default EnumExample;
+>EnumExample : EnumExample
+
+=== tests/cases/compiler/index.ts ===
+import EnumExample from './EnumExample';
+>EnumExample : typeof EnumExample
+
+export default {
+>{    [EnumExample.TEST]: {},} : { [EnumExample.TEST]: {}; }
+
+    [EnumExample.TEST]: {},
+>[EnumExample.TEST] : {}
+>EnumExample.TEST : EnumExample
+>EnumExample : typeof EnumExample
+>TEST : EnumExample
+>{} : {}
+
+};

--- a/tests/baselines/reference/parserComputedPropertyName35.types
+++ b/tests/baselines/reference/parserComputedPropertyName35.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName35.ts ===
 var x = {
->x : { [0, 1]: {}; }
+>x : { 1: {}; }
 >{    [0, 1]: { }} : { [0, 1]: {}; }
 
     [0, 1]: { }

--- a/tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts
+++ b/tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts
@@ -1,0 +1,14 @@
+// @declaration: true
+// @filename: EnumExample.ts
+enum EnumExample {
+    TEST = 'TEST',
+}
+
+export default EnumExample;
+
+// @filename: index.ts
+import EnumExample from './EnumExample';
+
+export default {
+    [EnumExample.TEST]: {},
+};


### PR DESCRIPTION
Fixes #28574

