### PR TITLE
Allow per-file setting for rename default behavior preferences

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -904,7 +904,7 @@ namespace ts.server {
 
         getPreferences(file: NormalizedPath): protocol.UserPreferences {
             const info = this.getScriptInfoForNormalizedPath(file);
-            return info && info.getPreferences() || this.hostConfiguration.preferences;
+            return { ...this.hostConfiguration.preferences, ...info && info.getPreferences() };
         }
 
         getHostFormatCodeOptions(): FormatCodeSettings {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1178,7 +1178,7 @@ namespace ts.server {
         private getRenameInfo(args: protocol.FileLocationRequestArgs): RenameInfo {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
-            const preferences = this.getHostPreferences();
+            const preferences = {...this.getHostPreferences(), ...this.getPreferences(file)};
             return project.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: preferences.allowRenameOfImportPath });
         }
 
@@ -1234,12 +1234,13 @@ namespace ts.server {
                 { fileName: args.file, pos: position },
                 !!args.findInStrings,
                 !!args.findInComments,
-                this.getHostPreferences()
+                {...this.getHostPreferences(), ...this.getPreferences(file)}
             );
             if (!simplifiedResult) return locations;
 
             const defaultProject = this.getDefaultProject(args);
-            const renameInfo: protocol.RenameInfo = this.mapRenameInfo(defaultProject.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: this.getHostPreferences().allowRenameOfImportPath }), Debug.assertDefined(this.projectService.getScriptInfo(file)));
+            const preferences = {...this.getHostPreferences(), ...this.getPreferences(file)};
+            const renameInfo: protocol.RenameInfo = this.mapRenameInfo(defaultProject.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: preferences.allowRenameOfImportPath }), Debug.assertDefined(this.projectService.getScriptInfo(file)));
             return { info: renameInfo, locs: this.toSpanGroups(locations) };
         }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1178,7 +1178,7 @@ namespace ts.server {
         private getRenameInfo(args: protocol.FileLocationRequestArgs): RenameInfo {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
-            const preferences = {...this.getHostPreferences(), ...this.getPreferences(file)};
+            const preferences = { ...this.getHostPreferences(), ...this.getPreferences(file) };
             return project.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: preferences.allowRenameOfImportPath });
         }
 
@@ -1234,12 +1234,12 @@ namespace ts.server {
                 { fileName: args.file, pos: position },
                 !!args.findInStrings,
                 !!args.findInComments,
-                {...this.getHostPreferences(), ...this.getPreferences(file)}
+                { ...this.getHostPreferences(), ...this.getPreferences(file) }
             );
             if (!simplifiedResult) return locations;
 
             const defaultProject = this.getDefaultProject(args);
