### PR TITLE
Never overwrite resolved types of symbols

### DIFF
--- a/tests/baselines/reference/jsFileClassSelfReferencedProperty.types
+++ b/tests/baselines/reference/jsFileClassSelfReferencedProperty.types
@@ -4,11 +4,11 @@ export class StackOverflowTest {
 
   constructor () {
     this.testStackOverflow = this.testStackOverflow.bind(this)
->this.testStackOverflow = this.testStackOverflow.bind(this) : error
+>this.testStackOverflow = this.testStackOverflow.bind(this) : any
 >this.testStackOverflow : any
 >this : this
 >testStackOverflow : any
->this.testStackOverflow.bind(this) : error
+>this.testStackOverflow.bind(this) : any
 >this.testStackOverflow.bind : any
 >this.testStackOverflow : any
 >this : this

--- a/tests/baselines/reference/parserES5ForOfStatement18.types
+++ b/tests/baselines/reference/parserES5ForOfStatement18.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement18.ts ===
 for (var of of of) { }
 >of : any
->of : error
+>of : any
 

--- a/tests/baselines/reference/parserES5ForOfStatement19.types
+++ b/tests/baselines/reference/parserES5ForOfStatement19.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts ===
 for (var of in of) { }
 >of : any
->of : error
+>of : any
 

--- a/tests/baselines/reference/parserForOfStatement18.types
+++ b/tests/baselines/reference/parserForOfStatement18.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement18.ts ===
 for (var of of of) { }
 >of : any
->of : error
+>of : any
 

--- a/tests/baselines/reference/parserForOfStatement19.types
+++ b/tests/baselines/reference/parserForOfStatement19.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts ===
 for (var of in of) { }
 >of : any
->of : error
+>of : any
 

--- a/tests/baselines/reference/recur1.types
+++ b/tests/baselines/reference/recur1.types
@@ -15,7 +15,7 @@ salt.pepper = function() {}
 
 var cobalt = new cobalt.pitch();   
 >cobalt : any
->new cobalt.pitch() : error
+>new cobalt.pitch() : any
 >cobalt.pitch : any
 >cobalt : any
 >pitch : any

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.types
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.types
@@ -14,7 +14,7 @@ import self = require("recursiveExportAssignmentAndFindAliasedType7_moduleD");
 
 var selfVar = self;
 >selfVar : any
->self : error
+>self : any
 
 export = selfVar;
 >selfVar : any


### PR DESCRIPTION
Symbol type resolution is supposed to be idempotent, but in certain recursive scenarios we would overwrite the resolved type of a symbol with another (possibly different) type. That could cause quick info to display different types depending on the order in which types are examined. With this PR we ensure that the `type` property of `SymbolLinks` is still `undefined` before assigning to it.

Fixes #27927.