### PR TITLE
Prevent substitution of 'super' in async super helper

### DIFF
--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -690,9 +690,15 @@ namespace ts {
                     /* parameters */ [],
                     /* type */ undefined,
                     /* equalsGreaterThanToken */ undefined,
-                    createPropertyAccess(
-                        createSuper(),
-                        name
+                    setEmitFlags(
+                        createPropertyAccess(
+                            setEmitFlags(
+                                createSuper(),
+                                EmitFlags.NoSubstitution
+                            ),
+                            name
+                        ),
+                        EmitFlags.NoSubstitution
                     )
                 )
             ));
@@ -717,9 +723,16 @@ namespace ts {
                             /* type */ undefined,
                             /* equalsGreaterThanToken */ undefined,
                             createAssignment(
-                                createPropertyAccess(
-                                    createSuper(),
-                                    name),
+                                setEmitFlags(
+                                    createPropertyAccess(
+                                        setEmitFlags(
+                                            createSuper(),
+                                            EmitFlags.NoSubstitution
+                                        ),
+                                        name
+                                    ),
+                                    EmitFlags.NoSubstitution
+                                ),
                                 createIdentifier("v")
                             )
                         )

--- a/tests/baselines/reference/asyncMethodWithSuper_es6.js
+++ b/tests/baselines/reference/asyncMethodWithSuper_es6.js
@@ -124,6 +124,66 @@ class B extends A {
         // element access (assign) in async arrow
         (async () => super["x"] = f);
     }
+
+    async * property_access_only_read_only_in_generator() {
+        // call with property access
+        super.x();
+
+        // property access (read)
+        const a = super.x;
+
+        // property access in arrow
+        (() => super.x());
+
+        // property access in async arrow
+        (async () => super.x());
+    }
+
+    async * property_access_only_write_only_in_generator() {
+        const f = () => {};
+
+        // property access (assign)
+        super.x = f;
+
+        // destructuring assign with property access
+        ({ f: super.x } = { f });
+
+        // property access (assign) in arrow
+        (() => super.x = f);
+
+        // property access (assign) in async arrow
+        (async () => super.x = f);
+    }
+
+    async * element_access_only_read_only_in_generator() {
+        // call with element access
+        super["x"]();
+
+        // element access (read)
+        const a = super["x"];
+
+        // element access in arrow
+        (() => super["x"]());
+
+        // element access in async arrow
+        (async () => super["x"]());
+    }
+
+    async * element_access_only_write_only_in_generator() {
+        const f = () => {};
+
+        // element access (assign)
+        super["x"] = f;
+
+        // destructuring assign with element access
+        ({ f: super["x"] } = { f });
+
+        // element access (assign) in arrow
+        (() => super["x"] = f);
+
+        // element access (assign) in async arrow
+        (async () => super["x"] = f);
+    }
 }
 
 
