### PR TITLE
fix #31012 allow noEmitOnError with isolatedModules

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2707,10 +2707,6 @@ namespace ts {
                     createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, getEmitDeclarationOptionName(options), "isolatedModules");
                 }
 
-                if (options.noEmitOnError) {
-                    createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "noEmitOnError", "isolatedModules");
-                }
-
                 if (options.out) {
                     createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "out", "isolatedModules");
                 }

--- a/tests/baselines/reference/isolatedModulesNoEmitOnError.errors.txt
+++ b/tests/baselines/reference/isolatedModulesNoEmitOnError.errors.txt
@@ -1,6 +1,7 @@
-error TS5053: Option 'noEmitOnError' cannot be specified with option 'isolatedModules'.
+tests/cases/compiler/file1.ts(1,14): error TS2322: Type '3' is not assignable to type 'string'.
 
 
-!!! error TS5053: Option 'noEmitOnError' cannot be specified with option 'isolatedModules'.
-==== tests/cases/compiler/file1.ts (0 errors) ====
-    export var x;
+==== tests/cases/compiler/file1.ts (1 errors) ====
+    export const x: string = 3;
+                 ~
+!!! error TS2322: Type '3' is not assignable to type 'string'.

--- a/tests/baselines/reference/isolatedModulesNoEmitOnError.symbols
+++ b/tests/baselines/reference/isolatedModulesNoEmitOnError.symbols
@@ -1,4 +1,4 @@
 === tests/cases/compiler/file1.ts ===
-export var x;
->x : Symbol(x, Decl(file1.ts, 0, 10))
+export const x: string = 3;
+>x : Symbol(x, Decl(file1.ts, 0, 12))
 

--- a/tests/baselines/reference/isolatedModulesNoEmitOnError.types
+++ b/tests/baselines/reference/isolatedModulesNoEmitOnError.types
@@ -1,4 +1,5 @@
 === tests/cases/compiler/file1.ts ===
-export var x;
->x : any
+export const x: string = 3;
+>x : string
+>3 : 3
 

--- a/tests/cases/compiler/isolatedModulesNoEmitOnError.ts
+++ b/tests/cases/compiler/isolatedModulesNoEmitOnError.ts
@@ -3,4 +3,4 @@
 // @target: es6
 
 // @filename: file1.ts
-export var x;
+export const x: string = 3;


### PR DESCRIPTION
fix #31012

Allow noEmitOnError with isolatedModules.

If I understand correctly, the purpose of `isolatedModules` is to
do extra validation to ensure that separate compilation is safe.

Such validation seems complementary to disallowing emit in the presence of errors.

checklist
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

