### PR TITLE
Account for `this` type parameters when comparing identifier predicate indices

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14284,8 +14284,10 @@ namespace ts {
         function applyToReturnTypes(source: Signature, target: Signature, callback: (s: Type, t: Type) => void) {
             const sourceTypePredicate = getTypePredicateOfSignature(source);
             const targetTypePredicate = getTypePredicateOfSignature(target);
+            const sourcePredicateOffset = source.declaration && source.declaration.parameters[0] && parameterIsThisKeyword(source.declaration.parameters[0]) ? 1 : 0;
+            const targetPredicateOffset = target.declaration && target.declaration.parameters[0] && parameterIsThisKeyword(target.declaration.parameters[0]) ? 1 : 0;
             if (sourceTypePredicate && targetTypePredicate && sourceTypePredicate.kind === targetTypePredicate.kind &&
-                (sourceTypePredicate.kind === TypePredicateKind.This || sourceTypePredicate.parameterIndex === (<IdentifierTypePredicate>targetTypePredicate).parameterIndex)) {
+                (sourceTypePredicate.kind === TypePredicateKind.This || (sourceTypePredicate.parameterIndex - sourcePredicateOffset) === ((<IdentifierTypePredicate>targetTypePredicate).parameterIndex - targetPredicateOffset))) {
                 callback(sourceTypePredicate.type, targetTypePredicate.type);
             }
             else {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3492,7 +3492,7 @@ namespace ts {
         }
     }
 
-    export function parameterIsThisKeyword(parameter: ParameterDeclaration): boolean {
+    export function parameterIsThisKeyword(parameter: ParameterDeclaration | JSDocParameterTag): boolean {
         return isThisIdentifier(parameter.name);
     }
 

--- a/tests/baselines/reference/contravariantInferenceAndTypeGuard.js
+++ b/tests/baselines/reference/contravariantInferenceAndTypeGuard.js
@@ -1,0 +1,39 @@
+//// [contravariantInferenceAndTypeGuard.ts]
+interface ListItem<TData> {
+    prev: ListItem<TData> | null;
+    next: ListItem<TData> | null;
+    data: TData;
+}
+type IteratorFn<TData, TResult, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => TResult;
+type FilterFn<TData, TResult extends TData, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => item is TResult;
+
+declare class List<TData> {
+    filter<TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>;
+    filter<TResult extends TData>(fn: FilterFn<TData, TResult>): List<TResult>;
+    filter<TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>;
+    filter(fn: IteratorFn<TData, boolean>): List<TData>;
+}
+interface Test {
+    a: string;
+}
+const list2 = new List<Test | null>();
+const filter1 = list2.filter(function(item, node, list): item is Test {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test | null
+    node; // $ExpectType ListItem<Test | null>
+    list; // $ExpectType List<Test | null>
+    return !!item;
+}, {b: 'c'});
+const x: List<Test> = filter1; // $ExpectType List<Test>
+
+//// [contravariantInferenceAndTypeGuard.js]
+"use strict";
+var list2 = new List();
+var filter1 = list2.filter(function (item, node, list) {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test | null
+    node; // $ExpectType ListItem<Test | null>
+    list; // $ExpectType List<Test | null>
+    return !!item;
+}, { b: 'c' });
+var x = filter1; // $ExpectType List<Test>

--- a/tests/baselines/reference/contravariantInferenceAndTypeGuard.symbols
+++ b/tests/baselines/reference/contravariantInferenceAndTypeGuard.symbols
@@ -1,0 +1,157 @@
+=== tests/cases/compiler/contravariantInferenceAndTypeGuard.ts ===
+interface ListItem<TData> {
+>ListItem : Symbol(ListItem, Decl(contravariantInferenceAndTypeGuard.ts, 0, 0))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 0, 19))
+
+    prev: ListItem<TData> | null;
+>prev : Symbol(ListItem.prev, Decl(contravariantInferenceAndTypeGuard.ts, 0, 27))
+>ListItem : Symbol(ListItem, Decl(contravariantInferenceAndTypeGuard.ts, 0, 0))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 0, 19))
+
+    next: ListItem<TData> | null;
+>next : Symbol(ListItem.next, Decl(contravariantInferenceAndTypeGuard.ts, 1, 33))
+>ListItem : Symbol(ListItem, Decl(contravariantInferenceAndTypeGuard.ts, 0, 0))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 0, 19))
+
+    data: TData;
+>data : Symbol(ListItem.data, Decl(contravariantInferenceAndTypeGuard.ts, 2, 33))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 0, 19))
+}
+type IteratorFn<TData, TResult, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => TResult;
+>IteratorFn : Symbol(IteratorFn, Decl(contravariantInferenceAndTypeGuard.ts, 4, 1))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 5, 16))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 5, 22))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 5, 31))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 5, 16))
+>this : Symbol(this, Decl(contravariantInferenceAndTypeGuard.ts, 5, 59))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 5, 31))
+>item : Symbol(item, Decl(contravariantInferenceAndTypeGuard.ts, 5, 74))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 5, 16))
+>node : Symbol(node, Decl(contravariantInferenceAndTypeGuard.ts, 5, 87))
+>ListItem : Symbol(ListItem, Decl(contravariantInferenceAndTypeGuard.ts, 0, 0))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 5, 16))
+>list : Symbol(list, Decl(contravariantInferenceAndTypeGuard.ts, 5, 110))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 5, 16))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 5, 22))
+
+type FilterFn<TData, TResult extends TData, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => item is TResult;
+>FilterFn : Symbol(FilterFn, Decl(contravariantInferenceAndTypeGuard.ts, 5, 141))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 6, 14))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 6, 20))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 6, 14))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 6, 43))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 6, 14))
+>this : Symbol(this, Decl(contravariantInferenceAndTypeGuard.ts, 6, 71))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 6, 43))
+>item : Symbol(item, Decl(contravariantInferenceAndTypeGuard.ts, 6, 86))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 6, 14))
+>node : Symbol(node, Decl(contravariantInferenceAndTypeGuard.ts, 6, 99))
+>ListItem : Symbol(ListItem, Decl(contravariantInferenceAndTypeGuard.ts, 0, 0))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 6, 14))
+>list : Symbol(list, Decl(contravariantInferenceAndTypeGuard.ts, 6, 122))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 6, 14))
+>item : Symbol(item, Decl(contravariantInferenceAndTypeGuard.ts, 6, 86))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 6, 20))
+
+declare class List<TData> {
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 8, 19))
+
+    filter<TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>;
+>filter : Symbol(List.filter, Decl(contravariantInferenceAndTypeGuard.ts, 8, 27), Decl(contravariantInferenceAndTypeGuard.ts, 9, 118), Decl(contravariantInferenceAndTypeGuard.ts, 10, 79), Decl(contravariantInferenceAndTypeGuard.ts, 11, 95))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 9, 11))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 9, 20))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 8, 19))
+>fn : Symbol(fn, Decl(contravariantInferenceAndTypeGuard.ts, 9, 44))
+>FilterFn : Symbol(FilterFn, Decl(contravariantInferenceAndTypeGuard.ts, 5, 141))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 8, 19))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 9, 20))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 9, 11))
+>context : Symbol(context, Decl(contravariantInferenceAndTypeGuard.ts, 9, 83))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 9, 11))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 9, 20))
+
+    filter<TResult extends TData>(fn: FilterFn<TData, TResult>): List<TResult>;
+>filter : Symbol(List.filter, Decl(contravariantInferenceAndTypeGuard.ts, 8, 27), Decl(contravariantInferenceAndTypeGuard.ts, 9, 118), Decl(contravariantInferenceAndTypeGuard.ts, 10, 79), Decl(contravariantInferenceAndTypeGuard.ts, 11, 95))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 10, 11))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 8, 19))
+>fn : Symbol(fn, Decl(contravariantInferenceAndTypeGuard.ts, 10, 34))
+>FilterFn : Symbol(FilterFn, Decl(contravariantInferenceAndTypeGuard.ts, 5, 141))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 8, 19))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 10, 11))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>TResult : Symbol(TResult, Decl(contravariantInferenceAndTypeGuard.ts, 10, 11))
+
+    filter<TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>;
+>filter : Symbol(List.filter, Decl(contravariantInferenceAndTypeGuard.ts, 8, 27), Decl(contravariantInferenceAndTypeGuard.ts, 9, 118), Decl(contravariantInferenceAndTypeGuard.ts, 10, 79), Decl(contravariantInferenceAndTypeGuard.ts, 11, 95))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 11, 11))
+>fn : Symbol(fn, Decl(contravariantInferenceAndTypeGuard.ts, 11, 21))
+>IteratorFn : Symbol(IteratorFn, Decl(contravariantInferenceAndTypeGuard.ts, 4, 1))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 8, 19))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 11, 11))
+>context : Symbol(context, Decl(contravariantInferenceAndTypeGuard.ts, 11, 62))
+>TContext : Symbol(TContext, Decl(contravariantInferenceAndTypeGuard.ts, 11, 11))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 8, 19))
+
+    filter(fn: IteratorFn<TData, boolean>): List<TData>;
+>filter : Symbol(List.filter, Decl(contravariantInferenceAndTypeGuard.ts, 8, 27), Decl(contravariantInferenceAndTypeGuard.ts, 9, 118), Decl(contravariantInferenceAndTypeGuard.ts, 10, 79), Decl(contravariantInferenceAndTypeGuard.ts, 11, 95))
+>fn : Symbol(fn, Decl(contravariantInferenceAndTypeGuard.ts, 12, 11))
+>IteratorFn : Symbol(IteratorFn, Decl(contravariantInferenceAndTypeGuard.ts, 4, 1))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 8, 19))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>TData : Symbol(TData, Decl(contravariantInferenceAndTypeGuard.ts, 8, 19))
+}
+interface Test {
+>Test : Symbol(Test, Decl(contravariantInferenceAndTypeGuard.ts, 13, 1))
+
+    a: string;
+>a : Symbol(Test.a, Decl(contravariantInferenceAndTypeGuard.ts, 14, 16))
+}
+const list2 = new List<Test | null>();
+>list2 : Symbol(list2, Decl(contravariantInferenceAndTypeGuard.ts, 17, 5))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>Test : Symbol(Test, Decl(contravariantInferenceAndTypeGuard.ts, 13, 1))
+
+const filter1 = list2.filter(function(item, node, list): item is Test {
+>filter1 : Symbol(filter1, Decl(contravariantInferenceAndTypeGuard.ts, 18, 5))
+>list2.filter : Symbol(List.filter, Decl(contravariantInferenceAndTypeGuard.ts, 8, 27), Decl(contravariantInferenceAndTypeGuard.ts, 9, 118), Decl(contravariantInferenceAndTypeGuard.ts, 10, 79), Decl(contravariantInferenceAndTypeGuard.ts, 11, 95))
+>list2 : Symbol(list2, Decl(contravariantInferenceAndTypeGuard.ts, 17, 5))
+>filter : Symbol(List.filter, Decl(contravariantInferenceAndTypeGuard.ts, 8, 27), Decl(contravariantInferenceAndTypeGuard.ts, 9, 118), Decl(contravariantInferenceAndTypeGuard.ts, 10, 79), Decl(contravariantInferenceAndTypeGuard.ts, 11, 95))
+>item : Symbol(item, Decl(contravariantInferenceAndTypeGuard.ts, 18, 38))
+>node : Symbol(node, Decl(contravariantInferenceAndTypeGuard.ts, 18, 43))
+>list : Symbol(list, Decl(contravariantInferenceAndTypeGuard.ts, 18, 49))
+>item : Symbol(item, Decl(contravariantInferenceAndTypeGuard.ts, 18, 38))
+>Test : Symbol(Test, Decl(contravariantInferenceAndTypeGuard.ts, 13, 1))
+
+    this.b; // $ExpectType string
+>this.b : Symbol(b, Decl(contravariantInferenceAndTypeGuard.ts, 24, 4))
+>this : Symbol(this, Decl(contravariantInferenceAndTypeGuard.ts, 6, 71))
+>b : Symbol(b, Decl(contravariantInferenceAndTypeGuard.ts, 24, 4))
+
+    item; // $ExpectType Test | null
+>item : Symbol(item, Decl(contravariantInferenceAndTypeGuard.ts, 18, 38))
+
+    node; // $ExpectType ListItem<Test | null>
+>node : Symbol(node, Decl(contravariantInferenceAndTypeGuard.ts, 18, 43))
+
+    list; // $ExpectType List<Test | null>
+>list : Symbol(list, Decl(contravariantInferenceAndTypeGuard.ts, 18, 49))
+
+    return !!item;
+>item : Symbol(item, Decl(contravariantInferenceAndTypeGuard.ts, 18, 38))
+
+}, {b: 'c'});
+>b : Symbol(b, Decl(contravariantInferenceAndTypeGuard.ts, 24, 4))
+
+const x: List<Test> = filter1; // $ExpectType List<Test>
+>x : Symbol(x, Decl(contravariantInferenceAndTypeGuard.ts, 25, 5))
+>List : Symbol(List, Decl(contravariantInferenceAndTypeGuard.ts, 6, 161))
+>Test : Symbol(Test, Decl(contravariantInferenceAndTypeGuard.ts, 13, 1))
+>filter1 : Symbol(filter1, Decl(contravariantInferenceAndTypeGuard.ts, 18, 5))
+

