### PR TITLE
add stronger typings for `Object.keys`

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -238,7 +238,7 @@ interface ObjectConstructor {
       * Returns the names of the enumerable properties and methods of an object.
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
-    keys(o: {}): string[];
+    keys<T>(o: T): (keyof T)[];
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled
  'Bug' or 'help wanted' or is in the Community milestone
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] You've signed the CLA
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

`Object.keys` is currently typed as outputting `string[]` which is _technically correct_ but causes issues when you forxample want to use the key with the original object if that object does not have an index signature.

```ts
const foo = {
   a: {
    bar: 'something'
  },
  b: {
    bar: 'else'
  }
}

Object.keys(foo).map((key) => {
  return foo[key].bar // Not valid because `foo` has no index signature
})
```

This is a bit annoying as `key` can only be a valid index of `foo` but TS won't let you use it as such.

Using this PR the above code works as `key` has the type `keyof foo` which is usable to index `foo`.

I have to apologise as the tests aren't passing at the moment. I'm struggling to see where they are failing and could do with some help. I also can't sign in to cla.opensource.microsoft.com to sign the CLA.

