### PR TITLE
Do not emit code for `@extends` tags in JS.

### DIFF
--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -780,7 +780,7 @@ namespace ts {
                 enableSubstitutionsForBlockScopedBindings();
             }
 
-            const extendsClauseElement = getEffectiveBaseTypeNode(node);
+            const extendsClauseElement = getClassExtendsHeritageElement(node);
             const classFunction = createFunctionExpression(
                 /*modifiers*/ undefined,
                 /*asteriskToken*/ undefined,

--- a/tests/baselines/reference/extendsJavaScript.js
+++ b/tests/baselines/reference/extendsJavaScript.js
@@ -1,0 +1,18 @@
+//// [extendsJavaScript.js]
+/**
+ * @extends {SomeBase}
+ */
+class MyClass {
+
+}
+
+
+//// [extendsJavaScript.js]
+/**
+ * @extends {SomeBase}
+ */
+var MyClass = /** @class */ (function () {
+    function MyClass() {
+    }
+    return MyClass;
+}());

--- a/tests/baselines/reference/extendsJavaScript.symbols
+++ b/tests/baselines/reference/extendsJavaScript.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/extendsJavaScript.js ===
+/**
+ * @extends {SomeBase}
+ */
+class MyClass {
+>MyClass : Symbol(MyClass, Decl(extendsJavaScript.js, 0, 0))
+
+}
+

--- a/tests/baselines/reference/extendsJavaScript.types
+++ b/tests/baselines/reference/extendsJavaScript.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/extendsJavaScript.js ===
+/**
+ * @extends {SomeBase}
+ */
+class MyClass {
+>MyClass : MyClass
+
+}
+

--- a/tests/cases/compiler/extendsJavaScript.ts
+++ b/tests/cases/compiler/extendsJavaScript.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @checkJs: false
+// @outDir: ./out
+// @filename: extendsJavaScript.js
+
+/**
+ * @extends {SomeBase}
+ */
+class MyClass {
+
+}


### PR DESCRIPTION
When transpiling JavaScript, TS3.1+ emits `@extends` tags as code. E.g.

    /** @extends {SuperClass} */
    class SubClass {}

Causes an ES5 emit that references SuperClass:

    /**
    * @extends {SomeBase}
    */
    var SubClass = /** @class */ (function (_super) {
        __extends(SubClass, _super);
        function SubClass() {
            return _super !== null && _super.apply(this, arguments) || this;
        }
        return SubClass;
    }(SomeBase));

Note the literal references to `SomeBase`.

This appears to be an accidental effect of
0f55566cf48bdc5f817f0b888c6b485e42eff870. It refactored
`getEffectiveBaseTypeNode` for type checking, but missed an instance
where it is also used for emit logic. This change fixes the problem by
specifically getting the heritage clauses directly off the AST.
