### PR TITLE
Adjust travis branch spec to capture all release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,7 @@ matrix:
 branches:
   only:
   - master
-  - release-2.7
-  - release-2.8
-  - release-2.9
-  - release-3.0
-  - release-3.1
+  - /^release-.*/
 
 install:
   - npm uninstall typescript --no-save


### PR DESCRIPTION
I noticed `travis` wasn;t triggering on `3.2` PRs. This changes to travis config to use a regex to capture all current and future `release` branches.
