### PR TITLE
Infer to partially homomorphic types (such as Pick<T, K>)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14570,8 +14570,6 @@ namespace ts {
                 return undefined;
             }
 
-            // target: { [P in 'a' | 'b' | keyof T | keyof U]: XXX }
-            // source: { a: xxx, b: xxx, c: xxx, d: xxx }
             function inferToMappedType(source: Type, target: MappedType, constraintType: Type): boolean {
                 if (constraintType.flags & TypeFlags.Union) {
                     let result = false;

--- a/tests/baselines/reference/isomorphicMappedTypeInference.js
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.js
@@ -151,6 +151,30 @@ let o = {a: 5, b: 7};
 foo(o, {b: 9});
 o = foo(o, {b: 9});
 
+// Inferring to { [P in K]: X }, where K extends keyof T, produces same inferences as
+// inferring to { [P in keyof T]: X }.
+
+declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
+declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
+declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+
+let x0 = f20({ foo: 42, bar: "hello" });
+let x1 = f21({ foo: 42, bar: "hello" });
+let x2 = f22({ foo: { value: 42} , bar: { value: "hello" } });
+
+// Repro from #29765
+
+function getProps<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K> {
+    return {} as any;
+}
+
+const myAny: any = {};
+
+const o1 = getProps(myAny, ['foo', 'bar']);
+
+const o2: { foo: any; bar: any } = getProps(myAny, ['foo', 'bar']);
+
+
 //// [isomorphicMappedTypeInference.js]
 function box(x) {
     return { value: x };
@@ -255,6 +279,16 @@ var foo = function (object, partial) { return object; };
 var o = { a: 5, b: 7 };
 foo(o, { b: 9 });
 o = foo(o, { b: 9 });
+var x0 = f20({ foo: 42, bar: "hello" });
+var x1 = f21({ foo: 42, bar: "hello" });
+var x2 = f22({ foo: { value: 42 }, bar: { value: "hello" } });
+// Repro from #29765
+function getProps(obj, list) {
+    return {};
+}
+var myAny = {};
+var o1 = getProps(myAny, ['foo', 'bar']);
+var o2 = getProps(myAny, ['foo', 'bar']);
 
 
 //// [isomorphicMappedTypeInference.d.ts]
@@ -322,4 +356,23 @@ declare const foo: <T>(object: T, partial: Partial<T>) => T;
 declare let o: {
     a: number;
     b: number;
+};
+declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
+declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
+declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+declare let x0: {
+    foo: number;
+    bar: string;
+};
+declare let x1: "foo" | "bar";
+declare let x2: {
+    foo: number;
+    bar: string;
+};
+declare function getProps<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K>;
+declare const myAny: any;
+declare const o1: Pick<any, "foo" | "bar">;
+declare const o2: {
+    foo: any;
+    bar: any;
 };

--- a/tests/baselines/reference/isomorphicMappedTypeInference.js
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.js
@@ -157,10 +157,14 @@ o = foo(o, {b: 9});
 declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
 declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
 declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+declare function f23<T, U extends keyof T, K extends U>(obj: Pick<T, K>): T;
+declare function f24<T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>): T & U;
 
 let x0 = f20({ foo: 42, bar: "hello" });
 let x1 = f21({ foo: 42, bar: "hello" });
 let x2 = f22({ foo: { value: 42} , bar: { value: "hello" } });
+let x3 = f23({ foo: 42, bar: "hello" });
+let x4 = f24({ foo: 42, bar: "hello" });
 
 // Repro from #29765
 
@@ -282,6 +286,8 @@ o = foo(o, { b: 9 });
 var x0 = f20({ foo: 42, bar: "hello" });
 var x1 = f21({ foo: 42, bar: "hello" });
 var x2 = f22({ foo: { value: 42 }, bar: { value: "hello" } });
+var x3 = f23({ foo: 42, bar: "hello" });
+var x4 = f24({ foo: 42, bar: "hello" });
 // Repro from #29765
 function getProps(obj, list) {
     return {};
@@ -360,12 +366,25 @@ declare let o: {
 declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
 declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
 declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+declare function f23<T, U extends keyof T, K extends U>(obj: Pick<T, K>): T;
+declare function f24<T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>): T & U;
 declare let x0: {
     foo: number;
     bar: string;
 };
 declare let x1: "foo" | "bar";
 declare let x2: {
+    foo: number;
+    bar: string;
+};
+declare let x3: {
+    foo: number;
+    bar: string;
+};
+declare let x4: {
+    foo: number;
+    bar: string;
+} & {
     foo: number;
     bar: string;
 };

--- a/tests/baselines/reference/isomorphicMappedTypeInference.symbols
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.symbols
@@ -523,56 +523,96 @@ declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
 >K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 157, 23))
 >T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 157, 21))
 
