### PR TITLE
NOT READY TO MERGE - Use conditional type inference for promise resolution

### DIFF
--- a/src/lib/es2015.promise.d.ts
+++ b/src/lib/es2015.promise.d.ts
@@ -10,7 +10,7 @@ interface PromiseConstructor {
      * a resolve callback used to resolve the promise with a value or the result of another promise,
      * and a reject callback used to reject the promise with a provided reason or error.
      */
-    new <T>(executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void): Promise<T>;
+    new <T>(executor: (resolve: (value?: T) => void, reject: (reason?: any) => void) => void): Promise<ResolveType<T>>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -18,7 +18,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>, T10 | PromiseLike<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
+    all<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Promise<[ResolveType<T1>, ResolveType<T2>, ResolveType<T3>, ResolveType<T4>, ResolveType<T5>, ResolveType<T6>, ResolveType<T7>, ResolveType<T8>, ResolveType<T9>, ResolveType<T10>]>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -26,7 +26,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+    all<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1, T2, T3, T4, T5, T6, T7, T8, T9]): Promise<[ResolveType<T1>, ResolveType<T2>, ResolveType<T3>, ResolveType<T4>, ResolveType<T5>, ResolveType<T6>, ResolveType<T7>, ResolveType<T8>, ResolveType<T9>]>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -34,7 +34,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+    all<T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1, T2, T3, T4, T5, T6, T7, T8]): Promise<[ResolveType<T1>, ResolveType<T2>, ResolveType<T3>, ResolveType<T4>, ResolveType<T5>, ResolveType<T6>, ResolveType<T7>, ResolveType<T8>]>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -42,7 +42,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T1, T2, T3, T4, T5, T6, T7>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>]): Promise<[T1, T2, T3, T4, T5, T6, T7]>;
+    all<T1, T2, T3, T4, T5, T6, T7>(values: [T1, T2, T3, T4, T5, T6, T7]): Promise<[ResolveType<T1>, ResolveType<T2>, ResolveType<T3>, ResolveType<T4>, ResolveType<T5>, ResolveType<T6>, ResolveType<T7>]>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -50,7 +50,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T1, T2, T3, T4, T5, T6>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>]): Promise<[T1, T2, T3, T4, T5, T6]>;
+    all<T1, T2, T3, T4, T5, T6>(values: [T1, T2, T3, T4, T5, T6]): Promise<[ResolveType<T1>, ResolveType<T2>, ResolveType<T3>, ResolveType<T4>, ResolveType<T5>, ResolveType<T6>]>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -58,7 +58,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T1, T2, T3, T4, T5>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>, T5 | PromiseLike<T5>]): Promise<[T1, T2, T3, T4, T5]>;
+    all<T1, T2, T3, T4, T5>(values: [T1, T2, T3, T4, T5]): Promise<[ResolveType<T1>, ResolveType<T2>, ResolveType<T3>, ResolveType<T4>, ResolveType<T5>]>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -66,7 +66,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T1, T2, T3, T4>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike <T4>]): Promise<[T1, T2, T3, T4]>;
+    all<T1, T2, T3, T4>(values: [T1, T2, T3, T4]): Promise<[ResolveType<T1>, ResolveType<T2>, ResolveType<T3>, ResolveType<T4>]>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -74,7 +74,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T1, T2, T3>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<[T1, T2, T3]>;
+    all<T1, T2, T3>(values: [T1, T2, T3]): Promise<[ResolveType<T1>, ResolveType<T2>, ResolveType<T3>]>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -82,7 +82,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T1, T2>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<[T1, T2]>;
+    all<T1, T2>(values: [T1, T2]): Promise<[ResolveType<T1>, ResolveType<T2>]>;
 
     /**
      * Creates a Promise that is resolved with an array of results when all of the provided Promises
@@ -90,7 +90,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    all<T>(values: (T | PromiseLike<T>)[]): Promise<T[]>;
+    all<T>(values: ReadonlyArray<T>): Promise<ResolveType<T>[]>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -98,7 +98,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>, T10 | PromiseLike<T10>]): Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10>;
+    race<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]): Promise<ResolveType<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10>>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -106,7 +106,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>]): Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
+    race<T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1, T2, T3, T4, T5, T6, T7, T8, T9]): Promise<ResolveType<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -114,7 +114,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>]): Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
+    race<T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1, T2, T3, T4, T5, T6, T7, T8]): Promise<ResolveType<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -122,7 +122,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T1, T2, T3, T4, T5, T6, T7>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>]): Promise<T1 | T2 | T3 | T4 | T5 | T6 | T7>;
+    race<T1, T2, T3, T4, T5, T6, T7>(values: [T1, T2, T3, T4, T5, T6, T7]): Promise<ResolveType<T1 | T2 | T3 | T4 | T5 | T6 | T7>>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -130,7 +130,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T1, T2, T3, T4, T5, T6>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>]): Promise<T1 | T2 | T3 | T4 | T5 | T6>;
+    race<T1, T2, T3, T4, T5, T6>(values: [T1, T2, T3, T4, T5, T6]): Promise<ResolveType<T1 | T2 | T3 | T4 | T5 | T6>>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -138,7 +138,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T1, T2, T3, T4, T5>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>]): Promise<T1 | T2 | T3 | T4 | T5>;
+    race<T1, T2, T3, T4, T5>(values: [T1, T2, T3, T4, T5]): Promise<ResolveType<T1 | T2 | T3 | T4 | T5>>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -146,7 +146,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T1, T2, T3, T4>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>]): Promise<T1 | T2 | T3 | T4>;
+    race<T1, T2, T3, T4>(values: [T1, T2, T3, T4]): Promise<ResolveType<T1 | T2 | T3 | T4>>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -154,7 +154,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T1, T2, T3>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<T1 | T2 | T3>;
+    race<T1, T2, T3>(values: [T1, T2, T3]): Promise<ResolveType<T1 | T2 | T3>>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -162,7 +162,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T1, T2>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<T1 | T2>;
+    race<T1, T2>(values: [T1, T2]): Promise<ResolveType<T1 | T2>>;
 
     /**
      * Creates a Promise that is resolved or rejected when any of the provided Promises are resolved
@@ -170,7 +170,7 @@ interface PromiseConstructor {
      * @param values An array of Promises.
      * @returns A new Promise.
      */
-    race<T>(values: (T | PromiseLike<T>)[]): Promise<T>;
+    race<T>(values: ReadonlyArray<T>): Promise<ResolveType<T>>;
 
     /**
      * Creates a new rejected promise for the provided reason.
@@ -184,7 +184,7 @@ interface PromiseConstructor {
      * @param value A promise.
      * @returns A promise whose internal state matches the provided promise.
      */
-    resolve<T>(value: T | PromiseLike<T>): Promise<T>;
+    resolve<T>(value: T): Promise<ResolveType<T>>;
 
     /**
      * Creates a new resolved promise .

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1469,6 +1469,11 @@ type ReturnType<T extends (...args: any[]) => any> = T extends (...args: any[]) 
 type InstanceType<T extends new (...args: any[]) => any> = T extends new (...args: any[]) => infer R ? R : any;
 
 /**
+ * Obtain the resolved type of a PromiseLike type
+ */
+type ResolveType<T> = T extends PromiseLike<infer R> ? R : T
+
+/**
  * Marker for contextual 'this' type
  */
 interface ThisType<T> { }


### PR DESCRIPTION
This improves the quality of the type resolution for promise constructor
methods, as using conditional type inference is distributive, whereas
the inference provided by arguments is not.

Alternatively, the arguments based inference could be improved, but that
would be a completely different kind of change.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `jake runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

