### PR TITLE
Remove duplication from transformers

### DIFF
--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -73,7 +73,7 @@ namespace ts {
 
         addRange(transformers, customTransformers && customTransformers.after);
 
-        return map(transformers, (tf:TransformerFactory<SourceFile>) => (context: TransformationContext) => chainBundle(tf(context)));
+        return map(transformers, (tf: TransformerFactory<SourceFile>) => (context: TransformationContext) => chainBundle(tf(context)));
     }
 
     export function noEmitSubstitution(_hint: EmitHint, node: Node) {

--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -73,7 +73,7 @@ namespace ts {
 
         addRange(transformers, customTransformers && customTransformers.after);
 
-        return transformers;
+        return map(transformers, (tf:TransformerFactory<SourceFile>) => (context: TransformationContext) => chainBundle(tf(context)));
     }
 
     export function noEmitSubstitution(_hint: EmitHint, node: Node) {

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -305,7 +305,7 @@ namespace ts {
          */
         let enabledSubstitutions: ES2015SubstitutionFlags;
 
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         function transformSourceFile(node: SourceFile) {
             if (node.isDeclarationFile) {

--- a/src/compiler/transformers/es2016.ts
+++ b/src/compiler/transformers/es2016.ts
@@ -3,7 +3,7 @@ namespace ts {
     export function transformES2016(context: TransformationContext) {
         const { hoistVariableDeclaration } = context;
 
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         function transformSourceFile(node: SourceFile) {
             if (node.isDeclarationFile) {

--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -49,7 +49,7 @@ namespace ts {
         context.onEmitNode = onEmitNode;
         context.onSubstituteNode = onSubstituteNode;
 
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         function transformSourceFile(node: SourceFile) {
             if (node.isDeclarationFile) {

--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -33,7 +33,7 @@ namespace ts {
         /** A set of node IDs for generated super accessors. */
         const substitutedSuperAccessors: boolean[] = [];
 
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         function transformSourceFile(node: SourceFile) {
             if (node.isDeclarationFile) {

--- a/src/compiler/transformers/es2019.ts
+++ b/src/compiler/transformers/es2019.ts
@@ -1,7 +1,7 @@
 /*@internal*/
 namespace ts {
     export function transformES2019(context: TransformationContext) {
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         function transformSourceFile(node: SourceFile) {
             if (node.isDeclarationFile) {

--- a/src/compiler/transformers/es5.ts
+++ b/src/compiler/transformers/es5.ts
@@ -24,7 +24,7 @@ namespace ts {
         context.onSubstituteNode = onSubstituteNode;
         context.enableSubstitution(SyntaxKind.PropertyAccessExpression);
         context.enableSubstitution(SyntaxKind.PropertyAssignment);
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         /**
          * Transforms an ES5 source file to ES3.

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -1,7 +1,7 @@
 /*@internal*/
 namespace ts {
     export function transformESNext(context: TransformationContext) {
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         function transformSourceFile(node: SourceFile) {
             if (node.isDeclarationFile) {

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -290,7 +290,7 @@ namespace ts {
         let currentExceptionBlock: ExceptionBlock | undefined; // The current exception block.
         let withBlockStack: WithBlock[] | undefined; // A stack containing `with` blocks.
 
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         function transformSourceFile(node: SourceFile) {
             if (node.isDeclarationFile || (node.transformFlags & TransformFlags.ContainsGenerator) === 0) {

--- a/src/compiler/transformers/jsx.ts
+++ b/src/compiler/transformers/jsx.ts
@@ -4,7 +4,7 @@ namespace ts {
         const compilerOptions = context.getCompilerOptions();
         let currentSourceFile: SourceFile;
 
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         /**
          * Transform JSX-specific syntax in a SourceFile.

--- a/src/compiler/transformers/module/es2015.ts
+++ b/src/compiler/transformers/module/es2015.ts
@@ -10,7 +10,7 @@ namespace ts {
         context.enableSubstitution(SyntaxKind.Identifier);
 
         let currentSourceFile: SourceFile | undefined;
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         function transformSourceFile(node: SourceFile) {
             if (node.isDeclarationFile) {

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -45,7 +45,7 @@ namespace ts {
         let noSubstitution: boolean[]; // Set of nodes for which substitution rules should be ignored.
         let needUMDDynamicImportHelper: boolean;
 
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         /**
          * Transforms the module aspects of a SourceFile.

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -39,7 +39,7 @@ namespace ts {
         let enclosingBlockScopedContainer: Node;
         let noSubstitution: boolean[] | undefined; // Set of nodes for which substitution rules should be ignored.
 
-        return chainBundle(transformSourceFile);
+        return transformSourceFile;
 
         /**
          * Transforms the module aspects of a SourceFile.

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -89,23 +89,7 @@ namespace ts {
          */
         let pendingExpressions: Expression[] | undefined;
 
-        return transformSourceFileOrBundle;
-
-        function transformSourceFileOrBundle(node: SourceFile | Bundle) {
-            if (node.kind === SyntaxKind.Bundle) {
-                return transformBundle(node);
-            }
-            return transformSourceFile(node);
-        }
-
-        function transformBundle(node: Bundle) {
-            return createBundle(node.sourceFiles.map(transformSourceFile), mapDefined(node.prepends, prepend => {
-                if (prepend.kind === SyntaxKind.InputFiles) {
-                    return createUnparsedSourceFile(prepend, "js");
-                }
-                return prepend;
-            }));
-        }
+        return transformSourceFile;
 
         /**
          * Transform TypeScript-specific syntax in a SourceFile.

--- a/src/compiler/transformers/utilities.ts
+++ b/src/compiler/transformers/utilities.ts
@@ -33,7 +33,12 @@ namespace ts {
         }
 
         function transformBundle(node: Bundle) {
-            return createBundle(map(node.sourceFiles, transformSourceFile), node.prepends);
+            return createBundle(node.sourceFiles.map(transformSourceFile), mapDefined(node.prepends, prepend => {
+                if (prepend.kind === SyntaxKind.InputFiles) {
+                    return createUnparsedSourceFile(prepend, "js");
+                }
+                return prepend;
+            }));
         }
     }
 


### PR DESCRIPTION
Fixes #28310, #24459, cevek/ttypescript#29

This pull requests removes duplication (chainBundle) from all the transformer functions and moves it to a single place (getTransformers). 

This will then fix custom transformers so they work with single outFile compiler option (Bundle being passed) and gets rid of the need for chainBundle to be exposed.

This pull request is a refactoring to remove duplication and increase consistence by having a single way all transformers are used. 

