### PR TITLE
Add type error when destructuring zero elements from void

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19518,6 +19518,21 @@ namespace ts {
             return type;
         }
 
+        function checkNonNullNonVoidType(
+            type: Type,
+            node: Node,
+            nullDiagnostic?: DiagnosticMessage,
+            undefinedDiagnostic?: DiagnosticMessage,
+            nullOrUndefinedDiagnostic?: DiagnosticMessage,
+            voidDiagnostic?: DiagnosticMessage
+        ): Type {
+            const nonNullType = checkNonNullType(type, node, nullDiagnostic, undefinedDiagnostic, nullOrUndefinedDiagnostic);
+            if (nonNullType !== errorType && nonNullType.flags & TypeFlags.Void) {
+                error(node, voidDiagnostic || Diagnostics.Object_is_possibly_undefined);
+            }
+            return nonNullType;
+        }
+
         function checkPropertyAccessExpression(node: PropertyAccessExpression) {
             return checkPropertyAccessExpressionOrQualifiedName(node, node.expression, node.name);
         }
@@ -26258,7 +26273,7 @@ namespace ts {
                 if (node.initializer && node.parent.parent.kind !== SyntaxKind.ForInStatement) {
                     const initializerType = checkExpressionCached(node.initializer);
                     if (strictNullChecks && node.name.elements.length === 0) {
-                        checkNonNullType(initializerType, node);
+                        checkNonNullNonVoidType(initializerType, node);
                     }
                     else {
                         checkTypeAssignableToAndOptionallyElaborate(initializerType, getWidenedTypeForVariableLikeDeclaration(node), node, node.initializer);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19518,17 +19518,10 @@ namespace ts {
             return type;
         }
 
-        function checkNonNullNonVoidType(
-            type: Type,
-            node: Node,
-            nullDiagnostic?: DiagnosticMessage,
-            undefinedDiagnostic?: DiagnosticMessage,
-            nullOrUndefinedDiagnostic?: DiagnosticMessage,
-            voidDiagnostic?: DiagnosticMessage
-        ): Type {
-            const nonNullType = checkNonNullType(type, node, nullDiagnostic, undefinedDiagnostic, nullOrUndefinedDiagnostic);
+        function checkNonNullNonVoidType(type: Type, node: Node): Type {
+            const nonNullType = checkNonNullType(type, node);
             if (nonNullType !== errorType && nonNullType.flags & TypeFlags.Void) {
-                error(node, voidDiagnostic || Diagnostics.Object_is_possibly_undefined);
+                error(node, Diagnostics.Object_is_possibly_undefined);
             }
             return nonNullType;
         }

--- a/tests/baselines/reference/destructuringVoid.js
+++ b/tests/baselines/reference/destructuringVoid.js
@@ -1,0 +1,7 @@
+//// [destructuringVoid.ts]
+declare const v: void;
+const {} = v;
+
+
+//// [destructuringVoid.js]
+var _a = v;

--- a/tests/baselines/reference/destructuringVoid.symbols
+++ b/tests/baselines/reference/destructuringVoid.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/es6/destructuring/destructuringVoid.ts ===
+declare const v: void;
+>v : Symbol(v, Decl(destructuringVoid.ts, 0, 13))
+
+const {} = v;
+>v : Symbol(v, Decl(destructuringVoid.ts, 0, 13))
+

--- a/tests/baselines/reference/destructuringVoid.types
+++ b/tests/baselines/reference/destructuringVoid.types
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/es6/destructuring/destructuringVoid.ts ===
+declare const v: void;
+>v : void
+
+const {} = v;
+>v : void
+

--- a/tests/baselines/reference/destructuringVoidStrictNullChecks.errors.txt
+++ b/tests/baselines/reference/destructuringVoidStrictNullChecks.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts(2,7): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts (1 errors) ====
+    declare const v: void;
+    const {} = v;
+          ~~
+!!! error TS2532: Object is possibly 'undefined'.
+    

--- a/tests/baselines/reference/destructuringVoidStrictNullChecks.js
+++ b/tests/baselines/reference/destructuringVoidStrictNullChecks.js
@@ -1,0 +1,7 @@
+//// [destructuringVoidStrictNullChecks.ts]
+declare const v: void;
+const {} = v;
+
+
+//// [destructuringVoidStrictNullChecks.js]
+var _a = v;

--- a/tests/baselines/reference/destructuringVoidStrictNullChecks.symbols
+++ b/tests/baselines/reference/destructuringVoidStrictNullChecks.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts ===
+declare const v: void;
+>v : Symbol(v, Decl(destructuringVoidStrictNullChecks.ts, 0, 13))
+
+const {} = v;
+>v : Symbol(v, Decl(destructuringVoidStrictNullChecks.ts, 0, 13))
+

--- a/tests/baselines/reference/destructuringVoidStrictNullChecks.types
+++ b/tests/baselines/reference/destructuringVoidStrictNullChecks.types
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts ===
+declare const v: void;
+>v : void
+
+const {} = v;
+>v : void
+

--- a/tests/cases/conformance/es6/destructuring/destructuringVoid.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringVoid.ts
@@ -1,0 +1,3 @@
+// @strictNullChecks: false
+declare const v: void;
+const {} = v;

--- a/tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts
@@ -1,0 +1,3 @@
+// @strictNullChecks: true
+declare const v: void;
+const {} = v;


### PR DESCRIPTION
Adds special handling for `void` when checking initializers of binding patterns with zero elements. Previously checked only that the initializer type was not null or undefined.

Fixes #30638

