### PR TITLE
Fix inference from enum object type to generic mapped type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14960,12 +14960,10 @@ namespace ts {
                     }
                     // If no inferences can be made to K's constraint, infer from a union of the property types
                     // in the source to the template type X.
-                    const valueTypes = compact([
-                        getIndexTypeOfType(source, IndexKind.String),
-                        getIndexTypeOfType(source, IndexKind.Number),
-                        ...map(getPropertiesOfType(source), getTypeOfSymbol)
-                    ]);
-                    inferFromTypes(getUnionType(valueTypes), getTemplateTypeFromMappedType(target));
+                    const indexType = source.symbol && source.symbol.flags & SymbolFlags.Enum && getEnumKind(source.symbol) === EnumKind.Literal ?
+                        undefined : getIndexTypeOfType(source, IndexKind.String) || getIndexTypeOfType(source, IndexKind.Number);
+                    const sourcePropsType = indexType || getUnionType(map(getPropertiesOfType(source), getTypeOfSymbol));
+                    inferFromTypes(sourcePropsType, getTemplateTypeFromMappedType(target));
                     return true;
                 }
                 return false;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14960,9 +14960,11 @@ namespace ts {
                     }
                     // If no inferences can be made to K's constraint, infer from a union of the property types
                     // in the source to the template type X.
-                    const indexInfo = getIndexInfoOfType(source, IndexKind.String) || getNonEnumNumberIndexInfo(source);
-                    const sourcePropsType = indexInfo && indexInfo.type || getUnionType(map(getPropertiesOfType(source), getTypeOfSymbol));
-                    inferFromTypes(sourcePropsType, getTemplateTypeFromMappedType(target));
+                    const propTypes = map(getPropertiesOfType(source), getTypeOfSymbol);
+                    const stringIndexType = getIndexTypeOfType(source, IndexKind.String);
+                    const numberIndexInfo = getNonEnumNumberIndexInfo(source);
+                    const numberIndexType = numberIndexInfo && numberIndexInfo.type;
+                    inferFromTypes(getUnionType(append(append(propTypes, stringIndexType), numberIndexType)), getTemplateTypeFromMappedType(target));
                     return true;
                 }
                 return false;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14960,8 +14960,8 @@ namespace ts {
                     }
                     // If no inferences can be made to K's constraint, infer from a union of the property types
                     // in the source to the template type X.
-                    const indexType = source.symbol && source.symbol.flags & SymbolFlags.Enum && getEnumKind(source.symbol) === EnumKind.Literal ?
-                        undefined : getIndexTypeOfType(source, IndexKind.String) || getIndexTypeOfType(source, IndexKind.Number);
+                    const indexInfo = getIndexInfoOfType(source, IndexKind.String) || getIndexInfoOfType(source, IndexKind.Number);
+                    const indexType = indexInfo && indexInfo !== enumNumberIndexInfo ? indexInfo.type : undefined;
                     const sourcePropsType = indexType || getUnionType(map(getPropertiesOfType(source), getTypeOfSymbol));
                     inferFromTypes(sourcePropsType, getTemplateTypeFromMappedType(target));
                     return true;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14960,9 +14960,8 @@ namespace ts {
                     }
                     // If no inferences can be made to K's constraint, infer from a union of the property types
                     // in the source to the template type X.
-                    const indexInfo = getIndexInfoOfType(source, IndexKind.String) || getIndexInfoOfType(source, IndexKind.Number);
-                    const indexType = indexInfo && indexInfo !== enumNumberIndexInfo ? indexInfo.type : undefined;
-                    const sourcePropsType = indexType || getUnionType(map(getPropertiesOfType(source), getTypeOfSymbol));
+                    const indexInfo = getIndexInfoOfType(source, IndexKind.String) || getNonEnumNumberIndexInfo(source);
+                    const sourcePropsType = indexInfo && indexInfo.type || getUnionType(map(getPropertiesOfType(source), getTypeOfSymbol));
                     inferFromTypes(sourcePropsType, getTemplateTypeFromMappedType(target));
                     return true;
                 }

--- a/tests/baselines/reference/mappedToToIndexSignatureInference.js
+++ b/tests/baselines/reference/mappedToToIndexSignatureInference.js
@@ -3,6 +3,20 @@ declare const fn: <K extends string, V>(object: { [Key in K]: V }) => object;
 declare const a: { [index: string]: number };
 fn(a);
 
