### PR TITLE
Improve error message for using value as type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1518,7 +1518,8 @@ namespace ts {
                         !checkAndReportErrorForExtendingInterface(errorLocation) &&
                         !checkAndReportErrorForUsingTypeAsNamespace(errorLocation, name, meaning) &&
                         !checkAndReportErrorForUsingTypeAsValue(errorLocation, name, meaning) &&
-                        !checkAndReportErrorForUsingNamespaceModuleAsValue(errorLocation, name, meaning)) {
+                        !checkAndReportErrorForUsingNamespaceModuleAsValue(errorLocation, name, meaning) && 
+                        !checkAndReportErrorForUsingValueAsType(errorLocation, name, meaning)) {
                         let suggestion: Symbol | undefined;
                         if (suggestedNameNotFoundMessage && suggestionCount < maximumSuggestionCount) {
                             suggestion = getSuggestedSymbolForNonexistentSymbol(originalLocation, name, meaning);
@@ -1705,6 +1706,17 @@ namespace ts {
                 }
             }
 
+            return false;
+        }
+
+        function checkAndReportErrorForUsingValueAsType(errorLocation: Node, name: __String, meaning: SymbolFlags): boolean {
+            if (meaning & (SymbolFlags.Type & ~SymbolFlags.Namespace)) {
+                const symbol = resolveSymbol(resolveName(errorLocation, name, ~SymbolFlags.Type & SymbolFlags.Value, /*nameNotFoundMessage*/undefined, /*nameArg*/ undefined, /*isUse*/ false));
+                if (symbol && !(symbol.flags & SymbolFlags.Namespace)) {
+                    error(errorLocation, Diagnostics._0_refers_to_a_value_but_is_being_used_as_a_type_here, unescapeLeadingUnderscores(name));
+                    return true;
+                }
+            }
             return false;
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1518,7 +1518,7 @@ namespace ts {
                         !checkAndReportErrorForExtendingInterface(errorLocation) &&
                         !checkAndReportErrorForUsingTypeAsNamespace(errorLocation, name, meaning) &&
                         !checkAndReportErrorForUsingTypeAsValue(errorLocation, name, meaning) &&
-                        !checkAndReportErrorForUsingNamespaceModuleAsValue(errorLocation, name, meaning) && 
+                        !checkAndReportErrorForUsingNamespaceModuleAsValue(errorLocation, name, meaning) &&
                         !checkAndReportErrorForUsingValueAsType(errorLocation, name, meaning)) {
                         let suggestion: Symbol | undefined;
                         if (suggestedNameNotFoundMessage && suggestionCount < maximumSuggestionCount) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2581,6 +2581,10 @@
         "category": "Error",
         "code": 2748
     },
+    "'{0}' refers to a value, but is being used as a type here.": {
+        "category": "Error",
+        "code": 2749
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/allowImportClausesToMergeWithTypes.errors.txt
+++ b/tests/baselines/reference/allowImportClausesToMergeWithTypes.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/index.ts(4,1): error TS2693: 'zzz' only refers to a type, but is being used as a value here.
-tests/cases/compiler/index.ts(9,10): error TS2304: Cannot find name 'originalZZZ'.
+tests/cases/compiler/index.ts(9,10): error TS2749: 'originalZZZ' refers to a value, but is being used as a type here.
 
 
 ==== tests/cases/compiler/b.ts (0 errors) ====
@@ -31,4 +31,4 @@ tests/cases/compiler/index.ts(9,10): error TS2304: Cannot find name 'originalZZZ
     
     const y: originalZZZ = x;
              ~~~~~~~~~~~
-!!! error TS2304: Cannot find name 'originalZZZ'.
+!!! error TS2749: 'originalZZZ' refers to a value, but is being used as a type here.

--- a/tests/baselines/reference/callOverloads3.errors.txt
+++ b/tests/baselines/reference/callOverloads3.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/callOverloads3.ts(1,10): error TS2300: Duplicate identifier 'Foo'.
-tests/cases/compiler/callOverloads3.ts(1,16): error TS2304: Cannot find name 'Foo'.
+tests/cases/compiler/callOverloads3.ts(1,16): error TS2749: 'Foo' refers to a value, but is being used as a type here.
 tests/cases/compiler/callOverloads3.ts(2,10): error TS2300: Duplicate identifier 'Foo'.
 tests/cases/compiler/callOverloads3.ts(2,10): error TS2391: Function implementation is missing or not immediately following the declaration.
-tests/cases/compiler/callOverloads3.ts(2,24): error TS2304: Cannot find name 'Foo'.
+tests/cases/compiler/callOverloads3.ts(2,24): error TS2749: 'Foo' refers to a value, but is being used as a type here.
 tests/cases/compiler/callOverloads3.ts(3,7): error TS2300: Duplicate identifier 'Foo'.
 tests/cases/compiler/callOverloads3.ts(11,10): error TS2350: Only a void function can be called with the 'new' keyword.
 
@@ -12,14 +12,14 @@ tests/cases/compiler/callOverloads3.ts(11,10): error TS2350: Only a void functio
              ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
                    ~~~
-!!! error TS2304: Cannot find name 'Foo'.
+!!! error TS2749: 'Foo' refers to a value, but is being used as a type here.
     function Foo(s:string):Foo; // error
              ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
              ~~~
 !!! error TS2391: Function implementation is missing or not immediately following the declaration.
                            ~~~
-!!! error TS2304: Cannot find name 'Foo'.
+!!! error TS2749: 'Foo' refers to a value, but is being used as a type here.
     class Foo { // error
           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.

--- a/tests/baselines/reference/callOverloads4.errors.txt
+++ b/tests/baselines/reference/callOverloads4.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/callOverloads4.ts(1,10): error TS2300: Duplicate identifier 'Foo'.
-tests/cases/compiler/callOverloads4.ts(1,16): error TS2304: Cannot find name 'Foo'.
+tests/cases/compiler/callOverloads4.ts(1,16): error TS2749: 'Foo' refers to a value, but is being used as a type here.
 tests/cases/compiler/callOverloads4.ts(2,10): error TS2300: Duplicate identifier 'Foo'.
 tests/cases/compiler/callOverloads4.ts(2,10): error TS2391: Function implementation is missing or not immediately following the declaration.
-tests/cases/compiler/callOverloads4.ts(2,24): error TS2304: Cannot find name 'Foo'.
+tests/cases/compiler/callOverloads4.ts(2,24): error TS2749: 'Foo' refers to a value, but is being used as a type here.
 tests/cases/compiler/callOverloads4.ts(3,7): error TS2300: Duplicate identifier 'Foo'.
 tests/cases/compiler/callOverloads4.ts(11,10): error TS2350: Only a void function can be called with the 'new' keyword.
 
@@ -12,14 +12,14 @@ tests/cases/compiler/callOverloads4.ts(11,10): error TS2350: Only a void functio
              ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
                    ~~~
-!!! error TS2304: Cannot find name 'Foo'.
+!!! error TS2749: 'Foo' refers to a value, but is being used as a type here.
     function Foo(s:string):Foo; // error
              ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
              ~~~
 !!! error TS2391: Function implementation is missing or not immediately following the declaration.
                            ~~~
-!!! error TS2304: Cannot find name 'Foo'.
+!!! error TS2749: 'Foo' refers to a value, but is being used as a type here.
     class Foo { // error
           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.

--- a/tests/baselines/reference/callOverloads5.errors.txt
+++ b/tests/baselines/reference/callOverloads5.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/callOverloads5.ts(1,10): error TS2300: Duplicate identifier 'Foo'.
-tests/cases/compiler/callOverloads5.ts(1,16): error TS2304: Cannot find name 'Foo'.
+tests/cases/compiler/callOverloads5.ts(1,16): error TS2749: 'Foo' refers to a value, but is being used as a type here.
 tests/cases/compiler/callOverloads5.ts(2,10): error TS2300: Duplicate identifier 'Foo'.
 tests/cases/compiler/callOverloads5.ts(2,10): error TS2391: Function implementation is missing or not immediately following the declaration.
-tests/cases/compiler/callOverloads5.ts(2,24): error TS2304: Cannot find name 'Foo'.
+tests/cases/compiler/callOverloads5.ts(2,24): error TS2749: 'Foo' refers to a value, but is being used as a type here.
 tests/cases/compiler/callOverloads5.ts(3,7): error TS2300: Duplicate identifier 'Foo'.
 tests/cases/compiler/callOverloads5.ts(13,10): error TS2350: Only a void function can be called with the 'new' keyword.
 
@@ -12,14 +12,14 @@ tests/cases/compiler/callOverloads5.ts(13,10): error TS2350: Only a void functio
              ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
                    ~~~
-!!! error TS2304: Cannot find name 'Foo'.
+!!! error TS2749: 'Foo' refers to a value, but is being used as a type here.
     function Foo(s:string):Foo; // error
              ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.
              ~~~
 !!! error TS2391: Function implementation is missing or not immediately following the declaration.
                            ~~~
-!!! error TS2304: Cannot find name 'Foo'.
+!!! error TS2749: 'Foo' refers to a value, but is being used as a type here.
     class Foo { // error
           ~~~
 !!! error TS2300: Duplicate identifier 'Foo'.

--- a/tests/baselines/reference/constructorOverloads7.errors.txt
+++ b/tests/baselines/reference/constructorOverloads7.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/constructorOverloads7.ts(1,15): error TS2300: Duplicate identifier 'Point'.
-tests/cases/compiler/constructorOverloads7.ts(7,35): error TS2304: Cannot find name 'Point'.
-tests/cases/compiler/constructorOverloads7.ts(8,14): error TS2304: Cannot find name 'Point'.
+tests/cases/compiler/constructorOverloads7.ts(7,35): error TS2749: 'Point' refers to a value, but is being used as a type here.
+tests/cases/compiler/constructorOverloads7.ts(8,14): error TS2749: 'Point' refers to a value, but is being used as a type here.
 tests/cases/compiler/constructorOverloads7.ts(15,10): error TS2300: Duplicate identifier 'Point'.
 tests/cases/compiler/constructorOverloads7.ts(22,18): error TS2384: Overload signatures must all be ambient or non-ambient.
 
@@ -16,10 +16,10 @@ tests/cases/compiler/constructorOverloads7.ts(22,18): error TS2384: Overload sig
     
          add(dx: number, dy: number): Point;
                                       ~~~~~
-!!! error TS2304: Cannot find name 'Point'.
+!!! error TS2749: 'Point' refers to a value, but is being used as a type here.
          origin: Point;
                  ~~~~~
-!!! error TS2304: Cannot find name 'Point'.
+!!! error TS2749: 'Point' refers to a value, but is being used as a type here.
     
     }
     

--- a/tests/baselines/reference/intrinsics.errors.txt
+++ b/tests/baselines/reference/intrinsics.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/intrinsics.ts(1,21): error TS2304: Cannot find name 'hasOwnProperty'.
+tests/cases/compiler/intrinsics.ts(1,21): error TS2749: 'hasOwnProperty' refers to a value, but is being used as a type here.
 tests/cases/compiler/intrinsics.ts(1,21): error TS4025: Exported variable 'hasOwnProperty' has or is using private name 'hasOwnProperty'.
 tests/cases/compiler/intrinsics.ts(10,1): error TS2304: Cannot find name '__proto__'.
 
@@ -6,7 +6,7 @@ tests/cases/compiler/intrinsics.ts(10,1): error TS2304: Cannot find name '__prot
 ==== tests/cases/compiler/intrinsics.ts (3 errors) ====
     var hasOwnProperty: hasOwnProperty; // Error
                         ~~~~~~~~~~~~~~
-!!! error TS2304: Cannot find name 'hasOwnProperty'.
+!!! error TS2749: 'hasOwnProperty' refers to a value, but is being used as a type here.
                         ~~~~~~~~~~~~~~
 !!! error TS4025: Exported variable 'hasOwnProperty' has or is using private name 'hasOwnProperty'.
     

--- a/tests/baselines/reference/jsdocTypeNongenericInstantiationAttempt.errors.txt
+++ b/tests/baselines/reference/jsdocTypeNongenericInstantiationAttempt.errors.txt
@@ -5,7 +5,7 @@ tests/cases/compiler/index4.js(2,19): error TS2315: Type 'Function' is not gener
 tests/cases/compiler/index5.js(2,19): error TS2315: Type 'String' is not generic.
 tests/cases/compiler/index6.js(2,19): error TS2315: Type 'Number' is not generic.
 tests/cases/compiler/index7.js(2,19): error TS2315: Type 'Object' is not generic.
-tests/cases/compiler/index8.js(4,12): error TS2304: Cannot find name 'fn'.
+tests/cases/compiler/index8.js(4,12): error TS2749: 'fn' refers to a value, but is being used as a type here.
 tests/cases/compiler/index8.js(4,15): error TS2304: Cannot find name 'T'.
 
 
@@ -90,7 +90,7 @@ tests/cases/compiler/index8.js(4,15): error TS2304: Cannot find name 'T'.
     /**
      * @param {fn<T>} somebody
                ~~
-!!! error TS2304: Cannot find name 'fn'.
+!!! error TS2749: 'fn' refers to a value, but is being used as a type here.
                   ~
 !!! error TS2304: Cannot find name 'T'.
      */

--- a/tests/baselines/reference/parserAmbiguityWithBinaryOperator4.errors.txt
+++ b/tests/baselines/reference/parserAmbiguityWithBinaryOperator4.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,9): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,11): error TS2304: Cannot find name 'b'.
-tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,14): error TS2304: Cannot find name 'b'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,11): error TS2749: 'b' refers to a value, but is being used as a type here.
+tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,14): error TS2749: 'b' refers to a value, but is being used as a type here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts (3 errors) ====
@@ -10,7 +10,7 @@ tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOpe
             ~~~~~~~~~~~~~~
 !!! error TS2347: Untyped function calls may not accept type arguments.
               ~
