### PR TITLE
Don’t show auto-import suggestion if there’s a global by the same name

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -782,7 +782,7 @@ namespace FourSlash {
                         const name = typeof include === "string" ? include : include.name;
                         const found = nameToEntries.get(name);
                         if (!found) throw this.raiseError(`No completion ${name} found`);
-                        assert(found.length === 1); // Must use 'exact' for multiple completions with same name
+                        assert(found.length === 1, `Multiple completions named '${name}' were found. Using 'exact' is required.`);
                         this.verifyCompletionEntry(ts.first(found), include);
                     }
                 }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -273,6 +273,7 @@ namespace ts.Completions {
         // Based on the order we add things we will always see locals first, then globals, then module exports.
         // So adding a completion for a local will prevent us from adding completions for external module exports sharing the same name.
         const uniques = createMap<true>();
+        const uniqueGlobals = createMap<true>();
         for (const symbol of symbols) {
             const origin = symbolToOriginInfoMap ? symbolToOriginInfoMap[getSymbolId(symbol)] : undefined;
             const entry = createCompletionEntry(symbol, location, sourceFile, typeChecker, target, kind, origin, recommendedCompletion, propertyAccessToConvert, isJsxInitializer, preferences);
@@ -285,12 +286,20 @@ namespace ts.Completions {
                 continue;
             }
 
-            // Latter case tests whether this is a global variable.
-            if (!origin && !(symbol.parent === undefined && !some(symbol.declarations, d => d.getSourceFile() === location!.getSourceFile()))) { // TODO: GH#18217
+            const isExternalModule = !!origin;
+            const isTopLevel = symbol.parent === undefined;
+            const hasDeclarationInFile = some(symbol.declarations, d => d.getSourceFile() === location!.getSourceFile());
+            if (!isExternalModule && !(isTopLevel && !hasDeclarationInFile)) {
                 uniques.set(name, true);
             }
+            else if (isTopLevel && !isExternalModule && !hasDeclarationInFile) {
+                uniqueGlobals.set(name, true);
+            }
 
-            entries.push(entry);
+            const shouldBeShadowedByGlobal = isExternalModule && uniqueGlobals.has(name);
+            if (!shouldBeShadowedByGlobal) {
+                entries.push(entry);
+            }
         }
 
         log("getCompletionsAtPosition: getCompletionEntriesFromSymbols: " + (timestamp() - start));

--- a/tests/cases/fourslash/completionsImport_multipleWithSameName.ts
+++ b/tests/cases/fourslash/completionsImport_multipleWithSameName.ts
@@ -3,10 +3,6 @@
 // @module: esnext
 // @noLib: true
 
-// @Filename: /global.d.ts
-// A local variable would prevent import completions (see `completionsImport_shadowedByLocal.ts`), but a global doesn't.
-////declare var foo: number;
-
 // @Filename: /a.ts
 ////export const foo = 0;
 
@@ -21,7 +17,6 @@ verify.completions({
     marker: "",
     exact: [
         "globalThis",
-        { name: "foo", text: "var foo: number", kind: "var", kindModifiers: "declare" },
         "undefined",
         {
             name: "foo",

--- a/tests/cases/fourslash/completionsImport_shadowedByGlobal.ts
+++ b/tests/cases/fourslash/completionsImport_shadowedByGlobal.ts
@@ -1,0 +1,13 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.ts
+//// export const parseInt = 0;
+
+// @Filename: /b.ts
+////parseI/**/
+
+verify.completions({
+  marker: "",
+  includes: [{ name: "parseInt", kind: "function", kindModifiers: "declare" }],
+  preferences: { includeCompletionsForModuleExports: true },
+});

--- a/tests/cases/fourslash/completionsImport_shadowedByGlobal.ts
+++ b/tests/cases/fourslash/completionsImport_shadowedByGlobal.ts
@@ -8,6 +8,7 @@
 
 verify.completions({
   marker: "",
-  includes: [{ name: "parseInt", kind: "function", kindModifiers: "declare" }],
+  // The real parseInt is in 'globalVars', the fake one exported from a.ts is missing
+  exact: ["globalThis", ...completion.globalsVars, "undefined", ...completion.statementKeywordsWithTypes],
   preferences: { includeCompletionsForModuleExports: true },
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [ ] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
Fixes #30713 

Locals already shadow auto-import suggestions, but people were having issues with globals like `clearTimeout` being auto-imported from `'timers'`, for example.

**I'm not 100% sure this is the right thing to do.** Thinking about the `clearTimeout` example:

```ts
// node_modules/@types/node/globals.d.ts
declare function clearTimeout(timeoutId: NodeJS.Timeout): void;

// node_modules/@types/node/timers.d.ts
declare module 'timers' {
  function clearTimeout(timeoutId: NodeJS.Timeout): void;
}
```

(Depending on the user’s tsconfig, they’ll likely have another ambient declaration in lib.dom.d.ts, but it becomes an overload with @types/node’s ambient declaration, so it’s not particularly relevant to the problem.)

Between these two declarations, I don't care about the one in `timers` at all. I never ever want to import `clearTimeout` from `timers`. Why?

1. If I'm writing for node, I don't want the import because it's equivalent to the global, and it's unconventional to import it. I probably don't even know that a module called “timers” exists.
2. If I'm writing for the browser, I probably have `@types/node` on accident or indirectly, and the import actually _won’t work_ because _I'm writing for the browser_.

On the other hand, I can envision some scenarios where I have different motivations and desired outcomes:

```ts
// file.ts
export class File {}

// index.ts
const file = new Fi/**/
```

There's a DOM global `File`, but as files are a pretty common thing to talk about in computing, it's also quite common to write a type or class called `File` in your own project. In this case, I _probably_ want to auto-import my own `File` class. The global gets ranked higher, but at least I can press the down arrow key and get the auto-import. If we merge this PR, nothing called `File` will ever be auto-importable (in a program that has lib.dom.d.ts).

**Observations:**

- We can't actually _know_ that the two `clearTimeout` declarations in `@types/node` are truly the same runtime function, but it seems highly likely since they’re both in `@types/node`.
- If a module export shares the same name with a global, the chances that you want to import that thing instead of use the global are probably much higher for a local module like `file.ts` than for a module we found in `node_modules` like `timers`.
- `@types/node` is special, because it’s the only exception I can think of to the rule: “If I have a package.json, I do not want to auto-import from any package not listed in it.”

**Possible solutions:**

- Retain same-name auto-import suggestions for local modules, suppress them for `node_modules`
- Suppress auto-import suggestions that have the same name as an ambient declaration _from the same package_; i.e. `clearTimeout` from `timers` gets hidden because it’s in `@types/node` and so is a global one.
- Just go with this PR and see if compelling arguments for doing it another way arise in practice.