### PR TITLE
Consistently error on circular constraints

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2589,6 +2589,10 @@
         "category": "Error",
         "code": 2750
     },
+    "Circularity originates in type at this location.": {
+        "category": "Error",
+        "code": 2751
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/recursiveMappedTypes.errors.txt
+++ b/tests/baselines/reference/recursiveMappedTypes.errors.txt
@@ -5,9 +5,10 @@ tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(8,11): error TS2313
 tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(11,6): error TS2456: Type alias 'Recurse2' circularly references itself.
 tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(12,11): error TS2313: Type parameter 'K' has a circular constraint.
 tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(20,19): error TS2589: Type instantiation is excessively deep and possibly infinite.
+tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(66,25): error TS2313: Type parameter 'P' has a circular constraint.
 
 
-==== tests/cases/conformance/types/mapped/recursiveMappedTypes.ts (7 errors) ====
+==== tests/cases/conformance/types/mapped/recursiveMappedTypes.ts (8 errors) ====
     // Recursive mapped types simply appear empty
     
     type Recurse = {
@@ -84,4 +85,25 @@ tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(20,19): error TS258
       
     type a = Remap1<string[]>;  // string[]
     type b = Remap2<string[]>;  // string[]
+    
+    // Repro from #29992
+    
+    type NonOptionalKeys<T> = { [P in keyof T]: undefined extends T[P] ? never : P }[keyof T];
+    type Child<T> = { [P in NonOptionalKeys<T>]: T[P] }
+                            ~~~~~~~~~~~~~~~~~~
+!!! error TS2313: Type parameter 'P' has a circular constraint.
+!!! related TS2751 tests/cases/conformance/types/mapped/recursiveMappedTypes.ts:79:1: Circularity originates in type at this location.
+    
+    export interface ListWidget {
+        "type": "list",
+        "minimum_count": number,
+        "maximum_count": number,
+        "collapsable"?: boolean, //default to false, means all expanded
+        "each": Child<ListWidget>;
+    }
+    
+    type ListChild = Child<ListWidget>
+    
+    declare let x: ListChild;
+    x.type;
     

--- a/tests/baselines/reference/recursiveMappedTypes.errors.txt
+++ b/tests/baselines/reference/recursiveMappedTypes.errors.txt
@@ -32,6 +32,7 @@ tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(20,19): error TS258
         [K in keyof Recurse1]: Recurse1[K]
               ~~~~~~~~~~~~~~
 !!! error TS2313: Type parameter 'K' has a circular constraint.
+!!! related TS2751 tests/cases/conformance/types/mapped/recursiveMappedTypes.ts:8:17: Circularity originates in type at this location.
     }
     
     // Repro from #27881

--- a/tests/baselines/reference/recursiveMappedTypes.js
+++ b/tests/baselines/reference/recursiveMappedTypes.js
@@ -61,6 +61,24 @@ type Remap2<T> = T extends object ? { [P in keyof T]: Remap2<T[P]>; } : T;
 type a = Remap1<string[]>;  // string[]
 type b = Remap2<string[]>;  // string[]
 
+// Repro from #29992
+
+type NonOptionalKeys<T> = { [P in keyof T]: undefined extends T[P] ? never : P }[keyof T];
+type Child<T> = { [P in NonOptionalKeys<T>]: T[P] }
+
+export interface ListWidget {
+    "type": "list",
+    "minimum_count": number,
+    "maximum_count": number,
+    "collapsable"?: boolean, //default to false, means all expanded
+    "each": Child<ListWidget>;
+}
+
+type ListChild = Child<ListWidget>
+
+declare let x: ListChild;
+x.type;
+
 
 //// [recursiveMappedTypes.js]
 "use strict";
@@ -70,9 +88,24 @@ function foo(arg) {
     return arg;
 }
 product.users; // (Transform<User> | Transform<Guest>)[]
+x.type;
 
 
 //// [recursiveMappedTypes.d.ts]
 export declare type Circular<T> = {
     [P in keyof T]: Circular<T>;
 };
+declare type NonOptionalKeys<T> = {
+    [P in keyof T]: undefined extends T[P] ? never : P;
+}[keyof T];
+declare type Child<T> = {
+    [P in NonOptionalKeys<T>]: T[P];
+};
+export interface ListWidget {
+    "type": "list";
+    "minimum_count": number;
+    "maximum_count": number;
+    "collapsable"?: boolean;
+    "each": Child<ListWidget>;
+}
+export {};

--- a/tests/baselines/reference/recursiveMappedTypes.symbols
+++ b/tests/baselines/reference/recursiveMappedTypes.symbols
@@ -165,3 +165,57 @@ type b = Remap2<string[]>;  // string[]
 >b : Symbol(b, Decl(recursiveMappedTypes.ts, 59, 26))
 >Remap2 : Symbol(Remap2, Decl(recursiveMappedTypes.ts, 56, 51))
 
+// Repro from #29992
+
+type NonOptionalKeys<T> = { [P in keyof T]: undefined extends T[P] ? never : P }[keyof T];
+>NonOptionalKeys : Symbol(NonOptionalKeys, Decl(recursiveMappedTypes.ts, 60, 26))
+>T : Symbol(T, Decl(recursiveMappedTypes.ts, 64, 21))
+>P : Symbol(P, Decl(recursiveMappedTypes.ts, 64, 29))
+>T : Symbol(T, Decl(recursiveMappedTypes.ts, 64, 21))
+>T : Symbol(T, Decl(recursiveMappedTypes.ts, 64, 21))
+>P : Symbol(P, Decl(recursiveMappedTypes.ts, 64, 29))
+>P : Symbol(P, Decl(recursiveMappedTypes.ts, 64, 29))
+>T : Symbol(T, Decl(recursiveMappedTypes.ts, 64, 21))
+
+type Child<T> = { [P in NonOptionalKeys<T>]: T[P] }
+>Child : Symbol(Child, Decl(recursiveMappedTypes.ts, 64, 90))
+>T : Symbol(T, Decl(recursiveMappedTypes.ts, 65, 11))
+>P : Symbol(P, Decl(recursiveMappedTypes.ts, 65, 19))
+>NonOptionalKeys : Symbol(NonOptionalKeys, Decl(recursiveMappedTypes.ts, 60, 26))
+>T : Symbol(T, Decl(recursiveMappedTypes.ts, 65, 11))
+>T : Symbol(T, Decl(recursiveMappedTypes.ts, 65, 11))
+>P : Symbol(P, Decl(recursiveMappedTypes.ts, 65, 19))
+
+export interface ListWidget {
+>ListWidget : Symbol(ListWidget, Decl(recursiveMappedTypes.ts, 65, 51))
+
+    "type": "list",
+>"type" : Symbol(ListWidget["type"], Decl(recursiveMappedTypes.ts, 67, 29))
+
+    "minimum_count": number,
+>"minimum_count" : Symbol(ListWidget["minimum_count"], Decl(recursiveMappedTypes.ts, 68, 19))
+
+    "maximum_count": number,
+>"maximum_count" : Symbol(ListWidget["maximum_count"], Decl(recursiveMappedTypes.ts, 69, 28))
+
+    "collapsable"?: boolean, //default to false, means all expanded
+>"collapsable" : Symbol(ListWidget["collapsable"], Decl(recursiveMappedTypes.ts, 70, 28))
+
+    "each": Child<ListWidget>;
+>"each" : Symbol(ListWidget["each"], Decl(recursiveMappedTypes.ts, 71, 28))
+>Child : Symbol(Child, Decl(recursiveMappedTypes.ts, 64, 90))
+>ListWidget : Symbol(ListWidget, Decl(recursiveMappedTypes.ts, 65, 51))
+}
+
+type ListChild = Child<ListWidget>
+>ListChild : Symbol(ListChild, Decl(recursiveMappedTypes.ts, 73, 1))
+>Child : Symbol(Child, Decl(recursiveMappedTypes.ts, 64, 90))
+>ListWidget : Symbol(ListWidget, Decl(recursiveMappedTypes.ts, 65, 51))
+
+declare let x: ListChild;
+>x : Symbol(x, Decl(recursiveMappedTypes.ts, 77, 11))
+>ListChild : Symbol(ListChild, Decl(recursiveMappedTypes.ts, 73, 1))
+
+x.type;
+>x : Symbol(x, Decl(recursiveMappedTypes.ts, 77, 11))
+

--- a/tests/baselines/reference/recursiveMappedTypes.types
+++ b/tests/baselines/reference/recursiveMappedTypes.types
@@ -97,3 +97,39 @@ type a = Remap1<string[]>;  // string[]
 type b = Remap2<string[]>;  // string[]
 >b : string[]
 
+// Repro from #29992
+
+type NonOptionalKeys<T> = { [P in keyof T]: undefined extends T[P] ? never : P }[keyof T];
+>NonOptionalKeys : { [P in keyof T]: undefined extends T[P] ? never : P; }[keyof T]
+
+type Child<T> = { [P in NonOptionalKeys<T>]: T[P] }
+>Child : Child<T>
+
+export interface ListWidget {
+    "type": "list",
+>"type" : "list"
+
+    "minimum_count": number,
+>"minimum_count" : number
+
+    "maximum_count": number,
+>"maximum_count" : number
+
+    "collapsable"?: boolean, //default to false, means all expanded
+>"collapsable" : boolean
+
+    "each": Child<ListWidget>;
+>"each" : Child<ListWidget>
+}
+
+type ListChild = Child<ListWidget>
+>ListChild : Child<ListWidget>
+
+declare let x: ListChild;
+>x : Child<ListWidget>
+
+x.type;
+>x.type : any
+>x : Child<ListWidget>
+>type : any
+

--- a/tests/cases/conformance/types/mapped/recursiveMappedTypes.ts
+++ b/tests/cases/conformance/types/mapped/recursiveMappedTypes.ts
@@ -61,3 +61,21 @@ type Remap2<T> = T extends object ? { [P in keyof T]: Remap2<T[P]>; } : T;
   
 type a = Remap1<string[]>;  // string[]
 type b = Remap2<string[]>;  // string[]
+
+// Repro from #29992
+
+type NonOptionalKeys<T> = { [P in keyof T]: undefined extends T[P] ? never : P }[keyof T];
+type Child<T> = { [P in NonOptionalKeys<T>]: T[P] }
+
+export interface ListWidget {
+    "type": "list",
+    "minimum_count": number,
+    "maximum_count": number,
+    "collapsable"?: boolean, //default to false, means all expanded
+    "each": Child<ListWidget>;
+}
+
+type ListChild = Child<ListWidget>
+
+declare let x: ListChild;
+x.type;


### PR DESCRIPTION
With this PR we consistently error when detecting circular constraints. In particular, we now report errors when circularities occur during instantiation but not when checking the original declaration. When the node currently being checked (the node referenced by `currentNode`) is neither a descendant nor an ancestor of the constraint type node, we also report the current node as the associated source location in which the circularity originates.

Fixes #29992.