### PR TITLE
Don't treat interfaces as implementations

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1682,7 +1682,8 @@ namespace ts.FindAllReferences.Core {
 
     function isImplementation(node: Node): boolean {
         return !!(node.flags & NodeFlags.Ambient)
-            || (isVariableLike(node) ? hasInitializer(node)
+            ? !(isInterfaceDeclaration(node) || isTypeAliasDeclaration(node))
+            : (isVariableLike(node) ? hasInitializer(node)
                 : isFunctionLikeDeclaration(node) ? !!node.body
                 : isClassLike(node) || isModuleOrEnumDeclaration(node));
     }

--- a/tests/cases/fourslash/goToImplementationInterface_09.ts
+++ b/tests/cases/fourslash/goToImplementationInterface_09.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts'/>
+
+// Should go to object literals within cast expressions when invoked on interface
+
+// @Filename: def.d.ts
+//// export interface Interface { P: number }
+
+// @Filename: ref.ts
+//// import { Interface } from "./def";
+//// const c: I/*ref*/nterface = [|{ P: 2 }|];
+
+verify.allRangesAppearInImplementationList("ref");

--- a/tests/cases/fourslash/goToImplementationTypeAlias_00.ts
+++ b/tests/cases/fourslash/goToImplementationTypeAlias_00.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts'/>
+
+// Should go to object literals within cast expressions when invoked on interface
+
+// @Filename: def.d.ts
+//// export type TypeAlias = { P: number }
+
+// @Filename: ref.ts
+//// import { TypeAlias } from "./def";
+//// const c: T/*ref*/ypeAlias = [|{ P: 2 }|];
+
+verify.allRangesAppearInImplementationList("ref");


### PR DESCRIPTION
...even if they're in ambient contexts.  Same for type aliases.