### PR TITLE
fix trailing comma should not allowed in dynamic import argument

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31178,7 +31178,7 @@ namespace ts {
             if (nodeArguments.length !== 1) {
                 return grammarErrorOnNode(node, Diagnostics.Dynamic_import_must_have_one_specifier_as_an_argument);
             }
-
+            checkGrammarForDisallowedTrailingComma(nodeArguments);
             // see: parseArgumentOrArrayLiteralElement...we use this function which parse arguments of callExpression to parse specifier for dynamic import.
             // parseArgumentOrArrayLiteralElement allows spread element to be in an argument list which is not allowed as specifier in dynamic import.
             if (isSpreadElement(nodeArguments[0])) {

--- a/tests/baselines/reference/dynamicImportTrailingComma.errors.txt
+++ b/tests/baselines/reference/dynamicImportTrailingComma.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/dynamicImportTrailingComma.ts(2,12): error TS1009: Trailing comma not allowed.
+
+
+==== tests/cases/compiler/dynamicImportTrailingComma.ts (1 errors) ====
+    const path = './foo';
+    import(path,);
+               ~
+!!! error TS1009: Trailing comma not allowed.

--- a/tests/baselines/reference/dynamicImportTrailingComma.js
+++ b/tests/baselines/reference/dynamicImportTrailingComma.js
@@ -1,0 +1,7 @@
+//// [dynamicImportTrailingComma.ts]
+const path = './foo';
+import(path,);
+
+//// [dynamicImportTrailingComma.js]
+var path = './foo';
+Promise.resolve().then(function () { return require(path); });

--- a/tests/baselines/reference/dynamicImportTrailingComma.symbols
+++ b/tests/baselines/reference/dynamicImportTrailingComma.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/dynamicImportTrailingComma.ts ===
+const path = './foo';
+>path : Symbol(path, Decl(dynamicImportTrailingComma.ts, 0, 5))
+
+import(path,);
+>path : Symbol(path, Decl(dynamicImportTrailingComma.ts, 0, 5))
+

--- a/tests/baselines/reference/dynamicImportTrailingComma.types
+++ b/tests/baselines/reference/dynamicImportTrailingComma.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/dynamicImportTrailingComma.ts ===
+const path = './foo';
+>path : "./foo"
+>'./foo' : "./foo"
+
+import(path,);
+>import(path,) : Promise<any>
+>path : "./foo"
+

--- a/tests/cases/compiler/dynamicImportTrailingComma.ts
+++ b/tests/cases/compiler/dynamicImportTrailingComma.ts
@@ -1,0 +1,4 @@
+// @skipLibCheck: true
+// @lib: es6
+const path = './foo';
+import(path,);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [Y] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [Y] Code is up-to-date with the `master` branch
* [Y] You've successfully run `jake runtests` locally
* [Y] You've signed the CLA
* [Y] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #29545

