### PR TITLE
Fix regex warning from LGTM.com

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -625,7 +625,7 @@ namespace ts.Completions {
                     //    *         |c|
                     //    */
                     const lineStart = getLineStartPositionForPosition(position, sourceFile);
-                    if (!(sourceFile.text.substring(lineStart, position).match(/[^\*|\s|(/\*\*)]/))) {
+                    if (!(sourceFile.text.substring(lineStart, position).match(/[^\*\s|(/)]/))) {
                         return { kind: CompletionDataKind.JsDocTag };
                     }
                 }


### PR DESCRIPTION
This fixes a regex warning found by LGTM.com [here](https://lgtm.com/projects/g/Microsoft/TypeScript/alerts/?mode=tree&ruleFocus=1790078)

I am not entirely sure about the intent of this regex but I choose the behaviour preserving option of just removing the duplicate characters but it might be more correct to also remove `|`, `(` and `)` from the character class as well.

_(Disclaimer: I work for semmle, the company behind LGTM.com)_