### PR TITLE
Add flag to allow access to UMD globals from modules

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1632,10 +1632,10 @@ namespace ts {
                 }
 
                 // If we're in an external module, we can't reference value symbols created from UMD export declarations
-                if (!compilerOptions.allowUmdGlobalAccess && result && isInExternalModule && (meaning & SymbolFlags.Value) === SymbolFlags.Value && !(originalLocation!.flags & NodeFlags.JSDoc)) {
+                if (result && isInExternalModule && (meaning & SymbolFlags.Value) === SymbolFlags.Value && !(originalLocation!.flags & NodeFlags.JSDoc)) {
                     const merged = getMergedSymbol(result);
                     if (length(merged.declarations) && every(merged.declarations, d => isNamespaceExportDeclaration(d) || isSourceFile(d) && !!d.symbol.globalExports)) {
-                        error(errorLocation!, Diagnostics._0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead, unescapeLeadingUnderscores(name));
+                        errorOrSuggestion(!compilerOptions.allowUmdGlobalAccess, errorLocation!, Diagnostics._0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead, unescapeLeadingUnderscores(name));
                     }
                 }
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1632,10 +1632,10 @@ namespace ts {
                 }
 
                 // If we're in an external module, we can't reference value symbols created from UMD export declarations
-                if (result && isInExternalModule && (meaning & SymbolFlags.Value) === SymbolFlags.Value && !(originalLocation!.flags & NodeFlags.JSDoc)) {
+                if (!compilerOptions.allowUmdGlobalAccess && result && isInExternalModule && (meaning & SymbolFlags.Value) === SymbolFlags.Value && !(originalLocation!.flags & NodeFlags.JSDoc)) {
                     const merged = getMergedSymbol(result);
                     if (length(merged.declarations) && every(merged.declarations, d => isNamespaceExportDeclaration(d) || isSourceFile(d) && !!d.symbol.globalExports)) {
-                        error(errorLocation!, Diagnostics._0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead, unescapeLeadingUnderscores(name)); // TODO: GH#18217
+                        error(errorLocation!, Diagnostics._0_refers_to_a_UMD_global_but_the_current_file_is_a_module_Consider_adding_an_import_instead, unescapeLeadingUnderscores(name));
                     }
                 }
             }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -575,6 +575,13 @@ namespace ts {
             category: Diagnostics.Module_Resolution_Options,
             description: Diagnostics.Do_not_resolve_the_real_path_of_symlinks,
         },
+        {
+            name: "allowUmdGlobalAccess",
+            type: "boolean",
+            affectsSemanticDiagnostics: true,
+            category: Diagnostics.Module_Resolution_Options,
+            description: Diagnostics.Allow_accessing_UMD_globals_from_modules,
+        },
 
         // Source Maps
         {
@@ -602,12 +609,6 @@ namespace ts {
             type: "boolean",
             category: Diagnostics.Source_Map_Options,
             description: Diagnostics.Emit_the_source_alongside_the_sourcemaps_within_a_single_file_requires_inlineSourceMap_or_sourceMap_to_be_set
-        },
-        {
-            name: "allowUmdGlobalAccess",
-            type: "boolean",
-            category: Diagnostics.Module_Resolution_Options,
-            description: Diagnostics.Allow_accessing_UMD_globals_from_modules,
         },
 
         // Experimental

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -603,6 +603,12 @@ namespace ts {
             category: Diagnostics.Source_Map_Options,
             description: Diagnostics.Emit_the_source_alongside_the_sourcemaps_within_a_single_file_requires_inlineSourceMap_or_sourceMap_to_be_set
         },
+        {
+            name: "allowUmdGlobalAccess",
+            type: "boolean",
+            category: Diagnostics.Module_Resolution_Options,
+            description: Diagnostics.Allow_accessing_UMD_globals_from_modules,
+        },
 
         // Experimental
         {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4938,5 +4938,9 @@
     "Convert parameters to destructured object": {
         "category": "Message",
         "code": 95075
+    },
+    "Allow accessing UMD globals from modules": {
+        "category": "Message",
+        "code": 95076
     }
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4939,7 +4939,7 @@
         "category": "Message",
         "code": 95075
     },
-    "Allow accessing UMD globals from modules": {
+    "Allow accessing UMD globals from modules.": {
         "category": "Message",
         "code": 95076
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4580,6 +4580,7 @@ namespace ts {
         allowJs?: boolean;
         /*@internal*/ allowNonTsExtensions?: boolean;
         allowSyntheticDefaultImports?: boolean;
+        allowUmdGlobalAccess?: boolean;
         allowUnreachableCode?: boolean;
         allowUnusedLabels?: boolean;
         alwaysStrict?: boolean;  // Always combine with strict property

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2489,6 +2489,7 @@ declare namespace ts {
     interface CompilerOptions {
         allowJs?: boolean;
         allowSyntheticDefaultImports?: boolean;
+        allowUmdGlobalAccess?: boolean;
         allowUnreachableCode?: boolean;
         allowUnusedLabels?: boolean;
         alwaysStrict?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2489,6 +2489,7 @@ declare namespace ts {
     interface CompilerOptions {
         allowJs?: boolean;
         allowSyntheticDefaultImports?: boolean;
+        allowUmdGlobalAccess?: boolean;
         allowUnreachableCode?: boolean;
         allowUnusedLabels?: boolean;
         alwaysStrict?: boolean;

--- a/tests/baselines/reference/showConfig/Shows tsconfig for single option/allowUmdGlobalAccess/tsconfig.json
+++ b/tests/baselines/reference/showConfig/Shows tsconfig for single option/allowUmdGlobalAccess/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "allowUmdGlobalAccess": true
+    }
+}

--- a/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
@@ -48,6 +48,7 @@
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
@@ -48,6 +48,7 @@
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -48,6 +48,7 @@
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -48,6 +48,7 @@
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
@@ -48,6 +48,7 @@
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -48,6 +48,7 @@
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -48,6 +48,7 @@
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -48,6 +48,7 @@
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -48,6 +48,7 @@
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 
     /* Source Map Options */
     // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */

--- a/tests/baselines/reference/umd9.js
+++ b/tests/baselines/reference/umd9.js
@@ -1,0 +1,19 @@
+//// [tests/cases/conformance/externalModules/umd9.ts] ////
+
+//// [foo.d.ts]
+declare class Thing {
+  foo(): number;
+}
+export = Thing;
+export as namespace Foo;
+
+//// [a.ts]
+/// <reference path="foo.d.ts" />
+export const x = Foo; // OK in value position because allowUmdGlobalAccess: true
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+/// <reference path="foo.d.ts" />
+exports.x = Foo; // OK in value position because allowUmdGlobalAccess: true

--- a/tests/baselines/reference/umd9.symbols
+++ b/tests/baselines/reference/umd9.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/externalModules/a.ts ===
+/// <reference path="foo.d.ts" />
+export const x = Foo; // OK in value position because allowUmdGlobalAccess: true
+>x : Symbol(x, Decl(a.ts, 1, 12))
+>Foo : Symbol(Foo, Decl(foo.d.ts, 3, 15))
+
+=== tests/cases/conformance/externalModules/foo.d.ts ===
+declare class Thing {
+>Thing : Symbol(Thing, Decl(foo.d.ts, 0, 0))
+
+  foo(): number;
+>foo : Symbol(Thing.foo, Decl(foo.d.ts, 0, 21))
+}
+export = Thing;
+>Thing : Symbol(Thing, Decl(foo.d.ts, 0, 0))
+
+export as namespace Foo;
+>Foo : Symbol(Foo, Decl(foo.d.ts, 3, 15))
+

--- a/tests/baselines/reference/umd9.types
+++ b/tests/baselines/reference/umd9.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/externalModules/a.ts ===
+/// <reference path="foo.d.ts" />
+export const x = Foo; // OK in value position because allowUmdGlobalAccess: true
+>x : typeof Thing
+>Foo : typeof Thing
+
+=== tests/cases/conformance/externalModules/foo.d.ts ===
+declare class Thing {
+>Thing : Thing
+
+  foo(): number;
+>foo : () => number
+}
+export = Thing;
+>Thing : Thing
+
+export as namespace Foo;
+>Foo : typeof Thing
+

--- a/tests/cases/conformance/externalModules/umd9.ts
+++ b/tests/cases/conformance/externalModules/umd9.ts
@@ -1,0 +1,14 @@
+// @module: commonjs
+// @noImplicitReferences: true
+// @allowUmdGlobalAccess: true
+
+// @filename: foo.d.ts
+declare class Thing {
+  foo(): number;
+}
+export = Thing;
+export as namespace Foo;
+
+// @filename: a.ts
+/// <reference path="foo.d.ts" />
+export const x = Foo; // OK in value position because allowUmdGlobalAccess: true


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Closes #10178.

A summary, since the issue discussion is quite long: the `allowUmdGlobalAccess` flag will allow accessing a global defined in a UMD module from anywhere, including from modules. This could potentially be unsafe since not all UMD modules define a global in the presence of a module system, but under some circumstances you really might need the ability. E.g. in a browser environment where one UMD module loads before require.js, that module will _only_ be available as a global. So, this flag is an escape hatch for users stuck in scenarios like that.