### PR TITLE
Always check extends clause of classes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27424,6 +27424,11 @@ namespace ts {
                 if (languageVersion < ScriptTarget.ES2015) {
                     checkExternalEmitHelpers(baseTypeNode.parent, ExternalEmitHelpers.Extends);
                 }
+                // check both @extends and extends if both are specified.
+                const extendsNode = getClassExtendsHeritageElement(node);
+                if (extendsNode && extendsNode !== baseTypeNode) {
+                    checkExpression(extendsNode.expression);
+                }
 
                 const baseTypes = getBaseTypes(type);
                 if (baseTypes.length && produceDiagnostics) {
@@ -27432,10 +27437,6 @@ namespace ts {
                     const staticBaseType = getApparentType(baseConstructorType);
                     checkBaseTypeAccessibility(staticBaseType, baseTypeNode);
                     checkSourceElement(baseTypeNode.expression);
-                    const extendsNode = getClassExtendsHeritageElement(node);
-                    if (extendsNode && extendsNode !== baseTypeNode) {
-                        checkExpression(extendsNode.expression);
-                    }
                     if (some(baseTypeNode.typeArguments)) {
                         forEach(baseTypeNode.typeArguments, checkSourceElement);
                         for (const constructor of getConstructorsForTypeArguments(staticBaseType, baseTypeNode.typeArguments, baseTypeNode)) {

--- a/tests/baselines/reference/extendsTagEmit.errors.txt
+++ b/tests/baselines/reference/extendsTagEmit.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/conformance/jsdoc/main.js(2,15): error TS2304: Cannot find name 'Mismatch'.
+tests/cases/conformance/jsdoc/main.js(2,15): error TS8023: JSDoc '@extends Mismatch' does not match the 'extends B' clause.
+
+
+==== tests/cases/conformance/jsdoc/super.js (0 errors) ====
+    export class B { }
+    
+==== tests/cases/conformance/jsdoc/main.js (2 errors) ====
+    import { B } from './super'
+    /** @extends {Mismatch} */
+                  ~~~~~~~~
+!!! error TS2304: Cannot find name 'Mismatch'.
+                  ~~~~~~~~
+!!! error TS8023: JSDoc '@extends Mismatch' does not match the 'extends B' clause.
+    class C extends B { }
+    
+    

--- a/tests/baselines/reference/extendsTagEmit.js
+++ b/tests/baselines/reference/extendsTagEmit.js
@@ -1,0 +1,20 @@
+//// [tests/cases/conformance/jsdoc/extendsTagEmit.ts] ////
+
+//// [super.js]
+export class B { }
+
+//// [main.js]
+import { B } from './super'
+/** @extends {Mismatch} */
+class C extends B { }
+
+
+
+//// [super.js]
+export class B {
+}
+//// [main.js]
+import { B } from './super';
+/** @extends {Mismatch} */
+class C extends B {
+}

--- a/tests/baselines/reference/extendsTagEmit.symbols
+++ b/tests/baselines/reference/extendsTagEmit.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/super.js ===
+export class B { }
+>B : Symbol(B, Decl(super.js, 0, 0))
+
+=== tests/cases/conformance/jsdoc/main.js ===
+import { B } from './super'
+>B : Symbol(B, Decl(main.js, 0, 8))
+
+/** @extends {Mismatch} */
+class C extends B { }
+>C : Symbol(C, Decl(main.js, 0, 27))
+>B : Symbol(B, Decl(main.js, 0, 8))
+
+

--- a/tests/baselines/reference/extendsTagEmit.types
+++ b/tests/baselines/reference/extendsTagEmit.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/super.js ===
+export class B { }
+>B : B
+
+=== tests/cases/conformance/jsdoc/main.js ===
+import { B } from './super'
+>B : typeof B
+
+/** @extends {Mismatch} */
+class C extends B { }
+>C : C
+>B : typeof B
+
+

--- a/tests/cases/conformance/jsdoc/extendsTagEmit.ts
+++ b/tests/cases/conformance/jsdoc/extendsTagEmit.ts
@@ -1,0 +1,12 @@
+// @allowJs: true
+// @checkJs: true
+// @target: esnext
+// @outDir: out
+// @Filename: super.js
+export class B { }
+
+// @Filename: main.js
+import { B } from './super'
+/** @extends {Mismatch} */
+class C extends B { }
+


### PR DESCRIPTION
Even if (1) @extends is provided and (2) we're not producing diagnostics. That's because we need to know whether the extends clause references an imported alias.

Fixes #29983 
Better fix for #25111.