### PR TITLE
Do not generate dts files for tsc/tsserver and such when we do not use it at all.

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -138,7 +138,7 @@ gulp.task(typescriptServicesProject, /*help*/ false, () => {
         compilerOptions: {
             "removeComments": false,
             "stripInternal": true,
-            "declarationMap": false,
+            "declaration": true,
             "outFile": "typescriptServices.out.js" // must align with same task in jakefile. We fix this name below.
         }
     });

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -361,7 +361,7 @@ file(ConfigFileFor.tsserverLibrary, [], function () {
         compilerOptions: {
             "removeComments": false,
             "stripInternal": true,
-            "declarationMap": false,
+            "declaration": true,
             "outFile": "tsserverlibrary.out.js"
         }
     })

--- a/src/cancellationToken/tsconfig.json
+++ b/src/cancellationToken/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../tsconfig-base",
+    "extends": "../tsconfig-noncomposite-base",
     "compilerOptions": {
         "outDir": "../../built/local/",
         "rootDir": ".",

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../tsconfig-base",
+    "extends": "../tsconfig-noncomposite-base",
     "compilerOptions": {
         "outFile": "../../built/local/run.js",
         "composite": false,

--- a/src/tsc/tsconfig.json
+++ b/src/tsc/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../tsconfig-base",
+    "extends": "../tsconfig-noncomposite-base",
     "compilerOptions": {
         "outFile": "../../built/local/tsc.js"
     },

--- a/src/tsconfig-noncomposite-base.json
+++ b/src/tsconfig-noncomposite-base.json
@@ -1,0 +1,8 @@
+{
+    "extends": "./tsconfig-base",
+    "compilerOptions": {
+        "declaration": false,
+        "declarationMap": false,
+        "composite":  false
+    }
+}

--- a/src/tsserver/tsconfig.json
+++ b/src/tsserver/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../tsconfig-base",
+    "extends": "../tsconfig-noncomposite-base",
  
     "compilerOptions": {
         "outFile": "../../built/local/tsserver.js",

--- a/src/typingsInstaller/tsconfig.json
+++ b/src/typingsInstaller/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../tsconfig-base",
+    "extends": "../tsconfig-noncomposite-base",
     "compilerOptions": {
         "removeComments": true,
         "outFile": "../../built/local/typingsInstaller.js",

--- a/src/watchGuard/tsconfig.json
+++ b/src/watchGuard/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "../tsconfig-base",
+    "extends": "../tsconfig-noncomposite-base",
     "compilerOptions": {
         "removeComments": true,
         "outFile": "../../built/local/watchGuard.js",


### PR DESCRIPTION
These end results don't need `.d.ts` files.
