### PR TITLE
fix goto implementations not includes subtypes

### DIFF
--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_05.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_05.ts
@@ -15,7 +15,7 @@
 //// }
 ////
 //// class OtherBar extends SuperBar {
-////     hello() {}
+////     [|hello|]() {}
 ////     hello2() {}
 ////     hello3() {}
 //// }
@@ -27,7 +27,7 @@
 //// }
 ////
 //// class NotBar extends SuperBar {
-////     hello() {}         // Should not be returned because it is not structurally equivalent to Bar
+////     [|hello|]() {}
 //// }
 ////
 //// function whatever(x: Bar) {

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_06.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_06.ts
@@ -28,7 +28,7 @@
 //// };
 ////
 //// class FooLike implements SuperFoo {
-////      hello() {}
+////      [|hello|]() {}
 ////      someOtherFunction() {}
 //// }
 ////
@@ -38,7 +38,7 @@
 //// }
 ////
 //// class NotFoo implements SuperFoo {
-////      hello() {}                // We only want implementations of Foo, even though the function is declared in SuperFoo
+////      [|hello|]() {}
 //// }
 ////
 //// function (x: Foo) {

--- a/tests/cases/fourslash/goToImplementationInterfaceMethod_09.ts
+++ b/tests/cases/fourslash/goToImplementationInterfaceMethod_09.ts
@@ -7,11 +7,11 @@
 //// }
 ////
 //// class SubBar extends Bar {
-////     hello() {}
+////     [|hello|]() {}
 //// }
 ////
 //// class Bar extends SuperBar {
-////     hello() {}
+////     [|hello|]() {}
 ////
 ////     whatever() {
 ////         super.he/*function_call*/llo();

--- a/tests/cases/fourslash/goToImplementationInterface_01.ts
+++ b/tests/cases/fourslash/goToImplementationInterface_01.ts
@@ -10,10 +10,10 @@
 ////     abstract hello (): void;
 //// }
 ////
-//// class Bar extends SuperBar {
+//// class [|Bar|] extends SuperBar {
 //// }
 ////
-//// class NotAbstractBar extends AbstractBar {
+//// class [|NotAbstractBar|] extends AbstractBar {
 ////     hello () {}
 //// }
 ////

--- a/tests/cases/fourslash/goToImplementationSuper_00.ts
+++ b/tests/cases/fourslash/goToImplementationSuper_00.ts
@@ -6,7 +6,7 @@
 ////     constructor() {}
 //// }
 ////
-//// class Bar extends Foo {
+//// class [|Bar|] extends Foo {
 ////     constructor() {
 ////         su/*super_call*/per();
 ////     }

--- a/tests/cases/fourslash/goToImplementationSuper_01.ts
+++ b/tests/cases/fourslash/goToImplementationSuper_01.ts
@@ -6,7 +6,7 @@
 ////     hello() {}
 //// }
 ////
-//// class Bar extends Foo {
+//// class [|Bar|] extends Foo {
 ////     hello() {
 ////         sup/*super_call*/er.hello();
 ////     }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [Y] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [Y] Code is up-to-date with the `master` branch
* [Y] You've successfully run `jake runtests` locally
* [Y] You've signed the CLA
* [Y] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #29724

I not sure it is a good fix for this issue, I think it depends on the how to define "go to implementation", jetbrains team seems to find the declaration first and then find the implementation, while TypeScript seems to consider whether it is a function call or a declaration. This pr follows jetbrains' approach, and it breaks some existing tests, I will close it if it is not a good fix.

