### PR TITLE
Remove duplicated fetch declaration

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -17787,7 +17787,6 @@ declare function clearInterval(handle?: number): void;
 declare function clearTimeout(handle?: number): void;
 declare function createImageBitmap(image: ImageBitmapSource): Promise<ImageBitmap>;
 declare function createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number): Promise<ImageBitmap>;
-declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 declare function queueMicrotask(callback: Function): void;
 declare function setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
 declare function setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;


### PR DESCRIPTION
I've noticed duplicated declaration of `fetch` 
```ts
declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
```

in `master` ([lib.dom.d.ts:17778](https://github.com/evolution-gaming/TypeScript/blob/master/lib/lib.dom.d.ts#L17778) and [lib.dom.d.ts:17790](https://github.com/evolution-gaming/TypeScript/blob/master/lib/lib.dom.d.ts#L17790))