-            const preferences = {...this.getHostPreferences(), ...this.getPreferences(file)};
+            const preferences = { ...this.getHostPreferences(), ...this.getPreferences(file) };
             const renameInfo: protocol.RenameInfo = this.mapRenameInfo(defaultProject.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: preferences.allowRenameOfImportPath }), Debug.assertDefined(this.projectService.getScriptInfo(file)));
             return { info: renameInfo, locs: this.toSpanGroups(locations) };
         }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1178,8 +1178,7 @@ namespace ts.server {
         private getRenameInfo(args: protocol.FileLocationRequestArgs): RenameInfo {
             const { file, project } = this.getFileAndProject(args);
             const position = this.getPositionInFile(args, file);
-            const preferences = { ...this.getHostPreferences(), ...this.getPreferences(file) };
-            return project.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: preferences.allowRenameOfImportPath });
+            return project.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: this.getPreferences(file).allowRenameOfImportPath });
         }
 
         private getProjects(args: protocol.FileRequestArgs, getScriptInfoEnsuringProjectsUptoDate?: boolean, ignoreNoProjectError?: boolean): Projects {
@@ -1234,13 +1233,12 @@ namespace ts.server {
                 { fileName: args.file, pos: position },
                 !!args.findInStrings,
                 !!args.findInComments,
-                { ...this.getHostPreferences(), ...this.getPreferences(file) }
+                this.getPreferences(file)
             );
             if (!simplifiedResult) return locations;
 
             const defaultProject = this.getDefaultProject(args);
-            const preferences = { ...this.getHostPreferences(), ...this.getPreferences(file) };
-            const renameInfo: protocol.RenameInfo = this.mapRenameInfo(defaultProject.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: preferences.allowRenameOfImportPath }), Debug.assertDefined(this.projectService.getScriptInfo(file)));
+            const renameInfo: protocol.RenameInfo = this.mapRenameInfo(defaultProject.getLanguageService().getRenameInfo(file, position, { allowRenameOfImportPath: this.getPreferences(file).allowRenameOfImportPath }), Debug.assertDefined(this.projectService.getScriptInfo(file)));
             return { info: renameInfo, locs: this.toSpanGroups(locations) };
         }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -41,6 +41,7 @@ namespace ts.FindAllReferences {
         readonly implementations?: boolean;
         /**
          * True to opt in for enhanced renaming of shorthand properties and import/export specifiers.
+         * The options controls the behavior for the whole rename operation; it cannot be changed on a per-file basis.
          * Default is false for backwards compatibility.
          */
         readonly providePrefixAndSuffixTextForRename?: boolean;

--- a/src/testRunner/unittests/tsserver/rename.ts
+++ b/src/testRunner/unittests/tsserver/rename.ts
@@ -7,6 +7,7 @@ namespace ts.projectSystem {
             const session = createSession(createServerHost([aTs, bTs]));
             openFilesForSession([bTs], session);
 
+            // rename fails with allowRenameOfImportPath disabled
             const response1 = executeSessionRequest<protocol.RenameRequest, protocol.RenameResponse>(session, protocol.CommandTypes.Rename, protocolFileLocationFromSubstring(bTs, 'a";'));
             assert.deepEqual<protocol.RenameResponseBody | undefined>(response1, {
                 info: {
@@ -16,9 +17,27 @@ namespace ts.projectSystem {
                 locs: [{ file: bTs.path, locs: [protocolRenameSpanFromSubstring(bTs.content, "./a")] }],
             });
 
+            // rename succeeds with allowRenameOfImportPath enabled in host
             session.getProjectService().setHostConfiguration({ preferences: { allowRenameOfImportPath: true } });
             const response2 = executeSessionRequest<protocol.RenameRequest, protocol.RenameResponse>(session, protocol.CommandTypes.Rename, protocolFileLocationFromSubstring(bTs, 'a";'));
             assert.deepEqual<protocol.RenameResponseBody | undefined>(response2, {
+                info: {
+                    canRename: true,
+                    fileToRename: aTs.path,
+                    displayName: aTs.path,
+                    fullDisplayName: aTs.path,
+                    kind: ScriptElementKind.moduleElement,
+                    kindModifiers: "",
+                    triggerSpan: protocolTextSpanFromSubstring(bTs.content, "a", { index: 1 }),
+                },
+                locs: [{ file: bTs.path, locs: [protocolRenameSpanFromSubstring(bTs.content, "./a")] }],
+            });
+
+            // rename succeeds with allowRenameOfImportPath enabled in file
+            session.getProjectService().setHostConfiguration({ preferences: { allowRenameOfImportPath: false } });
+            session.getProjectService().setHostConfiguration({ file: "/b.ts", formatOptions: {}, preferences: { allowRenameOfImportPath: true } });
+            const response3 = executeSessionRequest<protocol.RenameRequest, protocol.RenameResponse>(session, protocol.CommandTypes.Rename, protocolFileLocationFromSubstring(bTs, 'a";'));
+            assert.deepEqual<protocol.RenameResponseBody | undefined>(response3, {
                 info: {
                     canRename: true,
                     fileToRename: aTs.path,
@@ -61,10 +80,35 @@ namespace ts.projectSystem {
                 ],
             });
 
-            // rename with prefixText and suffixText enabled
+            // rename with prefixText and suffixText enabled in host
             session.getProjectService().setHostConfiguration({ preferences: { providePrefixAndSuffixTextForRename: true } });
             const response2 = executeSessionRequest<protocol.RenameRequest, protocol.RenameResponse>(session, protocol.CommandTypes.Rename, protocolFileLocationFromSubstring(aTs, "x"));
             assert.deepEqual<protocol.RenameResponseBody | undefined>(response2, {
+                info: {
+                    canRename: true,
+                    fileToRename: undefined,
+                    displayName: "x",
+                    fullDisplayName: "x",
+                    kind: ScriptElementKind.constElement,
+                    kindModifiers: ScriptElementKindModifier.none,
+                    triggerSpan: protocolTextSpanFromSubstring(aTs.content, "x"),
+                },
+                locs: [
+                    {
+                        file: aTs.path,
+                        locs: [
+                            protocolRenameSpanFromSubstring(aTs.content, "x"),
+                            protocolRenameSpanFromSubstring(aTs.content, "x", { index: 1 }, { prefixText: "x: " }),
+                        ],
+                    },
+                ],
+            });
+
+            // rename with prefixText and suffixText enabled for file
+            session.getProjectService().setHostConfiguration({ preferences: { providePrefixAndSuffixTextForRename: false } });
+            session.getProjectService().setHostConfiguration({ file: "/a.ts", formatOptions: {}, preferences: { providePrefixAndSuffixTextForRename: true } });
+            const response3 = executeSessionRequest<protocol.RenameRequest, protocol.RenameResponse>(session, protocol.CommandTypes.Rename, protocolFileLocationFromSubstring(aTs, "x"));
+            assert.deepEqual<protocol.RenameResponseBody | undefined>(response3, {
                 info: {
                     canRename: true,
                     fileToRename: undefined,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #29585.
#29314 and #29385 made it so their respective settings are only recognized when provided to the host as a whole.
This PR makes it so that the relevant settings for the preferences on the file override those of the preferences on the host.

