### PR TITLE
Improve error message for use of 'await' in non-async context

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23093,7 +23093,7 @@ namespace ts {
                         const span = getSpanOfTokenAtPosition(sourceFile, node.pos);
                         const diagnostic = createFileDiagnostic(sourceFile, span.start, span.length, Diagnostics.await_expression_is_only_allowed_within_an_async_function);
                         const func = getContainingFunction(node);
-                        if (func) {
+                        if (func && func.kind !== SyntaxKind.Constructor) {
                             Debug.assert((getFunctionFlags(func) & FunctionFlags.Async) === 0, "Enclosing function should never be an async function.");
                             const relatedInfo = createDiagnosticForNode(func, Diagnostics.Did_you_mean_to_mark_this_function_as_async);
                             addRelatedInfo(diagnostic, relatedInfo);
@@ -31603,7 +31603,7 @@ namespace ts {
                     if (!hasParseDiagnostics(sourceFile)) {
                         const diagnostic = createDiagnosticForNode(forInOrOfStatement.awaitModifier, Diagnostics.A_for_await_of_statement_is_only_allowed_within_an_async_function_or_async_generator);
                         const func = getContainingFunction(forInOrOfStatement);
-                        if (func) {
+                        if (func && func.kind !== SyntaxKind.Constructor) {
                             Debug.assert((getFunctionFlags(func) & FunctionFlags.Async) === 0, "Enclosing function should never be an async function.");
                             const relatedInfo = createDiagnosticForNode(func, Diagnostics.Did_you_mean_to_mark_this_function_as_async);
                             addRelatedInfo(diagnostic, relatedInfo);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23097,7 +23097,6 @@ namespace ts {
                             Debug.assert((getFunctionFlags(func) & FunctionFlags.Async) === 0, "Enclosing function should never be an async function.");
                             const relatedInfo = createDiagnosticForNode(func, Diagnostics.Did_you_mean_to_mark_this_function_as_async);
                             addRelatedInfo(diagnostic, relatedInfo);
-
                         }
                         diagnostics.add(diagnostic);
                     }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1035,6 +1035,10 @@
         "category": "Error",
         "code": 1355
     },
+    "Did you mean to mark this function as 'async'?": {
+        "category": "Error",
+        "code": 1356
+    },
 
     "Duplicate identifier '{0}'.": {
         "category": "Error",
@@ -2959,7 +2963,7 @@
         "category": "Error",
         "code": 4104
     },
-    
+
     "The current host does not support the '{0}' option.": {
         "category": "Error",
         "code": 5001

--- a/tests/baselines/reference/awaitInNonAsyncFunction.errors.txt
+++ b/tests/baselines/reference/awaitInNonAsyncFunction.errors.txt
@@ -1,0 +1,103 @@
+tests/cases/compiler/awaitInNonAsyncFunction.ts(4,7): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(5,10): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(9,7): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(10,10): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(14,7): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(15,3): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(19,7): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(20,10): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(24,7): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(25,9): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(30,9): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(31,5): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(34,7): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(35,5): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(39,5): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(40,1): error TS1308: 'await' expression is only allowed within an async function.
+
+
+==== tests/cases/compiler/awaitInNonAsyncFunction.ts (16 errors) ====
+    // https://github.com/Microsoft/TypeScript/issues/26586
+    
+    function normalFunc(p: Promise<number>) {
+      for await (const _ of []);
+          ~~~~~
+!!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:3:10: Did you mean to mark this function as 'async'?
+      return await p;
+             ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:3:10: Did you mean to mark this function as 'async'?
+    }
+    
+    export function exportedFunc(p: Promise<number>) {
+      for await (const _ of []);
+          ~~~~~
+!!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:8:17: Did you mean to mark this function as 'async'?
+      return await p;
+             ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:8:17: Did you mean to mark this function as 'async'?
+    }
+    
+    const functionExpression = function(p: Promise<number>) {
+      for await (const _ of []);
+          ~~~~~
+!!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:13:28: Did you mean to mark this function as 'async'?
+      await p;
+      ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:13:28: Did you mean to mark this function as 'async'?
+    }
+    
+    const arrowFunc = (p: Promise<number>) => {
+      for await (const _ of []);
+          ~~~~~
+!!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:18:19: Did you mean to mark this function as 'async'?
+      return await p;
+             ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:18:19: Did you mean to mark this function as 'async'?
+    };
+    
+    function* generatorFunc(p: Promise<number>) {
+      for await (const _ of []);
+          ~~~~~
+!!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:23:11: Did you mean to mark this function as 'async'?
+      yield await p;
+            ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:23:11: Did you mean to mark this function as 'async'?
+    }
+    
+    class clazz {
+      constructor(p: Promise<number>) {
+        for await (const _ of []);
+            ~~~~~
+!!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+        await p;
+        ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+      }
+      method(p: Promise<number>) {
+      for await (const _ of []);
+          ~~~~~
+!!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:33:3: Did you mean to mark this function as 'async'?
+        await p;
+        ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitInNonAsyncFunction.ts:33:3: Did you mean to mark this function as 'async'?
+      }
+    }
+    
+    for await (const _ of []);
+        ~~~~~
+!!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+    await null;
+    ~~~~~
+!!! error TS1308: 'await' expression is only allowed within an async function.

--- a/tests/baselines/reference/awaitInNonAsyncFunction.js
+++ b/tests/baselines/reference/awaitInNonAsyncFunction.js
@@ -1,0 +1,84 @@
+//// [awaitInNonAsyncFunction.ts]
+// https://github.com/Microsoft/TypeScript/issues/26586
+
+function normalFunc(p: Promise<number>) {
+  for await (const _ of []);
+  return await p;
+}
+
+export function exportedFunc(p: Promise<number>) {
+  for await (const _ of []);
+  return await p;
+}
+
+const functionExpression = function(p: Promise<number>) {
+  for await (const _ of []);
+  await p;
+}
+
+const arrowFunc = (p: Promise<number>) => {
+  for await (const _ of []);
+  return await p;
+};
+
+function* generatorFunc(p: Promise<number>) {
+  for await (const _ of []);
+  yield await p;
+}
+
+class clazz {
+  constructor(p: Promise<number>) {
+    for await (const _ of []);
+    await p;
+  }
+  method(p: Promise<number>) {
+  for await (const _ of []);
+    await p;
+  }
+}
+
+for await (const _ of []);
+await null;
+
+//// [awaitInNonAsyncFunction.js]
+// https://github.com/Microsoft/TypeScript/issues/26586
+function normalFunc(p) {
+    for await (const _ of [])
+        ;
+    return await p;
+}
+export function exportedFunc(p) {
+    for await (const _ of [])
+        ;
+    return await p;
+}
+const functionExpression = function (p) {
+    for await (const _ of [])
+        ;
+    await p;
+};
+const arrowFunc = (p) => {
+    for await (const _ of [])
+        ;
+    return await p;
+};
+function* generatorFunc(p) {
+    for await (const _ of [])
+        ;
+    yield await p;
+}
+class clazz {
+    constructor(p) {
+        for await (const _ of [])
+            ;
+        await p;
+    }
+    method(p) {
+        for await (const _ of [])
+            ;
+        await p;
+    }
+}
+for await (const _ of [])
+    ;
+await null;

--- a/tests/baselines/reference/awaitInNonAsyncFunction.symbols
+++ b/tests/baselines/reference/awaitInNonAsyncFunction.symbols
@@ -1,0 +1,94 @@
+=== tests/cases/compiler/awaitInNonAsyncFunction.ts ===
+// https://github.com/Microsoft/TypeScript/issues/26586
+
+function normalFunc(p: Promise<number>) {
+>normalFunc : Symbol(normalFunc, Decl(awaitInNonAsyncFunction.ts, 0, 0))
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 2, 20))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+  for await (const _ of []);
+>_ : Symbol(_, Decl(awaitInNonAsyncFunction.ts, 3, 18))
+
+  return await p;
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 2, 20))
+}
+
+export function exportedFunc(p: Promise<number>) {
+>exportedFunc : Symbol(exportedFunc, Decl(awaitInNonAsyncFunction.ts, 5, 1))
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 7, 29))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+  for await (const _ of []);
+>_ : Symbol(_, Decl(awaitInNonAsyncFunction.ts, 8, 18))
+
+  return await p;
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 7, 29))
+}
+
+const functionExpression = function(p: Promise<number>) {
+>functionExpression : Symbol(functionExpression, Decl(awaitInNonAsyncFunction.ts, 12, 5))
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 12, 36))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+  for await (const _ of []);
+>_ : Symbol(_, Decl(awaitInNonAsyncFunction.ts, 13, 18))
+
+  await p;
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 12, 36))
+}
+
+const arrowFunc = (p: Promise<number>) => {
+>arrowFunc : Symbol(arrowFunc, Decl(awaitInNonAsyncFunction.ts, 17, 5))
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 17, 19))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+  for await (const _ of []);
+>_ : Symbol(_, Decl(awaitInNonAsyncFunction.ts, 18, 18))
+
+  return await p;
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 17, 19))
+
+};
+
+function* generatorFunc(p: Promise<number>) {
+>generatorFunc : Symbol(generatorFunc, Decl(awaitInNonAsyncFunction.ts, 20, 2))
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 22, 24))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+  for await (const _ of []);
+>_ : Symbol(_, Decl(awaitInNonAsyncFunction.ts, 23, 18))
+
+  yield await p;
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 22, 24))
+}
+
+class clazz {
+>clazz : Symbol(clazz, Decl(awaitInNonAsyncFunction.ts, 25, 1))
+
+  constructor(p: Promise<number>) {
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 28, 14))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+    for await (const _ of []);
+>_ : Symbol(_, Decl(awaitInNonAsyncFunction.ts, 29, 20))
+
+    await p;
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 28, 14))
+  }
+  method(p: Promise<number>) {
+>method : Symbol(clazz.method, Decl(awaitInNonAsyncFunction.ts, 31, 3))
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 32, 9))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2018.promise.d.ts, --, --))
+
+  for await (const _ of []);
+>_ : Symbol(_, Decl(awaitInNonAsyncFunction.ts, 33, 18))
+
+    await p;
+>p : Symbol(p, Decl(awaitInNonAsyncFunction.ts, 32, 9))
+  }
+}
+
+for await (const _ of []);
+>_ : Symbol(_, Decl(awaitInNonAsyncFunction.ts, 38, 16))
+
+await null;

