### PR TITLE
Fix start position of intersection/union node

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3087,14 +3087,15 @@ namespace ts {
         }
 
         function parseUnionOrIntersectionType(kind: SyntaxKind.UnionType | SyntaxKind.IntersectionType, parseConstituentType: () => TypeNode, operator: SyntaxKind.BarToken | SyntaxKind.AmpersandToken): TypeNode {
-            parseOptional(operator);
+            const leadingToken = parseOptionalToken(operator);
             let type = parseConstituentType();
+            const startPos = leadingToken ? leadingToken.pos : type.pos;
             if (token() === operator) {
                 const types = [type];
                 while (parseOptional(operator)) {
                     types.push(parseConstituentType());
                 }
-                const node = <UnionOrIntersectionTypeNode>createNode(kind, type.pos);
+                const node = <UnionOrIntersectionTypeNode>createNode(kind, startPos);
                 node.types = createNodeArray(types, type.pos);
                 type = finishNode(node);
             }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #30995 

- I am not sure how to write a baseline test for startPos, do we have  docs or examples?
- `parseOptionalToken` use `scanner.getStartPos()` as start position. What about use `scanner.getTokenPos()` instead?