+declare function f23<T, U extends keyof T, K extends U>(obj: Pick<T, K>): T;
+>f23 : Symbol(f23, Decl(isomorphicMappedTypeInference.ts, 157, 73))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 158, 21))
+>U : Symbol(U, Decl(isomorphicMappedTypeInference.ts, 158, 23))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 158, 21))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 158, 42))
+>U : Symbol(U, Decl(isomorphicMappedTypeInference.ts, 158, 23))
+>obj : Symbol(obj, Decl(isomorphicMappedTypeInference.ts, 158, 56))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 158, 21))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 158, 42))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 158, 21))
+
+declare function f24<T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>): T & U;
+>f24 : Symbol(f24, Decl(isomorphicMappedTypeInference.ts, 158, 76))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 159, 21))
+>U : Symbol(U, Decl(isomorphicMappedTypeInference.ts, 159, 23))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 159, 26))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 159, 21))
+>U : Symbol(U, Decl(isomorphicMappedTypeInference.ts, 159, 23))
+>obj : Symbol(obj, Decl(isomorphicMappedTypeInference.ts, 159, 56))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 159, 21))
+>U : Symbol(U, Decl(isomorphicMappedTypeInference.ts, 159, 23))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 159, 26))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 159, 21))
+>U : Symbol(U, Decl(isomorphicMappedTypeInference.ts, 159, 23))
+
 let x0 = f20({ foo: 42, bar: "hello" });
->x0 : Symbol(x0, Decl(isomorphicMappedTypeInference.ts, 159, 3))
+>x0 : Symbol(x0, Decl(isomorphicMappedTypeInference.ts, 161, 3))
 >f20 : Symbol(f20, Decl(isomorphicMappedTypeInference.ts, 150, 19))
->foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 159, 14))
->bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 159, 23))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 161, 14))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 161, 23))
 
 let x1 = f21({ foo: 42, bar: "hello" });
->x1 : Symbol(x1, Decl(isomorphicMappedTypeInference.ts, 160, 3))
+>x1 : Symbol(x1, Decl(isomorphicMappedTypeInference.ts, 162, 3))
 >f21 : Symbol(f21, Decl(isomorphicMappedTypeInference.ts, 155, 63))
->foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 160, 14))
->bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 160, 23))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 162, 14))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 162, 23))
 
 let x2 = f22({ foo: { value: 42} , bar: { value: "hello" } });
->x2 : Symbol(x2, Decl(isomorphicMappedTypeInference.ts, 161, 3))
+>x2 : Symbol(x2, Decl(isomorphicMappedTypeInference.ts, 163, 3))
 >f22 : Symbol(f22, Decl(isomorphicMappedTypeInference.ts, 156, 63))
->foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 161, 14))
->value : Symbol(value, Decl(isomorphicMappedTypeInference.ts, 161, 21))
->bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 161, 34))
->value : Symbol(value, Decl(isomorphicMappedTypeInference.ts, 161, 41))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 163, 14))
+>value : Symbol(value, Decl(isomorphicMappedTypeInference.ts, 163, 21))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 163, 34))
+>value : Symbol(value, Decl(isomorphicMappedTypeInference.ts, 163, 41))
+
+let x3 = f23({ foo: 42, bar: "hello" });
+>x3 : Symbol(x3, Decl(isomorphicMappedTypeInference.ts, 164, 3))
+>f23 : Symbol(f23, Decl(isomorphicMappedTypeInference.ts, 157, 73))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 164, 14))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 164, 23))
+
+let x4 = f24({ foo: 42, bar: "hello" });
+>x4 : Symbol(x4, Decl(isomorphicMappedTypeInference.ts, 165, 3))
+>f24 : Symbol(f24, Decl(isomorphicMappedTypeInference.ts, 158, 76))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 165, 14))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 165, 23))
 
 // Repro from #29765
 
 function getProps<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K> {
->getProps : Symbol(getProps, Decl(isomorphicMappedTypeInference.ts, 161, 62))
->T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 165, 18))
->K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 165, 20))
->T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 165, 18))
->obj : Symbol(obj, Decl(isomorphicMappedTypeInference.ts, 165, 40))
->T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 165, 18))
->list : Symbol(list, Decl(isomorphicMappedTypeInference.ts, 165, 47))
->K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 165, 20))
+>getProps : Symbol(getProps, Decl(isomorphicMappedTypeInference.ts, 165, 40))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 169, 18))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 169, 20))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 169, 18))
+>obj : Symbol(obj, Decl(isomorphicMappedTypeInference.ts, 169, 40))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 169, 18))
+>list : Symbol(list, Decl(isomorphicMappedTypeInference.ts, 169, 47))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 169, 20))
 >Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
->T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 165, 18))
->K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 165, 20))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 169, 18))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 169, 20))
 
     return {} as any;
 }
 
 const myAny: any = {};
->myAny : Symbol(myAny, Decl(isomorphicMappedTypeInference.ts, 169, 5))
+>myAny : Symbol(myAny, Decl(isomorphicMappedTypeInference.ts, 173, 5))
 
 const o1 = getProps(myAny, ['foo', 'bar']);
->o1 : Symbol(o1, Decl(isomorphicMappedTypeInference.ts, 171, 5))
->getProps : Symbol(getProps, Decl(isomorphicMappedTypeInference.ts, 161, 62))
->myAny : Symbol(myAny, Decl(isomorphicMappedTypeInference.ts, 169, 5))
+>o1 : Symbol(o1, Decl(isomorphicMappedTypeInference.ts, 175, 5))
+>getProps : Symbol(getProps, Decl(isomorphicMappedTypeInference.ts, 165, 40))
+>myAny : Symbol(myAny, Decl(isomorphicMappedTypeInference.ts, 173, 5))
 
 const o2: { foo: any; bar: any } = getProps(myAny, ['foo', 'bar']);
->o2 : Symbol(o2, Decl(isomorphicMappedTypeInference.ts, 173, 5))
->foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 173, 11))
->bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 173, 21))
->getProps : Symbol(getProps, Decl(isomorphicMappedTypeInference.ts, 161, 62))
->myAny : Symbol(myAny, Decl(isomorphicMappedTypeInference.ts, 169, 5))
+>o2 : Symbol(o2, Decl(isomorphicMappedTypeInference.ts, 177, 5))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 177, 11))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 177, 21))
+>getProps : Symbol(getProps, Decl(isomorphicMappedTypeInference.ts, 165, 40))
+>myAny : Symbol(myAny, Decl(isomorphicMappedTypeInference.ts, 173, 5))
 

--- a/tests/baselines/reference/isomorphicMappedTypeInference.symbols
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.symbols
@@ -486,3 +486,93 @@ o = foo(o, {b: 9});
 >o : Symbol(o, Decl(isomorphicMappedTypeInference.ts, 148, 3))
 >b : Symbol(b, Decl(isomorphicMappedTypeInference.ts, 150, 12))
 
