### PR TITLE
Make ReadableStreamReadResult<T> type more strict

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -12325,10 +12325,7 @@ interface ReadableStreamDefaultReader<R = any> {
     releaseLock(): void;
 }
 
-interface ReadableStreamReadResult<T> {
-    done: boolean;
-    value: T;
-}
+type ReadableStreamReadResult<T> = { done: false, value: T } | { done: true, value?: undefined }
 
 interface ReadableStreamReader<R = any> {
     cancel(): Promise<void>;


### PR DESCRIPTION
Hi, developers. Thank you very much for your project!

I'm very new to contribute to this repo.
This PR makes `ReadableStreamReadResult<T>` more strict.

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

## References
* <https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamDefaultReader/read#Return_value>
* <https://developer.mozilla.org/en-US/docs/Web/API/ReadableStreamBYOBReader/read#Return_value>