@@ -242,6 +302,69 @@ class B extends A {
             return name => cache[name] || (cache[name] = { get value() { return geti(name); }, set value(v) { seti(name, v); } });
         })(name => super[name], (name, value) => super[name] = value);
         return __awaiter(this, void 0, void 0, function* () {
+            const f = () => { };
+            // element access (assign)
+            _superIndex("x").value = f;
+            // destructuring assign with element access
+            ({ f: _superIndex("x").value } = { f });
+            // element access (assign) in arrow
+            (() => _superIndex("x").value = f);
+            // element access (assign) in async arrow
+            (() => __awaiter(this, void 0, void 0, function* () { return _superIndex("x").value = f; }));
+        });
+    }
+    property_access_only_read_only_in_generator() {
+        const _super = Object.create(null, {
+            x: { get: () => super.x }
+        });
+        return __asyncGenerator(this, arguments, function* property_access_only_read_only_in_generator_1() {
+            // call with property access
+            _super.x.call(this);
+            // property access (read)
+            const a = _super.x;
+            // property access in arrow
+            (() => _super.x.call(this));
+            // property access in async arrow
+            (() => __awaiter(this, void 0, void 0, function* () { return _super.x.call(this); }));
+        });
+    }
+    property_access_only_write_only_in_generator() {
+        const _super = Object.create(null, {
+            x: { get: () => super.x, set: v => super.x = v }
+        });
+        return __asyncGenerator(this, arguments, function* property_access_only_write_only_in_generator_1() {
+            const f = () => { };
+            // property access (assign)
+            _super.x = f;
+            // destructuring assign with property access
+            ({ f: _super.x } = { f });
+            // property access (assign) in arrow
+            (() => _super.x = f);
+            // property access (assign) in async arrow
+            (() => __awaiter(this, void 0, void 0, function* () { return _super.x = f; }));
+        });
+    }
+    element_access_only_read_only_in_generator() {
+        const _superIndex = name => super[name];
+        const _super = Object.create(null, {});
+        return __asyncGenerator(this, arguments, function* element_access_only_read_only_in_generator_1() {
+            // call with element access
+            _superIndex("x").call(this);
+            // element access (read)
+            const a = _superIndex("x");
+            // element access in arrow
+            (() => _superIndex("x").call(this));
+            // element access in async arrow
+            (() => __awaiter(this, void 0, void 0, function* () { return _superIndex("x").call(this); }));
+        });
+    }
+    element_access_only_write_only_in_generator() {
+        const _superIndex = (function (geti, seti) {
+            const cache = Object.create(null);
+            return name => cache[name] || (cache[name] = { get value() { return geti(name); }, set value(v) { seti(name, v); } });
+        })(name => super[name], (name, value) => super[name] = value);
+        const _super = Object.create(null, {});
+        return __asyncGenerator(this, arguments, function* element_access_only_write_only_in_generator_1() {
             const f = () => { };
             // element access (assign)
             _superIndex("x").value = f;

--- a/tests/baselines/reference/asyncMethodWithSuper_es6.symbols
+++ b/tests/baselines/reference/asyncMethodWithSuper_es6.symbols
@@ -252,5 +252,127 @@ class B extends A {
 >"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
 >f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 111, 13))
     }
+
+    async * property_access_only_read_only_in_generator() {
+>property_access_only_read_only_in_generator : Symbol(B.property_access_only_read_only_in_generator, Decl(asyncMethodWithSuper_es6.ts, 124, 5))
+
+        // call with property access
+        super.x();
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+
+        // property access (read)
+        const a = super.x;
+>a : Symbol(a, Decl(asyncMethodWithSuper_es6.ts, 131, 13))
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+
+        // property access in arrow
+        (() => super.x());
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+
+        // property access in async arrow
+        (async () => super.x());
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+    }
+
+    async * property_access_only_write_only_in_generator() {
+>property_access_only_write_only_in_generator : Symbol(B.property_access_only_write_only_in_generator, Decl(asyncMethodWithSuper_es6.ts, 138, 5))
+
+        const f = () => {};
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 141, 13))
+
+        // property access (assign)
+        super.x = f;
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 141, 13))
+
+        // destructuring assign with property access
+        ({ f: super.x } = { f });
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 147, 10))
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 147, 27))
+
+        // property access (assign) in arrow
+        (() => super.x = f);
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 141, 13))
+
+        // property access (assign) in async arrow
+        (async () => super.x = f);
+>super.x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>x : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 141, 13))
+    }
+
+    async * element_access_only_read_only_in_generator() {
+>element_access_only_read_only_in_generator : Symbol(B.element_access_only_read_only_in_generator, Decl(asyncMethodWithSuper_es6.ts, 154, 5))
+
+        // call with element access
+        super["x"]();
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+
+        // element access (read)
+        const a = super["x"];
+>a : Symbol(a, Decl(asyncMethodWithSuper_es6.ts, 161, 13))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+
+        // element access in arrow
+        (() => super["x"]());
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+
+        // element access in async arrow
+        (async () => super["x"]());
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+    }
+
+    async * element_access_only_write_only_in_generator() {
+>element_access_only_write_only_in_generator : Symbol(B.element_access_only_write_only_in_generator, Decl(asyncMethodWithSuper_es6.ts, 168, 5))
+
+        const f = () => {};
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 171, 13))
+
+        // element access (assign)
+        super["x"] = f;
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 171, 13))
+
+        // destructuring assign with element access
+        ({ f: super["x"] } = { f });
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 177, 10))
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 177, 30))
+
+        // element access (assign) in arrow
+        (() => super["x"] = f);
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 171, 13))
+
+        // element access (assign) in async arrow
+        (async () => super["x"] = f);
+>super : Symbol(A, Decl(asyncMethodWithSuper_es6.ts, 0, 0))
+>"x" : Symbol(A.x, Decl(asyncMethodWithSuper_es6.ts, 0, 9))
+>f : Symbol(f, Decl(asyncMethodWithSuper_es6.ts, 171, 13))
+    }
 }
 

--- a/tests/baselines/reference/asyncMethodWithSuper_es6.types
+++ b/tests/baselines/reference/asyncMethodWithSuper_es6.types
@@ -334,5 +334,173 @@ class B extends A {
 >"x" : "x"
 >f : () => void
     }
