### PR TITLE
Add explicit "auto" quotePreference

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5862,7 +5862,7 @@ namespace ts {
 
     export interface UserPreferences {
         readonly disableSuggestions?: boolean;
-        readonly quotePreference?: "double" | "single";
+        readonly quotePreference?: "auto" | "double" | "single";
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeCompletionsWithInsertText?: boolean;
         readonly importModuleSpecifierPreference?: "relative" | "non-relative";

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2891,7 +2891,7 @@ namespace ts.server.protocol {
 
     export interface UserPreferences {
         readonly disableSuggestions?: boolean;
-        readonly quotePreference?: "double" | "single";
+        readonly quotePreference?: "auto" | "double" | "single";
         /**
          * If enabled, TypeScript will search through all external modules' exports and add them to the completions list.
          * This affects lone identifier completions but not completions on the right hand side of `obj.`.

--- a/src/services/codefixes/helpers.ts
+++ b/src/services/codefixes/helpers.ts
@@ -264,6 +264,7 @@ namespace ts.codefix {
                 createNew(
                     createIdentifier("Error"),
                     /*typeArguments*/ undefined,
+                    // TODO Handle auto quote preference.
                     [createLiteral("Method not implemented.", /*isSingleQuote*/ preferences.quotePreference === "single")]))],
             /*multiline*/ true);
     }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1315,10 +1315,9 @@ namespace ts {
     }
 
     export function getQuotePreference(sourceFile: SourceFile, preferences: UserPreferences): QuotePreference {
-        if (preferences.quotePreference) {
+        if (preferences.quotePreference && preferences.quotePreference !== "auto") {
             return preferences.quotePreference === "single" ? QuotePreference.Single : QuotePreference.Double;
-        }
-        else {
+        } else {
             const firstModuleSpecifier = sourceFile.imports && find(sourceFile.imports, isStringLiteral);
             return firstModuleSpecifier ? quotePreferenceFromString(firstModuleSpecifier, sourceFile) : QuotePreference.Double;
         }
@@ -1868,15 +1867,18 @@ namespace ts {
         if (/^\d+$/.test(text)) {
             return text;
         }
+        // Editors can pass in undefined or empty string - we want to infer the preference in those cases.
+        const quotePreference = preferences.quotePreference || "auto";
         const quoted = JSON.stringify(text);
-        switch (preferences.quotePreference) {
-            case undefined:
+        switch (quotePreference) {
+            // TODO use getQuotePreference to infer the actual quote style.
+            case "auto":
             case "double":
                 return quoted;
             case "single":
                 return `'${stripQuotes(quoted).replace("'", "\\'").replace('\\"', '"')}'`;
             default:
-                return Debug.assertNever(preferences.quotePreference);
+                return Debug.assertNever(quotePreference);
         }
     }
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1317,7 +1317,8 @@ namespace ts {
     export function getQuotePreference(sourceFile: SourceFile, preferences: UserPreferences): QuotePreference {
         if (preferences.quotePreference && preferences.quotePreference !== "auto") {
             return preferences.quotePreference === "single" ? QuotePreference.Single : QuotePreference.Double;
-        } else {
+        }
+        else {
             const firstModuleSpecifier = sourceFile.imports && find(sourceFile.imports, isStringLiteral);
             return firstModuleSpecifier ? quotePreferenceFromString(firstModuleSpecifier, sourceFile) : QuotePreference.Double;
         }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3010,7 +3010,7 @@ declare namespace ts {
     }
     interface UserPreferences {
         readonly disableSuggestions?: boolean;
-        readonly quotePreference?: "double" | "single";
+        readonly quotePreference?: "auto" | "double" | "single";
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeCompletionsWithInsertText?: boolean;
         readonly importModuleSpecifierPreference?: "relative" | "non-relative";
@@ -7927,7 +7927,7 @@ declare namespace ts.server.protocol {
     }
     interface UserPreferences {
         readonly disableSuggestions?: boolean;
-        readonly quotePreference?: "double" | "single";
+        readonly quotePreference?: "auto" | "double" | "single";
         /**
          * If enabled, TypeScript will search through all external modules' exports and add them to the completions list.
          * This affects lone identifier completions but not completions on the right hand side of `obj.`.

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3010,7 +3010,7 @@ declare namespace ts {
     }
     interface UserPreferences {
         readonly disableSuggestions?: boolean;
-        readonly quotePreference?: "double" | "single";
+        readonly quotePreference?: "auto" | "double" | "single";
         readonly includeCompletionsForModuleExports?: boolean;
         readonly includeCompletionsWithInsertText?: boolean;
         readonly importModuleSpecifierPreference?: "relative" | "non-relative";


### PR DESCRIPTION
Fixes #29762

Today, VS passes `""` for `UserPreferences.quotePreference` to imply "infer from existing imports". This was causing an exception to be thrown from `createCompletionEntry`/`quote` when wrapping some properties in quotes.

This PR accomplishes two things

- For older editors, handle `""` more gracefully so the exception is avoided
- Allow newer editors to be able to pass in an explicit `auto` option for this preference.

@jessetrinity wrote this.

FYI @mjbvz for VS Code

@RyanCavanaugh we'd like to take this into 3.3.2 as a fix for that exception.