### PR TITLE
Qualified name param tag error

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24757,9 +24757,17 @@ namespace ts {
                         return;
                     }
                     if (!containsArgumentsReference(decl)) {
-                        error(node.name,
-                            Diagnostics.JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name,
-                            idText(node.name.kind === SyntaxKind.QualifiedName ? node.name.right : node.name));
+                        if (isQualifiedName(node.name)) {
+                            error(node.name,
+                                Diagnostics.Qualified_name_0_is_not_allowed_without_a_leading_param_object_1,
+                                entityNameToString(node.name),
+                                entityNameToString(node.name.left));
+                        }
+                        else {
+                            error(node.name,
+                                Diagnostics.JSDoc_param_tag_has_name_0_but_there_is_no_parameter_with_that_name,
+                                idText(node.name));
+                        }
                     }
                     else if (findLast(getJSDocTags(decl), isJSDocParameterTag) === node &&
                         node.typeExpression && node.typeExpression.type &&

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4266,6 +4266,10 @@
         "category": "Error",
         "code": 8031
     },
+    "Qualified name '{0}' is not allowed without a leading '@param {object} {1}'.": {
+        "category": "Error",
+        "code": 8032
+    },
     "Only identifiers/qualified-names with optional type arguments are currently supported in a class 'extends' clause.": {
         "category": "Error",
         "code": 9002

--- a/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.errors.txt
+++ b/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.errors.txt
@@ -8,5 +8,5 @@ tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.js(2,20): erro
 !!! error TS8032: Qualified name 'xyz.p' is not allowed without a leading '@param {object} xyz'.
      */
     function g(xyz) {
-        xyz.x;
+        return xyz.p;
     }

--- a/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.errors.txt
+++ b/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.js(2,20): error TS8032: Qualified name 'xyz.p' is not allowed without a leading '@param {object} xyz'.
+
+
+==== tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.js (1 errors) ====
+    /**
+     * @param {number} xyz.p
+                       ~~~~~
+!!! error TS8032: Qualified name 'xyz.p' is not allowed without a leading '@param {object} xyz'.
+     */
+    function g(xyz) {
+        xyz.x;
+    }

--- a/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.symbols
+++ b/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.js ===
+/**
+ * @param {number} xyz.p
+ */
+function g(xyz) {
+>g : Symbol(g, Decl(paramTagNestedWithoutTopLevelObject.js, 0, 0))
+>xyz : Symbol(xyz, Decl(paramTagNestedWithoutTopLevelObject.js, 3, 11))
+
+    xyz.x;
+>xyz : Symbol(xyz, Decl(paramTagNestedWithoutTopLevelObject.js, 3, 11))
+}

--- a/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.symbols
+++ b/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.symbols
@@ -6,6 +6,6 @@ function g(xyz) {
 >g : Symbol(g, Decl(paramTagNestedWithoutTopLevelObject.js, 0, 0))
 >xyz : Symbol(xyz, Decl(paramTagNestedWithoutTopLevelObject.js, 3, 11))
 
-    xyz.x;
+    return xyz.p;
 >xyz : Symbol(xyz, Decl(paramTagNestedWithoutTopLevelObject.js, 3, 11))
 }

--- a/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.types
+++ b/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.types
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.js ===
+/**
+ * @param {number} xyz.p
+ */
+function g(xyz) {
+>g : (xyz: any) => void
+>xyz : any
+
+    xyz.x;
+>xyz.x : any
+>xyz : any
+>x : any
+}

--- a/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.types
+++ b/tests/baselines/reference/paramTagNestedWithoutTopLevelObject.types
@@ -3,11 +3,11 @@
  * @param {number} xyz.p
  */
 function g(xyz) {
->g : (xyz: any) => void
+>g : (xyz: any) => any
 >xyz : any
 
-    xyz.x;
->xyz.x : any
+    return xyz.p;
+>xyz.p : any
 >xyz : any
->x : any
+>p : any
 }

--- a/tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.ts
+++ b/tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.ts
@@ -1,0 +1,11 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: paramTagNestedWithoutTopLevelObject.js
+
+/**
+ * @param {number} xyz.p
+ */
+function g(xyz) {
+    xyz.x;
+}

--- a/tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.ts
+++ b/tests/cases/conformance/jsdoc/paramTagNestedWithoutTopLevelObject.ts
@@ -7,5 +7,5 @@
  * @param {number} xyz.p
  */
 function g(xyz) {
-    xyz.x;
+    return xyz.p;
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
Fixes #27010 by displaying a better error message.
The following code

```javascript
/**
 * @param {number} xyz.p
 */
function g(xyz) {
    return xyz.p;
}
```
generates the following error message:
`Qualified name 'xyz.p' is not allowed without a leading '@param {object} xyz'.`

