### PR TITLE
When adding resolvedMembers ensure lateBoundSymbol is added whether it was previously checked or not

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6607,11 +6607,12 @@ namespace ts {
          * unique symbol type which we can then use as the name of the member. This allows users
          * to define custom symbols that can be used in the members of an object type.
          *
+         * @param parent The containing symbol for the member.
          * @param earlySymbols The early-bound symbols of the parent.
          * @param lateSymbols The late-bound symbols of the parent.
          * @param decl The member to bind.
          */
-        function lateBindMember(earlySymbols: SymbolTable | undefined, lateSymbols: SymbolTable, decl: LateBoundDeclaration) {
+        function lateBindMember(parent: Symbol, earlySymbols: SymbolTable | undefined, lateSymbols: SymbolTable, decl: LateBoundDeclaration) {
             Debug.assert(!!decl.symbol, "The member is expected to have a symbol.");
             const links = getNodeLinks(decl);
             if (!links.resolvedSymbol) {
@@ -6642,7 +6643,6 @@ namespace ts {
                     }
                     lateSymbol.nameType = type;
                     addDeclarationToLateBoundSymbol(lateSymbol, decl, symbolFlags);
-                    const parent = getSymbolOfNode(decl.parent);
                     if (lateSymbol.parent) {
                         Debug.assert(lateSymbol.parent === parent, "Existing symbol parent should match new one");
                     }
@@ -6650,15 +6650,6 @@ namespace ts {
                         lateSymbol.parent = parent;
                     }
                     return links.resolvedSymbol = lateSymbol;
-                }
-            }
-            else {
-                const type = checkComputedPropertyName(decl.name);
-                if (isTypeUsableAsPropertyName(type)) {
-                    const memberName = getPropertyNameFromType(type);
-                    if (!lateSymbols.has(memberName)) {
-                        lateSymbols.set(memberName, links.resolvedSymbol);
-                    }
                 }
             }
             return links.resolvedSymbol;
@@ -6684,7 +6675,7 @@ namespace ts {
                     if (members) {
                         for (const member of members) {
                             if (isStatic === hasStaticModifier(member) && hasLateBindableName(member)) {
-                                lateBindMember(earlySymbols, lateSymbols, member);
+                                lateBindMember(symbol, earlySymbols, lateSymbols, member);
                             }
                         }
                     }
@@ -6718,11 +6709,12 @@ namespace ts {
                 const links = getSymbolLinks(symbol);
                 if (!links.lateSymbol && some(symbol.declarations, hasLateBindableName)) {
                     // force late binding of members/exports. This will set the late-bound symbol
+                    const parent = getMergedSymbol(symbol.parent)!;
                     if (some(symbol.declarations, hasStaticModifier)) {
-                        getExportsOfSymbol(symbol.parent!);
+                        getExportsOfSymbol(parent);
                     }
                     else {
-                        getMembersOfSymbol(symbol.parent!);
+                        getMembersOfSymbol(parent);
                     }
                 }
                 return links.lateSymbol || (links.lateSymbol = symbol);

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -92,6 +92,7 @@
         "unittests/tsbuild/amdModulesWithOut.ts",
         "unittests/tsbuild/emptyFiles.ts",
         "unittests/tsbuild/graphOrdering.ts",
+        "unittests/tsbuild/lateBoundSymbol.ts",
         "unittests/tsbuild/missingExtendedFile.ts",
         "unittests/tsbuild/outFile.ts",
         "unittests/tsbuild/referencesWithRootDirInParent.ts",

--- a/src/testRunner/unittests/tsbuild/helpers.ts
+++ b/src/testRunner/unittests/tsbuild/helpers.ts
@@ -285,8 +285,10 @@ Mismatch Actual(path, actual, expected): ${JSON.stringify(arrayFrom(mapDefinedIt
                     let newFs: vfs.FileSystem;
                     let actualReadFileMap: Map<number>;
                     let host: fakes.SolutionBuilderHost;
+                    let beforeBuildTime: number;
+                    let afterBuildTime: number;
                     before(() => {
-                        assert.equal(fs.statSync(lastProjectOutputJs).mtimeMs, firstBuildTime, "First build timestamp is correct");
+                        beforeBuildTime = fs.statSync(lastProjectOutputJs).mtimeMs;
                         tick();
                         newFs = fs.shadow();
                         tick();
@@ -298,14 +300,18 @@ Mismatch Actual(path, actual, expected): ${JSON.stringify(arrayFrom(mapDefinedIt
                             expectedBuildInfoFilesForSectionBaselines,
                             modifyFs: incrementalModifyFs,
                         }));
-                        assert.equal(newFs.statSync(lastProjectOutputJs).mtimeMs, time(), "Second build timestamp is correct");
+                        afterBuildTime = newFs.statSync(lastProjectOutputJs).mtimeMs;
                     });
                     after(() => {
                         newFs = undefined!;
                         actualReadFileMap = undefined!;
                         host = undefined!;
                     });
-                    if (!baselineOnly) {
+                    it("verify build output times", () => {
+                        assert.equal(beforeBuildTime, firstBuildTime, "First build timestamp is correct");
+                        assert.equal(afterBuildTime, time(), "Second build timestamp is correct");
+                    });
+                    if (!baselineOnly || verifyDiagnostics) {
                         it(`verify diagnostics`, () => {
                             host.assertDiagnosticMessages(...(incrementalExpectedDiagnostics || emptyArray));
                         });

--- a/src/testRunner/unittests/tsbuild/lateBoundSymbol.ts
+++ b/src/testRunner/unittests/tsbuild/lateBoundSymbol.ts
@@ -1,0 +1,47 @@
+namespace ts {
+    describe("unittests:: tsbuild:: lateBoundSymbol:: interface is merged and contains late bound member", () => {
+        let projFs: vfs.FileSystem;
+        const { time, tick } = getTime();
+        before(() => {
+            projFs = loadProjectFromDisk("tests/projects/lateBoundSymbol", time);
+        });
+        after(() => {
+            projFs = undefined!; // Release the contents
+        });
+
+        verifyTsbuildOutput({
+            scenario: "interface is merged and contains late bound member",
+            projFs: () => projFs,
+            time,
+            tick,
+            proj: "lateBoundSymbol",
+            rootNames: ["/src/tsconfig.json"],
+            expectedMapFileNames: emptyArray,
+            lastProjectOutputJs: "/src/src/main.js",
+            outputFiles: [
+                "/src/src/hkt.js",
+                "/src/src/main.js",
+                "/src/tsconfig.tsbuildinfo",
+            ],
+            initialBuild: {
+                modifyFs: noop,
+                expectedDiagnostics: [
+                    getExpectedDiagnosticForProjectsInBuild("src/tsconfig.json"),
+                    [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/tsconfig.json", "src/src/hkt.js"],
+                    [Diagnostics.Building_project_0, "/src/tsconfig.json"]
+                ]
+            },
+            incrementalDtsUnchangedBuild: {
+                modifyFs: fs => replaceText(fs, "/src/src/main.ts", "const x = 10;", ""),
+                expectedDiagnostics: [
+                    getExpectedDiagnosticForProjectsInBuild("src/tsconfig.json"),
+                    [Diagnostics.Project_0_is_out_of_date_because_oldest_output_1_is_older_than_newest_input_2, "src/tsconfig.json", "src/src/hkt.js", "src/src/main.ts"],
+                    [Diagnostics.Building_project_0, "/src/tsconfig.json"],
+                    [Diagnostics.Updating_unchanged_output_timestamps_of_project_0, "/src/tsconfig.json"]
+                ]
+            },
+            baselineOnly: true,
+            verifyDiagnostics: true
+        });
+    });
+}

--- a/tests/baselines/reference/tsbuild/lateBoundSymbol/incremental-declaration-doesnt-change/interface-is-merged-and-contains-late-bound-member.js
+++ b/tests/baselines/reference/tsbuild/lateBoundSymbol/incremental-declaration-doesnt-change/interface-is-merged-and-contains-late-bound-member.js
@@ -1,0 +1,13 @@
+//// [/src/src/main.ts]
+import { HKT } from "./hkt";
+
+const sym = Symbol();
+
+declare module "./hkt" {
+  interface HKT<T> {
+    [sym]: { a: T }
+  }
+}
+
+type A = HKT<number>[typeof sym];
+

--- a/tests/baselines/reference/tsbuild/lateBoundSymbol/incremental-declaration-doesnt-change/interface-is-merged-and-contains-late-bound-member.js
+++ b/tests/baselines/reference/tsbuild/lateBoundSymbol/incremental-declaration-doesnt-change/interface-is-merged-and-contains-late-bound-member.js
@@ -1,3 +1,9 @@
+//// [/src/src/main.js]
+"use strict";
+exports.__esModule = true;
+var sym = Symbol();
+
+
 //// [/src/src/main.ts]
 import { HKT } from "./hkt";
 
@@ -10,4 +16,98 @@ declare module "./hkt" {
 }
 
 type A = HKT<number>[typeof sym];
+
+//// [/src/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "/lib/lib.es5.d.ts": {
+        "version": "/lib/lib.es5.d.ts",
+        "signature": "/lib/lib.es5.d.ts"
+      },
+      "/lib/lib.es2015.d.ts": {
+        "version": "/lib/lib.es2015.d.ts",
+        "signature": "/lib/lib.es2015.d.ts"
+      },
+      "/lib/lib.es2015.core.d.ts": {
+        "version": "/lib/lib.es2015.core.d.ts",
+        "signature": "/lib/lib.es2015.core.d.ts"
+      },
+      "/lib/lib.es2015.collection.d.ts": {
+        "version": "/lib/lib.es2015.collection.d.ts",
+        "signature": "/lib/lib.es2015.collection.d.ts"
+      },
+      "/lib/lib.es2015.generator.d.ts": {
+        "version": "/lib/lib.es2015.generator.d.ts",
+        "signature": "/lib/lib.es2015.generator.d.ts"
+      },
+      "/lib/lib.es2015.iterable.d.ts": {
+        "version": "/lib/lib.es2015.iterable.d.ts",
+        "signature": "/lib/lib.es2015.iterable.d.ts"
+      },
+      "/lib/lib.es2015.promise.d.ts": {
+        "version": "/lib/lib.es2015.promise.d.ts",
+        "signature": "/lib/lib.es2015.promise.d.ts"
+      },
+      "/lib/lib.es2015.proxy.d.ts": {
+        "version": "/lib/lib.es2015.proxy.d.ts",
+        "signature": "/lib/lib.es2015.proxy.d.ts"
+      },
+      "/lib/lib.es2015.reflect.d.ts": {
+        "version": "/lib/lib.es2015.reflect.d.ts",
+        "signature": "/lib/lib.es2015.reflect.d.ts"
+      },
+      "/lib/lib.es2015.symbol.d.ts": {
+        "version": "/lib/lib.es2015.symbol.d.ts",
+        "signature": "/lib/lib.es2015.symbol.d.ts"
+      },
+      "/lib/lib.es2015.symbol.wellknown.d.ts": {
+        "version": "/lib/lib.es2015.symbol.wellknown.d.ts",
+        "signature": "/lib/lib.es2015.symbol.wellknown.d.ts"
+      },
+      "/src/src/hkt.ts": {
+        "version": "675797797",
+        "signature": "2373810515"
+      },
+      "/src/src/main.ts": {
+        "version": "-27494779858",
+        "signature": "-7779857705"
+      }
+    },
+    "options": {
+      "rootDir": "/src/src",
+      "lib": [
+        "lib.es2015.d.ts"
+      ],
+      "incremental": true,
+      "configFilePath": "/src/tsconfig.json"
+    },
+    "referencedMap": {
+      "/src/src/main.ts": [
+        "/src/src/hkt.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "/src/src/main.ts": [
+        "/src/src/hkt.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "/lib/lib.es2015.collection.d.ts",
+      "/lib/lib.es2015.core.d.ts",
+      "/lib/lib.es2015.d.ts",
+      "/lib/lib.es2015.generator.d.ts",
+      "/lib/lib.es2015.iterable.d.ts",
+      "/lib/lib.es2015.promise.d.ts",
+      "/lib/lib.es2015.proxy.d.ts",
+      "/lib/lib.es2015.reflect.d.ts",
+      "/lib/lib.es2015.symbol.d.ts",
+      "/lib/lib.es2015.symbol.wellknown.d.ts",
+      "/lib/lib.es5.d.ts",
+      "/src/src/hkt.ts",
+      "/src/src/main.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
 

--- a/tests/baselines/reference/tsbuild/lateBoundSymbol/initial-Build/interface-is-merged-and-contains-late-bound-member.js
+++ b/tests/baselines/reference/tsbuild/lateBoundSymbol/initial-Build/interface-is-merged-and-contains-late-bound-member.js
@@ -1,0 +1,106 @@
+//// [/src/src/hkt.js]
+"use strict";
+exports.__esModule = true;
+
+
+//// [/src/src/main.js]
+"use strict";
+exports.__esModule = true;
+var sym = Symbol();
+var x = 10;
+
+
+//// [/src/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "/lib/lib.es5.d.ts": {
+        "version": "/lib/lib.es5.d.ts",
+        "signature": "/lib/lib.es5.d.ts"
+      },
+      "/lib/lib.es2015.d.ts": {
+        "version": "/lib/lib.es2015.d.ts",
+        "signature": "/lib/lib.es2015.d.ts"
+      },
+      "/lib/lib.es2015.core.d.ts": {
+        "version": "/lib/lib.es2015.core.d.ts",
+        "signature": "/lib/lib.es2015.core.d.ts"
+      },
+      "/lib/lib.es2015.collection.d.ts": {
+        "version": "/lib/lib.es2015.collection.d.ts",
+        "signature": "/lib/lib.es2015.collection.d.ts"
+      },
+      "/lib/lib.es2015.generator.d.ts": {
+        "version": "/lib/lib.es2015.generator.d.ts",
+        "signature": "/lib/lib.es2015.generator.d.ts"
+      },
+      "/lib/lib.es2015.iterable.d.ts": {
+        "version": "/lib/lib.es2015.iterable.d.ts",
+        "signature": "/lib/lib.es2015.iterable.d.ts"
+      },
+      "/lib/lib.es2015.promise.d.ts": {
+        "version": "/lib/lib.es2015.promise.d.ts",
+        "signature": "/lib/lib.es2015.promise.d.ts"
+      },
+      "/lib/lib.es2015.proxy.d.ts": {
+        "version": "/lib/lib.es2015.proxy.d.ts",
+        "signature": "/lib/lib.es2015.proxy.d.ts"
+      },
+      "/lib/lib.es2015.reflect.d.ts": {
+        "version": "/lib/lib.es2015.reflect.d.ts",
+        "signature": "/lib/lib.es2015.reflect.d.ts"
+      },
+      "/lib/lib.es2015.symbol.d.ts": {
+        "version": "/lib/lib.es2015.symbol.d.ts",
+        "signature": "/lib/lib.es2015.symbol.d.ts"
+      },
+      "/lib/lib.es2015.symbol.wellknown.d.ts": {
+        "version": "/lib/lib.es2015.symbol.wellknown.d.ts",
+        "signature": "/lib/lib.es2015.symbol.wellknown.d.ts"
+      },
+      "/src/src/hkt.ts": {
+        "version": "675797797",
+        "signature": "2373810515"
+      },
+      "/src/src/main.ts": {
+        "version": "-28387946490",
+        "signature": "-7779857705"
+      }
+    },
+    "options": {
+      "rootDir": "/src/src",
+      "lib": [
+        "lib.es2015.d.ts"
+      ],
+      "incremental": true,
+      "configFilePath": "/src/tsconfig.json"
+    },
+    "referencedMap": {
+      "/src/src/main.ts": [
+        "/src/src/hkt.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "/src/src/main.ts": [
+        "/src/src/hkt.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "/lib/lib.es2015.collection.d.ts",
+      "/lib/lib.es2015.core.d.ts",
+      "/lib/lib.es2015.d.ts",
+      "/lib/lib.es2015.generator.d.ts",
+      "/lib/lib.es2015.iterable.d.ts",
+      "/lib/lib.es2015.promise.d.ts",
+      "/lib/lib.es2015.proxy.d.ts",
+      "/lib/lib.es2015.reflect.d.ts",
+      "/lib/lib.es2015.symbol.d.ts",
+      "/lib/lib.es2015.symbol.wellknown.d.ts",
+      "/lib/lib.es5.d.ts",
+      "/src/src/hkt.ts",
+      "/src/src/main.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+

--- a/tests/baselines/reference/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.js
+++ b/tests/baselines/reference/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.js
@@ -1,0 +1,18 @@
+//// [uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts]
+const FOO_SYMBOL = Symbol('Foo');
+
+declare global {
+    interface Promise<T> {
+        [FOO_SYMBOL]?: number;
+    }
+}
+
+export function foo<T>(p: Promise<T>) {
+    p[FOO_SYMBOL] = 3;
+}
+
+//// [uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.js]
+const FOO_SYMBOL = Symbol('Foo');
+export function foo(p) {
+    p[FOO_SYMBOL] = 3;
+}

--- a/tests/baselines/reference/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.symbols
+++ b/tests/baselines/reference/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts ===
+const FOO_SYMBOL = Symbol('Foo');
+>FOO_SYMBOL : Symbol(FOO_SYMBOL, Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 0, 5))
+>Symbol : Symbol(Symbol, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+declare global {
+>global : Symbol(global, Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 0, 33))
+
+    interface Promise<T> {
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 2, 16))
+>T : Symbol(T, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 3, 22))
+
+        [FOO_SYMBOL]?: number;
+>[FOO_SYMBOL] : Symbol(Promise[FOO_SYMBOL], Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 3, 26))
+>FOO_SYMBOL : Symbol(FOO_SYMBOL, Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 0, 5))
+    }
+}
+
+export function foo<T>(p: Promise<T>) {
+>foo : Symbol(foo, Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 6, 1))
+>T : Symbol(T, Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 8, 20))
+>p : Symbol(p, Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 8, 23))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 2, 16))
+>T : Symbol(T, Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 8, 20))
+
+    p[FOO_SYMBOL] = 3;
+>p : Symbol(p, Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 8, 23))
+>FOO_SYMBOL : Symbol(FOO_SYMBOL, Decl(uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts, 0, 5))
+}

