### PR TITLE
Generic type-safe implementation for Object.assign

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -261,36 +261,9 @@ interface ObjectConstructor {
      * Copy the values of all of the enumerable own properties from one or more source objects to a
      * target object. Returns the target object.
      * @param target The target object to copy to.
-     * @param source The source object from which to copy properties.
+     * @param sources The source objects from which to copy properties.
      */
-    assign<T, U>(target: T, source: U): T & U;
-
-    /**
-     * Copy the values of all of the enumerable own properties from one or more source objects to a
-     * target object. Returns the target object.
-     * @param target The target object to copy to.
-     * @param source1 The first source object from which to copy properties.
-     * @param source2 The second source object from which to copy properties.
-     */
-    assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
-
-    /**
-     * Copy the values of all of the enumerable own properties from one or more source objects to a
-     * target object. Returns the target object.
-     * @param target The target object to copy to.
-     * @param source1 The first source object from which to copy properties.
-     * @param source2 The second source object from which to copy properties.
-     * @param source3 The third source object from which to copy properties.
-     */
-    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
-
-    /**
-     * Copy the values of all of the enumerable own properties from one or more source objects to a
-     * target object. Returns the target object.
-     * @param target The target object to copy to.
-     * @param sources One or more source objects from which to copy properties
-     */
-    assign(target: object, ...sources: any[]): any;
+    assign<Source extends {}, Result extends Source>(target: Source, ...sources: Source[]): Pick<Result, keyof Source>;
 
     /**
      * Returns an array of all symbol properties found directly on object o.


### PR DESCRIPTION
It seems that it can be possible to make a type-safe `Object.assign`-like functions with TypeScript, without having to make lots of overrides.

Here's an example on the playground:

https://www.typescriptlang.org/play/index.html#src=function%20assign%3CSource%20extends%20%7B%7D%2C%20Result%20extends%20Source%3E(%0D%0A%20%20%20%20target%3A%20Source%2C%0D%0A%20%20%20%20...sources%3A%20Source%5B%5D%0D%0A)%3A%20Pick%3CResult%2C%20keyof%20Source%3E%20%7B%0D%0A%20%20%20%20return%20Object.assign(target%2C%20...sources)%3B%0D%0A%7D%0D%0A%0D%0Alet%20x%20%3D%0D%0A%20%20%20%20assign(%0D%0A%20%20%20%20%20%20%20%20%7B%20hello%3A%20%22world%22%20%7D%2C%0D%0A%20%20%20%20%20%20%20%20%7B%20something%3A%20%22is%20good%22%20%7D%2C%0D%0A%20%20%20%20%20%20%20%20%7B%20%22yes%22%3A%20true%20%7D%2C%0D%0A%20%20%20%20%20%20%20%20%7B%20yes%3A%20%22hello%22%20%7D%0D%0A%20%20%20%20)%3B%0D%0A%0D%0Ax.hello%3B%0D%0Ax.world%3B%20%2F%2F%20error!%0D%0Ax.yes%3B

You can see that the compiler says `x.hello` is fine, and complains about `x.world`

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->