### PR TITLE
Gracefully parse 'super' with type arguments (#10677)

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2605,6 +2605,10 @@
         "category": "Error",
         "code": 2753
     },
+    "'super' may not use type arguments.": {
+        "category": "Error",
+        "code": 2754
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4189,6 +4189,14 @@ namespace ts {
 
         function parseSuperExpression(): MemberExpression {
             const expression = parseTokenNode<PrimaryExpression>();
+            if (token() === SyntaxKind.LessThanToken) {
+                const startPos = getNodePos();
+                const typeArguments = tryParse(parseTypeArgumentsInExpression);
+                if (typeArguments !== undefined) {
+                    parseErrorAt(startPos, getNodePos(), Diagnostics.super_may_not_use_type_arguments);
+                }
+            }
+
             if (token() === SyntaxKind.OpenParenToken || token() === SyntaxKind.DotToken || token() === SyntaxKind.OpenBracketToken) {
                 return expression;
             }

--- a/tests/baselines/reference/errorSuperCalls.errors.txt
+++ b/tests/baselines/reference/errorSuperCalls.errors.txt
@@ -7,15 +7,14 @@ tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(26,9): error T
 tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(30,16): error TS2337: Super calls are not permitted outside constructors or in nested functions inside constructors.
 tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(34,9): error TS2337: Super calls are not permitted outside constructors or in nested functions inside constructors.
 tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(38,9): error TS2337: Super calls are not permitted outside constructors or in nested functions inside constructors.
-tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(46,9): error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(46,14): error TS1034: 'super' must be followed by an argument list or member access.
+tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(46,14): error TS2754: 'super' may not use type arguments.
 tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(58,9): error TS2337: Super calls are not permitted outside constructors or in nested functions inside constructors.
 tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(62,9): error TS2337: Super calls are not permitted outside constructors or in nested functions inside constructors.
 tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(67,9): error TS2337: Super calls are not permitted outside constructors or in nested functions inside constructors.
 tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(71,9): error TS2337: Super calls are not permitted outside constructors or in nested functions inside constructors.
 
 
-==== tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts (15 errors) ====
+==== tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts (14 errors) ====
     //super call in class constructor with no base type
     class NoBase {
         constructor() {
@@ -80,10 +79,8 @@ tests/cases/conformance/expressions/superCalls/errorSuperCalls.ts(71,9): error T
         //super call with type arguments 
         constructor() {
             super<string>();
-            ~~~~~
-!!! error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-                 ~
-!!! error TS1034: 'super' must be followed by an argument list or member access.
+                 ~~~~~~~~
+!!! error TS2754: 'super' may not use type arguments.
             super();
         }
     }

--- a/tests/baselines/reference/errorSuperCalls.js
+++ b/tests/baselines/reference/errorSuperCalls.js
@@ -140,8 +140,7 @@ var Derived = /** @class */ (function (_super) {
     __extends(Derived, _super);
     //super call with type arguments 
     function Derived() {
-        var _this = this;
-        _super.prototype..call(_this);
+        var _this = _super.call(this) || this;
         _this = _super.call(this) || this;
         return _this;
     }

--- a/tests/baselines/reference/errorSuperCalls.types
+++ b/tests/baselines/reference/errorSuperCalls.types
@@ -91,10 +91,8 @@ class Derived<T> extends Base<T> {
     //super call with type arguments 
     constructor() {
         super<string>();
->super<string>() : any
->super : any
->super : Base<T>
-> : any
+>super<string>() : void
+>super : typeof Base
 
         super();
 >super() : void

--- a/tests/baselines/reference/parserSuperExpression2.errors.txt
+++ b/tests/baselines/reference/parserSuperExpression2.errors.txt
@@ -1,17 +1,14 @@
-tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts(3,5): error TS2335: 'super' can only be referenced in a derived class.
-tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts(3,10): error TS1034: 'super' must be followed by an argument list or member access.
-tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts(3,11): error TS2304: Cannot find name 'T'.
+tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts(3,5): error TS2337: Super calls are not permitted outside constructors or in nested functions inside constructors.
+tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts(3,10): error TS2754: 'super' may not use type arguments.
 
 
-==== tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts (2 errors) ====
     class C {
       M() {
         super<T>(0);
         ~~~~~
-!!! error TS2335: 'super' can only be referenced in a derived class.
-             ~
-!!! error TS1034: 'super' must be followed by an argument list or member access.
-              ~
-!!! error TS2304: Cannot find name 'T'.
+!!! error TS2337: Super calls are not permitted outside constructors or in nested functions inside constructors.
+             ~~~
+!!! error TS2754: 'super' may not use type arguments.
       }
     }

--- a/tests/baselines/reference/parserSuperExpression2.js
+++ b/tests/baselines/reference/parserSuperExpression2.js
@@ -10,7 +10,7 @@ var C = /** @class */ (function () {
     function C() {
     }
     C.prototype.M = function () {
-        _super.prototype..call(this, 0);
+        _this = _super.call(this, 0) || this;
     };
     return C;
 }());

--- a/tests/baselines/reference/parserSuperExpression2.types
+++ b/tests/baselines/reference/parserSuperExpression2.types
@@ -6,10 +6,8 @@ class C {
 >M : () => void
 
     super<T>(0);
->super<T>(0) : any
+>super<T>(0) : void
 >super : any
->super : any
-> : any
 >0 : 0
   }
 }

--- a/tests/baselines/reference/superWithTypeArgument.errors.txt
+++ b/tests/baselines/reference/superWithTypeArgument.errors.txt
@@ -1,23 +1,15 @@
-tests/cases/compiler/superWithTypeArgument.ts(6,5): error TS2377: Constructors for derived classes must contain a 'super' call.
-tests/cases/compiler/superWithTypeArgument.ts(7,9): error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-tests/cases/compiler/superWithTypeArgument.ts(7,14): error TS1034: 'super' must be followed by an argument list or member access.
+tests/cases/compiler/superWithTypeArgument.ts(7,14): error TS2754: 'super' may not use type arguments.
 
 
-==== tests/cases/compiler/superWithTypeArgument.ts (3 errors) ====
+==== tests/cases/compiler/superWithTypeArgument.ts (1 errors) ====
     class C {
         
     }
     
     class D<T> extends C {
         constructor() {
-        ~~~~~~~~~~~~~~~
             super<T>();
-    ~~~~~~~~~~~~~~~~~~~
-            ~~~~~
-!!! error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-                 ~
-!!! error TS1034: 'super' must be followed by an argument list or member access.
+                 ~~~
+!!! error TS2754: 'super' may not use type arguments.
         }
-    ~~~~~
-!!! error TS2377: Constructors for derived classes must contain a 'super' call.
     }

--- a/tests/baselines/reference/superWithTypeArgument.js
+++ b/tests/baselines/reference/superWithTypeArgument.js
@@ -31,9 +31,7 @@ var C = /** @class */ (function () {
 var D = /** @class */ (function (_super) {
     __extends(D, _super);
     function D() {
-        var _this = this;
-        _super.prototype..call(_this);
-        return _this;
+        return _super.call(this) || this;
     }
     return D;
 }(C));

--- a/tests/baselines/reference/superWithTypeArgument.symbols
+++ b/tests/baselines/reference/superWithTypeArgument.symbols
@@ -12,6 +12,5 @@ class D<T> extends C {
     constructor() {
         super<T>();
 >super : Symbol(C, Decl(superWithTypeArgument.ts, 0, 0))
->T : Symbol(T, Decl(superWithTypeArgument.ts, 4, 8))
     }
 }

--- a/tests/baselines/reference/superWithTypeArgument.types
+++ b/tests/baselines/reference/superWithTypeArgument.types
@@ -10,9 +10,7 @@ class D<T> extends C {
 
     constructor() {
         super<T>();
->super<T>() : any
->super : any
->super : C
-> : any
+>super<T>() : void
+>super : typeof C
     }
 }

--- a/tests/baselines/reference/superWithTypeArgument2.errors.txt
+++ b/tests/baselines/reference/superWithTypeArgument2.errors.txt
@@ -1,23 +1,18 @@
-tests/cases/compiler/superWithTypeArgument2.ts(6,5): error TS2377: Constructors for derived classes must contain a 'super' call.
-tests/cases/compiler/superWithTypeArgument2.ts(7,9): error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-tests/cases/compiler/superWithTypeArgument2.ts(7,14): error TS1034: 'super' must be followed by an argument list or member access.
+tests/cases/compiler/superWithTypeArgument2.ts(7,14): error TS2754: 'super' may not use type arguments.
+tests/cases/compiler/superWithTypeArgument2.ts(7,18): error TS2554: Expected 0 arguments, but got 1.
 
 
-==== tests/cases/compiler/superWithTypeArgument2.ts (3 errors) ====
+==== tests/cases/compiler/superWithTypeArgument2.ts (2 errors) ====
     class C<T> {
         foo: T;
     }
     
     class D<T> extends C<T> {
         constructor(x) {
-        ~~~~~~~~~~~~~~~~
             super<T>(x);
-    ~~~~~~~~~~~~~~~~~~~~
-            ~~~~~
-!!! error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-                 ~
-!!! error TS1034: 'super' must be followed by an argument list or member access.
+                 ~~~
+!!! error TS2754: 'super' may not use type arguments.
+                     ~
+!!! error TS2554: Expected 0 arguments, but got 1.
         }
-    ~~~~~
-!!! error TS2377: Constructors for derived classes must contain a 'super' call.
     }

--- a/tests/baselines/reference/superWithTypeArgument2.js
+++ b/tests/baselines/reference/superWithTypeArgument2.js
@@ -31,9 +31,7 @@ var C = /** @class */ (function () {
 var D = /** @class */ (function (_super) {
     __extends(D, _super);
     function D(x) {
-        var _this = this;
-        _super.prototype..call(_this, x);
-        return _this;
+        return _super.call(this, x) || this;
     }
     return D;
 }(C));

--- a/tests/baselines/reference/superWithTypeArgument2.symbols
+++ b/tests/baselines/reference/superWithTypeArgument2.symbols
@@ -19,7 +19,6 @@ class D<T> extends C<T> {
 
         super<T>(x);
 >super : Symbol(C, Decl(superWithTypeArgument2.ts, 0, 0))
->T : Symbol(T, Decl(superWithTypeArgument2.ts, 4, 8))
 >x : Symbol(x, Decl(superWithTypeArgument2.ts, 5, 16))
     }
 }

--- a/tests/baselines/reference/superWithTypeArgument2.types
+++ b/tests/baselines/reference/superWithTypeArgument2.types
@@ -14,10 +14,8 @@ class D<T> extends C<T> {
 >x : any
 
         super<T>(x);
->super<T>(x) : any
->super : any
->super : C<T>
-> : any
+>super<T>(x) : void
+>super : typeof C
 >x : any
     }
 }

--- a/tests/baselines/reference/superWithTypeArgument3.errors.txt
+++ b/tests/baselines/reference/superWithTypeArgument3.errors.txt
@@ -1,9 +1,7 @@
-tests/cases/compiler/superWithTypeArgument3.ts(7,5): error TS2377: Constructors for derived classes must contain a 'super' call.
-tests/cases/compiler/superWithTypeArgument3.ts(8,9): error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-tests/cases/compiler/superWithTypeArgument3.ts(8,14): error TS1034: 'super' must be followed by an argument list or member access.
+tests/cases/compiler/superWithTypeArgument3.ts(8,14): error TS2754: 'super' may not use type arguments.
 
 
-==== tests/cases/compiler/superWithTypeArgument3.ts (3 errors) ====
+==== tests/cases/compiler/superWithTypeArgument3.ts (1 errors) ====
     class C<T> {
         foo: T;
         bar<U>(x: U) { }
@@ -11,16 +9,10 @@ tests/cases/compiler/superWithTypeArgument3.ts(8,14): error TS1034: 'super' must
     
     class D<T> extends C<T> {
         constructor() {
-        ~~~~~~~~~~~~~~~
             super<T>();
-    ~~~~~~~~~~~~~~~~~~~
-            ~~~~~
-!!! error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-                 ~
-!!! error TS1034: 'super' must be followed by an argument list or member access.
+                 ~~~
+!!! error TS2754: 'super' may not use type arguments.
         }
-    ~~~~~
-!!! error TS2377: Constructors for derived classes must contain a 'super' call.
         bar() {
             super.bar<T>(null);
         }

--- a/tests/baselines/reference/superWithTypeArgument3.js
+++ b/tests/baselines/reference/superWithTypeArgument3.js
@@ -36,9 +36,7 @@ var C = /** @class */ (function () {
 var D = /** @class */ (function (_super) {
     __extends(D, _super);
     function D() {
-        var _this = this;
-        _super.prototype..call(_this);
-        return _this;
+        return _super.call(this) || this;
     }
     D.prototype.bar = function () {
         _super.prototype.bar.call(this, null);

--- a/tests/baselines/reference/superWithTypeArgument3.symbols
+++ b/tests/baselines/reference/superWithTypeArgument3.symbols
@@ -23,7 +23,6 @@ class D<T> extends C<T> {
     constructor() {
         super<T>();
 >super : Symbol(C, Decl(superWithTypeArgument3.ts, 0, 0))
->T : Symbol(T, Decl(superWithTypeArgument3.ts, 5, 8))
     }
     bar() {
 >bar : Symbol(D.bar, Decl(superWithTypeArgument3.ts, 8, 5))

--- a/tests/baselines/reference/superWithTypeArgument3.types
+++ b/tests/baselines/reference/superWithTypeArgument3.types
@@ -16,10 +16,8 @@ class D<T> extends C<T> {
 
     constructor() {
         super<T>();
->super<T>() : any
->super : any
->super : C<T>
-> : any
+>super<T>() : void
+>super : typeof C
     }
     bar() {
 >bar : () => void

--- a/tests/baselines/reference/taggedTemplatesWithTypeArguments2.errors.txt
+++ b/tests/baselines/reference/taggedTemplatesWithTypeArguments2.errors.txt
@@ -3,10 +3,11 @@ tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(15,11
 tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(17,30): error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'number'.
 tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(35,5): error TS2377: Constructors for derived classes must contain a 'super' call.
 tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,9): error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,14): error TS1034: 'super' must be followed by an argument list or member access.
+tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,14): error TS2754: 'super' may not use type arguments.
+tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,34): error TS1034: 'super' must be followed by an argument list or member access.
 
 
-==== tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts (6 errors) ====
+==== tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts (7 errors) ====
     export interface SomethingTaggable {
         <T>(t: TemplateStringsArray, ...args: T[]): SomethingNewable;
     }
@@ -53,7 +54,9 @@ tests/cases/conformance/es6/templates/taggedTemplatesWithTypeArguments2.ts(36,14
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             ~~~~~
 !!! error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
-                 ~
+                 ~~~~~~~~~~~~~~~~~~~
+!!! error TS2754: 'super' may not use type arguments.
+                                     ~~~~~~~~~~~~~
 !!! error TS1034: 'super' must be followed by an argument list or member access.
         }
     ~~~~~

--- a/tests/baselines/reference/taggedTemplatesWithTypeArguments2.symbols
+++ b/tests/baselines/reference/taggedTemplatesWithTypeArguments2.symbols
@@ -78,6 +78,5 @@ class SomeDerived<T> extends SomeBase<number, string, T> {
     constructor() {
         super<number, string, T> `hello world`;
 >super : Symbol(SomeBase, Decl(taggedTemplatesWithTypeArguments2.ts, 27, 10))
->T : Symbol(T, Decl(taggedTemplatesWithTypeArguments2.ts, 33, 18))
     }
 }

--- a/tests/baselines/reference/taggedTemplatesWithTypeArguments2.types
+++ b/tests/baselines/reference/taggedTemplatesWithTypeArguments2.types
@@ -92,7 +92,7 @@ class SomeDerived<T> extends SomeBase<number, string, T> {
     constructor() {
         super<number, string, T> `hello world`;
 >super<number, string, T> `hello world` : any
->super : any
+>super<number, string, T> : any
 >super : SomeBase<number, string, T>
 > : any
 >`hello world` : "hello world"


### PR DESCRIPTION
Changes the way we are parsing the following code:

```
class C<T> {
    foo: T;
    bar<U>(x: U) { }
}

class D<T> extends C<T> {
    constructor() {
        super<T>();
    }
    bar() {
        super.bar<T>(null);
    }
}
```

This will now throw `error TS2754: 'super' may not use type arguments.` instead of 

```
error TS17011: 'super' must be called before accessing a property of 'super' in the constructor of a derived class.
error TS1034: 'super' must be followed by an argument list or member access.
error TS2377: Constructors for derived classes must contain a 'super' call.
```

Fixes #10677
