### PR TITLE
Fixes #29212: In JS, completion won't suggest TypeScript Syntax

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1022,7 +1022,7 @@ namespace ts.Completions {
             isInSnippetScope = isSnippetScope(scopeNode);
 
             const isTypeOnly = isTypeOnlyCompletion();
-            const symbolMeanings = (isTypeOnly ? SymbolFlags.None : SymbolFlags.Value) | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias;
+            const symbolMeanings = ( !isSourceFileJS(sourceFile) ? SymbolFlags.None : SymbolFlags.Value) | SymbolFlags.Type | SymbolFlags.Namespace | SymbolFlags.Alias;
 
             symbols = Debug.assertEachDefined(typeChecker.getSymbolsInScope(scopeNode, symbolMeanings), "getSymbolsInScope() should all be defined");
 


### PR DESCRIPTION
Fixes #29212 
* [Y] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [Y] Code is up-to-date with the `master` branch
* [N] You've successfully run `jake runtests` locally
* [N] You've signed the CLA
* [N] There are new or updated unit tests validating the change

I had gone through [0] link, and implement the changes accordingly.
I wasn't able to add test, I might some extra help :(

0: https://github.com/Microsoft/TypeScript/pull/21257/files