### PR TITLE
assertNever no longer crashes on string input

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1652,7 +1652,7 @@ namespace ts {
         }
 
         export function assertNever(member: never, message = "Illegal value:", stackCrawlMark?: AnyFunction): never {
-            const detail = "kind" in member && "pos" in member ? "SyntaxKind: " + showSyntaxKind(member as Node) : JSON.stringify(member);
+            const detail = typeof member === "object" && "kind" in member && "pos" in member ? "SyntaxKind: " + showSyntaxKind(member as Node) : JSON.stringify(member);
             return fail(`${message} ${detail}`, stackCrawlMark || assertNever);
         }
 

--- a/src/testRunner/unittests/asserts.ts
+++ b/src/testRunner/unittests/asserts.ts
@@ -5,5 +5,8 @@ namespace ts {
             assert.throws(() => assert.deepEqual(createNodeArray([], /*hasTrailingComma*/ true), createNodeArray([], /*hasTrailingComma*/ false)));
             assert.deepEqual(createNodeArray([createIdentifier("A")], /*hasTrailingComma*/ true), createNodeArray([createIdentifier("A")], /*hasTrailingComma*/ true));
         });
+        it("assertNever on string has correct error", () => {
+            assert.throws(() => Debug.assertNever("hi" as never), "Debug Failure. Illegal value: \"hi\"");
+        });
     });
 }


### PR DESCRIPTION
Thanks to @amcasey for reporting this one.

Fixes #29761

