### PR TITLE
Update pull_request_template.md

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,11 +2,9 @@
 Thank you for submitting a pull request!
 
 Here's a checklist you might find useful.
-* [ ] There is an associated issue that is labeled
-  'Bug' or 'help wanted' or is in the Community milestone
+* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
 * [ ] Code is up-to-date with the `master` branch
 * [ ] You've successfully run `gulp runtests` locally
-* [ ] You've signed the CLA
 * [ ] There are new or updated unit tests validating the change
 
 Refer to CONTRIBUTING.MD for more details.


### PR DESCRIPTION
CLA signing is easier to do after the PR is posted, and we no longer use the Community milestone
