### PR TITLE
Use sha256 to hash file contents

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -632,7 +632,7 @@ namespace ts {
                 getModifiedTime,
                 setModifiedTime,
                 deleteFile,
-                createHash: _crypto ? createMD5HashUsingNativeCrypto : generateDjb2Hash,
+                createHash: _crypto ? createSHA256Hash : generateDjb2Hash,
                 createSHA256Hash: _crypto ? createSHA256Hash : undefined,
                 getMemoryUsage() {
                     if (global.gc) {
@@ -1123,12 +1123,6 @@ namespace ts {
                 catch (e) {
                     return;
                 }
-            }
-
-            function createMD5HashUsingNativeCrypto(data: string): string {
-                const hash = _crypto!.createHash("md5");
-                hash.update(data);
-                return hash.digest("hex");
             }
 
             function createSHA256Hash(data: string): string {


### PR DESCRIPTION
The security team is complaining because we're not allowed to use cryptographically-compromised hash functions for non-crypto purposes if those functions were ever used by other people for crypto purposes in the past. 🤷‍♂️

Benchmarks show this to be about 30% slower compared to MD5, but we're generally looking at about 8.7ms to SHA256 checker.ts vs 6.4ms for MD5, so the net effect on any program that fits in memory should be less than 30ms overall.

As a side note, generateDjb2Hash is *40 times* slower than sha256 - if this is *ever* called in practice, we should probably make it faster.