### PR TITLE
Fix isStringIndexSignatureOnlyType function

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12043,7 +12043,7 @@ namespace ts {
         }
 
         function isStringIndexSignatureOnlyType(type: Type): boolean {
-            return type.flags & TypeFlags.Object && getPropertiesOfType(type).length === 0 && getIndexInfoOfType(type, IndexKind.String) && !getIndexInfoOfType(type, IndexKind.Number) ||
+            return type.flags & TypeFlags.Object && !isGenericMappedType(type) && getPropertiesOfType(type).length === 0 && getIndexInfoOfType(type, IndexKind.String) && !getIndexInfoOfType(type, IndexKind.Number) ||
                 type.flags & TypeFlags.UnionOrIntersection && every((<UnionOrIntersectionType>type).types, isStringIndexSignatureOnlyType) ||
                 false;
         }

--- a/tests/baselines/reference/keyofAndIndexedAccess2.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccess2.errors.txt
@@ -188,3 +188,10 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(108,5): error TS23
 !!! error TS2322:     Type '123' is not assignable to type '"some string"'.
     }
     
+    // Repro from #30920
+    
+    type StrictExtract<T, U> = T extends U ? U extends T ? T : never : never;
+    type StrictExclude<T, U> = T extends StrictExtract<T, U> ? never : T;
+    type A<T> = { [Q in { [P in keyof T]: P; }[keyof T]]: T[Q]; };
+    type B<T, V> = A<{ [Q in keyof T]: StrictExclude<B<T[Q], V>, {}>; }>;
+    

--- a/tests/baselines/reference/keyofAndIndexedAccess2.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess2.js
@@ -109,6 +109,13 @@ function get123<K extends keyof Type>(): Type[K] {
     return 123;  // Error
 }
 
+// Repro from #30920
+
+type StrictExtract<T, U> = T extends U ? U extends T ? T : never : never;
+type StrictExclude<T, U> = T extends StrictExtract<T, U> ? never : T;
+type A<T> = { [Q in { [P in keyof T]: P; }[keyof T]]: T[Q]; };
+type B<T, V> = A<{ [Q in keyof T]: StrictExclude<B<T[Q], V>, {}>; }>;
+
 
 //// [keyofAndIndexedAccess2.js]
 function f1(obj, k0, k1, k2) {

--- a/tests/baselines/reference/keyofAndIndexedAccess2.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess2.symbols
@@ -388,3 +388,49 @@ function get123<K extends keyof Type>(): Type[K] {
     return 123;  // Error
 }
 
+// Repro from #30920
+
+type StrictExtract<T, U> = T extends U ? U extends T ? T : never : never;
+>StrictExtract : Symbol(StrictExtract, Decl(keyofAndIndexedAccess2.ts, 108, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 112, 19))
+>U : Symbol(U, Decl(keyofAndIndexedAccess2.ts, 112, 21))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 112, 19))
+>U : Symbol(U, Decl(keyofAndIndexedAccess2.ts, 112, 21))
+>U : Symbol(U, Decl(keyofAndIndexedAccess2.ts, 112, 21))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 112, 19))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 112, 19))
+
+type StrictExclude<T, U> = T extends StrictExtract<T, U> ? never : T;
+>StrictExclude : Symbol(StrictExclude, Decl(keyofAndIndexedAccess2.ts, 112, 73))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 113, 19))
+>U : Symbol(U, Decl(keyofAndIndexedAccess2.ts, 113, 21))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 113, 19))
+>StrictExtract : Symbol(StrictExtract, Decl(keyofAndIndexedAccess2.ts, 108, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 113, 19))
+>U : Symbol(U, Decl(keyofAndIndexedAccess2.ts, 113, 21))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 113, 19))
+
+type A<T> = { [Q in { [P in keyof T]: P; }[keyof T]]: T[Q]; };
+>A : Symbol(A, Decl(keyofAndIndexedAccess2.ts, 113, 69))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 114, 7))
+>Q : Symbol(Q, Decl(keyofAndIndexedAccess2.ts, 114, 15))
+>P : Symbol(P, Decl(keyofAndIndexedAccess2.ts, 114, 23))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 114, 7))
+>P : Symbol(P, Decl(keyofAndIndexedAccess2.ts, 114, 23))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 114, 7))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 114, 7))
+>Q : Symbol(Q, Decl(keyofAndIndexedAccess2.ts, 114, 15))
+
+type B<T, V> = A<{ [Q in keyof T]: StrictExclude<B<T[Q], V>, {}>; }>;
+>B : Symbol(B, Decl(keyofAndIndexedAccess2.ts, 114, 62))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 115, 7))
+>V : Symbol(V, Decl(keyofAndIndexedAccess2.ts, 115, 9))
+>A : Symbol(A, Decl(keyofAndIndexedAccess2.ts, 113, 69))
+>Q : Symbol(Q, Decl(keyofAndIndexedAccess2.ts, 115, 20))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 115, 7))
+>StrictExclude : Symbol(StrictExclude, Decl(keyofAndIndexedAccess2.ts, 112, 73))
+>B : Symbol(B, Decl(keyofAndIndexedAccess2.ts, 114, 62))
+>T : Symbol(T, Decl(keyofAndIndexedAccess2.ts, 115, 7))
+>Q : Symbol(Q, Decl(keyofAndIndexedAccess2.ts, 115, 20))
+>V : Symbol(V, Decl(keyofAndIndexedAccess2.ts, 115, 9))
+

