### PR TITLE
Make 'gulp min' build tsc/tsserver in parallel

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -232,7 +232,7 @@ task("watch-tsserver").flags = {
     "   --built": "Compile using the built version of the compiler."
 }
 
-task("min", series(lkgPreBuild, buildTsc, buildServer));
+task("min", series(lkgPreBuild, parallel(buildTsc, buildServer)));
 task("min").description = "Builds only tsc and tsserver";
 task("min").flags = {
     "   --built": "Compile using the built version of the compiler."


### PR DESCRIPTION
Fixes a small typo in the `gulp min` task. The `buildTsc` and `buildServer` tasks should be run "in parallel" so that they are both passed to `tsc -b` at the same time.