### PR TITLE
Wrong super keyword async scope resolution

### DIFF
--- a/tests/baselines/reference/asyncMethodWithSuperConflict_es6.js
+++ b/tests/baselines/reference/asyncMethodWithSuperConflict_es6.js
@@ -56,6 +56,14 @@ class B extends A {
         // destructuring assign with element access
         ({ f: super["x"] } = { f });
     }
+
+    // inner async super call
+    async inner() {
+        (async () => {
+            super["x"]();
+            super.x();
+        })();
+    }
 }
 
 
@@ -126,6 +134,19 @@ class B extends A {
             ({ f: _super_1.x } = { f });
             // destructuring assign with element access
             ({ f: _superIndex_1("x").value } = { f });
+        });
+    }
+    // inner async super call
+    inner() {
+        const _superIndex_1 = name => super[name];
+        const _super_1 = Object.create(null, {
+            x: { get: () => super.x }
+        });
+        return __awaiter(this, void 0, void 0, function* () {
+            (() => __awaiter(this, void 0, void 0, function* () {
+                _superIndex_1("x").call(this);
+                _super_1.x.call(this);
+            }))();
         });
     }
 }

--- a/tests/baselines/reference/asyncMethodWithSuperConflict_es6.symbols
+++ b/tests/baselines/reference/asyncMethodWithSuperConflict_es6.symbols
@@ -120,5 +120,22 @@ class B extends A {
 >"x" : Symbol(A.x, Decl(asyncMethodWithSuperConflict_es6.ts, 0, 9))
 >f : Symbol(f, Decl(asyncMethodWithSuperConflict_es6.ts, 55, 30))
     }
+
+    // inner async super call
+    async inner() {
+>inner : Symbol(B.inner, Decl(asyncMethodWithSuperConflict_es6.ts, 56, 5))
+
+        (async () => {
+            super["x"]();
+>super : Symbol(A, Decl(asyncMethodWithSuperConflict_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuperConflict_es6.ts, 0, 9))
+
+            super.x();
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuperConflict_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuperConflict_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuperConflict_es6.ts, 0, 9))
+
+        })();
+    }
 }
 

--- a/tests/baselines/reference/asyncMethodWithSuperConflict_es6.types
+++ b/tests/baselines/reference/asyncMethodWithSuperConflict_es6.types
@@ -146,5 +146,29 @@ class B extends A {
 >{ f } : { f: () => void; }
 >f : () => void
     }
+
+    // inner async super call
+    async inner() {
+>inner : () => Promise<void>
+
+        (async () => {
+>(async () => {            super["x"]();            super.x();        })() : Promise<void>
+>(async () => {            super["x"]();            super.x();        }) : () => Promise<void>
+>async () => {            super["x"]();            super.x();        } : () => Promise<void>
+
+            super["x"]();
+>super["x"]() : void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+
+            super.x();
+>super.x() : void
+>super.x : () => void
+>super : A
+>x : () => void
+
+        })();
+    }
 }
 

--- a/tests/baselines/reference/asyncMethodWithSuper_es2017.js
+++ b/tests/baselines/reference/asyncMethodWithSuper_es2017.js
@@ -52,6 +52,14 @@ class B extends A {
         // destructuring assign with element access
         ({ f: super["x"] } = { f });
     }
+
+    // inner async super call
+    async inner() {
+        (async () => {
+            super["x"]();
+            super.x();
+        })();
+    }
 }
 
 
@@ -95,5 +103,12 @@ class B extends A {
         ({ f: super.x } = { f });
         // destructuring assign with element access
         ({ f: super["x"] } = { f });
+    }
+    // inner async super call
+    async inner() {
+        (async () => {
+            super["x"]();
+            super.x();
+        })();
     }
 }

--- a/tests/baselines/reference/asyncMethodWithSuper_es2017.symbols
+++ b/tests/baselines/reference/asyncMethodWithSuper_es2017.symbols
@@ -108,5 +108,22 @@ class B extends A {
 >"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es2017.ts, 0, 9))
 >f : Symbol(f, Decl(asyncMethodWithSuper_es2017.ts, 51, 30))
     }
