### PR TITLE
Fix conditional type simplification

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10210,7 +10210,7 @@ namespace ts {
 
         function getConditionalTypeWorker(root: ConditionalRoot, mapper: TypeMapper | undefined, checkType: Type, extendsType: Type, trueType: Type, falseType: Type) {
             // Simplifications for types of the form `T extends U ? T : never` and `T extends U ? never : T`.
-            if (falseType.flags & TypeFlags.Never && isTypeIdenticalTo(getActualTypeVariable(trueType), getActualTypeVariable(checkType))) {
+            if (falseType.flags & TypeFlags.Never && getActualTypeVariable(trueType) === getActualTypeVariable(checkType)) {
                 if (checkType.flags & TypeFlags.Any || isTypeAssignableTo(getRestrictiveInstantiation(checkType), getRestrictiveInstantiation(extendsType))) { // Always true
                     return trueType;
                 }
@@ -10218,7 +10218,7 @@ namespace ts {
                     return neverType;
                 }
             }
-            else if (trueType.flags & TypeFlags.Never && isTypeIdenticalTo(getActualTypeVariable(falseType), getActualTypeVariable(checkType))) {
+            else if (trueType.flags & TypeFlags.Never && getActualTypeVariable(falseType) === getActualTypeVariable(checkType)) {
                 if (!(checkType.flags & TypeFlags.Any) && isTypeAssignableTo(getRestrictiveInstantiation(checkType), getRestrictiveInstantiation(extendsType))) { // Always true
                     return neverType;
                 }

--- a/tests/baselines/reference/conditionalTypeSimplification.js
+++ b/tests/baselines/reference/conditionalTypeSimplification.js
@@ -1,0 +1,15 @@
+//// [conditionalTypeSimplification.ts]
+// Repro from #30794
+
+interface AbstractSchema<S, V> {
+  m1<T> (v: T): SchemaType<S, Exclude<V, T>>;
+  m2<T> (v: T): SchemaType<S, T>;
+}
+
+type SchemaType<S, V> = S extends object ? AnySchema<V> : never;
+interface AnySchema<V> extends AnySchemaType<AnySchema<undefined>, V> { }
+interface AnySchemaType<S extends AbstractSchema<any, any>, V> extends AbstractSchema<S, V> { }
+
+
+//// [conditionalTypeSimplification.js]
+// Repro from #30794

--- a/tests/baselines/reference/conditionalTypeSimplification.symbols
+++ b/tests/baselines/reference/conditionalTypeSimplification.symbols
@@ -1,0 +1,53 @@
+=== tests/cases/compiler/conditionalTypeSimplification.ts ===
+// Repro from #30794
+
+interface AbstractSchema<S, V> {
+>AbstractSchema : Symbol(AbstractSchema, Decl(conditionalTypeSimplification.ts, 0, 0))
+>S : Symbol(S, Decl(conditionalTypeSimplification.ts, 2, 25))
+>V : Symbol(V, Decl(conditionalTypeSimplification.ts, 2, 27))
+
+  m1<T> (v: T): SchemaType<S, Exclude<V, T>>;
+>m1 : Symbol(AbstractSchema.m1, Decl(conditionalTypeSimplification.ts, 2, 32))
+>T : Symbol(T, Decl(conditionalTypeSimplification.ts, 3, 5))
+>v : Symbol(v, Decl(conditionalTypeSimplification.ts, 3, 9))
+>T : Symbol(T, Decl(conditionalTypeSimplification.ts, 3, 5))
+>SchemaType : Symbol(SchemaType, Decl(conditionalTypeSimplification.ts, 5, 1))
+>S : Symbol(S, Decl(conditionalTypeSimplification.ts, 2, 25))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>V : Symbol(V, Decl(conditionalTypeSimplification.ts, 2, 27))
+>T : Symbol(T, Decl(conditionalTypeSimplification.ts, 3, 5))
+
+  m2<T> (v: T): SchemaType<S, T>;
+>m2 : Symbol(AbstractSchema.m2, Decl(conditionalTypeSimplification.ts, 3, 45))
+>T : Symbol(T, Decl(conditionalTypeSimplification.ts, 4, 5))
+>v : Symbol(v, Decl(conditionalTypeSimplification.ts, 4, 9))
+>T : Symbol(T, Decl(conditionalTypeSimplification.ts, 4, 5))
+>SchemaType : Symbol(SchemaType, Decl(conditionalTypeSimplification.ts, 5, 1))
+>S : Symbol(S, Decl(conditionalTypeSimplification.ts, 2, 25))
+>T : Symbol(T, Decl(conditionalTypeSimplification.ts, 4, 5))
+}
+
+type SchemaType<S, V> = S extends object ? AnySchema<V> : never;
+>SchemaType : Symbol(SchemaType, Decl(conditionalTypeSimplification.ts, 5, 1))
+>S : Symbol(S, Decl(conditionalTypeSimplification.ts, 7, 16))
+>V : Symbol(V, Decl(conditionalTypeSimplification.ts, 7, 18))
+>S : Symbol(S, Decl(conditionalTypeSimplification.ts, 7, 16))
+>AnySchema : Symbol(AnySchema, Decl(conditionalTypeSimplification.ts, 7, 64))
+>V : Symbol(V, Decl(conditionalTypeSimplification.ts, 7, 18))
+
+interface AnySchema<V> extends AnySchemaType<AnySchema<undefined>, V> { }
+>AnySchema : Symbol(AnySchema, Decl(conditionalTypeSimplification.ts, 7, 64))
+>V : Symbol(V, Decl(conditionalTypeSimplification.ts, 8, 20))
+>AnySchemaType : Symbol(AnySchemaType, Decl(conditionalTypeSimplification.ts, 8, 73))
+>AnySchema : Symbol(AnySchema, Decl(conditionalTypeSimplification.ts, 7, 64))
+>V : Symbol(V, Decl(conditionalTypeSimplification.ts, 8, 20))
+
+interface AnySchemaType<S extends AbstractSchema<any, any>, V> extends AbstractSchema<S, V> { }
+>AnySchemaType : Symbol(AnySchemaType, Decl(conditionalTypeSimplification.ts, 8, 73))
+>S : Symbol(S, Decl(conditionalTypeSimplification.ts, 9, 24))
+>AbstractSchema : Symbol(AbstractSchema, Decl(conditionalTypeSimplification.ts, 0, 0))
+>V : Symbol(V, Decl(conditionalTypeSimplification.ts, 9, 59))
+>AbstractSchema : Symbol(AbstractSchema, Decl(conditionalTypeSimplification.ts, 0, 0))
+>S : Symbol(S, Decl(conditionalTypeSimplification.ts, 9, 24))
+>V : Symbol(V, Decl(conditionalTypeSimplification.ts, 9, 59))
+

--- a/tests/baselines/reference/conditionalTypeSimplification.types
+++ b/tests/baselines/reference/conditionalTypeSimplification.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/conditionalTypeSimplification.ts ===
+// Repro from #30794
+
+interface AbstractSchema<S, V> {
+  m1<T> (v: T): SchemaType<S, Exclude<V, T>>;
+>m1 : <T>(v: T) => SchemaType<S, Exclude<V, T>>
+>v : T
+
+  m2<T> (v: T): SchemaType<S, T>;
+>m2 : <T>(v: T) => SchemaType<S, T>
+>v : T
+}
+
+type SchemaType<S, V> = S extends object ? AnySchema<V> : never;
+>SchemaType : SchemaType<S, V>
+
+interface AnySchema<V> extends AnySchemaType<AnySchema<undefined>, V> { }
+interface AnySchemaType<S extends AbstractSchema<any, any>, V> extends AbstractSchema<S, V> { }
+

--- a/tests/cases/compiler/conditionalTypeSimplification.ts
+++ b/tests/cases/compiler/conditionalTypeSimplification.ts
@@ -1,0 +1,10 @@
+// Repro from #30794
+
+interface AbstractSchema<S, V> {
+  m1<T> (v: T): SchemaType<S, Exclude<V, T>>;
+  m2<T> (v: T): SchemaType<S, T>;
+}
+
+type SchemaType<S, V> = S extends object ? AnySchema<V> : never;
+interface AnySchema<V> extends AnySchemaType<AnySchema<undefined>, V> { }
+interface AnySchemaType<S extends AbstractSchema<any, any>, V> extends AbstractSchema<S, V> { }


### PR DESCRIPTION
This PR switches conditional type simplification to use an object identity check instead of `isTypeIdenticalTo`. This is slightly more restrictive but certainly will never cause runaway recursion and doesn't appear to affect the scenarios we care about.

It would of course be nice to revise `isTypeIdenticalTo` to avoid the runaway recursion, but meanwhile I think this is a good fix.

Fixes #30794.