### PR TITLE
Fix unneeded cast lints

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -78,7 +78,8 @@ namespace ts {
         if (useOldState) {
             // Verify the sanity of old state
             if (!oldState!.currentChangedFilePath) {
-                Debug.assert(!oldState!.affectedFiles && (!oldState!.currentAffectedFilesSignatures || !oldState!.currentAffectedFilesSignatures!.size), "Cannot reuse if only few affected files of currentChangedFile were iterated");
+                const affectedSignatures = oldState!.currentAffectedFilesSignatures;
+                Debug.assert(!oldState!.affectedFiles && (!affectedSignatures || !affectedSignatures.size), "Cannot reuse if only few affected files of currentChangedFile were iterated");
             }
             if (canCopySemanticDiagnostics) {
                 Debug.assert(!forEachKey(oldState!.changedFilesSet, path => oldState!.semanticDiagnosticsPerFile!.has(path)), "Semantic diagnostics shouldnt be available for changed files");

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7774,17 +7774,18 @@ namespace ts {
                     const libReferenceDirectives = context.libReferenceDirectives;
                     forEach(toArray(entryOrList), (arg: PragmaPseudoMap["reference"]) => {
                         // TODO: GH#18217
+                        const { types, lib, path } = arg!.arguments;
                         if (arg!.arguments["no-default-lib"]) {
                             context.hasNoDefaultLib = true;
                         }
-                        else if (arg!.arguments.types) {
-                            typeReferenceDirectives.push({ pos: arg!.arguments.types!.pos, end: arg!.arguments.types!.end, fileName: arg!.arguments.types!.value });
+                        else if (types) {
+                            typeReferenceDirectives.push({ pos: types.pos, end: types.end, fileName: types.value });
                         }
-                        else if (arg!.arguments.lib) {
-                            libReferenceDirectives.push({ pos: arg!.arguments.lib!.pos, end: arg!.arguments.lib!.end, fileName: arg!.arguments.lib!.value });
+                        else if (lib) {
+                            libReferenceDirectives.push({ pos: lib.pos, end: lib.end, fileName: lib.value });
                         }
-                        else if (arg!.arguments.path) {
-                            referencedFiles.push({ pos: arg!.arguments.path!.pos, end: arg!.arguments.path!.end, fileName: arg!.arguments.path!.value });
+                        else if (path) {
+                            referencedFiles.push({ pos: path.pos, end: path.end, fileName: path.value });
                         }
                         else {
                             reportDiagnostic(arg!.range.pos, arg!.range.end - arg!.range.pos, Diagnostics.Invalid_reference_directive_syntax);

--- a/src/harness/compiler.ts
+++ b/src/harness/compiler.ts
@@ -183,8 +183,9 @@ namespace compiler {
         }
 
         public getSourceMapRecord(): string | undefined {
-            if (this.result!.sourceMaps && this.result!.sourceMaps!.length > 0) {
-                return Harness.SourceMapRecorder.getSourceMapRecord(this.result!.sourceMaps!, this.program!, Array.from(this.js.values()).filter(d => !ts.fileExtensionIs(d.file, ts.Extension.Json)), Array.from(this.dts.values()));
+            const maps = this.result!.sourceMaps;
+            if (maps && maps.length > 0) {
+                return Harness.SourceMapRecorder.getSourceMapRecord(maps, this.program!, Array.from(this.js.values()).filter(d => !ts.fileExtensionIs(d.file, ts.Extension.Json)), Array.from(this.dts.values()));
             }
         }
 


### PR DESCRIPTION
We pulled a change into our nightly that allowed references in control flow to contain `!` and still match, which makes some casts in our codebase unneeded. Our LKG is older than the nightly, so we technically still need the casts right now, even though the linter knows we won't. As a compromise, I just refactored the offending locations to a form that didn't use so many `!`. IMO, it's nicer this way.

