### PR TITLE
Fix ternaries where "true" is a parenthesized variable and "false" is a function expression

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3695,7 +3695,7 @@ namespace ts {
             //  - "a ? (b): c" will have "(b):" parsed as a signature with a return type annotation.
             //
             // So we need just a bit of lookahead to ensure that it can only be a signature.
-            if (!allowAmbiguity && token() !== SyntaxKind.EqualsGreaterThanToken && token() !== SyntaxKind.OpenBraceToken) {
+            if (!allowAmbiguity && token() !== SyntaxKind.EqualsGreaterThanToken && (contextFlags & NodeFlags.InConditionalWhenTrue || token() !== SyntaxKind.OpenBraceToken)) {
                 // Returning undefined here will cause our caller to rewind to where we started from.
                 return undefined;
             }
@@ -3747,7 +3747,9 @@ namespace ts {
             const node = <ConditionalExpression>createNode(SyntaxKind.ConditionalExpression, leftOperand.pos);
             node.condition = leftOperand;
             node.questionToken = questionToken;
-            node.whenTrue = doOutsideOfContext(disallowInAndDecoratorContext, parseAssignmentExpressionOrHigher);
+            node.whenTrue = doInsideOfContext(
+                NodeFlags.InConditionalWhenTrue,
+                () => doOutsideOfContext(disallowInAndDecoratorContext, parseAssignmentExpressionOrHigher));
             node.colonToken = parseExpectedToken(SyntaxKind.ColonToken);
             node.whenFalse = nodeIsPresent(node.colonToken)
                 ? parseAssignmentExpressionOrHigher()

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -553,7 +553,6 @@ namespace ts {
         /* @internal */ Ambient                       = 1 << 22, // If node was inside an ambient context -- a declaration file, or inside something with the `declare` modifier.
         /* @internal */ InWithStatement               = 1 << 23, // If any ancestor of node was the `statement` of a WithStatement (not the `expression`)
         JsonFile                                      = 1 << 24, // If node was parsed in a Json
-        /* @internal */ InConditionalWhenTrue         = 1 << 25, // If node was parsed in the true side of a ConditionalExpression
 
         BlockScoped = Let | Const,
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -553,6 +553,7 @@ namespace ts {
         /* @internal */ Ambient                       = 1 << 22, // If node was inside an ambient context -- a declaration file, or inside something with the `declare` modifier.
         /* @internal */ InWithStatement               = 1 << 23, // If any ancestor of node was the `statement` of a WithStatement (not the `expression`)
         JsonFile                                      = 1 << 24, // If node was parsed in a Json
+        /* @internal */ InConditionalWhenTrue         = 1 << 25, // If node was parsed in the true side of a ConditionalExpression
 
         BlockScoped = Let | Const,
 

--- a/tests/baselines/reference/parserParenthesizedVariableAndFunctionInTernary.js
+++ b/tests/baselines/reference/parserParenthesizedVariableAndFunctionInTernary.js
@@ -1,0 +1,8 @@
+//// [parserParenthesizedVariableAndFunctionInTernary.ts]
+let a: any;
+const c = true ? (a) : function() {};
+
+
+//// [parserParenthesizedVariableAndFunctionInTernary.js]
+var a;
+var c = true ? (a) : function () { };

--- a/tests/baselines/reference/parserParenthesizedVariableAndFunctionInTernary.symbols
+++ b/tests/baselines/reference/parserParenthesizedVariableAndFunctionInTernary.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndFunctionInTernary.ts ===
+let a: any;
+>a : Symbol(a, Decl(parserParenthesizedVariableAndFunctionInTernary.ts, 0, 3))
+
+const c = true ? (a) : function() {};
+>c : Symbol(c, Decl(parserParenthesizedVariableAndFunctionInTernary.ts, 1, 5))
+>a : Symbol(a, Decl(parserParenthesizedVariableAndFunctionInTernary.ts, 0, 3))
+

--- a/tests/baselines/reference/parserParenthesizedVariableAndFunctionInTernary.types
+++ b/tests/baselines/reference/parserParenthesizedVariableAndFunctionInTernary.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndFunctionInTernary.ts ===
+let a: any;
+>a : any
+
+const c = true ? (a) : function() {};
+>c : any
+>true ? (a) : function() {} : any
+>true : true
+>(a) : any
+>a : any
+>function() {} : () => void
+

--- a/tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndFunctionInTernary.ts
+++ b/tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndFunctionInTernary.ts
@@ -1,0 +1,2 @@
+let a: any;
+const c = true ? (a) : function() {};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #30635

~Decided to try parsing JSDoc function types (e.g. `/** @type {function(): void} */`) only inside JSDoc per @weswigham’s suggestion, see what breaks, and gather feedback.~

~Looks like what breaks is the error message on code like~

```ts
var g: function(number, number): number = (n,m) => n + m;
```

~Previously, the error was `JSDoc types can only be used inside documentation comments`. With this change, it becomes a series of nasty parse errors and `Cannot find name 'function'`. 😕~

Possible simple options off the top of my head:

- Go with this because people probably don't often try to write code like the snippet above
- Try to disable JSDoc function keyword parsing only when parsing the `whenTrue` of a conditional expression: super magically edge-casey but keeps all existing nice error messages.

Thoughts?

---

**EDIT**

Updated with a different approach. Typically, arrow functions parse successfully even if they're missing the `=>` token, since in _most_ cases it's still unambiguously an arrow function that's just missing a `=>`. When parsing the true side of a conditional expression, combined with the fact that `function()` parses as a _type_ for JSDoc compatibility, it's not unambiguously an arrow function.

So, when the arrow function in-progress has a `JSDocFunctionType` type, I don't allow a missing `=>` token.