### PR TITLE
Fix type reference dts emit failure

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29540,9 +29540,12 @@ namespace ts {
                         return;
                     }
                     const file = host.getSourceFile(resolvedDirective.resolvedFileName)!;
-                    fileToDirective.set(file.path, key);
+                    // Add the transitive closure of path references loaded by this file (as long as they are not)
+                    // part of an existing type reference.
+                    addReferencedFilesToTypeDirective(file, key);
                 });
             }
+
             return {
                 getReferencedExportContainer,
                 getReferencedImportDeclaration,
@@ -29700,6 +29703,18 @@ namespace ts {
                     }
                 }
                 return false;
+            }
+
+            function addReferencedFilesToTypeDirective(file: SourceFile, key: string) {
+                if (fileToDirective.has(file.path)) return;
+                fileToDirective.set(file.path, key);
+                for (const { fileName } of file.referencedFiles) {
+                    const resolvedFile = resolveTripleslashReference(fileName, file.originalFileName);
+                    const referencedFile = host.getSourceFile(resolvedFile);
+                    if (referencedFile) {
+                        addReferencedFilesToTypeDirective(referencedFile, key);
+                    }
+                }
             }
         }
 

--- a/tests/baselines/reference/typeReferenceRelatedFiles.js
+++ b/tests/baselines/reference/typeReferenceRelatedFiles.js
@@ -1,0 +1,34 @@
+//// [tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts] ////
+
+//// [index.d.ts]
+/// <reference path="fs.d.ts" />
+//// [fs.d.ts]
+declare module "fs" {
+    interface FSWatcher {}
+}
+//// [package.json]
+{
+    "name": "@types/node",
+    "version": "1.0.0"
+}
+//// [main.ts]
+/// <reference types="node" />
+import { FSWatcher } from "fs";
+export function f() {
+    return {} as FSWatcher;
+}
+
+
+//// [main.js]
+"use strict";
+exports.__esModule = true;
+function f() {
+    return {};
+}
+exports.f = f;
+
+
+//// [main.d.ts]
+/// <reference types="node" />
+import { FSWatcher } from "fs";
+export declare function f(): FSWatcher;

--- a/tests/baselines/reference/typeReferenceRelatedFiles.symbols
+++ b/tests/baselines/reference/typeReferenceRelatedFiles.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/declarationEmit/node_modules/@types/node/index.d.ts ===
+/// <reference path="fs.d.ts" />
+No type information for this code.=== tests/cases/conformance/declarationEmit/node_modules/@types/node/fs.d.ts ===
+declare module "fs" {
+>"fs" : Symbol("fs", Decl(fs.d.ts, 0, 0))
+
+    interface FSWatcher {}
+>FSWatcher : Symbol(FSWatcher, Decl(fs.d.ts, 0, 21))
+}
+=== tests/cases/conformance/declarationEmit/main.ts ===
+/// <reference types="node" />
+import { FSWatcher } from "fs";
+>FSWatcher : Symbol(FSWatcher, Decl(main.ts, 1, 8))
+
+export function f() {
+>f : Symbol(f, Decl(main.ts, 1, 31))
+
+    return {} as FSWatcher;
+>FSWatcher : Symbol(FSWatcher, Decl(main.ts, 1, 8))
+}
+

--- a/tests/baselines/reference/typeReferenceRelatedFiles.types
+++ b/tests/baselines/reference/typeReferenceRelatedFiles.types
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/declarationEmit/node_modules/@types/node/index.d.ts ===
+/// <reference path="fs.d.ts" />
+No type information for this code.=== tests/cases/conformance/declarationEmit/node_modules/@types/node/fs.d.ts ===
+declare module "fs" {
+>"fs" : typeof import("fs")
+
+    interface FSWatcher {}
+}
+=== tests/cases/conformance/declarationEmit/main.ts ===
+/// <reference types="node" />
+import { FSWatcher } from "fs";
+>FSWatcher : any
+
+export function f() {
+>f : () => FSWatcher
+
+    return {} as FSWatcher;
+>{} as FSWatcher : FSWatcher
+>{} : {}
+}
+

--- a/tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts
+++ b/tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts
@@ -1,0 +1,18 @@
+// @declaration: true
+// @filename: node_modules/@types/node/index.d.ts
+/// <reference path="fs.d.ts" />
+// @filename: node_modules/@types/node/fs.d.ts
+declare module "fs" {
+    interface FSWatcher {}
+}
+// @filename: node_modules/@types/node/package.json
+{
+    "name": "@types/node",
+    "version": "1.0.0"
+}
+// @filename: main.ts
+/// <reference types="node" />
+import { FSWatcher } from "fs";
+export function f() {
+    return {} as FSWatcher;
+}


### PR DESCRIPTION
When we emit declaration files, we sometimes do not emit `/// <reference type="" />` directives when the declaration file contains a symbol exposed by the type reference entry point file via a `/// <reference path="" />` directive.

Fixes https://github.com/DefinitelyTyped/DefinitelyTyped/issues/32720