--- a/tests/baselines/reference/keyofAndIndexedAccess2.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess2.types
@@ -423,3 +423,17 @@ function get123<K extends keyof Type>(): Type[K] {
 >123 : 123
 }
 
+// Repro from #30920
+
+type StrictExtract<T, U> = T extends U ? U extends T ? T : never : never;
+>StrictExtract : StrictExtract<T, U>
+
+type StrictExclude<T, U> = T extends StrictExtract<T, U> ? never : T;
+>StrictExclude : StrictExclude<T, U>
+
+type A<T> = { [Q in { [P in keyof T]: P; }[keyof T]]: T[Q]; };
+>A : A<T>
+
+type B<T, V> = A<{ [Q in keyof T]: StrictExclude<B<T[Q], V>, {}>; }>;
+>B : A<{ [Q in keyof T]: StrictExclude<A<{ [Q in keyof T[Q]]: StrictExclude<A<{ [Q in keyof T[Q][Q]]: StrictExclude<A<{ [Q in keyof T[Q][Q][Q]]: StrictExclude<A<{ [Q in keyof T[Q][Q][Q][Q]]: StrictExclude<A<{ [Q in keyof T[Q][Q][Q][Q][Q]]: StrictExclude<A<{ [Q in keyof T[Q][Q][Q][Q][Q][Q]]: StrictExclude<A<{ [Q in keyof T[Q][Q][Q][Q][Q][Q][Q]]: StrictExclude<A<{ [Q in keyof T[Q][Q][Q][Q][Q][Q][Q][Q]]: StrictExclude<A<{ [Q in keyof T[Q][Q][Q][Q][Q][Q][Q][Q][Q]]: StrictExclude<A<{ [Q in keyof T[Q][Q][Q][Q][Q][Q][Q][Q][Q][Q]]: StrictExclude<A<any>, {}>; }>, {}>; }>, {}>; }>, {}>; }>, {}>; }>, {}>; }>, {}>; }>, {}>; }>, {}>; }>, {}>; }>, {}>; }>
+

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts
@@ -110,3 +110,10 @@ interface Type {
 function get123<K extends keyof Type>(): Type[K] {
     return 123;  // Error
 }
+
+// Repro from #30920
+
+type StrictExtract<T, U> = T extends U ? U extends T ? T : never : never;
+type StrictExclude<T, U> = T extends StrictExtract<T, U> ? never : T;
+type A<T> = { [Q in { [P in keyof T]: P; }[keyof T]]: T[Q]; };
+type B<T, V> = A<{ [Q in keyof T]: StrictExclude<B<T[Q], V>, {}>; }>;


### PR DESCRIPTION
We now ignore generic mapped types in the `isStringIndexSignatureOnlyType` function.

Fixes #30920.