### PR TITLE
Instantiating a signature in the context of another should infer from return type predicates if they match up

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20042,6 +20042,12 @@ namespace ts {
             });
             if (!contextualMapper) {
                 inferTypes(context.inferences, getReturnTypeOfSignature(contextualSignature), getReturnTypeOfSignature(signature), InferencePriority.ReturnType);
+                const signaturePredicate = getTypePredicateOfSignature(signature);
+                const contextualPredicate = getTypePredicateOfSignature(sourceSignature);
+                if (signaturePredicate && contextualPredicate && signaturePredicate.kind === contextualPredicate.kind &&
+                    (signaturePredicate.kind !== TypePredicateKind.Identifier || signaturePredicate.parameterIndex === (contextualPredicate as IdentifierTypePredicate).parameterIndex)) {
+                    inferTypes(context.inferences, contextualPredicate.type, signaturePredicate.type, InferencePriority.ReturnType);
+                }
             }
             return getSignatureInstantiation(signature, getInferredTypes(context), isInJSFile(contextualSignature.declaration));
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20045,7 +20045,7 @@ namespace ts {
                 const signaturePredicate = getTypePredicateOfSignature(signature);
                 const contextualPredicate = getTypePredicateOfSignature(sourceSignature);
                 if (signaturePredicate && contextualPredicate && signaturePredicate.kind === contextualPredicate.kind &&
-                    (signaturePredicate.kind !== TypePredicateKind.Identifier || signaturePredicate.parameterIndex === (contextualPredicate as IdentifierTypePredicate).parameterIndex)) {
+                    (signaturePredicate.kind === TypePredicateKind.This || signaturePredicate.parameterIndex === (contextualPredicate as IdentifierTypePredicate).parameterIndex)) {
                     inferTypes(context.inferences, contextualPredicate.type, signaturePredicate.type, InferencePriority.ReturnType);
                 }
             }

--- a/tests/baselines/reference/returnTypePredicateIsInstantiateInContextOfTarget.js
+++ b/tests/baselines/reference/returnTypePredicateIsInstantiateInContextOfTarget.js
@@ -1,0 +1,49 @@
+//// [returnTypePredicateIsInstantiateInContextOfTarget.tsx]
+/// <reference path="/.lib/react16.d.ts" />
+import * as React from "react";
+class TestComponent extends React.Component<{ isAny: <T>(obj: any) => obj is T }> {
+    static defaultProps = {
+        isAny: TestComponent.isAny
+    }
+
+    // Type guard is defined as a static class property
+    static isAny<T>(obj: any): obj is T {
+        return true;
+    }
+}
+
+const TestRender = () => <TestComponent />;
+
+//// [returnTypePredicateIsInstantiateInContextOfTarget.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+/// <reference path="react16.d.ts" />
+var React = require("react");
+var TestComponent = /** @class */ (function (_super) {
+    __extends(TestComponent, _super);
+    function TestComponent() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    // Type guard is defined as a static class property
+    TestComponent.isAny = function (obj) {
+        return true;
+    };
+    TestComponent.defaultProps = {
+        isAny: TestComponent.isAny
+    };
+    return TestComponent;
+}(React.Component));
+var TestRender = function () { return React.createElement(TestComponent, null); };