--- a/tests/baselines/reference/contravariantInferenceAndTypeGuard.types
+++ b/tests/baselines/reference/contravariantInferenceAndTypeGuard.types
@@ -1,0 +1,97 @@
+=== tests/cases/compiler/contravariantInferenceAndTypeGuard.ts ===
+interface ListItem<TData> {
+    prev: ListItem<TData> | null;
+>prev : ListItem<TData> | null
+>null : null
+
+    next: ListItem<TData> | null;
+>next : ListItem<TData> | null
+>null : null
+
+    data: TData;
+>data : TData
+}
+type IteratorFn<TData, TResult, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => TResult;
+>IteratorFn : IteratorFn<TData, TResult, TContext>
+>this : TContext
+>item : TData
+>node : ListItem<TData>
+>list : List<TData>
+
+type FilterFn<TData, TResult extends TData, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => item is TResult;
+>FilterFn : FilterFn<TData, TResult, TContext>
+>this : TContext
+>item : TData
+>node : ListItem<TData>
+>list : List<TData>
+
+declare class List<TData> {
+>List : List<TData>
+
+    filter<TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>;
+>filter : { <TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>; <TResult extends TData>(fn: FilterFn<TData, TResult, List<TData>>): List<TResult>; <TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>; (fn: IteratorFn<TData, boolean, List<TData>>): List<TData>; }
+>fn : FilterFn<TData, TResult, TContext>
+>context : TContext
+
+    filter<TResult extends TData>(fn: FilterFn<TData, TResult>): List<TResult>;
+>filter : { <TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>; <TResult extends TData>(fn: FilterFn<TData, TResult, List<TData>>): List<TResult>; <TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>; (fn: IteratorFn<TData, boolean, List<TData>>): List<TData>; }
+>fn : FilterFn<TData, TResult, List<TData>>
+
+    filter<TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>;
+>filter : { <TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>; <TResult extends TData>(fn: FilterFn<TData, TResult, List<TData>>): List<TResult>; <TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>; (fn: IteratorFn<TData, boolean, List<TData>>): List<TData>; }
+>fn : IteratorFn<TData, boolean, TContext>
+>context : TContext
+
+    filter(fn: IteratorFn<TData, boolean>): List<TData>;
+>filter : { <TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>; <TResult extends TData>(fn: FilterFn<TData, TResult, List<TData>>): List<TResult>; <TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>; (fn: IteratorFn<TData, boolean, List<TData>>): List<TData>; }
+>fn : IteratorFn<TData, boolean, List<TData>>
+}
+interface Test {
+    a: string;
+>a : string
+}
+const list2 = new List<Test | null>();
+>list2 : List<Test | null>
+>new List<Test | null>() : List<Test | null>
+>List : typeof List
+>null : null
+
+const filter1 = list2.filter(function(item, node, list): item is Test {
+>filter1 : List<Test>
+>list2.filter(function(item, node, list): item is Test {    this.b; // $ExpectType string    item; // $ExpectType Test | null    node; // $ExpectType ListItem<Test | null>    list; // $ExpectType List<Test | null>    return !!item;}, {b: 'c'}) : List<Test>
+>list2.filter : { <TContext, TResult extends Test | null>(fn: FilterFn<Test | null, TResult, TContext>, context: TContext): List<TResult>; <TResult extends Test | null>(fn: FilterFn<Test | null, TResult, List<Test | null>>): List<TResult>; <TContext>(fn: IteratorFn<Test | null, boolean, TContext>, context: TContext): List<Test | null>; (fn: IteratorFn<Test | null, boolean, List<Test | null>>): List<Test | null>; }
+>list2 : List<Test | null>
+>filter : { <TContext, TResult extends Test | null>(fn: FilterFn<Test | null, TResult, TContext>, context: TContext): List<TResult>; <TResult extends Test | null>(fn: FilterFn<Test | null, TResult, List<Test | null>>): List<TResult>; <TContext>(fn: IteratorFn<Test | null, boolean, TContext>, context: TContext): List<Test | null>; (fn: IteratorFn<Test | null, boolean, List<Test | null>>): List<Test | null>; }
+>function(item, node, list): item is Test {    this.b; // $ExpectType string    item; // $ExpectType Test | null    node; // $ExpectType ListItem<Test | null>    list; // $ExpectType List<Test | null>    return !!item;} : (this: { b: string; }, item: Test | null, node: ListItem<Test | null>, list: List<Test | null>) => item is Test
+>item : Test | null
+>node : ListItem<Test | null>
+>list : List<Test | null>
+
+    this.b; // $ExpectType string
+>this.b : string
+>this : { b: string; }
+>b : string
+
+    item; // $ExpectType Test | null
+>item : Test | null
+
+    node; // $ExpectType ListItem<Test | null>
+>node : ListItem<Test | null>
+
+    list; // $ExpectType List<Test | null>
+>list : List<Test | null>
+
+    return !!item;
+>!!item : boolean
+>!item : boolean
+>item : Test | null
+
+}, {b: 'c'});
+>{b: 'c'} : { b: string; }
+>b : string
+>'c' : "c"
+
+const x: List<Test> = filter1; // $ExpectType List<Test>
+>x : List<Test>
+>filter1 : List<Test>
+

--- a/tests/cases/compiler/contravariantInferenceAndTypeGuard.ts
+++ b/tests/cases/compiler/contravariantInferenceAndTypeGuard.ts
@@ -1,0 +1,27 @@
+// @strict: true
+interface ListItem<TData> {
+    prev: ListItem<TData> | null;
+    next: ListItem<TData> | null;
+    data: TData;
+}
+type IteratorFn<TData, TResult, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => TResult;
+type FilterFn<TData, TResult extends TData, TContext = List<TData>> = (this: TContext, item: TData, node: ListItem<TData>, list: List<TData>) => item is TResult;
+
+declare class List<TData> {
+    filter<TContext, TResult extends TData>(fn: FilterFn<TData, TResult, TContext>, context: TContext): List<TResult>;
+    filter<TResult extends TData>(fn: FilterFn<TData, TResult>): List<TResult>;
+    filter<TContext>(fn: IteratorFn<TData, boolean, TContext>, context: TContext): List<TData>;
+    filter(fn: IteratorFn<TData, boolean>): List<TData>;
+}
+interface Test {
+    a: string;
+}
+const list2 = new List<Test | null>();
+const filter1 = list2.filter(function(item, node, list): item is Test {
+    this.b; // $ExpectType string
+    item; // $ExpectType Test | null
+    node; // $ExpectType ListItem<Test | null>
+    list; // $ExpectType List<Test | null>
+    return !!item;
+}, {b: 'c'});
+const x: List<Test> = filter1; // $ExpectType List<Test>


### PR DESCRIPTION
Fixes the `css-tree` failure in DT on the linked PR.
