### PR TITLE
Update `lib.d.ts`: Change the type of `uriComponent` (passed to `encodeURIComponent`) from `string` to `string | number | boolean`

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -60,7 +60,7 @@ declare function encodeURI(uri: string): string;
   * Encodes a text string as a valid component of a Uniform Resource Identifier (URI).
   * @param uriComponent A value representing an encoded URI component.
   */
-declare function encodeURIComponent(uriComponent: string): string;
+declare function encodeURIComponent(uriComponent: string | number | boolean): string;
 
 /**
   * Computes a new string in which certain characters have been replaced by a hexadecimal escape sequence.

--- a/tests/baselines/reference/1.0lib-noErrors.js
+++ b/tests/baselines/reference/1.0lib-noErrors.js
@@ -78,7 +78,7 @@ declare function encodeURI(uri: string): string;
   * Encodes a text string as a valid component of a Uniform Resource Identifier (URI).
   * @param uriComponent A value representing an encoded URI component.
   */
-declare function encodeURIComponent(uriComponent: string): string;
+declare function encodeURIComponent(uriComponent: string | number | boolean): string;
 
 interface PropertyDescriptor {
     configurable?: boolean;
@@ -1141,7 +1141,7 @@ declare var Array: {
     <T>(...items: T[]): T[];
     isArray(arg: any): boolean;
     prototype: Array<any>;
-}
+}
 
 //// [1.0lib-noErrors.js]
 /* *****************************************************************************

--- a/tests/baselines/reference/1.0lib-noErrors.symbols
+++ b/tests/baselines/reference/1.0lib-noErrors.symbols
@@ -98,12 +98,12 @@ declare function encodeURI(uri: string): string;
   * Encodes a text string as a valid component of a Uniform Resource Identifier (URI).
   * @param uriComponent A value representing an encoded URI component.
   */