--- a/tests/baselines/reference/returnTypePredicateIsInstantiateInContextOfTarget.symbols
+++ b/tests/baselines/reference/returnTypePredicateIsInstantiateInContextOfTarget.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx ===
+/// <reference path="react16.d.ts" />
+import * as React from "react";
+>React : Symbol(React, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 1, 6))
+
+class TestComponent extends React.Component<{ isAny: <T>(obj: any) => obj is T }> {
+>TestComponent : Symbol(TestComponent, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 1, 31))
+>React.Component : Symbol(React.Component, Decl(react16.d.ts, 345, 54), Decl(react16.d.ts, 349, 94))
+>React : Symbol(React, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 1, 6))
+>Component : Symbol(React.Component, Decl(react16.d.ts, 345, 54), Decl(react16.d.ts, 349, 94))
+>isAny : Symbol(isAny, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 2, 45))
+>T : Symbol(T, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 2, 54))
+>obj : Symbol(obj, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 2, 57))
+>obj : Symbol(obj, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 2, 57))
+>T : Symbol(T, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 2, 54))
+
+    static defaultProps = {
+>defaultProps : Symbol(TestComponent.defaultProps, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 2, 83))
+
+        isAny: TestComponent.isAny
+>isAny : Symbol(isAny, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 3, 27))
+>TestComponent.isAny : Symbol(TestComponent.isAny, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 5, 5))
+>TestComponent : Symbol(TestComponent, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 1, 31))
+>isAny : Symbol(TestComponent.isAny, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 5, 5))
+    }
+
+    // Type guard is defined as a static class property
+    static isAny<T>(obj: any): obj is T {
+>isAny : Symbol(TestComponent.isAny, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 5, 5))
+>T : Symbol(T, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 8, 17))
+>obj : Symbol(obj, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 8, 20))
+>obj : Symbol(obj, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 8, 20))
+>T : Symbol(T, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 8, 17))
+
+        return true;
+    }
+}
+
+const TestRender = () => <TestComponent />;
+>TestRender : Symbol(TestRender, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 13, 5))
+>TestComponent : Symbol(TestComponent, Decl(returnTypePredicateIsInstantiateInContextOfTarget.tsx, 1, 31))
+

--- a/tests/baselines/reference/returnTypePredicateIsInstantiateInContextOfTarget.types
+++ b/tests/baselines/reference/returnTypePredicateIsInstantiateInContextOfTarget.types
@@ -1,0 +1,40 @@
+=== tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx ===
+/// <reference path="react16.d.ts" />
+import * as React from "react";
+>React : typeof React
+
+class TestComponent extends React.Component<{ isAny: <T>(obj: any) => obj is T }> {
+>TestComponent : TestComponent
+>React.Component : React.Component<{ isAny: <T>(obj: any) => obj is T; }, {}, any>
+>React : typeof React
+>Component : typeof React.Component
+>isAny : <T>(obj: any) => obj is T
+>obj : any
+
+    static defaultProps = {
+>defaultProps : { isAny: <T>(obj: any) => obj is T; }
+>{        isAny: TestComponent.isAny    } : { isAny: <T>(obj: any) => obj is T; }
+
+        isAny: TestComponent.isAny
+>isAny : <T>(obj: any) => obj is T
+>TestComponent.isAny : <T>(obj: any) => obj is T
+>TestComponent : typeof TestComponent
+>isAny : <T>(obj: any) => obj is T
+    }
+
+    // Type guard is defined as a static class property
+    static isAny<T>(obj: any): obj is T {
+>isAny : <T>(obj: any) => obj is T
+>obj : any
+
+        return true;
+>true : true
+    }
+}
+
+const TestRender = () => <TestComponent />;
+>TestRender : () => JSX.Element
+>() => <TestComponent /> : () => JSX.Element
+><TestComponent /> : JSX.Element
+>TestComponent : typeof TestComponent
+

--- a/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
+++ b/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
@@ -1,0 +1,16 @@
+// @jsx: react
+// @strict: true
+/// <reference path="/.lib/react16.d.ts" />
+import * as React from "react";
+class TestComponent extends React.Component<{ isAny: <T>(obj: any) => obj is T }> {
+    static defaultProps = {
+        isAny: TestComponent.isAny
+    }
+
+    // Type guard is defined as a static class property
+    static isAny<T>(obj: any): obj is T {
+        return true;
+    }
+}
+
+const TestRender = () => <TestComponent />;


### PR DESCRIPTION
Fixes #29819

As it turns out, it's super important when the type parameter only appears in the return predicate position (however rare that may be).
