### PR TITLE
Add additional type overload to Object.values

### DIFF
--- a/src/lib/es2017.object.d.ts
+++ b/src/lib/es2017.object.d.ts
@@ -9,6 +9,12 @@ interface ObjectConstructor {
      * Returns an array of values of the enumerable properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
+    values<T extends object>(o: T): (T[keyof T])[]
+    
+    /**
+     * Returns an array of values of the enumerable properties of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
     values(o: {}): any[];
 
     /**
@@ -17,6 +23,12 @@ interface ObjectConstructor {
      */
     entries<T>(o: { [s: string]: T } | ArrayLike<T>): [string, T][];
 
+    /**
+     * Returns an array of key/values of the enumerable properties of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
+    entries<T extends object>(o: T): [string, T[keyof T]][];
+    
     /**
      * Returns an array of key/values of the enumerable properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.


### PR DESCRIPTION
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change


### I'm making this PR on github, gonna check out the project and run gulp/tests as soon as I open it


## Motivation

I use a lot of enums, and I am very frequently writing code which exhuastively switches over enums, and so on. Fairly often I find that I want to check whether a value is contained within an enum, or iterate over the values in the enum.

The way I've been doing that is like this:
```typescript
enum Foo {
  A,
  B,
}

if ((Object.values(Foo) as Foo[]).includes(value) {
  ...
}
```

with this new overload, I can more simply do
```typescript
if (Object.values(Foo).includes(value) {
  ...
}
```

As far as I can tell, this new overload doesn't interfere with standard uses of `Object.values`

## Tests

still working on it. opening as draft for now

