### PR TITLE
Fix crash on decorated field with negative literal type

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1898,6 +1898,7 @@ namespace ts {
                         case SyntaxKind.StringLiteral:
                             return createIdentifier("String");
 
+                        case SyntaxKind.PrefixUnaryExpression:
                         case SyntaxKind.NumericLiteral:
                             return createIdentifier("Number");
 

--- a/tests/baselines/reference/decoratorWithNegativeLiteralTypeNoCrash.js
+++ b/tests/baselines/reference/decoratorWithNegativeLiteralTypeNoCrash.js
@@ -1,0 +1,28 @@
+//// [decoratorWithNegativeLiteralTypeNoCrash.ts]
+class A {
+    @decorator
+    public field1: -1 = -1;
+}
+function decorator(target: any, field: any) {}
+
+//// [decoratorWithNegativeLiteralTypeNoCrash.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var A = /** @class */ (function () {
+    function A() {
+        this.field1 = -1;
+    }
+    __decorate([
+        decorator,
+        __metadata("design:type", Number)
+    ], A.prototype, "field1", void 0);
+    return A;
+}());
+function decorator(target, field) { }

--- a/tests/baselines/reference/decoratorWithNegativeLiteralTypeNoCrash.symbols
+++ b/tests/baselines/reference/decoratorWithNegativeLiteralTypeNoCrash.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/decoratorWithNegativeLiteralTypeNoCrash.ts ===
+class A {
+>A : Symbol(A, Decl(decoratorWithNegativeLiteralTypeNoCrash.ts, 0, 0))
+
+    @decorator
+>decorator : Symbol(decorator, Decl(decoratorWithNegativeLiteralTypeNoCrash.ts, 3, 1))
+
+    public field1: -1 = -1;
+>field1 : Symbol(A.field1, Decl(decoratorWithNegativeLiteralTypeNoCrash.ts, 0, 9))
+}
+function decorator(target: any, field: any) {}
+>decorator : Symbol(decorator, Decl(decoratorWithNegativeLiteralTypeNoCrash.ts, 3, 1))
+>target : Symbol(target, Decl(decoratorWithNegativeLiteralTypeNoCrash.ts, 4, 19))
+>field : Symbol(field, Decl(decoratorWithNegativeLiteralTypeNoCrash.ts, 4, 31))
+

--- a/tests/baselines/reference/decoratorWithNegativeLiteralTypeNoCrash.types
+++ b/tests/baselines/reference/decoratorWithNegativeLiteralTypeNoCrash.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/decoratorWithNegativeLiteralTypeNoCrash.ts ===
+class A {
+>A : A
+
+    @decorator
+>decorator : (target: any, field: any) => void
+
+    public field1: -1 = -1;
+>field1 : -1
+>-1 : -1
+>1 : 1
+>-1 : -1
+>1 : 1
+}
+function decorator(target: any, field: any) {}
+>decorator : (target: any, field: any) => void
+>target : any
+>field : any
+

--- a/tests/cases/compiler/decoratorWithNegativeLiteralTypeNoCrash.ts
+++ b/tests/cases/compiler/decoratorWithNegativeLiteralTypeNoCrash.ts
@@ -1,0 +1,8 @@
+// @target: es5
+// @experimentalDecorators: true
+// @emitDecoratorMetadata: true
+class A {
+    @decorator
+    public field1: -1 = -1;
+}
+function decorator(target: any, field: any) {}


### PR DESCRIPTION
Fixes #29329

Sadly the type of the thing we're switching over isn't guaranteed to be exhaustive because `LiteralExpression` isn't discriminable. A refactoring for another time, perhaps.