--- a/tests/baselines/reference/awaitInNonAsyncFunction.types
+++ b/tests/baselines/reference/awaitInNonAsyncFunction.types
@@ -1,0 +1,108 @@
+=== tests/cases/compiler/awaitInNonAsyncFunction.ts ===
+// https://github.com/Microsoft/TypeScript/issues/26586
+
+function normalFunc(p: Promise<number>) {
+>normalFunc : (p: Promise<number>) => number
+>p : Promise<number>
+
+  for await (const _ of []);
+>_ : any
+>[] : undefined[]
+
+  return await p;
+>await p : number
+>p : Promise<number>
+}
+
+export function exportedFunc(p: Promise<number>) {
+>exportedFunc : (p: Promise<number>) => number
+>p : Promise<number>
+
+  for await (const _ of []);
+>_ : any
+>[] : undefined[]
+
+  return await p;
+>await p : number
+>p : Promise<number>
+}
+
+const functionExpression = function(p: Promise<number>) {
+>functionExpression : (p: Promise<number>) => void
+>function(p: Promise<number>) {  for await (const _ of []);  await p;} : (p: Promise<number>) => void
+>p : Promise<number>
+
+  for await (const _ of []);
+>_ : any
+>[] : undefined[]
+
+  await p;
+>await p : number
+>p : Promise<number>
+}
+
+const arrowFunc = (p: Promise<number>) => {
+>arrowFunc : (p: Promise<number>) => number
+>(p: Promise<number>) => {  for await (const _ of []);  return await p;} : (p: Promise<number>) => number
+>p : Promise<number>
+
+  for await (const _ of []);
+>_ : any
+>[] : undefined[]
+
+  return await p;
+>await p : number
+>p : Promise<number>
+
+};
+
+function* generatorFunc(p: Promise<number>) {
+>generatorFunc : (p: Promise<number>) => IterableIterator<number>
+>p : Promise<number>
+
+  for await (const _ of []);
+>_ : any
+>[] : undefined[]
+
+  yield await p;
+>yield await p : any
+>await p : number
+>p : Promise<number>
+}
+
+class clazz {
+>clazz : clazz
+
+  constructor(p: Promise<number>) {
+>p : Promise<number>
+
+    for await (const _ of []);
+>_ : any
+>[] : undefined[]
+
+    await p;
+>await p : number
+>p : Promise<number>
+  }
+  method(p: Promise<number>) {
+>method : (p: Promise<number>) => void
+>p : Promise<number>
+
+  for await (const _ of []);
+>_ : any
+>[] : undefined[]
+
+    await p;
+>await p : number
+>p : Promise<number>
+  }
+}
+
+for await (const _ of []);
+>_ : any
+>[] : undefined[]
+
+await null;
+>await null : null
+>null : null
+

