### PR TITLE
Readd configure-insiders task to Gulpfile

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -618,6 +618,10 @@ const configureNightly = () => exec(process.execPath, ["scripts/configurePrerele
 task("configure-nightly", series(buildScripts, configureNightly));
 task("configure-nightly").description = "Runs scripts/configurePrerelease.ts to prepare a build for nightly publishing";
 
+const configureInsiders = () => exec(process.execPath, ["scripts/configurePrerelease.js", "insiders", "package.json", "src/compiler/core.ts"])
+task("configure-insiders", series(buildScripts, configureInsiders));
+task("configure-insiders").description = "Runs scripts/configurePrerelease.ts to prepare a build for insiders publishing";
+
 const publishNightly = () => exec("npm", ["publish", "--tag", "next"]);
 task("publish-nightly", series(task("clean"), task("LKG"), task("clean"), task("runtests-parallel"), publishNightly));
 task("publish-nightly").description = "Runs `npm publish --tag next` to create a new nightly build on npm";


### PR DESCRIPTION
It's identical to configure-nightly but with the flag changed from dev to insiders. We use it to manually publish an insiders build via pipeline, and went missing when we copied functionality from the jakefile.



