### PR TITLE
Exclude tests/cases/* from tslint

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -3,7 +3,7 @@
     "rulesDirectory": "built/local/tslint/rules",
     "linterOptions": {
         "exclude": [
-            "tests/cases/**/*"
+            "tests/**/*"
         ]
     },
     "rules": {

--- a/tslint.json
+++ b/tslint.json
@@ -1,6 +1,11 @@
 {
     "extends": "tslint:latest",
     "rulesDirectory": "built/local/tslint/rules",
+    "linterOptions": {
+        "exclude": [
+            "tests/cases/**/*"
+        ]
+    },
     "rules": {
         "no-unnecessary-type-assertion": true,
 


### PR DESCRIPTION
Linting doesn't run against these files in any tests or CI anyway, but if you have lint status in your editor, it can be super annoying.

| Before | After |
|--------|------|
| ![Screen Shot 2019-04-24 at 10 40 11 AM](https://user-images.githubusercontent.com/3277153/56681215-b4191a80-667d-11e9-80b3-3fb67af724fc.png) | ![Screen Shot 2019-04-24 at 10 40 39 AM](https://user-images.githubusercontent.com/3277153/56681228-ba0efb80-667d-11e9-8d93-f62f8fed9dc6.png) |

😄 