### PR TITLE
Fix conditional type resolution

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3916,7 +3916,9 @@ namespace ts {
         aliasTypeArguments?: ReadonlyArray<Type>;     // Alias type arguments (if any)
         /* @internal */ aliasTypeArgumentsContainsMarker?: boolean;   // Alias type arguments (if any)
         /* @internal */
-        wildcardInstantiation?: Type;    // Instantiation with type parameters mapped to wildcard type
+        permissiveInstantiation?: Type;  // Instantiation with type parameters mapped to wildcard type
+        /* @internal */
+        restrictiveInstantiation?: Type; // Instantiation with type parameters mapped to unconstrained form
         /* @internal */
         immediateBaseConstraint?: Type;  // Immediate base constraint cache
     }

--- a/tests/baselines/reference/conditionalTypes1.errors.txt
+++ b/tests/baselines/reference/conditionalTypes1.errors.txt
@@ -472,3 +472,11 @@ tests/cases/conformance/types/conditional/conditionalTypes1.ts(288,43): error TS
     var a = {o: 1, b: 2, c: [{a: 1, c: '213'}]}
     assign(a, {o: 2, c: {0: {a: 2, c: '213123'}}})
     
+    // Repros from #23843
+    
+    type Weird1 = (<U extends boolean>(a: U) => never) extends 
+        (<U extends true>(a: U) => never) ? never : never;
+    
+    type Weird2 = (<U extends boolean>(a: U) => U) extends 
+        (<U extends true>(a: U) => infer T) ? T : never;
+    

--- a/tests/baselines/reference/conditionalTypes1.js
+++ b/tests/baselines/reference/conditionalTypes1.js
@@ -352,6 +352,14 @@ declare function assign<T>(o: T, a: RecursivePartial<T>): void;
 var a = {o: 1, b: 2, c: [{a: 1, c: '213'}]}
 assign(a, {o: 2, c: {0: {a: 2, c: '213123'}}})
 
+// Repros from #23843
+
+type Weird1 = (<U extends boolean>(a: U) => never) extends 
+    (<U extends true>(a: U) => never) ? never : never;
+
+type Weird2 = (<U extends boolean>(a: U) => U) extends 
+    (<U extends true>(a: U) => infer T) ? T : never;
+
 
 //// [conditionalTypes1.js]
 "use strict";
@@ -715,3 +723,5 @@ declare var a: {
         c: string;
     }[];
 };
+declare type Weird1 = (<U extends boolean>(a: U) => never) extends (<U extends true>(a: U) => never) ? never : never;
+declare type Weird2 = (<U extends boolean>(a: U) => U) extends (<U extends true>(a: U) => infer T) ? T : never;

--- a/tests/baselines/reference/conditionalTypes1.symbols
+++ b/tests/baselines/reference/conditionalTypes1.symbols
@@ -1371,3 +1371,30 @@ assign(a, {o: 2, c: {0: {a: 2, c: '213123'}}})
 >a : Symbol(a, Decl(conditionalTypes1.ts, 351, 25))
 >c : Symbol(c, Decl(conditionalTypes1.ts, 351, 30))
 
+// Repros from #23843
+
+type Weird1 = (<U extends boolean>(a: U) => never) extends 
+>Weird1 : Symbol(Weird1, Decl(conditionalTypes1.ts, 351, 46))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 355, 16))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 355, 35))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 355, 16))
+
+    (<U extends true>(a: U) => never) ? never : never;
+>U : Symbol(U, Decl(conditionalTypes1.ts, 356, 6))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 356, 22))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 356, 6))
+
+type Weird2 = (<U extends boolean>(a: U) => U) extends 
+>Weird2 : Symbol(Weird2, Decl(conditionalTypes1.ts, 356, 54))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 358, 16))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 358, 35))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 358, 16))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 358, 16))
+
+    (<U extends true>(a: U) => infer T) ? T : never;
+>U : Symbol(U, Decl(conditionalTypes1.ts, 359, 6))
+>a : Symbol(a, Decl(conditionalTypes1.ts, 359, 22))
+>U : Symbol(U, Decl(conditionalTypes1.ts, 359, 6))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 359, 36))
+>T : Symbol(T, Decl(conditionalTypes1.ts, 359, 36))
+

--- a/tests/baselines/reference/conditionalTypes1.types
+++ b/tests/baselines/reference/conditionalTypes1.types
@@ -1054,3 +1054,21 @@ assign(a, {o: 2, c: {0: {a: 2, c: '213123'}}})
 >c : string
 >'213123' : "213123"
 
+// Repros from #23843
+
+type Weird1 = (<U extends boolean>(a: U) => never) extends 
+>Weird1 : never
+>a : U
+
+    (<U extends true>(a: U) => never) ? never : never;
+>true : true
+>a : U
+
+type Weird2 = (<U extends boolean>(a: U) => U) extends 
+>Weird2 : boolean
+>a : U
+
+    (<U extends true>(a: U) => infer T) ? T : never;
+>true : true
+>a : U
+

--- a/tests/cases/conformance/types/conditional/conditionalTypes1.ts
+++ b/tests/cases/conformance/types/conditional/conditionalTypes1.ts
@@ -353,3 +353,11 @@ declare function assign<T>(o: T, a: RecursivePartial<T>): void;
 
 var a = {o: 1, b: 2, c: [{a: 1, c: '213'}]}
 assign(a, {o: 2, c: {0: {a: 2, c: '213123'}}})
+
+// Repros from #23843
+
+type Weird1 = (<U extends boolean>(a: U) => never) extends 
+    (<U extends true>(a: U) => never) ? never : never;
+
+type Weird2 = (<U extends boolean>(a: U) => U) extends 
+    (<U extends true>(a: U) => infer T) ? T : never;


### PR DESCRIPTION
This PR improves our logic for determining when to resolve conditional types. We previously used a special "definitely assignable" relation which ignored type parameter constraints, but that didn't correctly distinguish between type parameters referenced in the conditional type vs. type parameters local to contained members such as generic methods. The PR gets rid of this special relation and instead uses the regular assignable relation on a special restrictive form of each type parameter that has no constraint. Now, for a conditional type `T extends U ? X : Y`, the algorithm we use to determine whether to defer resolution of a conditional type is:

* we resolve to `Y` when `T` is not assignable to `U` _considering all type parameters referenced in `T` and `U` related_ (i.e. `T` is definitely not assignable to `U`),
* otherwise we resolve to `X` when `T` is assignable to `U` _considering all type parameters referenced in `T` and `U` unrelated_ (i.e. `T` is definitely assignable to `U`),
* otherwise we defer resolution.

Fixes #23843.