### PR TITLE
Only provide suggestion for outermost async fix

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -60,7 +60,7 @@ namespace ts.codefix {
         const setOfExpressionsToReturn = getAllPromiseExpressionsToReturn(functionToConvert, checker);
         const functionToConvertRenamed = renameCollidingVarNames(functionToConvert, checker, synthNamesMap, context, setOfExpressionsToReturn, originalTypeMap, allVarNames);
         const constIdentifiers = getConstIdentifiers(synthNamesMap);
-        const returnStatements = functionToConvertRenamed.body && isBlock(functionToConvertRenamed.body) ? getReturnStatementsWithPromiseHandlers(functionToConvertRenamed.body, checker) : emptyArray;
+        const returnStatements = functionToConvertRenamed.body && isBlock(functionToConvertRenamed.body) ? getReturnStatementsWithPromiseHandlers(functionToConvertRenamed.body) : emptyArray;
         const transformer: Transformer = { checker, synthNamesMap, allVarNames, setOfExpressionsToReturn, constIdentifiers, originalTypeMap, isInJSFile: isInJavascript };
 
         if (!returnStatements.length) {
@@ -87,10 +87,10 @@ namespace ts.codefix {
         }
     }
 
-    function getReturnStatementsWithPromiseHandlers(body: Block, checker: TypeChecker): ReadonlyArray<ReturnStatement> {
+    function getReturnStatementsWithPromiseHandlers(body: Block): ReadonlyArray<ReturnStatement> {
         const res: ReturnStatement[] = [];
         forEachReturnStatement(body, ret => {
-            if (isReturnStatementWithFixablePromiseHandler(ret, checker)) res.push(ret);
+            if (isReturnStatementWithFixablePromiseHandler(ret)) res.push(ret);
         });
         return res;
     }
@@ -450,7 +450,7 @@ namespace ts.codefix {
                             seenReturnStatement = true;
                         }
 
-                        if (isReturnStatementWithFixablePromiseHandler(statement, transformer.checker)) {
+                        if (isReturnStatementWithFixablePromiseHandler(statement)) {
                             refactoredStmts = refactoredStmts.concat(getInnerTransformationBody(transformer, [statement], prevArgName));
                         }
                         else {
@@ -466,7 +466,7 @@ namespace ts.codefix {
                             seenReturnStatement);
                 }
                 else {
-                    const innerRetStmts = isFixablePromiseHandler(funcBody, transformer.checker) ? [createReturn(funcBody)] : emptyArray;
+                    const innerRetStmts = isFixablePromiseHandler(funcBody) ? [createReturn(funcBody)] : emptyArray;
                     const innerCbBody = getInnerTransformationBody(transformer, innerRetStmts, prevArgName);
 
                     if (innerCbBody.length > 0) {

--- a/src/services/suggestionDiagnostics.ts
+++ b/src/services/suggestionDiagnostics.ts
@@ -117,14 +117,14 @@ namespace ts {
     }
 
     function addConvertToAsyncFunctionDiagnostics(node: FunctionLikeDeclaration, checker: TypeChecker, diags: Push<DiagnosticWithLocation>): void {
-        if (!visitedNestedConvertibleFunctions.has(getKeyFromNode(node)) && isConvertableFunction(node, checker)) {
+        if (!visitedNestedConvertibleFunctions.has(getKeyFromNode(node)) && isConvertibleFunction(node, checker)) {
             diags.push(createDiagnosticForNode(
                 !node.name && isVariableDeclaration(node.parent) && isIdentifier(node.parent.name) ? node.parent.name : node,
                 Diagnostics.This_may_be_converted_to_an_async_function));
         }
     }
 
-    function isConvertableFunction(node: FunctionLikeDeclaration, checker: TypeChecker) {
+    function isConvertibleFunction(node: FunctionLikeDeclaration, checker: TypeChecker) {
         return !isAsyncFunction(node) &&
             node.body &&
             isBlock(node.body) &&
@@ -179,7 +179,7 @@ namespace ts {
             case SyntaxKind.FunctionDeclaration:
             case SyntaxKind.FunctionExpression:
             case SyntaxKind.ArrowFunction:
-                if (isConvertableFunction(arg as FunctionLikeDeclaration, checker)) {
+                if (isConvertibleFunction(arg as FunctionLikeDeclaration, checker)) {
                     visitedNestedConvertibleFunctions.set(getKeyFromNode(arg as FunctionLikeDeclaration), true);
                 }
                 /* falls through */

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_OutermostOnlyFailure.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_OutermostOnlyFailure.ts
@@ -1,0 +1,16 @@
+// ==ORIGINAL==
+
+function foo() {
+    return fetch('a').then(/*[#|*/() => {/*|]*/
+        return fetch('b').then(() => 'c');
+    })
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+function foo() {
+    return fetch('a').then(async () => {
+        await fetch('b');
+        return 'c';
+    })
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_OutermostOnlySuccess.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_OutermostOnlySuccess.js
@@ -1,0 +1,15 @@
+// ==ORIGINAL==
+
+function /*[#|*/foo/*|]*/() {
+    return fetch('a').then(() => {
+        return fetch('b').then(() => 'c');
+    })
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function foo() {
+    await fetch('a');
+    await fetch('b');
+    return 'c';
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_OutermostOnlySuccess.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_OutermostOnlySuccess.ts
@@ -1,0 +1,15 @@
+// ==ORIGINAL==
+
+function /*[#|*/foo/*|]*/() {
+    return fetch('a').then(() => {
+        return fetch('b').then(() => 'c');
+    })
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function foo() {
+    await fetch('a');
+    await fetch('b');
+    return 'c';
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_bindingPattern.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_bindingPattern.js
@@ -5,7 +5,7 @@ function /*[#|*/f/*|]*/() {
 }
 function res({ status, trailer }){
     console.log(status);
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -15,4 +15,4 @@ async function f() {
 }
 function res({ status, trailer }){
     console.log(status);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_bindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_bindingPattern.ts
@@ -5,7 +5,7 @@ function /*[#|*/f/*|]*/() {
 }
 function res({ status, trailer }){
     console.log(status);
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -15,4 +15,4 @@ async function f() {
 }
 function res({ status, trailer }){
     console.log(status);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_bindingPatternNameCollision.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_bindingPatternNameCollision.js
@@ -6,7 +6,7 @@ function /*[#|*/f/*|]*/() {
 }
 function res({ status, trailer }){
     console.log(status);
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -17,4 +17,4 @@ async function f() {
 }
 function res({ status, trailer }){
     console.log(status);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_bindingPatternNameCollision.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_bindingPatternNameCollision.ts
@@ -6,7 +6,7 @@ function /*[#|*/f/*|]*/() {
 }
 function res({ status, trailer }){
     console.log(status);
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -17,4 +17,4 @@ async function f() {
 }
 function res({ status, trailer }){
     console.log(status);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.js
@@ -4,7 +4,7 @@ function /*[#|*/f/*|]*/() {
     return Promise.resolve(1)
         .then(x => Promise.reject(x))
         .catch(err => console.log(err));
-}    
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -16,4 +16,4 @@ async function f() {
     catch (err) {
         return console.log(err);
     }
-}    
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_callbackReturnsRejectedPromiseInTryBlock.ts
@@ -4,7 +4,7 @@ function /*[#|*/f/*|]*/() {
     return Promise.resolve(1)
         .then(x => Promise.reject(x))
         .catch(err => console.log(err));
-}    
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -16,4 +16,4 @@ async function f() {
     catch (err) {
         return console.log(err);
     }
-}    
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.js
@@ -1,8 +1,8 @@
 // ==ORIGINAL==
 
 function /*[#|*/f/*|]*/() {
-	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x); 
-} 
+	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x);
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -15,5 +15,5 @@ async function f() {
     catch (x_1) {
         x_2 = "a";
     }
-    return !!x_2; 
-} 
+    return !!x_2;
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.ts
@@ -1,8 +1,8 @@
 // ==ORIGINAL==
 
 function /*[#|*/f/*|]*/() {
-	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x); 
-} 
+	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x);
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -15,5 +15,5 @@ async function f() {
     catch (x_1) {
         x_2 = "a";
     }
-    return !!x_2; 
-} 
+    return !!x_2;
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_runEffectfulContinuation.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_runEffectfulContinuation.js
@@ -5,7 +5,7 @@ function /*[#|*/f/*|]*/() {
 }
 function res(result) {
     return Promise.resolve().then(x => console.log(result));
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -16,4 +16,4 @@ async function f() {
 }
 function res(result) {
     return Promise.resolve().then(x => console.log(result));
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_runEffectfulContinuation.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_runEffectfulContinuation.ts
@@ -5,7 +5,7 @@ function /*[#|*/f/*|]*/() {
 }
 function res(result) {
     return Promise.resolve().then(x => console.log(result));
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -16,4 +16,4 @@ async function f() {
 }
 function res(result) {
     return Promise.resolve().then(x => console.log(result));
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpression.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpression.js
@@ -2,11 +2,11 @@
 
 const /*[#|*/foo/*|]*/ = function () {
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 const foo = async function () {
     const result = await fetch('https://typescriptlang.org');
     console.log(result);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpression.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpression.ts
@@ -2,11 +2,11 @@
 
 const /*[#|*/foo/*|]*/ = function () {
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 const foo = async function () {
     const result = await fetch('https://typescriptlang.org');
     console.log(result);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionAssignedToBindingPattern.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionAssignedToBindingPattern.js
@@ -2,11 +2,11 @@
 
 const { length } = /*[#|*/function/*|]*/ () {
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 const { length } = async function () {
     const result = await fetch('https://typescriptlang.org');
     console.log(result);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionAssignedToBindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionAssignedToBindingPattern.ts
@@ -2,11 +2,11 @@
 
 const { length } = /*[#|*/function/*|]*/ () {
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 const { length } = async function () {
     const result = await fetch('https://typescriptlang.org');
     console.log(result);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionWithName.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionWithName.js
@@ -2,11 +2,11 @@
 
 const foo = function /*[#|*/f/*|]*/() {
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 const foo = async function f() {
     const result = await fetch('https://typescriptlang.org');
     console.log(result);
-} 
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionWithName.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_simpleFunctionExpressionWithName.ts
@@ -2,11 +2,11 @@
 
 const foo = function /*[#|*/f/*|]*/() {
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });
-} 
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 const foo = async function f() {
     const result = await fetch('https://typescriptlang.org');
     console.log(result);
-} 
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #27488.

Currently, if `getCombinedCodeFix` is triggered in a file with nested functions that can be converted to async functions, the call fails since our text change mechanism cannot handle overlapping changes.
This PR makes it so that only the outermost suggestion diagnostic for nested convertible functions is provided so that such a conflict is not encountered. Note that if `getCodeActions` is triggered at the location of an inner convertible function, it will return the action, since we do not inspect the surrounding context of a given function.

This PR also removes unnecessary trailing spaces from several tests.
