### PR TITLE
update docs: dated build cmd

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ The TypeScript repository is relatively large. To save some time, you might want
 
 ### Using local builds
 
-Run `gulp build` to build a version of the compiler/language service that reflects changes you've made. You can then run `node <repo-root>/built/local/tsc.js` in place of `tsc` in your project. For example, to run `tsc --watch` from within the root of the repository on a file called `test.ts`, you can run `node ./built/local/tsc.js --watch test.ts`.
+Run `gulp` to build a version of the compiler/language service that reflects changes you've made. You can then run `node <repo-root>/built/local/tsc.js` in place of `tsc` in your project. For example, to run `tsc --watch` from within the root of the repository on a file called `test.ts`, you can run `node ./built/local/tsc.js --watch test.ts`.
 
 ## Contributing bug fixes
 


### PR DESCRIPTION
Hopefully I didn't miss something obvious.

Running `gulp build` as suggested causes the following:
```
$ gulp build
[18:26:11] Using gulpfile ~/git/TypeScript/Gulpfile.js
[18:26:11] Task never defined: build
[18:26:11] To list available tasks, try running: gulp --tasks
```

```
$ gulp --tasks
gulp --tasks
[18:21:26] Tasks for ~/git/TypeScript/Gulpfile.js
[18:21:26] ├── lib                           Builds the library targets
...
...
[18:21:27] ├─┬ default                       Runs 'local'
[18:21:27] │ └─┬ <series>
[18:21:27] │   └─┬ local
[18:21:27] │     └─┬ <series>
[18:21:27] │       ├── buildFoldStart
[18:21:27] │       ├─┬ <parallel>
[18:21:27] │       │ ├── generateLibs
[18:21:27] │       │ └─┬ <series>
[18:21:27] │       │   ├── buildScripts
[18:21:27] │       │   └── generateDiagnostics
[18:21:27] │       ├─┬ <parallel>
[18:21:27] │       │ ├── localize
[18:21:27] │       │ ├── buildTsc
[18:21:27] │       │ ├── buildServer
[18:21:27] │       │ ├─┬ <series>
[18:21:27] │       │ │ ├── flattenServicesConfig
[18:21:27] │       │ │ ├── buildTypescriptServicesOut
[18:21:27] │       │ │ ├── createTypescriptServicesJs
[18:21:27] │       │ │ ├── createTypescriptServicesDts
[18:21:27] │       │ │ ├── createTypescriptJs
[18:21:27] │       │ │ ├── createTypescriptDts
[18:21:27] │       │ │ └── createTypescriptStandaloneDts
[18:21:27] │       │ └─┬ <series>
[18:21:27] │       │   ├── flattenTsServerProject
[18:21:27] │       │   ├── buildServerLibraryOut
[18:21:27] │       │   ├── createServerLibraryJs
[18:21:27] │       │   └── createServerLibraryDts
[18:21:27] │       └── buildFoldEnd
[18:21:27] └── help                          Prints the top-level tasks.
```

The default task seems to do something useful:
```
$ gulp
[18:21:49] Using gulpfile ~/git/TypeScript/Gulpfile.js
[18:21:49] Starting 'default'...
[18:21:49] Starting 'local'...
[18:21:49] Starting 'buildFoldStart'...
[18:21:49] Finished 'buildFoldStart' after 726 μs
[18:21:49] Starting 'generateLibs'...
[18:21:49] Starting 'buildScripts'...
[18:21:49] Finished 'generateLibs' after 207 ms
[18:21:49] Finished 'buildScripts' after 686 ms
[18:21:49] Starting 'generateDiagnostics'...
[18:21:49] Finished 'generateDiagnostics' after 700 μs
[18:21:49] Starting 'localize'...
[18:21:49] Starting 'buildTsc'...
[18:21:49] Starting 'buildServer'...
[18:21:49] > /usr/bin/node scripts/generateLocalizedDiagnosticMessages.js src/loc/lcl built/local src/compiler/diagnosticMessages.generated.json
[18:21:49] Starting 'flattenServicesConfig'...
[18:21:49] Starting 'flattenTsServerProject'...
[18:21:49] Finished 'flattenServicesConfig' after 54 ms
[18:21:49] Starting 'buildTypescriptServicesOut'...
[18:21:49] Finished 'flattenTsServerProject' after 54 ms
[18:21:49] Starting 'buildServerLibraryOut'...
[18:21:53] Finished 'localize' after 3.38 s
[18:23:17] Finished 'buildTsc' after 1.45 min
[18:23:17] Finished 'buildServer' after 1.45 min
[18:23:17] Finished 'buildTypescriptServicesOut' after 1.45 min
[18:23:17] Starting 'createTypescriptServicesJs'...
[18:23:17] Finished 'buildServerLibraryOut' after 1.45 min
[18:23:17] Starting 'createServerLibraryJs'...
[18:23:17] Finished 'createServerLibraryJs' after 635 ms
[18:23:17] Starting 'createServerLibraryDts'...
[18:23:18] Finished 'createTypescriptServicesJs' after 642 ms
[18:23:18] Starting 'createTypescriptServicesDts'...
[18:23:18] Finished 'createTypescriptServicesDts' after 20 ms
[18:23:18] Starting 'createTypescriptJs'...
[18:23:18] Finished 'createServerLibraryDts' after 30 ms
[18:23:18] Finished 'createTypescriptJs' after 260 ms
[18:23:18] Starting 'createTypescriptDts'...
[18:23:18] Finished 'createTypescriptDts' after 4.47 ms
[18:23:18] Starting 'createTypescriptStandaloneDts'...
[18:23:18] Finished 'createTypescriptStandaloneDts' after 5.59 ms
[18:23:18] Starting 'buildFoldEnd'...
[18:23:18] Finished 'buildFoldEnd' after 350 μs
[18:23:18] Finished 'local' after 1.48 min
[18:23:18] Finished 'default' after 1.48 min
```

I'm I'm guessing wrongly, please reject & correct the docs to whatever the right way to run builds is.

_There is no currently associated issue_

