### PR TITLE
Duplicate `wait` instead of `wait` and `notify` at `es2017.sharedmemory.d.ts`

### DIFF
--- a/src/lib/es2017.sharedmemory.d.ts
+++ b/src/lib/es2017.sharedmemory.d.ts
@@ -103,7 +103,7 @@ interface Atomics {
      * Wakes up sleeping agents that are waiting on the given index of the array, returning the
      * number of agents that were awoken.
      */
-    wake(typedArray: Int32Array, index: number, count: number): number;
+    notify(typedArray: Int32Array, index: number, count: number): number;
 
     /**
      * Stores the bitwise XOR of a value with the value at the given position in the array,


### PR DESCRIPTION
Fixes #

**Original Code**
```
     /**
     * If the value at the given position in the array is equal to the provided value, the current
     * agent is put to sleep causing execution to suspend until the timeout expires (returning
     * `"timed-out"`) or until the agent is awoken (returning `"ok"`); otherwise, returns
     * `"not-equal"`.
     */
    wait(typedArray: Int32Array, index: number, value: number, timeout?: number): "ok" | "not-equal" | "timed-out";

    /**
     * Wakes up sleeping agents that are waiting on the given index of the array, returning the
     * number of agents that were awoken.
     */
    wait(typedArray: Int32Array, index: number, count: number): number;
```
it seems to be a mistake, the second method should be `notify` (the first wait is fine)

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Atomics/notify

Changed to:
```
notify(typedArray: Int32Array, index: number, count: number): number;
```
