### PR TITLE
Allow referencing 'this' in parameters of functions in the constructor

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16831,7 +16831,7 @@ namespace ts {
         }
 
         function isInConstructorArgumentInitializer(node: Node, constructorDecl: Node): boolean {
-            return !!findAncestor(node, n => n === constructorDecl ? "quit" : n.kind === SyntaxKind.Parameter);
+            return !!findAncestor(node, n => isFunctionLikeDeclaration(n) ? "quit" : n.kind === SyntaxKind.Parameter && n.parent === constructorDecl);
         }
 
         function checkSuperExpression(node: Node): Type {

--- a/tests/baselines/reference/superAccess2.errors.txt
+++ b/tests/baselines/reference/superAccess2.errors.txt
@@ -7,7 +7,6 @@ tests/cases/compiler/superAccess2.ts(11,33): error TS1034: 'super' must be follo
 tests/cases/compiler/superAccess2.ts(11,40): error TS2336: 'super' cannot be referenced in constructor arguments.
 tests/cases/compiler/superAccess2.ts(11,40): error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
 tests/cases/compiler/superAccess2.ts(11,45): error TS1034: 'super' must be followed by an argument list or member access.
-tests/cases/compiler/superAccess2.ts(11,59): error TS2336: 'super' cannot be referenced in constructor arguments.
 tests/cases/compiler/superAccess2.ts(11,59): error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
 tests/cases/compiler/superAccess2.ts(11,64): error TS1034: 'super' must be followed by an argument list or member access.
 tests/cases/compiler/superAccess2.ts(15,19): error TS1034: 'super' must be followed by an argument list or member access.
@@ -16,7 +15,7 @@ tests/cases/compiler/superAccess2.ts(20,26): error TS1034: 'super' must be follo
 tests/cases/compiler/superAccess2.ts(21,15): error TS2339: Property 'x' does not exist on type 'typeof P'.
 
 
-==== tests/cases/compiler/superAccess2.ts (16 errors) ====
+==== tests/cases/compiler/superAccess2.ts (15 errors) ====
     class P {
         x() { }
         static y() { }
@@ -46,8 +45,6 @@ tests/cases/compiler/superAccess2.ts(21,15): error TS2339: Property 'x' does not
 !!! error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
                                                 ~
 !!! error TS1034: 'super' must be followed by an argument list or member access.
-                                                              ~~~~~
-!!! error TS2336: 'super' cannot be referenced in constructor arguments.
                                                               ~~~~~
 !!! error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
                                                                    ~

--- a/tests/baselines/reference/superAccess2.symbols
+++ b/tests/baselines/reference/superAccess2.symbols
@@ -25,6 +25,7 @@ class Q extends P {
 >z : Symbol(Q.z, Decl(superAccess2.ts, 10, 16))
 >zz : Symbol(zz, Decl(superAccess2.ts, 10, 33))
 >zzz : Symbol(zzz, Decl(superAccess2.ts, 10, 45))
+>super : Symbol(P, Decl(superAccess2.ts, 0, 0))
 
         super();
 >super : Symbol(P, Decl(superAccess2.ts, 0, 0))

--- a/tests/baselines/reference/superAccess2.types
+++ b/tests/baselines/reference/superAccess2.types
@@ -38,7 +38,7 @@ class Q extends P {
 >zzz : () => any
 >() => super : () => any
 >super : any
->super : any
+>super : P
 > : any
 
         super();

--- a/tests/baselines/reference/thisInConstructorParameter2.errors.txt
+++ b/tests/baselines/reference/thisInConstructorParameter2.errors.txt
@@ -10,11 +10,13 @@ tests/cases/compiler/thisInConstructorParameter2.ts(5,39): error TS2333: 'this' 
                    ~~~~
 !!! error TS2334: 'this' cannot be referenced in a static property initializer.
     
-        constructor(public z = this, zz = this) { }
+        constructor(public z = this, zz = this, zzz = (p = this) => this) {
                                ~~~~
 !!! error TS2333: 'this' cannot be referenced in constructor arguments.
                                           ~~~~
 !!! error TS2333: 'this' cannot be referenced in constructor arguments.
+            zzz = (p = this) => this;
+        }
     
         foo(zz = this) { zz.x; }
         static bar(zz = this) { zz.y; }

--- a/tests/baselines/reference/thisInConstructorParameter2.js
+++ b/tests/baselines/reference/thisInConstructorParameter2.js
@@ -3,7 +3,9 @@ class P {
     x = this;
     static y = this;
 
-    constructor(public z = this, zz = this) { }
+    constructor(public z = this, zz = this, zzz = (p = this) => this) {
+        zzz = (p = this) => this;
+    }
 
     foo(zz = this) { zz.x; }
     static bar(zz = this) { zz.y; }
@@ -12,11 +14,20 @@ class P {
 //// [thisInConstructorParameter2.js]
 var _this = this;
 var P = /** @class */ (function () {
-    function P(z, zz) {
+    function P(z, zz, zzz) {
         if (z === void 0) { z = this; }
         if (zz === void 0) { zz = this; }
+        if (zzz === void 0) { zzz = function (p) {
+            if (p === void 0) { p = _this; }
+            return _this;
+        }; }
+        var _this = this;
         this.z = z;
         this.x = this;
+        zzz = function (p) {
+            if (p === void 0) { p = _this; }
+            return _this;
+        };
     }
     P.prototype.foo = function (zz) {
         if (zz === void 0) { zz = this; }

--- a/tests/baselines/reference/thisInConstructorParameter2.symbols
+++ b/tests/baselines/reference/thisInConstructorParameter2.symbols
@@ -10,25 +10,36 @@ class P {
 >y : Symbol(P.y, Decl(thisInConstructorParameter2.ts, 1, 13))
 >this : Symbol(P, Decl(thisInConstructorParameter2.ts, 0, 0))
 
-    constructor(public z = this, zz = this) { }
+    constructor(public z = this, zz = this, zzz = (p = this) => this) {
 >z : Symbol(P.z, Decl(thisInConstructorParameter2.ts, 4, 16))
 >this : Symbol(P, Decl(thisInConstructorParameter2.ts, 0, 0))
 >zz : Symbol(zz, Decl(thisInConstructorParameter2.ts, 4, 32))
 >this : Symbol(P, Decl(thisInConstructorParameter2.ts, 0, 0))
+>zzz : Symbol(zzz, Decl(thisInConstructorParameter2.ts, 4, 43))
+>p : Symbol(p, Decl(thisInConstructorParameter2.ts, 4, 51))
+>this : Symbol(P, Decl(thisInConstructorParameter2.ts, 0, 0))
+>this : Symbol(P, Decl(thisInConstructorParameter2.ts, 0, 0))
+
+        zzz = (p = this) => this;
+>zzz : Symbol(zzz, Decl(thisInConstructorParameter2.ts, 4, 43))
+>p : Symbol(p, Decl(thisInConstructorParameter2.ts, 5, 15))
+>this : Symbol(P, Decl(thisInConstructorParameter2.ts, 0, 0))
+>this : Symbol(P, Decl(thisInConstructorParameter2.ts, 0, 0))
+    }
 
     foo(zz = this) { zz.x; }
->foo : Symbol(P.foo, Decl(thisInConstructorParameter2.ts, 4, 47))
->zz : Symbol(zz, Decl(thisInConstructorParameter2.ts, 6, 8))
+>foo : Symbol(P.foo, Decl(thisInConstructorParameter2.ts, 6, 5))
+>zz : Symbol(zz, Decl(thisInConstructorParameter2.ts, 8, 8))
 >this : Symbol(P, Decl(thisInConstructorParameter2.ts, 0, 0))
 >zz.x : Symbol(P.x, Decl(thisInConstructorParameter2.ts, 0, 9))
->zz : Symbol(zz, Decl(thisInConstructorParameter2.ts, 6, 8))
+>zz : Symbol(zz, Decl(thisInConstructorParameter2.ts, 8, 8))
 >x : Symbol(P.x, Decl(thisInConstructorParameter2.ts, 0, 9))
 
     static bar(zz = this) { zz.y; }
->bar : Symbol(P.bar, Decl(thisInConstructorParameter2.ts, 6, 28))
->zz : Symbol(zz, Decl(thisInConstructorParameter2.ts, 7, 15))
+>bar : Symbol(P.bar, Decl(thisInConstructorParameter2.ts, 8, 28))
+>zz : Symbol(zz, Decl(thisInConstructorParameter2.ts, 9, 15))
 >this : Symbol(P, Decl(thisInConstructorParameter2.ts, 0, 0))
 >zz.y : Symbol(P.y, Decl(thisInConstructorParameter2.ts, 1, 13))
->zz : Symbol(zz, Decl(thisInConstructorParameter2.ts, 7, 15))
+>zz : Symbol(zz, Decl(thisInConstructorParameter2.ts, 9, 15))
 >y : Symbol(P.y, Decl(thisInConstructorParameter2.ts, 1, 13))
 }

--- a/tests/baselines/reference/thisInConstructorParameter2.types
+++ b/tests/baselines/reference/thisInConstructorParameter2.types
@@ -10,11 +10,25 @@ class P {
 >y : typeof P
 >this : typeof P
 
-    constructor(public z = this, zz = this) { }
+    constructor(public z = this, zz = this, zzz = (p = this) => this) {
 >z : this
 >this : this
 >zz : this
 >this : this
+>zzz : (p?: this) => this
+>(p = this) => this : (p?: this) => this
+>p : this
+>this : this
+>this : this
+
+        zzz = (p = this) => this;
+>zzz = (p = this) => this : (p?: this) => this
+>zzz : (p?: this) => this
+>(p = this) => this : (p?: this) => this
+>p : this
+>this : this
+>this : this
+    }
 
     foo(zz = this) { zz.x; }
 >foo : (zz?: this) => void

--- a/tests/cases/compiler/thisInConstructorParameter2.ts
+++ b/tests/cases/compiler/thisInConstructorParameter2.ts
@@ -2,7 +2,9 @@ class P {
     x = this;
     static y = this;
 
-    constructor(public z = this, zz = this) { }
+    constructor(public z = this, zz = this, zzz = (p = this) => this) {
+        zzz = (p = this) => this;
+    }
 
     foo(zz = this) { zz.x; }
     static bar(zz = this) { zz.y; }


### PR DESCRIPTION
Fixes: #29286

This also affects referencing `super` in parameters or unrelated functions.

A future PR could update this check to treat immediately invoked arrow functions as inlined (like #29160 does for 'parameter cannot reference identifiers declared after it')