### PR TITLE
Fix crash when binding deep module.exports assignment

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2710,8 +2710,7 @@ namespace ts {
             }
             else {
                 const s = forEachIdentifierInEntityName(e.expression, parent, action);
-                if (!s || !s.exports) return Debug.fail();
-                return action(e.name, s.exports.get(e.name.escapedText), s);
+                return action(e.name, s && s.exports && s.exports.get(e.name.escapedText), s);
             }
         }
 

--- a/tests/baselines/reference/jsFileCompilationBindDeepExportsAssignment.errors.txt
+++ b/tests/baselines/reference/jsFileCompilationBindDeepExportsAssignment.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/a.js(1,9): error TS2339: Property 'a' does not exist on type 'typeof import("tests/cases/compiler/a")'.
+
+
+==== tests/cases/compiler/a.js (1 errors) ====
+    exports.a.b.c = 0;
+            ~
+!!! error TS2339: Property 'a' does not exist on type 'typeof import("tests/cases/compiler/a")'.
+    

--- a/tests/baselines/reference/jsFileCompilationBindDeepExportsAssignment.symbols
+++ b/tests/baselines/reference/jsFileCompilationBindDeepExportsAssignment.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/a.js ===
+exports.a.b.c = 0;
+>exports : Symbol("tests/cases/compiler/a", Decl(a.js, 0, 0))
+

--- a/tests/baselines/reference/jsFileCompilationBindDeepExportsAssignment.types
+++ b/tests/baselines/reference/jsFileCompilationBindDeepExportsAssignment.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/a.js ===
+exports.a.b.c = 0;
+>exports.a.b.c = 0 : 0
+>exports.a.b.c : any
+>exports.a.b : any
+>exports.a : any
+>exports : typeof import("tests/cases/compiler/a")
+>a : any
+>b : any
+>c : any
+>0 : 0
+

--- a/tests/cases/compiler/jsFileCompilationBindDeepExportsAssignment.ts
+++ b/tests/cases/compiler/jsFileCompilationBindDeepExportsAssignment.ts
@@ -1,0 +1,5 @@
+// @allowJs: true
+// @noEmit: true
+// @filename: a.js
+
+exports.a.b.c = 0;

--- a/tests/cases/compiler/jsFileCompilationBindDeepExportsAssignment.ts
+++ b/tests/cases/compiler/jsFileCompilationBindDeepExportsAssignment.ts
@@ -1,5 +1,6 @@
 // @allowJs: true
 // @noEmit: true
+// @checkJs: true
 // @filename: a.js
 
 exports.a.b.c = 0;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #30668 

