### PR TITLE
Give appropriate outlining span for array and object literals as args in call expression

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -206,10 +206,10 @@ namespace ts.OutliningElementsCollector {
         }
 
         function spanForObjectOrArrayLiteral(node: Node, open: SyntaxKind.OpenBraceToken | SyntaxKind.OpenBracketToken = SyntaxKind.OpenBraceToken): OutliningSpan | undefined {
-            // If the block has no leading keywords and is inside an array literal,
+            // If the block has no leading keywords and is inside an array literal or call expression,
             // we only want to collapse the span of the block.
             // Otherwise, the collapsed section will include the end of the previous line.
-            return spanForNode(node, /*autoCollapse*/ false, /*useFullStart*/ !isArrayLiteralExpression(node.parent), open);
+            return spanForNode(node, /*autoCollapse*/ false, /*useFullStart*/ !isArrayLiteralExpression(node.parent) && !isCallExpression(node.parent), open);
         }
 
         function spanForNode(hintSpanNode: Node, autoCollapse = false, useFullStart = true, open: SyntaxKind.OpenBraceToken | SyntaxKind.OpenBracketToken = SyntaxKind.OpenBraceToken): OutliningSpan | undefined {

--- a/tests/cases/fourslash/getOutliningSpans.ts
+++ b/tests/cases/fourslash/getOutliningSpans.ts
@@ -96,5 +96,18 @@
 //////outline after a deeply nested node
 ////class AfterNestedNodes[| {
 ////}|]
+////// function arguments
+////function f(x: number[], y: number[])[| {
+////    return 3;
+////}|]
+////f(
+//////  single line array literal span won't render in VS
+////    [|[0]|],
+////    [|[
+////        1,
+////        2
+////    ]|]
+////);
+
 
 verify.outliningSpansInCurrentFile(test.ranges(), "code");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #26030.