+
+    async * property_access_only_read_only_in_generator() {
+>property_access_only_read_only_in_generator : () => AsyncIterableIterator<any>
+
+        // call with property access
+        super.x();
+>super.x() : void
+>super.x : () => void
+>super : A
+>x : () => void
+
+        // property access (read)
+        const a = super.x;
+>a : () => void
+>super.x : () => void
+>super : A
+>x : () => void
+
+        // property access in arrow
+        (() => super.x());
+>(() => super.x()) : () => void
+>() => super.x() : () => void
+>super.x() : void
+>super.x : () => void
+>super : A
+>x : () => void
+
+        // property access in async arrow
+        (async () => super.x());
+>(async () => super.x()) : () => Promise<void>
+>async () => super.x() : () => Promise<void>
+>super.x() : void
+>super.x : () => void
+>super : A
+>x : () => void
+    }
+
+    async * property_access_only_write_only_in_generator() {
+>property_access_only_write_only_in_generator : () => AsyncIterableIterator<any>
+
+        const f = () => {};
+>f : () => void
+>() => {} : () => void
+
+        // property access (assign)
+        super.x = f;
+>super.x = f : () => void
+>super.x : () => void
+>super : A
+>x : () => void
+>f : () => void
+
+        // destructuring assign with property access
+        ({ f: super.x } = { f });
+>({ f: super.x } = { f }) : { f: () => void; }
+>{ f: super.x } = { f } : { f: () => void; }
+>{ f: super.x } : { f: () => void; }
+>f : () => void
+>super.x : () => void
+>super : A
+>x : () => void
+>{ f } : { f: () => void; }
+>f : () => void
+
+        // property access (assign) in arrow
+        (() => super.x = f);
+>(() => super.x = f) : () => () => void
+>() => super.x = f : () => () => void
+>super.x = f : () => void
+>super.x : () => void
+>super : A
+>x : () => void
+>f : () => void
+
+        // property access (assign) in async arrow
+        (async () => super.x = f);
+>(async () => super.x = f) : () => Promise<() => void>
+>async () => super.x = f : () => Promise<() => void>
+>super.x = f : () => void
+>super.x : () => void
+>super : A
+>x : () => void
+>f : () => void
+    }
+
+    async * element_access_only_read_only_in_generator() {
+>element_access_only_read_only_in_generator : () => AsyncIterableIterator<any>
+
+        // call with element access
+        super["x"]();
+>super["x"]() : void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+
+        // element access (read)
+        const a = super["x"];
+>a : () => void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+
+        // element access in arrow
+        (() => super["x"]());
+>(() => super["x"]()) : () => void
+>() => super["x"]() : () => void
+>super["x"]() : void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+
+        // element access in async arrow
+        (async () => super["x"]());
+>(async () => super["x"]()) : () => Promise<void>
+>async () => super["x"]() : () => Promise<void>
+>super["x"]() : void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+    }
+
+    async * element_access_only_write_only_in_generator() {
+>element_access_only_write_only_in_generator : () => AsyncIterableIterator<any>
+
+        const f = () => {};
+>f : () => void
+>() => {} : () => void
+
+        // element access (assign)
+        super["x"] = f;
+>super["x"] = f : () => void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+>f : () => void
+
+        // destructuring assign with element access
+        ({ f: super["x"] } = { f });
+>({ f: super["x"] } = { f }) : { f: () => void; }
+>{ f: super["x"] } = { f } : { f: () => void; }
+>{ f: super["x"] } : { f: () => void; }
+>f : () => void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+>{ f } : { f: () => void; }
+>f : () => void
+
+        // element access (assign) in arrow
+        (() => super["x"] = f);
+>(() => super["x"] = f) : () => () => void
+>() => super["x"] = f : () => () => void
+>super["x"] = f : () => void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+>f : () => void
+
+        // element access (assign) in async arrow
+        (async () => super["x"] = f);
+>(async () => super["x"] = f) : () => Promise<() => void>
+>async () => super["x"] = f : () => Promise<() => void>
+>super["x"] = f : () => void
+>super["x"] : () => void
+>super : A
+>"x" : "x"
+>f : () => void
+    }
 }
 

--- a/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
@@ -1,4 +1,5 @@
 // @target: ES6
+// @lib: esnext
 // @noEmitHelpers: true
 class A {
     x() {
@@ -111,6 +112,66 @@ class B extends A {
     }
 
     async element_access_only_write_only() {
+        const f = () => {};
+
+        // element access (assign)
+        super["x"] = f;
+
+        // destructuring assign with element access
+        ({ f: super["x"] } = { f });
+
+        // element access (assign) in arrow
+        (() => super["x"] = f);
+
+        // element access (assign) in async arrow
+        (async () => super["x"] = f);
+    }
+
+    async * property_access_only_read_only_in_generator() {
+        // call with property access
+        super.x();
+
+        // property access (read)
+        const a = super.x;
+
+        // property access in arrow
+        (() => super.x());
+
+        // property access in async arrow
+        (async () => super.x());
+    }
+
+    async * property_access_only_write_only_in_generator() {
+        const f = () => {};
+
+        // property access (assign)
+        super.x = f;
+
+        // destructuring assign with property access
+        ({ f: super.x } = { f });
+
+        // property access (assign) in arrow
+        (() => super.x = f);
+
+        // property access (assign) in async arrow
+        (async () => super.x = f);
+    }
+
+    async * element_access_only_read_only_in_generator() {
+        // call with element access
+        super["x"]();
+
+        // element access (read)
+        const a = super["x"];
+
+        // element access in arrow
+        (() => super["x"]());
+
+        // element access in async arrow
+        (async () => super["x"]());
+    }
+
+    async * element_access_only_write_only_in_generator() {
         const f = () => {};
 
         // element access (assign)


### PR DESCRIPTION
This marks parts of the synthesized `_super` helper used in async methods and async generators as `EmitFlags.NoSubstitution` to prevent later transforms from replacing `_super`.

Fixes #29561

