### PR TITLE
feat(history): `.pushState()` and `.replaceState` now accept `URL` object

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -8815,8 +8815,8 @@ interface History {
     back(): void;
     forward(): void;
     go(delta?: number): void;
-    pushState(data: any, title: string, url?: string | null): void;
-    replaceState(data: any, title: string, url?: string | null): void;
+    pushState(data: any, title: string, url?: string | URL | null): void;
+    replaceState(data: any, title: string, url?: string | URL | null): void;
 }
 
 declare var History: {


### PR DESCRIPTION
The following code works in plain JavaScript, but there are some typings issues on `history.pushState` and `history.replaceState`:  
```js
const url = new URL(location.href)
url.search = '?foo=bar'
history.pushState({}, 'Title', url)
```

![Sélection_026](https://user-images.githubusercontent.com/2103975/54716703-9de7de00-4b56-11e9-8898-2a5d8a4876b9.jpg)


Also I was looking for tests, but `lib.dom.d.ts` is not tested right? :thinking: 

Thanks!