### PR TITLE
Check to make sure default npm exists at path before trying to use it

### DIFF
--- a/src/jsTyping/shared.ts
+++ b/src/jsTyping/shared.ts
@@ -21,6 +21,11 @@ namespace ts.server {
          * typingsInstaller will run the command with `${npmLocation} install ...`.
          */
         export const NpmLocation = "--npmLocation";
+        /**
+         * Flag indicating that the typings installer should try to validate the default npm location.
+         * If the default npm is not found when this flag is enabled, fallback to `npm install`
+         */
+        export const ValidateDefaultNpmLocation = "--validateDefaultNpmLocation";
     }
 
     export function hasArgument(argumentName: string) {

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -242,6 +242,7 @@ namespace ts.server {
             readonly typingSafeListLocation: string,
             readonly typesMapLocation: string,
             private readonly npmLocation: string | undefined,
+            private readonly validateDefaultNpmLocation: boolean,
             private event: Event) {
         }
 
@@ -296,6 +297,9 @@ namespace ts.server {
             }
             if (this.npmLocation) {
                 args.push(Arguments.NpmLocation, this.npmLocation);
+            }
+            if (this.validateDefaultNpmLocation) {
+                args.push(Arguments.ValidateDefaultNpmLocation);
             }
 
             const execArgv: string[] = [];
@@ -497,7 +501,7 @@ namespace ts.server {
 
             const typingsInstaller = disableAutomaticTypingAcquisition
                 ? undefined
-                : new NodeTypingsInstaller(telemetryEnabled, logger, host, getGlobalTypingsCacheLocation(), typingSafeListLocation, typesMapLocation, npmLocation, event);
+                : new NodeTypingsInstaller(telemetryEnabled, logger, host, getGlobalTypingsCacheLocation(), typingSafeListLocation, typesMapLocation, npmLocation, validateDefaultNpmLocation, event);
 
             super({
                 host,
@@ -932,6 +936,7 @@ namespace ts.server {
     const typingSafeListLocation = findArgument(Arguments.TypingSafeListLocation)!; // TODO: GH#18217
     const typesMapLocation = findArgument(Arguments.TypesMapLocation) || combinePaths(getDirectoryPath(sys.getExecutingFilePath()), "typesMap.json");
     const npmLocation = findArgument(Arguments.NpmLocation);
+    const validateDefaultNpmLocation = hasArgument(Arguments.ValidateDefaultNpmLocation);
 
     function parseStringArray(argName: string): ReadonlyArray<string> {
         const arg = findArgument(argName);

--- a/src/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/typingsInstaller/nodeTypingsInstaller.ts
@@ -33,7 +33,7 @@ namespace ts.server.typingsInstaller {
         if (path.basename(processName).indexOf("node") === 0) {
             const npmPath = path.join(path.dirname(process.argv[0]), "npm");
             if (!validateDefaultNpmLocation) {
-                return npmPath
+                return npmPath;
             }
             if (host.fileExists(npmPath)) {
                 return `"${npmPath}"`;

--- a/src/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/typingsInstaller/nodeTypingsInstaller.ts
@@ -29,9 +29,12 @@ namespace ts.server.typingsInstaller {
     }
 
     /** Used if `--npmLocation` is not passed. */
-    function getDefaultNPMLocation(processName: string, host: InstallTypingHost): string {
+    function getDefaultNPMLocation(processName: string, validateDefaultNpmLocation: boolean, host: InstallTypingHost): string {
         if (path.basename(processName).indexOf("node") === 0) {
             const npmPath = path.join(path.dirname(process.argv[0]), "npm");
+            if (!validateDefaultNpmLocation) {
+                return npmPath
+            }
             if (host.fileExists(npmPath)) {
                 return `"${npmPath}"`;
             }
@@ -80,7 +83,7 @@ namespace ts.server.typingsInstaller {
 
         private delayedInitializationError: InitializationFailedResponse | undefined;
 
-        constructor(globalTypingsCacheLocation: string, typingSafeListLocation: string, typesMapLocation: string, npmLocation: string | undefined, throttleLimit: number, log: Log) {
+        constructor(globalTypingsCacheLocation: string, typingSafeListLocation: string, typesMapLocation: string, npmLocation: string | undefined, validateDefaultNpmLocation: boolean, throttleLimit: number, log: Log) {
             super(
                 sys,
                 globalTypingsCacheLocation,
@@ -88,7 +91,7 @@ namespace ts.server.typingsInstaller {
                 typesMapLocation ? toPath(typesMapLocation, "", createGetCanonicalFileName(sys.useCaseSensitiveFileNames)) : toPath("typesMap.json", __dirname, createGetCanonicalFileName(sys.useCaseSensitiveFileNames)),
                 throttleLimit,
                 log);
-            this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0], this.installTypingHost);
+            this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0], validateDefaultNpmLocation, this.installTypingHost);
 
             // If the NPM path contains spaces and isn't wrapped in quotes, do so.
             if (stringContains(this.npmPath, " ") && this.npmPath[0] !== `"`) {
@@ -97,6 +100,7 @@ namespace ts.server.typingsInstaller {
             if (this.log.isEnabled()) {
                 this.log.writeLine(`Process id: ${process.pid}`);
                 this.log.writeLine(`NPM location: ${this.npmPath} (explicit '${Arguments.NpmLocation}' ${npmLocation === undefined ? "not " : ""} provided)`);
+                this.log.writeLine(`validateDefaultNpmLocation: ${validateDefaultNpmLocation}`);
             }
             ({ execSync: this.nodeExecSync } = require("child_process"));
 
@@ -230,6 +234,7 @@ namespace ts.server.typingsInstaller {
     const typingSafeListLocation = findArgument(Arguments.TypingSafeListLocation);
     const typesMapLocation = findArgument(Arguments.TypesMapLocation);
     const npmLocation = findArgument(Arguments.NpmLocation);
+    const validateDefaultNpmLocation = hasArgument(Arguments.ValidateDefaultNpmLocation);
 
     const log = new FileLog(logFilePath);
     if (log.isEnabled()) {
@@ -243,7 +248,7 @@ namespace ts.server.typingsInstaller {
         }
         process.exit(0);
     });
-    const installer = new NodeTypingsInstaller(globalTypingsCacheLocation!, typingSafeListLocation!, typesMapLocation!, npmLocation, /*throttleLimit*/5, log); // TODO: GH#18217
+    const installer = new NodeTypingsInstaller(globalTypingsCacheLocation!, typingSafeListLocation!, typesMapLocation!, npmLocation, validateDefaultNpmLocation, /*throttleLimit*/5, log); // TODO: GH#18217
     installer.listen();
 
     function indent(newline: string, str: string): string {

--- a/src/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/typingsInstaller/nodeTypingsInstaller.ts
@@ -29,13 +29,14 @@ namespace ts.server.typingsInstaller {
     }
 
     /** Used if `--npmLocation` is not passed. */
-    function getDefaultNPMLocation(processName: string) {
+    function getDefaultNPMLocation(processName: string, host: InstallTypingHost): string {
         if (path.basename(processName).indexOf("node") === 0) {
-            return `"${path.join(path.dirname(process.argv[0]), "npm")}"`;
+            const npmPath = path.join(path.dirname(process.argv[0]), "npm");
+            if (host.fileExists(npmPath)) {
+                return `"${npmPath}"`;
+            }
         }
-        else {
-            return "npm";
-        }
+        return "npm";
     }
 
     interface TypesRegistryFile {
@@ -87,7 +88,7 @@ namespace ts.server.typingsInstaller {
                 typesMapLocation ? toPath(typesMapLocation, "", createGetCanonicalFileName(sys.useCaseSensitiveFileNames)) : toPath("typesMap.json", __dirname, createGetCanonicalFileName(sys.useCaseSensitiveFileNames)),
                 throttleLimit,
                 log);
-            this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0]);
+            this.npmPath = npmLocation !== undefined ? npmLocation : getDefaultNPMLocation(process.argv[0], this.installTypingHost);
 
             // If the NPM path contains spaces and isn't wrapped in quotes, do so.
             if (stringContains(this.npmPath, " ") && this.npmPath[0] !== `"`) {


### PR DESCRIPTION
**Bug**
If the typings installer is run under a copy of node that does not include npm—but on a machine that does have npm installed—it will incorrectly try to use the npm that does not exist next to its running version of node

**Fix**
Make sure that we check that npm we select exists before trying to use it as the default. Otherwise, fall back to using plain old `npm`

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [X] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #30909