+// Inferring to { [P in K]: X }, where K extends keyof T, produces same inferences as
+// inferring to { [P in keyof T]: X }.
+
+declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
+>f20 : Symbol(f20, Decl(isomorphicMappedTypeInference.ts, 150, 19))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 155, 21))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 155, 23))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 155, 21))
+>obj : Symbol(obj, Decl(isomorphicMappedTypeInference.ts, 155, 43))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 155, 21))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 155, 23))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 155, 21))
+
+declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
+>f21 : Symbol(f21, Decl(isomorphicMappedTypeInference.ts, 155, 63))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 156, 21))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 156, 23))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 156, 21))
+>obj : Symbol(obj, Decl(isomorphicMappedTypeInference.ts, 156, 43))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 156, 21))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 156, 23))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 156, 23))
+
+declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+>f22 : Symbol(f22, Decl(isomorphicMappedTypeInference.ts, 156, 63))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 157, 21))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 157, 23))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 157, 21))
+>obj : Symbol(obj, Decl(isomorphicMappedTypeInference.ts, 157, 43))
+>Boxified : Symbol(Boxified, Decl(isomorphicMappedTypeInference.ts, 2, 1))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 157, 21))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 157, 23))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 157, 21))
+
+let x0 = f20({ foo: 42, bar: "hello" });
+>x0 : Symbol(x0, Decl(isomorphicMappedTypeInference.ts, 159, 3))
+>f20 : Symbol(f20, Decl(isomorphicMappedTypeInference.ts, 150, 19))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 159, 14))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 159, 23))
+
+let x1 = f21({ foo: 42, bar: "hello" });
+>x1 : Symbol(x1, Decl(isomorphicMappedTypeInference.ts, 160, 3))
+>f21 : Symbol(f21, Decl(isomorphicMappedTypeInference.ts, 155, 63))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 160, 14))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 160, 23))
+
+let x2 = f22({ foo: { value: 42} , bar: { value: "hello" } });
+>x2 : Symbol(x2, Decl(isomorphicMappedTypeInference.ts, 161, 3))
+>f22 : Symbol(f22, Decl(isomorphicMappedTypeInference.ts, 156, 63))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 161, 14))
+>value : Symbol(value, Decl(isomorphicMappedTypeInference.ts, 161, 21))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 161, 34))
+>value : Symbol(value, Decl(isomorphicMappedTypeInference.ts, 161, 41))
+
+// Repro from #29765
+
+function getProps<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K> {
+>getProps : Symbol(getProps, Decl(isomorphicMappedTypeInference.ts, 161, 62))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 165, 18))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 165, 20))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 165, 18))
+>obj : Symbol(obj, Decl(isomorphicMappedTypeInference.ts, 165, 40))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 165, 18))
+>list : Symbol(list, Decl(isomorphicMappedTypeInference.ts, 165, 47))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 165, 20))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(isomorphicMappedTypeInference.ts, 165, 18))
+>K : Symbol(K, Decl(isomorphicMappedTypeInference.ts, 165, 20))
+
+    return {} as any;
+}
+
+const myAny: any = {};
+>myAny : Symbol(myAny, Decl(isomorphicMappedTypeInference.ts, 169, 5))
+
+const o1 = getProps(myAny, ['foo', 'bar']);
+>o1 : Symbol(o1, Decl(isomorphicMappedTypeInference.ts, 171, 5))
+>getProps : Symbol(getProps, Decl(isomorphicMappedTypeInference.ts, 161, 62))
+>myAny : Symbol(myAny, Decl(isomorphicMappedTypeInference.ts, 169, 5))
+
+const o2: { foo: any; bar: any } = getProps(myAny, ['foo', 'bar']);
+>o2 : Symbol(o2, Decl(isomorphicMappedTypeInference.ts, 173, 5))
+>foo : Symbol(foo, Decl(isomorphicMappedTypeInference.ts, 173, 11))
+>bar : Symbol(bar, Decl(isomorphicMappedTypeInference.ts, 173, 21))
+>getProps : Symbol(getProps, Decl(isomorphicMappedTypeInference.ts, 161, 62))
+>myAny : Symbol(myAny, Decl(isomorphicMappedTypeInference.ts, 169, 5))
+

