### PR TITLE
Skip excess property elaborations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12234,7 +12234,12 @@ namespace ts {
                                         const propDeclaration = prop.valueDeclaration as ObjectLiteralElementLike;
                                         Debug.assertNode(propDeclaration, isObjectLiteralElementLike);
 
+                                        // Give a specific error message span on the property declaration, and signal
+                                        // to the rest of the relationship check not to provide the trail of context.
+                                        // We don't want to overwhelm our users with the context, and hopefully they
+                                        // already have enough information to piece this together.
                                         errorNode = propDeclaration;
+                                        shouldConstructDiagnosticTrail = false;
 
                                         const name = propDeclaration.name!;
                                         if (isIdentifier(name)) {
@@ -12250,7 +12255,6 @@ namespace ts {
                                         reportError(Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
                                             symbolToString(prop), typeToString(errorTarget));
                                     }
-                                    shouldConstructDiagnosticTrail = false;
                                 }
                             }
                             return true;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11888,7 +11888,7 @@ namespace ts {
             let suppressNextError = false;
             // Ordinarily, we want to construct "breadcrumbs" at each level as we dive into types
             // so that the user can build up the same context that the relationship checker had and
-            // diagnose issues. However, sometimes this trail becomes noise when the deepest elabration
+            // diagnose issues; however, sometimes this trail is just noise when the deepest elaboration
             // is already so specific and obvious. In some cases, we want to just bubble up a single diagnostic.
             let shouldConstructDiagnosticTrail = true;
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11886,6 +11886,11 @@ namespace ts {
             let expandingFlags = ExpandingFlags.None;
             let overflow = false;
             let suppressNextError = false;
+            // Ordinarily, we want to construct "breadcrumbs" at each level as we dive into types
+            // so that the user can build up the same context that the relationship checker had and
+            // diagnose issues. However, sometimes this trail becomes noise when the deepest elabration
+            // is already so specific and obvious. In some cases, we want to just bubble up a single diagnostic.
+            let shouldConstructDiagnosticTrail = true;
 
             Debug.assert(relation !== identityRelation || !errorNode, "no error reporting in identity checking");
 
@@ -11928,7 +11933,9 @@ namespace ts {
 
             function reportError(message: DiagnosticMessage, arg0?: string | number, arg1?: string | number, arg2?: string | number, arg3?: string | number): void {
                 Debug.assert(!!errorNode);
-                errorInfo = chainDiagnosticMessages(errorInfo, message, arg0, arg1, arg2, arg3);
+                if (shouldConstructDiagnosticTrail) {
+                    errorInfo = chainDiagnosticMessages(errorInfo, message, arg0, arg1, arg2, arg3);
+                }
             }
 
             function associateRelatedInfo(info: DiagnosticRelatedInformation) {
@@ -12243,6 +12250,7 @@ namespace ts {
                                         reportError(Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
                                             symbolToString(prop), typeToString(errorTarget));
                                     }
+                                    shouldConstructDiagnosticTrail = false;
                                 }
                             }
                             return true;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12234,12 +12234,7 @@ namespace ts {
                                         const propDeclaration = prop.valueDeclaration as ObjectLiteralElementLike;
                                         Debug.assertNode(propDeclaration, isObjectLiteralElementLike);
 
-                                        // Give a specific error message span on the property declaration, and signal
-                                        // to the rest of the relationship check not to provide the trail of context.
-                                        // We don't want to overwhelm our users with the context, and hopefully they
-                                        // already have enough information to piece this together.
                                         errorNode = propDeclaration;
-                                        shouldConstructDiagnosticTrail = false;
 
                                         const name = propDeclaration.name!;
                                         if (isIdentifier(name)) {
@@ -12255,6 +12250,13 @@ namespace ts {
                                         reportError(Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
                                             symbolToString(prop), typeToString(errorTarget));
                                     }
+
+                                    // Signal to the rest of the relationship check not to provide the trail of context.
+                                    // We don't want to overwhelm our users with the context, and hopefully they
+                                    // already have enough information to piece this together.
+                                    // NOTE: don't move this closer to the re-assignment of `errorNode` since
+                                    // this needs to happen *after* reporting errors at this level.
+                                    shouldConstructDiagnosticTrail = false;
                                 }
                             }
                             return true;

--- a/src/testRunner/unittests/tscWatch/emitAndErrorUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/emitAndErrorUpdates.ts
@@ -199,11 +199,11 @@ getPoint().c.x;`
                 change: host => host.writeFile(aFile.path, aFile.content.replace("x2", "x")),
                 getInitialErrors: watch => [
                     getDiagnosticOfFileFromProgram(watch(), cFile.path, cFile.content.indexOf("x: 1"), 4, chainDiagnosticMessages(
-                        chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1, "x", "Coords"),
-                        Diagnostics.Type_0_is_not_assignable_to_type_1,
-                        "{ x: number; y: number; }",
-                        "Coords"
-                    )),
+                        /*details*/ undefined,
+                        Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
+                        "x",
+                        "Coords"),
+                    ),
                     getDiagnosticOfFileFromProgram(watch(), dFile.path, dFile.content.lastIndexOf("x"), 1, Diagnostics.Property_0_does_not_exist_on_type_1, "x", "Coords")
                 ],
                 getIncrementalErrors: () => emptyArray
@@ -272,7 +272,7 @@ export class Data {
                     change: host => host.writeFile(lib1ToolsInterface.path, lib1ToolsInterface.content.replace("title", "title2")),
                     getInitialErrors: () => emptyArray,
                     getIncrementalErrors: () => [
-                        "lib2/data.ts(5,13): error TS2322: Type '{ title: string; }' is not assignable to type 'ITest'.\n  Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?\n"
+                        "lib2/data.ts(5,13): error TS2561: Object literal may only specify known properties, but 'title' does not exist in type 'ITest'. Did you mean to write 'title2'?\n"
                     ]
                 });
             }

--- a/tests/baselines/reference/arrayCast.errors.txt
+++ b/tests/baselines/reference/arrayCast.errors.txt
@@ -1,6 +1,4 @@
-tests/cases/compiler/arrayCast.ts(3,23): error TS2352: Conversion of type '{ foo: string; }[]' to type '{ id: number; }[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
-  Type '{ foo: string; }' is not comparable to type '{ id: number; }'.
-    Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
+tests/cases/compiler/arrayCast.ts(3,23): error TS2353: Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/arrayCast.ts (1 errors) ====
@@ -8,9 +6,7 @@ tests/cases/compiler/arrayCast.ts(3,23): error TS2352: Conversion of type '{ foo
     // has type { foo: string }[], which is not assignable to { id: number }[].
     <{ id: number; }[]>[{ foo: "s" }];
                           ~~~~~~~~
-!!! error TS2352: Conversion of type '{ foo: string; }[]' to type '{ id: number; }[]' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
-!!! error TS2352:   Type '{ foo: string; }' is not comparable to type '{ id: number; }'.
-!!! error TS2352:     Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
     
     // Should succeed, as the {} element causes the type of the array to be {}[]
     <{ id: number; }[]>[{ foo: "s" }, {}]; 

--- a/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
+++ b/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
@@ -1,11 +1,7 @@
-tests/cases/compiler/arrayLiteralTypeInference.ts(14,14): error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
-  Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
-tests/cases/compiler/arrayLiteralTypeInference.ts(15,14): error TS2322: Type '{ id: number; name: string; }' is not assignable to type 'Action'.
-  Object literal may only specify known properties, and 'name' does not exist in type 'Action'.
-tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
-tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(14,14): error TS2353: Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(15,14): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type 'Action'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2353: Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/arrayLiteralTypeInference.ts (4 errors) ====
@@ -24,12 +20,10 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2322: Type '{ 
     var x1: Action[] = [
         { id: 2, trueness: false },
                  ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
-!!! error TS2322:   Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
+!!! error TS2353: Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
         { id: 3, name: "three" }
                  ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type 'Action'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type 'Action'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type 'Action'.
     ]
     
     var x2: Action[] = [
@@ -47,12 +41,10 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(32,18): error TS2322: Type '{ 
         [
             { id: 2, trueness: false },
                      ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
             { id: 3, name: "three" }
                      ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
         ]
     
     var z2: { id: number }[] =

--- a/tests/baselines/reference/arrayLiterals.errors.txt
+++ b/tests/baselines/reference/arrayLiterals.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,77): error TS2322: Type '{ a: string; b: number; c: string; }' is not assignable to type '{ a: string; b: number; }'.
-  Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
-tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,101): error TS2322: Type '{ a: string; b: number; c: number; }' is not assignable to type '{ a: string; b: number; }'.
-  Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
+tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,77): error TS2353: Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
+tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,101): error TS2353: Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
 
 
 ==== tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts (2 errors) ====
@@ -30,12 +28,10 @@ tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,101): erro
     // Contextual type C with numeric index signature makes array literal of EveryType E of type BCT(E,C)[]
     var context1: { [n: number]: { a: string; b: number; }; } = [{ a: '', b: 0, c: '' }, { a: "", b: 3, c: 0 }];
                                                                                 ~~~~~
-!!! error TS2322: Type '{ a: string; b: number; c: string; }' is not assignable to type '{ a: string; b: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
 !!! related TS6501 tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts:24:17: The expected type comes from this index signature.
                                                                                                         ~~~~
-!!! error TS2322: Type '{ a: string; b: number; c: number; }' is not assignable to type '{ a: string; b: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
 !!! related TS6501 tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts:24:17: The expected type comes from this index signature.
     var context2 = [{ a: '', b: 0, c: '' }, { a: "", b: 3, c: 0 }];
     

--- a/tests/baselines/reference/assignmentCompatBug2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug2.errors.txt
@@ -1,9 +1,6 @@
-tests/cases/compiler/assignmentCompatBug2.ts(1,27): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
-  Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
-tests/cases/compiler/assignmentCompatBug2.ts(3,8): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
-  Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
-tests/cases/compiler/assignmentCompatBug2.ts(5,13): error TS2322: Type '{ b: number; a: number; }' is not assignable to type '{ b: number; }'.
-  Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+tests/cases/compiler/assignmentCompatBug2.ts(1,27): error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+tests/cases/compiler/assignmentCompatBug2.ts(3,8): error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+tests/cases/compiler/assignmentCompatBug2.ts(5,13): error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(15,1): error TS2741: Property 'm' is missing in type '{ f: (n: number) => number; g: (s: string) => number; }' but required in type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(20,1): error TS2741: Property 'g' is missing in type '{ f: (n: number) => number; m: number; }' but required in type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(33,1): error TS2741: Property 'm' is missing in type '{ f: (n: number) => number; g: (s: string) => number; n: number; k: (a: any) => any; }' but required in type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
@@ -12,18 +9,15 @@ tests/cases/compiler/assignmentCompatBug2.ts(33,1): error TS2741: Property 'm' i
 ==== tests/cases/compiler/assignmentCompatBug2.ts (6 errors) ====
     var b2: { b: number;} = { a: 0 }; // error
                               ~~~~
-!!! error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     
     b2 = { a: 0 }; // error
            ~~~~
-!!! error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     
     b2 = {b: 0, a: 0 };
                 ~~~~
-!!! error TS2322: Type '{ b: number; a: number; }' is not assignable to type '{ b: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     
     var b3: { f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; };
     

--- a/tests/baselines/reference/assignmentCompatBug5.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug5.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/compiler/assignmentCompatBug5.ts(2,8): error TS2345: Argument of type '{ b: number; }' is not assignable to parameter of type '{ a: number; }'.
-  Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+tests/cases/compiler/assignmentCompatBug5.ts(2,8): error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
 tests/cases/compiler/assignmentCompatBug5.ts(5,7): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/assignmentCompatBug5.ts(5,12): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/assignmentCompatBug5.ts(8,6): error TS2345: Argument of type '(s: string) => void' is not assignable to parameter of type '(n: number) => number'.
@@ -13,8 +12,7 @@ tests/cases/compiler/assignmentCompatBug5.ts(9,6): error TS2345: Argument of typ
     function foo1(x: { a: number; }) { }
     foo1({ b: 5 });
            ~~~~
-!!! error TS2345: Argument of type '{ b: number; }' is not assignable to parameter of type '{ a: number; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
     
     function foo2(x: number[]) { }
     foo2(["s", "t"]);

--- a/tests/baselines/reference/contextualTyping12.errors.txt
+++ b/tests/baselines/reference/contextualTyping12.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/compiler/contextualTyping12.ts(1,57): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+tests/cases/compiler/contextualTyping12.ts(1,57): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping12.ts (1 errors) ====
     class foo { public bar:{id:number;}[] = [{id:1}, {id:2, name:"foo"}]; }
                                                             ~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping17.errors.txt
+++ b/tests/baselines/reference/contextualTyping17.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/compiler/contextualTyping17.ts(1,47): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+tests/cases/compiler/contextualTyping17.ts(1,47): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping17.ts (1 errors) ====
     var foo: {id:number;} = {id:4}; foo = {id: 5, name:"foo"};
                                                   ~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping2.errors.txt
+++ b/tests/baselines/reference/contextualTyping2.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/compiler/contextualTyping2.ts(1,32): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+tests/cases/compiler/contextualTyping2.ts(1,32): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping2.ts (1 errors) ====
     var foo: {id:number;} = {id:4, name:"foo"};
                                    ~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping20.errors.txt
+++ b/tests/baselines/reference/contextualTyping20.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/compiler/contextualTyping20.ts(1,58): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+tests/cases/compiler/contextualTyping20.ts(1,58): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping20.ts (1 errors) ====
     var foo:{id:number;}[] = [{id:1}]; foo = [{id:1}, {id:2, name:"foo"}];
                                                              ~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping4.errors.txt
+++ b/tests/baselines/reference/contextualTyping4.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/compiler/contextualTyping4.ts(1,46): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+tests/cases/compiler/contextualTyping4.ts(1,46): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping4.ts (1 errors) ====
     class foo { public bar:{id:number;} = {id:5, name:"foo"}; }
                                                  ~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping9.errors.txt
+++ b/tests/baselines/reference/contextualTyping9.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/compiler/contextualTyping9.ts(1,42): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+tests/cases/compiler/contextualTyping9.ts(1,42): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping9.ts (1 errors) ====
     var foo:{id:number;}[] = [{id:1}, {id:2, name:"foo"}];
                                              ~~~~~~~~~~
-!!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.errors.txt
+++ b/tests/baselines/reference/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts(14,36): error TS2345: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type '{ a: number; }'.
-  Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts(14,36): error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
 
 
 ==== tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts (1 errors) ====
@@ -18,8 +17,7 @@ tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclara
             var r = super.foo({ a: 1 }); // { a: number }
             var r2 = super.foo({ a: 1, b: 2 }); // { a: number }
                                        ~~~~
-!!! error TS2345: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type '{ a: number; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
             var r3 = this.foo({ a: 1, b: 2 }); // { a: number; b: number; }
         }
     }

--- a/tests/baselines/reference/destructuringParameterProperties5.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties5.errors.txt
@@ -7,8 +7,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,51): error TS2339: Property 'x3' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,62): error TS2339: Property 'y' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,72): error TS2339: Property 'z' does not exist on type 'C1'.
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,19): error TS2322: Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type 'ObjType1'.
-  Object literal may only specify known properties, and 'x1' does not exist in type 'ObjType1'.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,19): error TS2353: Object literal may only specify known properties, and 'x1' does not exist in type 'ObjType1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,47): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,51): error TS2322: Type 'false' is not assignable to type 'string'.
 
@@ -44,8 +43,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(1
     
     var a = new C1([{ x1: 10, x2: "", x3: true }, "", false]);
                       ~~~~~~
-!!! error TS2322: Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type 'ObjType1'.
-!!! error TS2322:   Object literal may only specify known properties, and 'x1' does not exist in type 'ObjType1'.
+!!! error TS2353: Object literal may only specify known properties, and 'x1' does not exist in type 'ObjType1'.
                                                   ~~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
                                                       ~~~~~

--- a/tests/baselines/reference/discriminatedUnionErrorMessage.errors.txt
+++ b/tests/baselines/reference/discriminatedUnionErrorMessage.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/compiler/discriminatedUnionErrorMessage.ts(10,5): error TS2322: Type '{ kind: "sq"; x: number; y: number; }' is not assignable to type 'Shape'.
-  Object literal may only specify known properties, and 'x' does not exist in type 'Square'.
+tests/cases/compiler/discriminatedUnionErrorMessage.ts(10,5): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type 'Square'.
 
 
 ==== tests/cases/compiler/discriminatedUnionErrorMessage.ts (1 errors) ====
@@ -14,8 +13,7 @@ tests/cases/compiler/discriminatedUnionErrorMessage.ts(10,5): error TS2322: Type
         kind: "sq",
         x: 12,
         ~~~~~
-!!! error TS2322: Type '{ kind: "sq"; x: number; y: number; }' is not assignable to type 'Shape'.
-!!! error TS2322:   Object literal may only specify known properties, and 'x' does not exist in type 'Square'.
+!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type 'Square'.
         y: 13,
     }
     

--- a/tests/baselines/reference/discriminatedUnionTypes2.errors.txt
+++ b/tests/baselines/reference/discriminatedUnionTypes2.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/types/union/discriminatedUnionTypes2.ts(27,30): error TS2322: Type '{ a: null; b: string; c: number; }' is not assignable to type '{ a: null; b: string; } | { a: string; c: number; }'.
-  Object literal may only specify known properties, and 'c' does not exist in type '{ a: null; b: string; }'.
+tests/cases/conformance/types/union/discriminatedUnionTypes2.ts(27,30): error TS2353: Object literal may only specify known properties, and 'c' does not exist in type '{ a: null; b: string; }'.
 tests/cases/conformance/types/union/discriminatedUnionTypes2.ts(32,11): error TS2339: Property 'b' does not exist on type '{ a: 0; b: string; } | { a: T; c: number; }'.
   Property 'b' does not exist on type '{ a: T; c: number; }'.
 
@@ -33,8 +32,7 @@ tests/cases/conformance/types/union/discriminatedUnionTypes2.ts(32,11): error TS
     function f13(x: { a: null; b: string } | { a: string, c: number }) {
         x = { a: null, b: "foo", c: 4};  // Error
                                  ~~~~
-!!! error TS2322: Type '{ a: null; b: string; c: number; }' is not assignable to type '{ a: null; b: string; } | { a: string; c: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'c' does not exist in type '{ a: null; b: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'c' does not exist in type '{ a: null; b: string; }'.
     }
     
     function f14<T>(x: { a: 0; b: string } | { a: T, c: number }) {

--- a/tests/baselines/reference/errorsOnUnionsOfOverlappingObjects01.errors.txt
+++ b/tests/baselines/reference/errorsOnUnionsOfOverlappingObjects01.errors.txt
@@ -6,14 +6,12 @@ tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(19,3): error TS2345
   Type '{ a: string; b: string; }' is not assignable to type 'Foo'.
     Types of property 'b' are incompatible.
       Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(24,5): error TS2345: Argument of type '{ a: string; b: string; }' is not assignable to parameter of type 'Bar | Other'.
-  Object literal may only specify known properties, and 'a' does not exist in type 'Bar | Other'.
+tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(24,5): error TS2353: Object literal may only specify known properties, and 'a' does not exist in type 'Bar | Other'.
 tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(42,10): error TS2345: Argument of type '{ dog: string; }' is not assignable to parameter of type 'ExoticAnimal'.
   Property 'cat' is missing in type '{ dog: string; }' but required in type 'CatDog'.
 tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(43,10): error TS2345: Argument of type '{ man: string; bear: string; }' is not assignable to parameter of type 'ExoticAnimal'.
   Property 'pig' is missing in type '{ man: string; bear: string; }' but required in type 'ManBearPig'.
-tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(46,26): error TS2345: Argument of type '{ man: string; beer: string; }' is not assignable to parameter of type 'ExoticAnimal'.
-  Object literal may only specify known properties, and 'beer' does not exist in type 'ExoticAnimal'.
+tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(46,26): error TS2353: Object literal may only specify known properties, and 'beer' does not exist in type 'ExoticAnimal'.
 tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(47,10): error TS2345: Argument of type '{ man: string; beer: string; }' is not assignable to parameter of type 'ExoticAnimal'.
   Type '{ man: string; beer: string; }' is missing the following properties from type 'ManBearPig': bear, pig
 
@@ -54,8 +52,7 @@ tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(47,10): error TS234
     g(x);
     g({ a: '', b: '' })
         ~~~~~
-!!! error TS2345: Argument of type '{ a: string; b: string; }' is not assignable to parameter of type 'Bar | Other'.
-!!! error TS2345:   Object literal may only specify known properties, and 'a' does not exist in type 'Bar | Other'.
+!!! error TS2353: Object literal may only specify known properties, and 'a' does not exist in type 'Bar | Other'.
     
     declare function h(x: Foo | Bar | Other): any;
     
@@ -87,8 +84,7 @@ tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts(47,10): error TS234
     const manBeer = { man: "Manny", beer: "Coffee" };
     addToZoo({ man: "Manny", beer: "Coffee" });
                              ~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ man: string; beer: string; }' is not assignable to parameter of type 'ExoticAnimal'.
-!!! error TS2345:   Object literal may only specify known properties, and 'beer' does not exist in type 'ExoticAnimal'.
+!!! error TS2353: Object literal may only specify known properties, and 'beer' does not exist in type 'ExoticAnimal'.
     addToZoo(manBeer);
              ~~~~~~~
 !!! error TS2345: Argument of type '{ man: string; beer: string; }' is not assignable to parameter of type 'ExoticAnimal'.

--- a/tests/baselines/reference/excessPropertyCheckWithEmptyObject.errors.txt
+++ b/tests/baselines/reference/excessPropertyCheckWithEmptyObject.errors.txt
@@ -1,9 +1,6 @@
-tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts(4,58): error TS2345: Argument of type '{ value: string; readonly: boolean; }' is not assignable to parameter of type 'PropertyDescriptor & ThisType<any>'.
-  Object literal may only specify known properties, and 'readonly' does not exist in type 'PropertyDescriptor & ThisType<any>'.
-tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts(9,30): error TS2322: Type '{ y: number; }' is not assignable to type 'A & ThisType<any>'.
-  Object literal may only specify known properties, and 'y' does not exist in type 'A & ThisType<any>'.
-tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts(14,34): error TS2322: Type '{ y: string; }' is not assignable to type 'Empty & { x: number; }'.
-  Object literal may only specify known properties, and 'y' does not exist in type 'Empty & { x: number; }'.
+tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts(4,58): error TS2353: Object literal may only specify known properties, and 'readonly' does not exist in type 'PropertyDescriptor & ThisType<any>'.
+tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts(9,30): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'A & ThisType<any>'.
+tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts(14,34): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'Empty & { x: number; }'.
 
 
 ==== tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts (3 errors) ====
@@ -12,22 +9,19 @@ tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts(14,34): error TS2322:
     // Excess property error expected here
     Object.defineProperty(window, "prop", { value: "v1.0.0", readonly: false });
                                                              ~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ value: string; readonly: boolean; }' is not assignable to parameter of type 'PropertyDescriptor & ThisType<any>'.
-!!! error TS2345:   Object literal may only specify known properties, and 'readonly' does not exist in type 'PropertyDescriptor & ThisType<any>'.
+!!! error TS2353: Object literal may only specify known properties, and 'readonly' does not exist in type 'PropertyDescriptor & ThisType<any>'.
     
     interface A { x?: string }
     
     // Excess property error expected here
     let a: A & ThisType<any> = { y: 10 };
                                  ~~~~~
-!!! error TS2322: Type '{ y: number; }' is not assignable to type 'A & ThisType<any>'.
-!!! error TS2322:   Object literal may only specify known properties, and 'y' does not exist in type 'A & ThisType<any>'.
+!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'A & ThisType<any>'.
     
     interface Empty {}
     
     // Excess property error expected here
     let x: Empty & { x: number } = { y: "hello" };
                                      ~~~~~~~~~~
-!!! error TS2322: Type '{ y: string; }' is not assignable to type 'Empty & { x: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'y' does not exist in type 'Empty & { x: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'Empty & { x: number; }'.
     

--- a/tests/baselines/reference/excessPropertyCheckWithUnions.errors.txt
+++ b/tests/baselines/reference/excessPropertyCheckWithUnions.errors.txt
@@ -1,13 +1,9 @@
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(10,30): error TS2322: Type '{ tag: "T"; a1: string; }' is not assignable to type 'ADT'.
-  Object literal may only specify known properties, and 'a1' does not exist in type '{ tag: "T"; }'.
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(11,21): error TS2322: Type '{ tag: "A"; d20: number; }' is not assignable to type 'ADT'.
-  Object literal may only specify known properties, and 'd20' does not exist in type '{ tag: "A"; a1: string; }'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(10,30): error TS2353: Object literal may only specify known properties, and 'a1' does not exist in type '{ tag: "T"; }'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(11,21): error TS2353: Object literal may only specify known properties, and 'd20' does not exist in type '{ tag: "A"; a1: string; }'.
 tests/cases/compiler/excessPropertyCheckWithUnions.ts(12,1): error TS2322: Type '{ tag: "D"; }' is not assignable to type 'ADT'.
   Property 'd20' is missing in type '{ tag: "D"; }' but required in type '{ tag: "D"; d20: 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 14 | 15 | 16 | 17 | 18 | 19 | 20; }'.
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(33,28): error TS2322: Type '{ tag: "A"; x: string; extra: number; }' is not assignable to type 'Ambiguous'.
-  Object literal may only specify known properties, and 'extra' does not exist in type 'Ambiguous'.
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(34,26): error TS2322: Type '{ tag: "A"; y: number; extra: number; }' is not assignable to type 'Ambiguous'.
-  Object literal may only specify known properties, and 'extra' does not exist in type 'Ambiguous'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(33,28): error TS2353: Object literal may only specify known properties, and 'extra' does not exist in type 'Ambiguous'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(34,26): error TS2353: Object literal may only specify known properties, and 'extra' does not exist in type 'Ambiguous'.
 tests/cases/compiler/excessPropertyCheckWithUnions.ts(39,1): error TS2322: Type '{ tag: "A"; }' is not assignable to type 'Ambiguous'.
   Type '{ tag: "A"; }' is not assignable to type '{ tag: "C"; }'.
     Types of property 'tag' are incompatible.
@@ -16,15 +12,9 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(40,1): error TS2322: Type 
   Type '{ tag: "A"; z: true; }' is not assignable to type '{ tag: "B"; z: boolean; }'.
     Types of property 'tag' are incompatible.
       Type '"A"' is not assignable to type '"B"'.
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(49,35): error TS2322: Type '{ a: 1; b: 1; first: string; second: string; }' is not assignable to type 'Overlapping'.
-  Object literal may only specify known properties, and 'second' does not exist in type '{ a: 1; b: 1; first: string; }'.
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(50,35): error TS2322: Type '{ a: 1; b: 1; first: string; third: string; }' is not assignable to type 'Overlapping'.
-  Object literal may only specify known properties, and 'third' does not exist in type '{ a: 1; b: 1; first: string; }'.
-tests/cases/compiler/excessPropertyCheckWithUnions.ts(66,9): error TS2322: Type '{ kind: "A"; n: { a: string; b: string; }; }' is not assignable to type 'AB'.
-  Type '{ kind: "A"; n: { a: string; b: string; }; }' is not assignable to type '{ kind: "A"; n: AN; }'.
-    Types of property 'n' are incompatible.
-      Type '{ a: string; b: string; }' is not assignable to type 'AN'.
-        Object literal may only specify known properties, and 'b' does not exist in type 'AN'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(49,35): error TS2353: Object literal may only specify known properties, and 'second' does not exist in type '{ a: 1; b: 1; first: string; }'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(50,35): error TS2353: Object literal may only specify known properties, and 'third' does not exist in type '{ a: 1; b: 1; first: string; }'.
+tests/cases/compiler/excessPropertyCheckWithUnions.ts(66,9): error TS2353: Object literal may only specify known properties, and 'b' does not exist in type 'AN'.
 
 
 ==== tests/cases/compiler/excessPropertyCheckWithUnions.ts (10 errors) ====
@@ -39,12 +29,10 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(66,9): error TS2322: Type 
     }
     let wrong: ADT = { tag: "T", a1: "extra" }
                                  ~~~~~~~~~~~
-!!! error TS2322: Type '{ tag: "T"; a1: string; }' is not assignable to type 'ADT'.
-!!! error TS2322:   Object literal may only specify known properties, and 'a1' does not exist in type '{ tag: "T"; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'a1' does not exist in type '{ tag: "T"; }'.
     wrong = { tag: "A", d20: 12 }
                         ~~~~~~~
-!!! error TS2322: Type '{ tag: "A"; d20: number; }' is not assignable to type 'ADT'.
-!!! error TS2322:   Object literal may only specify known properties, and 'd20' does not exist in type '{ tag: "A"; a1: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'd20' does not exist in type '{ tag: "A"; a1: string; }'.
     wrong = { tag: "D" }
     ~~~~~
 !!! error TS2322: Type '{ tag: "D"; }' is not assignable to type 'ADT'.
@@ -72,12 +60,10 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(66,9): error TS2322: Type 
     // correctly error on excess property 'extra', even when ambiguous
     amb = { tag: "A", x: "hi", extra: 12 }
                                ~~~~~~~~~
-!!! error TS2322: Type '{ tag: "A"; x: string; extra: number; }' is not assignable to type 'Ambiguous'.
-!!! error TS2322:   Object literal may only specify known properties, and 'extra' does not exist in type 'Ambiguous'.
+!!! error TS2353: Object literal may only specify known properties, and 'extra' does not exist in type 'Ambiguous'.
     amb = { tag: "A", y: 12, extra: 12 }
                              ~~~~~~~~~
-!!! error TS2322: Type '{ tag: "A"; y: number; extra: number; }' is not assignable to type 'Ambiguous'.
-!!! error TS2322:   Object literal may only specify known properties, and 'extra' does not exist in type 'Ambiguous'.
+!!! error TS2353: Object literal may only specify known properties, and 'extra' does not exist in type 'Ambiguous'.
     
     // assignability errors still work.
     // But note that the error for `z: true` is the fallback one of reporting on
@@ -104,12 +90,10 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(66,9): error TS2322: Type 
     // these two are still errors despite their doubled up discriminants
     over = { a: 1, b: 1, first: "ok", second: "error" }
                                       ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 1; b: 1; first: string; second: string; }' is not assignable to type 'Overlapping'.
-!!! error TS2322:   Object literal may only specify known properties, and 'second' does not exist in type '{ a: 1; b: 1; first: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'second' does not exist in type '{ a: 1; b: 1; first: string; }'.
     over = { a: 1, b: 1, first: "ok", third: "error" }
                                       ~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 1; b: 1; first: string; third: string; }' is not assignable to type 'Overlapping'.
-!!! error TS2322:   Object literal may only specify known properties, and 'third' does not exist in type '{ a: 1; b: 1; first: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'third' does not exist in type '{ a: 1; b: 1; first: string; }'.
     
     // Freshness disappears after spreading a union
     declare let t0: { a: any, b: any } | { d: any, e: any }
@@ -127,11 +111,7 @@ tests/cases/compiler/excessPropertyCheckWithUnions.ts(66,9): error TS2322: Type 
             a: "a",
             b: "b", // excess -- kind: "A"
             ~~~~~~
-!!! error TS2322: Type '{ kind: "A"; n: { a: string; b: string; }; }' is not assignable to type 'AB'.
-!!! error TS2322:   Type '{ kind: "A"; n: { a: string; b: string; }; }' is not assignable to type '{ kind: "A"; n: AN; }'.
-!!! error TS2322:     Types of property 'n' are incompatible.
-!!! error TS2322:       Type '{ a: string; b: string; }' is not assignable to type 'AN'.
-!!! error TS2322:         Object literal may only specify known properties, and 'b' does not exist in type 'AN'.
+!!! error TS2353: Object literal may only specify known properties, and 'b' does not exist in type 'AN'.
         }
     }
     const abac: AB = {

--- a/tests/baselines/reference/excessPropertyErrorForFunctionTypes.errors.txt
+++ b/tests/baselines/reference/excessPropertyErrorForFunctionTypes.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/compiler/excessPropertyErrorForFunctionTypes.ts(4,44): error TS2322: Type '{ a: number; c: number; d: number; }' is not assignable to type 'DoesntWork'.
-  Object literal may only specify known properties, and 'd' does not exist in type 'DoesntWork'.
+tests/cases/compiler/excessPropertyErrorForFunctionTypes.ts(4,44): error TS2353: Object literal may only specify known properties, and 'd' does not exist in type 'DoesntWork'.
 
 
 ==== tests/cases/compiler/excessPropertyErrorForFunctionTypes.ts (1 errors) ====
@@ -8,5 +7,4 @@ tests/cases/compiler/excessPropertyErrorForFunctionTypes.ts(4,44): error TS2322:
     
     let doesntWork: DoesntWork = { a: 1, c: 2, d: 3 }
                                                ~~~~
-!!! error TS2322: Type '{ a: number; c: number; d: number; }' is not assignable to type 'DoesntWork'.
-!!! error TS2322:   Object literal may only specify known properties, and 'd' does not exist in type 'DoesntWork'.
+!!! error TS2353: Object literal may only specify known properties, and 'd' does not exist in type 'DoesntWork'.

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -13,10 +13,8 @@ tests/cases/compiler/incompatibleTypes.ts(42,5): error TS2345: Argument of type 
   Types of property 'p1' are incompatible.
     Type '() => string' is not assignable to type '(s: string) => number'.
       Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/incompatibleTypes.ts(49,7): error TS2345: Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
-  Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
-tests/cases/compiler/incompatibleTypes.ts(66,47): error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
-  Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
+tests/cases/compiler/incompatibleTypes.ts(49,7): error TS2353: Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
+tests/cases/compiler/incompatibleTypes.ts(66,47): error TS2353: Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
 tests/cases/compiler/incompatibleTypes.ts(72,5): error TS2322: Type '5' is not assignable to type '() => string'.
 tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) => number' is not assignable to type '() => any'.
 
@@ -92,8 +90,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     
     of1({ e: 0, f: 0 });
           ~~~~
-!!! error TS2345: Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
     
     interface IMap {
      [key:string]:string;
@@ -112,8 +109,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     
     var o1: { a: { a: string; }; b: string; } = { e: 0, f: 0 };
                                                   ~~~~
-!!! error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
     
     var a1 = [{ e: 0, f: 0 }, { e: 0, f: 0 }, { e: 0, g: 0 }];
     

--- a/tests/baselines/reference/logicalOrExpressionIsContextuallyTyped.errors.txt
+++ b/tests/baselines/reference/logicalOrExpressionIsContextuallyTyped.errors.txt
@@ -1,6 +1,4 @@
-tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts(6,33): error TS2322: Type '{ a: string; b: number; } | { a: string; b: boolean; }' is not assignable to type '{ a: string; }'.
-  Type '{ a: string; b: number; }' is not assignable to type '{ a: string; }'.
-    Object literal may only specify known properties, and 'b' does not exist in type '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts(6,33): error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ a: string; }'.
 
 
 ==== tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts (1 errors) ====
@@ -11,6 +9,4 @@ tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrE
     
     var r: { a: string } = { a: '', b: 123 } || { a: '', b: true };
                                     ~~~~~~
-!!! error TS2322: Type '{ a: string; b: number; } | { a: string; b: boolean; }' is not assignable to type '{ a: string; }'.
-!!! error TS2322:   Type '{ a: string; b: number; }' is not assignable to type '{ a: string; }'.
-!!! error TS2322:     Object literal may only specify known properties, and 'b' does not exist in type '{ a: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ a: string; }'.

--- a/tests/baselines/reference/mappedTypeErrors.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors.errors.txt
@@ -23,16 +23,12 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(61,9): error TS2403: Su
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(66,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ [P in keyof T]: T[P][]; }'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(75,45): error TS2345: Argument of type '{ x: number; }' is not assignable to parameter of type 'Readonly<{ x: number; y: number; }>'.
   Property 'y' is missing in type '{ x: number; }' but required in type 'Readonly<{ x: number; y: number; }>'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(77,59): error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Readonly<{ x: number; y: number; }>'.
-  Object literal may only specify known properties, and 'z' does not exist in type 'Readonly<{ x: number; y: number; }>'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(83,58): error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Partial<{ x: number; y: number; }>'.
-  Object literal may only specify known properties, and 'z' does not exist in type 'Partial<{ x: number; y: number; }>'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(77,59): error TS2353: Object literal may only specify known properties, and 'z' does not exist in type 'Readonly<{ x: number; y: number; }>'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(83,58): error TS2353: Object literal may only specify known properties, and 'z' does not exist in type 'Partial<{ x: number; y: number; }>'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(105,17): error TS2322: Type 'undefined' is not assignable to type 'string'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(106,17): error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
-  Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(106,17): error TS2353: Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(123,14): error TS2322: Type 'undefined' is not assignable to type 'string'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(124,14): error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
-  Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(124,14): error TS2353: Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(128,16): error TS2322: Type 'string' is not assignable to type 'number | undefined'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(129,25): error TS2322: Type 'string' is not assignable to type 'number | undefined'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(130,39): error TS2322: Type 'string' is not assignable to type 'number | undefined'.
@@ -162,8 +158,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(152,17): error TS2339: 
         let x2 = objAndReadonly({ x: 0, y: 0 }, { x: 1, y: 1 });
         let x3 = objAndReadonly({ x: 0, y: 0 }, { x: 1, y: 1, z: 1 });  // Error
                                                               ~~~~
-!!! error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Readonly<{ x: number; y: number; }>'.
-!!! error TS2345:   Object literal may only specify known properties, and 'z' does not exist in type 'Readonly<{ x: number; y: number; }>'.
+!!! error TS2353: Object literal may only specify known properties, and 'z' does not exist in type 'Readonly<{ x: number; y: number; }>'.
     }
     
     function f21() {
@@ -171,8 +166,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(152,17): error TS2339: 
         let x2 = objAndPartial({ x: 0, y: 0 }, { x: 1, y: 1 });
         let x3 = objAndPartial({ x: 0, y: 0 }, { x: 1, y: 1, z: 1 });  // Error
                                                              ~~~~
-!!! error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Partial<{ x: number; y: number; }>'.
-!!! error TS2345:   Object literal may only specify known properties, and 'z' does not exist in type 'Partial<{ x: number; y: number; }>'.
+!!! error TS2353: Object literal may only specify known properties, and 'z' does not exist in type 'Partial<{ x: number; y: number; }>'.
     }
     
     // Verify use of Pick<T, K> for setState functions (#12793)
@@ -200,8 +194,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(152,17): error TS2339: 
 !!! related TS6500 tests/cases/conformance/types/mapped/mappedTypeErrors.ts:89:5: The expected type comes from property 'a' which is declared here on type 'Pick<Foo, "a">'
     setState(foo, { c: true });  // Error
                     ~~~~~~~
-!!! error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
-!!! error TS2345:   Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
+!!! error TS2353: Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
     
     class C<T> {
         state: T;
@@ -224,8 +217,7 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(152,17): error TS2339: 
 !!! related TS6500 tests/cases/conformance/types/mapped/mappedTypeErrors.ts:89:5: The expected type comes from property 'a' which is declared here on type 'Pick<Foo, "a">'
     c.setState({ c: true });  // Error
                  ~~~~~~~
-!!! error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
-!!! error TS2345:   Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
+!!! error TS2353: Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
     
     type T2 = { a?: number, [key: string]: any };
     

--- a/tests/baselines/reference/multiLineContextDiagnosticWithPretty.errors.txt
+++ b/tests/baselines/reference/multiLineContextDiagnosticWithPretty.errors.txt
@@ -1,5 +1,4 @@
-[96mtests/cases/compiler/multiLineContextDiagnosticWithPretty.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2322: [0mType '{ a: { b: string; }; }' is not assignable to type '{ c: string; }'.
-  Object literal may only specify known properties, and 'a' does not exist in type '{ c: string; }'.
+[96mtests/cases/compiler/multiLineContextDiagnosticWithPretty.ts[0m:[93m2[0m:[93m5[0m - [91merror[0m[90m TS2353: [0mObject literal may only specify known properties, and 'a' does not exist in type '{ c: string; }'.
 
 [7m2[0m     a: {
 [7m [0m [91m    ~~~~[0m
@@ -17,8 +16,7 @@
     ~~~~~~~~~~~~~~
         }
     ~~~~~
-!!! error TS2322: Type '{ a: { b: string; }; }' is not assignable to type '{ c: string; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ c: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{ c: string; }'.
     };
     
 Found 1 error.

--- a/tests/baselines/reference/nestedFreshLiteral.errors.txt
+++ b/tests/baselines/reference/nestedFreshLiteral.errors.txt
@@ -1,7 +1,4 @@
-tests/cases/compiler/nestedFreshLiteral.ts(12,21): error TS2322: Type '{ prop: { colour: string; }; }' is not assignable to type 'NestedSelector'.
-  Types of property 'prop' are incompatible.
-    Type '{ colour: string; }' is not assignable to type 'CSSProps'.
-      Object literal may only specify known properties, but 'colour' does not exist in type 'CSSProps'. Did you mean to write 'color'?
+tests/cases/compiler/nestedFreshLiteral.ts(12,21): error TS2561: Object literal may only specify known properties, but 'colour' does not exist in type 'CSSProps'. Did you mean to write 'color'?
 
 
 ==== tests/cases/compiler/nestedFreshLiteral.ts (1 errors) ====
@@ -18,9 +15,6 @@ tests/cases/compiler/nestedFreshLiteral.ts(12,21): error TS2322: Type '{ prop: {
     let stylen: NestedCSSProps = {
       nested: { prop: { colour: 'red' } }
                         ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ prop: { colour: string; }; }' is not assignable to type 'NestedSelector'.
-!!! error TS2322:   Types of property 'prop' are incompatible.
-!!! error TS2322:     Type '{ colour: string; }' is not assignable to type 'CSSProps'.
-!!! error TS2322:       Object literal may only specify known properties, but 'colour' does not exist in type 'CSSProps'. Did you mean to write 'color'?
+!!! error TS2561: Object literal may only specify known properties, but 'colour' does not exist in type 'CSSProps'. Did you mean to write 'color'?
 !!! related TS6500 tests/cases/compiler/nestedFreshLiteral.ts:5:3: The expected type comes from property 'nested' which is declared here on type 'NestedCSSProps'
     }

--- a/tests/baselines/reference/nestedRecursiveArraysOrObjectsError01.errors.txt
+++ b/tests/baselines/reference/nestedRecursiveArraysOrObjectsError01.errors.txt
@@ -1,17 +1,4 @@
-tests/cases/compiler/nestedRecursiveArraysOrObjectsError01.ts(10,9): error TS2322: Type '{ foo: string; jj: number; }[][][]' is not assignable to type 'Style'.
-  Type '{ foo: string; jj: number; }[][][]' is not assignable to type 'StyleArray'.
-    Types of property 'pop' are incompatible.
-      Type '() => { foo: string; jj: number; }[][]' is not assignable to type '() => Style'.
-        Type '{ foo: string; jj: number; }[][]' is not assignable to type 'Style'.
-          Type '{ foo: string; jj: number; }[][]' is not assignable to type 'StyleArray'.
-            Types of property 'pop' are incompatible.
-              Type '() => { foo: string; jj: number; }[]' is not assignable to type '() => Style'.
-                Type '{ foo: string; jj: number; }[]' is not assignable to type 'Style'.
-                  Type '{ foo: string; jj: number; }[]' is not assignable to type 'StyleArray'.
-                    Types of property 'pop' are incompatible.
-                      Type '() => { foo: string; jj: number; }' is not assignable to type '() => Style'.
-                        Type '{ foo: string; jj: number; }' is not assignable to type 'Style'.
-                          Object literal may only specify known properties, and 'jj' does not exist in type 'Style'.
+tests/cases/compiler/nestedRecursiveArraysOrObjectsError01.ts(10,9): error TS2353: Object literal may only specify known properties, and 'jj' does not exist in type 'Style'.
 
 
 ==== tests/cases/compiler/nestedRecursiveArraysOrObjectsError01.ts (1 errors) ====
@@ -26,20 +13,7 @@ tests/cases/compiler/nestedRecursiveArraysOrObjectsError01.ts(10,9): error TS232
             foo: 'asdf',
             jj: 1 // intentional error
             ~~~~~
-!!! error TS2322: Type '{ foo: string; jj: number; }[][][]' is not assignable to type 'Style'.
-!!! error TS2322:   Type '{ foo: string; jj: number; }[][][]' is not assignable to type 'StyleArray'.
-!!! error TS2322:     Types of property 'pop' are incompatible.
-!!! error TS2322:       Type '() => { foo: string; jj: number; }[][]' is not assignable to type '() => Style'.
-!!! error TS2322:         Type '{ foo: string; jj: number; }[][]' is not assignable to type 'Style'.
-!!! error TS2322:           Type '{ foo: string; jj: number; }[][]' is not assignable to type 'StyleArray'.
-!!! error TS2322:             Types of property 'pop' are incompatible.
-!!! error TS2322:               Type '() => { foo: string; jj: number; }[]' is not assignable to type '() => Style'.
-!!! error TS2322:                 Type '{ foo: string; jj: number; }[]' is not assignable to type 'Style'.
-!!! error TS2322:                   Type '{ foo: string; jj: number; }[]' is not assignable to type 'StyleArray'.
-!!! error TS2322:                     Types of property 'pop' are incompatible.
-!!! error TS2322:                       Type '() => { foo: string; jj: number; }' is not assignable to type '() => Style'.
-!!! error TS2322:                         Type '{ foo: string; jj: number; }' is not assignable to type 'Style'.
-!!! error TS2322:                           Object literal may only specify known properties, and 'jj' does not exist in type 'Style'.
+!!! error TS2353: Object literal may only specify known properties, and 'jj' does not exist in type 'Style'.
         }]]
     ];
     

--- a/tests/baselines/reference/nonPrimitiveUnionIntersection.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveUnionIntersection.errors.txt
@@ -4,8 +4,7 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(3,5)
   Type '123' is not assignable to type 'object'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(4,1): error TS2322: Type 'string' is not assignable to type 'object & string'.
   Type 'string' is not assignable to type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(8,38): error TS2322: Type '{ bar: string; }' is not assignable to type 'object & { err: string; }'.
-  Object literal may only specify known properties, and 'bar' does not exist in type 'object & { err: string; }'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(8,38): error TS2353: Object literal may only specify known properties, and 'bar' does not exist in type 'object & { err: string; }'.
 
 
 ==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts (4 errors) ====
@@ -27,6 +26,5 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts(8,38
     const foo: object & {} = {bar: 'bar'}; // ok
     const bar: object & {err: string} = {bar: 'bar'}; // error
                                          ~~~~~~~~~~
-!!! error TS2322: Type '{ bar: string; }' is not assignable to type 'object & { err: string; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'bar' does not exist in type 'object & { err: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'bar' does not exist in type 'object & { err: string; }'.
     

--- a/tests/baselines/reference/objectLitIndexerContextualType.errors.txt
+++ b/tests/baselines/reference/objectLitIndexerContextualType.errors.txt
@@ -2,8 +2,7 @@ tests/cases/compiler/objectLitIndexerContextualType.ts(12,13): error TS2362: The
 tests/cases/compiler/objectLitIndexerContextualType.ts(12,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 tests/cases/compiler/objectLitIndexerContextualType.ts(15,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 tests/cases/compiler/objectLitIndexerContextualType.ts(15,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-tests/cases/compiler/objectLitIndexerContextualType.ts(18,5): error TS2322: Type '{ s: (t: any) => number; }' is not assignable to type 'J'.
-  Object literal may only specify known properties, and 's' does not exist in type 'J'.
+tests/cases/compiler/objectLitIndexerContextualType.ts(18,5): error TS2353: Object literal may only specify known properties, and 's' does not exist in type 'J'.
 tests/cases/compiler/objectLitIndexerContextualType.ts(21,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 tests/cases/compiler/objectLitIndexerContextualType.ts(21,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
 
@@ -36,8 +35,7 @@ tests/cases/compiler/objectLitIndexerContextualType.ts(21,17): error TS2363: The
     y = {
         s: t => t * t, // Should error
         ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ s: (t: any) => number; }' is not assignable to type 'J'.
-!!! error TS2322:   Object literal may only specify known properties, and 's' does not exist in type 'J'.
+!!! error TS2353: Object literal may only specify known properties, and 's' does not exist in type 'J'.
     };
     y = {
         0: t => t * t, // Should error

--- a/tests/baselines/reference/objectLitStructuralTypeMismatch.errors.txt
+++ b/tests/baselines/reference/objectLitStructuralTypeMismatch.errors.txt
@@ -1,10 +1,8 @@
-tests/cases/compiler/objectLitStructuralTypeMismatch.ts(2,27): error TS2322: Type '{ b: number; }' is not assignable to type '{ a: number; }'.
-  Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+tests/cases/compiler/objectLitStructuralTypeMismatch.ts(2,27): error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
 
 
 ==== tests/cases/compiler/objectLitStructuralTypeMismatch.ts (1 errors) ====
     // Shouldn't compile
     var x: { a: number; } = { b: 5 };
                               ~~~~
-!!! error TS2322: Type '{ b: number; }' is not assignable to type '{ a: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.

--- a/tests/baselines/reference/objectLiteralExcessProperties.errors.txt
+++ b/tests/baselines/reference/objectLiteralExcessProperties.errors.txt
@@ -1,36 +1,21 @@
-tests/cases/compiler/objectLiteralExcessProperties.ts(9,18): error TS2322: Type '{ forword: string; }' is not assignable to type 'Book'.
-  Object literal may only specify known properties, but 'forword' does not exist in type 'Book'. Did you mean to write 'foreword'?
-tests/cases/compiler/objectLiteralExcessProperties.ts(11,27): error TS2322: Type '{ foreward: string; }' is not assignable to type 'string | Book'.
-  Object literal may only specify known properties, but 'foreward' does not exist in type 'Book'. Did you mean to write 'foreword'?
-tests/cases/compiler/objectLiteralExcessProperties.ts(13,53): error TS2322: Type '({ foreword: string; } | { forwards: string; })[]' is not assignable to type 'Book | Book[]'.
-  Type '({ foreword: string; } | { forwards: string; })[]' is not assignable to type 'Book[]'.
-    Type '{ foreword: string; } | { forwards: string; }' is not assignable to type 'Book'.
-      Type '{ forwards: string; }' is not assignable to type 'Book'.
-        Object literal may only specify known properties, and 'forwards' does not exist in type 'Book'.
-tests/cases/compiler/objectLiteralExcessProperties.ts(15,42): error TS2322: Type '{ foreword: string; colour: string; }' is not assignable to type 'Book & Cover'.
-  Object literal may only specify known properties, but 'colour' does not exist in type 'Book & Cover'. Did you mean to write 'color'?
-tests/cases/compiler/objectLiteralExcessProperties.ts(17,26): error TS2322: Type '{ foreward: string; color: string; }' is not assignable to type 'Book & Cover'.
-  Object literal may only specify known properties, but 'foreward' does not exist in type 'Book & Cover'. Did you mean to write 'foreword'?
-tests/cases/compiler/objectLiteralExcessProperties.ts(19,57): error TS2322: Type '{ foreword: string; color: string; price: number; }' is not assignable to type 'Book & Cover'.
-  Object literal may only specify known properties, and 'price' does not exist in type 'Book & Cover'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(9,18): error TS2561: Object literal may only specify known properties, but 'forword' does not exist in type 'Book'. Did you mean to write 'foreword'?
+tests/cases/compiler/objectLiteralExcessProperties.ts(11,27): error TS2561: Object literal may only specify known properties, but 'foreward' does not exist in type 'Book'. Did you mean to write 'foreword'?
+tests/cases/compiler/objectLiteralExcessProperties.ts(13,53): error TS2353: Object literal may only specify known properties, and 'forwards' does not exist in type 'Book'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(15,42): error TS2561: Object literal may only specify known properties, but 'colour' does not exist in type 'Book & Cover'. Did you mean to write 'color'?
+tests/cases/compiler/objectLiteralExcessProperties.ts(17,26): error TS2561: Object literal may only specify known properties, but 'foreward' does not exist in type 'Book & Cover'. Did you mean to write 'foreword'?
+tests/cases/compiler/objectLiteralExcessProperties.ts(19,57): error TS2353: Object literal may only specify known properties, and 'price' does not exist in type 'Book & Cover'.
 tests/cases/compiler/objectLiteralExcessProperties.ts(21,5): error TS2322: Type '{ foreword: string; price: number; }' is not assignable to type 'Book & number'.
   Type '{ foreword: string; price: number; }' is not assignable to type 'number'.
-tests/cases/compiler/objectLiteralExcessProperties.ts(23,29): error TS2322: Type '{ couleur: string; }' is not assignable to type 'Cover | Cover[]'.
-  Object literal may only specify known properties, and 'couleur' does not exist in type 'Cover | Cover[]'.
-tests/cases/compiler/objectLiteralExcessProperties.ts(25,27): error TS2322: Type '{ forewarned: string; }' is not assignable to type 'Book | Book[]'.
-  Object literal may only specify known properties, and 'forewarned' does not exist in type 'Book | Book[]'.
-tests/cases/compiler/objectLiteralExcessProperties.ts(33,27): error TS2322: Type '{ colour: string; }' is not assignable to type 'Cover'.
-  Object literal may only specify known properties, but 'colour' does not exist in type 'Cover'. Did you mean to write 'color'?
+tests/cases/compiler/objectLiteralExcessProperties.ts(23,29): error TS2353: Object literal may only specify known properties, and 'couleur' does not exist in type 'Cover | Cover[]'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(25,27): error TS2353: Object literal may only specify known properties, and 'forewarned' does not exist in type 'Book | Book[]'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(33,27): error TS2561: Object literal may only specify known properties, but 'colour' does not exist in type 'Cover'. Did you mean to write 'color'?
 tests/cases/compiler/objectLiteralExcessProperties.ts(37,25): error TS2304: Cannot find name 'IFoo'.
 tests/cases/compiler/objectLiteralExcessProperties.ts(39,11): error TS2322: Type '{ name: string; }' is not assignable to type 'T'.
 tests/cases/compiler/objectLiteralExcessProperties.ts(41,11): error TS2322: Type '{ name: string; prop: boolean; }' is not assignable to type 'T & { prop: boolean; }'.
   Type '{ name: string; prop: boolean; }' is not assignable to type 'T'.
-tests/cases/compiler/objectLiteralExcessProperties.ts(43,43): error TS2322: Type '{ name: string; prop: true; }' is not assignable to type 'T | { prop: boolean; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ prop: boolean; }'.
-tests/cases/compiler/objectLiteralExcessProperties.ts(45,76): error TS2322: Type '{ name: string; prop: boolean; }' is not assignable to type '{ name: string; } | (T & { prop: boolean; })'.
-  Object literal may only specify known properties, and 'prop' does not exist in type '{ name: string; }'.
-tests/cases/compiler/objectLiteralExcessProperties.ts(49,44): error TS2322: Type '{ z: string; }' is not assignable to type 'object & { x: string; }'.
-  Object literal may only specify known properties, and 'z' does not exist in type 'object & { x: string; }'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(43,43): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ prop: boolean; }'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(45,76): error TS2353: Object literal may only specify known properties, and 'prop' does not exist in type '{ name: string; }'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(49,44): error TS2353: Object literal may only specify known properties, and 'z' does not exist in type 'object & { x: string; }'.
 
 
 ==== tests/cases/compiler/objectLiteralExcessProperties.ts (16 errors) ====
@@ -44,36 +29,27 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(49,44): error TS2322: Type
     
     var b1: Book = { forword: "oops" };
                      ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ forword: string; }' is not assignable to type 'Book'.
-!!! error TS2322:   Object literal may only specify known properties, but 'forword' does not exist in type 'Book'. Did you mean to write 'foreword'?
+!!! error TS2561: Object literal may only specify known properties, but 'forword' does not exist in type 'Book'. Did you mean to write 'foreword'?
     
     var b2: Book | string = { foreward: "nope" };
                               ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ foreward: string; }' is not assignable to type 'string | Book'.
-!!! error TS2322:   Object literal may only specify known properties, but 'foreward' does not exist in type 'Book'. Did you mean to write 'foreword'?
+!!! error TS2561: Object literal may only specify known properties, but 'foreward' does not exist in type 'Book'. Did you mean to write 'foreword'?
     
     var b3: Book | (Book[]) = [{ foreword: "hello" }, { forwards: "back" }];
                                                         ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '({ foreword: string; } | { forwards: string; })[]' is not assignable to type 'Book | Book[]'.
-!!! error TS2322:   Type '({ foreword: string; } | { forwards: string; })[]' is not assignable to type 'Book[]'.
-!!! error TS2322:     Type '{ foreword: string; } | { forwards: string; }' is not assignable to type 'Book'.
-!!! error TS2322:       Type '{ forwards: string; }' is not assignable to type 'Book'.
-!!! error TS2322:         Object literal may only specify known properties, and 'forwards' does not exist in type 'Book'.
+!!! error TS2353: Object literal may only specify known properties, and 'forwards' does not exist in type 'Book'.
     
     var b4: Book & Cover = { foreword: "hi", colour: "blue" };
                                              ~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ foreword: string; colour: string; }' is not assignable to type 'Book & Cover'.
-!!! error TS2322:   Object literal may only specify known properties, but 'colour' does not exist in type 'Book & Cover'. Did you mean to write 'color'?
+!!! error TS2561: Object literal may only specify known properties, but 'colour' does not exist in type 'Book & Cover'. Did you mean to write 'color'?
     
     var b5: Book & Cover = { foreward: "hi", color: "blue" };
                              ~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ foreward: string; color: string; }' is not assignable to type 'Book & Cover'.
-!!! error TS2322:   Object literal may only specify known properties, but 'foreward' does not exist in type 'Book & Cover'. Did you mean to write 'foreword'?
+!!! error TS2561: Object literal may only specify known properties, but 'foreward' does not exist in type 'Book & Cover'. Did you mean to write 'foreword'?
     
     var b6: Book & Cover = { foreword: "hi", color: "blue", price: 10.99 };
                                                             ~~~~~~~~~~~~
-!!! error TS2322: Type '{ foreword: string; color: string; price: number; }' is not assignable to type 'Book & Cover'.
-!!! error TS2322:   Object literal may only specify known properties, and 'price' does not exist in type 'Book & Cover'.
+!!! error TS2353: Object literal may only specify known properties, and 'price' does not exist in type 'Book & Cover'.
     
     var b7: Book & number = { foreword: "hi", price: 10.99 };
         ~~
@@ -82,13 +58,11 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(49,44): error TS2322: Type
     
     var b8: Cover | Cover[] = { couleur : "non" };
                                 ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ couleur: string; }' is not assignable to type 'Cover | Cover[]'.
-!!! error TS2322:   Object literal may only specify known properties, and 'couleur' does not exist in type 'Cover | Cover[]'.
+!!! error TS2353: Object literal may only specify known properties, and 'couleur' does not exist in type 'Cover | Cover[]'.
     
     var b9: Book | Book[] = { forewarned: "still no" };
                               ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ forewarned: string; }' is not assignable to type 'Book | Book[]'.
-!!! error TS2322:   Object literal may only specify known properties, and 'forewarned' does not exist in type 'Book | Book[]'.
+!!! error TS2353: Object literal may only specify known properties, and 'forewarned' does not exist in type 'Book | Book[]'.
     
     interface Indexed {
         [n: number]: Cover;
@@ -98,8 +72,7 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(49,44): error TS2322: Type
     
     var b11: Indexed = { 0: { colour: "blue" } }; // nested object literal still errors
                               ~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ colour: string; }' is not assignable to type 'Cover'.
-!!! error TS2322:   Object literal may only specify known properties, but 'colour' does not exist in type 'Cover'. Did you mean to write 'color'?
+!!! error TS2561: Object literal may only specify known properties, but 'colour' does not exist in type 'Cover'. Did you mean to write 'color'?
 !!! related TS6501 tests/cases/compiler/objectLiteralExcessProperties.ts:28:5: The expected type comes from this index signature.
     
     // Repros inspired by #28752
@@ -119,19 +92,16 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(49,44): error TS2322: Type
         // Excess property checks only on non-generic parts of unions
         const obj3: T | { prop: boolean } = { name: "test", prop: true };
                                               ~~~~~~~~~~~~
-!!! error TS2322: Type '{ name: string; prop: true; }' is not assignable to type 'T | { prop: boolean; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ prop: boolean; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ prop: boolean; }'.
         // Excess property checks only on non-generic parts of unions
         const obj4: T & { prop: boolean } | { name: string } = { name: "test", prop: true };
                                                                                ~~~~~~~~~~
-!!! error TS2322: Type '{ name: string; prop: boolean; }' is not assignable to type '{ name: string; } | (T & { prop: boolean; })'.
-!!! error TS2322:   Object literal may only specify known properties, and 'prop' does not exist in type '{ name: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'prop' does not exist in type '{ name: string; }'.
         // No excess property checks when union includes 'object' type
         const obj5: object | { x: string } = { z: 'abc' }
         // The 'object' type has no effect on intersections
         const obj6: object & { x: string } = { z: 'abc' }
                                                ~~~~~~~~
-!!! error TS2322: Type '{ z: string; }' is not assignable to type 'object & { x: string; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type 'object & { x: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'z' does not exist in type 'object & { x: string; }'.
     }
     

--- a/tests/baselines/reference/objectLiteralFreshnessWithSpread.errors.txt
+++ b/tests/baselines/reference/objectLiteralFreshnessWithSpread.errors.txt
@@ -1,11 +1,9 @@
-tests/cases/compiler/objectLiteralFreshnessWithSpread.ts(2,35): error TS2322: Type '{ z: number; b: number; extra: number; a: number; }' is not assignable to type '{ a: any; b: any; }'.
-  Object literal may only specify known properties, and 'z' does not exist in type '{ a: any; b: any; }'.
+tests/cases/compiler/objectLiteralFreshnessWithSpread.ts(2,35): error TS2353: Object literal may only specify known properties, and 'z' does not exist in type '{ a: any; b: any; }'.
 
 
 ==== tests/cases/compiler/objectLiteralFreshnessWithSpread.ts (1 errors) ====
     let x = { b: 1, extra: 2 }
     let xx: { a, b }  = { a: 1, ...x, z: 3 } // error for 'z', no error for 'extra'
                                       ~~~~
-!!! error TS2322: Type '{ z: number; b: number; extra: number; a: number; }' is not assignable to type '{ a: any; b: any; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ a: any; b: any; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'z' does not exist in type '{ a: any; b: any; }'.
     

--- a/tests/baselines/reference/objectLiteralFunctionArgContextualTyping.errors.txt
+++ b/tests/baselines/reference/objectLiteralFunctionArgContextualTyping.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(8,6): error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I'.
-  Object literal may only specify known properties, and 'hello' does not exist in type 'I'.
-tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(10,17): error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I'.
-  Object literal may only specify known properties, and 'what' does not exist in type 'I'.
+tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(8,6): error TS2353: Object literal may only specify known properties, and 'hello' does not exist in type 'I'.
+tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(10,17): error TS2353: Object literal may only specify known properties, and 'what' does not exist in type 'I'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(11,4): error TS2345: Argument of type '{ toString: (s: string) => string; }' is not assignable to parameter of type 'I'.
   Property 'value' is missing in type '{ toString: (s: string) => string; }' but required in type 'I'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(12,4): error TS2345: Argument of type '{ toString: (s: string) => string; }' is not assignable to parameter of type 'I'.
@@ -19,13 +17,11 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(13,36): error T
     
     f2({ hello: 1 }) // error 
          ~~~~~~~~
-!!! error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I'.
-!!! error TS2345:   Object literal may only specify known properties, and 'hello' does not exist in type 'I'.
+!!! error TS2353: Object literal may only specify known properties, and 'hello' does not exist in type 'I'.
     f2({ value: '' }) // missing toString satisfied by Object's member
     f2({ value: '', what: 1 }) // missing toString satisfied by Object's member
                     ~~~~~~~
-!!! error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I'.
-!!! error TS2345:   Object literal may only specify known properties, and 'what' does not exist in type 'I'.
+!!! error TS2353: Object literal may only specify known properties, and 'what' does not exist in type 'I'.
     f2({ toString: (s) => s }) // error, missing property value from ArgsString
        ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ toString: (s: string) => string; }' is not assignable to parameter of type 'I'.

--- a/tests/baselines/reference/objectLiteralFunctionArgContextualTyping2.errors.txt
+++ b/tests/baselines/reference/objectLiteralFunctionArgContextualTyping2.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(8,6): error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I2'.
-  Object literal may only specify known properties, and 'hello' does not exist in type 'I2'.
+tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(8,6): error TS2353: Object literal may only specify known properties, and 'hello' does not exist in type 'I2'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(9,4): error TS2345: Argument of type '{ value: string; }' is not assignable to parameter of type 'I2'.
   Property 'doStuff' is missing in type '{ value: string; }' but required in type 'I2'.
-tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(10,17): error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I2'.
-  Object literal may only specify known properties, and 'what' does not exist in type 'I2'.
+tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(10,17): error TS2353: Object literal may only specify known properties, and 'what' does not exist in type 'I2'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(11,6): error TS2322: Type '(s: any) => any' is not assignable to type '() => string'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(12,6): error TS2322: Type '(s: string) => string' is not assignable to type '() => string'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(13,17): error TS2322: Type '(s: any) => any' is not assignable to type '() => string'.
@@ -19,8 +17,7 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(13,17): error 
     
     f2({ hello: 1 }) 
          ~~~~~~~~
-!!! error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I2'.
-!!! error TS2345:   Object literal may only specify known properties, and 'hello' does not exist in type 'I2'.
+!!! error TS2353: Object literal may only specify known properties, and 'hello' does not exist in type 'I2'.
     f2({ value: '' })
        ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ value: string; }' is not assignable to parameter of type 'I2'.
@@ -28,8 +25,7 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(13,17): error 
 !!! related TS2728 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts:3:5: 'doStuff' is declared here.
     f2({ value: '', what: 1 }) 
                     ~~~~~~~
-!!! error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I2'.
-!!! error TS2345:   Object literal may only specify known properties, and 'what' does not exist in type 'I2'.
+!!! error TS2353: Object literal may only specify known properties, and 'what' does not exist in type 'I2'.
     f2({ toString: (s) => s }) 
          ~~~~~~~~
 !!! error TS2322: Type '(s: any) => any' is not assignable to type '() => string'.

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(4,43): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(4,43): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(6,81): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(6,87): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(8,13): error TS2322: Type 'number' is not assignable to type 'boolean'.
@@ -11,8 +10,7 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
     
     var person: { b: string; id: number } = { name, id };  // error
                                               ~~~~
-!!! error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
     var person1: { name, id };  // ok
     function foo(name: string, id: number): { id: string, name: number } { return { name, id }; }  // error
                                                                                     ~~~~

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(4,43): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(4,43): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(5,81): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(5,87): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(8,5): error TS2322: Type '{ name: number; id: string; }' is not assignable to type '{ name: string; id: number; }'.
@@ -13,8 +12,7 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
     
     var person: { b: string; id: number } = { name, id };  // error
                                               ~~~~
-!!! error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
     function bar(name: string, id: number): { name: number, id: string } { return { name, id }; }  // error
                                                                                     ~~~~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/orderMattersForSignatureGroupIdentity.errors.txt
+++ b/tests/baselines/reference/orderMattersForSignatureGroupIdentity.errors.txt
@@ -1,8 +1,6 @@
-tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(19,5): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
-  Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
+tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(19,5): error TS2353: Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
 tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(22,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'w' must be of type 'A', but here has type 'C'.
-tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
-  Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
+tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS2353: Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
 
 
 ==== tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts (3 errors) ====
@@ -26,8 +24,7 @@ tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS234
     
     v({ s: "", n: 0 }).toLowerCase();
         ~~~~~
-!!! error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
     
     var w: A;
     var w: C;
@@ -36,5 +33,4 @@ tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS234
     
     w({ s: "", n: 0 }).toLowerCase();
         ~~~~~
-!!! error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.

--- a/tests/baselines/reference/propertyAccess.errors.txt
+++ b/tests/baselines/reference/propertyAccess.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(11,55): error TS2322: Type '{ 3: string; 'three': string; }' is not assignable to type '{ [n: number]: string; }'.
-  Object literal may only specify known properties, and ''three'' does not exist in type '{ [n: number]: string; }'.
+tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(11,55): error TS2353: Object literal may only specify known properties, and ''three'' does not exist in type '{ [n: number]: string; }'.
 tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(45,14): error TS2339: Property 'qqq' does not exist on type '{ 10: string; x: string; y: number; z: { n: string; m: number; o: () => boolean; }; 'literal property': number; }'.
 tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(80,19): error TS2538: Type '{ name: string; }' cannot be used as an index type.
 tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(117,18): error TS2538: Type '{ name: string; }' cannot be used as an index type.
@@ -20,8 +19,7 @@ tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(149,5): err
     
     var numIndex: { [n: number]: string } = { 3: 'three', 'three': 'three' };
                                                           ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ 3: string; 'three': string; }' is not assignable to type '{ [n: number]: string; }'.
-!!! error TS2322:   Object literal may only specify known properties, and ''three'' does not exist in type '{ [n: number]: string; }'.
+!!! error TS2353: Object literal may only specify known properties, and ''three'' does not exist in type '{ [n: number]: string; }'.
     var strIndex: { [n: string]: Compass } = { 'N': Compass.North, 'E': Compass.East };
     var bothIndex:
         {

--- a/tests/baselines/reference/spellingSuggestionLeadingUnderscores01.errors.txt
+++ b/tests/baselines/reference/spellingSuggestionLeadingUnderscores01.errors.txt
@@ -1,6 +1,5 @@
 tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts(6,3): error TS2551: Property '___foo' does not exist on type '{ __foo: 10; }'. Did you mean '__foo'?
-tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts(14,5): error TS2322: Type '{ ___foo: number; }' is not assignable to type '{ __foo: number; }'.
-  Object literal may only specify known properties, but '___foo' does not exist in type '{ __foo: number; }'. Did you mean to write '__foo'?
+tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts(14,5): error TS2561: Object literal may only specify known properties, but '___foo' does not exist in type '{ __foo: number; }'. Did you mean to write '__foo'?
 
 
 ==== tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts (2 errors) ====
@@ -22,8 +21,7 @@ tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts(14,5): error TS23
     b = {
         ___foo: 100,
         ~~~~~~~~~~~
-!!! error TS2322: Type '{ ___foo: number; }' is not assignable to type '{ __foo: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, but '___foo' does not exist in type '{ __foo: number; }'. Did you mean to write '__foo'?
+!!! error TS2561: Object literal may only specify known properties, but '___foo' does not exist in type '{ __foo: number; }'. Did you mean to write '__foo'?
     }
     
     

--- a/tests/baselines/reference/switchStatements.errors.txt
+++ b/tests/baselines/reference/switchStatements.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/statements/switchStatements/switchStatements.ts(35,20): error TS2678: Type '{ id: number; name: string; }' is not comparable to type 'C'.
-  Object literal may only specify known properties, and 'name' does not exist in type 'C'.
+tests/cases/conformance/statements/switchStatements/switchStatements.ts(35,20): error TS2353: Object literal may only specify known properties, and 'name' does not exist in type 'C'.
 
 
 ==== tests/cases/conformance/statements/switchStatements/switchStatements.ts (1 errors) ====
@@ -39,8 +38,7 @@ tests/cases/conformance/statements/switchStatements/switchStatements.ts(35,20): 
         case new D():
         case { id: 12, name: '' }:
                        ~~~~~~~~
-!!! error TS2678: Type '{ id: number; name: string; }' is not comparable to type 'C'.
-!!! error TS2678:   Object literal may only specify known properties, and 'name' does not exist in type 'C'.
+!!! error TS2353: Object literal may only specify known properties, and 'name' does not exist in type 'C'.
         case new C():
     }
     

--- a/tests/baselines/reference/symbolProperty21.errors.txt
+++ b/tests/baselines/reference/symbolProperty21.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
-  Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2353: Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
 
 
 ==== tests/cases/conformance/es6/Symbols/symbolProperty21.ts (1 errors) ====
@@ -14,7 +13,6 @@ tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Arg
         [Symbol.isConcatSpreadable]: "",
         [Symbol.toPrimitive]: 0,
         ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: true; }' is not assignable to parameter of type 'I<boolean, string>'.
-!!! error TS2345:   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
+!!! error TS2353: Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
         [Symbol.unscopables]: true
     });

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.errors.txt
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.errors.txt
@@ -4,12 +4,9 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(49,1): err
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(51,1): error TS2684: The 'this' context of type 'void' is not assignable to method's 'this' of type 'I'.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(56,21): error TS2339: Property 'notFound' does not exist on type '{ y: number; }'.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(59,21): error TS2339: Property 'notSpecified' does not exist on type 'void'.
-tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(61,79): error TS2322: Type '{ y: number; explicitStructural: (this: { y: number; }, x: number) => number; }' is not assignable to type '{ y: number; f: (this: { y: number; }, x: number) => number; }'.
-  Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ y: number; f: (this: { y: number; }, x: number) => number; }'.
-tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(62,97): error TS2322: Type '{ y: string; explicitStructural: (this: { y: number; }, x: number) => number; }' is not assignable to type '{ y: string; f: (this: { y: number; }, x: number) => number; }'.
-  Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ y: string; f: (this: { y: number; }, x: number) => number; }'.
-tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(63,110): error TS2322: Type '{ wrongName: number; explicitStructural: (this: { y: number; }, x: number) => number; }' is not assignable to type '{ wrongName: number; f: (this: { y: number; }, x: number) => number; }'.
-  Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ wrongName: number; f: (this: { y: number; }, x: number) => number; }'.
+tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(61,79): error TS2353: Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ y: number; f: (this: { y: number; }, x: number) => number; }'.
+tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(62,97): error TS2353: Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ y: string; f: (this: { y: number; }, x: number) => number; }'.
+tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(63,110): error TS2353: Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ wrongName: number; f: (this: { y: number; }, x: number) => number; }'.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(65,1): error TS2554: Expected 1 arguments, but got 0.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(66,6): error TS2345: Argument of type '"wrong type"' is not assignable to parameter of type 'number'.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(67,1): error TS2554: Expected 1 arguments, but got 2.
@@ -170,16 +167,13 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(178,22): e
     }
     let ok: {y: number, f: (this: { y: number }, x: number) => number} = { y: 12, explicitStructural };
                                                                                   ~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y: number; explicitStructural: (this: { y: number; }, x: number) => number; }' is not assignable to type '{ y: number; f: (this: { y: number; }, x: number) => number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ y: number; f: (this: { y: number; }, x: number) => number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ y: number; f: (this: { y: number; }, x: number) => number; }'.
     let wrongPropertyType: {y: string, f: (this: { y: number }, x: number) => number} = { y: 'foo', explicitStructural };
                                                                                                     ~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y: string; explicitStructural: (this: { y: number; }, x: number) => number; }' is not assignable to type '{ y: string; f: (this: { y: number; }, x: number) => number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ y: string; f: (this: { y: number; }, x: number) => number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ y: string; f: (this: { y: number; }, x: number) => number; }'.
     let wrongPropertyName: {wrongName: number, f: (this: { y: number }, x: number) => number} = { wrongName: 12, explicitStructural };
                                                                                                                  ~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ wrongName: number; explicitStructural: (this: { y: number; }, x: number) => number; }' is not assignable to type '{ wrongName: number; f: (this: { y: number; }, x: number) => number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ wrongName: number; f: (this: { y: number; }, x: number) => number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'explicitStructural' does not exist in type '{ wrongName: number; f: (this: { y: number; }, x: number) => number; }'.
     
     ok.f(); // not enough arguments
     ~~~~~~

--- a/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.errors.txt
+++ b/tests/baselines/reference/typeArgumentDefaultUsesConstraintOnCircularDefault.errors.txt
@@ -1,6 +1,5 @@
 tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts(1,30): error TS2744: Type parameter defaults can only reference previously declared type parameters.
-tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts(3,18): error TS2322: Type '{ foo: string; }' is not assignable to type 'Test<any>'.
-  Object literal may only specify known properties, and 'foo' does not exist in type 'Test<any>'.
+tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts(3,18): error TS2353: Object literal may only specify known properties, and 'foo' does not exist in type 'Test<any>'.
 
 
 ==== tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts (2 errors) ====
@@ -10,8 +9,7 @@ tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts(3,18)
     
     let zz: Test = { foo: "abc" };  // should error on comparison with Test<string>
                      ~~~~~~~~~~
-!!! error TS2322: Type '{ foo: string; }' is not assignable to type 'Test<any>'.
-!!! error TS2322:   Object literal may only specify known properties, and 'foo' does not exist in type 'Test<any>'.
+!!! error TS2353: Object literal may only specify known properties, and 'foo' does not exist in type 'Test<any>'.
     
     let zzy: Test = { value: {} };
     

--- a/tests/baselines/reference/typeArgumentInference.errors.txt
+++ b/tests/baselines/reference/typeArgumentInference.errors.txt
@@ -1,7 +1,6 @@
 tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(68,29): error TS2345: Argument of type '0' is not assignable to parameter of type '""'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(83,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'a9e' must be of type '{ x: number; z: Date; y?: undefined; } | { x: number; y: string; z?: undefined; }', but here has type '{}'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,74): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-  Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,74): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts (3 errors) ====
@@ -94,8 +93,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,74
 !!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'a9e' must be of type '{ x: number; z: Date; y?: undefined; } | { x: number; y: string; z?: undefined; }', but here has type '{}'.
     var a9f = someGenerics9<A92>(undefined, { x: 6, z: new Date() }, { x: 6, y: '' });
                                                                              ~~~~~
-!!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-!!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;
     
     // Generic call with multiple parameters of generic type passed arguments with a single best common type

--- a/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
@@ -10,8 +10,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
     Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(106,33): error TS2345: Argument of type '0' is not assignable to parameter of type '""'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(121,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'a9e' must be of type '{ x: number; z: Window; y?: undefined; } | { x: number; y: string; z?: undefined; }', but here has type '{}'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,74): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-  Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,74): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts (7 errors) ====
@@ -156,8 +155,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
 !!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'a9e' must be of type '{ x: number; z: Window; y?: undefined; } | { x: number; y: string; z?: undefined; }', but here has type '{}'.
     var a9f = new someGenerics9<A92>(undefined, { x: 6, z: window }, { x: 6, y: '' });
                                                                              ~~~~~
-!!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-!!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;
     
     // Generic call with multiple parameters of generic type passed arguments with a single best common type

--- a/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
@@ -16,8 +16,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(66,31): error TS2345: Argument of type '<A, B extends string, C>(a: (a: A) => A, b: (b: B) => B, c: (c: C) => C) => void' is not assignable to parameter of type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(73,29): error TS2345: Argument of type '0' is not assignable to parameter of type '""'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(88,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'a9e' must be of type '{ x: number; z: Window; y?: undefined; } | { x: number; y: string; z?: undefined; }', but here has type '{}'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,70): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-  Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,70): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts (13 errors) ====
@@ -142,8 +141,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
 !!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'a9e' must be of type '{ x: number; z: Window; y?: undefined; } | { x: number; y: string; z?: undefined; }', but here has type '{}'.
     var a9f = someGenerics9<A92>(undefined, { x: 6, z: window }, { x: 6, y: '' });
                                                                          ~~~~~
-!!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-!!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;
     
     // Generic call with multiple parameters of generic type passed arguments with a single best common type

--- a/tests/baselines/reference/typeFromPropertyAssignment28.errors.txt
+++ b/tests/baselines/reference/typeFromPropertyAssignment28.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/salsa/a.js(7,17): error TS2322: Type '{ q: number; }' is not assignable to type 'C'.
-  Object literal may only specify known properties, and 'q' does not exist in type 'C'.
+tests/cases/conformance/salsa/a.js(7,17): error TS2353: Object literal may only specify known properties, and 'q' does not exist in type 'C'.
 tests/cases/conformance/salsa/a.js(11,3): error TS2339: Property 'q' does not exist on type 'C'.
 
 
@@ -12,8 +11,7 @@ tests/cases/conformance/salsa/a.js(11,3): error TS2339: Property 'q' does not ex
     // (Object.defineProperty isn't recognised as a JS special assignment right now.)
     C.prototype = { q: 2 };
                     ~~~~
-!!! error TS2322: Type '{ q: number; }' is not assignable to type 'C'.
-!!! error TS2322:   Object literal may only specify known properties, and 'q' does not exist in type 'C'.
+!!! error TS2353: Object literal may only specify known properties, and 'q' does not exist in type 'C'.
     
     const c = new C()
     c.p

--- a/tests/baselines/reference/typeInfer1.errors.txt
+++ b/tests/baselines/reference/typeInfer1.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/compiler/typeInfer1.ts(12,5): error TS2322: Type '{ Moo: () => string; }' is not assignable to type 'ITextWriter2'.
-  Object literal may only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
+tests/cases/compiler/typeInfer1.ts(12,5): error TS2353: Object literal may only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
 
 
 ==== tests/cases/compiler/typeInfer1.ts (1 errors) ====
@@ -16,6 +15,5 @@ tests/cases/compiler/typeInfer1.ts(12,5): error TS2322: Type '{ Moo: () => strin
     var yyyyyyyy: ITextWriter2 = {
         Moo: function() { return "cow"; }
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ Moo: () => string; }' is not assignable to type 'ITextWriter2'.
-!!! error TS2322:   Object literal may only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
+!!! error TS2353: Object literal may only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
     }

--- a/tests/baselines/reference/typeMatch2.errors.txt
+++ b/tests/baselines/reference/typeMatch2.errors.txt
@@ -1,16 +1,13 @@
 tests/cases/compiler/typeMatch2.ts(3,2): error TS2739: Type '{}' is missing the following properties from type '{ x: number; y: number; }': x, y
 tests/cases/compiler/typeMatch2.ts(4,5): error TS2741: Property 'y' is missing in type '{ x: number; }' but required in type '{ x: number; y: number; }'.
-tests/cases/compiler/typeMatch2.ts(5,20): error TS2322: Type '{ x: number; y: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-  Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
-tests/cases/compiler/typeMatch2.ts(6,17): error TS2322: Type '{ x: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-  Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+tests/cases/compiler/typeMatch2.ts(5,20): error TS2353: Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+tests/cases/compiler/typeMatch2.ts(6,17): error TS2353: Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
 tests/cases/compiler/typeMatch2.ts(18,5): error TS2322: Type 'Animal[]' is not assignable to type 'Giraffe[]'.
   Property 'g' is missing in type 'Animal' but required in type 'Giraffe'.
 tests/cases/compiler/typeMatch2.ts(22,5): error TS2322: Type '{ f1: number; f2: Animal[]; }' is not assignable to type '{ f1: number; f2: Giraffe[]; }'.
   Types of property 'f2' are incompatible.
     Type 'Animal[]' is not assignable to type 'Giraffe[]'.
-tests/cases/compiler/typeMatch2.ts(34,26): error TS2322: Type '{ x: number; y: any; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-  Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+tests/cases/compiler/typeMatch2.ts(34,26): error TS2353: Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
 tests/cases/compiler/typeMatch2.ts(35,5): error TS2741: Property 'y' is missing in type '{ x: number; }' but required in type '{ x: number; y: number; }'.
 
 
@@ -26,12 +23,10 @@ tests/cases/compiler/typeMatch2.ts(35,5): error TS2741: Property 'y' is missing 
 !!! related TS2728 tests/cases/compiler/typeMatch2.ts:2:18: 'y' is declared here.
     	a = { x: 1, y: 2, z: 3 };
     	                  ~~~~
-!!! error TS2322: Type '{ x: number; y: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
         a = { x: 1, z: 3 };  // error
                     ~~~~
-!!! error TS2322: Type '{ x: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
     }
     
     class Animal { private a; }
@@ -69,8 +64,7 @@ tests/cases/compiler/typeMatch2.ts(35,5): error TS2741: Property 'y' is missing 
         a = { x: 1, y: _any }; 
         a = { x: 1, y: _any, z:1 }; 
                              ~~~
-!!! error TS2322: Type '{ x: number; y: any; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+!!! error TS2353: Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
         a = { x: 1 }; // error
         ~
 !!! error TS2741: Property 'y' is missing in type '{ x: number; }' but required in type '{ x: number; y: number; }'.


### PR DESCRIPTION
Tries to fix #29759, but I haven't gotten the chance to review the baselines (I know, sounds dumb but I'm on a phone call now). One thing to keep in mind is the fact that we lose context of which branch in a union we're picking. That can be pretty bad, and I'm not sure exactly how to address that.