+
+    // inner async super call
+    async inner() {
+>inner : Symbol(B.inner, Decl(asyncMethodWithSuper_es2017.ts, 52, 5))
+
+        (async () => {
+            super["x"]();
+>super : Symbol(A, Decl(asyncMethodWithSuper_es2017.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es2017.ts, 0, 9))
+
+            super.x();
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es2017.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es2017.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es2017.ts, 0, 9))
+
+        })();
+    }
 }
 

--- a/tests/baselines/reference/asyncMethodWithSuper_es2017.types
+++ b/tests/baselines/reference/asyncMethodWithSuper_es2017.types
@@ -130,5 +130,29 @@ class B extends A {
 >{ f } : { f: () => void; }
 >f : () => void
     }
+
+    // inner async super call
+    async inner() {
+>inner : () => Promise<void>
+
+        (async () => {
+>(async () => {            super["x"]();            super.x();        })() : Promise<void>
+>(async () => {            super["x"]();            super.x();        }) : () => Promise<void>
+>async () => {            super["x"]();            super.x();        } : () => Promise<void>
+
+            super["x"]();
+>super["x"]() : void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+
+            super.x();
+>super.x() : void
+>super.x : () => void
+>super : A
+>x : () => void
+
+        })();
+    }
 }
 

--- a/tests/baselines/reference/asyncMethodWithSuper_es5.js
+++ b/tests/baselines/reference/asyncMethodWithSuper_es5.js
@@ -52,6 +52,14 @@ class B extends A {
         // destructuring assign with element access
         ({ f: super["x"] } = { f });
     }
+
+    // inner async super call
+    async inner() {
+        (async () => {
+            super["x"]();
+            super.x();
+        })();
+    }
 }
 
 
@@ -107,6 +115,22 @@ var B = /** @class */ (function (_super) {
                 (_super.prototype.x = { f: f }.f);
                 // destructuring assign with element access
                 (_super.prototype["x"] = { f: f }.f);
+                return [2 /*return*/];
+            });
+        });
+    };
+    // inner async super call
+    B.prototype.inner = function () {
+        return __awaiter(this, void 0, void 0, function () {
+            var _this = this;
+            return __generator(this, function (_a) {
+                (function () { return __awaiter(_this, void 0, void 0, function () {
+                    return __generator(this, function (_a) {
+                        _super.prototype["x"].call(this);
+                        _super.prototype.x.call(this);
+                        return [2 /*return*/];
+                    });
+                }); })();
                 return [2 /*return*/];
             });
         });

--- a/tests/baselines/reference/asyncMethodWithSuper_es5.symbols
+++ b/tests/baselines/reference/asyncMethodWithSuper_es5.symbols
@@ -108,5 +108,22 @@ class B extends A {
 >"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es5.ts, 0, 9))
 >f : Symbol(f, Decl(asyncMethodWithSuper_es5.ts, 51, 30))
     }
+
+    // inner async super call
+    async inner() {
+>inner : Symbol(B.inner, Decl(asyncMethodWithSuper_es5.ts, 52, 5))
+
+        (async () => {
+            super["x"]();
+>super : Symbol(A, Decl(asyncMethodWithSuper_es5.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es5.ts, 0, 9))
+
+            super.x();
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es5.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es5.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es5.ts, 0, 9))
+
+        })();
+    }
 }
 

--- a/tests/baselines/reference/asyncMethodWithSuper_es5.types
+++ b/tests/baselines/reference/asyncMethodWithSuper_es5.types
@@ -130,5 +130,29 @@ class B extends A {
 >{ f } : { f: () => void; }
 >f : () => void
     }
+
+    // inner async super call
+    async inner() {
+>inner : () => Promise<void>
+
+        (async () => {
+>(async () => {            super["x"]();            super.x();        })() : Promise<void>
+>(async () => {            super["x"]();            super.x();        }) : () => Promise<void>
+>async () => {            super["x"]();            super.x();        } : () => Promise<void>
+
+            super["x"]();
+>super["x"]() : void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+
+            super.x();
+>super.x() : void
+>super.x : () => void
+>super : A
+>x : () => void
+
+        })();
+    }
 }
 

--- a/tests/baselines/reference/asyncMethodWithSuper_es6.js
+++ b/tests/baselines/reference/asyncMethodWithSuper_es6.js
@@ -52,6 +52,14 @@ class B extends A {
         // destructuring assign with element access
         ({ f: super["x"] } = { f });
     }
+
+    // inner async super call
+    async inner() {
+        (async () => {
+            super["x"]();
+            super.x();
+        })();
+    }
 }
 
 