--- a/tests/baselines/reference/isomorphicMappedTypeInference.types
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.types
@@ -522,6 +522,14 @@ declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
 >f22 : <T, K extends keyof T>(obj: Boxified<Pick<T, K>>) => T
 >obj : Boxified<Pick<T, K>>
 
+declare function f23<T, U extends keyof T, K extends U>(obj: Pick<T, K>): T;
+>f23 : <T, U extends keyof T, K extends U>(obj: Pick<T, K>) => T
+>obj : Pick<T, K>
+
+declare function f24<T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>): T & U;
+>f24 : <T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>) => T & U
+>obj : Pick<T & U, K>
+
 let x0 = f20({ foo: 42, bar: "hello" });
 >x0 : { foo: number; bar: string; }
 >f20({ foo: 42, bar: "hello" }) : { foo: number; bar: string; }
@@ -554,6 +562,26 @@ let x2 = f22({ foo: { value: 42} , bar: { value: "hello" } });
 >bar : { value: string; }
 >{ value: "hello" } : { value: string; }
 >value : string
+>"hello" : "hello"
+
+let x3 = f23({ foo: 42, bar: "hello" });
+>x3 : { foo: number; bar: string; }
+>f23({ foo: 42, bar: "hello" }) : { foo: number; bar: string; }
+>f23 : <T, U extends keyof T, K extends U>(obj: Pick<T, K>) => T
+>{ foo: 42, bar: "hello" } : { foo: number; bar: string; }
+>foo : number
+>42 : 42
+>bar : string
+>"hello" : "hello"
+
+let x4 = f24({ foo: 42, bar: "hello" });
+>x4 : { foo: number; bar: string; } & { foo: number; bar: string; }
+>f24({ foo: 42, bar: "hello" }) : { foo: number; bar: string; } & { foo: number; bar: string; }
+>f24 : <T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>) => T & U
+>{ foo: 42, bar: "hello" } : { foo: number; bar: string; }
+>foo : number
+>42 : 42
+>bar : string
 >"hello" : "hello"
 
 // Repro from #29765

--- a/tests/baselines/reference/isomorphicMappedTypeInference.types
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.types
@@ -507,3 +507,88 @@ o = foo(o, {b: 9});
 >b : number
 >9 : 9
 
