### PR TITLE
Contextual typing based on instantiated types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20264,15 +20264,15 @@ namespace ts {
                         getArrayifiedType(checkExpressionWithContextualType((<SpreadElement>arg).expression, restType, context, CheckMode.Normal));
                 }
             }
-            const contextualType = getIndexedAccessType(restType, numberType);
-            const hasPrimitiveContextualType = maybeTypeOfKind(contextualType, TypeFlags.Primitive | TypeFlags.Index);
             const types = [];
             let spreadIndex = -1;
             for (let i = index; i < argCount; i++) {
+                const contextualType = getIndexedAccessType(restType, getLiteralType(i - index));
                 const argType = checkExpressionWithContextualType(args[i], contextualType, context, CheckMode.Normal);
                 if (spreadIndex < 0 && isSpreadArgument(args[i])) {
                     spreadIndex = i - index;
                 }
+                const hasPrimitiveContextualType = maybeTypeOfKind(contextualType, TypeFlags.Primitive | TypeFlags.Index);
                 types.push(hasPrimitiveContextualType ? getRegularTypeOfLiteralType(argType) : getWidenedLiteralType(argType));
             }
             return spreadIndex < 0 ?

--- a/tests/baselines/reference/fillInMissingTypeArgsOnConstructCalls.types
+++ b/tests/baselines/reference/fillInMissingTypeArgsOnConstructCalls.types
@@ -6,7 +6,7 @@ class A<T extends Object>{
 >list : T
 }
 var a = new A();
->a : A<{}>
->new A() : A<{}>
+>a : A<Object>
+>new A() : A<Object>
 >A : typeof A
 

--- a/tests/baselines/reference/genericCallWithConstraintsTypeArgumentInference2.types
+++ b/tests/baselines/reference/genericCallWithConstraintsTypeArgumentInference2.types
@@ -19,14 +19,14 @@ var r = foo(1); // ok
 >1 : 1
 
 var r2 = foo(null); // {}
->r2 : {}
->foo(null) : {}
+>r2 : any
+>foo(null) : any
 >foo : <T, U extends T>(t: T) => U
 >null : null
 
 var r3 = foo(new Object()); // {}
->r3 : {}
->foo(new Object()) : {}
+>r3 : Object
+>foo(new Object()) : Object
 >foo : <T, U extends T>(t: T) => U
 >new Object() : Object
 >Object : ObjectConstructor

--- a/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints4.types
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgsAndConstraints4.types
@@ -96,11 +96,11 @@ var r8 = foo(() => { }, () => { });
 >() => { } : () => void
 
 var r9 = foo(() => { }, () => 1);
->r9 : (x: () => void) => () => 1
->foo(() => { }, () => 1) : (x: () => void) => () => 1
+>r9 : (x: () => void) => () => number
+>foo(() => { }, () => 1) : (x: () => void) => () => number
 >foo : <T, U extends T>(t: T, t2: U) => (x: T) => U
 >() => { } : () => void
