### PR TITLE
Fall back from `globalReadonlyArrayType` to `globalArrayType` when transpiling

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30307,7 +30307,7 @@ namespace ts {
                 autoArrayType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, undefined, undefined);
             }
 
-            globalReadonlyArrayType = <GenericType>getGlobalTypeOrUndefined("ReadonlyArray" as __String, /*arity*/ 1);
+            globalReadonlyArrayType = <GenericType>getGlobalTypeOrUndefined("ReadonlyArray" as __String, /*arity*/ 1) || globalArrayType;
             anyReadonlyArrayType = globalReadonlyArrayType ? createTypeFromGenericGlobalType(globalReadonlyArrayType, [anyType]) : anyArrayType;
             globalThisType = <GenericType>getGlobalTypeOrUndefined("ThisType" as __String, /*arity*/ 1);
 

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -445,5 +445,13 @@ var x = 0;`, {
                 }
             }
         });
+
+        transpilesCorrectly("Supports readonly keyword for arrays", "let x: readonly string[];", {
+            options: { compilerOptions: { module: ModuleKind.CommonJS } }
+        });
+
+        transpilesCorrectly("Supports 'as const' arrays", `([] as const).forEach(k => console.log(k));`, {
+            options: { compilerOptions: { module: ModuleKind.CommonJS } }
+        });
     });
 }

--- a/tests/baselines/reference/transpile/Supports as const arrays.js
+++ b/tests/baselines/reference/transpile/Supports as const arrays.js
@@ -1,0 +1,2 @@
+[].forEach(function (k) { return console.log(k); });
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Supports as const arrays.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports as const arrays.oldTranspile.js
@@ -1,0 +1,2 @@
+[].forEach(function (k) { return console.log(k); });
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Supports readonly keyword for arrays.js
+++ b/tests/baselines/reference/transpile/Supports readonly keyword for arrays.js
@@ -1,0 +1,2 @@
+var x;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Supports readonly keyword for arrays.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports readonly keyword for arrays.oldTranspile.js
@@ -1,0 +1,2 @@
+var x;
+//# sourceMappingURL=file.js.map


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Syntax like `([''] as const).forEach` or `let x: readonly string[]` implicitly references `ReadonlyArray` which isn't included when transpiling, so fall back to referencing the global Array type instead.

Fixes #30664 