-!!! error TS2304: Cannot find name 'b'.
+!!! error TS2749: 'b' refers to a value, but is being used as a type here.
                  ~
-!!! error TS2304: Cannot find name 'b'.
+!!! error TS2749: 'b' refers to a value, but is being used as a type here.
     }

--- a/tests/baselines/reference/typeAssertions.errors.txt
+++ b/tests/baselines/reference/typeAssertions.errors.txt
@@ -7,7 +7,7 @@ tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(37,13): err
   Property 'q' is missing in type 'SomeDerived' but required in type 'SomeOther'.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(38,13): error TS2352: Conversion of type 'SomeBase' to type 'SomeOther' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
   Property 'q' is missing in type 'SomeBase' but required in type 'SomeOther'.
-tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,5): error TS2304: Cannot find name 'numOrStr'.
+tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,5): error TS2749: 'numOrStr' refers to a value, but is being used as a type here.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,14): error TS1005: '>' expected.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,14): error TS2304: Cannot find name 'is'.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,17): error TS1005: ')' expected.
@@ -15,7 +15,7 @@ tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,17): err
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(44,48): error TS1005: ';' expected.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(45,2): error TS2322: Type 'string | number' is not assignable to type 'string'.
   Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,32): error TS2304: Cannot find name 'numOrStr'.
+tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,32): error TS2749: 'numOrStr' refers to a value, but is being used as a type here.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,41): error TS1005: ')' expected.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,41): error TS2304: Cannot find name 'is'.
 tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,44): error TS1005: ';' expected.
@@ -86,7 +86,7 @@ tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,50): err
     var str: string;
     if(<numOrStr is string>(numOrStr === undefined)) { // Error
         ~~~~~~~~
-!!! error TS2304: Cannot find name 'numOrStr'.
+!!! error TS2749: 'numOrStr' refers to a value, but is being used as a type here.
                  ~~
 !!! error TS1005: '>' expected.
                  ~~
@@ -105,7 +105,7 @@ tests/cases/conformance/expressions/typeAssertions/typeAssertions.ts(48,50): err
     
     if((numOrStr === undefined) as numOrStr is string) { // Error
                                    ~~~~~~~~
-!!! error TS2304: Cannot find name 'numOrStr'.
+!!! error TS2749: 'numOrStr' refers to a value, but is being used as a type here.
                                             ~~
 !!! error TS1005: ')' expected.
                                             ~~

--- a/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
+++ b/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(1,7): error TS2300: Duplicate identifier 'A'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(14,5): error TS2322: Type '""' is not assignable to type 'boolean'.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(17,55): error TS2304: Cannot find name 'x'.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(17,55): error TS2749: 'x' refers to a value, but is being used as a type here.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(17,57): error TS1144: '{' or ';' expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(17,60): error TS1005: ';' expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(17,62): error TS1005: ';' expected.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(21,33): error TS2304: Cannot find name 'x'.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(21,33): error TS2749: 'x' refers to a value, but is being used as a type here.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(25,33): error TS1225: Cannot find parameter 'x'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(29,10): error TS2391: Function implementation is missing or not immediately following the declaration.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(30,5): error TS1131: Property or signature expected.
@@ -28,14 +28,14 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(84,1):
   Type predicate 'p2 is A' is not assignable to 'p1 is A'.
     Parameter 'p2' is not in the same position as parameter 'p1'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(90,1): error TS2322: Type '(p1: any, p2: any, p3: any) => p1 is A' is not assignable to type '(p1: any, p2: any) => p1 is A'.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(95,9): error TS2304: Cannot find name 'b'.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(95,9): error TS2749: 'b' refers to a value, but is being used as a type here.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(95,11): error TS1005: ',' expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(95,14): error TS1005: ',' expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(95,14): error TS2300: Duplicate identifier 'A'.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(96,16): error TS2304: Cannot find name 'b'.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(96,16): error TS2749: 'b' refers to a value, but is being used as a type here.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(96,18): error TS1005: ',' expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(96,21): error TS1005: ',' expected.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(97,20): error TS2304: Cannot find name 'b'.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(97,20): error TS2749: 'b' refers to a value, but is being used as a type here.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(97,22): error TS1144: '{' or ';' expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(97,25): error TS1005: ';' expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(97,27): error TS1005: ';' expected.
@@ -91,7 +91,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(166,54
     
     function hasTypeGuardTypeInsideTypeGuardType(x): x is x is A {
                                                           ~
-!!! error TS2304: Cannot find name 'x'.
+!!! error TS2749: 'x' refers to a value, but is being used as a type here.
                                                             ~~
 !!! error TS1144: '{' or ';' expected.
                                                                ~
@@ -103,7 +103,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(166,54
     
     function hasMissingIsKeyword(): x {
                                     ~
-!!! error TS2304: Cannot find name 'x'.
+!!! error TS2749: 'x' refers to a value, but is being used as a type here.
         return true;
     }
     
@@ -222,7 +222,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(166,54
     // Type predicates in non-return type positions
     var b1: b is A;
             ~
-!!! error TS2304: Cannot find name 'b'.
+!!! error TS2749: 'b' refers to a value, but is being used as a type here.
               ~~
 !!! error TS1005: ',' expected.
                  ~
@@ -231,14 +231,14 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(166,54
 !!! error TS2300: Duplicate identifier 'A'.
     function b2(a: b is A) {};
                    ~
-!!! error TS2304: Cannot find name 'b'.
+!!! error TS2749: 'b' refers to a value, but is being used as a type here.
                      ~~
 !!! error TS1005: ',' expected.
                         ~
 !!! error TS1005: ',' expected.
     function b3(): A | b is A {
                        ~
-!!! error TS2304: Cannot find name 'b'.
+!!! error TS2749: 'b' refers to a value, but is being used as a type here.
                          ~~
 !!! error TS1144: '{' or ';' expected.
                             ~


### PR DESCRIPTION
Fixes #29778. 

The new error message is in most casses an improvement over the old. There are a few corner casses where there are already other errors and the new message might not be helpful, but I would like an opinion on them

1. Self referencing variable.
```ts 
var hasOwnProperty: hasOwnProperty; // Error
// Previous tests/cases/compiler/intrinsics.ts(1,21): error TS2304: Cannot find name 'hasOwnProperty'.
///Current tests/cases/compiler/intrinsics.ts(1,21): error TS2749: 'hasOwnProperty' refers to a value, but is being used as a type here.
```
If this is deemed too confusing, I could check that the found symbol declaration is not a parent of the node being checked.

2. Duplicate symbols 

```ts
declare class Point
{
    x: number;
    y: number;
    constructor(x: number, y: number);

     add(dx: number, dy: number): Point; 
//!!! error TS2304: Cannot find name 'Point'.
//!!! error TS2749: 'Point' refers to a value, but is being used as a type here.
}

function Point(x, y) {
    this.x = x;
    this.y = y;

    return this;
}
```
This one I am not sure how to revert back to the old error, ideally I would not report the new error message if the found symbol has a duplicate, but I have not found a wat to access this information in `resolveName`.