@@ -110,6 +118,19 @@ class B extends A {
             ({ f: _super.x } = { f });
             // destructuring assign with element access
             ({ f: _superIndex("x").value } = { f });
+        });
+    }
+    // inner async super call
+    inner() {
+        const _superIndex = name => super[name];
+        const _super = Object.create(null, {
+            x: { get: () => super.x }
+        });
+        return __awaiter(this, void 0, void 0, function* () {
+            (() => __awaiter(this, void 0, void 0, function* () {
+                _superIndex("x").call(this);
+                _super.x.call(this);
+            }))();
         });
     }
 }

--- a/tests/baselines/reference/asyncMethodWithSuper_es6.symbols
+++ b/tests/baselines/reference/asyncMethodWithSuper_es6.symbols
@@ -108,5 +108,22 @@ class B extends A {
 >"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
 >f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 51, 30))
     }
+
+    // inner async super call
+    async inner() {
+>inner : Symbol(B.inner, Decl(asyncMethodWithSuper_es6.ts, 52, 5))
+
+        (async () => {
+            super["x"]();
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+
+            super.x();
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+
+        })();
+    }
 }
 

--- a/tests/baselines/reference/asyncMethodWithSuper_es6.types
+++ b/tests/baselines/reference/asyncMethodWithSuper_es6.types
@@ -130,5 +130,29 @@ class B extends A {
 >{ f } : { f: () => void; }
 >f : () => void
     }
+
+    // inner async super call
+    async inner() {
+>inner : () => Promise<void>
+
+        (async () => {
+>(async () => {            super["x"]();            super.x();        })() : Promise<void>
+>(async () => {            super["x"]();            super.x();        }) : () => Promise<void>
+>async () => {            super["x"]();            super.x();        } : () => Promise<void>
+
+            super["x"]();
+>super["x"]() : void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+
+            super.x();
+>super.x() : void
+>super.x : () => void
+>super : A
+>x : () => void
+
+        })();
+    }
 }
 

--- a/tests/cases/conformance/async/es2017/asyncMethodWithSuperConflict_es6.ts
+++ b/tests/cases/conformance/async/es2017/asyncMethodWithSuperConflict_es6.ts
@@ -56,4 +56,12 @@ class B extends A {
         // destructuring assign with element access
         ({ f: super["x"] } = { f });
     }
+
+    // inner async super call
+    async inner() {
+        (async () => {
+            super["x"]();
+            super.x();
+        })();
+    }
 }

--- a/tests/cases/conformance/async/es2017/asyncMethodWithSuper_es2017.ts
+++ b/tests/cases/conformance/async/es2017/asyncMethodWithSuper_es2017.ts
@@ -53,4 +53,12 @@ class B extends A {
         // destructuring assign with element access
         ({ f: super["x"] } = { f });
     }
+
+    // inner async super call
+    async inner() {
+        (async () => {
+            super["x"]();
+            super.x();
+        })();
+    }
 }

--- a/tests/cases/conformance/async/es5/asyncMethodWithSuper_es5.ts
+++ b/tests/cases/conformance/async/es5/asyncMethodWithSuper_es5.ts
@@ -54,4 +54,12 @@ class B extends A {
         // destructuring assign with element access
         ({ f: super["x"] } = { f });
     }
+
+    // inner async super call
+    async inner() {
+        (async () => {
+            super["x"]();
+            super.x();
+        })();
+    }
 }

--- a/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
@@ -53,4 +53,12 @@ class B extends A {
         // destructuring assign with element access
         ({ f: super["x"] } = { f });
     }
+
+    // inner async super call
+    async inner() {
+        (async () => {
+            super["x"]();
+            super.x();
+        })();
+    }
 }


### PR DESCRIPTION
Fix runtime error when calling the super methods class within nested async functions.

Fixes #30066 

A simpler way to reproduce it:

```ts
class A {
    x() {
    }
}

class B extends A {
    // inner async super call
    async inner() {
        (async () => {
            super["x"]();
        })();
    }
}

new B().inner();
```

This patch already fixes the bug when you're calling directly a method inside an inner async function and the compiler does not generate the _super variable.

```ts
class A {
    x() {
    }
}

class B extends A {
    // inner async super call
    async inner() {
        (async () => {
            super.x();
        })();
    }
}

new B().inner();
```