### PR TITLE
updated error message 8020 to 'expected '}' or ';''

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24127,7 +24127,7 @@ namespace ts {
         function checkTypeReferenceNode(node: TypeReferenceNode | ExpressionWithTypeArguments) {
             checkGrammarTypeArguments(node, node.typeArguments);
             if (node.kind === SyntaxKind.TypeReference && node.typeName.jsdocDotPos !== undefined && !isInJSFile(node) && !isInJSDoc(node)) {
-                grammarErrorAtPos(node, node.typeName.jsdocDotPos, 1, Diagnostics.JSDoc_types_can_only_be_used_inside_documentation_comments);
+                grammarErrorAtPos(node, node.typeName.jsdocDotPos, 1, Diagnostics.Expected_or);
             }
             const type = getTypeFromTypeReference(node);
             if (type !== errorType) {
@@ -28305,7 +28305,7 @@ namespace ts {
 
         function checkJSDocTypeIsInJsFile(node: Node): void {
             if (!isInJSFile(node)) {
-                grammarErrorOnNode(node, Diagnostics.JSDoc_types_can_only_be_used_inside_documentation_comments);
+                grammarErrorOnNode(node, Diagnostics.Expected_or);
             }
         }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4270,7 +4270,7 @@
         "category": "Message",
         "code": 8019
     },
-    "JSDoc types can only be used inside documentation comments.": {
+    "Expected '}' or ';'.": {
         "category": "Error",
         "code": 8020
     },

--- a/src/services/codefixes/fixJSDocTypes.ts
+++ b/src/services/codefixes/fixJSDocTypes.ts
@@ -2,7 +2,7 @@
 namespace ts.codefix {
     const fixIdPlain = "fixJSDocTypes_plain";
     const fixIdNullable = "fixJSDocTypes_nullable";
-    const errorCodes = [Diagnostics.JSDoc_types_can_only_be_used_inside_documentation_comments.code];
+    const errorCodes = [Diagnostics.Expected_or.code];
     registerCodeFix({
         errorCodes,
         getCodeActions(context) {

--- a/tests/baselines/reference/jsdocDisallowedInTypescript.errors.txt
+++ b/tests/baselines/reference/jsdocDisallowedInTypescript.errors.txt
@@ -1,75 +1,75 @@
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(2,15): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(4,15): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(4,32): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(7,20): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(10,18): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(2,15): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(4,15): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(4,32): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(7,20): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(10,18): error TS8020: Expected '}' or ';'.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(11,12): error TS2554: Expected 1 arguments, but got 2.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(13,14): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(14,11): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(15,8): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(16,11): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(17,17): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(13,14): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(14,11): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(15,8): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(16,11): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(17,17): error TS8020: Expected '}' or ';'.
 tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(18,5): error TS2322: Type 'undefined' is not assignable to type 'number | null'.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(18,17): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(20,16): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(21,16): error TS8020: JSDoc types can only be used inside documentation comments.
-tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(22,17): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(18,17): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(20,16): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(21,16): error TS8020: Expected '}' or ';'.
+tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts(22,17): error TS8020: Expected '}' or ';'.
 
 
 ==== tests/cases/conformance/jsdoc/jsdocDisallowedInTypescript.ts (16 errors) ====
     // grammar error from checker
     var ara: Array.<number> = [1,2,3];
                   ~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     
     function f(x: ?number, y: Array.<number>) {
                   ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
                                    ~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
         return x ? x + y[1] : y[0];
     }
     function hof(ctor: function(new: number, string)) {
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
         return new ctor('hi');
     }
     function hof2(f: function(this: number, string): string) {
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
         return f(12, 'hullo');
                ~~~~~~~~~~~~~~
 !!! error TS2554: Expected 1 arguments, but got 2.
     }
     var whatevs: * = 1001;
                  ~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     var ques: ? = 'what';
               ~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     var g: function(number, number): number = (n,m) => n + m;
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     var most: !string = 'definite';
               ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     var postfixdef: number! = 101;
                     ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     var postfixopt: number? = undefined;
         ~~~~~~~~~~
 !!! error TS2322: Type 'undefined' is not assignable to type 'number | null'.
                     ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     
     var nns: Array<?number>;
                    ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     var dns: Array<!number>;
                    ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     var anys: Array<*>;
                     ~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     
     

--- a/tests/baselines/reference/restTupleElements1.errors.txt
+++ b/tests/baselines/reference/restTupleElements1.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/types/tuple/restTupleElements1.ts(3,22): error TS1257: A
 tests/cases/conformance/types/tuple/restTupleElements1.ts(8,13): error TS1256: A rest element must be last in a tuple type.
 tests/cases/conformance/types/tuple/restTupleElements1.ts(9,13): error TS2574: A rest element type must be an array type.
 tests/cases/conformance/types/tuple/restTupleElements1.ts(10,13): error TS2574: A rest element type must be an array type.
-tests/cases/conformance/types/tuple/restTupleElements1.ts(10,16): error TS8020: JSDoc types can only be used inside documentation comments.
+tests/cases/conformance/types/tuple/restTupleElements1.ts(10,16): error TS8020: Expected '}' or ';'.
 tests/cases/conformance/types/tuple/restTupleElements1.ts(23,31): error TS2344: Type 'number[]' does not satisfy the constraint '[number, ...number[]]'.
   Property '0' is missing in type 'number[]' but required in type '[number, ...number[]]'.
 tests/cases/conformance/types/tuple/restTupleElements1.ts(24,31): error TS2344: Type '[]' does not satisfy the constraint '[number, ...number[]]'.
@@ -46,7 +46,7 @@ tests/cases/conformance/types/tuple/restTupleElements1.ts(59,4): error TS2345: A
                 ~~~~~~~~~~
 !!! error TS2574: A rest element type must be an array type.
                    ~~~~~~~
-!!! error TS8020: JSDoc types can only be used inside documentation comments.
+!!! error TS8020: Expected '}' or ';'.
     type T10 = [string, ...[...string[]]];
     type T11 = [string, ...[...[...string[]]]];
     


### PR DESCRIPTION
### Related Issue
#29648 
Error message 8020("JSDoc types can only be used inside documentation comments") is actually caused because of syntax error not related to JSDoc. Updated error message to "Expected '}' or ';'" to provide better understanding.