### PR TITLE
Exclude JSDoc @extends from 'super()' checks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16625,7 +16625,7 @@ namespace ts {
 
         function checkThisBeforeSuper(node: Node, container: Node, diagnosticMessage: DiagnosticMessage) {
             const containingClassDecl = <ClassDeclaration>container.parent;
-            const baseTypeNode = getEffectiveBaseTypeNode(containingClassDecl);
+            const baseTypeNode = getClassExtendsHeritageElement(containingClassDecl);
 
             // If a containing class does not have extends clause or the class extends null
             // skip checking whether super statement is called before "this" accessing.
@@ -23575,7 +23575,7 @@ namespace ts {
             // Constructors of classes with no extends clause may not contain super calls, whereas
             // constructors of derived classes must contain at least one super call somewhere in their function body.
             const containingClassDecl = <ClassDeclaration>node.parent;
-            if (getEffectiveBaseTypeNode(containingClassDecl)) {
+            if (getClassExtendsHeritageElement(containingClassDecl)) {
                 captureLexicalThis(node.parent, containingClassDecl);
                 const classExtendsNull = classDeclarationExtendsNull(containingClassDecl);
                 const superCall = getSuperCallInConstructor(node);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16974,7 +16974,7 @@ namespace ts {
 
             // at this point the only legal case for parent is ClassLikeDeclaration
             const classLikeDeclaration = <ClassLikeDeclaration>container.parent;
-            if (!getEffectiveBaseTypeNode(classLikeDeclaration)) {
+            if (!getClassExtendsHeritageElement(classLikeDeclaration)) {
                 error(node, Diagnostics.super_can_only_be_referenced_in_a_derived_class);
                 return errorType;
             }

--- a/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.errors.txt
+++ b/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/noSuperInJSDocExtends.js(14,9): error TS2335: 'super' can only be referenced in a derived class.
+
+
+==== tests/cases/compiler/noSuperInJSDocExtends.js (1 errors) ====
+    class Based { }
+    /** @extends {Based} */
+    class Derived {
+        constructor() {
+            this;
+            this.x = 10;
+            var that = this;
+        }
+    }
+    
+    /** @extends {Based} */
+    class Derived2 {
+        constructor() {
+            super();
+            ~~~~~
+!!! error TS2335: 'super' can only be referenced in a derived class.
+        }
+    }

--- a/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.symbols
+++ b/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.symbols
@@ -27,6 +27,5 @@ class Derived2 {
 
     constructor() {
         super();
->super : Symbol(Based, Decl(noSuperInJSDocExtends.js, 0, 0))
     }
 }

--- a/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.symbols
+++ b/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/noSuperInJSDocExtends.js ===
+class Based { }
+>Based : Symbol(Based, Decl(noSuperInJSDocExtends.js, 0, 0))
+
+/** @extends {Based} */
+class Derived {
+>Derived : Symbol(Derived, Decl(noSuperInJSDocExtends.js, 0, 15))
+
+    constructor() {
+        this;
+>this : Symbol(Derived, Decl(noSuperInJSDocExtends.js, 0, 15))
+
+        this.x = 10;
+>this.x : Symbol(Derived.x, Decl(noSuperInJSDocExtends.js, 4, 13))
+>this : Symbol(Derived, Decl(noSuperInJSDocExtends.js, 0, 15))
+>x : Symbol(Derived.x, Decl(noSuperInJSDocExtends.js, 4, 13))
+
+        var that = this;
+>that : Symbol(that, Decl(noSuperInJSDocExtends.js, 6, 11))
+>this : Symbol(Derived, Decl(noSuperInJSDocExtends.js, 0, 15))
+    }
+}
+
+/** @extends {Based} */
+class Derived2 {
+>Derived2 : Symbol(Derived2, Decl(noSuperInJSDocExtends.js, 8, 1))
+
+    constructor() {
+        super();
+>super : Symbol(Based, Decl(noSuperInJSDocExtends.js, 0, 0))
+    }
+}

--- a/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.types
+++ b/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/noSuperInJSDocExtends.js ===
+class Based { }
+>Based : Based
+
+/** @extends {Based} */
+class Derived {
+>Derived : Derived
+
+    constructor() {
+        this;
+>this : this
+
+        this.x = 10;
+>this.x = 10 : 10
+>this.x : number
+>this : this
+>x : number
+>10 : 10
+
+        var that = this;
+>that : this
+>this : this
+    }
+}
+
+/** @extends {Based} */
+class Derived2 {
+>Derived2 : Derived2
+
+    constructor() {
+        super();
+>super() : void
+>super : typeof Based
+    }
+}

--- a/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.types
+++ b/tests/baselines/reference/checkSuperCallBeforeThisAccessing9.types
@@ -30,6 +30,6 @@ class Derived2 {
     constructor() {
         super();
 >super() : void
->super : typeof Based
+>super : any
     }
 }

--- a/tests/cases/compiler/checkSuperCallBeforeThisAccessing9.ts
+++ b/tests/cases/compiler/checkSuperCallBeforeThisAccessing9.ts
@@ -1,0 +1,21 @@
+﻿// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @filename: noSuperInJSDocExtends.js
+class Based { }
+/** @extends {Based} */
+class Derived {
+    constructor() {
+        this;
+        this.x = 10;
+        var that = this;
+    }
+}
+
+/** @extends {Based} */
+class Derived2 {
+    constructor() {
+        super();
+    }
+}


### PR DESCRIPTION
This fixes a similar problem as #29244 where JSDoc `@extends` is treated as `class X extends`