### PR TITLE
Improve performance of fallback hash function

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -8,8 +8,11 @@ namespace ts {
      */
     /* @internal */
     export function generateDjb2Hash(data: string): string {
-        const chars = data.split("").map(str => str.charCodeAt(0));
-        return `${chars.reduce((prev, curr) => ((prev << 5) + prev) + curr, 5381)}`;
+        let acc = 5381;
+        for (let i = 0; i < data.length; i++) {
+            acc = ((acc << 5) + acc) + data.charCodeAt(i);
+        }
+        return acc.toString();
     }
 
     /**


### PR DESCRIPTION
This code only runs on systems where the node crypto module isn't available, which I don't even know when happens, but if it does run it's basically a denial of service attack on the GC and is problematically slow. The imperative version isn't as fancy but is about 25 times faster.