### PR TITLE
Add definite assignment assertions to harness members which are only any-assigned

### DIFF
--- a/src/harness/collections.ts
+++ b/src/harness/collections.ts
@@ -245,7 +245,7 @@ namespace collections {
     export class Metadata {
         private static readonly _undefinedValue = {};
         private _parent: Metadata | undefined;
-        private _map: { [key: string]: any };
+        private _map!: { [key: string]: any };
         private _version = 0;
         private _size = -1;
         private _parentVersion: number | undefined;

--- a/src/harness/fakes.ts
+++ b/src/harness/fakes.ts
@@ -207,7 +207,7 @@ namespace fakes {
      */
     export class CompilerHost implements ts.CompilerHost {
         public readonly sys: System;
-        public readonly defaultLibLocation: string;
+        public readonly defaultLibLocation!: string;
         public readonly outputs: documents.TextDocument[] = [];
         private readonly _outputsMap: collections.SortedMap<string, number>;
         public readonly traces: string[] = [];


### PR DESCRIPTION
Which should fixup the nightly build, which uses the LKG to build the harness.
