### PR TITLE
Don't pass a candidates array to getResolvedSignature

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -171,8 +171,7 @@ namespace ts.SymbolDisplay {
             }
 
             if (callExpressionLike) {
-                const candidateSignatures: Signature[] = [];
-                signature = typeChecker.getResolvedSignature(callExpressionLike, candidateSignatures)!; // TODO: GH#18217
+                signature = typeChecker.getResolvedSignature(callExpressionLike)!; // TODO: GH#18217
 
                 const useConstructSignatures = callExpressionLike.kind === SyntaxKind.NewExpression || (isCallExpression(callExpressionLike) && callExpressionLike.expression.kind === SyntaxKind.SuperKeyword);
 


### PR DESCRIPTION
Found when investigating #30505 (does not fix the bug; ignore the branch name)
