### PR TITLE
Have runtests always throw on failure, make rm stream signal end of read queue

### DIFF
--- a/scripts/build/tests.js
+++ b/scripts/build/tests.js
@@ -140,13 +140,8 @@ async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode,
     await deleteTemporaryProjectOutput();
 
     if (error !== undefined) {
-        if (watchMode) {
-            throw error;
-        }
-        else {
-            log.error(error);
-            process.exit(typeof errorStatus === "number" ? errorStatus : 2);
-        }
+        process.exitCode = typeof errorStatus === "number" ? errorStatus : 2;
+        throw error;
     }
 }
 exports.runConsoleTests = runConsoleTests;

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -340,6 +340,7 @@ function rm(dest, opts) {
             duplex.push(file);
             cb();
         }
+        duplex.push(null); // signal end of read queue
     };
 
     const duplex = new Duplex({


### PR DESCRIPTION
Our `rm` helper never pushed a `null` into the read stream to indicate end-of-stream, so `gulp` never detected the stream as having completed.

Fixes #30027

