### PR TITLE
Supports incremental build in tsc --b --w mode

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -265,11 +265,11 @@ namespace ts {
         const { affectedFilesPendingEmit } = state;
         if (affectedFilesPendingEmit) {
             const seenEmittedFiles = state.seenEmittedFiles || (state.seenEmittedFiles = createMap());
-            for (let affectedFilesIndex = state.affectedFilesPendingEmitIndex!; affectedFilesIndex < affectedFilesPendingEmit.length; affectedFilesIndex++) {
-                const affectedFile = Debug.assertDefined(state.program).getSourceFileByPath(affectedFilesPendingEmit[affectedFilesIndex]);
+            for (let i = state.affectedFilesPendingEmitIndex!; i < affectedFilesPendingEmit.length; i++) {
+                const affectedFile = Debug.assertDefined(state.program).getSourceFileByPath(affectedFilesPendingEmit[i]);
                 if (affectedFile && !seenEmittedFiles.has(affectedFile.path)) {
                     // emit this file
-                    state.affectedFilesPendingEmitIndex = affectedFilesIndex;
+                    state.affectedFilesPendingEmitIndex = i;
                     return affectedFile;
                 }
             }
@@ -695,6 +695,10 @@ namespace ts {
             // In case of emit builder, cache the files to be emitted
             if (affectedFilesPendingEmit) {
                 state.affectedFilesPendingEmit = concatenate(state.affectedFilesPendingEmit, affectedFilesPendingEmit);
+                // affectedFilesPendingEmitIndex === undefined
+                // - means the emit state.affectedFilesPendingEmit was undefined before adding current affected files
+                //   so start from 0 as array would be affectedFilesPendingEmit
+                // else, continue to iterate from existing index, the current set is appended to existing files
                 if (state.affectedFilesPendingEmitIndex === undefined) {
                     state.affectedFilesPendingEmitIndex = 0;
                 }

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -717,22 +717,26 @@ namespace ts {
             getState: notImplemented,
             backupCurrentState: noop,
             useBackupState: noop,
-            getProgram: () => Debug.assertDefined(state.program),
+            getProgram,
             getProgramOrUndefined: () => state.program,
             releaseProgram: () => state.program = undefined,
             getCompilerOptions: () => state.compilerOptions,
-            getSourceFile: fileName => Debug.assertDefined(state.program).getSourceFile(fileName),
-            getSourceFiles: () => Debug.assertDefined(state.program).getSourceFiles(),
-            getOptionsDiagnostics: cancellationToken => Debug.assertDefined(state.program).getOptionsDiagnostics(cancellationToken),
-            getGlobalDiagnostics: cancellationToken => Debug.assertDefined(state.program).getGlobalDiagnostics(cancellationToken),
+            getSourceFile: fileName => getProgram().getSourceFile(fileName),
+            getSourceFiles: () => getProgram().getSourceFiles(),
+            getOptionsDiagnostics: cancellationToken => getProgram().getOptionsDiagnostics(cancellationToken),
+            getGlobalDiagnostics: cancellationToken => getProgram().getGlobalDiagnostics(cancellationToken),
             getConfigFileParsingDiagnostics: () => configFileParsingDiagnostics,
-            getSyntacticDiagnostics: (sourceFile, cancellationToken) => Debug.assertDefined(state.program).getSyntacticDiagnostics(sourceFile, cancellationToken),
-            getDeclarationDiagnostics: (sourceFile, cancellationToken) => Debug.assertDefined(state.program).getDeclarationDiagnostics(sourceFile, cancellationToken),
-            getSemanticDiagnostics: (sourceFile, cancellationToken) => Debug.assertDefined(state.program).getSemanticDiagnostics(sourceFile, cancellationToken),
-            emit: (sourceFile, writeFile, cancellationToken, emitOnlyDts, customTransformers) => Debug.assertDefined(state.program).emit(sourceFile, writeFile, cancellationToken, emitOnlyDts, customTransformers),
+            getSyntacticDiagnostics: (sourceFile, cancellationToken) => getProgram().getSyntacticDiagnostics(sourceFile, cancellationToken),
+            getDeclarationDiagnostics: (sourceFile, cancellationToken) => getProgram().getDeclarationDiagnostics(sourceFile, cancellationToken),
+            getSemanticDiagnostics: (sourceFile, cancellationToken) => getProgram().getSemanticDiagnostics(sourceFile, cancellationToken),
+            emit: (sourceFile, writeFile, cancellationToken, emitOnlyDts, customTransformers) => getProgram().emit(sourceFile, writeFile, cancellationToken, emitOnlyDts, customTransformers),
             getAllDependencies: notImplemented,
-            getCurrentDirectory: () => Debug.assertDefined(state.program).getCurrentDirectory()
+            getCurrentDirectory: () => getProgram().getCurrentDirectory()
         };
+
+        function getProgram() {
+            return Debug.assertDefined(state.program);
+        }
     }
 }
 

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -155,6 +155,38 @@ namespace ts {
     }
 
     /**
+     * Releases program and other related not needed properties
+     */
+    function releaseCache(state: BuilderProgramState) {
+        BuilderState.releaseCache(state);
+        state.program = undefined;
+    }
+
+    /**
+     * Creates a clone of the state
+     */
+    function cloneBuilderProgramState(state: Readonly<BuilderProgramState>): BuilderProgramState {
+        const newState = BuilderState.clone(state) as BuilderProgramState;
+        newState.semanticDiagnosticsPerFile = cloneMapOrUndefined(state.semanticDiagnosticsPerFile);
+        newState.changedFilesSet = cloneMap(state.changedFilesSet);
+        newState.affectedFiles = state.affectedFiles;
+        newState.affectedFilesIndex = state.affectedFilesIndex;
+        newState.currentChangedFilePath = state.currentChangedFilePath;
+        newState.currentAffectedFilesSignatures = cloneMapOrUndefined(state.currentAffectedFilesSignatures);
+        newState.currentAffectedFilesExportedModulesMap = cloneMapOrUndefined(state.currentAffectedFilesExportedModulesMap);
+        newState.seenAffectedFiles = cloneMapOrUndefined(state.seenAffectedFiles);
+        newState.cleanedDiagnosticsOfLibFiles = state.cleanedDiagnosticsOfLibFiles;
+        newState.semanticDiagnosticsFromOldState = cloneMapOrUndefined(state.semanticDiagnosticsFromOldState);
+        newState.program = state.program;
+        newState.compilerOptions = state.compilerOptions;
+        newState.affectedFilesPendingEmit = state.affectedFilesPendingEmit;
+        newState.affectedFilesPendingEmitIndex = state.affectedFilesPendingEmitIndex;
+        newState.seenEmittedFiles = cloneMapOrUndefined(state.seenEmittedFiles);
+        newState.programEmitComplete = state.programEmitComplete;
+        return newState;
+    }
+
+    /**
      * Verifies that source file is ok to be used in calls that arent handled by next
      */
     function assertSourceFileOkWithoutNextAffectedCall(state: BuilderProgramState, sourceFile: SourceFile | undefined) {
@@ -458,7 +490,8 @@ namespace ts {
          * Computing hash to for signature verification
          */
         const computeHash = host.createHash || generateDjb2Hash;
-        const state = createBuilderProgramState(newProgram, getCanonicalFileName, oldState);
+        let state = createBuilderProgramState(newProgram, getCanonicalFileName, oldState);
+        let backupState: BuilderProgramState | undefined;
 
         // To ensure that we arent storing any references to old program or new program without state
         newProgram = undefined!; // TODO: GH#18217
@@ -467,9 +500,21 @@ namespace ts {
 
         const result = createRedirectedBuilderProgram(state, configFileParsingDiagnostics);
         result.getState = () => state;
+        result.backupCurrentState = () => {
+            Debug.assert(backupState === undefined);
+            backupState = cloneBuilderProgramState(state);
+        };
+        result.useBackupState = () => {
+            state = Debug.assertDefined(backupState);
+            backupState = undefined;
+        };
         result.getAllDependencies = sourceFile => BuilderState.getAllDependencies(state, Debug.assertDefined(state.program), sourceFile);
         result.getSemanticDiagnostics = getSemanticDiagnostics;
         result.emit = emit;
+        result.releaseProgram = () => {
+            releaseCache(state);
+            backupState = undefined;
+        };
 
         if (kind === BuilderProgramKind.SemanticDiagnosticsBuilderProgram) {
             (result as SemanticDiagnosticsBuilderProgram).getSemanticDiagnosticsOfNextAffectedFile = getSemanticDiagnosticsOfNextAffectedFile;
@@ -650,6 +695,8 @@ namespace ts {
     export function createRedirectedBuilderProgram(state: { program: Program | undefined; compilerOptions: CompilerOptions; }, configFileParsingDiagnostics: ReadonlyArray<Diagnostic>): BuilderProgram {
         return {
             getState: notImplemented,
+            backupCurrentState: noop,
+            useBackupState: noop,
             getProgram: () => Debug.assertDefined(state.program),
             getProgramOrUndefined: () => state.program,
             releaseProgram: () => state.program = undefined,
@@ -694,6 +741,10 @@ namespace ts {
     export interface BuilderProgram {
         /*@internal*/
         getState(): BuilderProgramState;
+        /*@internal*/
+        backupCurrentState(): void;
+        /*@internal*/
+        useBackupState(): void;
         /**
          * Returns current program
          */

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -54,6 +54,18 @@ namespace ts {
          * compilerOptions for the program
          */
         compilerOptions: CompilerOptions;
+        /**
+         * Files pending to be emitted
+         */
+        affectedFilesPendingEmit: ReadonlyArray<Path> | undefined;
+        /**
+         * Current index to retrieve pending affected file
+         */
+        affectedFilesPendingEmitIndex: number | undefined;
+        /**
+         * Already seen affected files
+         */
+        seenEmittedFiles: Map<true> | undefined;
     }
 
     function hasSameKeys<T, U>(map1: ReadonlyMap<T> | undefined, map2: ReadonlyMap<U> | undefined): boolean {
@@ -89,6 +101,10 @@ namespace ts {
 
             // Copy old state's changed files set
             copyEntries(oldState!.changedFilesSet, state.changedFilesSet);
+            if (!compilerOptions.outFile && !compilerOptions.out && oldState!.affectedFilesPendingEmit) {
+                state.affectedFilesPendingEmit = oldState!.affectedFilesPendingEmit;
+                state.affectedFilesPendingEmitIndex = oldState!.affectedFilesPendingEmitIndex;
+            }
         }
 
         // Update changed files and copy semantic diagnostics if we can
@@ -204,6 +220,27 @@ namespace ts {
     }
 
     /**
+     * Returns next file to be emitted from files that retrieved semantic diagnostics but did not emit yet
+     */
+    function getNextAffectedFilePendingEmit(state: BuilderProgramState): SourceFile | undefined {
+        const { affectedFilesPendingEmit } = state;
+        if (affectedFilesPendingEmit) {
+            const seenEmittedFiles = state.seenEmittedFiles || (state.seenEmittedFiles = createMap());
+            for (let affectedFilesIndex = state.affectedFilesPendingEmitIndex!; affectedFilesIndex < affectedFilesPendingEmit.length; affectedFilesIndex++) {
+                const affectedFile = Debug.assertDefined(state.program).getSourceFileByPath(affectedFilesPendingEmit[affectedFilesIndex]);
+                if (affectedFile && !seenEmittedFiles.has(affectedFile.path)) {
+                    // emit this file
+                    state.affectedFilesPendingEmitIndex = affectedFilesIndex;
+                    return affectedFile;
+                }
+            }
+            state.affectedFilesPendingEmit = undefined;
+            state.affectedFilesPendingEmitIndex = undefined;
+        }
+        return undefined;
+    }
+
+    /**
      * Remove the semantic diagnostics cached from old state for affected File and the files that are referencing modules that export entities from affected file
      */
     function cleanSemanticDiagnosticsOfAffectedFile(state: BuilderProgramState, affectedFile: SourceFile) {
@@ -312,21 +349,26 @@ namespace ts {
      * This is called after completing operation on the next affected file.
      * The operations here are postponed to ensure that cancellation during the iteration is handled correctly
      */
-    function doneWithAffectedFile(state: BuilderProgramState, affected: SourceFile | Program) {
+    function doneWithAffectedFile(state: BuilderProgramState, affected: SourceFile | Program, isPendingEmit?: boolean) {
         if (affected === state.program) {
             state.changedFilesSet.clear();
         }
         else {
             state.seenAffectedFiles!.set((affected as SourceFile).path, true);
-            state.affectedFilesIndex!++;
+            if (isPendingEmit) {
+                state.affectedFilesPendingEmitIndex!++;
+            }
+            else {
+                state.affectedFilesIndex!++;
+            }
         }
     }
 
     /**
      * Returns the result with affected file
      */
-    function toAffectedFileResult<T>(state: BuilderProgramState, result: T, affected: SourceFile | Program): AffectedFileResult<T> {
-        doneWithAffectedFile(state, affected);
+    function toAffectedFileResult<T>(state: BuilderProgramState, result: T, affected: SourceFile | Program, isPendingEmit?: boolean): AffectedFileResult<T> {
+        doneWithAffectedFile(state, affected, isPendingEmit);
         return { result, affected };
     }
 
@@ -442,10 +484,20 @@ namespace ts {
          * in that order would be used to write the files
          */
         function emitNextAffectedFile(writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): AffectedFileResult<EmitResult> {
-            const affected = getNextAffectedFile(state, cancellationToken, computeHash);
+            let affected = getNextAffectedFile(state, cancellationToken, computeHash);
+            let isPendingEmitFile = false;
             if (!affected) {
+                affected = getNextAffectedFilePendingEmit(state);
                 // Done
-                return undefined;
+                if (!affected) {
+                    return undefined;
+                }
+                isPendingEmitFile = true;
+            }
+
+            // Mark seen emitted files if there are pending files to be emitted
+            if (state.affectedFilesPendingEmit && state.program !== affected) {
+                (state.seenEmittedFiles || (state.seenEmittedFiles = createMap())).set((affected as SourceFile).path, true);
             }
 
             return toAffectedFileResult(
@@ -453,7 +505,8 @@ namespace ts {
                 // When whole program is affected, do emit only once (eg when --out or --outFile is specified)
                 // Otherwise just affected file
                 Debug.assertDefined(state.program).emit(affected === state.program ? undefined : affected as SourceFile, writeFile || host.writeFile, cancellationToken, emitOnlyDtsFiles, customTransformers),
-                affected
+                affected,
+                isPendingEmitFile
             );
         }
 
@@ -552,12 +605,22 @@ namespace ts {
                 return getSemanticDiagnosticsOfFile(state, sourceFile, cancellationToken);
             }
 
-            if (kind === BuilderProgramKind.SemanticDiagnosticsBuilderProgram) {
-                // When semantic builder asks for diagnostics of the whole program,
-                // ensure that all the affected files are handled
-                let affected: SourceFile | Program | undefined;
-                while (affected = getNextAffectedFile(state, cancellationToken, computeHash)) {
-                    doneWithAffectedFile(state, affected);
+            // When semantic builder asks for diagnostics of the whole program,
+            // ensure that all the affected files are handled
+            let affected: SourceFile | Program | undefined;
+            let affectedFilesPendingEmit: Path[] | undefined;
+            while (affected = getNextAffectedFile(state, cancellationToken, computeHash)) {
+                if (affected !== state.program && kind === BuilderProgramKind.EmitAndSemanticDiagnosticsBuilderProgram) {
+                    (affectedFilesPendingEmit || (affectedFilesPendingEmit = [])).push((affected as SourceFile).path);
+                }
+                doneWithAffectedFile(state, affected);
+            }
+
+            // In case of emit builder, cache the files to be emitted
+            if (affectedFilesPendingEmit) {
+                state.affectedFilesPendingEmit = concatenate(state.affectedFilesPendingEmit, affectedFilesPendingEmit);
+                if (state.affectedFilesPendingEmitIndex === undefined) {
+                    state.affectedFilesPendingEmitIndex = 0;
                 }
             }
 

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -516,11 +516,11 @@ namespace ts {
 
         const result = createRedirectedBuilderProgram(state, configFileParsingDiagnostics);
         result.getState = () => state;
-        result.backupCurrentState = () => {
+        result.backupState = () => {
             Debug.assert(backupState === undefined);
             backupState = cloneBuilderProgramState(state);
         };
-        result.useBackupState = () => {
+        result.restoreState = () => {
             state = Debug.assertDefined(backupState);
             backupState = undefined;
         };
@@ -715,8 +715,8 @@ namespace ts {
     export function createRedirectedBuilderProgram(state: { program: Program | undefined; compilerOptions: CompilerOptions; }, configFileParsingDiagnostics: ReadonlyArray<Diagnostic>): BuilderProgram {
         return {
             getState: notImplemented,
-            backupCurrentState: noop,
-            useBackupState: noop,
+            backupState: noop,
+            restoreState: noop,
             getProgram,
             getProgramOrUndefined: () => state.program,
             releaseProgram: () => state.program = undefined,
@@ -766,9 +766,9 @@ namespace ts {
         /*@internal*/
         getState(): BuilderProgramState;
         /*@internal*/
-        backupCurrentState(): void;
+        backupState(): void;
         /*@internal*/
-        useBackupState(): void;
+        restoreState(): void;
         /**
          * Returns current program
          */

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -410,7 +410,7 @@ namespace ts {
         /**
          * Computing hash to for signature verification
          */
-        const computeHash = host.createHash || identity;
+        const computeHash = host.createHash || generateDjb2Hash;
         const state = createBuilderProgramState(newProgram, getCanonicalFileName, oldState);
 
         // To ensure that we arent storing any references to old program or new program without state

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -505,14 +505,14 @@ namespace ts.BuilderState {
 
         // Start with the paths this file was referenced by
         seenFileNamesMap.set(sourceFileWithUpdatedShape.path, sourceFileWithUpdatedShape);
-        const queue = getReferencedByPaths(state, sourceFileWithUpdatedShape.path);
+        const queue = getReferencedByPaths(state, sourceFileWithUpdatedShape.resolvedPath);
         while (queue.length > 0) {
             const currentPath = queue.pop()!;
             if (!seenFileNamesMap.has(currentPath)) {
                 const currentSourceFile = programOfThisState.getSourceFileByPath(currentPath)!;
                 seenFileNamesMap.set(currentPath, currentSourceFile);
                 if (currentSourceFile && updateShapeSignature(state, programOfThisState, currentSourceFile, cacheToUpdateSignature, cancellationToken, computeHash!, exportedModulesMapCache)) { // TODO: GH#18217
-                    queue.push(...getReferencedByPaths(state, currentPath));
+                    queue.push(...getReferencedByPaths(state, currentSourceFile.resolvedPath));
                 }
             }
         }

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -50,11 +50,15 @@ namespace ts {
         /**
          * Cache of all files excluding default library file for the current program
          */
-        allFilesExcludingDefaultLibraryFile: ReadonlyArray<SourceFile> | undefined;
+        allFilesExcludingDefaultLibraryFile?: ReadonlyArray<SourceFile>;
         /**
          * Cache of all the file names
          */
-        allFileNames: ReadonlyArray<string> | undefined;
+        allFileNames?: ReadonlyArray<string>;
+    }
+
+    export function cloneMapOrUndefined<T>(map: ReadonlyMap<T> | undefined) {
+        return map ? cloneMap(map) : undefined;
     }
 }
 
@@ -230,9 +234,32 @@ namespace ts.BuilderState {
             fileInfos,
             referencedMap,
             exportedModulesMap,
-            hasCalledUpdateShapeSignature,
-            allFilesExcludingDefaultLibraryFile: undefined,
-            allFileNames: undefined
+            hasCalledUpdateShapeSignature
+        };
+    }
+
+    /**
+     * Releases needed properties
+     */
+    export function releaseCache(state: BuilderState) {
+        state.allFilesExcludingDefaultLibraryFile = undefined;
+        state.allFileNames = undefined;
+    }
+
+    /**
+     * Creates a clone of the state
+     */
+    export function clone(state: Readonly<BuilderState>): BuilderState {
+        const fileInfos = createMap<FileInfo>();
+        state.fileInfos.forEach((value, key) => {
+            fileInfos.set(key, { ...value });
+        });
+        // Dont need to backup allFiles info since its cache anyway
+        return {
+            fileInfos,
+            referencedMap: cloneMapOrUndefined(state.referencedMap),
+            exportedModulesMap: cloneMapOrUndefined(state.exportedModulesMap),
+            hasCalledUpdateShapeSignature: cloneMap(state.hasCalledUpdateShapeSignature),
         };
     }
 

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1370,6 +1370,10 @@ namespace ts {
         return result;
     }
 
+    export function createRedirectObject<T extends object>(redirectTarget: T): T {
+        return Object.create(redirectTarget);
+    }
+
     export function extend<T1, T2>(first: T1, second: T2): T1 & T2 {
         const result: T1 & T2 = <any>{};
         for (const id in second) {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1391,6 +1391,14 @@ namespace ts {
         return result;
     }
 
+    export function copyProperities<T1 extends T2, T2>(first: T1, second: T2) {
+        for (const id in second) {
+            if (hasOwnProperty.call(second, id)) {
+                (first as any)[id] = second[id];
+            }
+        }
+    }
+
     export interface MultiMap<T> extends Map<T[]> {
         /**
          * Adds the value to an array of values associated with the key, and returns the array.

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1391,7 +1391,7 @@ namespace ts {
         return result;
     }
 
-    export function copyProperities<T1 extends T2, T2>(first: T1, second: T2) {
+    export function copyProperties<T1 extends T2, T2>(first: T1, second: T2) {
         for (const id in second) {
             if (hasOwnProperty.call(second, id)) {
                 (first as any)[id] = second[id];

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1370,10 +1370,6 @@ namespace ts {
         return result;
     }
 
-    export function createRedirectObject<T extends object>(redirectTarget: T): T {
-        return Object.create(redirectTarget);
-    }
-
     export function extend<T1, T2>(first: T1, second: T2): T1 & T2 {
         const result: T1 & T2 = <any>{};
         for (const id in second) {
@@ -1397,6 +1393,10 @@ namespace ts {
                 (first as any)[id] = second[id];
             }
         }
+    }
+
+    export function maybeBind<T, A extends any[], R>(obj: T, fn: ((this: T, ...args: A) => R) | undefined): ((...args: A) => R) | undefined {
+        return fn ? fn.bind(obj) : undefined;
     }
 
     export interface MultiMap<T> extends Map<T[]> {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3945,6 +3945,10 @@
         "category": "Error",
         "code": 6370
     },
+    "Updating unchanged output timestamps of project '{0}'...": {
+        "category": "Message",
+        "code": 6371
+    },
 
     "The expected type comes from property '{0}' which is declared here on type '{1}'": {
         "category": "Message",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2180,7 +2180,7 @@ namespace ts {
         }
 
         function createRedirectSourceFile(redirectTarget: SourceFile, unredirected: SourceFile, fileName: string, path: Path, resolvedPath: Path, originalFileName: string): SourceFile {
-            const redirect: SourceFile = Object.create(redirectTarget);
+            const redirect = createRedirectObject(redirectTarget);
             redirect.fileName = fileName;
             redirect.path = path;
             redirect.resolvedPath = resolvedPath;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -69,6 +69,7 @@ namespace ts {
     export function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost {
         return createCompilerHostWorker(options, setParentNodes);
     }
+
     /*@internal*/
     // TODO(shkamat): update this after reworking ts build API
     export function createCompilerHostWorker(options: CompilerOptions, setParentNodes?: boolean, system = sys): CompilerHost {
@@ -93,7 +94,6 @@ namespace ts {
                 }
                 text = "";
             }
-
             return text !== undefined ? createSourceFile(fileName, text, languageVersion, setParentNodes) : undefined;
         }
 
@@ -203,18 +203,25 @@ namespace ts {
         return compilerHost;
     }
 
+    interface ComplierHostLikeForCache {
+        fileExists(fileName: string): boolean;
+        readFile(fileName: string, encoding?: string): string | undefined;
+        directoryExists?(directory: string): boolean;
+        createDirectory?(directory: string): void;
+        writeFile?: WriteFileCallback;
+    }
+
     /*@internal*/
-    export function changeCompilerHostToUseCache(
-        host: CompilerHost,
+    export function changeCompilerHostLikeToUseCache(
+        host: ComplierHostLikeForCache,
         toPath: (fileName: string) => Path,
-        useCacheForSourceFile: boolean
+        getSourceFile?: CompilerHost["getSourceFile"]
     ) {
         const originalReadFile = host.readFile;
         const originalFileExists = host.fileExists;
         const originalDirectoryExists = host.directoryExists;
         const originalCreateDirectory = host.createDirectory;
         const originalWriteFile = host.writeFile;
-        const originalGetSourceFile = host.getSourceFile;
         const readFileCache = createMap<string | false>();
         const fileExistsCache = createMap<boolean>();
         const directoryExistsCache = createMap<boolean>();
@@ -242,19 +249,17 @@ namespace ts {
             return setReadFileCache(key, fileName);
         };
 
-        if (useCacheForSourceFile) {
-            host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
-                const key = toPath(fileName);
-                const value = sourceFileCache.get(key);
-                if (value) return value;
+        const getSourceFileWithCache: CompilerHost["getSourceFile"] | undefined = getSourceFile ? (fileName, languageVersion, onError, shouldCreateNewSourceFile) => {
+            const key = toPath(fileName);
+            const value = sourceFileCache.get(key);
+            if (value) return value;
 
-                const sourceFile = originalGetSourceFile.call(host, fileName, languageVersion, onError, shouldCreateNewSourceFile);
-                if (sourceFile && (isDeclarationFileName(fileName) || fileExtensionIs(fileName, Extension.Json))) {
-                    sourceFileCache.set(key, sourceFile);
-                }
-                return sourceFile;
-            };
-        }
+            const sourceFile = getSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+            if (sourceFile && (isDeclarationFileName(fileName) || fileExtensionIs(fileName, Extension.Json))) {
+                sourceFileCache.set(key, sourceFile);
+            }
+            return sourceFile;
+        } : undefined;
 
         // fileExists for any kind of extension
         host.fileExists = fileName => {
@@ -265,23 +270,25 @@ namespace ts {
             fileExistsCache.set(key, !!newValue);
             return newValue;
         };
-        host.writeFile = (fileName, data, writeByteOrderMark, onError, sourceFiles) => {
-            const key = toPath(fileName);
-            fileExistsCache.delete(key);
+        if (originalWriteFile) {
+            host.writeFile = (fileName, data, writeByteOrderMark, onError, sourceFiles) => {
+                const key = toPath(fileName);
+                fileExistsCache.delete(key);
 
-            const value = readFileCache.get(key);
-            if (value && value !== data) {
-                readFileCache.delete(key);
-                sourceFileCache.delete(key);
-            }
-            else if (useCacheForSourceFile) {
-                const sourceFile = sourceFileCache.get(key);
-                if (sourceFile && sourceFile.text !== data) {
+                const value = readFileCache.get(key);
+                if (value && value !== data) {
+                    readFileCache.delete(key);
                     sourceFileCache.delete(key);
                 }
-            }
-            originalWriteFile.call(host, fileName, data, writeByteOrderMark, onError, sourceFiles);
-        };
+                else if (getSourceFileWithCache) {
+                    const sourceFile = sourceFileCache.get(key);
+                    if (sourceFile && sourceFile.text !== data) {
+                        sourceFileCache.delete(key);
+                    }
+                }
+                originalWriteFile.call(host, fileName, data, writeByteOrderMark, onError, sourceFiles);
+            };
+        }
 
         // directoryExists
         if (originalDirectoryExists && originalCreateDirectory) {
@@ -306,7 +313,7 @@ namespace ts {
             originalDirectoryExists,
             originalCreateDirectory,
             originalWriteFile,
-            originalGetSourceFile,
+            getSourceFileWithCache,
             readFileWithCache
         };
     }
@@ -735,7 +742,7 @@ namespace ts {
         performance.mark("beforeProgram");
 
         const host = createProgramOptions.host || createCompilerHost(options);
-        const configParsingHost = parseConfigHostFromCompilerHost(host);
+        const configParsingHost = parseConfigHostFromCompilerHostLike(host);
 
         let skipDefaultLib = options.noLib;
         const getDefaultLibraryFileName = memoize(() => host.getDefaultLibFileName(options));
@@ -3101,18 +3108,28 @@ namespace ts {
         }
     }
 
+    interface CompilerHostLike {
+        useCaseSensitiveFileNames(): boolean;
+        getCurrentDirectory(): string;
+        fileExists(fileName: string): boolean;
+        readFile(fileName: string): string | undefined;
+        readDirectory?(rootDir: string, extensions: ReadonlyArray<string>, excludes: ReadonlyArray<string> | undefined, includes: ReadonlyArray<string>, depth?: number): string[];
+        trace?(s: string): void;
+        onUnRecoverableConfigFileDiagnostic?: DiagnosticReporter;
+    }
+
     /* @internal */
-    export function parseConfigHostFromCompilerHost(host: CompilerHost): ParseConfigFileHost {
+    export function parseConfigHostFromCompilerHostLike(host: CompilerHostLike, directoryStructureHost: DirectoryStructureHost = host): ParseConfigFileHost {
         return {
             fileExists: f => host.fileExists(f),
             readDirectory(root, extensions, excludes, includes, depth) {
-                Debug.assertDefined(host.readDirectory, "'CompilerHost.readDirectory' must be implemented to correctly process 'projectReferences'");
-                return host.readDirectory!(root, extensions, excludes, includes, depth);
+                Debug.assertDefined(directoryStructureHost.readDirectory, "'CompilerHost.readDirectory' must be implemented to correctly process 'projectReferences'");
+                return directoryStructureHost.readDirectory!(root, extensions, excludes, includes, depth);
             },
             readFile: f => host.readFile(f),
             useCaseSensitiveFileNames: host.useCaseSensitiveFileNames(),
             getCurrentDirectory: () => host.getCurrentDirectory(),
-            onUnRecoverableConfigFileDiagnostic: () => undefined,
+            onUnRecoverableConfigFileDiagnostic: host.onUnRecoverableConfigFileDiagnostic || (() => undefined),
             trace: host.trace ? (s) => host.trace!(s) : undefined
         };
     }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -203,7 +203,7 @@ namespace ts {
         return compilerHost;
     }
 
-    interface ComplierHostLikeForCache {
+    interface CompilerHostLikeForCache {
         fileExists(fileName: string): boolean;
         readFile(fileName: string, encoding?: string): string | undefined;
         directoryExists?(directory: string): boolean;
@@ -213,7 +213,7 @@ namespace ts {
 
     /*@internal*/
     export function changeCompilerHostLikeToUseCache(
-        host: ComplierHostLikeForCache,
+        host: CompilerHostLikeForCache,
         toPath: (fileName: string) => Path,
         getSourceFile?: CompilerHost["getSourceFile"]
     ) {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2187,7 +2187,7 @@ namespace ts {
         }
 
         function createRedirectSourceFile(redirectTarget: SourceFile, unredirected: SourceFile, fileName: string, path: Path, resolvedPath: Path, originalFileName: string): SourceFile {
-            const redirect = Object.create(redirectTarget);
+            const redirect: SourceFile = Object.create(redirectTarget);
             redirect.fileName = fileName;
             redirect.path = path;
             redirect.resolvedPath = resolvedPath;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3121,12 +3121,12 @@ namespace ts {
     /* @internal */
     export function parseConfigHostFromCompilerHostLike(host: CompilerHostLike, directoryStructureHost: DirectoryStructureHost = host): ParseConfigFileHost {
         return {
-            fileExists: f => host.fileExists(f),
+            fileExists: f => directoryStructureHost.fileExists(f),
             readDirectory(root, extensions, excludes, includes, depth) {
                 Debug.assertDefined(directoryStructureHost.readDirectory, "'CompilerHost.readDirectory' must be implemented to correctly process 'projectReferences'");
                 return directoryStructureHost.readDirectory!(root, extensions, excludes, includes, depth);
             },
-            readFile: f => host.readFile(f),
+            readFile: f => directoryStructureHost.readFile(f),
             useCaseSensitiveFileNames: host.useCaseSensitiveFileNames(),
             getCurrentDirectory: () => host.getCurrentDirectory(),
             onUnRecoverableConfigFileDiagnostic: host.onUnRecoverableConfigFileDiagnostic || (() => undefined),

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2187,7 +2187,7 @@ namespace ts {
         }
 
         function createRedirectSourceFile(redirectTarget: SourceFile, unredirected: SourceFile, fileName: string, path: Path, resolvedPath: Path, originalFileName: string): SourceFile {
-            const redirect = createRedirectObject(redirectTarget);
+            const redirect = Object.create(redirectTarget);
             redirect.fileName = fileName;
             redirect.path = path;
             redirect.resolvedPath = resolvedPath;

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -3,6 +3,16 @@ declare function clearTimeout(handle: any): void;
 
 namespace ts {
     /**
+     * djb2 hashing algorithm
+     * http://www.cse.yorku.ca/~oz/hash.html
+     */
+    /* @internal */
+    export function generateDjb2Hash(data: string): string {
+        const chars = data.split("").map(str => str.charCodeAt(0));
+        return `${chars.reduce((prev, curr) => ((prev << 5) + prev) + curr, 5381)}`;
+    }
+
+    /**
      * Set a high stack trace limit to provide more information in case of an error.
      * Called for command-line and server use cases.
      * Not called if TypeScript is used as a library.
@@ -1113,15 +1123,6 @@ namespace ts {
                 catch (e) {
                     return;
                 }
-            }
-
-            /**
-             * djb2 hashing algorithm
-             * http://www.cse.yorku.ca/~oz/hash.html
-             */
-            function generateDjb2Hash(data: string): string {
-                const chars = data.split("").map(str => str.charCodeAt(0));
-                return `${chars.reduce((prev, curr) => ((prev << 5) + prev) + curr, 5381)}`;
             }
 
             function createMD5HashUsingNativeCrypto(data: string): string {

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -1065,8 +1065,9 @@ namespace ts {
 
             // Don't emit anything in the presence of syntactic errors or options diagnostics
             const syntaxDiagnostics = [
-                ...program.getOptionsDiagnostics(),
                 ...program.getConfigFileParsingDiagnostics(),
+                ...program.getOptionsDiagnostics(),
+                ...program.getGlobalDiagnostics(),
                 ...program.getSyntacticDiagnostics()];
             if (syntaxDiagnostics.length) {
                 return buildErrors(syntaxDiagnostics, BuildResultFlags.SyntaxErrors, "Syntactic");

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -1422,7 +1422,7 @@ namespace ts {
                 return first(outputs);
             }
         }
-        return Debug.fail(`project ${project.options.configFilePath} expected to have atleast one output`);
+        return Debug.fail(`project ${project.options.configFilePath} expected to have at least one output`);
     }
 
     export function formatUpToDateStatus<T>(configFileName: string, status: UpToDateStatus, relName: (fileName: string) => string, formatMessage: (message: DiagnosticMessage, ...args: string[]) => T) {

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -1129,7 +1129,7 @@ namespace ts {
             }
 
             // Before emitting lets backup state, so we can revert it back if there are declaration errors to handle emit and declaration errors correctly
-            program.backupCurrentState();
+            program.backupState();
             let newestDeclarationFileContentChangedTime = minimumDate;
             let anyDtsChanged = false;
             let declDiagnostics: Diagnostic[] | undefined;
@@ -1138,7 +1138,7 @@ namespace ts {
             emitFilesAndReportErrors(program, reportDeclarationDiagnostics, writeFileName, /*reportSummary*/ undefined, (name, text, writeByteOrderMark) => outputFiles.push({ name, text, writeByteOrderMark }));
             // Don't emit .d.ts if there are decl file errors
             if (declDiagnostics) {
-                program.useBackupState();
+                program.restoreState();
                 return buildErrors(declDiagnostics, BuildResultFlags.DeclarationEmitErrors, "Declaration file");
             }
 

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -1008,8 +1008,8 @@ namespace ts {
                 const project = buildQueue[index];
                 const prepend = referencingProjects.getValue(project);
                 if (prepend !== undefined) {
-                    // If the project is referenced with prepend, always build downstream project,
-                    // If declaration output is changed changed, build the project
+                    // If the project is referenced with prepend, always build downstream projects,
+                    // If declaration output is changed, build the project
                     // otherwise mark the project UpToDateWithUpstreamTypes so it updates output time stamps
                     const status = projectStatus.getValue(project);
                     if (prepend || !(buildResult & BuildResultFlags.DeclarationOutputUnchanged)) {

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -389,9 +389,8 @@ namespace ts {
         return host;
     }
 
-    // TODO: we should use emit and semantic diagnostics builder but that needs to handle errors little differently so handle it later
     export function createSolutionBuilderWithWatchHost<T extends BuilderProgram = SemanticDiagnosticsBuilderProgram>(system = sys, createProgram?: CreateProgram<T>, reportDiagnostic?: DiagnosticReporter, reportSolutionBuilderStatus?: DiagnosticReporter, reportWatchStatus?: WatchStatusReporter) {
-        const host = createSolutionBuilderHostBase(system, createProgram || createSemanticDiagnosticsBuilderProgram as any as CreateProgram<T>, reportDiagnostic, reportSolutionBuilderStatus) as SolutionBuilderWithWatchHost<T>;
+        const host = createSolutionBuilderHostBase(system, createProgram || createEmitAndSemanticDiagnosticsBuilderProgram as any as CreateProgram<T>, reportDiagnostic, reportSolutionBuilderStatus) as SolutionBuilderWithWatchHost<T>;
         const watchHost = createWatchHost(system, reportWatchStatus);
         copyProperities(host, watchHost);
         return host;

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -331,7 +331,7 @@ namespace ts {
 
         // TODO: To do better with watch mode and normal build mode api that creates program and emits files
         // This currently helps enable --diagnostics and --extendedDiagnostics
-        afterProgramEmitAndDiagnostics?(program: Program): void;
+        afterProgramEmitAndDiagnostics?(program: T): void;
     }
 
     export interface SolutionBuilderHost<T extends BuilderProgram> extends SolutionBuilderHostBase<T> {

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -393,7 +393,7 @@ namespace ts {
     export function createSolutionBuilderWithWatchHost<T extends BuilderProgram = SemanticDiagnosticsBuilderProgram>(system = sys, createProgram?: CreateProgram<T>, reportDiagnostic?: DiagnosticReporter, reportSolutionBuilderStatus?: DiagnosticReporter, reportWatchStatus?: WatchStatusReporter) {
         const host = createSolutionBuilderHostBase(system, createProgram || createEmitAndSemanticDiagnosticsBuilderProgram as any as CreateProgram<T>, reportDiagnostic, reportSolutionBuilderStatus) as SolutionBuilderWithWatchHost<T>;
         const watchHost = createWatchHost(system, reportWatchStatus);
-        copyProperities(host, watchHost);
+        copyProperties(host, watchHost);
         return host;
     }
 

--- a/src/compiler/tsbuild.ts
+++ b/src/compiler/tsbuild.ts
@@ -447,7 +447,7 @@ namespace ts {
         let nextProjectToBuild = 0;
         let timerToBuildInvalidatedProject: any;
         let reportFileChangeDetected = false;
-        const { watchFile, watchFilePath, watchDirectory } = createWatchFactory<ResolvedConfigFileName>(host, options);
+        const { watchFile, watchFilePath, watchDirectory, writeLog } = createWatchFactory<ResolvedConfigFileName>(host, options);
 
         // Watches for the solution
         const allWatchedWildcardDirectories = createFileMap<Map<WildcardDirectoryWatcher>>(toPath);
@@ -593,12 +593,12 @@ namespace ts {
                         fileOrDirectory => {
                             const fileOrDirectoryPath = toPath(fileOrDirectory);
                             if (fileOrDirectoryPath !== toPath(dir) && hasExtension(fileOrDirectoryPath) && !isSupportedSourceFileName(fileOrDirectory, parsed.options)) {
-                                // writeLog(`Project: ${configFileName} Detected file add/remove of non supported extension: ${fileOrDirectory}`);
+                                writeLog(`Project: ${resolved} Detected file add/remove of non supported extension: ${fileOrDirectory}`);
                                 return;
                             }
 
                             if (isOutputFile(fileOrDirectory, parsed)) {
-                                // writeLog(`${fileOrDirectory} is output file`);
+                                writeLog(`${fileOrDirectory} is output file`);
                                 return;
                             }
 
@@ -991,7 +991,7 @@ namespace ts {
             }
 
             if (status.type === UpToDateStatusType.UpToDateWithUpstreamTypes) {
-                // Fake build
+                // Fake that files have been built by updating output file stamps
                 updateOutputTimestamps(proj);
                 return;
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2827,7 +2827,7 @@ namespace ts {
         fileName: string,
         data: string,
         writeByteOrderMark: boolean,
-        onError: ((message: string) => void) | undefined,
+        onError?: (message: string) => void,
         sourceFiles?: ReadonlyArray<SourceFile>,
     ) => void;
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5000,7 +5000,6 @@ namespace ts {
         getDefaultLibLocation?(): string;
         writeFile: WriteFileCallback;
         getCurrentDirectory(): string;
-        getDirectories(path: string): string[];
         getCanonicalFileName(fileName: string): string;
         useCaseSensitiveFileNames(): boolean;
         getNewLine(): string;

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -88,21 +88,6 @@ namespace ts {
         return result;
     }
 
-    /**
-     * Program structure needed to emit the files and report diagnostics
-     */
-    export interface ProgramToEmitFilesAndReportErrors {
-        getCurrentDirectory(): string;
-        getCompilerOptions(): CompilerOptions;
-        getSourceFiles(): ReadonlyArray<SourceFile>;
-        getSyntacticDiagnostics(): ReadonlyArray<Diagnostic>;
-        getOptionsDiagnostics(): ReadonlyArray<Diagnostic>;
-        getGlobalDiagnostics(): ReadonlyArray<Diagnostic>;
-        getSemanticDiagnostics(): ReadonlyArray<Diagnostic>;
-        getConfigFileParsingDiagnostics(): ReadonlyArray<Diagnostic>;
-        emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback): EmitResult;
-    }
-
     export type ReportEmitErrorSummary = (errorCount: number) => void;
 
     export function getErrorCountForSummary(diagnostics: ReadonlyArray<Diagnostic>) {
@@ -124,7 +109,7 @@ namespace ts {
     /**
      * Helper that emit files, report diagnostics and lists emitted and/or source files depending on compiler options
      */
-    export function emitFilesAndReportErrors(program: ProgramToEmitFilesAndReportErrors, reportDiagnostic: DiagnosticReporter, writeFileName?: (s: string) => void, reportSummary?: ReportEmitErrorSummary, writeFile?: WriteFileCallback) {
+    export function emitFilesAndReportErrors(program: Program, reportDiagnostic: DiagnosticReporter, writeFileName?: (s: string) => void, reportSummary?: ReportEmitErrorSummary, writeFile?: WriteFileCallback) {
         // First get and report any syntactic errors.
         const diagnostics = program.getConfigFileParsingDiagnostics().slice();
         const configFileParsingDiagnosticsLength = diagnostics.length;

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -317,7 +317,7 @@ namespace ts {
     function createWatchCompilerHost<T extends BuilderProgram = EmitAndSemanticDiagnosticsBuilderProgram>(system = sys, createProgram: CreateProgram<T> | undefined, reportDiagnostic: DiagnosticReporter, reportWatchStatus?: WatchStatusReporter): WatchCompilerHost<T> {
         const writeFileName = (s: string) => system.write(s + system.newLine);
         const result = createProgramHost(system, createProgram || createEmitAndSemanticDiagnosticsBuilderProgram as any as CreateProgram<T>) as WatchCompilerHost<T>;
-        copyProperities(result, createWatchHost(system, reportWatchStatus));
+        copyProperties(result, createWatchHost(system, reportWatchStatus));
         result.afterProgramCreate = builderProgram => {
             const compilerOptions = builderProgram.getCompilerOptions();
             const newLine = getNewLineCharacter(compilerOptions, () => system.newLine);

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -203,17 +203,14 @@ namespace ts {
         TypeRoots = "Type roots"
     }
 
-    interface WatchFactory<X, Y= undefined> extends ts.WatchFactory<X, Y> {
-        watchLogLevel: WatchLogLevel;
+    interface WatchFactory<X, Y = undefined> extends ts.WatchFactory<X, Y> {
         writeLog: (s: string) => void;
     }
 
     export function createWatchFactory<Y = undefined>(host: { trace?(s: string): void; }, options: { extendedDiagnostics?: boolean; diagnostics?: boolean; }) {
-        const watchLogLevel = host.trace ? options.extendedDiagnostics ? WatchLogLevel.Verbose :
-            options.diagnostics ? WatchLogLevel.TriggerOnly : WatchLogLevel.None : WatchLogLevel.None;
+        const watchLogLevel = host.trace ? options.extendedDiagnostics ? WatchLogLevel.Verbose : options.diagnostics ? WatchLogLevel.TriggerOnly : WatchLogLevel.None : WatchLogLevel.None;
         const writeLog: (s: string) => void = watchLogLevel !== WatchLogLevel.None ? (s => host.trace!(s)) : noop;
         const result = getWatchFactory<WatchType, Y>(watchLogLevel, writeLog) as WatchFactory<WatchType, Y>;
-        result.watchLogLevel = watchLogLevel;
         result.writeLog = writeLog;
         return result;
     }
@@ -590,7 +587,7 @@ namespace ts {
             newLine = updateNewLine();
         }
 
-        const { watchFile, watchFilePath, watchDirectory, watchLogLevel, writeLog } = createWatchFactory<string>(host, compilerOptions);
+        const { watchFile, watchFilePath, watchDirectory, writeLog } = createWatchFactory<string>(host, compilerOptions);
         const getCanonicalFileName = createGetCanonicalFileName(useCaseSensitiveFileNames);
 
         writeLog(`Current directory: ${currentDirectory} CaseSensitiveFileNames: ${useCaseSensitiveFileNames}`);
@@ -685,11 +682,9 @@ namespace ts {
 
         function createNewProgram(program: Program, hasInvalidatedResolution: HasInvalidatedResolution) {
             // Compile the program
-            if (watchLogLevel !== WatchLogLevel.None) {
-                writeLog("CreatingProgramWith::");
-                writeLog(`  roots: ${JSON.stringify(rootFileNames)}`);
-                writeLog(`  options: ${JSON.stringify(compilerOptions)}`);
-            }
+            writeLog("CreatingProgramWith::");
+            writeLog(`  roots: ${JSON.stringify(rootFileNames)}`);
+            writeLog(`  options: ${JSON.stringify(compilerOptions)}`);
 
             const needsUpdateInTypeRootWatch = hasChangedCompilerOptions || !program;
             hasChangedCompilerOptions = false;

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -107,9 +107,24 @@ namespace ts {
     }
 
     /**
+     * Program structure needed to emit the files and report diagnostics
+     */
+    export interface ProgramToEmitFilesAndReportErrors {
+        getCurrentDirectory(): string;
+        getCompilerOptions(): CompilerOptions;
+        getSourceFiles(): ReadonlyArray<SourceFile>;
+        getSyntacticDiagnostics(): ReadonlyArray<Diagnostic>;
+        getOptionsDiagnostics(): ReadonlyArray<Diagnostic>;
+        getGlobalDiagnostics(): ReadonlyArray<Diagnostic>;
+        getSemanticDiagnostics(): ReadonlyArray<Diagnostic>;
+        getConfigFileParsingDiagnostics(): ReadonlyArray<Diagnostic>;
+        emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback): EmitResult;
+    }
+
+    /**
      * Helper that emit files, report diagnostics and lists emitted and/or source files depending on compiler options
      */
-    export function emitFilesAndReportErrors(program: Program, reportDiagnostic: DiagnosticReporter, writeFileName?: (s: string) => void, reportSummary?: ReportEmitErrorSummary, writeFile?: WriteFileCallback) {
+    export function emitFilesAndReportErrors(program: ProgramToEmitFilesAndReportErrors, reportDiagnostic: DiagnosticReporter, writeFileName?: (s: string) => void, reportSummary?: ReportEmitErrorSummary, writeFile?: WriteFileCallback) {
         // First get and report any syntactic errors.
         const diagnostics = program.getConfigFileParsingDiagnostics().slice();
         const configFileParsingDiagnosticsLength = diagnostics.length;

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -343,10 +343,10 @@ namespace ts {
     export interface WatchDirectoryHost {
         watchDirectory(path: string, callback: DirectoryWatcherCallback, recursive?: boolean): FileWatcher;
     }
-    export type WatchFile<X, Y> = (host: WatchFileHost, file: string, callback: FileWatcherCallback, pollingInterval: PollingInterval, detailInfo1?: X, detailInfo2?: Y) => FileWatcher;
+    export type WatchFile<X, Y> = (host: WatchFileHost, file: string, callback: FileWatcherCallback, pollingInterval: PollingInterval, detailInfo1: X, detailInfo2?: Y) => FileWatcher;
     export type FilePathWatcherCallback = (fileName: string, eventKind: FileWatcherEventKind, filePath: Path) => void;
-    export type WatchFilePath<X, Y> = (host: WatchFileHost, file: string, callback: FilePathWatcherCallback, pollingInterval: PollingInterval, path: Path, detailInfo1?: X, detailInfo2?: Y) => FileWatcher;
-    export type WatchDirectory<X, Y> = (host: WatchDirectoryHost, directory: string, callback: DirectoryWatcherCallback, flags: WatchDirectoryFlags, detailInfo1?: X, detailInfo2?: Y) => FileWatcher;
+    export type WatchFilePath<X, Y> = (host: WatchFileHost, file: string, callback: FilePathWatcherCallback, pollingInterval: PollingInterval, path: Path, detailInfo1: X, detailInfo2?: Y) => FileWatcher;
+    export type WatchDirectory<X, Y> = (host: WatchDirectoryHost, directory: string, callback: DirectoryWatcherCallback, flags: WatchDirectoryFlags, detailInfo1: X, detailInfo2?: Y) => FileWatcher;
 
     export interface WatchFactory<X, Y> {
         watchFile: WatchFile<X, Y>;
@@ -444,7 +444,7 @@ namespace ts {
     }
 
     function getWatchInfo<T, X, Y>(file: string, flags: T, detailInfo1: X, detailInfo2: Y | undefined, getDetailWatchInfo: GetDetailWatchInfo<X, Y> | undefined) {
-        return `WatchInfo: ${file} ${flags} ${getDetailWatchInfo ? getDetailWatchInfo(detailInfo1, detailInfo2) : detailInfo1}`;
+        return `WatchInfo: ${file} ${flags} ${getDetailWatchInfo ? getDetailWatchInfo(detailInfo1, detailInfo2) : detailInfo2 === undefined ? detailInfo1 : `${detailInfo1} ${detailInfo2}`}`;
     }
 
     export function closeFileWatcherOf<T extends { watcher: FileWatcher; }>(objWithWatcher: T) {

--- a/src/harness/fakes.ts
+++ b/src/harness/fakes.ts
@@ -375,7 +375,9 @@ namespace fakes {
         }
     }
 
-    export class SolutionBuilderHost extends CompilerHost implements ts.SolutionBuilderHost {
+    export class SolutionBuilderHost extends CompilerHost implements ts.SolutionBuilderHost<ts.BuilderProgram> {
+        createProgram = ts.createAbstractBuilder;
+
         diagnostics: ts.Diagnostic[] = [];
 
         reportDiagnostic(diagnostic: ts.Diagnostic) {

--- a/src/harness/fakes.ts
+++ b/src/harness/fakes.ts
@@ -377,6 +377,9 @@ namespace fakes {
 
     export class SolutionBuilderHost extends CompilerHost implements ts.SolutionBuilderHost<ts.BuilderProgram> {
         createProgram = ts.createAbstractBuilder;
+        now() {
+            return new Date(this.sys.vfs.time());
+        }
 
         diagnostics: ts.Diagnostic[] = [];
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -332,19 +332,6 @@ namespace ts.server {
         }
     }
 
-    /* @internal */
-    export const enum WatchType {
-        ConfigFilePath = "Config file for the program",
-        MissingFilePath = "Missing file from program",
-        WildcardDirectories = "Wild card directory",
-        ClosedScriptInfo = "Closed Script info",
-        ConfigFileForInferredRoot = "Config file for the inferred project root",
-        FailedLookupLocation = "Directory of Failed lookup locations in module resolution",
-        TypeRoots = "Type root directory",
-        NodeModulesForClosedScriptInfo = "node_modules for closed script infos in them",
-        MissingSourceMapFile = "Missing source map file"
-    }
-
     const enum ConfigFileWatcherStatus {
         ReloadingFiles = "Reloading configured projects for files",
         ReloadingInferredRootFiles = "Reloading configured projects for only inferred root files",
@@ -1035,7 +1022,7 @@ namespace ts.server {
                     }
                 },
                 flags,
-                WatchType.WildcardDirectories,
+                WatchType.WildcardDirectory,
                 project
             );
         }
@@ -1338,7 +1325,7 @@ namespace ts.server {
                 watches.push(WatchType.ConfigFileForInferredRoot);
             }
             if (this.configuredProjects.has(canonicalConfigFilePath)) {
-                watches.push(WatchType.ConfigFilePath);
+                watches.push(WatchType.ConfigFile);
             }
             this.logger.info(`ConfigFilePresence:: Current Watches: ${watches}:: File: ${configFileName} Currently impacted open files: RootsOfInferredProjects: ${inferredRoots} OtherOpenFiles: ${otherFiles} Status: ${status}`);
         }
@@ -1705,7 +1692,7 @@ namespace ts.server {
                 configFileName,
                 (_fileName, eventKind) => this.onConfigChangedForConfiguredProject(project, eventKind),
                 PollingInterval.High,
-                WatchType.ConfigFilePath,
+                WatchType.ConfigFile,
                 project
             );
             this.configuredProjects.set(project.canonicalConfigFilePath, project);

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -428,7 +428,7 @@ namespace ts.server {
                 directory,
                 cb,
                 flags,
-                WatchType.FailedLookupLocation,
+                WatchType.FailedLookupLocations,
                 this
             );
         }
@@ -989,7 +989,7 @@ namespace ts.server {
                     }
                 },
                 PollingInterval.Medium,
-                WatchType.MissingFilePath,
+                WatchType.MissingFile,
                 this
             );
             return fileWatcher;

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -217,3 +217,14 @@ namespace ts.server {
         return indentStr + JSON.stringify(json);
     }
 }
+
+/* @internal */
+namespace ts {
+    // Additional tsserver specific watch information
+    export const enum WatchType {
+        ClosedScriptInfo = "Closed Script info",
+        ConfigFileForInferredRoot = "Config file for the inferred project root",
+        NodeModulesForClosedScriptInfo = "node_modules for closed script infos in them",
+        MissingSourceMapFile = "Missing source map file",
+    }
+}

--- a/src/testRunner/unittests/config/projectReferences.ts
+++ b/src/testRunner/unittests/config/projectReferences.ts
@@ -85,7 +85,7 @@ namespace ts {
 
         // We shouldn't have any errors about invalid tsconfig files in these tests
         assert(config && !error, flattenDiagnosticMessageText(error && error.messageText, "\n"));
-        const file = parseJsonConfigFileContent(config, parseConfigHostFromCompilerHost(host), getDirectoryPath(entryPointConfigFileName), {}, entryPointConfigFileName);
+        const file = parseJsonConfigFileContent(config, parseConfigHostFromCompilerHostLike(host), getDirectoryPath(entryPointConfigFileName), {}, entryPointConfigFileName);
         file.options.configFilePath = entryPointConfigFileName;
         const prog = createProgram({
             rootNames: file.fileNames,

--- a/src/testRunner/unittests/tsbuild.ts
+++ b/src/testRunner/unittests/tsbuild.ts
@@ -265,7 +265,7 @@ export class cNew {}`);
                 // Build downstream projects should update 'tests', but not 'core'
                 tick();
                 builder.buildInvalidatedProject();
-                assert.isBelow(fs.statSync("/src/tests/index.js").mtimeMs, time(), "Downstream JS file should have been rebuilt");
+                assert.equal(fs.statSync("/src/tests/index.js").mtimeMs, time(), "Downstream JS file should have been rebuilt");
                 assert.isBelow(fs.statSync("/src/core/index.js").mtimeMs, time(), "Upstream JS file should not have been rebuilt");
             });
         });

--- a/src/testRunner/unittests/tsbuild.ts
+++ b/src/testRunner/unittests/tsbuild.ts
@@ -234,39 +234,46 @@ namespace ts {
                 // Update a timestamp in the middle project
                 tick();
                 touch(fs, "/src/logic/index.ts");
+                const originalWriteFile = fs.writeFileSync;
+                const writtenFiles = createMap<true>();
+                fs.writeFileSync = (path, data, encoding) => {
+                    writtenFiles.set(path, true);
+                    originalWriteFile.call(fs, path, data, encoding);
+                };
                 // Because we haven't reset the build context, the builder should assume there's nothing to do right now
                 const status = builder.getUpToDateStatusOfFile(builder.resolveProjectName("/src/logic"));
                 assert.equal(status.type, UpToDateStatusType.UpToDate, "Project should be assumed to be up-to-date");
+                verifyInvalidation(/*expectedToWriteTests*/ false);
 
                 // Rebuild this project
-                tick();
-                builder.invalidateProject("/src/logic");
-                builder.buildInvalidatedProject();
-                // The file should be updated
-                assert.equal(fs.statSync("/src/logic/index.js").mtimeMs, time(), "JS file should have been rebuilt");
-                assert.isBelow(fs.statSync("/src/tests/index.js").mtimeMs, time(), "Downstream JS file should *not* have been rebuilt");
-
-                // Does not build tests or core because there is no change in declaration file
-                tick();
-                builder.buildInvalidatedProject();
-                assert.isBelow(fs.statSync("/src/tests/index.js").mtimeMs, time(), "Downstream JS file should have been rebuilt");
-                assert.isBelow(fs.statSync("/src/core/index.js").mtimeMs, time(), "Upstream JS file should not have been rebuilt");
-
-                // Rebuild this project
-                tick();
                 fs.writeFileSync("/src/logic/index.ts", `${fs.readFileSync("/src/logic/index.ts")}
 export class cNew {}`);
-                builder.invalidateProject("/src/logic");
-                builder.buildInvalidatedProject();
-                // The file should be updated
-                assert.equal(fs.statSync("/src/logic/index.js").mtimeMs, time(), "JS file should have been rebuilt");
-                assert.isBelow(fs.statSync("/src/tests/index.js").mtimeMs, time(), "Downstream JS file should *not* have been rebuilt");
+                verifyInvalidation(/*expectedToWriteTests*/ true);
 
-                // Build downstream projects should update 'tests', but not 'core'
-                tick();
-                builder.buildInvalidatedProject();
-                assert.equal(fs.statSync("/src/tests/index.js").mtimeMs, time(), "Downstream JS file should have been rebuilt");
-                assert.isBelow(fs.statSync("/src/core/index.js").mtimeMs, time(), "Upstream JS file should not have been rebuilt");
+                function verifyInvalidation(expectedToWriteTests: boolean) {
+                    // Rebuild this project
+                    tick();
+                    builder.invalidateProject("/src/logic");
+                    builder.buildInvalidatedProject();
+                    // The file should be updated
+                    assert.isTrue(writtenFiles.has("/src/logic/index.js"), "JS file should have been rebuilt");
+                    assert.equal(fs.statSync("/src/logic/index.js").mtimeMs, time(), "JS file should have been rebuilt");
+                    assert.isFalse(writtenFiles.has("/src/tests/index.js"), "Downstream JS file should *not* have been rebuilt");
+                    assert.isBelow(fs.statSync("/src/tests/index.js").mtimeMs, time(), "Downstream JS file should *not* have been rebuilt");
+                    writtenFiles.clear();
+
+                    // Build downstream projects should update 'tests', but not 'core'
+                    tick();
+                    builder.buildInvalidatedProject();
+                    if (expectedToWriteTests) {
+                        assert.isTrue(writtenFiles.has("/src/tests/index.js"), "Downstream JS file should have been rebuilt");
+                    }
+                    else {
+                        assert.equal(writtenFiles.size, 0, "Should not write any new files");
+                    }
+                    assert.equal(fs.statSync("/src/tests/index.js").mtimeMs, time(), "Downstream JS file should have new timestamp");
+                    assert.isBelow(fs.statSync("/src/core/index.js").mtimeMs, time(), "Upstream JS file should not have been rebuilt");
+                }
             });
         });
 

--- a/src/testRunner/unittests/tsbuildWatchMode.ts
+++ b/src/testRunner/unittests/tsbuildWatchMode.ts
@@ -2,16 +2,35 @@ namespace ts.tscWatch {
     import projectsLocation = TestFSWithWatch.tsbuildProjectsLocation;
     import getFilePathInProject = TestFSWithWatch.getTsBuildProjectFilePath;
     import getFileFromProject = TestFSWithWatch.getTsBuildProjectFile;
+    type TsBuildWatchSystem = WatchedSystem & { writtenFiles: Map<true>; };
+
+    function createTsBuildWatchSystem(fileOrFolderList: ReadonlyArray<TestFSWithWatch.FileOrFolderOrSymLink>, params?: TestFSWithWatch.TestServerHostCreationParameters) {
+        const host = createWatchedSystem(fileOrFolderList, params) as TsBuildWatchSystem;
+        const originalWriteFile = host.writeFile;
+        host.writtenFiles = createMap<true>();
+        host.writeFile = (fileName, content) => {
+            originalWriteFile.call(host, fileName, content);
+            const path = host.toFullPath(fileName);
+            host.writtenFiles.set(path, true);
+        };
+        return host;
+    }
+
     export function createSolutionBuilder(system: WatchedSystem, rootNames: ReadonlyArray<string>, defaultOptions?: BuildOptions) {
         const host = createSolutionBuilderWithWatchHost(system);
         return ts.createSolutionBuilder(host, rootNames, defaultOptions || { watch: true });
     }
 
-    function createSolutionBuilderWithWatch(host: WatchedSystem, rootNames: ReadonlyArray<string>, defaultOptions?: BuildOptions) {
+    function createSolutionBuilderWithWatch(host: TsBuildWatchSystem, rootNames: ReadonlyArray<string>, defaultOptions?: BuildOptions) {
         const solutionBuilder = createSolutionBuilder(host, rootNames, defaultOptions);
         solutionBuilder.buildAllProjects();
         solutionBuilder.startWatching();
         return solutionBuilder;
+    }
+
+    type OutputFileStamp = [string, Date | undefined, boolean];
+    function transformOutputToOutputFileStamp(f: string, host: TsBuildWatchSystem): OutputFileStamp {
+        return [f, host.getModifiedTime(f), host.writtenFiles.has(host.toFullPath(f))] as OutputFileStamp;
     }
 
     describe("unittests:: tsbuild-watch program updates", () => {
@@ -61,12 +80,11 @@ namespace ts.tscWatch {
             return [`${file}.js`, `${file}.d.ts`];
         }
 
-        type OutputFileStamp = [string, Date | undefined];
-        function getOutputStamps(host: WatchedSystem, subProject: SubProject, baseFileNameWithoutExtension: string): OutputFileStamp[] {
-            return getOutputFileNames(subProject, baseFileNameWithoutExtension).map(f => [f, host.getModifiedTime(f)] as OutputFileStamp);
+        function getOutputStamps(host: TsBuildWatchSystem, subProject: SubProject, baseFileNameWithoutExtension: string): OutputFileStamp[] {
+            return getOutputFileNames(subProject, baseFileNameWithoutExtension).map(f => transformOutputToOutputFileStamp(f, host));
         }
 
-        function getOutputFileStamps(host: WatchedSystem, additionalFiles?: ReadonlyArray<[SubProject, string]>): OutputFileStamp[] {
+        function getOutputFileStamps(host: TsBuildWatchSystem, additionalFiles?: ReadonlyArray<[SubProject, string]>): OutputFileStamp[] {
             const result = [
                 ...getOutputStamps(host, SubProject.core, "anotherModule"),
                 ...getOutputStamps(host, SubProject.core, "index"),
@@ -76,18 +94,21 @@ namespace ts.tscWatch {
             if (additionalFiles) {
                 additionalFiles.forEach(([subProject, baseFileNameWithoutExtension]) => result.push(...getOutputStamps(host, subProject, baseFileNameWithoutExtension)));
             }
+            host.writtenFiles.clear();
             return result;
         }
 
-        function verifyChangedFiles(actualStamps: OutputFileStamp[], oldTimeStamps: OutputFileStamp[], changedFiles: string[]) {
+        function verifyChangedFiles(actualStamps: OutputFileStamp[], oldTimeStamps: OutputFileStamp[], changedFiles: ReadonlyArray<string>, modifiedTimeStampFiles: ReadonlyArray<string>) {
             for (let i = 0; i < oldTimeStamps.length; i++) {
                 const actual = actualStamps[i];
                 const old = oldTimeStamps[i];
-                if (contains(changedFiles, actual[0])) {
-                    assert.isTrue((actual[1] || 0) > (old[1] || 0), `${actual[0]} expected to written`);
+                const expectedIsChanged = contains(changedFiles, actual[0]);
+                assert.equal(actual[2], contains(changedFiles, actual[0]), `Expected ${actual[0]} to be written.`);
+                if (expectedIsChanged || contains(modifiedTimeStampFiles, actual[0])) {
+                    assert.isTrue((actual[1] || 0) > (old[1] || 0), `${actual[0]} file expected to have newer modified time because it is expected to ${expectedIsChanged ? "be changed" : "have modified time stamp"}`);
                 }
                 else {
-                    assert.equal(actual[1], old[1], `${actual[0]} expected to not change`);
+                    assert.equal(actual[1], old[1], `${actual[0]} expected to not change or have timestamp modified.`);
                 }
             }
         }
@@ -101,7 +122,7 @@ namespace ts.tscWatch {
         const testProjectExpectedWatchedDirectoriesRecursive = [projectPath(SubProject.core), projectPath(SubProject.logic)];
 
         function createSolutionInWatchMode(allFiles: ReadonlyArray<File>, defaultOptions?: BuildOptions, disableConsoleClears?: boolean) {
-            const host = createWatchedSystem(allFiles, { currentDirectory: projectsLocation });
+            const host = createTsBuildWatchSystem(allFiles, { currentDirectory: projectsLocation });
             createSolutionBuilderWithWatch(host, [`${project}/${SubProject.tests}`], defaultOptions);
             verifyWatches(host);
             checkOutputErrorsInitial(host, emptyArray, disableConsoleClears);
@@ -112,7 +133,7 @@ namespace ts.tscWatch {
             return host;
         }
 
-        function verifyWatches(host: WatchedSystem) {
+        function verifyWatches(host: TsBuildWatchSystem) {
             checkWatchedFiles(host, testProjectExpectedWatchedFiles);
             checkWatchedDirectories(host, emptyArray, /*recursive*/ false);
             checkWatchedDirectories(host, testProjectExpectedWatchedDirectoriesRecursive, /*recursive*/ true);
@@ -134,30 +155,50 @@ namespace ts.tscWatch {
                     const host = createSolutionInWatchMode(allFiles);
                     return { host, verifyChangeWithFile, verifyChangeAfterTimeout, verifyWatches };
 
-                    function verifyChangeWithFile(fileName: string, content: string) {
+                    function verifyChangeWithFile(fileName: string, content: string, local?: boolean) {
                         const outputFileStamps = getOutputFileStamps(host, additionalFiles);
                         host.writeFile(fileName, content);
-                        verifyChangeAfterTimeout(outputFileStamps);
+                        verifyChangeAfterTimeout(outputFileStamps, local);
                     }
 
-                    function verifyChangeAfterTimeout(outputFileStamps: OutputFileStamp[]) {
+                    function verifyChangeAfterTimeout(outputFileStamps: OutputFileStamp[], local?: boolean) {
                         host.checkTimeoutQueueLengthAndRun(1); // Builds core
                         const changedCore = getOutputFileStamps(host, additionalFiles);
-                        verifyChangedFiles(changedCore, outputFileStamps, [
-                            ...getOutputFileNames(SubProject.core, "anotherModule"), // This should not be written really
-                            ...getOutputFileNames(SubProject.core, "index"),
-                            ...(additionalFiles ? getOutputFileNames(SubProject.core, newFileWithoutExtension) : emptyArray)
-                        ]);
-                        host.checkTimeoutQueueLengthAndRun(1); // Builds logic
+                        verifyChangedFiles(
+                            changedCore,
+                            outputFileStamps,
+                            additionalFiles ?
+                                getOutputFileNames(SubProject.core, newFileWithoutExtension) :
+                                getOutputFileNames(SubProject.core, "index"), // Written files are new file or core index file thats changed
+                            [
+                                ...getOutputFileNames(SubProject.core, "anotherModule"),
+                                ...(additionalFiles ? getOutputFileNames(SubProject.core, "index") : emptyArray)
+                            ]
+                        );
+                        host.checkTimeoutQueueLengthAndRun(1); // Builds logic or updates timestamps
                         const changedLogic = getOutputFileStamps(host, additionalFiles);
-                        verifyChangedFiles(changedLogic, changedCore, [
-                            ...getOutputFileNames(SubProject.logic, "index") // Again these need not be written
-                        ]);
+                        verifyChangedFiles(
+                            changedLogic,
+                            changedCore,
+                            additionalFiles || local ?
+                                emptyArray :
+                                getOutputFileNames(SubProject.logic, "index"),
+                            additionalFiles || local ?
+                                getOutputFileNames(SubProject.logic, "index") :
+                                emptyArray
+                        );
                         host.checkTimeoutQueueLengthAndRun(1); // Builds tests
                         const changedTests = getOutputFileStamps(host, additionalFiles);
-                        verifyChangedFiles(changedTests, changedLogic, [
-                            ...getOutputFileNames(SubProject.tests, "index") // Again these need not be written
-                        ]);
+                        verifyChangedFiles(
+                            changedTests,
+                            changedLogic,
+                            additionalFiles || local ?
+                                emptyArray :
+                                getOutputFileNames(SubProject.tests, "index"),
+                            additionalFiles || local ?
+                                getOutputFileNames(SubProject.tests, "index") :
+                                emptyArray
+                        );
                         host.checkTimeoutQueueLength(0);
                         checkOutputErrorsIncremental(host, emptyArray);
                         verifyWatches();
@@ -193,19 +234,9 @@ export class someClass2 { }`);
                 });
 
                 it("non local change does not start build of referencing projects", () => {
-                    const host = createSolutionInWatchMode(allFiles);
-                    const outputFileStamps = getOutputFileStamps(host);
-                    host.writeFile(core[1].path, `${core[1].content}
-function foo() { }`);
-                    host.checkTimeoutQueueLengthAndRun(1); // Builds core
-                    const changedCore = getOutputFileStamps(host);
-                    verifyChangedFiles(changedCore, outputFileStamps, [
-                        ...getOutputFileNames(SubProject.core, "anotherModule"), // This should not be written really
-                        ...getOutputFileNames(SubProject.core, "index"),
-                    ]);
-                    host.checkTimeoutQueueLength(0);
-                    checkOutputErrorsIncremental(host, emptyArray);
-                    verifyWatches(host);
+                    const { verifyChangeWithFile } = createSolutionInWatchModeToVerifyChanges();
+                    verifyChangeWithFile(core[1].path, `${core[1].content}
+function foo() { }`, /*local*/ true);
                 });
 
                 it("builds when new file is added, and its subsequent updates", () => {
@@ -242,7 +273,7 @@ export class someClass2 { }`);
 
         it("watches config files that are not present", () => {
             const allFiles = [libFile, ...core, logic[1], ...tests];
-            const host = createWatchedSystem(allFiles, { currentDirectory: projectsLocation });
+            const host = createTsBuildWatchSystem(allFiles, { currentDirectory: projectsLocation });
             createSolutionBuilderWithWatch(host, [`${project}/${SubProject.tests}`]);
             checkWatchedFiles(host, [core[0], core[1], core[2]!, logic[0], ...tests].map(f => f.path.toLowerCase())); // tslint:disable-line no-unnecessary-type-assertion (TODO: type assertion should be necessary)
             checkWatchedDirectories(host, emptyArray, /*recursive*/ false);
@@ -268,14 +299,10 @@ export class someClass2 { }`);
             host.writeFile(logic[0].path, logic[0].content);
             host.checkTimeoutQueueLengthAndRun(1); // Builds logic
             const changedLogic = getOutputFileStamps(host);
-            verifyChangedFiles(changedLogic, initial, [
-                ...getOutputFileNames(SubProject.logic, "index")
-            ]);
+            verifyChangedFiles(changedLogic, initial, getOutputFileNames(SubProject.logic, "index"), emptyArray);
             host.checkTimeoutQueueLengthAndRun(1); // Builds tests
             const changedTests = getOutputFileStamps(host);
-            verifyChangedFiles(changedTests, changedLogic, [
-                ...getOutputFileNames(SubProject.tests, "index")
-            ]);
+            verifyChangedFiles(changedTests, changedLogic, getOutputFileNames(SubProject.tests, "index"), emptyArray);
             host.checkTimeoutQueueLength(0);
             checkOutputErrorsIncremental(host, emptyArray);
             verifyWatches(host);
@@ -305,7 +332,7 @@ export class someClass2 { }`);
             };
 
             const projectFiles = [coreTsConfig, coreIndex, logicTsConfig, logicIndex];
-            const host = createWatchedSystem([libFile, ...projectFiles], { currentDirectory: projectsLocation });
+            const host = createTsBuildWatchSystem([libFile, ...projectFiles], { currentDirectory: projectsLocation });
             createSolutionBuilderWithWatch(host, [`${project}/${SubProject.logic}`]);
             verifyWatches();
             checkOutputErrorsInitial(host, emptyArray);
@@ -318,6 +345,7 @@ export class someClass2 { }`);
             verifyChangeInCore(`${coreIndex.content}
 function myFunc() { return 10; }`);
 
+            // TODO:: local change does not build logic.js because builder doesnt find any changes in input files to generate output
             // Make local change to function bar
             verifyChangeInCore(`${coreIndex.content}
 function myFunc() { return 100; }`);
@@ -328,14 +356,20 @@ function myFunc() { return 100; }`);
 
                 host.checkTimeoutQueueLengthAndRun(1); // Builds core
                 const changedCore = getOutputFileStamps();
-                verifyChangedFiles(changedCore, outputFileStamps, [
-                    ...getOutputFileNames(SubProject.core, "index")
-                ]);
+                verifyChangedFiles(
+                    changedCore,
+                    outputFileStamps,
+                    getOutputFileNames(SubProject.core, "index"),
+                    emptyArray
+                );
                 host.checkTimeoutQueueLengthAndRun(1); // Builds logic
                 const changedLogic = getOutputFileStamps();
-                verifyChangedFiles(changedLogic, changedCore, [
-                    ...getOutputFileNames(SubProject.logic, "index")
-                ]);
+                verifyChangedFiles(
+                    changedLogic,
+                    changedCore,
+                    getOutputFileNames(SubProject.logic, "index"),
+                    emptyArray
+                );
                 host.checkTimeoutQueueLength(0);
                 checkOutputErrorsIncremental(host, emptyArray);
                 verifyWatches();
@@ -346,6 +380,7 @@ function myFunc() { return 100; }`);
                     ...getOutputStamps(host, SubProject.core, "index"),
                     ...getOutputStamps(host, SubProject.logic, "index"),
                 ];
+                host.writtenFiles.clear();
                 return result;
             }
 
@@ -389,7 +424,7 @@ createSomeObject().message;`
             };
 
             const files = [libFile, libraryTs, libraryTsconfig, appTs, appTsconfig];
-            const host = createWatchedSystem(files, { currentDirectory: `${projectsLocation}/${project}` });
+            const host = createTsBuildWatchSystem(files, { currentDirectory: `${projectsLocation}/${project}` });
             createSolutionBuilderWithWatch(host, ["App"]);
             checkOutputErrorsInitial(host, emptyArray);
 
@@ -418,7 +453,7 @@ let y: string = 10;`);
 
                 host.checkTimeoutQueueLengthAndRun(1); // Builds logic
                 const changedLogic = getOutputFileStamps(host);
-                verifyChangedFiles(changedLogic, outputFileStamps, emptyArray);
+                verifyChangedFiles(changedLogic, outputFileStamps, emptyArray, emptyArray);
                 host.checkTimeoutQueueLength(0);
                 checkOutputErrorsIncremental(host, [
                     `sample1/logic/index.ts(8,5): error TS2322: Type '10' is not assignable to type 'string'.\n`
@@ -429,7 +464,7 @@ let x: string = 10;`);
 
                 host.checkTimeoutQueueLengthAndRun(1); // Builds core
                 const changedCore = getOutputFileStamps(host);
-                verifyChangedFiles(changedCore, changedLogic, emptyArray);
+                verifyChangedFiles(changedCore, changedLogic, emptyArray, emptyArray);
                 host.checkTimeoutQueueLength(0);
                 checkOutputErrorsIncremental(host, [
                     `sample1/core/index.ts(5,5): error TS2322: Type '10' is not assignable to type 'string'.\n`,
@@ -448,7 +483,7 @@ let x: string = 10;`);
 
         describe("tsc-watch and tsserver works with project references", () => {
             describe("invoking when references are already built", () => {
-                function verifyWatchesOfProject(host: WatchedSystem, expectedWatchedFiles: ReadonlyArray<string>, expectedWatchedDirectoriesRecursive: ReadonlyArray<string>, expectedWatchedDirectories?: ReadonlyArray<string>) {
+                function verifyWatchesOfProject(host: TsBuildWatchSystem, expectedWatchedFiles: ReadonlyArray<string>, expectedWatchedDirectoriesRecursive: ReadonlyArray<string>, expectedWatchedDirectories?: ReadonlyArray<string>) {
                     checkWatchedFilesDetailed(host, expectedWatchedFiles, 1);
                     checkWatchedDirectoriesDetailed(host, expectedWatchedDirectories || emptyArray, 1, /*recursive*/ false);
                     checkWatchedDirectoriesDetailed(host, expectedWatchedDirectoriesRecursive, 1, /*recursive*/ true);
@@ -457,9 +492,9 @@ let x: string = 10;`);
                 function createSolutionOfProject(allFiles: ReadonlyArray<File>,
                     currentDirectory: string,
                     solutionBuilderconfig: string,
-                    getOutputFileStamps: (host: WatchedSystem) => ReadonlyArray<OutputFileStamp>) {
+                    getOutputFileStamps: (host: TsBuildWatchSystem) => ReadonlyArray<OutputFileStamp>) {
                     // Build the composite project
-                    const host = createWatchedSystem(allFiles, { currentDirectory });
+                    const host = createTsBuildWatchSystem(allFiles, { currentDirectory });
                     const solutionBuilder = createSolutionBuilder(host, [solutionBuilderconfig], {});
                     solutionBuilder.buildAllProjects();
                     const outputFileStamps = getOutputFileStamps(host);
@@ -474,7 +509,7 @@ let x: string = 10;`);
                     currentDirectory: string,
                     solutionBuilderconfig: string,
                     watchConfig: string,
-                    getOutputFileStamps: (host: WatchedSystem) => ReadonlyArray<OutputFileStamp>) {
+                    getOutputFileStamps: (host: TsBuildWatchSystem) => ReadonlyArray<OutputFileStamp>) {
                     // Build the composite project
                     const { host, solutionBuilder } = createSolutionOfProject(allFiles, currentDirectory, solutionBuilderconfig, getOutputFileStamps);
 
@@ -489,7 +524,7 @@ let x: string = 10;`);
                     currentDirectory: string,
                     solutionBuilderconfig: string,
                     openFileName: string,
-                    getOutputFileStamps: (host: WatchedSystem) => ReadonlyArray<OutputFileStamp>) {
+                    getOutputFileStamps: (host: TsBuildWatchSystem) => ReadonlyArray<OutputFileStamp>) {
                     // Build the composite project
                     const { host, solutionBuilder } = createSolutionOfProject(allFiles, currentDirectory, solutionBuilderconfig, getOutputFileStamps);
 
@@ -527,12 +562,12 @@ let x: string = 10;`);
                         return createSolutionAndServiceOfProject(allFiles, projectsLocation, `${project}/${SubProject.tests}`, tests[1].path, getOutputFileStamps);
                     }
 
-                    function verifyWatches(host: WatchedSystem, withTsserver?: boolean) {
+                    function verifyWatches(host: TsBuildWatchSystem, withTsserver?: boolean) {
                         verifyWatchesOfProject(host, withTsserver ? expectedWatchedFiles.filter(f => f !== tests[1].path.toLowerCase()) : expectedWatchedFiles, expectedWatchedDirectoriesRecursive);
                     }
 
                     function verifyScenario(
-                        edit: (host: WatchedSystem, solutionBuilder: SolutionBuilder) => void,
+                        edit: (host: TsBuildWatchSystem, solutionBuilder: SolutionBuilder) => void,
                         expectedFilesAfterEdit: ReadonlyArray<string>
                     ) {
                         it("with tsc-watch", () => {
@@ -635,7 +670,7 @@ export function gfoo() {
                     }
 
                     function verifyWatchState(
-                        host: WatchedSystem,
+                        host: TsBuildWatchSystem,
                         watch: Watch,
                         expectedProgramFiles: ReadonlyArray<string>,
                         expectedWatchedFiles: ReadonlyArray<string>,
@@ -722,20 +757,20 @@ export function gfoo() {
                             return createSolutionAndServiceOfProject(allFiles, getProjectPath(project), configToBuild, cTs.path, getOutputFileStamps);
                         }
 
-                        function getOutputFileStamps(host: WatchedSystem) {
-                            return expectedFiles.map(file => [file, host.getModifiedTime(file)] as OutputFileStamp);
+                        function getOutputFileStamps(host: TsBuildWatchSystem) {
+                            return expectedFiles.map(file => transformOutputToOutputFileStamp(file, host));
                         }
 
-                        function verifyProgram(host: WatchedSystem, watch: Watch) {
+                        function verifyProgram(host: TsBuildWatchSystem, watch: Watch) {
                             verifyWatchState(host, watch, expectedProgramFiles, expectedWatchedFiles, expectedWatchedDirectoriesRecursive, defaultDependencies, expectedWatchedDirectories);
                         }
 
-                        function verifyProject(host: WatchedSystem, service: projectSystem.TestProjectService, orphanInfos?: ReadonlyArray<string>) {
+                        function verifyProject(host: TsBuildWatchSystem, service: projectSystem.TestProjectService, orphanInfos?: ReadonlyArray<string>) {
                             verifyServerState(host, service, expectedProgramFiles, expectedWatchedFiles, expectedWatchedDirectoriesRecursive, orphanInfos);
                         }
 
                         function verifyServerState(
-                            host: WatchedSystem,
+                            host: TsBuildWatchSystem,
                             service: projectSystem.TestProjectService,
                             expectedProgramFiles: ReadonlyArray<string>,
                             expectedWatchedFiles: ReadonlyArray<string>,
@@ -755,13 +790,13 @@ export function gfoo() {
                         }
 
                         function verifyScenario(
-                            edit: (host: WatchedSystem, solutionBuilder: SolutionBuilder) => void,
+                            edit: (host: TsBuildWatchSystem, solutionBuilder: SolutionBuilder) => void,
                             expectedEditErrors: ReadonlyArray<string>,
                             expectedProgramFiles: ReadonlyArray<string>,
                             expectedWatchedFiles: ReadonlyArray<string>,
                             expectedWatchedDirectoriesRecursive: ReadonlyArray<string>,
                             dependencies: ReadonlyArray<[string, ReadonlyArray<string>]>,
-                            revert?: (host: WatchedSystem) => void,
+                            revert?: (host: TsBuildWatchSystem) => void,
                             orphanInfosAfterEdit?: ReadonlyArray<string>,
                             orphanInfosAfterRevert?: ReadonlyArray<string>) {
                             it("with tsc-watch", () => {
@@ -980,8 +1015,8 @@ export function gfoo() {
                                 [refs.path, [refs.path]],
                                 [cTsFile.path, [cTsFile.path, refs.path, bDts]]
                             ];
-                            function getOutputFileStamps(host: WatchedSystem) {
-                                return expectedFiles.map(file => [file, host.getModifiedTime(file)] as OutputFileStamp);
+                            function getOutputFileStamps(host: TsBuildWatchSystem) {
+                                return expectedFiles.map(file => transformOutputToOutputFileStamp(file, host));
                             }
                             const { host, watch } = createSolutionAndWatchModeOfProject(allFiles, getProjectPath(project), "tsconfig.c.json", "tsconfig.c.json", getOutputFileStamps);
                             verifyWatchState(host, watch, expectedProgramFiles, expectedWatchedFiles, expectedWatchedDirectoriesRecursive, defaultDependencies);

--- a/src/tsc/tsc.ts
+++ b/src/tsc/tsc.ts
@@ -204,9 +204,8 @@ namespace ts {
             reportWatchModeWithoutSysSupport();
         }
 
-        // TODO: change this to host if watch => watchHost otherwiue without watch
         const buildHost = buildOptions.watch ?
-            createSolutionBuilderWithWatchHost(sys, createSemanticDiagnosticsBuilderProgram, reportDiagnostic, createBuilderStatusReporter(sys, shouldBePretty()), createWatchStatusReporter()) :
+            createSolutionBuilderWithWatchHost(sys, createEmitAndSemanticDiagnosticsBuilderProgram, reportDiagnostic, createBuilderStatusReporter(sys, shouldBePretty()), createWatchStatusReporter()) :
             createSolutionBuilderHost(sys, createAbstractBuilder, reportDiagnostic, createBuilderStatusReporter(sys, shouldBePretty()), createReportErrorSummary(buildOptions));
         updateCreateProgram(buildHost);
         buildHost.afterProgramEmitAndDiagnostics = (program: BuilderProgram) => reportStatistics(program.getProgram());

--- a/src/tsc/tsc.ts
+++ b/src/tsc/tsc.ts
@@ -209,7 +209,7 @@ namespace ts {
             createSolutionBuilderWithWatchHost(sys, createSemanticDiagnosticsBuilderProgram, reportDiagnostic, createBuilderStatusReporter(sys, shouldBePretty()), createWatchStatusReporter()) :
             createSolutionBuilderHost(sys, createAbstractBuilder, reportDiagnostic, createBuilderStatusReporter(sys, shouldBePretty()), createReportErrorSummary(buildOptions));
         updateCreateProgram(buildHost);
-        buildHost.afterProgramEmitAndDiagnostics = reportStatistics;
+        buildHost.afterProgramEmitAndDiagnostics = (program: BuilderProgram) => reportStatistics(program.getProgram());
 
         const builder = createSolutionBuilder(buildHost, projects, buildOptions);
         if (buildOptions.clean) {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4245,39 +4245,11 @@ declare namespace ts {
     /**
      * Builder to manage the program state changes
      */
-    interface BuilderProgram {
+    interface BuilderProgram extends Program {
         /**
          * Returns current program
          */
         getProgram(): Program;
-        /**
-         * Get compiler options of the program
-         */
-        getCompilerOptions(): CompilerOptions;
-        /**
-         * Get the source file in the program with file name
-         */
-        getSourceFile(fileName: string): SourceFile | undefined;
-        /**
-         * Get a list of files in the program
-         */
-        getSourceFiles(): ReadonlyArray<SourceFile>;
-        /**
-         * Get the diagnostics for compiler options
-         */
-        getOptionsDiagnostics(cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
-        /**
-         * Get the diagnostics that dont belong to any file
-         */
-        getGlobalDiagnostics(cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
-        /**
-         * Get the diagnostics from config file parsing
-         */
-        getConfigFileParsingDiagnostics(): ReadonlyArray<Diagnostic>;
-        /**
-         * Get the syntax diagnostics, for all source files if source file is not supplied
-         */
-        getSyntacticDiagnostics(sourceFile?: SourceFile, cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
         /**
          * Get all the dependencies of the file
          */
@@ -4303,10 +4275,6 @@ declare namespace ts {
          * in that order would be used to write the files
          */
         emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult;
-        /**
-         * Get the current directory of the program
-         */
-        getCurrentDirectory(): string;
     }
     /**
      * The builder that caches the semantic diagnostics for the program and handles the changed files and affected files

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1778,7 +1778,7 @@ declare namespace ts {
     type ResolvedConfigFileName = string & {
         _isResolvedConfigFileName: never;
     };
-    type WriteFileCallback = (fileName: string, data: string, writeByteOrderMark: boolean, onError: ((message: string) => void) | undefined, sourceFiles?: ReadonlyArray<SourceFile>) => void;
+    type WriteFileCallback = (fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void, sourceFiles?: ReadonlyArray<SourceFile>) => void;
     class OperationCanceledException {
     }
     interface CancellationToken {
@@ -4332,13 +4332,11 @@ declare namespace ts {
         /** If provided, will be used to reset existing delayed compilation */
         clearTimeout?(timeoutId: any): void;
     }
-    interface WatchCompilerHost<T extends BuilderProgram> extends WatchHost {
+    interface ProgramHost<T extends BuilderProgram> {
         /**
          * Used to create the program when need for program creation or recreation detected
          */
         createProgram: CreateProgram<T>;
-        /** If provided, callback to invoke after every new program creation */
-        afterProgramCreate?(program: T): void;
         useCaseSensitiveFileNames(): boolean;
         getNewLine(): string;
         getCurrentDirectory(): string;
@@ -4371,6 +4369,10 @@ declare namespace ts {
         resolveModuleNames?(moduleNames: string[], containingFile: string, reusedNames?: string[], redirectedReference?: ResolvedProjectReference): (ResolvedModule | undefined)[];
         /** If provided, used to resolve type reference directives, otherwise typescript's default resolution */
         resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[], containingFile: string, redirectedReference?: ResolvedProjectReference): (ResolvedTypeReferenceDirective | undefined)[];
+    }
+    interface WatchCompilerHost<T extends BuilderProgram> extends ProgramHost<T>, WatchHost {
+        /** If provided, callback to invoke after every new program creation */
+        afterProgramCreate?(program: T): void;
     }
     /**
      * Host to create watch with root files and options

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4245,11 +4245,43 @@ declare namespace ts {
     /**
      * Builder to manage the program state changes
      */
-    interface BuilderProgram extends Program {
+    interface BuilderProgram {
         /**
          * Returns current program
          */
         getProgram(): Program;
+        /**
+         * Get compiler options of the program
+         */
+        getCompilerOptions(): CompilerOptions;
+        /**
+         * Get the source file in the program with file name
+         */
+        getSourceFile(fileName: string): SourceFile | undefined;
+        /**
+         * Get a list of files in the program
+         */
+        getSourceFiles(): ReadonlyArray<SourceFile>;
+        /**
+         * Get the diagnostics for compiler options
+         */
+        getOptionsDiagnostics(cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
+        /**
+         * Get the diagnostics that dont belong to any file
+         */
+        getGlobalDiagnostics(cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
+        /**
+         * Get the diagnostics from config file parsing
+         */
+        getConfigFileParsingDiagnostics(): ReadonlyArray<Diagnostic>;
+        /**
+         * Get the syntax diagnostics, for all source files if source file is not supplied
+         */
+        getSyntacticDiagnostics(sourceFile?: SourceFile, cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
+        /**
+         * Get the declaration diagnostics, for all source files if source file is not supplied
+         */
+        getDeclarationDiagnostics(sourceFile?: SourceFile, cancellationToken?: CancellationToken): ReadonlyArray<DiagnosticWithLocation>;
         /**
          * Get all the dependencies of the file
          */
@@ -4275,6 +4307,10 @@ declare namespace ts {
          * in that order would be used to write the files
          */
         emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult;
+        /**
+         * Get the current directory of the program
+         */
+        getCurrentDirectory(): string;
     }
     /**
      * The builder that caches the semantic diagnostics for the program and handles the changed files and affected files

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2689,7 +2689,6 @@ declare namespace ts {
         getDefaultLibLocation?(): string;
         writeFile: WriteFileCallback;
         getCurrentDirectory(): string;
-        getDirectories(path: string): string[];
         getCanonicalFileName(fileName: string): string;
         useCaseSensitiveFileNames(): boolean;
         getNewLine(): string;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4245,39 +4245,11 @@ declare namespace ts {
     /**
      * Builder to manage the program state changes
      */
-    interface BuilderProgram {
+    interface BuilderProgram extends Program {
         /**
          * Returns current program
          */
         getProgram(): Program;
-        /**
-         * Get compiler options of the program
-         */
-        getCompilerOptions(): CompilerOptions;
-        /**
-         * Get the source file in the program with file name
-         */
-        getSourceFile(fileName: string): SourceFile | undefined;
-        /**
-         * Get a list of files in the program
-         */
-        getSourceFiles(): ReadonlyArray<SourceFile>;
-        /**
-         * Get the diagnostics for compiler options
-         */
-        getOptionsDiagnostics(cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
-        /**
-         * Get the diagnostics that dont belong to any file
-         */
-        getGlobalDiagnostics(cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
-        /**
-         * Get the diagnostics from config file parsing
-         */
-        getConfigFileParsingDiagnostics(): ReadonlyArray<Diagnostic>;
-        /**
-         * Get the syntax diagnostics, for all source files if source file is not supplied
-         */
-        getSyntacticDiagnostics(sourceFile?: SourceFile, cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
         /**
          * Get all the dependencies of the file
          */
@@ -4303,10 +4275,6 @@ declare namespace ts {
          * in that order would be used to write the files
          */
         emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult;
-        /**
-         * Get the current directory of the program
-         */
-        getCurrentDirectory(): string;
     }
     /**
      * The builder that caches the semantic diagnostics for the program and handles the changed files and affected files

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1778,7 +1778,7 @@ declare namespace ts {
     type ResolvedConfigFileName = string & {
         _isResolvedConfigFileName: never;
     };
-    type WriteFileCallback = (fileName: string, data: string, writeByteOrderMark: boolean, onError: ((message: string) => void) | undefined, sourceFiles?: ReadonlyArray<SourceFile>) => void;
+    type WriteFileCallback = (fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void, sourceFiles?: ReadonlyArray<SourceFile>) => void;
     class OperationCanceledException {
     }
     interface CancellationToken {
@@ -4332,13 +4332,11 @@ declare namespace ts {
         /** If provided, will be used to reset existing delayed compilation */
         clearTimeout?(timeoutId: any): void;
     }
-    interface WatchCompilerHost<T extends BuilderProgram> extends WatchHost {
+    interface ProgramHost<T extends BuilderProgram> {
         /**
          * Used to create the program when need for program creation or recreation detected
          */
         createProgram: CreateProgram<T>;
-        /** If provided, callback to invoke after every new program creation */
-        afterProgramCreate?(program: T): void;
         useCaseSensitiveFileNames(): boolean;
         getNewLine(): string;
         getCurrentDirectory(): string;
@@ -4371,6 +4369,10 @@ declare namespace ts {
         resolveModuleNames?(moduleNames: string[], containingFile: string, reusedNames?: string[], redirectedReference?: ResolvedProjectReference): (ResolvedModule | undefined)[];
         /** If provided, used to resolve type reference directives, otherwise typescript's default resolution */
         resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[], containingFile: string, redirectedReference?: ResolvedProjectReference): (ResolvedTypeReferenceDirective | undefined)[];
+    }
+    interface WatchCompilerHost<T extends BuilderProgram> extends ProgramHost<T>, WatchHost {
+        /** If provided, callback to invoke after every new program creation */
+        afterProgramCreate?(program: T): void;
     }
     /**
      * Host to create watch with root files and options

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4245,11 +4245,43 @@ declare namespace ts {
     /**
      * Builder to manage the program state changes
      */
-    interface BuilderProgram extends Program {
+    interface BuilderProgram {
         /**
          * Returns current program
          */
         getProgram(): Program;
+        /**
+         * Get compiler options of the program
+         */
+        getCompilerOptions(): CompilerOptions;
+        /**
+         * Get the source file in the program with file name
+         */
+        getSourceFile(fileName: string): SourceFile | undefined;
+        /**
+         * Get a list of files in the program
+         */
+        getSourceFiles(): ReadonlyArray<SourceFile>;
+        /**
+         * Get the diagnostics for compiler options
+         */
+        getOptionsDiagnostics(cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
+        /**
+         * Get the diagnostics that dont belong to any file
+         */
+        getGlobalDiagnostics(cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
+        /**
+         * Get the diagnostics from config file parsing
+         */
+        getConfigFileParsingDiagnostics(): ReadonlyArray<Diagnostic>;
+        /**
+         * Get the syntax diagnostics, for all source files if source file is not supplied
+         */
+        getSyntacticDiagnostics(sourceFile?: SourceFile, cancellationToken?: CancellationToken): ReadonlyArray<Diagnostic>;
+        /**
+         * Get the declaration diagnostics, for all source files if source file is not supplied
+         */
+        getDeclarationDiagnostics(sourceFile?: SourceFile, cancellationToken?: CancellationToken): ReadonlyArray<DiagnosticWithLocation>;
         /**
          * Get all the dependencies of the file
          */
@@ -4275,6 +4307,10 @@ declare namespace ts {
          * in that order would be used to write the files
          */
         emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback, cancellationToken?: CancellationToken, emitOnlyDtsFiles?: boolean, customTransformers?: CustomTransformers): EmitResult;
+        /**
+         * Get the current directory of the program
+         */
+        getCurrentDirectory(): string;
     }
     /**
      * The builder that caches the semantic diagnostics for the program and handles the changed files and affected files

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2689,7 +2689,6 @@ declare namespace ts {
         getDefaultLibLocation?(): string;
         writeFile: WriteFileCallback;
         getCurrentDirectory(): string;
-        getDirectories(path: string): string[];
         getCanonicalFileName(fileName: string): string;
         useCaseSensitiveFileNames(): boolean;
         getNewLine(): string;


### PR DESCRIPTION
Some notes: 
- Since we use builder, the first time program is created, its going to emit all the files and not just changed - just like it does in tsc --watch mode
- We do not cache source files yet and that's something to be looked at later.
  Two things can be done: 
   - To keep source files for program thats being updated in last few cycles
   - To release the source files if size exceeds or program is not used for few build cycles
   - Adding this to #28640
- We use hash from source file's text as the version.
- Because in tsbuild we get semantic diagnostics before emit, the `EmitAndSemanticDiagnosticsBuilderProgram`'s existing assumption was not satisfied (that is changed files are already emitted before getting semantic diagnostics). So in such case, we store list of files to emit later so as to help with that case.
- In this we also have a new Builder method to release the program and its source files to ensure that we aren't holding on program after emit and/or semantic diagnostics are complete. That way the builder state can be in memory for comparison and finding out what are new changes that need emitting while creating new program but we aren't holding onto these costly (memory wise) resources. (all the program methods are thus available only till program is released.


Here are the perf numbers:
Local change::
```
File change detected. Starting incremental compilation...

Project 'SubProject 4' is out of date because oldest output 'someOutputFile.js' is older than newest input 'SubProject 2'

Building project 'SubProject 4'...

                                Updating unchanged output timestamps of project 'SubProject 4'...

Before                          After
Files:                  8305    Files:                  8305
Lines:                509633    Lines:                509633
Nodes:               1741390    Nodes:               1741390
Identifiers:          563590    Identifiers:          563590
Symbols:              597260    Symbols:              316035
Types:                175190    Types:                   232
Memory used:        1418992K    Memory used:        1859282K
I/O Read time:         2.83s    I/O Read time:         3.85s
Parse time:            2.43s    Parse time:            3.42s
Program time:         23.45s    Program time:         33.07s
Bind time:             1.56s    Bind time:             1.71s
Check time:           11.86s    Check time:            0.04s
transformTime time:   13.72s    transformTime time:    0.25s
Source Map time:       2.58s    Source Map time:       0.01s
commentTime time:      1.46s    commentTime time:      0.00s
printTime time:       27.08s    printTime time:        0.28s
Emit time:            27.08s    Emit time:             0.28s
I/O Write time:       16.16s    I/O Write time:        0.04s
Total time:           63.96s    Total time:           35.09s
Building project 'SubProject 5'...

                                Updating unchanged output timestamps of project 'SubProject 5'...

Before                          After
Files:                  1875    Files:            1875
Lines:                207731    Lines:          207731
Nodes:                632955    Nodes:          632955
Identifiers:          212573    Identifiers:    212573
Symbols:              162334    Symbols:        125245
Types:                 22975    Types:              71
Memory used:        1095817K    Memory used:   311574K
I/O Read time:         1.13s    I/O Read time:   0.74s
Parse time:            2.03s    Parse time:      0.87s
Program time:          9.64s    Program time:    5.97s
Bind time:             0.67s    Bind time:       0.48s
Check time:            2.17s
transformTime time:    1.22s
Source Map time:       0.77s
commentTime time:      0.34s
printTime time:        4.16s
Emit time:             4.16s
I/O Write time:        1.92s
Total time:           16.64s    Total time:      6.45s
Building project 'SubProject 6'...

                                Updating unchanged output timestamps of project 'SubProject 6'...

Before                          After
Files:                  2396    Files:            2396
Lines:                221677    Lines:          221677
Nodes:                669898    Nodes:          669898
Identifiers:          221017    Identifiers:    221017
Symbols:              189874    Symbols:        143939
Types:                 30412    Types:              71
Memory used:        1442324K    Memory used:   333909K
I/O Read time:         0.92s    I/O Read time:   0.91s
Parse time:            1.40s    Parse time:      1.17s
Program time:          8.91s    Program time:    7.73s
Bind time:             0.43s    Bind time:       0.39s
Check time:            1.74s
transformTime time:    0.67s
Source Map time:       0.18s
commentTime time:      0.10s
printTime time:        1.67s
Emit time:             1.67s
I/O Write time:        1.40s
Total time:           12.74s    Total time:      8.12s
Building project 'SubProject 7'...

                                Updating unchanged output timestamps of project 'SubProject 7'...

Before                          After
Files:                  9326    Files:            9326
Lines:                552828    Lines:          552830
Nodes:               1896877    Nodes:         1896879
Identifiers:          605603    Identifiers:    605605
Symbols:              608250    Symbols:        330625
Types:                173986    Types:              71
Memory used:        2367385K    Memory used:   953536K
I/O Read time:         4.22s    I/O Read time:   3.84s
Parse time:            3.18s    Parse time:      2.02s
Program time:         36.41s    Program time:   27.79s
Bind time:             2.73s    Bind time:       1.19s
Check time:           13.15s
transformTime time:   15.36s
Source Map time:       2.35s
commentTime time:      1.52s
printTime time:       28.95s
Emit time:            28.95s
I/O Write time:       13.41s
Total time:           81.23s    Total time:     28.98s
Building project 'SubProject 8'...

                                Updating unchanged output timestamps of project 'SubProject 8'...

Before                          After
Files:                  6146    Files:             6146
Lines:                367180    Lines:           367182
Nodes:               1201703    Nodes:          1201705
Identifiers:          386452    Identifiers:     386454
Symbols:              406182    Symbols:         232990
Types:                 94077    Types:               71
Memory used:        1704251K    Memory used:   1333457K
I/O Read time:         3.06s    I/O Read time:    2.50s
Parse time:            3.61s    Parse time:       2.06s
Program time:         31.86s    Program time:    19.05s
Bind time:             1.76s    Bind time:        0.77s
Check time:           10.90s
transformTime time:    7.64s
Source Map time:       0.96s
commentTime time:      0.91s
printTime time:       13.81s
Emit time:            13.81s
I/O Write time:        6.67s
Total time:           58.33s    Total time:      19.82s
Building project 'SubProject 9'...

                                Updating unchanged output timestamps of project 'SubProject 9'...

Before                          After
Files:                  3781    Files:             3781
Lines:                264899    Lines:           264899
Nodes:                834360    Nodes:           834360
Identifiers:          278052    Identifiers:     278052
Symbols:              261052    Symbols:         178924
Types:                 52797    Types:               71
Memory used:        2175398K    Memory used:   1620896K
I/O Read time:         1.67s    I/O Read time:    1.51s
Parse time:            1.98s    Parse time:       1.19s
Program time:         16.03s    Program time:    11.75s
Bind time:             0.77s    Bind time:        0.49s
Check time:            4.86s
transformTime time:    4.24s
Source Map time:       0.40s
commentTime time:      0.21s
printTime time:        6.63s
Emit time:             6.63s
I/O Write time:        2.03s
Total time:           28.29s    Total time:      12.24s


Solution Total Time:
Before: 261.19, After: 110.7
```

Local change:
```
File change detected. Starting incremental compilation...

Project 'SubProject 4' is out of date because oldest output 'someOutputFile.js' is older than newest input 'SubProject 2'

Building project 'SubProject 4'...

                                Updating unchanged output timestamps of project 'SubProject 4'...

Before                          After
Files:                  8305    Files:                 8305
Lines:                509635    Lines:               509635
Nodes:               1741406    Nodes:              1741406
Identifiers:          563597    Identifiers:         563597
Symbols:              597262    Symbols:             315957
Types:                175191    Types:                  114
Memory used:        3243603K    Memory used:        690192K
I/O Read time:         3.23s    I/O Read time:        3.28s
Parse time:            4.00s    Parse time:           2.31s
Program time:         35.91s    Program time:        24.59s
Bind time:             1.75s    Bind time:            1.27s
Check time:           15.76s    Check time:           0.01s
transformTime time:   15.10s    transformTime time:   0.00s
Source Map time:       2.93s    Source Map time:      0.00s
commentTime time:      1.85s    commentTime time:     0.00s
printTime time:       30.68s    printTime time:       0.00s
Emit time:            30.68s    Emit time:            0.00s
I/O Write time:       14.47s    I/O Write time:       0.00s
Total time:           84.10s    Total time:          25.87s
                                Project 'SubProject 5' is up to date with .d.ts files from its dependencies

                                Updating output timestamps of project 'SubProject 5'...

                                Project 'SubProject 6' is up to date with .d.ts files from its dependencies

                                Updating output timestamps of project 'SubProject 6'...

                                Project 'SubProject 7' is up to date with .d.ts files from its dependencies

                                Updating output timestamps of project 'SubProject 7'...

                                Project 'SubProject 8' is up to date with .d.ts files from its dependencies

                                Updating output timestamps of project 'SubProject 8'...

                                Project 'SubProject 9' is up to date with .d.ts files from its dependencies

                                Updating output timestamps of project 'SubProject 9'...


Solution Total Time:
Before: 84.1, After: 25.87
Found 0 errors. Watching for file changes.
```

```