### PR TITLE
Fix the up-to-date-ness checks of sucessive `gulp` invocations

### DIFF
--- a/scripts/build/project.js
+++ b/scripts/build/project.js
@@ -683,11 +683,17 @@ function ensureCompileTask(projectGraph, options) {
                     }
                 });
             }
-            const js = (projectGraphConfig.resolvedOptions.js ? projectGraphConfig.resolvedOptions.js(stream.js) : stream.js)
+
+            const additionalJsOutputs = projectGraphConfig.resolvedOptions.js ? projectGraphConfig.resolvedOptions.js(stream.js)
+                .pipe(gulpif(sourceMap || inlineSourceMap, sourcemaps.write(sourceMapPath, sourceMapOptions))) : undefined;
+            const additionalDtsOutputs = projectGraphConfig.resolvedOptions.dts ? projectGraphConfig.resolvedOptions.dts(stream.dts)
+                .pipe(gulpif(declarationMap, sourcemaps.write(sourceMapPath, sourceMapOptions))) : undefined;
+
+            const js = stream.js
                 .pipe(gulpif(sourceMap || inlineSourceMap, sourcemaps.write(sourceMapPath, sourceMapOptions)));
-            const dts = (projectGraphConfig.resolvedOptions.dts ? projectGraphConfig.resolvedOptions.dts(stream.dts) : stream.dts)
+            const dts = stream.dts
                 .pipe(gulpif(declarationMap, sourcemaps.write(sourceMapPath, sourceMapOptions)));
-            return merge2([js, dts])
+            return merge2([js, dts, additionalJsOutputs, additionalDtsOutputs].filter(x => !!x))
                 .pipe(gulp.dest(destPath));
         });
     }


### PR DESCRIPTION
The issue was simply that the files we were checking for up-to-dateness never actually hit disc, because they got renamed prior to being written out. With this change, we now always write out the outputs as written (so they still exist for up-to-date-ness checks), but also do the rename and writing the renamed copy.
