### PR TITLE
Revert change to strict property initialization checks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27225,7 +27225,7 @@ namespace ts {
             reference.expression.parent = reference;
             reference.parent = constructor;
             reference.flowNode = constructor.returnFlowNode;
-            const flowType = getFlowTypeOfReference(reference, getOptionalType(propType));
+            const flowType = getFlowTypeOfReference(reference, propType, getOptionalType(propType));
             return !(getFalsyFlags(flowType) & TypeFlags.Undefined);
         }
 

--- a/tests/baselines/reference/strictPropertyInitialization.errors.txt
+++ b/tests/baselines/reference/strictPropertyInitialization.errors.txt
@@ -118,3 +118,14 @@ tests/cases/conformance/classes/propertyMemberDeclarations/strictPropertyInitial
         }
     }
     
+    // Property is considered initialized by type any even though value could be undefined
+    
+    declare function someValue(): any;
+    
+    class C11 {
+        a: number;
+        constructor() {
+            this.a = someValue();
+        }
+    }
+    

--- a/tests/baselines/reference/strictPropertyInitialization.js
+++ b/tests/baselines/reference/strictPropertyInitialization.js
@@ -98,6 +98,17 @@ class C10 {
     }
 }
 
+// Property is considered initialized by type any even though value could be undefined
+
+declare function someValue(): any;
+
+class C11 {
+    a: number;
+    constructor() {
+        this.a = someValue();
+    }
+}
+
 
 //// [strictPropertyInitialization.js]
 "use strict";
@@ -172,6 +183,12 @@ var C10 = /** @class */ (function () {
     }
     return C10;
 }());
+var C11 = /** @class */ (function () {
+    function C11() {
+        this.a = someValue();
+    }
+    return C11;
+}());
 
 
 //// [strictPropertyInitialization.d.ts]
@@ -225,5 +242,10 @@ declare class C10 {
     a: number;
     b: number;
     c?: number;
+    constructor();
+}
+declare function someValue(): any;
+declare class C11 {
+    a: number;
     constructor();
 }

--- a/tests/baselines/reference/strictPropertyInitialization.symbols
+++ b/tests/baselines/reference/strictPropertyInitialization.symbols
@@ -210,3 +210,23 @@ class C10 {
     }
 }
 
+// Property is considered initialized by type any even though value could be undefined
+
+declare function someValue(): any;
+>someValue : Symbol(someValue, Decl(strictPropertyInitialization.ts, 97, 1))
+
+class C11 {
+>C11 : Symbol(C11, Decl(strictPropertyInitialization.ts, 101, 34))
+
+    a: number;
+>a : Symbol(C11.a, Decl(strictPropertyInitialization.ts, 103, 11))
+
+    constructor() {
+        this.a = someValue();
+>this.a : Symbol(C11.a, Decl(strictPropertyInitialization.ts, 103, 11))
+>this : Symbol(C11, Decl(strictPropertyInitialization.ts, 101, 34))
+>a : Symbol(C11.a, Decl(strictPropertyInitialization.ts, 103, 11))
+>someValue : Symbol(someValue, Decl(strictPropertyInitialization.ts, 97, 1))
+    }
+}
+

--- a/tests/baselines/reference/strictPropertyInitialization.types
+++ b/tests/baselines/reference/strictPropertyInitialization.types
@@ -227,3 +227,25 @@ class C10 {
     }
 }
 
+// Property is considered initialized by type any even though value could be undefined
+
+declare function someValue(): any;
+>someValue : () => any
+
+class C11 {
+>C11 : C11
+
+    a: number;
+>a : number
+
+    constructor() {
+        this.a = someValue();
+>this.a = someValue() : any
+>this.a : number
+>this : this
+>a : number
+>someValue() : any
+>someValue : () => any
+    }
+}
+

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/strictPropertyInitialization.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/strictPropertyInitialization.ts
@@ -99,3 +99,14 @@ class C10 {
         let y = this.c;
     }
 }
+
+// Property is considered initialized by type any even though value could be undefined
+
+declare function someValue(): any;
+
+class C11 {
+    a: number;
+    constructor() {
+        this.a = someValue();
+    }
+}


### PR DESCRIPTION
#29714 included a slight change to make strict property initialization checks more conservative. Turns out that isn't workable (it was inconsistent in its handling of `any` and broke the nightly build), so this PR reverts the change. The actual issue that #29714 fixed is unaffected by this.
