### PR TITLE
Improve intellisense inside Object.assign

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -263,7 +263,7 @@ interface ObjectConstructor {
      * @param target The target object to copy to.
      * @param source The source object from which to copy properties.
      */
-    assign<T, U>(target: T, source: U): T & U;
+    assign<T, U | T>(target: T, source: U): T & U;
 
     /**
      * Copy the values of all of the enumerable own properties from one or more source objects to a


### PR DESCRIPTION
Many times We use Object.assign to set the properties of some existing type, but intellisense don't work, with this change We can have intellisense inside the secondary parameter of Object.assign

Example:
```
var div = document.createElement("div");
Object.assign(div.style, {
    color: "red" // Here we can have intellisense with all the properties of the first element type
});

```
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

