### PR TITLE
Forbid function assignment to index signatures:any

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13574,7 +13574,10 @@ namespace ts {
                     return indexTypesIdenticalTo(source, target, kind);
                 }
                 const targetInfo = getIndexInfoOfType(target, kind);
-                if (!targetInfo || targetInfo.type.flags & TypeFlags.Any && !sourceIsPrimitive) {
+                if (!targetInfo ||
+                    targetInfo.type.flags & TypeFlags.Any && !sourceIsPrimitive &&
+                    getSignaturesOfStructuredType(source, SignatureKind.Call).length === 0 &&
+                    getSignaturesOfStructuredType(source, SignatureKind.Construct).length === 0) {
                     // Index signature of type any permits assignment from everything but primitives
                     return Ternary.True;
                 }

--- a/tests/baselines/reference/functionAssignableToArrayLike.errors.txt
+++ b/tests/baselines/reference/functionAssignableToArrayLike.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/compiler/functionAssignableToArrayLike.ts(1,5): error TS2322: Type '(x: any, y: any) => any' is not assignable to type 'ArrayLike<any>'.
+  Index signature is missing in type '(x: any, y: any) => any'.
+tests/cases/compiler/functionAssignableToArrayLike.ts(2,5): error TS2322: Type '(x: any, y: any) => any' is not assignable to type 'ArrayLike<string>'.
+  Index signature is missing in type '(x: any, y: any) => any'.
+
+
+==== tests/cases/compiler/functionAssignableToArrayLike.ts (2 errors) ====
+    var bad1: ArrayLike<any> = (x, y) => x + y
+        ~~~~
+!!! error TS2322: Type '(x: any, y: any) => any' is not assignable to type 'ArrayLike<any>'.
+!!! error TS2322:   Index signature is missing in type '(x: any, y: any) => any'.
+    var bad2: ArrayLike<string> = (x, y) => x + y
+        ~~~~
+!!! error TS2322: Type '(x: any, y: any) => any' is not assignable to type 'ArrayLike<string>'.
+!!! error TS2322:   Index signature is missing in type '(x: any, y: any) => any'.
+    

--- a/tests/baselines/reference/functionAssignableToArrayLike.js
+++ b/tests/baselines/reference/functionAssignableToArrayLike.js
@@ -1,0 +1,8 @@
+//// [functionAssignableToArrayLike.ts]
+var bad1: ArrayLike<any> = (x, y) => x + y
+var bad2: ArrayLike<string> = (x, y) => x + y
+
+
+//// [functionAssignableToArrayLike.js]
+var bad1 = function (x, y) { return x + y; };
+var bad2 = function (x, y) { return x + y; };

--- a/tests/baselines/reference/functionAssignableToArrayLike.symbols
+++ b/tests/baselines/reference/functionAssignableToArrayLike.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/functionAssignableToArrayLike.ts ===
+var bad1: ArrayLike<any> = (x, y) => x + y
+>bad1 : Symbol(bad1, Decl(functionAssignableToArrayLike.ts, 0, 3))
+>ArrayLike : Symbol(ArrayLike, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(functionAssignableToArrayLike.ts, 0, 28))
+>y : Symbol(y, Decl(functionAssignableToArrayLike.ts, 0, 30))
+>x : Symbol(x, Decl(functionAssignableToArrayLike.ts, 0, 28))
+>y : Symbol(y, Decl(functionAssignableToArrayLike.ts, 0, 30))
+
+var bad2: ArrayLike<string> = (x, y) => x + y
+>bad2 : Symbol(bad2, Decl(functionAssignableToArrayLike.ts, 1, 3))
+>ArrayLike : Symbol(ArrayLike, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(functionAssignableToArrayLike.ts, 1, 31))
+>y : Symbol(y, Decl(functionAssignableToArrayLike.ts, 1, 33))
+>x : Symbol(x, Decl(functionAssignableToArrayLike.ts, 1, 31))
+>y : Symbol(y, Decl(functionAssignableToArrayLike.ts, 1, 33))
+

--- a/tests/baselines/reference/functionAssignableToArrayLike.types
+++ b/tests/baselines/reference/functionAssignableToArrayLike.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/functionAssignableToArrayLike.ts ===
+var bad1: ArrayLike<any> = (x, y) => x + y
+>bad1 : ArrayLike<any>
+>(x, y) => x + y : (x: any, y: any) => any
+>x : any
+>y : any
+>x + y : any
+>x : any
+>y : any
+
+var bad2: ArrayLike<string> = (x, y) => x + y
+>bad2 : ArrayLike<string>
+>(x, y) => x + y : (x: any, y: any) => any
+>x : any
+>y : any
+>x + y : any
+>x : any
+>y : any
+

--- a/tests/baselines/reference/intTypeCheck.errors.txt
+++ b/tests/baselines/reference/intTypeCheck.errors.txt
@@ -36,6 +36,8 @@ tests/cases/compiler/intTypeCheck.ts(134,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(134,22): error TS2693: 'i3' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(135,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 tests/cases/compiler/intTypeCheck.ts(142,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
+tests/cases/compiler/intTypeCheck.ts(145,5): error TS2322: Type '() => void' is not assignable to type 'i4'.
+  Index signature is missing in type '() => void'.
 tests/cases/compiler/intTypeCheck.ts(148,5): error TS2322: Type 'boolean' is not assignable to type 'i4'.
 tests/cases/compiler/intTypeCheck.ts(148,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(148,22): error TS2693: 'i4' only refers to a type, but is being used as a value here.
@@ -78,13 +80,15 @@ tests/cases/compiler/intTypeCheck.ts(190,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(190,22): error TS2693: 'i7' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(191,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 tests/cases/compiler/intTypeCheck.ts(198,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
+tests/cases/compiler/intTypeCheck.ts(201,5): error TS2322: Type '() => void' is not assignable to type 'i8'.
+  Index signature is missing in type '() => void'.
 tests/cases/compiler/intTypeCheck.ts(204,5): error TS2322: Type 'boolean' is not assignable to type 'i8'.
 tests/cases/compiler/intTypeCheck.ts(204,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(204,22): error TS2693: 'i8' only refers to a type, but is being used as a value here.
 tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
 
 
-==== tests/cases/compiler/intTypeCheck.ts (63 errors) ====
+==== tests/cases/compiler/intTypeCheck.ts (65 errors) ====
     interface i1 {
         //Property Signatures
         p;
@@ -296,6 +300,9 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj37: i4 = new Base;
     var obj38: i4 = null;
     var obj39: i4 = function () { };
+        ~~~~~
+!!! error TS2322: Type '() => void' is not assignable to type 'i4'.
+!!! error TS2322:   Index signature is missing in type '() => void'.
     //var obj40: i4 = function foo() { };
     var obj41: i4 = <i4> anyVar;
     var obj42: i4 = new <i4> anyVar;
@@ -425,6 +432,9 @@ tests/cases/compiler/intTypeCheck.ts(205,17): error TS2351: Cannot use 'new' wit
     var obj81: i8 = new Base;
     var obj82: i8 = null;
     var obj83: i8 = function () { };
+        ~~~~~
+!!! error TS2322: Type '() => void' is not assignable to type 'i8'.
+!!! error TS2322:   Index signature is missing in type '() => void'.
     //var obj84: i8 = function foo() { };
     var obj85: i8 = <i8> anyVar;
     var obj86: i8 = new <i8> anyVar;

--- a/tests/cases/compiler/functionAssignableToArrayLike.ts
+++ b/tests/cases/compiler/functionAssignableToArrayLike.ts
@@ -1,0 +1,2 @@
+var bad1: ArrayLike<any> = (x, y) => x + y
+var bad2: ArrayLike<string> = (x, y) => x + y


### PR DESCRIPTION
I'll open a bug for this shortly, but in the meantime:

It doesn't make sense for functions or constructors to be assignable to types with an index signature; it doesn't even make sense for *anything* to be assignable to a target with an index signature if the source doesn't have one (h/t @weswigham). This PR makes a small change of exempting types with call/construct signatures from the rule that makes any non-primitive source type assignable to string/number index signature of `any`.

This has the concrete advantage of preventing functions from being assigned to `ArrayLike<any>`.