### PR TITLE
Fix crash when checking function call

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20600,7 +20600,7 @@ namespace ts {
                 spanArray = createNodeArray(args);
                 if (hasSpreadArgument && argCount) {
                     const nextArg = elementAt(args, getSpreadArgumentIndex(args) + 1) || undefined;
-                    spanArray = createNodeArray(args.slice(max > argCount && nextArg ? args.indexOf(nextArg) : max));
+                    spanArray = createNodeArray(args.slice(max > argCount && nextArg ? args.indexOf(nextArg) : Math.min(max, args.length - 1)));
                 }
             }
             else {

--- a/tests/baselines/reference/callWithSpread2.errors.txt
+++ b/tests/baselines/reference/callWithSpread2.errors.txt
@@ -1,26 +1,28 @@
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(22,13): error TS2556: Expected 1 arguments, but got 2 or more.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(23,7): error TS2556: Expected 0 arguments, but got 1 or more.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(26,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(23,13): error TS2556: Expected 1 arguments, but got 2 or more.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(24,7): error TS2556: Expected 0 arguments, but got 1 or more.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(27,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(27,5): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(28,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(28,5): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(29,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(29,13): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(30,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(30,13): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(31,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(31,11): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(32,8): error TS2556: Expected 1-3 arguments, but got 0 or more.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(32,11): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(33,8): error TS2556: Expected 1-3 arguments, but got 0 or more.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(34,8): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(34,8): error TS2556: Expected 1-3 arguments, but got 0 or more.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(35,8): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(36,14): error TS2556: Expected 2-4 arguments, but got 1 or more.
 
 
-==== tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts (11 errors) ====
+==== tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts (12 errors) ====
     declare function all(a?: number, b?: number): void;
     declare function weird(a?: number | string, b?: number | string): void;
     declare function prefix(s: string, a?: number, b?: number): void;
     declare function rest(s: string, a?: number, b?: number,  ...rest: number[]): void;
     declare function normal(s: string): void;
     declare function thunk(): string;
+    declare function prefix2(s: string, n: number, a?: number, b?: number): void;
     
     declare var ns: number[];
     declare var mixed: (number | string)[];
@@ -76,4 +78,8 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(34,8): erro
     prefix(...tuple)
            ~~~~~~~~
 !!! error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
+    prefix2("g", ...ns);
+                 ~~~~~
+!!! error TS2556: Expected 2-4 arguments, but got 1 or more.
+!!! related TS6210 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts:7:37: An argument for 'n' was not provided.
     

--- a/tests/baselines/reference/callWithSpread2.js
+++ b/tests/baselines/reference/callWithSpread2.js
@@ -5,6 +5,7 @@ declare function prefix(s: string, a?: number, b?: number): void;
 declare function rest(s: string, a?: number, b?: number,  ...rest: number[]): void;
 declare function normal(s: string): void;
 declare function thunk(): string;
+declare function prefix2(s: string, n: number, a?: number, b?: number): void;
 
 declare var ns: number[];
 declare var mixed: (number | string)[];
@@ -33,6 +34,7 @@ rest("f", ...tuple)
 prefix(...ns) // required parameters are required
 prefix(...mixed)
 prefix(...tuple)
+prefix2("g", ...ns);
 
 
 //// [callWithSpread2.js]
@@ -56,3 +58,4 @@ rest.apply(void 0, ["f"].concat(tuple));
 prefix.apply(void 0, ns); // required parameters are required
 prefix.apply(void 0, mixed);
 prefix.apply(void 0, tuple);
+prefix2.apply(void 0, ["g"].concat(ns));

--- a/tests/baselines/reference/callWithSpread2.symbols
+++ b/tests/baselines/reference/callWithSpread2.symbols
@@ -29,84 +29,95 @@ declare function normal(s: string): void;
 declare function thunk(): string;
 >thunk : Symbol(thunk, Decl(callWithSpread2.ts, 4, 41))
 
+declare function prefix2(s: string, n: number, a?: number, b?: number): void;
+>prefix2 : Symbol(prefix2, Decl(callWithSpread2.ts, 5, 33))
+>s : Symbol(s, Decl(callWithSpread2.ts, 6, 25))
+>n : Symbol(n, Decl(callWithSpread2.ts, 6, 35))
+>a : Symbol(a, Decl(callWithSpread2.ts, 6, 46))
+>b : Symbol(b, Decl(callWithSpread2.ts, 6, 58))
+
 declare var ns: number[];
->ns : Symbol(ns, Decl(callWithSpread2.ts, 7, 11))
+>ns : Symbol(ns, Decl(callWithSpread2.ts, 8, 11))
 
 declare var mixed: (number | string)[];
->mixed : Symbol(mixed, Decl(callWithSpread2.ts, 8, 11))
+>mixed : Symbol(mixed, Decl(callWithSpread2.ts, 9, 11))
 
 declare var tuple: [number, string];
->tuple : Symbol(tuple, Decl(callWithSpread2.ts, 9, 11))
+>tuple : Symbol(tuple, Decl(callWithSpread2.ts, 10, 11))
 
 // good
 all(...ns)
 >all : Symbol(all, Decl(callWithSpread2.ts, 0, 0))
->ns : Symbol(ns, Decl(callWithSpread2.ts, 7, 11))
+>ns : Symbol(ns, Decl(callWithSpread2.ts, 8, 11))
 
 weird(...ns)
 >weird : Symbol(weird, Decl(callWithSpread2.ts, 0, 51))
->ns : Symbol(ns, Decl(callWithSpread2.ts, 7, 11))
+>ns : Symbol(ns, Decl(callWithSpread2.ts, 8, 11))
 
 weird(...mixed)
 >weird : Symbol(weird, Decl(callWithSpread2.ts, 0, 51))
->mixed : Symbol(mixed, Decl(callWithSpread2.ts, 8, 11))
+>mixed : Symbol(mixed, Decl(callWithSpread2.ts, 9, 11))
 
 weird(...tuple)
 >weird : Symbol(weird, Decl(callWithSpread2.ts, 0, 51))
->tuple : Symbol(tuple, Decl(callWithSpread2.ts, 9, 11))
+>tuple : Symbol(tuple, Decl(callWithSpread2.ts, 10, 11))
 
 prefix("a", ...ns)
 >prefix : Symbol(prefix, Decl(callWithSpread2.ts, 1, 71))
->ns : Symbol(ns, Decl(callWithSpread2.ts, 7, 11))
+>ns : Symbol(ns, Decl(callWithSpread2.ts, 8, 11))
 
 rest("d", ...ns)
 >rest : Symbol(rest, Decl(callWithSpread2.ts, 2, 65))
->ns : Symbol(ns, Decl(callWithSpread2.ts, 7, 11))
+>ns : Symbol(ns, Decl(callWithSpread2.ts, 8, 11))
 
 
 // extra arguments
 normal("g", ...ns)
 >normal : Symbol(normal, Decl(callWithSpread2.ts, 3, 83))
->ns : Symbol(ns, Decl(callWithSpread2.ts, 7, 11))
+>ns : Symbol(ns, Decl(callWithSpread2.ts, 8, 11))
 
 thunk(...ns)
 >thunk : Symbol(thunk, Decl(callWithSpread2.ts, 4, 41))
->ns : Symbol(ns, Decl(callWithSpread2.ts, 7, 11))
+>ns : Symbol(ns, Decl(callWithSpread2.ts, 8, 11))
 
 // bad
 all(...mixed)
 >all : Symbol(all, Decl(callWithSpread2.ts, 0, 0))
->mixed : Symbol(mixed, Decl(callWithSpread2.ts, 8, 11))
+>mixed : Symbol(mixed, Decl(callWithSpread2.ts, 9, 11))
 
 all(...tuple)
 >all : Symbol(all, Decl(callWithSpread2.ts, 0, 0))
->tuple : Symbol(tuple, Decl(callWithSpread2.ts, 9, 11))
+>tuple : Symbol(tuple, Decl(callWithSpread2.ts, 10, 11))
 
 prefix("b", ...mixed)
 >prefix : Symbol(prefix, Decl(callWithSpread2.ts, 1, 71))
->mixed : Symbol(mixed, Decl(callWithSpread2.ts, 8, 11))
+>mixed : Symbol(mixed, Decl(callWithSpread2.ts, 9, 11))
 
 prefix("c", ...tuple)
 >prefix : Symbol(prefix, Decl(callWithSpread2.ts, 1, 71))
->tuple : Symbol(tuple, Decl(callWithSpread2.ts, 9, 11))
+>tuple : Symbol(tuple, Decl(callWithSpread2.ts, 10, 11))
 
 rest("e", ...mixed)
 >rest : Symbol(rest, Decl(callWithSpread2.ts, 2, 65))
->mixed : Symbol(mixed, Decl(callWithSpread2.ts, 8, 11))
+>mixed : Symbol(mixed, Decl(callWithSpread2.ts, 9, 11))
 
 rest("f", ...tuple)
 >rest : Symbol(rest, Decl(callWithSpread2.ts, 2, 65))
->tuple : Symbol(tuple, Decl(callWithSpread2.ts, 9, 11))
+>tuple : Symbol(tuple, Decl(callWithSpread2.ts, 10, 11))
 
 prefix(...ns) // required parameters are required
 >prefix : Symbol(prefix, Decl(callWithSpread2.ts, 1, 71))
->ns : Symbol(ns, Decl(callWithSpread2.ts, 7, 11))
+>ns : Symbol(ns, Decl(callWithSpread2.ts, 8, 11))
 
 prefix(...mixed)
 >prefix : Symbol(prefix, Decl(callWithSpread2.ts, 1, 71))
->mixed : Symbol(mixed, Decl(callWithSpread2.ts, 8, 11))
+>mixed : Symbol(mixed, Decl(callWithSpread2.ts, 9, 11))
 
 prefix(...tuple)
 >prefix : Symbol(prefix, Decl(callWithSpread2.ts, 1, 71))
->tuple : Symbol(tuple, Decl(callWithSpread2.ts, 9, 11))
+>tuple : Symbol(tuple, Decl(callWithSpread2.ts, 10, 11))
+
+prefix2("g", ...ns);
+>prefix2 : Symbol(prefix2, Decl(callWithSpread2.ts, 5, 33))
+>ns : Symbol(ns, Decl(callWithSpread2.ts, 8, 11))
 

--- a/tests/baselines/reference/callWithSpread2.types
+++ b/tests/baselines/reference/callWithSpread2.types
@@ -29,6 +29,13 @@ declare function normal(s: string): void;
 declare function thunk(): string;
 >thunk : () => string
 
+declare function prefix2(s: string, n: number, a?: number, b?: number): void;
+>prefix2 : (s: string, n: number, a?: number, b?: number) => void
+>s : string
+>n : number
+>a : number
+>b : number
+
 declare var ns: number[];
 >ns : number[]
 
@@ -150,4 +157,11 @@ prefix(...tuple)
 >prefix : (s: string, a?: number, b?: number) => void
 >...tuple : string | number
 >tuple : [number, string]
+
+prefix2("g", ...ns);
+>prefix2("g", ...ns) : void
+>prefix2 : (s: string, n: number, a?: number, b?: number) => void
+>"g" : "g"
+>...ns : number
+>ns : number[]
 

--- a/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
+++ b/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
@@ -4,6 +4,7 @@ declare function prefix(s: string, a?: number, b?: number): void;
 declare function rest(s: string, a?: number, b?: number,  ...rest: number[]): void;
 declare function normal(s: string): void;
 declare function thunk(): string;
+declare function prefix2(s: string, n: number, a?: number, b?: number): void;
 
 declare var ns: number[];
 declare var mixed: (number | string)[];
@@ -32,3 +33,4 @@ rest("f", ...tuple)
 prefix(...ns) // required parameters are required
 prefix(...mixed)
 prefix(...tuple)
+prefix2("g", ...ns);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #30647 

Crash occurred while getting diagnostic for a function call with

- at least one non-spread argument, AND
- at least one spread argument, AND
- overall, possibly too few arguments to satisfy the signature.

Under these circumstances, the node we were trying to put the error onto was incorrectly being calculated as an argument beyond the bounds of the arguments that actually exist.