--- a/tests/baselines/reference/awaitLiteralValues.errors.txt
+++ b/tests/baselines/reference/awaitLiteralValues.errors.txt
@@ -11,35 +11,41 @@ tests/cases/compiler/awaitLiteralValues.ts(22,5): error TS1308: 'await' expressi
         await 'literal';
         ~~~~~
 !!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitLiteralValues.ts:1:10: Did you mean to mark this function as 'async'?
     }
     
     function awaitNumber() {
         await 1;
         ~~~~~
 !!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitLiteralValues.ts:5:10: Did you mean to mark this function as 'async'?
     }
     
     function awaitTrue() {
         await true;
         ~~~~~
 !!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitLiteralValues.ts:9:10: Did you mean to mark this function as 'async'?
     }
     
     function awaitFalse() {
         await false;
         ~~~~~
 !!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitLiteralValues.ts:13:10: Did you mean to mark this function as 'async'?
     }
     
     function awaitNull() {
         await null;
         ~~~~~
 !!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitLiteralValues.ts:17:10: Did you mean to mark this function as 'async'?
     }
     
     function awaitUndefined() {
         await undefined;
         ~~~~~
 !!! error TS1308: 'await' expression is only allowed within an async function.
+!!! related TS1356 tests/cases/compiler/awaitLiteralValues.ts:21:10: Did you mean to mark this function as 'async'?
     }
     

