### PR TITLE
Fix globalThis completions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -890,7 +890,9 @@ namespace ts.Completions {
                         }
 
                         // If the module is merged with a value, we must get the type of the class and add its propertes (for inherited static methods).
-                        if (!isTypeLocation && symbol.declarations.some(d => d.kind !== SyntaxKind.SourceFile && d.kind !== SyntaxKind.ModuleDeclaration && d.kind !== SyntaxKind.EnumDeclaration)) {
+                        if (!isTypeLocation &&
+                            symbol.declarations &&
+                            symbol.declarations.some(d => d.kind !== SyntaxKind.SourceFile && d.kind !== SyntaxKind.ModuleDeclaration && d.kind !== SyntaxKind.EnumDeclaration)) {
                             addTypeProperties(typeChecker.getTypeOfSymbolAtLocation(symbol, node));
                         }
 

--- a/tests/cases/fourslash/completionAfterGlobalThis.ts
+++ b/tests/cases/fourslash/completionAfterGlobalThis.ts
@@ -1,0 +1,6 @@
+/// <reference path='fourslash.ts'/>
+
+////globalThis./**/
+
+// TODO: This is right except for globalThis and undefined
+verify.completions({ marker: "", exact: completion.globalsVars });

--- a/tests/cases/fourslash/completionAfterGlobalThis.ts
+++ b/tests/cases/fourslash/completionAfterGlobalThis.ts
@@ -2,7 +2,6 @@
 
 ////globalThis./**/
 
-// TODO: This is right except for globalThis and undefined
 verify.completions({
     marker: "",
     exact: [

--- a/tests/cases/fourslash/completionAfterGlobalThis.ts
+++ b/tests/cases/fourslash/completionAfterGlobalThis.ts
@@ -3,4 +3,11 @@
 ////globalThis./**/
 
 // TODO: This is right except for globalThis and undefined
-verify.completions({ marker: "", exact: completion.globalsVars });
+verify.completions({
+    marker: "",
+    exact: [
+        { name: "globalThis", kind: "module" },
+        ...completion.globalsVars,
+        { name: "undefined", kind: "var" }
+    ]
+});


### PR DESCRIPTION
globalThis has two special properties that are relevant here:

1. No declarations.
2. Both namespace and value flags are set.

Since it has a value flag but no declarations, it crashed the check in completions.ts. Adding a declarations list is not the right fix because that causes the completions list to be duplicated: once from the value side and once from the namespace side. The right fix is to skip the value side.

Fixes #30387 
