### PR TITLE
Swap KeywordCompletionFilter in filter globalcompletion to use all

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1073,7 +1073,7 @@ namespace ts.Completions {
         function filterGlobalCompletion(symbols: Symbol[]): void {
             const isTypeOnly = isTypeOnlyCompletion();
             const allowTypes = isTypeOnly || !isContextTokenValueLocation(contextToken) && isPossiblyTypeArgumentPosition(contextToken, sourceFile, typeChecker);
-            if (isTypeOnly) keywordFilters = KeywordCompletionFilters.TypeKeywords;
+            if (isTypeOnly) keywordFilters = KeywordCompletionFilters.All;
 
             filterMutate(symbols, symbol => {
                 if (!isSourceFile(location)) {
@@ -1101,7 +1101,7 @@ namespace ts.Completions {
                 // expressions are value space (which includes the value namespaces)
                 return !!(getCombinedLocalAndExportSymbolFlags(symbol) & SymbolFlags.Value);
             });
-        }
+    }
 
         function isTypeOnlyCompletion(): boolean {
             return insideJsDocTagTypeExpression || !isContextTokenValueLocation(contextToken) && (isPartOfTypeNode(location) || isContextTokenTypeLocation(contextToken));

--- a/tests/cases/fourslash/completionListAsConst.ts
+++ b/tests/cases/fourslash/completionListAsConst.ts
@@ -1,0 +1,5 @@
+/// <reference path='fourslash.ts'/>
+
+////1 as con/*1*/
+
+verify.completions({marker:"1", includes:"const"});

--- a/tests/cases/fourslash/completionListReadonlyType.ts
+++ b/tests/cases/fourslash/completionListReadonlyType.ts
@@ -1,0 +1,5 @@
+/// <reference path='fourslash.ts'/>
+
+////type T = read/*1*/
+
+verify.completions({marker:"1", includes:"readonly"});


### PR DESCRIPTION
Fixes #29658 and #29666.
The completions service fetches the keywords from the subset that did not contained the correct keyword to autocomplete. 
Now it fetches all keywords, which is guaranteed to contain the correct one.
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

