### PR TITLE
Fix crash in signatureHelp

### DIFF
--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -452,7 +452,7 @@ namespace ts.SignatureHelp {
     }
 
     function getContainingArgumentInfo(node: Node, position: number, sourceFile: SourceFile, checker: TypeChecker, isManuallyInvoked: boolean): ArgumentListInfo | undefined {
-        for (let n = node; isManuallyInvoked || (!isBlock(n) && !isSourceFile(n)); n = n.parent) {
+        for (let n = node; !isSourceFile(n) && (isManuallyInvoked || !isBlock(n)); n = n.parent) {
             // If the node is not a subspan of its parent, this is a big problem.
             // There have been crashes that might be caused by this violation.
             Debug.assert(rangeContainsRange(n.parent, n), "Not a subspan", () => `Child: ${Debug.showSyntaxKind(n)}, parent: ${Debug.showSyntaxKind(n.parent)}`);

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -967,4 +967,8 @@ namespace ts.server {
     (process as any).noAsar = true;
     // Start listening
     ioSession.listen();
+
+    if (ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
+        ts.sys.tryEnableSourceMapsForHost();
+    }
 }

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -968,6 +968,10 @@ namespace ts.server {
     // Start listening
     ioSession.listen();
 
+    if (Debug.isDebugging) {
+        Debug.enableDebugInfo();
+    }
+
     if (ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
         ts.sys.tryEnableSourceMapsForHost();
     }

--- a/tests/cases/fourslash/signatureHelpAtEOF2.ts
+++ b/tests/cases/fourslash/signatureHelpAtEOF2.ts
@@ -1,0 +1,6 @@
+/// <reference path='fourslash.ts' />
+
+////console.log()
+/////**/
+
+verify.noSignatureHelpForTriggerReason({ kind: "invoked" }, "");


### PR DESCRIPTION
This fixes a crash in signature help. When we pass `true` for `isManuallyInvoked` when calling `getContainingArgumentInfo`, we were shortcutting the `isSourceFile` check. Both the `rangeContainsRange` check and the following call to `getImmediatelyContainingArgumentOrContextualParameterInfo` require a node with a valid `parent`, and a `SourceFile` does not have a `parent`.

Fixes #29355

