### PR TITLE
#30697 - Confusing error message for definite assignment assertion without type annotation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -31454,7 +31454,7 @@ namespace ts {
             }
 
             if (node.exclamationToken && (node.parent.parent.kind !== SyntaxKind.VariableStatement || !node.type || node.initializer || node.flags & NodeFlags.Ambient)) {
-                return grammarErrorOnNode(node.exclamationToken, Diagnostics.A_definite_assignment_assertion_is_not_permitted_in_this_context);
+                return grammarErrorOnNode(node.exclamationToken, Diagnostics.Definite_assignment_assertions_can_only_be_used_along_with_a_type_annotation);
             }
 
             if (compilerOptions.module !== ModuleKind.ES2015 && compilerOptions.module !== ModuleKind.ESNext && compilerOptions.module !== ModuleKind.System && !compilerOptions.noEmit &&

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -847,6 +847,10 @@
         "category": "Error",
         "code": 1257
     },
+    "Definite assignment assertions can only be used along with a type annotation.": {
+        "category": "Error",
+        "code": 1258
+    },
     "'with' statements are not allowed in an async function block.": {
         "category": "Error",
         "code": 1300

--- a/tests/baselines/reference/definiteAssignmentAssertions.errors.txt
+++ b/tests/baselines/reference/definiteAssignmentAssertions.errors.txt
@@ -4,11 +4,11 @@ tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(21,6): error
 tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(22,13): error TS1255: A definite assignment assertion '!' is not permitted in this context.
 tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(28,6): error TS1255: A definite assignment assertion '!' is not permitted in this context.
 tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(34,15): error TS1255: A definite assignment assertion '!' is not permitted in this context.
-tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(68,10): error TS1255: A definite assignment assertion '!' is not permitted in this context.
-tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(69,10): error TS1255: A definite assignment assertion '!' is not permitted in this context.
-tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(70,10): error TS1255: A definite assignment assertion '!' is not permitted in this context.
-tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(75,15): error TS1255: A definite assignment assertion '!' is not permitted in this context.
-tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(76,15): error TS1255: A definite assignment assertion '!' is not permitted in this context.
+tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(68,10): error TS1258: Definite assignment assertions can only be used along with a type annotation.
+tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(69,10): error TS1258: Definite assignment assertions can only be used along with a type annotation.
+tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(70,10): error TS1258: Definite assignment assertions can only be used along with a type annotation.
+tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(75,15): error TS1258: Definite assignment assertions can only be used along with a type annotation.
+tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(76,15): error TS1258: Definite assignment assertions can only be used along with a type annotation.
 
 
 ==== tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts (11 errors) ====
@@ -93,21 +93,21 @@ tests/cases/conformance/controlFlow/definiteAssignmentAssertions.ts(76,15): erro
     function f4() {
         let a!;
              ~
-!!! error TS1255: A definite assignment assertion '!' is not permitted in this context.
+!!! error TS1258: Definite assignment assertions can only be used along with a type annotation.
         let b! = 1;
              ~
-!!! error TS1255: A definite assignment assertion '!' is not permitted in this context.
+!!! error TS1258: Definite assignment assertions can only be used along with a type annotation.
         let c!: number = 1;
              ~
-!!! error TS1255: A definite assignment assertion '!' is not permitted in this context.
+!!! error TS1258: Definite assignment assertions can only be used along with a type annotation.
     }
     
     // Definite assignment assertion not permitted in ambient context
     
     declare let v1!: number;
                   ~
-!!! error TS1255: A definite assignment assertion '!' is not permitted in this context.
+!!! error TS1258: Definite assignment assertions can only be used along with a type annotation.
     declare var v2!: number;
                   ~
-!!! error TS1255: A definite assignment assertion '!' is not permitted in this context.
+!!! error TS1258: Definite assignment assertions can only be used along with a type annotation.
     


### PR DESCRIPTION
Fixes #30697 

