### PR TITLE
Only check constraints in final phase of type inference

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4341,6 +4341,7 @@ namespace ts {
         None            =      0,  // No special inference behaviors
         NoDefault       = 1 << 0,  // Infer unknownType for no inferences (otherwise anyType or emptyObjectType)
         AnyDefault      = 1 << 1,  // Infer anyType for no inferences (otherwise emptyObjectType)
+        NoFixing        = 1 << 2,  // Disable type parameter fixing
     }
 
     /**

--- a/tests/baselines/reference/inferenceAndSelfReferentialConstraint.js
+++ b/tests/baselines/reference/inferenceAndSelfReferentialConstraint.js
@@ -1,0 +1,52 @@
+//// [inferenceAndSelfReferentialConstraint.ts]
+// @strict
+
+// Repro from #29520
+
+type Test<K extends keyof any> = {
+  [P in K | "foo"]: P extends "foo" ? true : () => any
+}
+
+function test<T extends Test<keyof T>>(arg: T) {
+  return arg;
+}
+
+const res1 = test({
+  foo: true,
+  bar() {
+  }
+});
+
+const res2 = test({
+  foo: true,
+  bar: function () {
+  }
+});
+
+const res3 = test({
+  foo: true,
+  bar: () => {
+  }
+});
+
+
+//// [inferenceAndSelfReferentialConstraint.js]
+// @strict
+function test(arg) {
+    return arg;
+}
+var res1 = test({
+    foo: true,
+    bar: function () {
+    }
+});
+var res2 = test({
+    foo: true,
+    bar: function () {
+    }
+});
+var res3 = test({
+    foo: true,
+    bar: function () {
+    }
+});

--- a/tests/baselines/reference/inferenceAndSelfReferentialConstraint.symbols
+++ b/tests/baselines/reference/inferenceAndSelfReferentialConstraint.symbols
@@ -1,0 +1,63 @@
+=== tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts ===
+// @strict
+
+// Repro from #29520
+
+type Test<K extends keyof any> = {
+>Test : Symbol(Test, Decl(inferenceAndSelfReferentialConstraint.ts, 0, 0))
+>K : Symbol(K, Decl(inferenceAndSelfReferentialConstraint.ts, 4, 10))
+
+  [P in K | "foo"]: P extends "foo" ? true : () => any
+>P : Symbol(P, Decl(inferenceAndSelfReferentialConstraint.ts, 5, 3))
+>K : Symbol(K, Decl(inferenceAndSelfReferentialConstraint.ts, 4, 10))
+>P : Symbol(P, Decl(inferenceAndSelfReferentialConstraint.ts, 5, 3))
+}
+
+function test<T extends Test<keyof T>>(arg: T) {
+>test : Symbol(test, Decl(inferenceAndSelfReferentialConstraint.ts, 6, 1))
+>T : Symbol(T, Decl(inferenceAndSelfReferentialConstraint.ts, 8, 14))
+>Test : Symbol(Test, Decl(inferenceAndSelfReferentialConstraint.ts, 0, 0))
+>T : Symbol(T, Decl(inferenceAndSelfReferentialConstraint.ts, 8, 14))
+>arg : Symbol(arg, Decl(inferenceAndSelfReferentialConstraint.ts, 8, 39))
+>T : Symbol(T, Decl(inferenceAndSelfReferentialConstraint.ts, 8, 14))
+
+  return arg;
+>arg : Symbol(arg, Decl(inferenceAndSelfReferentialConstraint.ts, 8, 39))
+}
+
+const res1 = test({
+>res1 : Symbol(res1, Decl(inferenceAndSelfReferentialConstraint.ts, 12, 5))
+>test : Symbol(test, Decl(inferenceAndSelfReferentialConstraint.ts, 6, 1))
+
+  foo: true,
+>foo : Symbol(foo, Decl(inferenceAndSelfReferentialConstraint.ts, 12, 19))
+
+  bar() {
+>bar : Symbol(bar, Decl(inferenceAndSelfReferentialConstraint.ts, 13, 12))
+  }
+});
+
+const res2 = test({
+>res2 : Symbol(res2, Decl(inferenceAndSelfReferentialConstraint.ts, 18, 5))
+>test : Symbol(test, Decl(inferenceAndSelfReferentialConstraint.ts, 6, 1))
+
+  foo: true,
+>foo : Symbol(foo, Decl(inferenceAndSelfReferentialConstraint.ts, 18, 19))
+
+  bar: function () {
+>bar : Symbol(bar, Decl(inferenceAndSelfReferentialConstraint.ts, 19, 12))
+  }
+});
+
+const res3 = test({
+>res3 : Symbol(res3, Decl(inferenceAndSelfReferentialConstraint.ts, 24, 5))
+>test : Symbol(test, Decl(inferenceAndSelfReferentialConstraint.ts, 6, 1))
+
+  foo: true,
+>foo : Symbol(foo, Decl(inferenceAndSelfReferentialConstraint.ts, 24, 19))
+
+  bar: () => {
+>bar : Symbol(bar, Decl(inferenceAndSelfReferentialConstraint.ts, 25, 12))
+  }
+});
+

--- a/tests/baselines/reference/inferenceAndSelfReferentialConstraint.types
+++ b/tests/baselines/reference/inferenceAndSelfReferentialConstraint.types
@@ -1,0 +1,67 @@
+=== tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts ===
+// @strict
+
+// Repro from #29520
+
+type Test<K extends keyof any> = {
+>Test : Test<K>
+
+  [P in K | "foo"]: P extends "foo" ? true : () => any
+>true : true
+}
+
+function test<T extends Test<keyof T>>(arg: T) {
+>test : <T extends Test<keyof T>>(arg: T) => T
+>arg : T
+
+  return arg;
+>arg : T
+}
+
+const res1 = test({
+>res1 : { foo: true; bar(): void; }
+>test({  foo: true,  bar() {  }}) : { foo: true; bar(): void; }
+>test : <T extends Test<keyof T>>(arg: T) => T
+>{  foo: true,  bar() {  }} : { foo: true; bar(): void; }
+
+  foo: true,
+>foo : true
+>true : true
+
+  bar() {
+>bar : () => void
+  }
+});
+
+const res2 = test({
+>res2 : { foo: true; bar: () => void; }
+>test({  foo: true,  bar: function () {  }}) : { foo: true; bar: () => void; }
+>test : <T extends Test<keyof T>>(arg: T) => T
+>{  foo: true,  bar: function () {  }} : { foo: true; bar: () => void; }
+
+  foo: true,
+>foo : true
+>true : true
+
+  bar: function () {
+>bar : () => void
+>function () {  } : () => void
+  }
+});
+
+const res3 = test({
+>res3 : { foo: true; bar: () => void; }
+>test({  foo: true,  bar: () => {  }}) : { foo: true; bar: () => void; }
+>test : <T extends Test<keyof T>>(arg: T) => T
+>{  foo: true,  bar: () => {  }} : { foo: true; bar: () => void; }
+
+  foo: true,
+>foo : true
+>true : true
+
+  bar: () => {
+>bar : () => void
+>() => {  } : () => void
+  }
+});
+

--- a/tests/baselines/reference/jsdocTemplateTag3.types
+++ b/tests/baselines/reference/jsdocTemplateTag3.types
@@ -52,7 +52,7 @@ function f(t, u, v, w, x) {
 }
 
 f({ a: 12, b: 'hi', c: null }, undefined, { c: false, d: 12, b: undefined }, 101, 'nope');
->f({ a: 12, b: 'hi', c: null }, undefined, { c: false, d: 12, b: undefined }, 101, 'nope') : string | number
+>f({ a: 12, b: 'hi', c: null }, undefined, { c: false, d: 12, b: undefined }, 101, 'nope') : 101 | "nope"
 >f : <T extends { a: number; b: string; }, U, V extends { c: boolean; }, W, X>(t: T, u: U, v: V, w: W, x: X) => W | X
 >{ a: 12, b: 'hi', c: null } : { a: number; b: string; c: null; }
 >a : number

--- a/tests/baselines/reference/spreadOfParamsFromGeneratorMakesRequiredParams.errors.txt
+++ b/tests/baselines/reference/spreadOfParamsFromGeneratorMakesRequiredParams.errors.txt
@@ -1,5 +1,5 @@
 error TS2318: Cannot find global type 'IterableIterator'.
-tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts(6,1): error TS2554: Expected 2 arguments, but got 1.
+tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts(6,1): error TS2345: Argument of type '[]' is not assignable to parameter of type 'never'.
 
 
 !!! error TS2318: Cannot find global type 'IterableIterator'.
@@ -11,5 +11,4 @@ tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts(6,1): err
     
     call(function* (a: 'a') { }); // error, 2nd argument required
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2554: Expected 2 arguments, but got 1.
-!!! related TS6210 tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts:3:5: An argument for 'args' was not provided.
+!!! error TS2345: Argument of type '[]' is not assignable to parameter of type 'never'.

--- a/tests/baselines/reference/spreadOfParamsFromGeneratorMakesRequiredParams.errors.txt
+++ b/tests/baselines/reference/spreadOfParamsFromGeneratorMakesRequiredParams.errors.txt
@@ -1,5 +1,5 @@
 error TS2318: Cannot find global type 'IterableIterator'.
-tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts(6,1): error TS2345: Argument of type '[]' is not assignable to parameter of type 'never'.
+tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts(6,1): error TS2554: Expected 2 arguments, but got 1.
 
 
 !!! error TS2318: Cannot find global type 'IterableIterator'.
@@ -11,4 +11,5 @@ tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts(6,1): err
     
     call(function* (a: 'a') { }); // error, 2nd argument required
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '[]' is not assignable to parameter of type 'never'.
+!!! error TS2554: Expected 2 arguments, but got 1.
+!!! related TS6210 tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts:3:5: An argument for 'args' was not provided.

--- a/tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts
+++ b/tests/cases/compiler/inferenceAndSelfReferentialConstraint.ts
@@ -1,0 +1,29 @@
+// @strict
+
+// Repro from #29520
+
+type Test<K extends keyof any> = {
+  [P in K | "foo"]: P extends "foo" ? true : () => any
+}
+
+function test<T extends Test<keyof T>>(arg: T) {
+  return arg;
+}
+
+const res1 = test({
+  foo: true,
+  bar() {
+  }
+});
+
+const res2 = test({
+  foo: true,
+  bar: function () {
+  }
+});
+
+const res3 = test({
+  foo: true,
+  bar: () => {
+  }
+});


### PR DESCRIPTION
This PR tweaks our inference logic to only check type parameter constraints in the final phase of type argument inference (and specifically not in the phase where contextually sensitive arguments are excluded). Checks prior to the final phase otherwise can cause inferences to become fixed when constraints are self-referential.

Fixes #29520.