+// Repro from #30218
+
+declare function enumValues<K extends string, V extends string>(e: Record<K, V>): V[];
+
+enum E { A = 'foo', B = 'bar' }
+
+let x: E[] = enumValues(E);
+
 
 //// [mappedToToIndexSignatureInference.js]
 fn(a);
+var E;
+(function (E) {
+    E["A"] = "foo";
+    E["B"] = "bar";
+})(E || (E = {}));
+var x = enumValues(E);

--- a/tests/baselines/reference/mappedToToIndexSignatureInference.symbols
+++ b/tests/baselines/reference/mappedToToIndexSignatureInference.symbols
@@ -16,3 +16,26 @@ fn(a);
 >fn : Symbol(fn, Decl(mappedToToIndexSignatureInference.ts, 0, 13))
 >a : Symbol(a, Decl(mappedToToIndexSignatureInference.ts, 1, 13))
 
+// Repro from #30218
+
+declare function enumValues<K extends string, V extends string>(e: Record<K, V>): V[];
+>enumValues : Symbol(enumValues, Decl(mappedToToIndexSignatureInference.ts, 2, 6))
+>K : Symbol(K, Decl(mappedToToIndexSignatureInference.ts, 6, 28))
+>V : Symbol(V, Decl(mappedToToIndexSignatureInference.ts, 6, 45))
+>e : Symbol(e, Decl(mappedToToIndexSignatureInference.ts, 6, 64))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+>K : Symbol(K, Decl(mappedToToIndexSignatureInference.ts, 6, 28))
+>V : Symbol(V, Decl(mappedToToIndexSignatureInference.ts, 6, 45))
+>V : Symbol(V, Decl(mappedToToIndexSignatureInference.ts, 6, 45))
+
+enum E { A = 'foo', B = 'bar' }
+>E : Symbol(E, Decl(mappedToToIndexSignatureInference.ts, 6, 86))
+>A : Symbol(E.A, Decl(mappedToToIndexSignatureInference.ts, 8, 8))
+>B : Symbol(E.B, Decl(mappedToToIndexSignatureInference.ts, 8, 19))
+
+let x: E[] = enumValues(E);
+>x : Symbol(x, Decl(mappedToToIndexSignatureInference.ts, 10, 3))
+>E : Symbol(E, Decl(mappedToToIndexSignatureInference.ts, 6, 86))
+>enumValues : Symbol(enumValues, Decl(mappedToToIndexSignatureInference.ts, 2, 6))
+>E : Symbol(E, Decl(mappedToToIndexSignatureInference.ts, 6, 86))
+

--- a/tests/baselines/reference/mappedToToIndexSignatureInference.types
+++ b/tests/baselines/reference/mappedToToIndexSignatureInference.types
@@ -12,3 +12,22 @@ fn(a);
 >fn : <K extends string, V>(object: { [Key in K]: V; }) => object
 >a : { [index: string]: number; }
 
+// Repro from #30218
+
+declare function enumValues<K extends string, V extends string>(e: Record<K, V>): V[];
+>enumValues : <K extends string, V extends string>(e: Record<K, V>) => V[]
+>e : Record<K, V>
+
+enum E { A = 'foo', B = 'bar' }
+>E : E
+>A : E.A
+>'foo' : "foo"
+>B : E.B
+>'bar' : "bar"
+
+let x: E[] = enumValues(E);
+>x : E[]
+>enumValues(E) : E[]
+>enumValues : <K extends string, V extends string>(e: Record<K, V>) => V[]
+>E : typeof E
+

--- a/tests/cases/compiler/mappedToToIndexSignatureInference.ts
+++ b/tests/cases/compiler/mappedToToIndexSignatureInference.ts
@@ -1,3 +1,11 @@
 declare const fn: <K extends string, V>(object: { [Key in K]: V }) => object;
 declare const a: { [index: string]: number };
 fn(a);
+
+// Repro from #30218
+
+declare function enumValues<K extends string, V extends string>(e: Record<K, V>): V[];
+
+enum E { A = 'foo', B = 'bar' }
+
+let x: E[] = enumValues(E);


### PR DESCRIPTION
This PR fixes a break introduced by #29253. We now exclude index signatures when inferring from an enum object type to a generic mapped type.

Fixes #30218.