### PR TITLE
Decrement line ends if they end with a carriage return.

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -91,7 +91,7 @@ namespace ts.OutliningElementsCollector {
                 const region = regions.pop();
                 if (region) {
                     region.textSpan.length = lineEnd - region.textSpan.start;
-                    region.textSpan.length = lineEnd - region.textSpan.start;
+                    region.hintSpan.length = lineEnd - region.textSpan.start;
                     out.push(region);
                 }
             }

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -71,8 +71,7 @@ namespace ts.OutliningElementsCollector {
     function addRegionOutliningSpans(sourceFile: SourceFile, out: Push<OutliningSpan>): void {
         const regions: OutliningSpan[] = [];
         const lineStarts = sourceFile.getLineStarts();
-        for (let i = 0; i < lineStarts.length; i++) {
-            const currentLineStart = lineStarts[i];
+        for (const currentLineStart of lineStarts) {
             const lineEnd = sourceFile.getLineEndOfPosition(currentLineStart);
             const lineText = sourceFile.text.substring(currentLineStart, lineEnd);
             const result = isRegionDelimiter(lineText);

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -81,21 +81,22 @@ namespace ts.OutliningElementsCollector {
             }
 
             if (!result[1]) {
-                const span = createTextSpanFromBounds(sourceFile.text.indexOf("//", currentLineStart), lineEnd);
+                const span = createTextSpanFromBounds(sourceFile.text.indexOf("//", currentLineStart), result[3] ? lineEnd - 1 : lineEnd);
                 regions.push(createOutliningSpan(span, OutliningSpanKind.Region, span, /*autoCollapse*/ false, result[2] || "#region"));
             }
             else {
                 const region = regions.pop();
                 if (region) {
-                    region.textSpan.length = lineEnd - region.textSpan.start;
-                    region.hintSpan.length = lineEnd - region.textSpan.start;
+                    region.textSpan.length = result[3] ? (lineEnd - 1) - region.textSpan.start : lineEnd - region.textSpan.start;
+                    region.hintSpan.length = result[3] ? (lineEnd - 1) - region.textSpan.start : lineEnd - region.textSpan.start;
                     out.push(region);
                 }
             }
         }
     }
 
-    const regionDelimiterRegExp = /^\s*\/\/\s*#(end)?region(?:\s+(.*))?(?:\r)?$/;
+    // [^\S\r\n]+ match any whitespace that is not \r \n. Note that we probably should not see \n here.
+    const regionDelimiterRegExp = /^\s*\/\/\s*#(end)?region(?:[^\S\r\n]+(.*))?(\r)?$/;
     function isRegionDelimiter(lineText: string) {
         return regionDelimiterRegExp.exec(lineText);
     }

--- a/src/testRunner/unittests/services/hostNewLineSupport.ts
+++ b/src/testRunner/unittests/services/hostNewLineSupport.ts
@@ -38,12 +38,34 @@ namespace ts {
             verifyNewLines(content, { newLine: NewLineKind.LineFeed });
         }
 
+        function verifyOutliningSpanNewLines(content: string, options: CompilerOptions) {
+            const ls = testLSWithFiles(options, [{
+                content,
+                fileOptions: {},
+                unitName: "input.ts"
+            }]);
+            const span = ls.getOutliningSpans("input.ts")[0];
+            const textAfterSpanCollapse = content.substring(span.textSpan.start + span.textSpan.length);
+            assert(textAfterSpanCollapse.match(options.newLine === NewLineKind.CarriageReturnLineFeed ? /\r\n/ : /[^\r]\n/), "expected to find appropriate newlines");
+            assert(!textAfterSpanCollapse.match(options.newLine === NewLineKind.CarriageReturnLineFeed ? /[^\r]\n/ : /\r\n/), "expected not to find inappropriate newlines");
+        }
+
         it("should exist and respect provided compiler options", () => {
             verifyBothNewLines(`
                 function foo() {
                     return 2 + 2;
                 }
             `);
+        });
+
+        it("should respect CRLF line endings around outlining spans", () => {
+            verifyOutliningSpanNewLines("// comment not included\r\n// #region name\r\nlet x = \"x\";\r\n// #endregion name\r\n",
+            { newLine: NewLineKind.CarriageReturnLineFeed });
+        });
+
+        it("should respect LF line endings around outlining spans", () => {
+            verifyOutliningSpanNewLines("// comment not included\n// #region name\nlet x = \"x\";\n// #endregion name\n\n",
+            { newLine: NewLineKind.LineFeed });
         });
     });
 }

--- a/src/testRunner/unittests/services/hostNewLineSupport.ts
+++ b/src/testRunner/unittests/services/hostNewLineSupport.ts
@@ -59,12 +59,12 @@ namespace ts {
         });
 
         it("should respect CRLF line endings around outlining spans", () => {
-            verifyOutliningSpanNewLines("// comment not included\r\n// #region name\r\nlet x = \"x\";\r\n// #endregion name\r\n",
+            verifyOutliningSpanNewLines("// comment not included\r\n// #region name\r\nlet x: string = \"x\";\r\n// #endregion name\r\n",
             { newLine: NewLineKind.CarriageReturnLineFeed });
         });
 
         it("should respect LF line endings around outlining spans", () => {
-            verifyOutliningSpanNewLines("// comment not included\n// #region name\nlet x = \"x\";\n// #endregion name\n\n",
+            verifyOutliningSpanNewLines("// comment not included\n// #region name\nlet x: string = \"x\";\n// #endregion name\n\n",
             { newLine: NewLineKind.LineFeed });
         });
     });


### PR DESCRIPTION
Attempting to enter a newline after the ```#name``` banner in the collapsed region depicted below causes a crash in Visual Studio.

```ts
//#region name

const a = 1;

//#endregion
```

```ts
//#name
```

Previously the carriage return character ```\r``` was being included in the outlining span, as line ends here are determined only by the presence of the new line character ```\n```.

This change simply decrements the line end by one if the line ends with a carriage return ```\r```.


Fixes [JS region collapse area after carriage return](https://developercommunity.visualstudio.com/content/problem/539812/js-region-%E6%8A%98%E5%8F%A0%E5%8C%BA%E5%9F%9F%E5%90%8E%E5%9B%9E%E8%BD%A6-%E6%97%A0%E6%95%88-%E8%BF%98%E5%8F%AF%E8%83%BD%E4%BC%9A%E5%BC%95%E8%B5%B7%E4%BB%A3%E7%A0%81%E9%94%99%E4%B9%B1.html).
