### PR TITLE
Cache ATA per patch version

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -3,7 +3,7 @@ namespace ts {
     // If changing the text in this section, be sure to test `configureNightly` too.
     export const versionMajorMinor = "3.4";
     /** The version of the TypeScript compiler release */
-    export const version = `${versionMajorMinor}.2`;
+    export const version = `${versionMajorMinor}.3`;
 }
 
 namespace ts {

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -29,7 +29,7 @@ namespace ts.server {
                     process.env.USERPROFILE ||
                     (process.env.HOMEDRIVE && process.env.HOMEPATH && normalizeSlashes(process.env.HOMEDRIVE + process.env.HOMEPATH)) ||
                     os.tmpdir();
-                return combinePaths(combinePaths(normalizeSlashes(basePath), "Microsoft/TypeScript"), versionMajorMinor);
+                return combinePaths(combinePaths(normalizeSlashes(basePath), "Microsoft/TypeScript"), version);
             }
             case "openbsd":
             case "freebsd":
@@ -37,7 +37,7 @@ namespace ts.server {
             case "linux":
             case "android": {
                 const cacheLocation = getNonWindowsCacheLocation(process.platform === "darwin");
-                return combinePaths(combinePaths(cacheLocation, "typescript"), versionMajorMinor);
+                return combinePaths(combinePaths(cacheLocation, "typescript"), version);
             }
             default:
                 return Debug.fail(`unsupported platform '${process.platform}'`);


### PR DESCRIPTION
Previously, we created one cache per minor version. This changes allows us to invalidate the ATA cache by releasing a new patch version of Typescript. Invaliding the ATA cache may be necessary to work around performance bugs in a version of Typescript, like those in 3.4.

Also, bump the version to 3.4.3.