### PR TITLE
getEffectiveBaseTypeNode: only use JSDoc augments if there is extends

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2513,14 +2513,15 @@ namespace ts {
     }
 
     export function getEffectiveBaseTypeNode(node: ClassLikeDeclaration | InterfaceDeclaration) {
-        if (isInJSFile(node)) {
+        const baseType = getClassExtendsHeritageElement(node);
+        if (baseType && isInJSFile(node)) {
             // Prefer an @augments tag because it may have type parameters.
             const tag = getJSDocAugmentsTag(node);
             if (tag) {
                 return tag.class;
             }
         }
-        return getClassExtendsHeritageElement(node);
+        return baseType;
     }
 
     export function getClassExtendsHeritageElement(node: ClassLikeDeclaration | InterfaceDeclaration) {

--- a/tests/baselines/reference/jsdocAugments_noExtends.errors.txt
+++ b/tests/baselines/reference/jsdocAugments_noExtends.errors.txt
@@ -1,0 +1,15 @@
+/b.js(6,21): error TS2339: Property 'x' does not exist on type 'B'.
+
+
+==== /b.js (1 errors) ====
+    class A { constructor() { this.x = 0; } }
+    
+    /** @augments A */
+    class B {
+        m() {
+            return this.x;
+                        ~
+!!! error TS2339: Property 'x' does not exist on type 'B'.
+        }
+    }
+    

--- a/tests/baselines/reference/jsdocAugments_noExtends.symbols
+++ b/tests/baselines/reference/jsdocAugments_noExtends.symbols
@@ -13,9 +13,7 @@ class B {
 >m : Symbol(B.m, Decl(b.js, 3, 9))
 
         return this.x;
->this.x : Symbol(A.x, Decl(b.js, 0, 25))
 >this : Symbol(B, Decl(b.js, 0, 41))
->x : Symbol(A.x, Decl(b.js, 0, 25))
     }
 }
 

--- a/tests/baselines/reference/jsdocAugments_noExtends.types
+++ b/tests/baselines/reference/jsdocAugments_noExtends.types
@@ -12,12 +12,12 @@ class B {
 >B : B
 
     m() {
->m : () => number
+>m : () => any
 
         return this.x;
->this.x : number
+>this.x : any
 >this : this
->x : number
+>x : any
     }
 }
 


### PR DESCRIPTION
Suggested by @sandersn in https://github.com/Microsoft/TypeScript/pull/29308#issuecomment-452385619