### PR TITLE
feat: Implement the `implicitUnknown` complier flag

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -397,6 +397,13 @@ namespace ts {
             description: Diagnostics.Raise_error_on_expressions_and_declarations_with_an_implied_any_type
         },
         {
+            name: "implicitUnknown",
+            type: "boolean",
+            showInSimplifiedHelpView: true,
+            category: Diagnostics.Strict_Type_Checking_Options,
+            description: Diagnostics.Use_unknown_as_implicit_type
+        },
+        {
             name: "strictNullChecks",
             type: "boolean",
             affectsSemanticDiagnostics: true,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3899,6 +3899,10 @@
         "category": "Message",
         "code": 6217
     },
+    "Use unknown as implicit type.": {
+        "category": "Message",
+        "code": 6218
+    },
 
     "Projects to reference": {
         "category": "Message",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4605,6 +4605,8 @@ namespace ts {
         experimentalDecorators?: boolean;
         forceConsistentCasingInFileNames?: boolean;
         /*@internal*/help?: boolean;
+        /** Changes the implicit type from `any` to `unknown`. */
+        implicitUnknown?: boolean;
         importHelpers?: boolean;
         /*@internal*/init?: boolean;
         inlineSourceMap?: boolean;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2956,6 +2956,8 @@ namespace ts.server.protocol {
         emitDecoratorMetadata?: boolean;
         experimentalDecorators?: boolean;
         forceConsistentCasingInFileNames?: boolean;
+        /** Changes the implicit type from `any` to `unknown`. */
+        implicitUnknown?: boolean;
         importHelpers?: boolean;
         inlineSourceMap?: boolean;
         inlineSources?: boolean;

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -260,6 +260,10 @@ var x = 0;`, {
             options: { compilerOptions: { forceConsistentCasingInFileNames: true }, fileName: "input.js", reportDiagnostics: true }
         });
 
+        transpilesCorrectly("Supports setting 'implicitUnknown'", "x;", {
+            options: { compilerOptions: { implicitUnknown: true }, fileName: "input.js", reportDiagnostics: true }
+        });
+
         transpilesCorrectly("Supports setting 'isolatedModules'", "x;", {
             options: { compilerOptions: { isolatedModules: true }, fileName: "input.js", reportDiagnostics: true }
         });
@@ -310,6 +314,10 @@ var x = 0;`, {
 
         transpilesCorrectly("Supports setting 'noImplicitAny'", "x;", {
             options: { compilerOptions: { noImplicitAny: true }, fileName: "input.js", reportDiagnostics: true }
+        });
+
+        transpilesCorrectly("Supports setting 'noImplicitAny' and 'implicitUnknown'", "x;", {
+            options: { compilerOptions: { noImplicitAny: true, implicitUnknown: true }, fileName: "input.js", reportDiagnostics: true }
         });
 
         transpilesCorrectly("Supports setting 'noImplicitReturns'", "x;", {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2505,6 +2505,8 @@ declare namespace ts {
         emitDecoratorMetadata?: boolean;
         experimentalDecorators?: boolean;
         forceConsistentCasingInFileNames?: boolean;
+        /** Changes the implicit type from `any` to `unknown`. */
+        implicitUnknown?: boolean;
         importHelpers?: boolean;
         inlineSourceMap?: boolean;
         inlineSources?: boolean;
@@ -8050,6 +8052,8 @@ declare namespace ts.server.protocol {
         emitDecoratorMetadata?: boolean;
         experimentalDecorators?: boolean;
         forceConsistentCasingInFileNames?: boolean;
+        /** Changes the implicit type from `any` to `unknown`. */
+        implicitUnknown?: boolean;
         importHelpers?: boolean;
         inlineSourceMap?: boolean;
         inlineSources?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2505,6 +2505,8 @@ declare namespace ts {
         emitDecoratorMetadata?: boolean;
         experimentalDecorators?: boolean;
         forceConsistentCasingInFileNames?: boolean;
+        /** Changes the implicit type from `any` to `unknown`. */
+        implicitUnknown?: boolean;
         importHelpers?: boolean;
         inlineSourceMap?: boolean;
         inlineSources?: boolean;

--- a/tests/baselines/reference/showConfig/Shows tsconfig for single option/implicitUnknown/tsconfig.json
+++ b/tests/baselines/reference/showConfig/Shows tsconfig for single option/implicitUnknown/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "implicitUnknown": true
+    }
+}

--- a/tests/baselines/reference/transpile/Supports setting implicitUnknown.js
+++ b/tests/baselines/reference/transpile/Supports setting implicitUnknown.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting implicitUnknown.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting implicitUnknown.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny and implicitUnknown.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny and implicitUnknown.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny and implicitUnknown.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny and implicitUnknown.oldTranspile.js
@@ -1,0 +1,2 @@
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Default initialized TSConfig/tsconfig.json
@@ -25,6 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "implicitUnknown": true,               /* Use unknown as implicit type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with advanced options/tsconfig.json
@@ -25,6 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "implicitUnknown": true,               /* Use unknown as implicit type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with boolean value compiler options/tsconfig.json
@@ -25,6 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "implicitUnknown": true,               /* Use unknown as implicit type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with enum value compiler options/tsconfig.json
@@ -25,6 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "implicitUnknown": true,               /* Use unknown as implicit type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with files options/tsconfig.json
@@ -25,6 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "implicitUnknown": true,               /* Use unknown as implicit type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option value/tsconfig.json
@@ -25,6 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "implicitUnknown": true,               /* Use unknown as implicit type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with incorrect compiler option/tsconfig.json
@@ -25,6 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "implicitUnknown": true,               /* Use unknown as implicit type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options with enum value/tsconfig.json
@@ -25,6 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "implicitUnknown": true,               /* Use unknown as implicit type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */

--- a/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
+++ b/tests/baselines/reference/tsConfig/Initialized TSConfig with list compiler options/tsconfig.json
@@ -25,6 +25,7 @@
     /* Strict Type-Checking Options */
     "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "implicitUnknown": true,               /* Use unknown as implicit type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
     // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */


### PR DESCRIPTION
See #27265 for details.

I have no idea if I’ve actually implemented this correctly or not.

## To do list:
- [ ] Ensure that generated `.d.ts` contain `unknown` where implicit `any` would have been previously.
- [ ] Test that explicit `any` still works correctly.
- [ ] Figure out how the tests work in this.

---

/cc @andy-ms, @mmkal, @RyanCavanaugh