->() => 1 : () => 1
+>() => 1 : () => number
 >1 : 1
 
 function other<T, U extends T>() {

--- a/tests/baselines/reference/instantiateContextualTypes.js
+++ b/tests/baselines/reference/instantiateContextualTypes.js
@@ -1,0 +1,164 @@
+//// [instantiateContextualTypes.ts]
+// #6611
+
+export interface A<a> {
+    value: a;
+}
+
+function fn<a>(values: A<a>, value: a) : void {
+}
+
+declare let handlers: A<(value: number) => void>;
+fn(handlers, value => alert(value));
+
+// #21382
+
+interface BaseProps<T> {
+  initialValues: T;
+  nextValues: (cur: T) => T;
+}
+declare class Component<P> { constructor(props: P); props: P; }
+declare class GenericComponent<Props = {}, Values = object>
+    extends Component<Props & BaseProps<Values>> {
+  iv: Values;
+}
+
+new GenericComponent({ initialValues: 12, nextValues: val => 12 });
+
+// #22149
+
+declare function useStringOrNumber<T extends string | number>(t: T, useIt: T extends string ? ((s: string) => void) : ((n: number) => void)): void;
+useStringOrNumber("", foo => {});
+
+// #25299
+
+type ActionType<P> = string & { attachPayloadTypeHack?: P & never }
+
+type Handler<S, P> = P extends void
+    ? (state: S) => S
+    : (state: S, payload: P) => S
+
+interface ActionHandler<S, P> {
+    actionType: ActionType<P>
+    handler: Handler<S, P>
+}
+
+declare function handler<S, P>(actionType: ActionType<P>, handler: Handler<S, P>): ActionHandler<S, P>
+
+declare function createReducer<S>(
+        defaultState: S,
+        ...actionHandlers: ActionHandler<S, any>[]
+    ): any
+
+interface AppState {
+    dummy: string
+}
+
+const defaultState: AppState = {
+    dummy: ''
+}
+
+const NON_VOID_ACTION: ActionType<number> = 'NON_VOID_ACTION'
+    , VOID_ACTION: ActionType<void> = 'VOID_ACTION'
+
+createReducer(
+    defaultState,
+    handler(NON_VOID_ACTION, (state, _payload) => state),
+    handler(VOID_ACTION, state => state)
+)
+
+// #25814
+
+type R = {
+  a: (x: number) => void;
+  b: (x: string) => void;
+};
+
+type O = {
+  on<P extends keyof R>(x: P, callback: R[P]): void;
+};
+
+declare var x: O;
+x.on('a', a => {});
+
+// #29775
+
+namespace N1 {
+
+declare class Component<P> { 
+  constructor(props: P);
+}
+    
+interface ComponentClass<P = {}> {
+  new (props: P): Component<P>;
+}
+
+type CreateElementChildren<P> =
+  P extends { children?: infer C }
+  ? C extends any[]
+    ? C
+    : C[]
+  : unknown;
+
+declare function createElement<P extends {}>(
+  type: ComponentClass<P>,
+  ...children: CreateElementChildren<P>
+): any;
+
+declare function createElement2<P extends {}>(
+  type: ComponentClass<P>,
+  child: CreateElementChildren<P>
+): any;
+
+class InferFunctionTypes extends Component<{children: (foo: number) => string}> {}
+
+createElement(InferFunctionTypes, (foo) => "" + foo);
+
+createElement2(InferFunctionTypes, [(foo) => "" + foo]);
+
+}
+
+// #30341
+
+type InnerBox<T> = {
+  value: T;
+}
+
+type OuterBox<T> = {
+  inner: InnerBox<T>
+};
+
+type BoxConsumerFromOuterBox<T> =
+  T extends OuterBox<infer U> ?
+      (box: InnerBox<U>) => void :
+      never;
+
+declare function passContentsToFunc<T>(outerBox: T, consumer: BoxConsumerFromOuterBox<T>): void;
+
+declare const outerBoxOfString: OuterBox<string>;
+
+passContentsToFunc(outerBoxOfString, box => box.value);
+
+
+//// [instantiateContextualTypes.js]
+// #6611
+function fn(values, value) {
+}
+fn(handlers, value => alert(value));
+new GenericComponent({ initialValues: 12, nextValues: val => 12 });
+useStringOrNumber("", foo => { });
+const defaultState = {
+    dummy: ''
+};
+const NON_VOID_ACTION = 'NON_VOID_ACTION', VOID_ACTION = 'VOID_ACTION';
+createReducer(defaultState, handler(NON_VOID_ACTION, (state, _payload) => state), handler(VOID_ACTION, state => state));
+x.on('a', a => { });
+// #29775
+var N1;
+(function (N1) {
+    class InferFunctionTypes extends Component {
+    }
+    createElement(InferFunctionTypes, (foo) => "" + foo);
+    createElement2(InferFunctionTypes, [(foo) => "" + foo]);
+})(N1 || (N1 = {}));
+passContentsToFunc(outerBoxOfString, box => box.value);

--- a/tests/baselines/reference/instantiateContextualTypes.symbols
+++ b/tests/baselines/reference/instantiateContextualTypes.symbols
@@ -1,0 +1,409 @@
+=== tests/cases/compiler/instantiateContextualTypes.ts ===
+// #6611
+
+export interface A<a> {
+>A : Symbol(A, Decl(instantiateContextualTypes.ts, 0, 0))
+>a : Symbol(a, Decl(instantiateContextualTypes.ts, 2, 19))
+
+    value: a;
+>value : Symbol(A.value, Decl(instantiateContextualTypes.ts, 2, 23))
+>a : Symbol(a, Decl(instantiateContextualTypes.ts, 2, 19))
+}
+
+function fn<a>(values: A<a>, value: a) : void {
+>fn : Symbol(fn, Decl(instantiateContextualTypes.ts, 4, 1))
+>a : Symbol(a, Decl(instantiateContextualTypes.ts, 6, 12))
+>values : Symbol(values, Decl(instantiateContextualTypes.ts, 6, 15))
+>A : Symbol(A, Decl(instantiateContextualTypes.ts, 0, 0))
+>a : Symbol(a, Decl(instantiateContextualTypes.ts, 6, 12))
+>value : Symbol(value, Decl(instantiateContextualTypes.ts, 6, 28))
+>a : Symbol(a, Decl(instantiateContextualTypes.ts, 6, 12))
+}
+
+declare let handlers: A<(value: number) => void>;
+>handlers : Symbol(handlers, Decl(instantiateContextualTypes.ts, 9, 11))
+>A : Symbol(A, Decl(instantiateContextualTypes.ts, 0, 0))
+>value : Symbol(value, Decl(instantiateContextualTypes.ts, 9, 25))
+
+fn(handlers, value => alert(value));
+>fn : Symbol(fn, Decl(instantiateContextualTypes.ts, 4, 1))
+>handlers : Symbol(handlers, Decl(instantiateContextualTypes.ts, 9, 11))
+>value : Symbol(value, Decl(instantiateContextualTypes.ts, 10, 12))
+>alert : Symbol(alert, Decl(lib.dom.d.ts, --, --))
+>value : Symbol(value, Decl(instantiateContextualTypes.ts, 10, 12))
+
+// #21382
+
+interface BaseProps<T> {
+>BaseProps : Symbol(BaseProps, Decl(instantiateContextualTypes.ts, 10, 36))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 14, 20))
+
+  initialValues: T;
+>initialValues : Symbol(BaseProps.initialValues, Decl(instantiateContextualTypes.ts, 14, 24))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 14, 20))
+
+  nextValues: (cur: T) => T;
+>nextValues : Symbol(BaseProps.nextValues, Decl(instantiateContextualTypes.ts, 15, 19))
+>cur : Symbol(cur, Decl(instantiateContextualTypes.ts, 16, 15))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 14, 20))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 14, 20))
+}
+declare class Component<P> { constructor(props: P); props: P; }
+>Component : Symbol(Component, Decl(instantiateContextualTypes.ts, 17, 1))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 18, 24))
+>props : Symbol(props, Decl(instantiateContextualTypes.ts, 18, 41))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 18, 24))
+>props : Symbol(Component.props, Decl(instantiateContextualTypes.ts, 18, 51))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 18, 24))
+
+declare class GenericComponent<Props = {}, Values = object>
+>GenericComponent : Symbol(GenericComponent, Decl(instantiateContextualTypes.ts, 18, 63))
+>Props : Symbol(Props, Decl(instantiateContextualTypes.ts, 19, 31))
+>Values : Symbol(Values, Decl(instantiateContextualTypes.ts, 19, 42))
+
+    extends Component<Props & BaseProps<Values>> {
+>Component : Symbol(Component, Decl(instantiateContextualTypes.ts, 17, 1))
+>Props : Symbol(Props, Decl(instantiateContextualTypes.ts, 19, 31))
+>BaseProps : Symbol(BaseProps, Decl(instantiateContextualTypes.ts, 10, 36))
+>Values : Symbol(Values, Decl(instantiateContextualTypes.ts, 19, 42))
+
+  iv: Values;
+>iv : Symbol(GenericComponent.iv, Decl(instantiateContextualTypes.ts, 20, 50))
+>Values : Symbol(Values, Decl(instantiateContextualTypes.ts, 19, 42))
+}
+
+new GenericComponent({ initialValues: 12, nextValues: val => 12 });
+>GenericComponent : Symbol(GenericComponent, Decl(instantiateContextualTypes.ts, 18, 63))
+>initialValues : Symbol(initialValues, Decl(instantiateContextualTypes.ts, 24, 22))
+>nextValues : Symbol(nextValues, Decl(instantiateContextualTypes.ts, 24, 41))
+>val : Symbol(val, Decl(instantiateContextualTypes.ts, 24, 53))
+
+// #22149
+
+declare function useStringOrNumber<T extends string | number>(t: T, useIt: T extends string ? ((s: string) => void) : ((n: number) => void)): void;
+>useStringOrNumber : Symbol(useStringOrNumber, Decl(instantiateContextualTypes.ts, 24, 67))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 28, 35))
+>t : Symbol(t, Decl(instantiateContextualTypes.ts, 28, 62))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 28, 35))
+>useIt : Symbol(useIt, Decl(instantiateContextualTypes.ts, 28, 67))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 28, 35))
+>s : Symbol(s, Decl(instantiateContextualTypes.ts, 28, 96))
+>n : Symbol(n, Decl(instantiateContextualTypes.ts, 28, 120))
+
+useStringOrNumber("", foo => {});
+>useStringOrNumber : Symbol(useStringOrNumber, Decl(instantiateContextualTypes.ts, 24, 67))
+>foo : Symbol(foo, Decl(instantiateContextualTypes.ts, 29, 21))
+
+// #25299
+
+type ActionType<P> = string & { attachPayloadTypeHack?: P & never }
+>ActionType : Symbol(ActionType, Decl(instantiateContextualTypes.ts, 29, 33))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 33, 16))
+>attachPayloadTypeHack : Symbol(attachPayloadTypeHack, Decl(instantiateContextualTypes.ts, 33, 31))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 33, 16))
+
+type Handler<S, P> = P extends void
+>Handler : Symbol(Handler, Decl(instantiateContextualTypes.ts, 33, 67))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 35, 13))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 35, 15))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 35, 15))
+
+    ? (state: S) => S
+>state : Symbol(state, Decl(instantiateContextualTypes.ts, 36, 7))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 35, 13))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 35, 13))
+
+    : (state: S, payload: P) => S
+>state : Symbol(state, Decl(instantiateContextualTypes.ts, 37, 7))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 35, 13))
+>payload : Symbol(payload, Decl(instantiateContextualTypes.ts, 37, 16))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 35, 15))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 35, 13))
+
+interface ActionHandler<S, P> {
+>ActionHandler : Symbol(ActionHandler, Decl(instantiateContextualTypes.ts, 37, 33))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 39, 24))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 39, 26))
+
+    actionType: ActionType<P>
+>actionType : Symbol(ActionHandler.actionType, Decl(instantiateContextualTypes.ts, 39, 31))
+>ActionType : Symbol(ActionType, Decl(instantiateContextualTypes.ts, 29, 33))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 39, 26))
+
+    handler: Handler<S, P>
+>handler : Symbol(ActionHandler.handler, Decl(instantiateContextualTypes.ts, 40, 29))
+>Handler : Symbol(Handler, Decl(instantiateContextualTypes.ts, 33, 67))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 39, 24))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 39, 26))
+}
+
+declare function handler<S, P>(actionType: ActionType<P>, handler: Handler<S, P>): ActionHandler<S, P>
+>handler : Symbol(handler, Decl(instantiateContextualTypes.ts, 42, 1))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 44, 25))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 44, 27))
+>actionType : Symbol(actionType, Decl(instantiateContextualTypes.ts, 44, 31))
+>ActionType : Symbol(ActionType, Decl(instantiateContextualTypes.ts, 29, 33))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 44, 27))
+>handler : Symbol(handler, Decl(instantiateContextualTypes.ts, 44, 57))
+>Handler : Symbol(Handler, Decl(instantiateContextualTypes.ts, 33, 67))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 44, 25))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 44, 27))
+>ActionHandler : Symbol(ActionHandler, Decl(instantiateContextualTypes.ts, 37, 33))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 44, 25))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 44, 27))
+
+declare function createReducer<S>(
+>createReducer : Symbol(createReducer, Decl(instantiateContextualTypes.ts, 44, 102))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 46, 31))
+
+        defaultState: S,
+>defaultState : Symbol(defaultState, Decl(instantiateContextualTypes.ts, 46, 34))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 46, 31))
+
+        ...actionHandlers: ActionHandler<S, any>[]
+>actionHandlers : Symbol(actionHandlers, Decl(instantiateContextualTypes.ts, 47, 24))
+>ActionHandler : Symbol(ActionHandler, Decl(instantiateContextualTypes.ts, 37, 33))
+>S : Symbol(S, Decl(instantiateContextualTypes.ts, 46, 31))
+
+    ): any
+
+interface AppState {
+>AppState : Symbol(AppState, Decl(instantiateContextualTypes.ts, 49, 10))
+
+    dummy: string
+>dummy : Symbol(AppState.dummy, Decl(instantiateContextualTypes.ts, 51, 20))
+}
+
+const defaultState: AppState = {
+>defaultState : Symbol(defaultState, Decl(instantiateContextualTypes.ts, 55, 5))
+>AppState : Symbol(AppState, Decl(instantiateContextualTypes.ts, 49, 10))
+
+    dummy: ''
+>dummy : Symbol(dummy, Decl(instantiateContextualTypes.ts, 55, 32))
+}
+
+const NON_VOID_ACTION: ActionType<number> = 'NON_VOID_ACTION'
+>NON_VOID_ACTION : Symbol(NON_VOID_ACTION, Decl(instantiateContextualTypes.ts, 59, 5))
+>ActionType : Symbol(ActionType, Decl(instantiateContextualTypes.ts, 29, 33))
+
+    , VOID_ACTION: ActionType<void> = 'VOID_ACTION'
+>VOID_ACTION : Symbol(VOID_ACTION, Decl(instantiateContextualTypes.ts, 60, 5))
+>ActionType : Symbol(ActionType, Decl(instantiateContextualTypes.ts, 29, 33))
+
+createReducer(
+>createReducer : Symbol(createReducer, Decl(instantiateContextualTypes.ts, 44, 102))
+
+    defaultState,
+>defaultState : Symbol(defaultState, Decl(instantiateContextualTypes.ts, 55, 5))
+
+    handler(NON_VOID_ACTION, (state, _payload) => state),
+>handler : Symbol(handler, Decl(instantiateContextualTypes.ts, 42, 1))
+>NON_VOID_ACTION : Symbol(NON_VOID_ACTION, Decl(instantiateContextualTypes.ts, 59, 5))
+>state : Symbol(state, Decl(instantiateContextualTypes.ts, 64, 30))
+>_payload : Symbol(_payload, Decl(instantiateContextualTypes.ts, 64, 36))
+>state : Symbol(state, Decl(instantiateContextualTypes.ts, 64, 30))
+
+    handler(VOID_ACTION, state => state)
+>handler : Symbol(handler, Decl(instantiateContextualTypes.ts, 42, 1))
+>VOID_ACTION : Symbol(VOID_ACTION, Decl(instantiateContextualTypes.ts, 60, 5))
+>state : Symbol(state, Decl(instantiateContextualTypes.ts, 65, 24))
+>state : Symbol(state, Decl(instantiateContextualTypes.ts, 65, 24))
+
+)
+
+// #25814
+
+type R = {
+>R : Symbol(R, Decl(instantiateContextualTypes.ts, 66, 1))
+
+  a: (x: number) => void;
+>a : Symbol(a, Decl(instantiateContextualTypes.ts, 70, 10))
+>x : Symbol(x, Decl(instantiateContextualTypes.ts, 71, 6))
+
+  b: (x: string) => void;
+>b : Symbol(b, Decl(instantiateContextualTypes.ts, 71, 25))
+>x : Symbol(x, Decl(instantiateContextualTypes.ts, 72, 6))
+
+};
+
+type O = {
+>O : Symbol(O, Decl(instantiateContextualTypes.ts, 73, 2))
+
+  on<P extends keyof R>(x: P, callback: R[P]): void;
+>on : Symbol(on, Decl(instantiateContextualTypes.ts, 75, 10))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 76, 5))
+>R : Symbol(R, Decl(instantiateContextualTypes.ts, 66, 1))
+>x : Symbol(x, Decl(instantiateContextualTypes.ts, 76, 24))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 76, 5))
+>callback : Symbol(callback, Decl(instantiateContextualTypes.ts, 76, 29))
+>R : Symbol(R, Decl(instantiateContextualTypes.ts, 66, 1))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 76, 5))
+
+};
+
+declare var x: O;
+>x : Symbol(x, Decl(instantiateContextualTypes.ts, 79, 11))
+>O : Symbol(O, Decl(instantiateContextualTypes.ts, 73, 2))
+
+x.on('a', a => {});
+>x.on : Symbol(on, Decl(instantiateContextualTypes.ts, 75, 10))
+>x : Symbol(x, Decl(instantiateContextualTypes.ts, 79, 11))
+>on : Symbol(on, Decl(instantiateContextualTypes.ts, 75, 10))
+>a : Symbol(a, Decl(instantiateContextualTypes.ts, 80, 9))
+
+// #29775
+
+namespace N1 {
+>N1 : Symbol(N1, Decl(instantiateContextualTypes.ts, 80, 19))
+
+declare class Component<P> { 
+>Component : Symbol(Component, Decl(instantiateContextualTypes.ts, 84, 14))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 86, 24))
+
+  constructor(props: P);
+>props : Symbol(props, Decl(instantiateContextualTypes.ts, 87, 14))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 86, 24))
+}
+    
+interface ComponentClass<P = {}> {
+>ComponentClass : Symbol(ComponentClass, Decl(instantiateContextualTypes.ts, 88, 1))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 90, 25))
+
+  new (props: P): Component<P>;
+>props : Symbol(props, Decl(instantiateContextualTypes.ts, 91, 7))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 90, 25))
+>Component : Symbol(Component, Decl(instantiateContextualTypes.ts, 84, 14))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 90, 25))
+}
+
+type CreateElementChildren<P> =
+>CreateElementChildren : Symbol(CreateElementChildren, Decl(instantiateContextualTypes.ts, 92, 1))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 94, 27))
+
+  P extends { children?: infer C }
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 94, 27))
+>children : Symbol(children, Decl(instantiateContextualTypes.ts, 95, 13))
+>C : Symbol(C, Decl(instantiateContextualTypes.ts, 95, 30))
+
+  ? C extends any[]
+>C : Symbol(C, Decl(instantiateContextualTypes.ts, 95, 30))
+
+    ? C
+>C : Symbol(C, Decl(instantiateContextualTypes.ts, 95, 30))
+
+    : C[]
+>C : Symbol(C, Decl(instantiateContextualTypes.ts, 95, 30))
+
+  : unknown;
+
+declare function createElement<P extends {}>(
+>createElement : Symbol(createElement, Decl(instantiateContextualTypes.ts, 99, 12))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 101, 31))
+
+  type: ComponentClass<P>,
+>type : Symbol(type, Decl(instantiateContextualTypes.ts, 101, 45))
+>ComponentClass : Symbol(ComponentClass, Decl(instantiateContextualTypes.ts, 88, 1))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 101, 31))
+
+  ...children: CreateElementChildren<P>
+>children : Symbol(children, Decl(instantiateContextualTypes.ts, 102, 26))
+>CreateElementChildren : Symbol(CreateElementChildren, Decl(instantiateContextualTypes.ts, 92, 1))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 101, 31))
+
+): any;
+
+declare function createElement2<P extends {}>(
+>createElement2 : Symbol(createElement2, Decl(instantiateContextualTypes.ts, 104, 7))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 106, 32))
+
+  type: ComponentClass<P>,
+>type : Symbol(type, Decl(instantiateContextualTypes.ts, 106, 46))
+>ComponentClass : Symbol(ComponentClass, Decl(instantiateContextualTypes.ts, 88, 1))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 106, 32))
+
+  child: CreateElementChildren<P>
+>child : Symbol(child, Decl(instantiateContextualTypes.ts, 107, 26))
+>CreateElementChildren : Symbol(CreateElementChildren, Decl(instantiateContextualTypes.ts, 92, 1))
+>P : Symbol(P, Decl(instantiateContextualTypes.ts, 106, 32))
+
+): any;
+
+class InferFunctionTypes extends Component<{children: (foo: number) => string}> {}
+>InferFunctionTypes : Symbol(InferFunctionTypes, Decl(instantiateContextualTypes.ts, 109, 7))
+>Component : Symbol(Component, Decl(instantiateContextualTypes.ts, 84, 14))
+>children : Symbol(children, Decl(instantiateContextualTypes.ts, 111, 44))
+>foo : Symbol(foo, Decl(instantiateContextualTypes.ts, 111, 55))
+
+createElement(InferFunctionTypes, (foo) => "" + foo);
+>createElement : Symbol(createElement, Decl(instantiateContextualTypes.ts, 99, 12))
+>InferFunctionTypes : Symbol(InferFunctionTypes, Decl(instantiateContextualTypes.ts, 109, 7))
+>foo : Symbol(foo, Decl(instantiateContextualTypes.ts, 113, 35))
+>foo : Symbol(foo, Decl(instantiateContextualTypes.ts, 113, 35))
+
+createElement2(InferFunctionTypes, [(foo) => "" + foo]);
+>createElement2 : Symbol(createElement2, Decl(instantiateContextualTypes.ts, 104, 7))
+>InferFunctionTypes : Symbol(InferFunctionTypes, Decl(instantiateContextualTypes.ts, 109, 7))
+>foo : Symbol(foo, Decl(instantiateContextualTypes.ts, 115, 37))
+>foo : Symbol(foo, Decl(instantiateContextualTypes.ts, 115, 37))
+
+}
+
+// #30341
+
+type InnerBox<T> = {
+>InnerBox : Symbol(InnerBox, Decl(instantiateContextualTypes.ts, 117, 1))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 121, 14))
+
+  value: T;
+>value : Symbol(value, Decl(instantiateContextualTypes.ts, 121, 20))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 121, 14))
+}
+
+type OuterBox<T> = {
+>OuterBox : Symbol(OuterBox, Decl(instantiateContextualTypes.ts, 123, 1))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 125, 14))
+
+  inner: InnerBox<T>
+>inner : Symbol(inner, Decl(instantiateContextualTypes.ts, 125, 20))
+>InnerBox : Symbol(InnerBox, Decl(instantiateContextualTypes.ts, 117, 1))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 125, 14))
+
+};
+
+type BoxConsumerFromOuterBox<T> =
+>BoxConsumerFromOuterBox : Symbol(BoxConsumerFromOuterBox, Decl(instantiateContextualTypes.ts, 127, 2))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 129, 29))
+
+  T extends OuterBox<infer U> ?
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 129, 29))
+>OuterBox : Symbol(OuterBox, Decl(instantiateContextualTypes.ts, 123, 1))
+>U : Symbol(U, Decl(instantiateContextualTypes.ts, 130, 26))
+
+      (box: InnerBox<U>) => void :
+>box : Symbol(box, Decl(instantiateContextualTypes.ts, 131, 7))
+>InnerBox : Symbol(InnerBox, Decl(instantiateContextualTypes.ts, 117, 1))
+>U : Symbol(U, Decl(instantiateContextualTypes.ts, 130, 26))
+
+      never;
+
+declare function passContentsToFunc<T>(outerBox: T, consumer: BoxConsumerFromOuterBox<T>): void;
+>passContentsToFunc : Symbol(passContentsToFunc, Decl(instantiateContextualTypes.ts, 132, 12))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 134, 36))
+>outerBox : Symbol(outerBox, Decl(instantiateContextualTypes.ts, 134, 39))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 134, 36))
+>consumer : Symbol(consumer, Decl(instantiateContextualTypes.ts, 134, 51))
+>BoxConsumerFromOuterBox : Symbol(BoxConsumerFromOuterBox, Decl(instantiateContextualTypes.ts, 127, 2))
+>T : Symbol(T, Decl(instantiateContextualTypes.ts, 134, 36))
+
+declare const outerBoxOfString: OuterBox<string>;
+>outerBoxOfString : Symbol(outerBoxOfString, Decl(instantiateContextualTypes.ts, 136, 13))
+>OuterBox : Symbol(OuterBox, Decl(instantiateContextualTypes.ts, 123, 1))
+
+passContentsToFunc(outerBoxOfString, box => box.value);
+>passContentsToFunc : Symbol(passContentsToFunc, Decl(instantiateContextualTypes.ts, 132, 12))
+>outerBoxOfString : Symbol(outerBoxOfString, Decl(instantiateContextualTypes.ts, 136, 13))
+>box : Symbol(box, Decl(instantiateContextualTypes.ts, 138, 36))
+>box.value : Symbol(value, Decl(instantiateContextualTypes.ts, 121, 20))
+>box : Symbol(box, Decl(instantiateContextualTypes.ts, 138, 36))
+>value : Symbol(value, Decl(instantiateContextualTypes.ts, 121, 20))
+

