### PR TITLE
 isNaN(number: number) should accept string values

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -48,9 +48,9 @@ declare function parseFloat(string: string): number;
 
 /**
   * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a number).
-  * @param number A numeric value.
+  * @param number A numeric value Or a string expression to check if its a valid number or not .
   */
-declare function isNaN(number: number): boolean;
+declare function isNaN(number: number|string): boolean;
 
 /**
   * Determines whether a supplied number is finite.


### PR DESCRIPTION
isNaN should accept string values, 
i use it to check if the string expression is a valid number ( my use case was parsing an xml object ) responses ,
 such the property type is always string , and i use isNaN to determine if this property value is a valid value to parse.

now i got typing issue that isNaN expects number param ! so either i should use isNaN(value as number)  or isNaN function should also accept string values :D

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

