### PR TITLE
Fix implement interface quickfix import types

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3037,8 +3037,10 @@ namespace ts {
         /* @internal */ typeToTypeNode(type: Type, enclosingDeclaration?: Node, flags?: NodeBuilderFlags, tracker?: SymbolTracker): TypeNode | undefined; // tslint:disable-line unified-signatures
         /** Note that the resulting nodes cannot be checked. */
         signatureToSignatureDeclaration(signature: Signature, kind: SyntaxKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): SignatureDeclaration & {typeArguments?: NodeArray<TypeNode>} | undefined;
+        /* @internal */ signatureToSignatureDeclaration(signature: Signature, kind: SyntaxKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags, tracker?: SymbolTracker): SignatureDeclaration & {typeArguments?: NodeArray<TypeNode>} | undefined;  // tslint:disable-line unified-signatures
         /** Note that the resulting nodes cannot be checked. */
         indexInfoToIndexSignatureDeclaration(indexInfo: IndexInfo, kind: IndexKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): IndexSignatureDeclaration | undefined;
+        /* @internal */ indexInfoToIndexSignatureDeclaration(indexInfo: IndexInfo, kind: IndexKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags, tracker?: SymbolTracker): IndexSignatureDeclaration | undefined;
         /** Note that the resulting nodes cannot be checked. */
         symbolToEntityName(symbol: Symbol, meaning: SymbolFlags, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): EntityName | undefined;
         /** Note that the resulting nodes cannot be checked. */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3040,7 +3040,7 @@ namespace ts {
         /* @internal */ signatureToSignatureDeclaration(signature: Signature, kind: SyntaxKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags, tracker?: SymbolTracker): SignatureDeclaration & {typeArguments?: NodeArray<TypeNode>} | undefined;  // tslint:disable-line unified-signatures
         /** Note that the resulting nodes cannot be checked. */
         indexInfoToIndexSignatureDeclaration(indexInfo: IndexInfo, kind: IndexKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): IndexSignatureDeclaration | undefined;
-        /* @internal */ indexInfoToIndexSignatureDeclaration(indexInfo: IndexInfo, kind: IndexKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags, tracker?: SymbolTracker): IndexSignatureDeclaration | undefined;
+        /* @internal */ indexInfoToIndexSignatureDeclaration(indexInfo: IndexInfo, kind: IndexKind, enclosingDeclaration?: Node, flags?: NodeBuilderFlags, tracker?: SymbolTracker): IndexSignatureDeclaration | undefined;  // tslint:disable-line unified-signatures
         /** Note that the resulting nodes cannot be checked. */
         symbolToEntityName(symbol: Symbol, meaning: SymbolFlags, enclosingDeclaration?: Node, flags?: NodeBuilderFlags): EntityName | undefined;
         /** Note that the resulting nodes cannot be checked. */

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -275,7 +275,7 @@ namespace ts.codefix {
         inJs: boolean,
         preferences: UserPreferences,
     ): void {
-        const methodDeclaration = createMethodFromCallExpression(context, callExpression, token.text, inJs, makeStatic, preferences, !isInterfaceDeclaration(typeDecl));
+        const methodDeclaration = createMethodFromCallExpression(context, callExpression, token.text, inJs, makeStatic, preferences, typeDecl);
         const containingMethodDeclaration = getAncestor(callExpression, SyntaxKind.MethodDeclaration);
 
         if (containingMethodDeclaration && containingMethodDeclaration.parent === typeDecl) {

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -6,23 +6,48 @@ namespace ts.codefix {
      * @param possiblyMissingSymbols The collection of symbols to filter and then get insertions for.
      * @returns Empty string iff there are no member insertions.
      */
-    export function createMissingMemberNodes(classDeclaration: ClassLikeDeclaration, possiblyMissingSymbols: ReadonlyArray<Symbol>, checker: TypeChecker, preferences: UserPreferences, out: (node: ClassElement) => void): void {
+    export function createMissingMemberNodes(classDeclaration: ClassLikeDeclaration, possiblyMissingSymbols: ReadonlyArray<Symbol>, context: TypeConstructionContext, preferences: UserPreferences, out: (node: ClassElement) => void): void {
         const classMembers = classDeclaration.symbol.members!;
         for (const symbol of possiblyMissingSymbols) {
             if (!classMembers.has(symbol.escapedName)) {
-                addNewNodeForMemberSymbol(symbol, classDeclaration, checker, preferences, out);
+                addNewNodeForMemberSymbol(symbol, classDeclaration, context, preferences, out);
             }
         }
+    }
+
+    function getModuleSpecifierResolverHost(context: TypeConstructionContext): SymbolTracker["moduleResolverHost"] {
+        return {
+            directoryExists: context.host.directoryExists ? d => context.host.directoryExists!(d) : undefined,
+            fileExists: context.host.fileExists ? f => context.host.fileExists!(f) : undefined,
+            getCurrentDirectory: context.host.getCurrentDirectory ? () => context.host.getCurrentDirectory!() : undefined,
+            readFile: context.host.readFile ? f => context.host.readFile!(f) : undefined,
+            useCaseSensitiveFileNames: context.host.useCaseSensitiveFileNames ? () => context.host.useCaseSensitiveFileNames!() : undefined,
+            getSourceFiles: () => context.program.getSourceFiles(),
+            getCommonSourceDirectory: () => context.program.getCommonSourceDirectory(),
+        }
+    }
+
+    export function getNoopSymbolTrackerWithResolver(context: TypeConstructionContext): SymbolTracker {
+        return {
+            trackSymbol: ts.noop,
+            moduleResolverHost: getModuleSpecifierResolverHost(context),
+        }
+    }
+
+    export interface TypeConstructionContext {
+        program: Program;
+        host: ModuleSpecifierResolutionHost;
     }
 
     /**
      * @returns Empty string iff there we can't figure out a representation for `symbol` in `enclosingDeclaration`.
      */
-    function addNewNodeForMemberSymbol(symbol: Symbol, enclosingDeclaration: ClassLikeDeclaration, checker: TypeChecker, preferences: UserPreferences, out: (node: Node) => void): void {
+    function addNewNodeForMemberSymbol(symbol: Symbol, enclosingDeclaration: ClassLikeDeclaration, context: TypeConstructionContext, preferences: UserPreferences, out: (node: Node) => void): void {
         const declarations = symbol.getDeclarations();
         if (!(declarations && declarations.length)) {
             return undefined;
         }
+        const checker = context.program.getTypeChecker();
 
         const declaration = declarations[0];
         const name = getSynthesizedDeepClone(getNameOfDeclaration(declaration), /*includeTrivia*/ false) as PropertyName;
@@ -36,7 +61,7 @@ namespace ts.codefix {
             case SyntaxKind.SetAccessor:
             case SyntaxKind.PropertySignature:
             case SyntaxKind.PropertyDeclaration:
-                const typeNode = checker.typeToTypeNode(type, enclosingDeclaration);
+                const typeNode = checker.typeToTypeNode(type, enclosingDeclaration, /*flags*/ undefined, getNoopSymbolTrackerWithResolver(context));
                 out(createProperty(
                     /*decorators*/undefined,
                     modifiers,
@@ -83,13 +108,13 @@ namespace ts.codefix {
         }
 
         function outputMethod(signature: Signature, modifiers: NodeArray<Modifier> | undefined, name: PropertyName, body?: Block): void {
-            const method = signatureToMethodDeclaration(checker, signature, enclosingDeclaration, modifiers, name, optional, body);
+            const method = signatureToMethodDeclaration(context, signature, enclosingDeclaration, modifiers, name, optional, body);
             if (method) out(method);
         }
     }
 
     function signatureToMethodDeclaration(
-        checker: TypeChecker,
+        context: TypeConstructionContext,
         signature: Signature,
         enclosingDeclaration: ClassLikeDeclaration,
         modifiers: NodeArray<Modifier> | undefined,
@@ -97,7 +122,8 @@ namespace ts.codefix {
         optional: boolean,
         body: Block | undefined,
     ): MethodDeclaration | undefined {
-        const signatureDeclaration = <MethodDeclaration>checker.signatureToSignatureDeclaration(signature, SyntaxKind.MethodDeclaration, enclosingDeclaration, NodeBuilderFlags.NoTruncation | NodeBuilderFlags.SuppressAnyReturnType);
+        const program = context.program;
+        const signatureDeclaration = <MethodDeclaration>program.getTypeChecker().signatureToSignatureDeclaration(signature, SyntaxKind.MethodDeclaration, enclosingDeclaration, NodeBuilderFlags.NoTruncation | NodeBuilderFlags.SuppressAnyReturnType, getNoopSymbolTrackerWithResolver(context));
         if (!signatureDeclaration) {
             return undefined;
         }
@@ -121,14 +147,15 @@ namespace ts.codefix {
     ): MethodDeclaration {
         const { typeArguments, arguments: args, parent } = call;
         const checker = context.program.getTypeChecker();
+        const tracker = getNoopSymbolTrackerWithResolver(context);
         const types = map(args, arg =>
             // Widen the type so we don't emit nonsense annotations like "function fn(x: 3) {"
-            checker.typeToTypeNode(checker.getBaseTypeOfLiteralType(checker.getTypeAtLocation(arg))));
+            checker.typeToTypeNode(checker.getBaseTypeOfLiteralType(checker.getTypeAtLocation(arg)), call, /*flags*/ undefined, tracker));
         const names = map(args, arg =>
             isIdentifier(arg) ? arg.text :
                 isPropertyAccessExpression(arg) ? arg.name.text : undefined);
         const contextualType = checker.getContextualType(call);
-        const returnType = inJs ? undefined : contextualType && checker.typeToTypeNode(contextualType, call) || createKeywordTypeNode(SyntaxKind.AnyKeyword);
+        const returnType = inJs ? undefined : contextualType && checker.typeToTypeNode(contextualType, call, /*flags*/ undefined, tracker) || createKeywordTypeNode(SyntaxKind.AnyKeyword);
         return createMethod(
             /*decorators*/ undefined,
             /*modifiers*/ makeStatic ? [createToken(SyntaxKind.StaticKeyword)] : undefined,

--- a/tests/cases/fourslash/codeFixClassImplementInterface_typeInOtherFile.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterface_typeInOtherFile.ts
@@ -17,8 +17,8 @@ verify.codeFix({
     newFileContent:
 `import { I } from "./I";
 export class C implements I {
-    x: import("/I").J;
-    m(): import("/I").J {
+    x: import("./I").J;
+    m(): import("./I").J {
         throw new Error("Method not implemented.");
     }
 }`,

--- a/tests/cases/fourslash/codeFixUndeclaredAcrossFiles3.ts
+++ b/tests/cases/fourslash/codeFixUndeclaredAcrossFiles3.ts
@@ -20,7 +20,7 @@
 verify.getAndApplyCodeFix(/*errorCode*/ undefined, 0);
 
 verify.rangeIs(`
-    m0(arg0: D): any {
+    m0(arg0: import("./f2").D): any {
         throw new Error("Method not implemented.");
     }
 `);

--- a/tests/cases/fourslash/quickfixImplementInterfaceUnreachableTypeUsesRelativeImport.ts
+++ b/tests/cases/fourslash/quickfixImplementInterfaceUnreachableTypeUsesRelativeImport.ts
@@ -1,0 +1,26 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: class.ts
+////export class Class { }
+// @Filename: interface.ts
+////import { Class } from './class';
+////
+////export interface Foo {
+////    x: Class;
+////}
+// @Filename: index.ts
+////import { Foo } from './interface';
+////
+////class /*1*/X implements Foo {}
+goTo.marker("1");
+verify.codeFix({
+    index: 0,
+    description: "Implement interface 'Foo'",
+    newFileContent: {
+        "/tests/cases/fourslash/index.ts": `import { Foo } from './interface';
+
+class X implements Foo {
+    x: import("./class").Class;
+}`
+    }
+});


### PR DESCRIPTION
The `implments` quick fixes were not providing the host required to generate good paths for import types into the type node helpers they used, so they were always generating absolute paths (or amd module names).

Fixes #29406