--- a/tests/baselines/reference/instantiateContextualTypes.types
+++ b/tests/baselines/reference/instantiateContextualTypes.types
@@ -1,0 +1,328 @@
+=== tests/cases/compiler/instantiateContextualTypes.ts ===
+// #6611
+
+export interface A<a> {
+    value: a;
+>value : a
+}
+
+function fn<a>(values: A<a>, value: a) : void {
+>fn : <a>(values: A<a>, value: a) => void
+>values : A<a>
+>value : a
+}
+
+declare let handlers: A<(value: number) => void>;
+>handlers : A<(value: number) => void>
+>value : number
+
+fn(handlers, value => alert(value));
+>fn(handlers, value => alert(value)) : void
+>fn : <a>(values: A<a>, value: a) => void
+>handlers : A<(value: number) => void>
+>value => alert(value) : (value: number) => void
+>value : number
+>alert(value) : void
+>alert : (message?: any) => void
+>value : number
+
+// #21382
+
+interface BaseProps<T> {
+  initialValues: T;
+>initialValues : T
+
+  nextValues: (cur: T) => T;
+>nextValues : (cur: T) => T
+>cur : T
+}
+declare class Component<P> { constructor(props: P); props: P; }
+>Component : Component<P>
+>props : P
+>props : P
+
+declare class GenericComponent<Props = {}, Values = object>
+>GenericComponent : GenericComponent<Props, Values>
+
+    extends Component<Props & BaseProps<Values>> {
+>Component : Component<Props & BaseProps<Values>>
+
+  iv: Values;
+>iv : Values
+}
+
+new GenericComponent({ initialValues: 12, nextValues: val => 12 });
+>new GenericComponent({ initialValues: 12, nextValues: val => 12 }) : GenericComponent<{ initialValues: number; nextValues: (val: number) => number; }, number>
+>GenericComponent : typeof GenericComponent
+>{ initialValues: 12, nextValues: val => 12 } : { initialValues: number; nextValues: (val: number) => number; }
+>initialValues : number
+>12 : 12
+>nextValues : (val: number) => number
+>val => 12 : (val: number) => number
+>val : number
+>12 : 12
+
+// #22149
+
+declare function useStringOrNumber<T extends string | number>(t: T, useIt: T extends string ? ((s: string) => void) : ((n: number) => void)): void;
+>useStringOrNumber : <T extends string | number>(t: T, useIt: T extends string ? (s: string) => void : (n: number) => void) => void
+>t : T
+>useIt : T extends string ? (s: string) => void : (n: number) => void
+>s : string
+>n : number
+
+useStringOrNumber("", foo => {});
+>useStringOrNumber("", foo => {}) : void
+>useStringOrNumber : <T extends string | number>(t: T, useIt: T extends string ? (s: string) => void : (n: number) => void) => void
+>"" : ""
+>foo => {} : (foo: string) => void
+>foo : string
+
+// #25299
+
+type ActionType<P> = string & { attachPayloadTypeHack?: P & never }
+>ActionType : ActionType<P>
+>attachPayloadTypeHack : undefined
+
+type Handler<S, P> = P extends void
+>Handler : Handler<S, P>
+
+    ? (state: S) => S
+>state : S
+
+    : (state: S, payload: P) => S
+>state : S
+>payload : P
+
+interface ActionHandler<S, P> {
+    actionType: ActionType<P>
+>actionType : ActionType<P>
+
+    handler: Handler<S, P>
+>handler : Handler<S, P>
+}
+
+declare function handler<S, P>(actionType: ActionType<P>, handler: Handler<S, P>): ActionHandler<S, P>
+>handler : <S, P>(actionType: ActionType<P>, handler: Handler<S, P>) => ActionHandler<S, P>
+>actionType : ActionType<P>
+>handler : Handler<S, P>
+
+declare function createReducer<S>(
+>createReducer : <S>(defaultState: S, ...actionHandlers: ActionHandler<S, any>[]) => any
+
+        defaultState: S,
+>defaultState : S
+
+        ...actionHandlers: ActionHandler<S, any>[]
+>actionHandlers : ActionHandler<S, any>[]
+
+    ): any
+
+interface AppState {
+    dummy: string
+>dummy : string
+}
+
+const defaultState: AppState = {
+>defaultState : AppState
+>{    dummy: ''} : { dummy: string; }
+
+    dummy: ''
+>dummy : string
+>'' : ""
+}
+
+const NON_VOID_ACTION: ActionType<number> = 'NON_VOID_ACTION'
+>NON_VOID_ACTION : ActionType<number>
+>'NON_VOID_ACTION' : "NON_VOID_ACTION"
+
+    , VOID_ACTION: ActionType<void> = 'VOID_ACTION'
+>VOID_ACTION : ActionType<void>
+>'VOID_ACTION' : "VOID_ACTION"
+
+createReducer(
+>createReducer(    defaultState,    handler(NON_VOID_ACTION, (state, _payload) => state),    handler(VOID_ACTION, state => state)) : any
+>createReducer : <S>(defaultState: S, ...actionHandlers: ActionHandler<S, any>[]) => any
+
+    defaultState,
+>defaultState : AppState
+
+    handler(NON_VOID_ACTION, (state, _payload) => state),
+>handler(NON_VOID_ACTION, (state, _payload) => state) : ActionHandler<AppState, number>
+>handler : <S, P>(actionType: ActionType<P>, handler: Handler<S, P>) => ActionHandler<S, P>
+>NON_VOID_ACTION : ActionType<number>
+>(state, _payload) => state : (state: AppState, _payload: number) => AppState
+>state : AppState
+>_payload : number
+>state : AppState
+
+    handler(VOID_ACTION, state => state)
+>handler(VOID_ACTION, state => state) : ActionHandler<AppState, void>
+>handler : <S, P>(actionType: ActionType<P>, handler: Handler<S, P>) => ActionHandler<S, P>
+>VOID_ACTION : ActionType<void>
+>state => state : (state: AppState) => AppState
+>state : AppState
+>state : AppState
+
+)
+
+// #25814
+
+type R = {
+>R : R
+
+  a: (x: number) => void;
+>a : (x: number) => void
+>x : number
+
+  b: (x: string) => void;
+>b : (x: string) => void
+>x : string
+
+};
+
+type O = {
+>O : O
+
+  on<P extends keyof R>(x: P, callback: R[P]): void;
+>on : <P extends "a" | "b">(x: P, callback: R[P]) => void
+>x : P
+>callback : R[P]
+
+};
+
+declare var x: O;
+>x : O
+
+x.on('a', a => {});
+>x.on('a', a => {}) : void
+>x.on : <P extends "a" | "b">(x: P, callback: R[P]) => void
+>x : O
+>on : <P extends "a" | "b">(x: P, callback: R[P]) => void
+>'a' : "a"
+>a => {} : (a: number) => void
+>a : number
+
+// #29775
+
+namespace N1 {
+>N1 : typeof N1
+
+declare class Component<P> { 
+>Component : Component<P>
+
+  constructor(props: P);
+>props : P
+}
+    
+interface ComponentClass<P = {}> {
+  new (props: P): Component<P>;
+>props : P
+}
+
+type CreateElementChildren<P> =
+>CreateElementChildren : P extends { children?: infer C | undefined; } ? C extends any[] ? C : C[] : unknown
+
+  P extends { children?: infer C }
+>children : C | undefined
+
+  ? C extends any[]
+    ? C
+    : C[]
+  : unknown;
+
+declare function createElement<P extends {}>(
+>createElement : <P extends {}>(type: ComponentClass<P>, ...children: P extends { children?: infer C | undefined; } ? C extends any[] ? C : C[] : unknown) => any
+
+  type: ComponentClass<P>,
+>type : ComponentClass<P>
+
+  ...children: CreateElementChildren<P>
+>children : P extends { children?: infer C | undefined; } ? C extends any[] ? C : C[] : unknown
+
+): any;
+
+declare function createElement2<P extends {}>(
+>createElement2 : <P extends {}>(type: ComponentClass<P>, child: P extends { children?: infer C | undefined; } ? C extends any[] ? C : C[] : unknown) => any
+
+  type: ComponentClass<P>,
+>type : ComponentClass<P>
+
+  child: CreateElementChildren<P>
+>child : P extends { children?: infer C | undefined; } ? C extends any[] ? C : C[] : unknown
+
+): any;
+
+class InferFunctionTypes extends Component<{children: (foo: number) => string}> {}
+>InferFunctionTypes : InferFunctionTypes
+>Component : Component<{ children: (foo: number) => string; }>
+>children : (foo: number) => string
+>foo : number
+
+createElement(InferFunctionTypes, (foo) => "" + foo);
+>createElement(InferFunctionTypes, (foo) => "" + foo) : any
+>createElement : <P extends {}>(type: ComponentClass<P>, ...children: P extends { children?: infer C | undefined; } ? C extends any[] ? C : C[] : unknown) => any
+>InferFunctionTypes : typeof InferFunctionTypes
+>(foo) => "" + foo : (foo: number) => string
+>foo : number
+>"" + foo : string
+>"" : ""
+>foo : number
+
+createElement2(InferFunctionTypes, [(foo) => "" + foo]);
+>createElement2(InferFunctionTypes, [(foo) => "" + foo]) : any
+>createElement2 : <P extends {}>(type: ComponentClass<P>, child: P extends { children?: infer C | undefined; } ? C extends any[] ? C : C[] : unknown) => any
+>InferFunctionTypes : typeof InferFunctionTypes
+>[(foo) => "" + foo] : ((foo: number) => string)[]
+>(foo) => "" + foo : (foo: number) => string
+>foo : number
+>"" + foo : string
+>"" : ""
+>foo : number
+
+}
+
+// #30341
+
+type InnerBox<T> = {
+>InnerBox : InnerBox<T>
+
+  value: T;
+>value : T
+}
+
+type OuterBox<T> = {
+>OuterBox : OuterBox<T>
+
+  inner: InnerBox<T>
+>inner : InnerBox<T>
+
+};
+
+type BoxConsumerFromOuterBox<T> =
+>BoxConsumerFromOuterBox : BoxConsumerFromOuterBox<T>
+
+  T extends OuterBox<infer U> ?
+      (box: InnerBox<U>) => void :
+>box : InnerBox<U>
+
+      never;
+
+declare function passContentsToFunc<T>(outerBox: T, consumer: BoxConsumerFromOuterBox<T>): void;
+>passContentsToFunc : <T>(outerBox: T, consumer: BoxConsumerFromOuterBox<T>) => void
+>outerBox : T
+>consumer : BoxConsumerFromOuterBox<T>
+
+declare const outerBoxOfString: OuterBox<string>;
+>outerBoxOfString : OuterBox<string>
+
+passContentsToFunc(outerBoxOfString, box => box.value);
+>passContentsToFunc(outerBoxOfString, box => box.value) : void
+>passContentsToFunc : <T>(outerBox: T, consumer: BoxConsumerFromOuterBox<T>) => void
+>outerBoxOfString : OuterBox<string>
+>box => box.value : (box: InnerBox<string>) => string
+>box : InnerBox<string>
+>box.value : string
+>box : InnerBox<string>
+>value : string
+

