### PR TITLE
fix(docs): Fixed the docs for Array#slice not specifying that the 'end' parameter is exclusive.

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1094,7 +1094,7 @@ interface ReadonlyArray<T> {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): T[];
     /**
@@ -1230,7 +1230,7 @@ interface Array<T> {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): T[];
     /**
@@ -1862,7 +1862,7 @@ interface Int8Array {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): Int8Array;
 
@@ -2137,7 +2137,7 @@ interface Uint8Array {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): Uint8Array;
 
@@ -2412,7 +2412,7 @@ interface Uint8ClampedArray {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): Uint8ClampedArray;
 
@@ -2685,7 +2685,7 @@ interface Int16Array {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): Int16Array;
 
@@ -2961,7 +2961,7 @@ interface Uint16Array {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): Uint16Array;
 
@@ -3236,7 +3236,7 @@ interface Int32Array {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): Int32Array;
 
@@ -3510,7 +3510,7 @@ interface Uint32Array {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): Uint32Array;
 
@@ -3785,7 +3785,7 @@ interface Float32Array {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): Float32Array;
 
@@ -4061,7 +4061,7 @@ interface Float64Array {
     /**
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
-      * @param end The end of the specified portion of the array.
+      * @param end The end of the specified portion of the array. This is exclusive of the element at the index 'end'.
       */
     slice(start?: number, end?: number): Float64Array;
 


### PR DESCRIPTION
The docs here are ambiguous as to whether the end parameter is exclusive in arrays.

Is an issue required for docs fixes? The contributing guidelines states it's needed for bug fixes, but doesn't mention it in the d.ts section. I can make an issue if required.
