### PR TITLE
fix(lib): Fix `RegExp` constructor with `string|RegExp` and `flags`

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -367,8 +367,8 @@ interface RegExp {
 }
 
 interface RegExpConstructor {
-    new (pattern: RegExp, flags?: string): RegExp;
-    (pattern: RegExp, flags?: string): RegExp;
+    new (pattern: RegExp | string, flags?: string): RegExp;
+    (pattern: RegExp | string, flags?: string): RegExp;
 }
 
 interface String {


### PR DESCRIPTION
Previously:
```ts
export function replace(str: string, from: string | RegExp, to: string): string {
	return String(str).replace(RegExp(from, 'g'), to);
}
```
Would result in:
```
error TS2345: Argument of type 'string | RegExp' is not assignable to parameter of type 'string'.
  Type 'RegExp' is not assignable to type 'string'.

 return String(str).replace(RegExp(from, 'g'), to);
                                   ~~~~
```
This fixes that.

See also: https://github.com/Microsoft/TypeScript/issues/14107

---

review?(@sandersn)