--- a/tests/cases/compiler/instantiateContextualTypes.ts
+++ b/tests/cases/compiler/instantiateContextualTypes.ts
@@ -1,0 +1,142 @@
+// @strict: true
+// @target: es6
+
+// #6611
+
+export interface A<a> {
+    value: a;
+}
+
+function fn<a>(values: A<a>, value: a) : void {
+}
+
+declare let handlers: A<(value: number) => void>;
+fn(handlers, value => alert(value));
+
+// #21382
+
+interface BaseProps<T> {
+  initialValues: T;
+  nextValues: (cur: T) => T;
+}
+declare class Component<P> { constructor(props: P); props: P; }
+declare class GenericComponent<Props = {}, Values = object>
+    extends Component<Props & BaseProps<Values>> {
+  iv: Values;
+}
+
+new GenericComponent({ initialValues: 12, nextValues: val => 12 });
+
+// #22149
+
+declare function useStringOrNumber<T extends string | number>(t: T, useIt: T extends string ? ((s: string) => void) : ((n: number) => void)): void;
+useStringOrNumber("", foo => {});
+
+// #25299
+
+type ActionType<P> = string & { attachPayloadTypeHack?: P & never }
+
+type Handler<S, P> = P extends void
+    ? (state: S) => S
+    : (state: S, payload: P) => S
+
+interface ActionHandler<S, P> {
+    actionType: ActionType<P>
+    handler: Handler<S, P>
+}
+
+declare function handler<S, P>(actionType: ActionType<P>, handler: Handler<S, P>): ActionHandler<S, P>
+
+declare function createReducer<S>(
+        defaultState: S,
+        ...actionHandlers: ActionHandler<S, any>[]
+    ): any
+
+interface AppState {
+    dummy: string
+}
+
+const defaultState: AppState = {
+    dummy: ''
+}
+
+const NON_VOID_ACTION: ActionType<number> = 'NON_VOID_ACTION'
+    , VOID_ACTION: ActionType<void> = 'VOID_ACTION'
+
+createReducer(
+    defaultState,
+    handler(NON_VOID_ACTION, (state, _payload) => state),
+    handler(VOID_ACTION, state => state)
+)
+
+// #25814
+
+type R = {
+  a: (x: number) => void;
+  b: (x: string) => void;
+};
+
+type O = {
+  on<P extends keyof R>(x: P, callback: R[P]): void;
+};
+
+declare var x: O;
+x.on('a', a => {});
+
+// #29775
+
+namespace N1 {
+
+declare class Component<P> { 
+  constructor(props: P);
+}
+    
+interface ComponentClass<P = {}> {
+  new (props: P): Component<P>;
+}
+
+type CreateElementChildren<P> =
+  P extends { children?: infer C }
+  ? C extends any[]
+    ? C
+    : C[]
+  : unknown;
+
+declare function createElement<P extends {}>(
+  type: ComponentClass<P>,
+  ...children: CreateElementChildren<P>
+): any;
+
+declare function createElement2<P extends {}>(
+  type: ComponentClass<P>,
+  child: CreateElementChildren<P>
+): any;
+
+class InferFunctionTypes extends Component<{children: (foo: number) => string}> {}
+
+createElement(InferFunctionTypes, (foo) => "" + foo);
+
+createElement2(InferFunctionTypes, [(foo) => "" + foo]);
+
+}
+
+// #30341
+
+type InnerBox<T> = {
+  value: T;
+}
+
+type OuterBox<T> = {
+  inner: InnerBox<T>
+};
+
+type BoxConsumerFromOuterBox<T> =
+  T extends OuterBox<infer U> ?
+      (box: InnerBox<U>) => void :
+      never;
+
+declare function passContentsToFunc<T>(outerBox: T, consumer: BoxConsumerFromOuterBox<T>): void;
+
+declare const outerBoxOfString: OuterBox<string>;
+
+passContentsToFunc(outerBoxOfString, box => box.value);


### PR DESCRIPTION
With this PR we improve our ability to contextually type parameters of arrow functions and function expressions passed as arguments, allowing contextual types to depend on inferences made from other arguments. For example:

```ts
type EventMap = {
  a: () => void,
  b: (x: number, y: number) => number;
  c: (s: string) => boolean;
}

type EventObject = {
  on<K extends keyof EventMap>(key: K, handler: EventMap[K]): ReturnType<EventMap[K]>;
}

declare var obj: EventObject;
obj.on('a', () => {});            // () => void
obj.on('b', (x, y) => x * y);     // (x: number, y: number) => number
obj.on('c', s => s.length > 10);  // (s: string) => boolean
```

Above, the contextual type for each arrow function arguments depends on the type inferred for `K` from the first argument. Specifically, the contextual type for the arrow function argument is instantiated with inferences made from other arguments before the contextual type is applied to the arrow function parameters.

Fixes #6611.
Fixes #21382.
Fixes #22149.
Fixes #25299.
Fixes #25759.
Fixes #25814.
Fixes #29775.
Fixes #30341.