### PR TITLE
Fix binder performance regression

### DIFF
--- a/tests/baselines/reference/globalThisCollision.errors.txt
+++ b/tests/baselines/reference/globalThisCollision.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/es2019/globalThisCollision.js(1,5): error TS2397: Declaration name conflicts with built-in global identifier 'globalThis'.
+
+
+==== tests/cases/conformance/es2019/globalThisCollision.js (1 errors) ====
+    var globalThis;
+        ~~~~~~~~~~
+!!! error TS2397: Declaration name conflicts with built-in global identifier 'globalThis'.

--- a/tests/baselines/reference/globalThisCollision.symbols
+++ b/tests/baselines/reference/globalThisCollision.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es2019/globalThisCollision.js ===
+var globalThis;
+>globalThis : Symbol(globalThis, Decl(globalThisCollision.js, 0, 3))
+

--- a/tests/baselines/reference/globalThisCollision.types
+++ b/tests/baselines/reference/globalThisCollision.types
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es2019/globalThisCollision.js ===
+var globalThis;
+>globalThis : any
+

--- a/tests/cases/conformance/es2019/globalThisCollision.ts
+++ b/tests/cases/conformance/es2019/globalThisCollision.ts
@@ -1,0 +1,5 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @filename: globalThisCollision.js
+var globalThis;


### PR DESCRIPTION
When we introduced `globalThis` support, we inadvertently regressed binder performance by over 100%. This regression appears to be due to an early change to the shape of our `Symbol` type prior to binder being called.