--- a/tests/baselines/reference/parser.forAwait.es2018.errors.txt
+++ b/tests/baselines/reference/parser.forAwait.es2018.errors.txt
@@ -52,6 +52,7 @@ tests/cases/conformance/parser/ecmascript2018/forAwait/topLevelWithExprIsError.t
         for await (const x of y) {
             ~~~~~
 !!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/conformance/parser/ecmascript2018/forAwait/inFunctionDeclWithDeclIsError.ts:1:10: Did you mean to mark this function as 'async'?
         }
     }
 ==== tests/cases/conformance/parser/ecmascript2018/forAwait/inFunctionDeclWithExprIsError.ts (1 errors) ====
@@ -60,6 +61,7 @@ tests/cases/conformance/parser/ecmascript2018/forAwait/topLevelWithExprIsError.t
         for await (x of y) {
             ~~~~~
 !!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/conformance/parser/ecmascript2018/forAwait/inFunctionDeclWithExprIsError.ts:1:10: Did you mean to mark this function as 'async'?
         }
     }
 ==== tests/cases/conformance/parser/ecmascript2018/forAwait/inAsyncFunctionWithDeclIsOk.ts (0 errors) ====
@@ -92,6 +94,7 @@ tests/cases/conformance/parser/ecmascript2018/forAwait/topLevelWithExprIsError.t
         for await (const x of y) {
             ~~~~~
 !!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/conformance/parser/ecmascript2018/forAwait/inGeneratorWithDeclIsError.ts:1:11: Did you mean to mark this function as 'async'?
         }
     }
 ==== tests/cases/conformance/parser/ecmascript2018/forAwait/inGeneratorWithExprIsError.ts (1 errors) ====
@@ -100,6 +103,7 @@ tests/cases/conformance/parser/ecmascript2018/forAwait/topLevelWithExprIsError.t
         for await (x of y) {
             ~~~~~
 !!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
+!!! related TS1356 tests/cases/conformance/parser/ecmascript2018/forAwait/inGeneratorWithExprIsError.ts:1:11: Did you mean to mark this function as 'async'?
         }
     }
     

--- a/tests/cases/compiler/awaitInNonAsyncFunction.ts
+++ b/tests/cases/compiler/awaitInNonAsyncFunction.ts
@@ -1,0 +1,41 @@
+// @target: esnext
+// https://github.com/Microsoft/TypeScript/issues/26586
+
+function normalFunc(p: Promise<number>) {
+  for await (const _ of []);
+  return await p;
+}
+
+export function exportedFunc(p: Promise<number>) {
+  for await (const _ of []);
+  return await p;
+}
+
+const functionExpression = function(p: Promise<number>) {
+  for await (const _ of []);
+  await p;
+}
+
+const arrowFunc = (p: Promise<number>) => {
+  for await (const _ of []);
+  return await p;
+};
+
+function* generatorFunc(p: Promise<number>) {
+  for await (const _ of []);
+  yield await p;
+}
+
+class clazz {
+  constructor(p: Promise<number>) {
+    for await (const _ of []);
+    await p;
+  }
+  method(p: Promise<number>) {
+  for await (const _ of []);
+    await p;
+  }
+}
+
+for await (const _ of []);
+await null;


### PR DESCRIPTION
As suggested in #26586, this PR adds to such an error a related span which points to its enclosing (non-async) function.



## Example
```ts
// test.ts
function foo() {
  await null;

  for await (const _ of []);
}
```

**Previous behavior:**

```
test.ts:2:3 - error TS1308: 'await' expression is only allowed within an async function.

2   await null;
    ~~~~~

test.ts:4:7 - error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.

4   for await (const _ of []);
        ~~~~~


Found 2 errors.
```

**New behavior:**

```
test.ts:2:3 - error TS1308: 'await' expression is only allowed within an async function.

2   await null;
    ~~~~~

  test.ts:1:10
    1 function foo() {
               ~~~
    Did you mean to mark this function as 'async'?

test.ts:4:7 - error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.

4   for await (const _ of []);
        ~~~~~

  test.ts:1:10
    1 function foo() {
               ~~~
    Did you mean to mark this function as 'async'?


Found 2 errors.
```


Fixes #26586
