### PR TITLE
Treat hoisted temp variables as a custom prologue.

### DIFF
--- a/src/compiler/transformer.ts
+++ b/src/compiler/transformer.ts
@@ -327,6 +327,8 @@ namespace ts {
                         createVariableDeclarationList(lexicalEnvironmentVariableDeclarations)
                     );
 
+                    setEmitFlags(statement, EmitFlags.CustomPrologue);
+
                     if (!statements) {
                         statements = [statement];
                     }

--- a/tests/baselines/reference/asyncArrowFunction11_es5.js
+++ b/tests/baselines/reference/asyncArrowFunction11_es5.js
@@ -53,7 +53,8 @@ var A = /** @class */ (function () {
                 args[_i] = arguments[_i];
             }
             return __awaiter(_this, void 0, void 0, function () {
-                var _a, obj;
+                var obj;
+                var _a;
                 var _this = this;
                 return __generator(this, function (_b) {
                     switch (_b.label) {

--- a/tests/baselines/reference/asyncArrowFunction8_es5.js
+++ b/tests/baselines/reference/asyncArrowFunction8_es5.js
@@ -6,7 +6,8 @@ var foo = async (): Promise<void> => {
 //// [asyncArrowFunction8_es5.js]
 var _this = this;
 var foo = function () { return __awaiter(_this, void 0, void 0, function () {
-    var _a, v;
+    var v;
+    var _a;
     return __generator(this, function (_b) {
         switch (_b.label) {
             case 0:

--- a/tests/baselines/reference/asyncFunctionDeclaration9_es5.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration9_es5.js
@@ -6,7 +6,8 @@ async function foo(): Promise<void> {
 //// [asyncFunctionDeclaration9_es5.js]
 function foo() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, v;
+        var v;
+        var _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:

--- a/tests/baselines/reference/bindingPatternOmittedExpressionNesting.js
+++ b/tests/baselines/reference/bindingPatternOmittedExpressionNesting.js
@@ -3,8 +3,8 @@ export let [,,[,[],,[],]] = undefined as any;
 
 //// [bindingPatternOmittedExpressionNesting.js]
 "use strict";
-exports.__esModule = true;
 var _a, _b, _c, _d;
+exports.__esModule = true;
 exports._e = (_a = undefined, _b = _a[2], _c = _b[1], _d = _b[3]);
 
 

--- a/tests/baselines/reference/blockScopedBindingsInDownlevelGenerator.js
+++ b/tests/baselines/reference/blockScopedBindingsInDownlevelGenerator.js
@@ -45,7 +45,8 @@ var __values = (this && this.__values) || function (o) {
     };
 };
 function a() {
-    var e_1, _a, _loop_1, _b, _c, i, e_1_1;
+    var _loop_1, _a, _b, i, e_1_1;
+    var e_1, _c;
     return __generator(this, function (_d) {
         switch (_d.label) {
             case 0:
@@ -64,17 +65,17 @@ function a() {
                 _d.label = 1;
             case 1:
                 _d.trys.push([1, 6, 7, 8]);
-                _b = __values([1, 2, 3]), _c = _b.next();
+                _a = __values([1, 2, 3]), _b = _a.next();
                 _d.label = 2;
             case 2:
-                if (!!_c.done) return [3 /*break*/, 5];
-                i = _c.value;
+                if (!!_b.done) return [3 /*break*/, 5];
+                i = _b.value;
                 return [5 /*yield**/, _loop_1(i)];
             case 3:
                 _d.sent();
                 _d.label = 4;
             case 4:
-                _c = _b.next();
+                _b = _a.next();
                 return [3 /*break*/, 2];
             case 5: return [3 /*break*/, 8];
             case 6:
@@ -83,7 +84,7 @@ function a() {
                 return [3 /*break*/, 8];
             case 7:
                 try {
-                    if (_c && !_c.done && (_a = _b.return)) _a.call(_b);
+                    if (_b && !_b.done && (_c = _a.return)) _c.call(_a);
                 }
                 finally { if (e_1) throw e_1.error; }
                 return [7 /*endfinally*/];

--- a/tests/baselines/reference/compoundExponentiationAssignmentLHSIsValue.js
+++ b/tests/baselines/reference/compoundExponentiationAssignmentLHSIsValue.js
@@ -148,9 +148,8 @@ _a = Math.pow(['', ''], value), '' = _a[0], '' = _a[1];
 var Derived = /** @class */ (function (_super) {
     __extends(Derived, _super);
     function Derived() {
-        var _this = this;
         var _a;
-        _this = _super.call(this) || this;
+        var _this = _super.call(this) || this;
         (_a = _super.prototype). = Math.pow(_a., value);
         return _this;
     }

--- a/tests/baselines/reference/declarationEmitComputedNameCausesImportToBePainted.js
+++ b/tests/baselines/reference/declarationEmitComputedNameCausesImportToBePainted.js
@@ -20,8 +20,8 @@ exports.__esModule = true;
 exports.Key = Symbol();
 //// [index.js]
 "use strict";
-exports.__esModule = true;
 var _a;
+exports.__esModule = true;
 var context_1 = require("./context");
 exports.context = (_a = {},
     _a[context_1.Key] = 'bar',

--- a/tests/baselines/reference/declarationEmitComputedNameConstEnumAlias.js
+++ b/tests/baselines/reference/declarationEmitComputedNameConstEnumAlias.js
@@ -24,8 +24,8 @@ var EnumExample;
 exports["default"] = EnumExample;
 //// [index.js]
 "use strict";
-exports.__esModule = true;
 var _a;
+exports.__esModule = true;
 var EnumExample_1 = require("./EnumExample");
 exports["default"] = (_a = {},
     _a[EnumExample_1["default"].TEST] = {},

--- a/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.js
+++ b/tests/baselines/reference/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.js
@@ -25,8 +25,8 @@ exports.__esModule = true;
 exports.x = Symbol();
 //// [b.js]
 "use strict";
-exports.__esModule = true;
 var _a;
+exports.__esModule = true;
 var a_1 = require("./a");
 var C = /** @class */ (function () {
     function C() {
@@ -51,8 +51,8 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-exports.__esModule = true;
 var _a;
+exports.__esModule = true;
 var a_1 = require("./a");
 var b_1 = require("./b");
 var D = /** @class */ (function (_super) {

--- a/tests/baselines/reference/declarationEmitWithDefaultAsComputedName.js
+++ b/tests/baselines/reference/declarationEmitWithDefaultAsComputedName.js
@@ -25,8 +25,8 @@ exports.default = createExperiment({
 });
 //// [main.js]
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
 var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
 var other_1 = require("./other");
 exports.obj = (_a = {},
     _a[other_1.default.name] = 1,

--- a/tests/baselines/reference/declarationEmitWithDefaultAsComputedName2.js
+++ b/tests/baselines/reference/declarationEmitWithDefaultAsComputedName2.js
@@ -25,8 +25,8 @@ exports.default = createExperiment({
 });
 //// [main.js]
 "use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
 var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
 var other2 = require("./other");
 exports.obj = (_a = {},
     _a[other2.default.name] = 1,

--- a/tests/baselines/reference/decoratedClassExportsCommonJS1.js
+++ b/tests/baselines/reference/decoratedClassExportsCommonJS1.js
@@ -14,8 +14,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-Object.defineProperty(exports, "__esModule", { value: true });
 var Testing123_1;
+Object.defineProperty(exports, "__esModule", { value: true });
 let Testing123 = Testing123_1 = class Testing123 {
 };
 Testing123.prop1 = Testing123_1.prop0;

--- a/tests/baselines/reference/decoratedClassExportsCommonJS2.js
+++ b/tests/baselines/reference/decoratedClassExportsCommonJS2.js
@@ -12,8 +12,8 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-Object.defineProperty(exports, "__esModule", { value: true });
 var Testing123_1;
+Object.defineProperty(exports, "__esModule", { value: true });
 let Testing123 = Testing123_1 = class Testing123 {
 };
 Testing123 = Testing123_1 = __decorate([

--- a/tests/baselines/reference/emitClassExpressionInDeclarationFile2.js
+++ b/tests/baselines/reference/emitClassExpressionInDeclarationFile2.js
@@ -44,8 +44,8 @@ var __extends = (this && this.__extends) || (function () {
         d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
     };
 })();
-exports.__esModule = true;
 var _a;
+exports.__esModule = true;
 exports.noPrivates = (_a = /** @class */ (function () {
         function class_1() {
             this.p = 12;

--- a/tests/baselines/reference/emitter.forAwait.es2015.js
+++ b/tests/baselines/reference/emitter.forAwait.es2015.js
@@ -58,8 +58,8 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 function f1() {
+    var e_1, _a;
     return __awaiter(this, void 0, void 0, function* () {
-        var e_1, _a;
         let y;
         try {
             for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), !y_1_1.done;) {
@@ -92,8 +92,8 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 function f2() {
+    var e_1, _a;
     return __awaiter(this, void 0, void 0, function* () {
-        var e_1, _a;
         let x, y;
         try {
             for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), !y_1_1.done;) {
@@ -203,8 +203,8 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 // https://github.com/Microsoft/TypeScript/issues/21363
 function f5() {
+    var e_1, _a;
     return __awaiter(this, void 0, void 0, function* () {
-        var e_1, _a;
         let y;
         try {
             outer: for (var y_1 = __asyncValues(y), y_1_1; y_1_1 = yield y_1.next(), !y_1_1.done;) {

--- a/tests/baselines/reference/emitter.forAwait.es5.js
+++ b/tests/baselines/reference/emitter.forAwait.es5.js
@@ -85,8 +85,9 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 function f1() {
+    var e_1, _a;
     return __awaiter(this, void 0, void 0, function () {
-        var e_1, _a, y, y_1, y_1_1, x, e_1_1;
+        var y, y_1, y_1_1, x, e_1_1;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
@@ -165,8 +166,9 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
     function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
 };
 function f2() {
+    var e_1, _a;
     return __awaiter(this, void 0, void 0, function () {
-        var e_1, _a, x, y, y_1, y_1_1, e_1_1;
+        var x, y, y_1, y_1_1, e_1_1;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
@@ -250,7 +252,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f3() {
     return __asyncGenerator(this, arguments, function f3_1() {
-        var e_1, _a, y, y_1, y_1_1, x, e_1_1;
+        var y, y_1, y_1_1, x, e_1_1;
+        var e_1, _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
@@ -334,7 +337,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f4() {
     return __asyncGenerator(this, arguments, function f4_1() {
-        var e_1, _a, x, y, y_1, y_1_1, e_1_1;
+        var x, y, y_1, y_1_1, e_1_1;
+        var e_1, _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
@@ -414,8 +418,9 @@ var __asyncValues = (this && this.__asyncValues) || function (o) {
 };
 // https://github.com/Microsoft/TypeScript/issues/21363
 function f5() {
+    var e_1, _a;
     return __awaiter(this, void 0, void 0, function () {
-        var e_1, _a, y, y_1, y_1_1, x, e_1_1;
+        var y, y_1, y_1_1, x, e_1_1;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
@@ -500,7 +505,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 // https://github.com/Microsoft/TypeScript/issues/21363
 function f6() {
     return __asyncGenerator(this, arguments, function f6_1() {
-        var e_1, _a, y, y_1, y_1_1, x, e_1_1;
+        var y, y_1, y_1_1, x, e_1_1;
+        var e_1, _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:

--- a/tests/baselines/reference/es5-asyncFunctionForOfStatements.js
+++ b/tests/baselines/reference/es5-asyncFunctionForOfStatements.js
@@ -315,7 +315,8 @@ function forOfStatement10() {
 }
 function forOfStatement11() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _i, y_8, _b;
+        var _i, y_8, _a;
+        var _b;
         return __generator(this, function (_c) {
             switch (_c.label) {
                 case 0:
@@ -323,17 +324,17 @@ function forOfStatement11() {
                     _c.label = 1;
                 case 1:
                     if (!(_i < y_8.length)) return [3 /*break*/, 6];
-                    _a = y_8[_i][0];
-                    if (!(_a === void 0)) return [3 /*break*/, 3];
+                    _b = y_8[_i][0];
+                    if (!(_b === void 0)) return [3 /*break*/, 3];
                     return [4 /*yield*/, a];
                 case 2:
-                    _b = _c.sent();
+                    _a = _c.sent();
                     return [3 /*break*/, 4];
                 case 3:
-                    _b = _a;
+                    _a = _b;
                     _c.label = 4;
                 case 4:
-                    x = _b;
+                    x = _a;
                     z;
                     _c.label = 5;
                 case 5:
@@ -346,18 +347,19 @@ function forOfStatement11() {
 }
 function forOfStatement12() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _i, _b;
+        var _i, _a;
+        var _b;
         return __generator(this, function (_c) {
             switch (_c.label) {
                 case 0:
                     _i = 0;
                     return [4 /*yield*/, y];
                 case 1:
-                    _b = _c.sent();
+                    _a = _c.sent();
                     _c.label = 2;
                 case 2:
-                    if (!(_i < _b.length)) return [3 /*break*/, 4];
-                    _a = _b[_i][0], x = _a === void 0 ? a : _a;
+                    if (!(_i < _a.length)) return [3 /*break*/, 4];
+                    _b = _a[_i][0], x = _b === void 0 ? a : _b;
                     z;
                     _c.label = 3;
                 case 3:
@@ -370,7 +372,8 @@ function forOfStatement12() {
 }
 function forOfStatement13() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _i, y_9;
+        var _i, y_9;
+        var _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:
@@ -440,7 +443,8 @@ function forOfStatement15() {
 }
 function forOfStatement16() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _i, y_11, _b;
+        var _i, y_11, _a;
+        var _b;
         return __generator(this, function (_c) {
             switch (_c.label) {
                 case 0:
@@ -448,17 +452,17 @@ function forOfStatement16() {
                     _c.label = 1;
                 case 1:
                     if (!(_i < y_11.length)) return [3 /*break*/, 6];
-                    _a = y_11[_i].x;
-                    if (!(_a === void 0)) return [3 /*break*/, 3];
+                    _b = y_11[_i].x;
+                    if (!(_b === void 0)) return [3 /*break*/, 3];
                     return [4 /*yield*/, a];
                 case 2:
-                    _b = _c.sent();
+                    _a = _c.sent();
                     return [3 /*break*/, 4];
                 case 3:
-                    _b = _a;
+                    _a = _b;
                     _c.label = 4;
                 case 4:
-                    x = _b;
+                    x = _a;
                     z;
                     _c.label = 5;
                 case 5:
@@ -471,18 +475,19 @@ function forOfStatement16() {
 }
 function forOfStatement17() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _i, _b;
+        var _i, _a;
+        var _b;
         return __generator(this, function (_c) {
             switch (_c.label) {
                 case 0:
                     _i = 0;
                     return [4 /*yield*/, y];
                 case 1:
-                    _b = _c.sent();
+                    _a = _c.sent();
                     _c.label = 2;
                 case 2:
-                    if (!(_i < _b.length)) return [3 /*break*/, 4];
-                    _a = _b[_i].x, x = _a === void 0 ? a : _a;
+                    if (!(_i < _a.length)) return [3 /*break*/, 4];
+                    _b = _a[_i].x, x = _b === void 0 ? a : _b;
                     z;
                     _c.label = 3;
                 case 3:
@@ -495,7 +500,8 @@ function forOfStatement17() {
 }
 function forOfStatement18() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _i, y_12;
+        var _i, y_12;
+        var _a;
         return __generator(this, function (_b) {
             switch (_b.label) {
                 case 0:

--- a/tests/baselines/reference/es5-asyncFunctionObjectLiterals.js
+++ b/tests/baselines/reference/es5-asyncFunctionObjectLiterals.js
@@ -105,17 +105,18 @@ function objectLiteral2() {
 }
 function objectLiteral3() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _b;
+        var _a;
+        var _b;
         return __generator(this, function (_c) {
             switch (_c.label) {
                 case 0:
-                    _a = {};
-                    _b = a;
+                    _b = {};
+                    _a = a;
                     return [4 /*yield*/, y];
                 case 1:
-                    x = (_a[_b] = _c.sent(),
-                        _a.b = z,
-                        _a);
+                    x = (_b[_a] = _c.sent(),
+                        _b.b = z,
+                        _b);
                     return [2 /*return*/];
             }
         });
@@ -158,18 +159,19 @@ function objectLiteral5() {
 }
 function objectLiteral6() {
     return __awaiter(this, void 0, void 0, function () {
-        var _a, _b;
+        var _a;
+        var _b;
         return __generator(this, function (_c) {
             switch (_c.label) {
                 case 0:
-                    _a = {
+                    _b = {
                             a: y
                         };
-                    _b = b;
+                    _a = b;
                     return [4 /*yield*/, z];
                 case 1:
-                    x = (_a[_b] = _c.sent(),
-                        _a);
+                    x = (_b[_a] = _c.sent(),
+                        _b);
                     return [2 /*return*/];
             }
         });

--- a/tests/baselines/reference/objectLiteralComputedNameNoDeclarationError.js
+++ b/tests/baselines/reference/objectLiteralComputedNameNoDeclarationError.js
@@ -9,8 +9,8 @@ export const Baa = {
 
 //// [objectLiteralComputedNameNoDeclarationError.js]
 "use strict";
-exports.__esModule = true;
 var _a;
+exports.__esModule = true;
 var Foo = {
     BANANA: 'banana'
 };

--- a/tests/baselines/reference/restParameterInDownlevelGenerator.js
+++ b/tests/baselines/reference/restParameterInDownlevelGenerator.js
@@ -1,0 +1,32 @@
+//// [restParameterInDownlevelGenerator.ts]
+// https://github.com/Microsoft/TypeScript/issues/30653
+function * mergeStringLists(...strings: string[]) {
+    for (var str of strings);
+}
+
+//// [restParameterInDownlevelGenerator.js]
+// https://github.com/Microsoft/TypeScript/issues/30653
+function mergeStringLists() {
+    var _i, strings_1, strings_1_1, str;
+    var e_1, _a;
+    var strings = [];
+    for (_i = 0; _i < arguments.length; _i++) {
+        strings[_i] = arguments[_i];
+    }
+    return __generator(this, function (_b) {
+        try {
+            for (strings_1 = __values(strings), strings_1_1 = strings_1.next(); !strings_1_1.done; strings_1_1 = strings_1.next()) {
+                str = strings_1_1.value;
+                ;
+            }
+        }
+        catch (e_1_1) { e_1 = { error: e_1_1 }; }
+        finally {
+            try {
+                if (strings_1_1 && !strings_1_1.done && (_a = strings_1.return)) _a.call(strings_1);
+            }
+            finally { if (e_1) throw e_1.error; }
+        }
+        return [2 /*return*/];
+    });
+}

--- a/tests/baselines/reference/restParameterInDownlevelGenerator.symbols
+++ b/tests/baselines/reference/restParameterInDownlevelGenerator.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/generators/restParameterInDownlevelGenerator.ts ===
+// https://github.com/Microsoft/TypeScript/issues/30653
+function * mergeStringLists(...strings: string[]) {
+>mergeStringLists : Symbol(mergeStringLists, Decl(restParameterInDownlevelGenerator.ts, 0, 0))
+>strings : Symbol(strings, Decl(restParameterInDownlevelGenerator.ts, 1, 28))
+
+    for (var str of strings);
+>str : Symbol(str, Decl(restParameterInDownlevelGenerator.ts, 2, 12))
+>strings : Symbol(strings, Decl(restParameterInDownlevelGenerator.ts, 1, 28))
+}

--- a/tests/baselines/reference/restParameterInDownlevelGenerator.types
+++ b/tests/baselines/reference/restParameterInDownlevelGenerator.types
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/generators/restParameterInDownlevelGenerator.ts ===
+// https://github.com/Microsoft/TypeScript/issues/30653
+function * mergeStringLists(...strings: string[]) {
+>mergeStringLists : (...strings: string[]) => IterableIterator<any>
+>strings : string[]
+
+    for (var str of strings);
+>str : string
+>strings : string[]
+}

--- a/tests/baselines/reference/uniqueSymbolAllowsIndexInObjectWithIndexSignature.js
+++ b/tests/baselines/reference/uniqueSymbolAllowsIndexInObjectWithIndexSignature.js
@@ -13,8 +13,8 @@ let b: I = {[SYM]: 'str'}; // Expect error
 
 //// [uniqueSymbolAllowsIndexInObjectWithIndexSignature.js]
 "use strict";
-exports.__esModule = true;
 var _a, _b;
+exports.__esModule = true;
 // https://github.com/Microsoft/TypeScript/issues/21962
 exports.SYM = Symbol('a unique symbol');
 var a = (_a = {}, _a[exports.SYM] = 'sym', _a); // Expect ok

--- a/tests/baselines/reference/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.js
+++ b/tests/baselines/reference/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.js
@@ -7,8 +7,8 @@ export class Foo {
 
 //// [variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.js]
 "use strict";
-exports.__esModule = true;
 var _a;
+exports.__esModule = true;
 var key = Symbol(), value = 12;
 var Foo = /** @class */ (function () {
     function Foo() {

--- a/tests/cases/conformance/generators/restParameterInDownlevelGenerator.ts
+++ b/tests/cases/conformance/generators/restParameterInDownlevelGenerator.ts
@@ -1,0 +1,9 @@
+// @target: es5
+// @lib: es2015
+// @downlevelIteration: true
+// @noEmitHelpers: true
+
+// https://github.com/Microsoft/TypeScript/issues/30653
+function * mergeStringLists(...strings: string[]) {
+    for (var str of strings);
+}


### PR DESCRIPTION
When transforming a generator function with a rest parameter for ES2015, we insert the `VariableStatement` we generate to hoist variables at the top of the resulting statement list after any standard prologues.

However, when we perform the generator transform, we move every node in the statement list after (and including) the first node not marked with `EmitFlags.CustomPrologue` into the generator state machine. Since the hoisted `VariableStatement` was not marked as a custom prologue, we would stop at that statement and would inadvertently move any trailing custom prologues.

This change marks the hoisted variable statement with `EmitFlags.CustomPrologue` since it is, in effect a custom prologue entry that we insert at the top of a function similar to rest argument handling, this parameter, capturing, etc.

Fixes #30653