-declare function encodeURIComponent(uriComponent: string): string;
+declare function encodeURIComponent(uriComponent: string | number | boolean): string;
 >encodeURIComponent : Symbol(encodeURIComponent, Decl(1.0lib-noErrors.ts, 73, 48))
 >uriComponent : Symbol(uriComponent, Decl(1.0lib-noErrors.ts, 79, 36))
 
 interface PropertyDescriptor {
->PropertyDescriptor : Symbol(PropertyDescriptor, Decl(1.0lib-noErrors.ts, 79, 66))
+>PropertyDescriptor : Symbol(PropertyDescriptor, Decl(1.0lib-noErrors.ts, 79, 85))
 
     configurable?: boolean;
 >configurable : Symbol(PropertyDescriptor.configurable, Decl(1.0lib-noErrors.ts, 81, 30))
@@ -130,7 +130,7 @@ interface PropertyDescriptorMap {
 
     [s: string]: PropertyDescriptor;
 >s : Symbol(s, Decl(1.0lib-noErrors.ts, 91, 5))
->PropertyDescriptor : Symbol(PropertyDescriptor, Decl(1.0lib-noErrors.ts, 79, 66))
+>PropertyDescriptor : Symbol(PropertyDescriptor, Decl(1.0lib-noErrors.ts, 79, 85))
 }
 
 interface Object {
@@ -217,7 +217,7 @@ declare var Object: {
 >getOwnPropertyDescriptor : Symbol(getOwnPropertyDescriptor, Decl(1.0lib-noErrors.ts, 141, 32))
 >o : Symbol(o, Decl(1.0lib-noErrors.ts, 149, 29))
 >p : Symbol(p, Decl(1.0lib-noErrors.ts, 149, 36))
->PropertyDescriptor : Symbol(PropertyDescriptor, Decl(1.0lib-noErrors.ts, 79, 66))
+>PropertyDescriptor : Symbol(PropertyDescriptor, Decl(1.0lib-noErrors.ts, 79, 85))
 
     /** 
       * Returns the names of the own properties of an object. The own properties of an object are those that are defined directly 
@@ -250,7 +250,7 @@ declare var Object: {
 >o : Symbol(o, Decl(1.0lib-noErrors.ts, 171, 19))
 >p : Symbol(p, Decl(1.0lib-noErrors.ts, 171, 26))
 >attributes : Symbol(attributes, Decl(1.0lib-noErrors.ts, 171, 37))
->PropertyDescriptor : Symbol(PropertyDescriptor, Decl(1.0lib-noErrors.ts, 79, 66))
+>PropertyDescriptor : Symbol(PropertyDescriptor, Decl(1.0lib-noErrors.ts, 79, 85))
 
     /**
       * Adds one or more properties to an object, and/or modifies attributes of existing properties. 
@@ -2084,3 +2084,4 @@ declare var Array: {
 >prototype : Symbol(prototype, Decl(1.0lib-noErrors.ts, 1140, 31))
 >Array : Symbol(Array, Decl(1.0lib-noErrors.ts, 973, 23), Decl(1.0lib-noErrors.ts, 1133, 11))
 }
+

--- a/tests/baselines/reference/1.0lib-noErrors.types
+++ b/tests/baselines/reference/1.0lib-noErrors.types
@@ -98,9 +98,9 @@ declare function encodeURI(uri: string): string;
   * Encodes a text string as a valid component of a Uniform Resource Identifier (URI).
   * @param uriComponent A value representing an encoded URI component.
   */
-declare function encodeURIComponent(uriComponent: string): string;
->encodeURIComponent : (uriComponent: string) => string
->uriComponent : string
+declare function encodeURIComponent(uriComponent: string | number | boolean): string;
+>encodeURIComponent : (uriComponent: string | number | boolean) => string
+>uriComponent : string | number | boolean
 
 interface PropertyDescriptor {
     configurable?: boolean;
@@ -1911,3 +1911,4 @@ declare var Array: {
     prototype: Array<any>;
 >prototype : any[]
 }
+

--- a/tests/baselines/reference/parserRegularExpression4.types
+++ b/tests/baselines/reference/parserRegularExpression4.types
@@ -61,7 +61,7 @@ if (Ca.test(c.href) || Ba.test(c.href) && /(\\?|&)adurl=/.test(c.href) && !/(\\?
 >"&q=" + encodeURIComponent(W("q") || W("as_q") || A) : string
 >"&q=" : "&q="
 >encodeURIComponent(W("q") || W("as_q") || A) : string
->encodeURIComponent : (uriComponent: string) => string
+>encodeURIComponent : (uriComponent: string | number | boolean) => string
 >W("q") || W("as_q") || A : any
 >W("q") || W("as_q") : any
 >W("q") : any

--- a/tests/cases/conformance/decorators/1.0lib-noErrors.ts
+++ b/tests/cases/conformance/decorators/1.0lib-noErrors.ts
@@ -78,7 +78,7 @@ declare function encodeURI(uri: string): string;
   * Encodes a text string as a valid component of a Uniform Resource Identifier (URI).
   * @param uriComponent A value representing an encoded URI component.
   */
-declare function encodeURIComponent(uriComponent: string): string;
+declare function encodeURIComponent(uriComponent: string | number | boolean): string;
 
 interface PropertyDescriptor {
     configurable?: boolean;
@@ -1141,4 +1141,4 @@ declare var Array: {
     <T>(...items: T[]): T[];
     isArray(arg: any): boolean;
     prototype: Array<any>;
-}
+}

--- a/tests/lib/lib.d.ts
+++ b/tests/lib/lib.d.ts
@@ -77,7 +77,7 @@ declare function encodeURI(uri: string): string;
   * Encodes a text string as a valid component of a Uniform Resource Identifier (URI).
   * @param uriComponent A value representing an encoded URI component.
   */
-declare function encodeURIComponent(uriComponent: string): string;
+declare function encodeURIComponent(uriComponent: string | number | boolean): string;
 
 /**
   * Computes a new string in which certain characters have been replaced by a hexadecimal escape sequence.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
* [x] There is an associated issue that is labeled 'Bug' or 'help wanted'
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

**Fixes #18159**

- According to the [ECMAScript 5.1 spec (§15.1.3.4)](https://www.ecma-international.org/ecma-262/5.1/#sec-15.1.3.4), `encodeURIComponent` invokes the abstract operation `ToString`
- [In the spec (§9.8)](https://www.ecma-international.org/ecma-262/5.1/#sec-9.8), `ToString` accepts an `Undefined`, `Null`, `Boolean`, `Number`, `String` or `Object` argument
- TypeScript’s `StringConstructor` accepts an argument with type `any`: https://github.com/Microsoft/TypeScript/blob/b0100100a18d740ad0b7c626bc81b800b5273ece/lib/lib.es5.d.ts#L517-L518

<br />
<br />

NB: This declaration also appears in `lib/lib.es5.d.ts`…
https://github.com/Microsoft/TypeScript/blob/b0100100a18d740ad0b7c626bc81b800b5273ece/lib/lib.es5.d.ts#L83
…but I left that file alone per the instructions in [“Contributing `lib.d.ts` fixes”](https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md#contributing-libdts-fixes).