### PR TITLE
Support binding patterns in Promise -> async/await refactor

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -196,8 +196,8 @@ namespace ts.codefix {
                     allVarNames.push({ identifier: synthName.identifier, symbol });
                     addNameToFrequencyMap(collidingSymbolMap, ident.text, symbol);
                 }
-                // we only care about identifiers that are parameters and declarations (don't care about other uses)
-                else if (node.parent && (isParameter(node.parent) || isVariableDeclaration(node.parent))) {
+                // we only care about identifiers that are parameters, declarations, or binding elements (don't care about other uses)
+                else if (node.parent && (isParameter(node.parent) || isVariableDeclaration(node.parent) || isBindingElement(node.parent))) {
                     const originalName = node.text;
                     const collidingSymbols = collidingSymbolMap.get(originalName);
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1717,7 +1717,19 @@ namespace ts {
 
     export function getSynthesizedDeepCloneWithRenames<T extends Node>(node: T, includeTrivia = true, renameMap?: Map<Identifier>, checker?: TypeChecker, callback?: (originalNode: Node, clone: Node) => any): T {
         let clone;
-        if (isIdentifier(node) && renameMap && checker) {
+        if (renameMap && checker && isBindingElement(node) && isIdentifier(node.name) && isObjectBindingPattern(node.parent)) {
+            const symbol = checker.getSymbolAtLocation(node.name);
+            const renameInfo = symbol && renameMap.get(String(getSymbolId(symbol)));
+
+            if (renameInfo && renameInfo.text !== (node.name || node.propertyName).getText()) {
+                clone = createBindingElement(
+                    node.dotDotDotToken,
+                    node.propertyName || node.name,
+                    renameInfo,
+                    node.initializer);
+            }
+        }
+        else if (renameMap && checker && isIdentifier(node) && !(node.parent && node.parent.parent && isBindingElement(node.parent) && isObjectBindingPattern(node.parent.parent))) {
             const symbol = checker.getSymbolAtLocation(node);
             const renameInfo = symbol && renameMap.get(String(getSymbolId(symbol)));
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1729,7 +1729,7 @@ namespace ts {
                     node.initializer);
             }
         }
-        else if (renameMap && checker && isIdentifier(node) && !(node.parent && node.parent.parent && isBindingElement(node.parent) && isObjectBindingPattern(node.parent.parent))) {
+        else if (renameMap && checker && isIdentifier(node)) {
             const symbol = checker.getSymbolAtLocation(node);
             const renameInfo = symbol && renameMap.get(String(getSymbolId(symbol)));
 

--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -655,6 +655,17 @@ function [#|innerPromise|](): Promise<string> {
 `
         );
 
+        _testConvertToAsyncFunction("convertToAsyncFunction_InnerPromiseRetBinding4", `
+function [#|innerPromise|](): Promise<string> {
+    return fetch("https://typescriptlang.org").then(resp => {
+        return resp.blob().then(({ blob }: { blob: { byteOffset: number } }) => [0, blob.byteOffset]).catch(({ message }: Error) => ['Error ', message]);
+    }).then(([x, y]) => {
+        return (x || y).toString();
+    });
+}
+`
+        );
+
         _testConvertToAsyncFunctionFailed("convertToAsyncFunction_VarReturn01", `
 function [#|f|]() {
     let blob = fetch("https://typescriptlang.org").then(resp => console.log(resp));
@@ -1220,6 +1231,12 @@ const { length } = [#|function|] () {
     _testConvertToAsyncFunction("convertToAsyncFunction_catchBlockUniqueParams", `
 function [#|f|]() {
 	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x);
+}
+`);
+
+    _testConvertToAsyncFunction("convertToAsyncFunction_catchBlockUniqueParamsBindingPattern", `
+function [#|f|]() {
+	return Promise.resolve().then(() => ({ x: 3 })).catch(() => ({ x: "a" })).then(({ x }) => !!x);
 }
 `);
 

--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -622,6 +622,39 @@ function [#|innerPromise|](): Promise<string> {
 `
         );
 
+        _testConvertToAsyncFunction("convertToAsyncFunction_InnerPromiseRetBinding1", `
+function [#|innerPromise|](): Promise<string> {
+    return fetch("https://typescriptlang.org").then(resp => {
+        return resp.blob().then(({ blob }) => blob.byteOffset).catch(({ message }) => 'Error ' + message);
+    }).then(blob => {
+        return blob.toString();
+    });
+}
+`
+        );
+
+        _testConvertToAsyncFunction("convertToAsyncFunction_InnerPromiseRetBinding2", `
+function [#|innerPromise|](): Promise<string> {
+    return fetch("https://typescriptlang.org").then(resp => {
+        return resp.blob().then(blob => blob.byteOffset).catch(err => 'Error');
+    }).then(({ x }) => {
+        return x.toString();
+    });
+}
+`
+        );
+
+        _testConvertToAsyncFunction("convertToAsyncFunction_InnerPromiseRetBinding3", `
+function [#|innerPromise|](): Promise<string> {
+    return fetch("https://typescriptlang.org").then(resp => {
+        return resp.blob().then(({ blob }) => blob.byteOffset).catch(({ message }) => 'Error ' + message);
+    }).then(([x, y]) => {
+        return (x || y).toString();
+    });
+}
+`
+        );
+
         _testConvertToAsyncFunctionFailed("convertToAsyncFunction_VarReturn01", `
 function [#|f|]() {
     let blob = fetch("https://typescriptlang.org").then(resp => console.log(resp));

--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -356,6 +356,16 @@ function [#|f|](): Promise<void>{
 function [#|f|](): Promise<void>{
     return fetch('https://typescriptlang.org').then(({ result }) => { console.log(result) });
 }`);
+        _testConvertToAsyncFunction("convertToAsyncFunction_arrayBindingPatternRename", `
+function [#|f|](): Promise<void>{
+    const result = getResult();
+    return fetch('https://typescriptlang.org').then(([result]) => { console.log(result) });
+}`);
+        _testConvertToAsyncFunction("convertToAsyncFunction_objectBindingPatternRename", `
+function [#|f|](): Promise<void>{
+    const result = getResult();
+    return fetch('https://typescriptlang.org').then(({ result }) => { console.log(result) });
+}`);
     _testConvertToAsyncFunction("convertToAsyncFunction_basicNoReturnTypeAnnotation", `
 function [#|f|]() {
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });

--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -1230,13 +1230,13 @@ const { length } = [#|function|] () {
 
     _testConvertToAsyncFunction("convertToAsyncFunction_catchBlockUniqueParams", `
 function [#|f|]() {
-	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x);
+    return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x);
 }
 `);
 
     _testConvertToAsyncFunction("convertToAsyncFunction_catchBlockUniqueParamsBindingPattern", `
 function [#|f|]() {
-	return Promise.resolve().then(() => ({ x: 3 })).catch(() => ({ x: "a" })).then(({ x }) => !!x);
+    return Promise.resolve().then(() => ({ x: 3 })).catch(() => ({ x: "a" })).then(({ x }) => !!x);
 }
 `);
 

--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -348,6 +348,14 @@ interface Array<T> {}`
 function [#|f|](): Promise<void>{
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });
 }`);
+        _testConvertToAsyncFunction("convertToAsyncFunction_arrayBindingPattern", `
+function [#|f|](): Promise<void>{
+    return fetch('https://typescriptlang.org').then(([result]) => { console.log(result) });
+}`);
+        _testConvertToAsyncFunction("convertToAsyncFunction_objectBindingPattern", `
+function [#|f|](): Promise<void>{
+    return fetch('https://typescriptlang.org').then(({ result }) => { console.log(result) });
+}`);
     _testConvertToAsyncFunction("convertToAsyncFunction_basicNoReturnTypeAnnotation", `
 function [#|f|]() {
     return fetch('https://typescriptlang.org').then(result => { console.log(result) });

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding1.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding1.ts
@@ -1,0 +1,24 @@
+// ==ORIGINAL==
+
+function /*[#|*/innerPromise/*|]*/(): Promise<string> {
+    return fetch("https://typescriptlang.org").then(resp => {
+        return resp.blob().then(({ blob }) => blob.byteOffset).catch(({ message }) => 'Error ' + message);
+    }).then(blob => {
+        return blob.toString();
+    });
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function innerPromise(): Promise<string> {
+    const resp = await fetch("https://typescriptlang.org");
+    let blob: any;
+    try {
+        const { blob } = await resp.blob();
+        blob = blob.byteOffset;
+    }
+    catch ({ message }) {
+        blob = 'Error ' + message;
+    }
+    return blob.toString();
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding2.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding2.ts
@@ -1,0 +1,25 @@
+// ==ORIGINAL==
+
+function /*[#|*/innerPromise/*|]*/(): Promise<string> {
+    return fetch("https://typescriptlang.org").then(resp => {
+        return resp.blob().then(blob => blob.byteOffset).catch(err => 'Error');
+    }).then(({ x }) => {
+        return x.toString();
+    });
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function innerPromise(): Promise<string> {
+    const resp = await fetch("https://typescriptlang.org");
+    let result: any;
+    try {
+        const blob = await resp.blob();
+        result = blob.byteOffset;
+    }
+    catch (err) {
+        result = 'Error';
+    }
+    const { x } = result;
+    return x.toString();
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding3.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding3.ts
@@ -1,0 +1,25 @@
+// ==ORIGINAL==
+
+function /*[#|*/innerPromise/*|]*/(): Promise<string> {
+    return fetch("https://typescriptlang.org").then(resp => {
+        return resp.blob().then(({ blob }) => blob.byteOffset).catch(({ message }) => 'Error ' + message);
+    }).then(([x, y]) => {
+        return (x || y).toString();
+    });
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function innerPromise(): Promise<string> {
+    const resp = await fetch("https://typescriptlang.org");
+    let result: any;
+    try {
+        const { blob } = await resp.blob();
+        result = blob.byteOffset;
+    }
+    catch ({ message }) {
+        result = 'Error ' + message;
+    }
+    const [x, y] = result;
+    return (x || y).toString();
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding4.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromiseRetBinding4.ts
@@ -1,0 +1,25 @@
+// ==ORIGINAL==
+
+function /*[#|*/innerPromise/*|]*/(): Promise<string> {
+    return fetch("https://typescriptlang.org").then(resp => {
+        return resp.blob().then(({ blob }: { blob: { byteOffset: number } }) => [0, blob.byteOffset]).catch(({ message }: Error) => ['Error ', message]);
+    }).then(([x, y]) => {
+        return (x || y).toString();
+    });
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function innerPromise(): Promise<string> {
+    const resp = await fetch("https://typescriptlang.org");
+    let result: any[];
+    try {
+        const { blob } = await resp.blob();
+        result = [0, blob.byteOffset];
+    }
+    catch ({ message }) {
+        result = ['Error ', message];
+    }
+    const [x, y] = result;
+    return (x || y).toString();
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_arrayBindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_arrayBindingPattern.ts
@@ -1,0 +1,11 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/(): Promise<void>{
+    return fetch('https://typescriptlang.org').then(([result]) => { console.log(result) });
+}
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f(): Promise<void>{
+    let [result] = await fetch('https://typescriptlang.org');
+    console.log(result);
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_arrayBindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_arrayBindingPattern.ts
@@ -6,6 +6,6 @@ function /*[#|*/f/*|]*/(): Promise<void>{
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f(): Promise<void>{
-    let [result] = await fetch('https://typescriptlang.org');
+    const [result] = await fetch('https://typescriptlang.org');
     console.log(result);
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_arrayBindingPatternRename.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_arrayBindingPatternRename.ts
@@ -1,0 +1,13 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/(): Promise<void>{
+    const result = getResult();
+    return fetch('https://typescriptlang.org').then(([result]) => { console.log(result) });
+}
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f(): Promise<void>{
+    const result = getResult();
+    const [result_1] = await fetch('https://typescriptlang.org');
+    console.log(result_1);
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.js
@@ -1,13 +1,13 @@
 // ==ORIGINAL==
 
 function /*[#|*/f/*|]*/() {
-	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x);
+    return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x);
 }
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f() {
-	let x_2;
+    let x_2;
     try {
         const x = await Promise.resolve();
         x_2 = 1;

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParams.ts
@@ -1,13 +1,13 @@
 // ==ORIGINAL==
 
 function /*[#|*/f/*|]*/() {
-	return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x);
+    return Promise.resolve().then(x => 1).catch(x => "a").then(x => !!x);
 }
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f() {
-	let x_2: string | number;
+    let x_2: string | number;
     try {
         const x = await Promise.resolve();
         x_2 = 1;

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.js
@@ -1,13 +1,13 @@
 // ==ORIGINAL==
 
 function /*[#|*/f/*|]*/() {
-	return Promise.resolve().then(() => ({ x: 3 })).catch(() => ({ x: "a" })).then(({ x }) => !!x);
+    return Promise.resolve().then(() => ({ x: 3 })).catch(() => ({ x: "a" })).then(({ x }) => !!x);
 }
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f() {
-	let result;
+    let result;
     try {
         await Promise.resolve();
         result = ({ x: 3 });

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.js
@@ -1,0 +1,20 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/() {
+	return Promise.resolve().then(() => ({ x: 3 })).catch(() => ({ x: "a" })).then(({ x }) => !!x);
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f() {
+	let result;
+    try {
+        await Promise.resolve();
+        result = ({ x: 3 });
+    }
+    catch (e) {
+        result = ({ x: "a" });
+    }
+    const { x } = result;
+    return !!x;
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.ts
@@ -1,13 +1,13 @@
 // ==ORIGINAL==
 
 function /*[#|*/f/*|]*/() {
-	return Promise.resolve().then(() => ({ x: 3 })).catch(() => ({ x: "a" })).then(({ x }) => !!x);
+    return Promise.resolve().then(() => ({ x: 3 })).catch(() => ({ x: "a" })).then(({ x }) => !!x);
 }
 
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f() {
-	let result: { x: number; } | { x: string; };
+    let result: { x: number; } | { x: string; };
     try {
         await Promise.resolve();
         result = ({ x: 3 });

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_catchBlockUniqueParamsBindingPattern.ts
@@ -1,0 +1,20 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/() {
+	return Promise.resolve().then(() => ({ x: 3 })).catch(() => ({ x: "a" })).then(({ x }) => !!x);
+}
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f() {
+	let result: { x: number; } | { x: string; };
+    try {
+        await Promise.resolve();
+        result = ({ x: 3 });
+    }
+    catch (e) {
+        result = ({ x: "a" });
+    }
+    const { x } = result;
+    return !!x;
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_objectBindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_objectBindingPattern.ts
@@ -1,0 +1,11 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/(): Promise<void>{
+    return fetch('https://typescriptlang.org').then(({ result }) => { console.log(result) });
+}
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f(): Promise<void>{
+    let { result } = await fetch('https://typescriptlang.org');
+    console.log(result);
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_objectBindingPattern.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_objectBindingPattern.ts
@@ -6,6 +6,6 @@ function /*[#|*/f/*|]*/(): Promise<void>{
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f(): Promise<void>{
-    let { result } = await fetch('https://typescriptlang.org');
+    const { result } = await fetch('https://typescriptlang.org');
     console.log(result);
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_objectBindingPatternRename.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_objectBindingPatternRename.ts
@@ -1,0 +1,13 @@
+// ==ORIGINAL==
+
+function /*[#|*/f/*|]*/(): Promise<void>{
+    const result = getResult();
+    return fetch('https://typescriptlang.org').then(({ result }) => { console.log(result) });
+}
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function f(): Promise<void>{
+    const result = getResult();
+    const { result: result_1 } = await fetch('https://typescriptlang.org');
+    console.log(result_1);
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #29358—the original refactor unsafely cast the params in callbacks in `.then()` and `.catch()` from `BindingName` to `Identifier`, which meant if they were in fact a binding pattern, the refactor would crash.