### PR TITLE
fix jsdoc iterator on expression of export assignment

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2217,6 +2217,7 @@ namespace ts {
     function getNextJSDocCommentLocation(node: Node) {
         const parent = node.parent;
         if (parent.kind === SyntaxKind.PropertyAssignment ||
+            parent.kind === SyntaxKind.ExportAssignment ||
             parent.kind === SyntaxKind.PropertyDeclaration ||
             parent.kind === SyntaxKind.ExpressionStatement && node.kind === SyntaxKind.PropertyAccessExpression ||
             getNestedModuleDeclaration(parent) ||

--- a/tests/baselines/reference/exportDefaultWithJSDoc1.symbols
+++ b/tests/baselines/reference/exportDefaultWithJSDoc1.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/a.js ===
+/**
+No type information for this code. * A number, or a string containing a number.
+No type information for this code. * @typedef {(number|string)} NumberLike
+No type information for this code. */
+No type information for this code.
+No type information for this code./** @type {NumberLike[]} */export default ([ ]);
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/b.ts ===
+import A from './a'
+>A : Symbol(A, Decl(b.ts, 0, 6))
+
+A[0]
+>A : Symbol(A, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/exportDefaultWithJSDoc1.types
+++ b/tests/baselines/reference/exportDefaultWithJSDoc1.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/a.js ===
+/**
+ * A number, or a string containing a number.
+ * @typedef {(number|string)} NumberLike
+ */
+
+/** @type {NumberLike[]} */export default ([ ]);
+>([ ]) : (string | number)[]
+>[ ] : undefined[]
+
+=== tests/cases/compiler/b.ts ===
+import A from './a'
+>A : (string | number)[]
+
+A[0]
+>A[0] : string | number
+>A : (string | number)[]
+>0 : 0
+

--- a/tests/baselines/reference/exportDefaultWithJSDoc2.symbols
+++ b/tests/baselines/reference/exportDefaultWithJSDoc2.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/a.js ===
+/**
+No type information for this code. * A number, or a string containing a number.
+No type information for this code. * @typedef {(number|string)} NumberLike
+No type information for this code. */
+No type information for this code.
+No type information for this code.export default /** @type {NumberLike[]} */([ ]);
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/b.ts ===
+import A from './a'
+>A : Symbol(A, Decl(b.ts, 0, 6))
+
+A[0]
+>A : Symbol(A, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/exportDefaultWithJSDoc2.types
+++ b/tests/baselines/reference/exportDefaultWithJSDoc2.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/a.js ===
+/**
+ * A number, or a string containing a number.
+ * @typedef {(number|string)} NumberLike
+ */
+
+export default /** @type {NumberLike[]} */([ ]);
+>([ ]) : (string | number)[]
+>[ ] : undefined[]
+
+=== tests/cases/compiler/b.ts ===
+import A from './a'
+>A : (string | number)[]
+
+A[0]
+>A[0] : string | number
+>A : (string | number)[]
+>0 : 0
+

--- a/tests/cases/compiler/exportDefaultWithJSDoc1.ts
+++ b/tests/cases/compiler/exportDefaultWithJSDoc1.ts
@@ -1,0 +1,16 @@
+
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+/**
+ * A number, or a string containing a number.
+ * @typedef {(number|string)} NumberLike
+ */
+
+// @Filename: a.js
+/** @type {NumberLike[]} */export default ([ ]);
+
+// @Filename: b.ts
+import A from './a'
+A[0]

--- a/tests/cases/compiler/exportDefaultWithJSDoc2.ts
+++ b/tests/cases/compiler/exportDefaultWithJSDoc2.ts
@@ -1,0 +1,16 @@
+
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+/**
+ * A number, or a string containing a number.
+ * @typedef {(number|string)} NumberLike
+ */
+
+// @Filename: a.js
+export default /** @type {NumberLike[]} */([ ]);
+
+// @Filename: b.ts
+import A from './a'
+A[0]


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #24033  

This pr fixed the jsdoc lookup， currently, jsdoc lookup does not allow export assignment

BTW: the test runner has the correct result, But in my local vscode is incorrectly. I guess that is caused vscode does not handle js file by special tsserver that I setted