--- a/tests/baselines/reference/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.types
+++ b/tests/baselines/reference/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.types
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts ===
+const FOO_SYMBOL = Symbol('Foo');
+>FOO_SYMBOL : unique symbol
+>Symbol('Foo') : unique symbol
+>Symbol : SymbolConstructor
+>'Foo' : "Foo"
+
+declare global {
+>global : any
+
+    interface Promise<T> {
+        [FOO_SYMBOL]?: number;
+>[FOO_SYMBOL] : number | undefined
+>FOO_SYMBOL : unique symbol
+    }
+}
+
+export function foo<T>(p: Promise<T>) {
+>foo : <T>(p: Promise<T>) => void
+>p : Promise<T>
+
+    p[FOO_SYMBOL] = 3;
+>p[FOO_SYMBOL] = 3 : 3
+>p[FOO_SYMBOL] : number | undefined
+>p : Promise<T>
+>FOO_SYMBOL : unique symbol
+>3 : 3
+}

--- a/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
+++ b/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
@@ -1,0 +1,13 @@
+// @strict: true
+// @target: es6
+const FOO_SYMBOL = Symbol('Foo');
+
+declare global {
+    interface Promise<T> {
+        [FOO_SYMBOL]?: number;
+    }
+}
+
+export function foo<T>(p: Promise<T>) {
+    p[FOO_SYMBOL] = 3;
+}

--- a/tests/projects/lateBoundSymbol/src/hkt.ts
+++ b/tests/projects/lateBoundSymbol/src/hkt.ts
@@ -1,0 +1,1 @@
+export interface HKT<T> { }

--- a/tests/projects/lateBoundSymbol/src/main.ts
+++ b/tests/projects/lateBoundSymbol/src/main.ts
@@ -1,0 +1,11 @@
+import { HKT } from "./hkt";
+
+const sym = Symbol();
+
+declare module "./hkt" {
+  interface HKT<T> {
+    [sym]: { a: T }
+  }
+}
+const x = 10;
+type A = HKT<number>[typeof sym];

--- a/tests/projects/lateBoundSymbol/tsconfig.json
+++ b/tests/projects/lateBoundSymbol/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "lib": [
+      "es2015"
+    ],
+    "incremental": true
+  }
+}


### PR DESCRIPTION
 When interfaces are merged, always ensure that the parent symbol of the late bound member symbol is declared symbol of containing the node.
Ensure that resolvedMembers adds the late bound symbol even when its resolved as lateBoundMember may or may not be added to resolved members depending on when its checked and how the symbols are resolved.
Fixes #30891