### PR TITLE
Hide the table of perf results from the bot inside an expando element

### DIFF
--- a/scripts/perf-result-post.js
+++ b/scripts/perf-result-post.js
@@ -22,9 +22,10 @@ gh.issues.createComment({
     owner: "Microsoft",
     repo: "TypeScript",
     body: `@${requester}
-The results of the perf run you requested are in! Here they are:
-
-${outputTableText}`
+The results of the perf run you requested are in!
+<details><summary> Here they are:</summary><p>
+${outputTableText}
+</p></details>`
 }).then(async data => {
     console.log(`Results posted!`);
     const newCommentUrl = data.data.html_url;


### PR DESCRIPTION
They're kinda big and really stretch a thread.
![example-expando](https://user-images.githubusercontent.com/2932786/56329820-3d8a9300-613a-11e9-82ce-886f47a3b37c.gif)
