### PR TITLE
Disable node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: node_js
 node_js:
   - 'node'
   - '10'
+  - '8'
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 node_js:
   - 'node'
   - '10'
-  - '6'
 
 sudo: false
 


### PR DESCRIPTION
Node 6 exits LTS in a couple of months, and doesn't support async/await, meaning that it blocks us from switching Travis to use gulp instead of jake.

