### PR TITLE
Cache substitution types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -392,6 +392,7 @@ namespace ts {
         const literalTypes = createMap<LiteralType>();
         const indexedAccessTypes = createMap<IndexedAccessType>();
         const conditionalTypes = createMap<Type>();
+        const substitutionTypes = createMap<SubstitutionType>();
         const evolvingArrayTypes: EvolvingArrayType[] = [];
         const undefinedProperties = createMap<Symbol>() as UnderscoreEscapedMap<Symbol>;
 
@@ -8914,9 +8915,15 @@ namespace ts {
             if (substitute.flags & TypeFlags.AnyOrUnknown) {
                 return typeVariable;
             }
+            const id = `${getTypeId(typeVariable)}>${getTypeId(substitute)}`;
+            const cached = substitutionTypes.get(id);
+            if (cached) {
+                return cached;
+            }
             const result = <SubstitutionType>createType(TypeFlags.Substitution);
             result.typeVariable = typeVariable;
             result.substitute = substitute;
+            substitutionTypes.set(id, result);
             return result;
         }
 

--- a/tests/baselines/reference/inlinedAliasAssignableToConstraintSameAsAlias.types
+++ b/tests/baselines/reference/inlinedAliasAssignableToConstraintSameAsAlias.types
@@ -31,7 +31,7 @@ class A {
 >z : A[]
 
   whereRelated< // Works // Type is same as A1, but is not assignable to type A
->whereRelated : <RF extends RelationFields = RelationFields, N extends "x" | "y" | "z" = "x" | "y" | "z", A1 extends A = RF[N] extends A[] ? RF[N][0] : never, A2 extends A = ShouldA<RF, N>>() => number
+>whereRelated : <RF extends RelationFields = RelationFields, N extends "x" | "y" | "z" = "x" | "y" | "z", A1 extends A = RF[N] extends A[] ? RF[N][0] : never, A2 extends A = RF[N] extends A[] ? RF[N][0] : never>() => number
 
     RF extends RelationFields = RelationFields,
     N extends Name = Name,


### PR DESCRIPTION
This doesn't fully fix anything, per se, but it _does_ reduce the compounding effects in some of our outstanding perf issues a bit. We cache conditional types heavily, but because we failed to cache substitution types (which are manufactured within conditional type `true` branches), we'd end up making way more conditional type identities than we thought. These not being cached is just an oversight on our part - they're essentially "invisible" intersections, which _are_ already cached.

Fixes #30663.