### PR TITLE
Fix gulp builds not building some targets, use LKG by default

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -489,28 +489,27 @@ gulp.task(
     ["local"]);
 
 gulp.task(
-    "watch-diagnostics",
-    /*help*/ false,
-    [processDiagnosticMessagesJs],
-    () => gulp.watch([diagnosticMessagesJson], [diagnosticInformationMapTs, builtGeneratedDiagnosticMessagesJson]));
-
-gulp.task(
     "watch-lib",
     /*help*/ false,
     () => gulp.watch(["src/lib/**/*"], ["lib"]));
 
+const watchTscPatterns = [
+    "src/tsconfig-base.json",
+    "src/lib/**/*",
+    "src/compiler/**/*",
+    "src/tsc/**/*",
+];
 gulp.task(
     "watch-tsc",
     /*help*/ false,
-    ["watch-diagnostics", "watch-lib"].concat(useCompilerDeps),
-    () => project.watch(tscProject, { typescript: useCompiler }));
+    useCompilerDeps,
+    () => gulp.watch(watchTscPatterns, ["tsc"]));
 
 const watchServicesPatterns = [
     "src/compiler/**/*",
     "src/jsTypings/**/*",
     "src/services/**/*"
 ];
-
 gulp.task(
     "watch-services",
     /*help*/ false,
@@ -522,39 +521,49 @@ const watchLsslPatterns = [
     "src/server/**/*",
     "src/tsserver/tsconfig.json"
 ];
-
 gulp.task(
     "watch-lssl",
     /*help*/ false,
     () => gulp.watch(watchLsslPatterns, ["lssl"]));
 
-gulp.task(
-    "watch-server",
-    /*help*/ false,
-    ["watch-diagnostics", "watch-lib"].concat(useCompilerDeps),
-    () => project.watch(tsserverProject, { typescript: useCompiler }));
-
-gulp.task(
-    "watch-runner",
-    /*help*/ false,
-    useCompilerDeps,
-    () => project.watch(testRunnerProject, { typescript: useCompiler }));
-
+const watchLocalPatterns = [
+    "src/tsconfig-base.json",
+    "src/lib/**/*",
+    "src/compiler/**/*",
+    "src/tsc/**/*",
+    "src/services/**/*",
+    "src/jsTyping/**/*",
+    "src/server/**/*",
+    "src/tsserver/**/*",
+    "src/typingsInstallerCore/**/*",
+    "src/harness/**/*",
+    "src/testRunner/**/*",
+];
 gulp.task(
     "watch-local",
     "Watches for changes to projects in src/ (but does not execute tests).",
-    ["watch-lib", "watch-tsc", "watch-services", "watch-server", "watch-runner", "watch-lssl"]);
+    () => gulp.watch(watchLocalPatterns, "local"));
 
+const watchPatterns = [
+    "src/tsconfig-base.json",
+    "src/lib/**/*",
+    "src/compiler/**/*",
+    "src/services/**/*",
+    "src/jsTyping/**/*",
+    "src/server/**/*",
+    "src/tsserver/**/*",
+    "src/typingsInstallerCore/**/*",
+    "src/harness/**/*",
+    "src/testRunner/**/*",
+];
 gulp.task(
     "watch",
     "Watches for changes to the build inputs for built/local/run.js, then runs tests.",
-    ["build-rules", "watch-runner", "watch-services", "watch-lssl"],
+    ["build-rules"],
     () => {
         const sem = new Semaphore(1);
 
-        gulp.watch([runJs, typescriptDts, tsserverlibraryDts], () => {
-            runTests();
-        });
+        gulp.watch(watchPatterns, () => { runTests(); });
 
         // NOTE: gulp.watch is far too slow when watching tests/cases/**/* as it first enumerates *every* file
         const testFilePattern = /(\.ts|[\\/]tsconfig\.json)$/;

--- a/scripts/build/options.js
+++ b/scripts/build/options.js
@@ -34,7 +34,7 @@ module.exports = minimist(process.argv.slice(2), {
         workers: process.env.workerCount || os.cpus().length,
         failed: false,
         keepFailed: false,
-        lkg: false,
+        lkg: true,
         dirty: false
     }
 });


### PR DESCRIPTION
When executing `gulp default` in a clean (or mostly clean) repo, the gulp build would sometimes exit prematurely without any indication. This was due to parallel executions of the compilation graph resulting in gulp task status being overwritten.

For now, the simple fix is to serialize access to the compilation graph so that tasks are always run cleanly.

This also changes the default behavior of the gulp builds to using the LKG compiler. To build the compiler using the built compiler, use `gulp --no-lkg`.
