### PR TITLE
Better typings of Object.keys when keys coming from enum

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -258,6 +258,12 @@ interface ObjectConstructor {
       * Returns the names of the enumerable properties and methods of an object.
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
+    keys<EnumType extends string>(o: { [K in EnumType]: any }): EnumType[];
+
+    /**
+      * Returns the names of the enumerable properties and methods of an object.
+      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+      */
     keys(o: {}): string[];
 }
 

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -238,6 +238,12 @@ interface ObjectConstructor {
       * Returns the names of the enumerable properties and methods of an object.
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
+    keys<EnumType extends string>(o: { [K in EnumType]: any }): EnumType[];
+
+    /**
+      * Returns the names of the enumerable properties and methods of an object.
+      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+      */
     keys(o: {}): string[];
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #13254

For the record, back in 2016, there was a [comment](https://github.com/Microsoft/TypeScript/pull/12253#issuecomment-263132208) from @ahejlsberg stating that using `keys<T>(o: T): Array<keyof T>` would not be safe because:

> Calling Object.keys with a Base would return a (keyof Base)[] which is almost certainly wrong

In this precise case an instance of `{ [K in EnumOfStrings]: any }` cannot define keys outside of `EnumOfStrings` so I think it would be OK.

The PR would at least improve the typings of objects taking their values from enums of strings.

Tested on TypeScript playground:

```ts
enum MyKeys {
    A = 'key-a',
    B = 'key-b'
}

type MyObj = { [key in MyKeys]: string };

const o: MyObj = {
    [MyKeys.A]: 'a',
    [MyKeys.B]: 'b',
//    '3': '4' // impossible to have other keys
}

function Object_keys_new<KeyType extends string>(obj: { [key in KeyType]: any }): KeyType[];
function Object_keys_new(obj: {}): string[];
function Object_keys_new(obj: {}): string[] {
    return [];
}

// const a: MyKeys[] = Object.keys(o); // today: type is string[]
const b: string[] = Object.keys({});

const c: MyKeys[] = Object_keys_new(o);
const d: string[] = Object_keys_new({});
```

More [here](https://www.typescriptlang.org/play/index.html#src=enum%20MyKeys%20%7B%0D%0A%20%20%20%20A%20%3D%20'key-a'%2C%0D%0A%20%20%20%20B%20%3D%20'key-b'%0D%0A%7D%0D%0A%0D%0Atype%20MyObj%20%3D%20%7B%20%5Bkey%20in%20MyKeys%5D%3A%20string%20%7D%3B%0D%0A%0D%0Aconst%20o%3A%20MyObj%20%3D%20%7B%0D%0A%20%20%20%20%5BMyKeys.A%5D%3A%20'a'%2C%0D%0A%20%20%20%20%5BMyKeys.B%5D%3A%20'b'%2C%0D%0A%2F%2F%20%20%20%20'3'%3A%20'4'%20%2F%2F%20impossible%20to%20have%20other%20keys%0D%0A%7D%0D%0A%0D%0Afunction%20Object_keys_new%3CKeyType%20extends%20string%3E(obj%3A%20%7B%20%5Bkey%20in%20KeyType%5D%3A%20any%20%7D)%3A%20KeyType%5B%5D%3B%0D%0Afunction%20Object_keys_new(obj%3A%20%7B%7D)%3A%20string%5B%5D%3B%0D%0Afunction%20Object_keys_new(obj%3A%20%7B%7D)%3A%20string%5B%5D%20%7B%0D%0A%20%20%20%20return%20%5B%5D%3B%0D%0A%7D%0D%0A%0D%0A%2F%2F%20const%20a%3A%20MyKeys%5B%5D%20%3D%20Object.keys(o)%3B%20%2F%2F%20today%3A%20type%20is%20string%5B%5D%0D%0Aconst%20b%3A%20string%5B%5D%20%3D%20Object.keys(%7B%7D)%3B%0D%0A%0D%0Aconst%20c%3A%20MyKeys%5B%5D%20%3D%20Object_keys_new(o)%3B%0D%0Aconst%20d%3A%20string%5B%5D%20%3D%20Object_keys_new(%7B%7D)%3B%0D%0A)
