### PR TITLE
Fixup restrictive instantiations to actually erase type parameter constraints

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10636,7 +10636,11 @@ namespace ts {
         }
 
         function getRestrictiveTypeParameter(tp: TypeParameter) {
-            return !tp.constraint ? tp : tp.restrictiveInstantiation || (tp.restrictiveInstantiation = createTypeParameter(tp.symbol));
+            return tp.constraint === unknownType ? tp : tp.restrictiveInstantiation || (
+                tp.restrictiveInstantiation = createTypeParameter(tp.symbol),
+                (tp.restrictiveInstantiation as TypeParameter).constraint = unknownType,
+                tp.restrictiveInstantiation
+            );
         }
 
         function restrictiveMapper(type: Type) {

--- a/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.errors.txt
+++ b/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.errors.txt
@@ -25,10 +25,9 @@ tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterInd
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(16,47): error TS2313: Type parameter 'V' has a circular constraint.
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(18,32): error TS2313: Type parameter 'T' has a circular constraint.
 tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(18,45): error TS2313: Type parameter 'V' has a circular constraint.
-tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts(23,24): error TS2313: Type parameter 'S' has a circular constraint.
 
 
-==== tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts (28 errors) ====
+==== tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts (27 errors) ====
     class C<U extends T, T extends U> { }
                       ~
 !!! error TS2313: Type parameter 'U' has a circular constraint.
@@ -106,6 +105,4 @@ tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterInd
     
     type Foo<T> = [T] extends [number] ? {} : {};
     function foo<S extends Foo<S>>() {}
-                           ~~~~~~
-!!! error TS2313: Type parameter 'S' has a circular constraint.
     

--- a/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.types
+++ b/tests/baselines/reference/typeParameterIndirectlyConstrainedToItself.types
@@ -38,5 +38,5 @@ type Foo<T> = [T] extends [number] ? {} : {};
 >Foo : Foo<T>
 
 function foo<S extends Foo<S>>() {}
->foo : <S>() => void
+>foo : <S extends Foo<S>>() => void
 


### PR DESCRIPTION
Split from #29437 as discussed at today's design meeting so it gets in for 3.3.