### PR TITLE
clarify error message for 'readonly' type operator

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30750,7 +30750,7 @@ namespace ts {
             }
             else if (node.operator === SyntaxKind.ReadonlyKeyword) {
                 if (node.type.kind !== SyntaxKind.ArrayType && node.type.kind !== SyntaxKind.TupleType) {
-                    return grammarErrorOnFirstToken(node, Diagnostics.readonly_type_modifier_is_only_permitted_on_array_and_tuple_types, tokenToString(SyntaxKind.SymbolKeyword));
+                    return grammarErrorOnFirstToken(node, Diagnostics.readonly_type_modifier_is_only_permitted_on_array_and_tuple_literal_types, tokenToString(SyntaxKind.SymbolKeyword));
                 }
             }
         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1023,7 +1023,7 @@
         "category": "Error",
         "code": 1353
     },
-    "'readonly' type modifier is only permitted on array and tuple types.": {
+    "'readonly' type modifier is only permitted on array and tuple literal types.": {
         "category": "Error",
         "code": 1354
     },

--- a/tests/baselines/reference/readonlyArraysAndTuples.errors.txt
+++ b/tests/baselines/reference/readonlyArraysAndTuples.errors.txt
@@ -1,16 +1,17 @@
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(9,12): error TS1354: 'readonly' type modifier is only permitted on array and tuple types.
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(10,15): error TS1354: 'readonly' type modifier is only permitted on array and tuple types.
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(11,12): error TS1354: 'readonly' type modifier is only permitted on array and tuple types.
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(14,5): error TS2740: Type 'readonly string[]' is missing the following properties from type 'string[]': pop, push, reverse, shift, and 3 more.
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(16,5): error TS2740: Type 'readonly [string, string]' is missing the following properties from type 'string[]': pop, push, reverse, shift, and 3 more.
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(20,5): error TS2739: Type 'string[]' is missing the following properties from type '[string, string]': 0, 1
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(21,5): error TS2740: Type 'readonly string[]' is missing the following properties from type '[string, string]': 0, 1, pop, push, and 5 more.
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(22,5): error TS2740: Type 'readonly [string, string]' is missing the following properties from type '[string, string]': pop, push, reverse, shift, and 3 more.
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(23,5): error TS2739: Type 'string[]' is missing the following properties from type 'readonly [string, string]': 0, 1
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(24,5): error TS2739: Type 'readonly string[]' is missing the following properties from type 'readonly [string, string]': 0, 1
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(9,12): error TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(10,15): error TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(11,12): error TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(12,12): error TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(15,5): error TS2740: Type 'readonly string[]' is missing the following properties from type 'string[]': pop, push, reverse, shift, and 3 more.
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(17,5): error TS2740: Type 'readonly [string, string]' is missing the following properties from type 'string[]': pop, push, reverse, shift, and 3 more.
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(21,5): error TS2739: Type 'string[]' is missing the following properties from type '[string, string]': 0, 1
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(22,5): error TS2740: Type 'readonly string[]' is missing the following properties from type '[string, string]': 0, 1, pop, push, and 5 more.
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(23,5): error TS2740: Type 'readonly [string, string]' is missing the following properties from type '[string, string]': pop, push, reverse, shift, and 3 more.
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(24,5): error TS2739: Type 'string[]' is missing the following properties from type 'readonly [string, string]': 0, 1
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(25,5): error TS2739: Type 'readonly string[]' is missing the following properties from type 'readonly [string, string]': 0, 1
 
 
-==== tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts (10 errors) ====
+==== tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts (11 errors) ====
     type T10 = string[];
     type T11 = Array<string>;
     type T12 = readonly string[];
@@ -21,13 +22,16 @@ tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(24,5): error TS27
     
     type T30 = readonly string;  // Error
                ~~~~~~~~
-!!! error TS1354: 'readonly' type modifier is only permitted on array and tuple types.
+!!! error TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
     type T31<T> = readonly T;  // Error
                   ~~~~~~~~
-!!! error TS1354: 'readonly' type modifier is only permitted on array and tuple types.
+!!! error TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
     type T32 = readonly readonly string[];  // Error
                ~~~~~~~~
-!!! error TS1354: 'readonly' type modifier is only permitted on array and tuple types.
+!!! error TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
+    type T33 = readonly Array<string>;  // Error
+               ~~~~~~~~
+!!! error TS1354: 'readonly' type modifier is only permitted on array and tuple literal types.
     
     function f1(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
         ma = ra;  // Error

--- a/tests/baselines/reference/readonlyArraysAndTuples.js
+++ b/tests/baselines/reference/readonlyArraysAndTuples.js
@@ -10,6 +10,7 @@ type T21 = readonly [number, number];
 type T30 = readonly string;  // Error
 type T31<T> = readonly T;  // Error
 type T32 = readonly readonly string[];  // Error
+type T33 = readonly Array<string>;  // Error
 
 function f1(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
     ma = ra;  // Error
@@ -55,4 +56,5 @@ declare type T21 = readonly [number, number];
 declare type T30 = readonly string;
 declare type T31<T> = readonly T;
 declare type T32 = readonly readonly string[];
+declare type T33 = readonly Array<string>;
 declare function f1(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]): void;

--- a/tests/baselines/reference/readonlyArraysAndTuples.symbols
+++ b/tests/baselines/reference/readonlyArraysAndTuples.symbols
@@ -30,59 +30,63 @@ type T31<T> = readonly T;  // Error
 type T32 = readonly readonly string[];  // Error
 >T32 : Symbol(T32, Decl(readonlyArraysAndTuples.ts, 9, 25))
 
+type T33 = readonly Array<string>;  // Error
+>T33 : Symbol(T33, Decl(readonlyArraysAndTuples.ts, 10, 38))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
 function f1(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
->f1 : Symbol(f1, Decl(readonlyArraysAndTuples.ts, 10, 38))
->ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 12, 12))
->ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 12, 25))
->mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 12, 48))
->rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 12, 70))
+>f1 : Symbol(f1, Decl(readonlyArraysAndTuples.ts, 11, 34))
+>ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 13, 12))
+>ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 13, 25))
+>mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 13, 48))
+>rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 13, 70))
 
     ma = ra;  // Error
->ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 12, 12))
->ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 12, 25))
+>ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 13, 12))
+>ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 13, 25))
 
     ma = mt;
->ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 12, 12))
->mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 12, 48))
+>ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 13, 12))
+>mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 13, 48))
 
     ma = rt;  // Error
->ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 12, 12))
->rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 12, 70))
+>ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 13, 12))
+>rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 13, 70))
 
     ra = ma;
->ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 12, 25))
->ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 12, 12))
+>ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 13, 25))
+>ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 13, 12))
 
     ra = mt;
->ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 12, 25))
->mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 12, 48))
+>ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 13, 25))
+>mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 13, 48))
 
     ra = rt;
->ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 12, 25))
->rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 12, 70))
+>ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 13, 25))
+>rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 13, 70))
 
     mt = ma;  // Error
->mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 12, 48))
->ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 12, 12))
+>mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 13, 48))
+>ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 13, 12))
 
     mt = ra;  // Error
->mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 12, 48))
->ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 12, 25))
+>mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 13, 48))
+>ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 13, 25))
 
     mt = rt;  // Error
->mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 12, 48))
->rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 12, 70))
+>mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 13, 48))
+>rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 13, 70))
 
     rt = ma;  // Error
->rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 12, 70))
->ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 12, 12))
+>rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 13, 70))
+>ma : Symbol(ma, Decl(readonlyArraysAndTuples.ts, 13, 12))
 
     rt = ra;  // Error
->rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 12, 70))
->ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 12, 25))
+>rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 13, 70))
+>ra : Symbol(ra, Decl(readonlyArraysAndTuples.ts, 13, 25))
 
     rt = mt;
->rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 12, 70))
->mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 12, 48))
+>rt : Symbol(rt, Decl(readonlyArraysAndTuples.ts, 13, 70))
+>mt : Symbol(mt, Decl(readonlyArraysAndTuples.ts, 13, 48))
 }
 

--- a/tests/baselines/reference/readonlyArraysAndTuples.types
+++ b/tests/baselines/reference/readonlyArraysAndTuples.types
@@ -26,6 +26,9 @@ type T31<T> = readonly T;  // Error
 type T32 = readonly readonly string[];  // Error
 >T32 : readonly string[]
 
+type T33 = readonly Array<string>;  // Error
+>T33 : string[]
+
 function f1(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
 >f1 : (ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) => void
 >ma : string[]

--- a/tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts
+++ b/tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts
@@ -12,6 +12,7 @@ type T21 = readonly [number, number];
 type T30 = readonly string;  // Error
 type T31<T> = readonly T;  // Error
 type T32 = readonly readonly string[];  // Error
+type T33 = readonly Array<string>;  // Error
 
 function f1(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
     ma = ra;  // Error


### PR DESCRIPTION
Mention that `readonly` can only be used with array and tuple **literal** types.
This may prevent future confusion about where `readonly` can be used. Ref: #29649