### PR TITLE
fix generate typenode from negative numerical literal

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3360,8 +3360,9 @@ namespace ts {
                     return createLiteralTypeNode(setEmitFlags(createLiteral((<StringLiteralType>type).value), EmitFlags.NoAsciiEscaping));
                 }
                 if (type.flags & TypeFlags.NumberLiteral) {
-                    context.approximateLength += (("" + (<NumberLiteralType>type).value).length);
-                    return createLiteralTypeNode((createLiteral((<NumberLiteralType>type).value)));
+                    const value = (<NumberLiteralType>type).value;
+                    context.approximateLength += ("" + value).length;
+                    return createLiteralTypeNode(value < 0 ? createPrefix(SyntaxKind.MinusToken, createLiteral(-value)) : createLiteral(value));
                 }
                 if (type.flags & TypeFlags.BigIntLiteral) {
                     context.approximateLength += (pseudoBigIntToString((<BigIntLiteralType>type).value).length) + 1;

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceWithNegativeNumber.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceWithNegativeNumber.ts
@@ -1,0 +1,9 @@
+
+
+/// <reference path='fourslash.ts' />
+
+//// interface X { value: -1 | 0 | 1; }
+//// class Y implements X { }
+
+// https://github.com/Microsoft/TypeScript/issues/30431
+verify.codeFixAvailable([{ description: "Implement interface 'X'" }]);

--- a/tests/cases/fourslash/codeFixInferFromFunctionUsage.ts
+++ b/tests/cases/fourslash/codeFixInferFromFunctionUsage.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+
+// @noImplicitAny: true
+////function wrap( [| arr |] ) {
+////     arr.sort(function (a: number, b: number) { return a < b ? -1 : 1 })
+//// }
+
+// https://github.com/Microsoft/TypeScript/issues/29330
+verify.rangeAfterCodeFix("arr: { sort: (arg0: (a: number, b: number) => 1 | -1) => void; }");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #29330, #30431
Closes #29492

