### PR TITLE
Add more information in case of incompatible constructor signature #2…

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13232,6 +13232,14 @@ namespace ts {
                     // to the quadratic nature of the logic below.
                     const eraseGenerics = relation === comparableRelation || !!compilerOptions.noStrictGenericChecks;
                     result = signatureRelatedTo(sourceSignatures[0], targetSignatures[0], eraseGenerics, reportErrors);
+                    if (result === Ternary.False && reportErrors && targetSignatures[0].declaration && isConstructSignatureDeclaration(targetSignatures[0].declaration)
+                        && getObjectFlags(source) & getObjectFlags(target)) {
+                        const flags = TypeFormatFlags.WriteArrowStyleSignature;
+                        const sourceSignature = signatureToString(sourceSignatures[0], /*enclosingDeclaration*/ undefined, flags, kind);
+                        const targetSignature = signatureToString(targetSignatures[0], /*enclosingDeclaration*/ undefined, flags, kind);
+                        reportError(Diagnostics.Type_0_is_not_assignable_to_type_1, sourceSignature, targetSignature);
+                        reportError(Diagnostics.Types_of_constructor_signature_are_incompatible);
+                    }
                 }
                 else {
                     outer: for (const t of targetSignatures) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2601,6 +2601,10 @@
         "category": "Error",
         "code": 2753
     },
+    "Types of constructor signature are incompatible.": {
+    "category": "Error",
+    "code": 2754
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/assigningIncompatibleConstructor.errors.txt
+++ b/tests/baselines/reference/assigningIncompatibleConstructor.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/assigningIncompatibleConstructor.ts(2,5): error TS2322: Type 'typeof Foo' is not assignable to type 'new () => Foo'.
+  Types of constructor signature are incompatible.
+    Type 'new (a: string) => Foo' is not assignable to type 'new () => Foo'.
+
+
+==== tests/cases/compiler/assigningIncompatibleConstructor.ts (1 errors) ====
+    class Foo { constructor(a: string) { } }
+    let FooConstructor: { new(): Foo } = Foo;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'typeof Foo' is not assignable to type 'new () => Foo'.
+!!! error TS2322:   Types of constructor signature are incompatible.
+!!! error TS2322:     Type 'new (a: string) => Foo' is not assignable to type 'new () => Foo'.
+    

--- a/tests/baselines/reference/assigningIncompatibleConstructor.js
+++ b/tests/baselines/reference/assigningIncompatibleConstructor.js
@@ -1,0 +1,12 @@
+//// [assigningIncompatibleConstructor.ts]
+class Foo { constructor(a: string) { } }
+let FooConstructor: { new(): Foo } = Foo;
+
+
+//// [assigningIncompatibleConstructor.js]
+var Foo = /** @class */ (function () {
+    function Foo(a) {
+    }
+    return Foo;
+}());
+var FooConstructor = Foo;

--- a/tests/baselines/reference/assigningIncompatibleConstructor.symbols
+++ b/tests/baselines/reference/assigningIncompatibleConstructor.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/assigningIncompatibleConstructor.ts ===
+class Foo { constructor(a: string) { } }
+>Foo : Symbol(Foo, Decl(assigningIncompatibleConstructor.ts, 0, 0))
+>a : Symbol(a, Decl(assigningIncompatibleConstructor.ts, 0, 24))
+
+let FooConstructor: { new(): Foo } = Foo;
+>FooConstructor : Symbol(FooConstructor, Decl(assigningIncompatibleConstructor.ts, 1, 3))
+>Foo : Symbol(Foo, Decl(assigningIncompatibleConstructor.ts, 0, 0))
+>Foo : Symbol(Foo, Decl(assigningIncompatibleConstructor.ts, 0, 0))
+

--- a/tests/baselines/reference/assigningIncompatibleConstructor.types
+++ b/tests/baselines/reference/assigningIncompatibleConstructor.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/assigningIncompatibleConstructor.ts ===
+class Foo { constructor(a: string) { } }
+>Foo : Foo
+>a : string
+
+let FooConstructor: { new(): Foo } = Foo;
+>FooConstructor : new () => Foo
+>Foo : typeof Foo
+

--- a/tests/cases/compiler/assigningIncompatibleConstructor.ts
+++ b/tests/cases/compiler/assigningIncompatibleConstructor.ts
@@ -1,0 +1,2 @@
+class Foo { constructor(a: string) { } }
+let FooConstructor: { new(): Foo } = Foo;


### PR DESCRIPTION
Fixes #21253 This is my first pull request to TypeScript, so I will free for your comments. At first I tried to implement code from pr of previous contributors, but one test "errorsWithInvokablesInUnions01" failed. So I investigated a problem and added new check on source/target objectFlag comparison. Actually I still not
so good familiar with TS logic, so maybe it's wrong way. If it's true, give me feedback, please.