+// Inferring to { [P in K]: X }, where K extends keyof T, produces same inferences as
+// inferring to { [P in keyof T]: X }.
+
+declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
+>f20 : <T, K extends keyof T>(obj: Pick<T, K>) => T
+>obj : Pick<T, K>
+
+declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
+>f21 : <T, K extends keyof T>(obj: Pick<T, K>) => K
+>obj : Pick<T, K>
+
+declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+>f22 : <T, K extends keyof T>(obj: Boxified<Pick<T, K>>) => T
+>obj : Boxified<Pick<T, K>>
+
+let x0 = f20({ foo: 42, bar: "hello" });
+>x0 : { foo: number; bar: string; }
+>f20({ foo: 42, bar: "hello" }) : { foo: number; bar: string; }
+>f20 : <T, K extends keyof T>(obj: Pick<T, K>) => T
+>{ foo: 42, bar: "hello" } : { foo: number; bar: string; }
+>foo : number
+>42 : 42
+>bar : string
+>"hello" : "hello"
+
+let x1 = f21({ foo: 42, bar: "hello" });
+>x1 : "foo" | "bar"
+>f21({ foo: 42, bar: "hello" }) : "foo" | "bar"
+>f21 : <T, K extends keyof T>(obj: Pick<T, K>) => K
+>{ foo: 42, bar: "hello" } : { foo: number; bar: string; }
+>foo : number
+>42 : 42
+>bar : string
+>"hello" : "hello"
+
+let x2 = f22({ foo: { value: 42} , bar: { value: "hello" } });
+>x2 : { foo: number; bar: string; }
+>f22({ foo: { value: 42} , bar: { value: "hello" } }) : { foo: number; bar: string; }
+>f22 : <T, K extends keyof T>(obj: Boxified<Pick<T, K>>) => T
+>{ foo: { value: 42} , bar: { value: "hello" } } : { foo: { value: number; }; bar: { value: string; }; }
+>foo : { value: number; }
+>{ value: 42} : { value: number; }
+>value : number
+>42 : 42
+>bar : { value: string; }
+>{ value: "hello" } : { value: string; }
+>value : string
+>"hello" : "hello"
+
+// Repro from #29765
+
+function getProps<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K> {
+>getProps : <T, K extends keyof T>(obj: T, list: K[]) => Pick<T, K>
+>obj : T
+>list : K[]
+
+    return {} as any;
+>{} as any : any
+>{} : {}
+}
+
+const myAny: any = {};
+>myAny : any
+>{} : {}
+
+const o1 = getProps(myAny, ['foo', 'bar']);
+>o1 : Pick<any, "foo" | "bar">
+>getProps(myAny, ['foo', 'bar']) : Pick<any, "foo" | "bar">
+>getProps : <T, K extends keyof T>(obj: T, list: K[]) => Pick<T, K>
+>myAny : any
+>['foo', 'bar'] : ("foo" | "bar")[]
+>'foo' : "foo"
+>'bar' : "bar"
+
+const o2: { foo: any; bar: any } = getProps(myAny, ['foo', 'bar']);
+>o2 : { foo: any; bar: any; }
+>foo : any
+>bar : any
+>getProps(myAny, ['foo', 'bar']) : Pick<any, "foo" | "bar">
+>getProps : <T, K extends keyof T>(obj: T, list: K[]) => Pick<T, K>
+>myAny : any
+>['foo', 'bar'] : ("foo" | "bar")[]
+>'foo' : "foo"
+>'bar' : "bar"
+

--- a/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
+++ b/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
@@ -153,3 +153,26 @@ const foo = <T>(object: T, partial: Partial<T>) => object;
 let o = {a: 5, b: 7};
 foo(o, {b: 9});
 o = foo(o, {b: 9});
+
+// Inferring to { [P in K]: X }, where K extends keyof T, produces same inferences as
+// inferring to { [P in keyof T]: X }.
+
+declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
+declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
+declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+
+let x0 = f20({ foo: 42, bar: "hello" });
+let x1 = f21({ foo: 42, bar: "hello" });
+let x2 = f22({ foo: { value: 42} , bar: { value: "hello" } });
+
+// Repro from #29765
+
+function getProps<T, K extends keyof T>(obj: T, list: K[]): Pick<T, K> {
+    return {} as any;
+}
+
+const myAny: any = {};
+
+const o1 = getProps(myAny, ['foo', 'bar']);
+
+const o2: { foo: any; bar: any } = getProps(myAny, ['foo', 'bar']);

--- a/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
+++ b/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
@@ -160,10 +160,14 @@ o = foo(o, {b: 9});
 declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
 declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
 declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
+declare function f23<T, U extends keyof T, K extends U>(obj: Pick<T, K>): T;
+declare function f24<T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>): T & U;
 
 let x0 = f20({ foo: 42, bar: "hello" });
 let x1 = f21({ foo: 42, bar: "hello" });
 let x2 = f22({ foo: { value: 42} , bar: { value: "hello" } });
+let x3 = f23({ foo: 42, bar: "hello" });
+let x4 = f24({ foo: 42, bar: "hello" });
 
 // Repro from #29765
 


### PR DESCRIPTION
With this PR we improve type inference for partially homomorphic types such as `Pick<T, K>`. Now, when inferring to a mapped type `{ [P in K]: X }`, where `K` is a type parameter `K extends keyof T`, we make the same inferences as we would for a homomorphic mapped type `{ [P in keyof T]: X }`.

Fixes #29765.