### PR TITLE
Harden telemetryOnOpenFile against disabled projects

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2780,7 +2780,7 @@ namespace ts.server {
             const project = scriptInfo.getDefaultProject();
             if (!project.languageServiceEnabled) {
                 return;
-            }       
+            }
 
             const info: OpenFileInfo = { checkJs: !!project.getSourceFile(scriptInfo.path)!.checkJsDirective };
             this.eventHandler({ eventName: OpenFileInfoTelemetryEvent, data: { info } });

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2777,7 +2777,12 @@ namespace ts.server {
                 return;
             }
 
-            const info: OpenFileInfo = { checkJs: !!scriptInfo.getDefaultProject().getSourceFile(scriptInfo.path)!.checkJsDirective };
+            const project = scriptInfo.getDefaultProject();
+            if (!project.languageServiceEnabled) {
+                return;
+            }       
+
+            const info: OpenFileInfo = { checkJs: !!project.getSourceFile(scriptInfo.path)!.checkJsDirective };
             this.eventHandler({ eventName: OpenFileInfoTelemetryEvent, data: { info } });
         }
 

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -103,6 +103,30 @@ namespace ts.projectSystem {
             assert.isFalse(proj3.languageServiceEnabled);
         });
 
+        it("should not crash when opening a file in a project with a disabled language service", () => {
+            const file1 = {
+                path: "/a/b/f1.js",
+                content: "let x =1;",
+                fileSize: 50 * 1024 * 1024
+            };
+            const file2 = {
+                path: "/a/b/f2.js",
+                content: "let x =1;",
+                fileSize: 100
+            };
+
+            const projName = "proj1";
+
+            const host = createServerHost([file1, file2]);
+            const projectService = createProjectService(host, { useSingleInferredProject: true }, { eventHandler: noop });
+
+            projectService.openExternalProject({ rootFiles: toExternalFiles([file1.path, file2.path]), options: {}, projectFileName: projName });
+            const proj1 = projectService.findProject(projName)!;
+            assert.isFalse(proj1.languageServiceEnabled);
+
+            assert.doesNotThrow(() => projectService.openClientFile(file2.path));
+        });
+
         describe("ignoreConfigFiles", () => {
             it("external project including config file", () => {
                 const file1 = {


### PR DESCRIPTION
As for syntax-only servers, we can't meaningfully report open-file
telemetry for projects with disabled language services.

Hopefully, a deeper fix will follow, but this solves the immediate
problem that VS disables the LS for all projects when it sees a failure
in applyChangedToOpenFiles (because it assumes the server state is
corrupt).