### PR TITLE
Fix some bad jsdoc comment indent

### DIFF
--- a/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
+++ b/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
@@ -1,0 +1,112 @@
+[
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 64
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 62,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "example",
+          "text": "if (true) {\n    foo()\n}"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 134
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 132,
+        "length": 4
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "foo2",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "example",
+          "text": "{\n    foo()\n}"
+        }
+      ]
+    }
+  }
+]

--- a/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
+++ b/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
@@ -221,5 +221,63 @@
         }
       ]
     }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 426
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 424,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "goo",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "func"
+        },
+        {
+          "name": "example",
+          "text": "x y\n12345\n   b"
+        }
+      ]
+    }
   }
 ]

--- a/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
+++ b/tests/baselines/reference/quickInfoForJSDocUnknownTag.baseline
@@ -108,5 +108,118 @@
         }
       ]
     }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 219
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 218,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "moo",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "example",
+          "text": "  x y\n  12345\n     b"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts",
+      "position": 313
+    },
+    "quickInfo": {
+      "kind": "function",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 312,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "function",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "boo",
+          "kind": "functionName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "func"
+        },
+        {
+          "name": "example",
+          "text": "  x y\n  12345\n     b"
+        }
+      ]
+    }
   }
 ]

--- a/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts
+++ b/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+/////**
+//// * @example
+//// * if (true) {
+//// *     foo()
+//// * }
+//// */
+////function fo/*1*/o() {
+////    return '2';
+////}
+/////**
+//// @example
+//// {
+////     foo()
+//// }
+//// */
+////function fo/*2*/o2() {
+////    return '2';
+////}
+
+verify.baselineQuickInfo();

--- a/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts
+++ b/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts
@@ -37,4 +37,13 @@
 ////function b/*4*/oo() {
 ////    return '2';
 ////}
+/////**
+//// * @func
+//// * @example    x y
+//// *             12345
+//// *                b
+//// */
+////function go/*5*/o() {
+////    return '2';
+////}
 verify.baselineQuickInfo();

--- a/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts
+++ b/tests/cases/fourslash/quickInfoForJSDocUnknownTag.ts
@@ -18,5 +18,23 @@
 ////function fo/*2*/o2() {
 ////    return '2';
 ////}
-
+/////**
+//// * @example
+//// *   x y
+//// *   12345
+//// *      b
+//// */
+////function m/*3*/oo() {
+////    return '2';
+////}
+/////**
+//// * @func
+//// * @example
+//// *   x y
+//// *   12345
+//// *      b
+//// */
+////function b/*4*/oo() {
+////    return '2';
+////}
 verify.baselineQuickInfo();


### PR DESCRIPTION
Fixes #15749 plus a few other cases I discovered.

Yes, I know the baseline format is horrible. Sorry.