### PR TITLE
Add maxInstantiationDepth to compiler optionDeclarations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -83,6 +83,7 @@ namespace ts {
         const noImplicitThis = getStrictOptionValue(compilerOptions, "noImplicitThis");
         const keyofStringsOnly = !!compilerOptions.keyofStringsOnly;
         const freshObjectLiteralFlag = compilerOptions.suppressExcessPropertyErrors ? 0 : ObjectFlags.FreshLiteral;
+        const maxInstantiationDepth = compilerOptions.maxInstantiationDepth || 50;
 
         const emitResolver = createResolver();
         const nodeBuilder = createNodeBuilder();
@@ -10939,10 +10940,12 @@ namespace ts {
             if (!type || !mapper || mapper === identityMapper) {
                 return type;
             }
-            if (instantiationDepth === 50) {
-                // We have reached 50 recursive type instantiations and there is a very high likelyhood we're dealing
+            if (instantiationDepth === maxInstantiationDepth) {
+                // We have reached too many recursive type instantiations and there is a very high likelyhood we're dealing
                 // with a combination of infinite generic types that perpetually generate new type identities. We stop
                 // the recursion here by yielding the error type.
+                // If stopping is undesirable, consider simplfying the type
+                // or increasing maxInstantiationDepth.
                 return errorType;
             }
             instantiationDepth++;

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -769,6 +769,11 @@ namespace ts {
             description: Diagnostics.Disallow_inconsistently_cased_references_to_the_same_file
         },
         {
+            name: "maxInstantiationDepth",
+            type: "number",
+            category: Diagnostics.Advanced_Options,
+        },
+        {
             name: "maxNodeModuleJsDepth",
             type: "number",
             affectsModuleResolution: true,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4530,6 +4530,7 @@ namespace ts {
         /*@internal*/listFiles?: boolean;
         locale?: string;
         mapRoot?: string;
+        maxInstantiationDepth?: number;
         maxNodeModuleJsDepth?: number;
         module?: ModuleKind;
         moduleResolution?: ModuleResolutionKind;

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2466,6 +2466,7 @@ declare namespace ts {
         lib?: string[];
         locale?: string;
         mapRoot?: string;
+        maxInstantiationDepth?: number;
         maxNodeModuleJsDepth?: number;
         module?: ModuleKind;
         moduleResolution?: ModuleResolutionKind;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2466,6 +2466,7 @@ declare namespace ts {
         lib?: string[];
         locale?: string;
         mapRoot?: string;
+        maxInstantiationDepth?: number;
         maxNodeModuleJsDepth?: number;
         module?: ModuleKind;
         moduleResolution?: ModuleResolutionKind;

--- a/tests/baselines/reference/showConfig/Shows tsconfig for single option/maxInstantiationDepth/tsconfig.json
+++ b/tests/baselines/reference/showConfig/Shows tsconfig for single option/maxInstantiationDepth/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "maxInstantiationDepth": 0
+    }
+}


### PR DESCRIPTION
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `jake runtests` locally *(Had to run `jake baseline-accept`)*
* [X] You've signed the CLA
* [ ] There are new or updated unit tests validating the change


Fixes #29511

![image](https://user-images.githubusercontent.com/5655961/51783565-a9e09200-2109-11e9-80ab-8dad7f7b3723.png)

The first two make sense to me, since I added a new field to the `CompilerOptions` interface in `types.ts`

The last one isn't so obvious to me and I'm not sure how I'd go about correcting this.

[EDIT]
Oh, I think it's just that I have to accept the new baseline file under `baselines/local/showConfig/Shows tsconfig for single option/maxInstantiationDepth/tsconfig.json`

```json
{
    "compilerOptions": {
        "maxInstantiationDepth": 0
    }
}
```

I looked at the baseline changes and they seem okay to me. Nothing wildly different. So, I went and accepted them.

I know it's just a test with a dummy value but setting `maxInstantiationDepth` to `0` is a bad idea =P
[/EDIT]

-----

The issue is only marked as `Needs Investigation` but I figured I'd take a stab at adding this compiler option. Being able to increase the maximum instantiation depth from `50` to an arbitrary value is useful for me because I seem to work with deeply nested, non-recursive, types a lot.

I'm not sure how to write unit tests to test this compiler option yet but I'll try and figure it out. I figured I'd just make the PR first.

I'm not sure what `description` to give this compiler option, and what `code` it would use.

Do I need to add `maxInstantiationDepth` to `protocol.ts > CompilerOptions`, too?

I'm also unsure what else I might be missing.

-----

While ~~`jake runtests` fails and~~ I haven't written a unit test for this compiler option, I've tested it against a project I'm working on and it seems to work.

Without setting `maxInstantiationDepth`, compiling my project fails, setting `maxInstantiationDepth` to `74` lets it compile successfully.

-----

I realize this PR has a bunch of problems but I'm out of my depth (No pun intended).