### PR TITLE
fix typo - identifer to identifier

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2836,7 +2836,7 @@ namespace ts {
         }
 
         // A reserved member name starts with two underscores, but the third character cannot be an underscore
-        // or the @ symbol. A third underscore indicates an escaped form of an identifer that started
+        // or the @ symbol. A third underscore indicates an escaped form of an identifier that started
         // with at least two underscores. The @ character indicates that the name is denoted by a well known ES
         // Symbol instance.
         function isReservedMemberName(name: __String) {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1912,8 +1912,8 @@ namespace ts.Completions {
             return undefined;
         }
 
-        const validIdentiferResult: CompletionEntryDisplayNameForSymbol = { name, needsConvertPropertyAccess: false };
-        if (isIdentifierText(name, target)) return validIdentiferResult;
+        const validIdentifierResult: CompletionEntryDisplayNameForSymbol = { name, needsConvertPropertyAccess: false };
+        if (isIdentifierText(name, target)) return validIdentifierResult;
         switch (kind) {
             case CompletionKind.MemberLike:
                 return undefined;
@@ -1926,7 +1926,7 @@ namespace ts.Completions {
                 return name.charCodeAt(0) === CharacterCodes.space ? undefined : { name, needsConvertPropertyAccess: true };
             case CompletionKind.None:
             case CompletionKind.String:
-                return validIdentiferResult;
+                return validIdentifierResult;
             default:
                 Debug.assertNever(kind);
         }

--- a/tests/cases/compiler/genericClassesRedeclaration.ts
+++ b/tests/cases/compiler/genericClassesRedeclaration.ts
@@ -26,7 +26,7 @@ declare module TypeScript {
         public lookup(key: string): T;
         public remove(key: string): void;
     }
-    class IdentiferNameHashTable<T> extends StringHashTable<T> {
+    class IdentifierNameHashTable<T> extends StringHashTable<T> {
         public getAllKeys(): string[];
         public add(key: string, data: T): boolean;
         public addOrUpdate(key: string, data: T): boolean;
@@ -65,7 +65,7 @@ declare module TypeScript {
         public lookup(key: string): T;
         public remove(key: string): void;
     }
-    class IdentiferNameHashTable<T> extends StringHashTable<T> {
+    class IdentifierNameHashTable<T> extends StringHashTable<T> {
         public getAllKeys(): string[];
         public add(key: string, data: T): boolean;
         public addOrUpdate(key: string, data: T): boolean;

--- a/tests/cases/fourslash/completionListInvalidMemberNames.ts
+++ b/tests/cases/fourslash/completionListInvalidMemberNames.ts
@@ -7,8 +7,8 @@
 ////    "any": "valid identifier name (matches a typescript keyword)",
 ////    "#": "invalid identifier name",
 ////    "$": "valid identifier name",
-////    "\u0062": "valid unicode identifer name (b)",
-////    "\u0031\u0062": "invalid unicode identifer name (1b)"
+////    "\u0062": "valid unicode identifier name (b)",
+////    "\u0031\u0062": "invalid unicode identifier name (1b)"
 ////};
 ////
 ////x[|./*a*/|];


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This PR fixes a typo across typescript, misspelling of the word 'identifier'. There are some generated files that still have this typo, but I was not able to find the gulp task to regenerate the files. 

