### PR TITLE
eslib definition update: named capture groups values may be undefined

### DIFF
--- a/src/lib/es2018.regexp.d.ts
+++ b/src/lib/es2018.regexp.d.ts
@@ -1,12 +1,12 @@
 interface RegExpMatchArray {
     groups?: {
-        [key: string]: string
+        [key: string]: string | undefined
     }
 }
 
 interface RegExpExecArray {
     groups?: {
-        [key: string]: string
+        [key: string]: string | undefined
     }
 }
 


### PR DESCRIPTION
mark `groups` key values as possibly being `undefined`.

This is because named groups in a regex can be optionally matching, but the overall regex can match.

i.e.

```ts
let match;

match = /(?<foo>[a-z])(?<bar>[a-z])/.exec("ab");

// will have values for both `foo` and `bar` groups
match!.groups!.foo; // "a"
match!.groups!.bar; // "b"

// ---


match = /(?<foo>[a-z])(?<bar>[a-z])?/.exec("a");

// but `bar` may be undefined in this case:
match!.groups!.foo; // "a"
match!.groups!.bar; // undefined
```

---

However, the rationale of conceding that a name capture group's value may be undefined may be at odds with the rationale of the decision in #17053