### PR TITLE
Remove no longer extant gulp command from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ gulp tests            # Build the test infrastructure using the built compiler.
 gulp runtests         # Run tests using the built compiler and test infrastructure. 
                       # You can override the host or specify a test for this command. 
                       # Use --host=<hostName> or --tests=<testPath>. 
-gulp runtests-browser # Runs the tests using the built run.js file. Syntax is gulp runtests. Optional
-                        parameters '--host=', '--tests=[regex], --reporter=[list|spec|json|<more>]'.
 gulp baseline-accept  # This replaces the baseline test results with the results obtained from gulp runtests.
 gulp lint             # Runs tslint on the TypeScript source.
 gulp help             # List the above commands. 


### PR DESCRIPTION
I'm totally mostly using this just to look at the perf baseline.
