### PR TITLE
Fix interface definition of Generator object. It should extend `IterableIterator<T>`

### DIFF
--- a/lib/lib.es2015.generator.d.ts
+++ b/lib/lib.es2015.generator.d.ts
@@ -18,19 +18,19 @@ and limitations under the License.
 /// <reference no-default-lib="true"/>
 
 
-interface Generator extends Iterator<any> { }
+interface Generator<T> extends IterableIterator<T> { }
 
-interface GeneratorFunction {
+interface GeneratorFunction<T> {
     /**
      * Creates a new Generator object.
      * @param args A list of arguments the function accepts.
      */
-    new (...args: any[]): Generator;
+    new (...args: any[]): Generator<T>;
     /**
      * Creates a new Generator object.
      * @param args A list of arguments the function accepts.
      */
-    (...args: any[]): Generator;
+    (...args: any[]): Generator<T>;
     /**
      * The length of the arguments.
      */
@@ -42,20 +42,20 @@ interface GeneratorFunction {
     /**
      * A reference to the prototype.
      */
-    readonly prototype: Generator;
+    readonly prototype: Generator<T>;
 }
 
-interface GeneratorFunctionConstructor {
+interface GeneratorFunctionConstructor<T> {
     /**
      * Creates a new Generator function.
      * @param args A list of arguments the function accepts.
      */
-    new (...args: string[]): GeneratorFunction;
+    new (...args: string[]): GeneratorFunction<T>;
     /**
      * Creates a new Generator function.
      * @param args A list of arguments the function accepts.
      */
-    (...args: string[]): GeneratorFunction;
+    (...args: string[]): GeneratorFunction<T>;
     /**
      * The length of the arguments.
      */
@@ -67,5 +67,5 @@ interface GeneratorFunctionConstructor {
     /**
      * A reference to the prototype.
      */
-    readonly prototype: GeneratorFunction;
+  readonly prototype: GeneratorFunction<T>;
 }

--- a/lib/lib.es2015.symbol.wellknown.d.ts
+++ b/lib/lib.es2015.symbol.wellknown.d.ts
@@ -157,7 +157,7 @@ interface Function {
     [Symbol.hasInstance](value: any): boolean;
 }
 
-interface GeneratorFunction {
+interface GeneratorFunction<T> {
     readonly [Symbol.toStringTag]: string;
 }
 

--- a/src/lib/es2015.generator.d.ts
+++ b/src/lib/es2015.generator.d.ts
@@ -1,16 +1,16 @@
-interface Generator extends Iterator<any> { }
+interface Generator<T> extends IterableIterator<T> { }
 
-interface GeneratorFunction {
+interface GeneratorFunction<T> {
     /**
      * Creates a new Generator object.
      * @param args A list of arguments the function accepts.
      */
-    new (...args: any[]): Generator;
+    new (...args: any[]): Generator<T>;
     /**
      * Creates a new Generator object.
      * @param args A list of arguments the function accepts.
      */
-    (...args: any[]): Generator;
+    (...args: any[]): Generator<T>;
     /**
      * The length of the arguments.
      */
@@ -22,20 +22,20 @@ interface GeneratorFunction {
     /**
      * A reference to the prototype.
      */
-    readonly prototype: Generator;
+    readonly prototype: Generator<T>;
 }
 
-interface GeneratorFunctionConstructor {
+interface GeneratorFunctionConstructor<T> {
     /**
      * Creates a new Generator function.
      * @param args A list of arguments the function accepts.
      */
-    new (...args: string[]): GeneratorFunction;
+    new (...args: string[]): GeneratorFunction<T>;
     /**
      * Creates a new Generator function.
      * @param args A list of arguments the function accepts.
      */
-    (...args: string[]): GeneratorFunction;
+    (...args: string[]): GeneratorFunction<T>;
     /**
      * The length of the arguments.
      */
@@ -47,5 +47,5 @@ interface GeneratorFunctionConstructor {
     /**
      * A reference to the prototype.
      */
-    readonly prototype: GeneratorFunction;
+    readonly prototype: GeneratorFunction<T>;
 }

--- a/src/lib/es2015.symbol.wellknown.d.ts
+++ b/src/lib/es2015.symbol.wellknown.d.ts
@@ -137,7 +137,7 @@ interface Function {
     [Symbol.hasInstance](value: any): boolean;
 }
 
-interface GeneratorFunction {
+interface GeneratorFunction<T> {
     readonly [Symbol.toStringTag]: string;
 }
 


### PR DESCRIPTION
The current definition is incomplete.  It is both an `Iterator` and `Iterable`.

* See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#Is_a_generator_object_an_iterator_or_an_iterable

Also see https://github.com/Microsoft/TypeScript/issues/2873#issue-70221605:
* > "This has been revised: IterableIterator<any> must be assignable to the type annotation instead."
* It references another pull request https://github.com/Microsoft/TypeScript/pull/3031 which notes it should be `IterableIterator<T>`, but it neglected to update the type definitions for  `lib.es2015.generator.d.ts` and `es2015.generator.d.ts`.