### PR TITLE
Show template literal in navtree function call args

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -660,7 +660,7 @@ namespace ts.NavigationBar {
         else if (isCallExpression(parent)) {
             const name = getCalledExpressionName(parent.expression);
             if (name !== undefined) {
-                const args = mapDefined(parent.arguments, a => isStringLiteral(a) ? a.getText(curSourceFile) : undefined).join(", ");
+                const args = mapDefined(parent.arguments, a => isStringLiteralLike(a) ? a.getText(curSourceFile) : undefined).join(", ");
                 return `${name}(${args}) callback`;
             }
         }

--- a/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
+++ b/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
@@ -18,7 +18,7 @@
 ////    // These will only show up as childItems.
 ////    function z() {}
 ////    console.log(function() {})
-////    describe("this", 'function', () => {});
+////    describe("this", 'function', `is a function`, `but this ${"wont"} show`, () => {});
 ////    [].map(() => {});
 ////})
 ////(function classes() {
@@ -77,7 +77,7 @@ verify.navigationTree({
                     "kind": "function"
                 },
                 {
-                    "text": `describe("this", 'function') callback`,
+                    "text": `describe("this", 'function', \`is a function\`) callback`,
                     "kind": "function"
                 },
                 {
@@ -199,7 +199,7 @@ verify.navigationBar([
                 "kind": "function"
             },
             {
-                "text": `describe("this", 'function') callback`,
+                "text": `describe("this", 'function', \`is a function\`) callback`,
                 "kind": "function"
             },
             {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #29014.
Currently we only check for string literals when determining the text for the navigation tree. This PR updates it so that we also check template literals with no substitutions.
