### PR TITLE
Add configure-experimental

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -545,6 +545,10 @@ const configureInsiders = () => exec(process.execPath, ["scripts/configurePrerel
 task("configure-insiders", series(buildScripts, configureInsiders));
 task("configure-insiders").description = "Runs scripts/configurePrerelease.ts to prepare a build for insiders publishing";
 
+const configureExperimental = () => exec(process.execPath, ["scripts/configurePrerelease.js", "experimental", "package.json", "src/compiler/core.ts"])
+task("configure-experimental", series(buildScripts, configureExperimental));
+task("configure-experimental").description = "Runs scripts/configurePrerelease.ts to prepare a build for experimental publishing";
+
 const publishNightly = () => exec("npm", ["publish", "--tag", "next"]);
 task("publish-nightly", series(task("clean"), task("LKG"), task("clean"), task("runtests-parallel"), publishNightly));
 task("publish-nightly").description = "Runs `npm publish --tag next` to create a new nightly build on npm";

--- a/scripts/configurePrerelease.ts
+++ b/scripts/configurePrerelease.ts
@@ -22,7 +22,7 @@ function main(): void {
     }
 
     const tag = args[0];
-    if (tag !== "dev" && tag !== "insiders") {
+    if (tag !== "dev" && tag !== "insiders" && tag !== "experimental") {
         throw new Error(`Unexpected tag name '${tag}'.`);
     }
 


### PR DESCRIPTION
Which is identical to `configure-insiders` and `configure-nightly`, but uses the `experimental` tag instead.

