### PR TITLE
fix no space before equal operator in type parameter

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -442,7 +442,7 @@ namespace ts.formatting {
             case SyntaxKind.ForInStatement:
             // "in" keyword in [P in keyof T]: T[P]
             case SyntaxKind.TypeParameter:
-                return context.currentTokenSpan.kind === SyntaxKind.InKeyword || context.nextTokenSpan.kind === SyntaxKind.InKeyword;
+                return context.currentTokenSpan.kind === SyntaxKind.InKeyword || context.nextTokenSpan.kind === SyntaxKind.InKeyword || context.currentTokenSpan.kind === SyntaxKind.EqualsToken || context.nextTokenSpan.kind === SyntaxKind.EqualsToken;
             // Technically, "of" is not a binary operator, but format it the same way as "in"
             case SyntaxKind.ForOfStatement:
                 return context.currentTokenSpan.kind === SyntaxKind.OfKeyword || context.nextTokenSpan.kind === SyntaxKind.OfKeyword;

--- a/tests/cases/fourslash/formatTypeParameters.ts
+++ b/tests/cases/fourslash/formatTypeParameters.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts"/>
+
+/////**/type Bar<T extends any[]= any[]> = T
+
+
+format.document();
+goTo.marker();
+verify.currentLineContentIs('type Bar<T extends any[] = any[]> = T');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [Y] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [Y] Code is up-to-date with the `master` branch
* [Y] You've successfully run `jake runtests` locally
* [Y] You've signed the CLA
* [Y] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #26656

