### PR TITLE
Add assignability rule relaxing the assignability of partial mapped types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12678,7 +12678,7 @@ namespace ts {
                             const hasOptionalUnionKeys = modifiers & MappedTypeModifiers.IncludeOptional && targetConstraint.flags & TypeFlags.Union;
                             const filteredByApplicability = hasOptionalUnionKeys ? filterType(targetConstraint, t => !!isRelatedTo(t, sourceKeys)) : undefined;
                             // A source type T is related to a target type { [P in Q]: X } if Q is related to keyof T and T[Q] is related to X.
-                            // A source type T is related to a target type { [P in Q]?: X } if some Q = Q' is related to keyof T and T[Q'] is related to X.
+                            // A source type T is related to a target type { [P in Q]?: X } if some constituent Q' of Q is related to keyof T and T[Q'] is related to X.
                             if (hasOptionalUnionKeys
                                     ? !(filteredByApplicability!.flags & TypeFlags.Never)
                                     : isRelatedTo(targetConstraint, sourceKeys)) {

--- a/tests/baselines/reference/mappedTypePartialNonHomomorphicBaseConstraint.js
+++ b/tests/baselines/reference/mappedTypePartialNonHomomorphicBaseConstraint.js
@@ -1,0 +1,21 @@
+//// [mappedTypePartialNonHomomorphicBaseConstraint.ts]
+export type Errors<D> = { readonly [K in keyof D | "base"]?: string[] };
+
+class Model<D> {
+  getErrors(): Errors<D> {
+    return { base: ["some base error"] };
+  }
+}
+
+
+//// [mappedTypePartialNonHomomorphicBaseConstraint.js]
+"use strict";
+exports.__esModule = true;
+var Model = /** @class */ (function () {
+    function Model() {
+    }
+    Model.prototype.getErrors = function () {
+        return { base: ["some base error"] };
+    };
+    return Model;
+}());

--- a/tests/baselines/reference/mappedTypePartialNonHomomorphicBaseConstraint.symbols
+++ b/tests/baselines/reference/mappedTypePartialNonHomomorphicBaseConstraint.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/mappedTypePartialNonHomomorphicBaseConstraint.ts ===
+export type Errors<D> = { readonly [K in keyof D | "base"]?: string[] };
+>Errors : Symbol(Errors, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 0, 0))
+>D : Symbol(D, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 0, 19))
+>K : Symbol(K, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 0, 36))
+>D : Symbol(D, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 0, 19))
+
+class Model<D> {
+>Model : Symbol(Model, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 0, 72))
+>D : Symbol(D, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 2, 12))
+
+  getErrors(): Errors<D> {
+>getErrors : Symbol(Model.getErrors, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 2, 16))
+>Errors : Symbol(Errors, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 0, 0))
+>D : Symbol(D, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 2, 12))
+
+    return { base: ["some base error"] };
+>base : Symbol(base, Decl(mappedTypePartialNonHomomorphicBaseConstraint.ts, 4, 12))
+  }
+}
+

--- a/tests/baselines/reference/mappedTypePartialNonHomomorphicBaseConstraint.types
+++ b/tests/baselines/reference/mappedTypePartialNonHomomorphicBaseConstraint.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/mappedTypePartialNonHomomorphicBaseConstraint.ts ===
+export type Errors<D> = { readonly [K in keyof D | "base"]?: string[] };
+>Errors : Errors<D>
+
+class Model<D> {
+>Model : Model<D>
+
+  getErrors(): Errors<D> {
+>getErrors : () => Errors<D>
+
+    return { base: ["some base error"] };
+>{ base: ["some base error"] } : { base: string[]; }
+>base : string[]
+>["some base error"] : string[]
+>"some base error" : "some base error"
+  }
+}
+

--- a/tests/cases/compiler/mappedTypePartialNonHomomorphicBaseConstraint.ts
+++ b/tests/cases/compiler/mappedTypePartialNonHomomorphicBaseConstraint.ts
@@ -1,0 +1,7 @@
+export type Errors<D> = { readonly [K in keyof D | "base"]?: string[] };
+
+class Model<D> {
+  getErrors(): Errors<D> {
+    return { base: ["some base error"] };
+  }
+}


### PR DESCRIPTION
Fixes #30081

The usual rule right now is that all the keys in the target mapped type's constraint must be assignable to the source's keys. With this change, for partial mapped types, only _some_ key of the partial mapped type must be assignable to the source's keys (and then only with those keys do we index into the source to compare values).