### PR TITLE
Fix `.npmignore` by adding the `.git` file and the `.failed-tests` file.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,7 +12,11 @@ tests
 tslint.json
 Jakefile.js
 .editorconfig
+.failed-tests
+.git
+.git/
 .gitattributes
+.github/
 .gitmodules
 .settings/
 .travis.yml
@@ -23,6 +27,5 @@ Jakefile.js
 test.config
 package-lock.json
 yarn.lock
-.github/
 CONTRIBUTING.md
 TEST-results.xml


### PR DESCRIPTION
This fixes minor publishing issues in the presence of some intermediate build files and git worktrees (which older versions of npm had some trouble with as discussed in #30077)

Fixes #30077, validated by `npm publish --dry-run`.