### PR TITLE
Allow circular umd-merged-with-augmentation refs to resolve to the module as intended

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5426,6 +5426,10 @@ namespace ts {
 
             // Handle variable, parameter or property
             if (!pushTypeResolution(symbol, TypeSystemPropertyName.Type)) {
+                // Symbol is property of some kind that is merged with something - should use `getTypeOfFuncClassEnumModule` and not `getTypeOfVariableOrParameterOrProperty`
+                if (symbol.flags & SymbolFlags.ValueModule) {
+                    return getTypeOfFuncClassEnumModule(symbol);
+                }
                 return errorType;
             }
             let type: Type | undefined;
@@ -5481,6 +5485,10 @@ namespace ts {
             }
 
             if (!popTypeResolution()) {
+                // Symbol is property of some kind that is merged with something - should use `getTypeOfFuncClassEnumModule` and not `getTypeOfVariableOrParameterOrProperty`
+                if (symbol.flags & SymbolFlags.ValueModule) {
+                    return getTypeOfFuncClassEnumModule(symbol);
+                }
                 type = reportCircularityError(symbol);
             }
             return type;

--- a/tests/baselines/reference/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.js
+++ b/tests/baselines/reference/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.js
@@ -1,0 +1,31 @@
+//// [tests/cases/compiler/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts] ////
+
+//// [global.d.ts]
+declare global {
+    const React: typeof import("./module");
+}
+
+export { };
+
+//// [module.d.ts]
+export = React;
+export as namespace React;
+
+declare namespace React {
+    function createRef(): any;
+}
+
+//// [some_module.ts]
+export { };
+React.createRef;
+
+//// [emits.ts]
+console.log("hello");
+React.createRef;
+
+//// [some_module.js]
+React.createRef;
+//// [emits.js]
+"use strict";
+console.log("hello");
+React.createRef;

--- a/tests/baselines/reference/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.symbols
+++ b/tests/baselines/reference/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/global.d.ts ===
+declare global {
+>global : Symbol(global, Decl(global.d.ts, 0, 0))
+
+    const React: typeof import("./module");
+>React : Symbol(React, Decl(module.d.ts, 1, 26), Decl(global.d.ts, 1, 9))
+}
+
+export { };
+
+=== tests/cases/compiler/module.d.ts ===
+export = React;
+>React : Symbol(React, Decl(module.d.ts, 1, 26))
+
+export as namespace React;
+>React : Symbol(React, Decl(module.d.ts, 0, 15))
+
+declare namespace React {
+>React : Symbol(React, Decl(module.d.ts, 1, 26), Decl(global.d.ts, 1, 9))
+
+    function createRef(): any;
+>createRef : Symbol(createRef, Decl(module.d.ts, 3, 25))
+}
+
+=== tests/cases/compiler/some_module.ts ===
+export { };
+React.createRef;
+>React.createRef : Symbol(React.createRef, Decl(module.d.ts, 3, 25))
+>React : Symbol(React, Decl(module.d.ts, 1, 26), Decl(global.d.ts, 1, 9))
+>createRef : Symbol(React.createRef, Decl(module.d.ts, 3, 25))
+
+=== tests/cases/compiler/emits.ts ===
+console.log("hello");
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+
+React.createRef;
+>React.createRef : Symbol(React.createRef, Decl(module.d.ts, 3, 25))
+>React : Symbol(React, Decl(module.d.ts, 1, 26), Decl(global.d.ts, 1, 9))
+>createRef : Symbol(React.createRef, Decl(module.d.ts, 3, 25))
+

--- a/tests/baselines/reference/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.types
+++ b/tests/baselines/reference/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.types
@@ -1,0 +1,44 @@
+=== tests/cases/compiler/global.d.ts ===
+declare global {
+>global : typeof global
+
+    const React: typeof import("./module");
+>React : typeof React
+}
+
+export { };
+
+=== tests/cases/compiler/module.d.ts ===
+export = React;
+>React : typeof React
+
+export as namespace React;
+>React : typeof React
+
+declare namespace React {
+>React : typeof React
+
+    function createRef(): any;
+>createRef : () => any
+}
+
+=== tests/cases/compiler/some_module.ts ===
+export { };
+React.createRef;
+>React.createRef : () => any
+>React : typeof React
+>createRef : () => any
+
+=== tests/cases/compiler/emits.ts ===
+console.log("hello");
+>console.log("hello") : void
+>console.log : (message?: any, ...optionalParams: any[]) => void
+>console : Console
+>log : (message?: any, ...optionalParams: any[]) => void
+>"hello" : "hello"
+
+React.createRef;
+>React.createRef : () => any
+>React : typeof React
+>createRef : () => any
+

--- a/tests/cases/compiler/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts
+++ b/tests/cases/compiler/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts
@@ -1,0 +1,26 @@
+// @strict: true
+// @module: esnext
+// @moduleResolution: node
+// @target: es2018
+// @filename: global.d.ts
+declare global {
+    const React: typeof import("./module");
+}
+
+export { };
+
+// @filename: module.d.ts
+export = React;
+export as namespace React;
+
+declare namespace React {
+    function createRef(): any;
+}
+
+// @filename: some_module.ts
+export { };
+React.createRef;
+
+// @filename: emits.ts
+console.log("hello");
+React.createRef;


### PR DESCRIPTION
Fixes #28924

We try to look up the type from the annotation, on the global, but because of the umd ref, it merged with the module declaration itself - the second time around we just want to go to the module rather than trying the annotation again (or reporting a circularity error, as it were).