### PR TITLE
Ignore the directories or files in node_modules starting with "." and any file or directory starting with ".git" even in the recursive directory watching logic

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -71,8 +71,8 @@ namespace ts {
         nonRecursive?: boolean;
     }
 
-    export function isPathInNodeModulesStartingWithDot(path: Path) {
-        return stringContains(path, "/node_modules/.");
+    export function isPathIgnored(path: Path) {
+        return some(ignoredPaths, searchPath => stringContains(path, searchPath));
     }
 
     export const maxNumberOfFilesToIterateForInvalidation = 256;
@@ -696,7 +696,7 @@ namespace ts {
             }
             else {
                 // If something to do with folder/file starting with "." in node_modules folder, skip it
-                if (isPathInNodeModulesStartingWithDot(fileOrDirectoryPath)) return false;
+                if (isPathIgnored(fileOrDirectoryPath)) return false;
 
                 // Some file or directory in the watching directory is created
                 // Return early if it does not have any of the watching extension or not the custom failed lookup path

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -987,7 +987,7 @@ namespace ts {
                     }
                     nextSourceFileVersion(fileOrDirectoryPath);
 
-                    if (isPathInNodeModulesStartingWithDot(fileOrDirectoryPath)) return;
+                    if (isPathIgnored(fileOrDirectoryPath)) return;
 
                     // If the the added or created file or directory is not supported file name, ignore the file
                     // But when watched directory is added/removed, we need to reload the file list

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1002,7 +1002,7 @@ namespace ts.server {
                 fileOrDirectory => {
                     const fileOrDirectoryPath = this.toPath(fileOrDirectory);
                     project.getCachedDirectoryStructureHost().addOrDeleteFileOrDirectory(fileOrDirectory, fileOrDirectoryPath);
-                    if (isPathInNodeModulesStartingWithDot(fileOrDirectoryPath)) return;
+                    if (isPathIgnored(fileOrDirectoryPath)) return;
                     const configFilename = project.getConfigFilePath();
 
                     // If the the added or created file or directory is not supported file name, ignore the file
@@ -2071,7 +2071,7 @@ namespace ts.server {
                 watchDir,
                 (fileOrDirectory) => {
                     const fileOrDirectoryPath = this.toPath(fileOrDirectory);
-                    if (isPathInNodeModulesStartingWithDot(fileOrDirectoryPath)) return;
+                    if (isPathIgnored(fileOrDirectoryPath)) return;
 
                     // Has extension
                     Debug.assert(result.refCount > 0);

--- a/src/testRunner/unittests/tsserver/watchEnvironment.ts
+++ b/src/testRunner/unittests/tsserver/watchEnvironment.ts
@@ -132,4 +132,63 @@ namespace ts.projectSystem {
             verifyRootedDirectoryWatch("c:/users/username/");
         });
     });
+
+    it(`unittests:: tsserver:: watchEnvironment:: tsserverProjectSystem recursive watch directory implementation does not watch files/directories in node_modules starting with "."`, () => {
+        const projectFolder = "/a/username/project";
+        const projectSrcFolder = `${projectFolder}/src`;
+        const configFile: File = {
+            path: `${projectFolder}/tsconfig.json`,
+            content: "{}"
+        };
+        const index: File = {
+            path: `${projectSrcFolder}/index.ts`,
+            content: `import {} from "file"`
+        };
+        const file1: File = {
+            path: `${projectSrcFolder}/file1.ts`,
+            content: ""
+        };
+        const nodeModulesExistingUnusedFile: File = {
+            path: `${projectFolder}/node_modules/someFile.d.ts`,
+            content: ""
+        };
+
+        const fileNames = [index, file1, configFile, libFile].map(file => file.path);
+        // All closed files(files other than index), project folder, project/src folder and project/node_modules/@types folder
+        const expectedWatchedFiles = arrayToMap(fileNames.slice(1), identity, () => 1);
+        const expectedWatchedDirectories = arrayToMap([projectFolder, projectSrcFolder, `${projectFolder}/${nodeModules}`, `${projectFolder}/${nodeModulesAtTypes}`], identity, () => 1);
+
+        const environmentVariables = createMap<string>();
+        environmentVariables.set("TSC_WATCHDIRECTORY", Tsc_WatchDirectory.NonRecursiveWatchDirectory);
+        const host = createServerHost([index, file1, configFile, libFile, nodeModulesExistingUnusedFile], { environmentVariables });
+        const projectService = createProjectService(host);
+        projectService.openClientFile(index.path);
+
+        const project = Debug.assertDefined(projectService.configuredProjects.get(configFile.path));
+        verifyProject();
+
+        const nodeModulesIgnoredFileFromIgnoreDirectory: File = {
+            path: `${projectFolder}/node_modules/.cache/someFile.d.ts`,
+            content: ""
+        };
+        host.ensureFileOrFolder(nodeModulesIgnoredFileFromIgnoreDirectory);
+        host.checkTimeoutQueueLength(0);
+        verifyProject();
+
+        const nodeModulesIgnoredFile: File = {
+            path: `${projectFolder}/node_modules/.cacheFile.ts`,
+            content: ""
+        };
+        host.ensureFileOrFolder(nodeModulesIgnoredFile);
+        host.checkTimeoutQueueLength(0);
+        verifyProject();
+
+        function verifyProject() {
+            checkWatchedDirectories(host, emptyArray, /*recursive*/ true);
+            checkWatchedFilesDetailed(host, expectedWatchedFiles);
+            checkWatchedDirectoriesDetailed(host, expectedWatchedDirectories, /*recursive*/ false);
+            checkProjectActualFiles(project, fileNames);
+        }
+    });
+
 }

--- a/src/testRunner/unittests/tsserver/watchEnvironment.ts
+++ b/src/testRunner/unittests/tsserver/watchEnvironment.ts
@@ -183,6 +183,22 @@ namespace ts.projectSystem {
         host.checkTimeoutQueueLength(0);
         verifyProject();
 
+        const gitIgnoredFileFromIgnoreDirectory: File = {
+            path: `${projectFolder}/.git/someFile.d.ts`,
+            content: ""
+        };
+        host.ensureFileOrFolder(gitIgnoredFileFromIgnoreDirectory);
+        host.checkTimeoutQueueLength(0);
+        verifyProject();
+
+        const gitIgnoredFile: File = {
+            path: `${projectFolder}/.gitCache.d.ts`,
+            content: ""
+        };
+        host.ensureFileOrFolder(gitIgnoredFile);
+        host.checkTimeoutQueueLength(0);
+        verifyProject();
+
         function verifyProject() {
             checkWatchedDirectories(host, emptyArray, /*recursive*/ true);
             checkWatchedFilesDetailed(host, expectedWatchedFiles);


### PR DESCRIPTION
Fixes #30004 and #29782

