### PR TITLE
Improve intellisense inside Object.assign

### DIFF
--- a/lib/lib.es2015.core.d.ts
+++ b/lib/lib.es2015.core.d.ts
@@ -283,7 +283,7 @@ interface ObjectConstructor {
      * @param target The target object to copy to.
      * @param source The source object from which to copy properties.
      */
-    assign<T, U>(target: T, source: U): T & U;
+    assign<T, U>(target: T, source: U | T): T & U;
 
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
@@ -292,7 +292,7 @@ interface ObjectConstructor {
      * @param source1 The first source object from which to copy properties.
      * @param source2 The second source object from which to copy properties.
      */
-    assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
+    assign<T, U, V>(target: T, source1: U | T, source2: V): T & U & V;
 
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a
@@ -302,7 +302,7 @@ interface ObjectConstructor {
      * @param source2 The second source object from which to copy properties.
      * @param source3 The third source object from which to copy properties.
      */
-    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+    assign<T, U, V, W>(target: T, source1: U | T, source2: V, source3: W): T & U & V & W;
 
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a


### PR DESCRIPTION
Many times We use Object.assign to set the properties of some existing type, but intellisense don't work, with this change We can have intellisense inside the second parameter of the Object.assign

Example:

```
var div = document.createElement("div");
Object.assign(div.style, {
    color: "red" // Here we can have intellisense with all the properties of the first element type
})
```

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

