### PR TITLE
Key of non nullable of generic type parameter

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12431,7 +12431,7 @@ namespace ts {
             }
 
             function isConditionalType(t: Type): t is ConditionalType {
-                return (t.flags & TypeFlags.Conditional) > 0
+                return (t.flags & TypeFlags.Conditional) > 0;
             }
 
             /**

--- a/tests/baselines/reference/keyofNonNullable.errors.txt
+++ b/tests/baselines/reference/keyofNonNullable.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/compiler/keyofNonNullable.ts(3,5): error TS2322: Type 'keyof Y' is not assignable to type 'keyof X'.
+  Type 'string | number | symbol' is not assignable to type 'keyof X'.
+    Type 'string' is not assignable to type 'keyof X'.
+
+
+==== tests/cases/compiler/keyofNonNullable.ts (1 errors) ====
+    function f<X, Y extends X>(keyofX: keyof X, keyofY: keyof Y) {
+        keyofY = keyofX;
+        keyofX = keyofY;
+        ~~~~~~
+!!! error TS2322: Type 'keyof Y' is not assignable to type 'keyof X'.
+!!! error TS2322:   Type 'string | number | symbol' is not assignable to type 'keyof X'.
+!!! error TS2322:     Type 'string' is not assignable to type 'keyof X'.
+    }
+    
+    
+    function f1<T>(keyofT: keyof T, keyofNonNullT: keyof NonNullable<T>) {
+        keyofT = keyofNonNullT
+    }
+    

--- a/tests/baselines/reference/keyofNonNullable.js
+++ b/tests/baselines/reference/keyofNonNullable.js
@@ -1,0 +1,20 @@
+//// [keyofNonNullable.ts]
+function f<X, Y extends X>(keyofX: keyof X, keyofY: keyof Y) {
+    keyofY = keyofX;
+    keyofX = keyofY;
+}
+
+
+function f1<T>(keyofT: keyof T, keyofNonNullT: keyof NonNullable<T>) {
+    keyofT = keyofNonNullT
+}
+
+
+//// [keyofNonNullable.js]
+function f(keyofX, keyofY) {
+    keyofY = keyofX;
+    keyofX = keyofY;
+}
+function f1(keyofT, keyofNonNullT) {
+    keyofT = keyofNonNullT;
+}

--- a/tests/baselines/reference/keyofNonNullable.symbols
+++ b/tests/baselines/reference/keyofNonNullable.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/keyofNonNullable.ts ===
+function f<X, Y extends X>(keyofX: keyof X, keyofY: keyof Y) {
+>f : Symbol(f, Decl(keyofNonNullable.ts, 0, 0))
+>X : Symbol(X, Decl(keyofNonNullable.ts, 0, 11))
+>Y : Symbol(Y, Decl(keyofNonNullable.ts, 0, 13))
+>X : Symbol(X, Decl(keyofNonNullable.ts, 0, 11))
+>keyofX : Symbol(keyofX, Decl(keyofNonNullable.ts, 0, 27))
+>X : Symbol(X, Decl(keyofNonNullable.ts, 0, 11))
+>keyofY : Symbol(keyofY, Decl(keyofNonNullable.ts, 0, 43))
+>Y : Symbol(Y, Decl(keyofNonNullable.ts, 0, 13))
+
+    keyofY = keyofX;
+>keyofY : Symbol(keyofY, Decl(keyofNonNullable.ts, 0, 43))
+>keyofX : Symbol(keyofX, Decl(keyofNonNullable.ts, 0, 27))
+
+    keyofX = keyofY;
+>keyofX : Symbol(keyofX, Decl(keyofNonNullable.ts, 0, 27))
+>keyofY : Symbol(keyofY, Decl(keyofNonNullable.ts, 0, 43))
+}
+
+
+function f1<T>(keyofT: keyof T, keyofNonNullT: keyof NonNullable<T>) {
+>f1 : Symbol(f1, Decl(keyofNonNullable.ts, 3, 1))
+>T : Symbol(T, Decl(keyofNonNullable.ts, 6, 12))
+>keyofT : Symbol(keyofT, Decl(keyofNonNullable.ts, 6, 15))
+>T : Symbol(T, Decl(keyofNonNullable.ts, 6, 12))
+>keyofNonNullT : Symbol(keyofNonNullT, Decl(keyofNonNullable.ts, 6, 31))
+>NonNullable : Symbol(NonNullable, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(keyofNonNullable.ts, 6, 12))
+
+    keyofT = keyofNonNullT
+>keyofT : Symbol(keyofT, Decl(keyofNonNullable.ts, 6, 15))
+>keyofNonNullT : Symbol(keyofNonNullT, Decl(keyofNonNullable.ts, 6, 31))
+}
+

--- a/tests/baselines/reference/keyofNonNullable.types
+++ b/tests/baselines/reference/keyofNonNullable.types
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/keyofNonNullable.ts ===
+function f<X, Y extends X>(keyofX: keyof X, keyofY: keyof Y) {
+>f : <X, Y extends X>(keyofX: keyof X, keyofY: keyof Y) => void
+>keyofX : keyof X
+>keyofY : keyof Y
+
+    keyofY = keyofX;
+>keyofY = keyofX : keyof X
+>keyofY : keyof Y
+>keyofX : keyof X
+
+    keyofX = keyofY;
+>keyofX = keyofY : keyof Y
+>keyofX : keyof X
+>keyofY : keyof Y
+}
+
+
+function f1<T>(keyofT: keyof T, keyofNonNullT: keyof NonNullable<T>) {
+>f1 : <T>(keyofT: keyof T, keyofNonNullT: keyof NonNullable<T>) => void
+>keyofT : keyof T
+>keyofNonNullT : keyof NonNullable<T>
+
+    keyofT = keyofNonNullT
+>keyofT = keyofNonNullT : keyof NonNullable<T>
+>keyofT : keyof T
+>keyofNonNullT : keyof NonNullable<T>
+}
+

--- a/tests/cases/compiler/keyofNonNullable.ts
+++ b/tests/cases/compiler/keyofNonNullable.ts
@@ -1,0 +1,9 @@
+function f<X, Y extends X>(keyofX: keyof X, keyofY: keyof Y) {
+    keyofY = keyofX;
+    keyofX = keyofY;
+}
+
+
+function f1<T>(keyofT: keyof T, keyofNonNullT: keyof NonNullable<T>) {
+    keyofT = keyofNonNullT
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #23368 ?

This specific issue is already kind of fixed but the underlying problem of `keyof NonNullable<T>` not being assignable to `keyof T` when `T` is an unconstrained generic parameter is still there (as demonstrated by the test case).

It's debatable weather this should be merged as this is a very narrow use case.

The only reason against it is performance. I haven't investigated.

