### PR TITLE
fix parsing of leading union/intersection operator

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3124,15 +3124,16 @@ namespace ts {
         }
 
         function parseUnionOrIntersectionType(kind: SyntaxKind.UnionType | SyntaxKind.IntersectionType, parseConstituentType: () => TypeNode, operator: SyntaxKind.BarToken | SyntaxKind.AmpersandToken): TypeNode {
-            parseOptional(operator);
+            const start = scanner.getStartPos();
+            const hasLeadingOperator = parseOptional(operator);
             let type = parseConstituentType();
-            if (token() === operator) {
+            if (token() === operator || hasLeadingOperator) {
                 const types = [type];
                 while (parseOptional(operator)) {
                     types.push(parseConstituentType());
                 }
-                const node = <UnionOrIntersectionTypeNode>createNode(kind, type.pos);
-                node.types = createNodeArray(types, type.pos);
+                const node = <UnionOrIntersectionTypeNode>createNode(kind, start);
+                node.types = createNodeArray(types, start);
                 type = finishNode(node);
             }
             return type;

--- a/src/testRunner/unittests/jsDocParsing.ts
+++ b/src/testRunner/unittests/jsDocParsing.ts
@@ -37,6 +37,8 @@ namespace ts {
                 parsesCorrectly("callSignatureInRecordType", "{{(): number}}");
                 parsesCorrectly("methodInRecordType", "{{foo(): number}}");
                 parsesCorrectly("unionType", "{(number|string)}");
+                parsesCorrectly("unionTypeWithLeadingOperator", "{( | number | string )}");
+                parsesCorrectly("unionTypeWithOneElementAndLeadingOperator", "{( | number )}");
                 parsesCorrectly("topLevelNoParenUnionType", "{number|string}");
                 parsesCorrectly("functionType1", "{function()}");
                 parsesCorrectly("functionType2", "{function(string, boolean)}");

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.unionTypeWithLeadingOperator.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.unionTypeWithLeadingOperator.json
@@ -1,0 +1,37 @@
+{
+    "kind": "ParenthesizedType",
+    "pos": 1,
+    "end": 22,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "type": {
+        "kind": "UnionType",
+        "pos": 2,
+        "end": 20,
+        "flags": "JSDoc",
+        "modifierFlagsCache": 0,
+        "transformFlags": 0,
+        "types": {
+            "0": {
+                "kind": "NumberKeyword",
+                "pos": 4,
+                "end": 11,
+                "flags": "JSDoc",
+                "modifierFlagsCache": 0,
+                "transformFlags": 0
+            },
+            "1": {
+                "kind": "StringKeyword",
+                "pos": 13,
+                "end": 20,
+                "flags": "JSDoc",
+                "modifierFlagsCache": 0,
+                "transformFlags": 0
+            },
+            "length": 2,
+            "pos": 2,
+            "end": 20
+        }
+    }
+}

--- a/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.unionTypeWithOneElementAndLeadingOperator.json
+++ b/tests/baselines/reference/JSDocParsing/TypeExpressions.parsesCorrectly.unionTypeWithOneElementAndLeadingOperator.json
@@ -1,0 +1,29 @@
+{
+    "kind": "ParenthesizedType",
+    "pos": 1,
+    "end": 13,
+    "flags": "JSDoc",
+    "modifierFlagsCache": 0,
+    "transformFlags": 0,
+    "type": {
+        "kind": "UnionType",
+        "pos": 2,
+        "end": 11,
+        "flags": "JSDoc",
+        "modifierFlagsCache": 0,
+        "transformFlags": 0,
+        "types": {
+            "0": {
+                "kind": "NumberKeyword",
+                "pos": 4,
+                "end": 11,
+                "flags": "JSDoc",
+                "modifierFlagsCache": 0,
+                "transformFlags": 0
+            },
+            "length": 1,
+            "pos": 2,
+            "end": 11
+        }
+    }
+}

--- a/tests/baselines/reference/unionTypeWithLeadingOperator.js
+++ b/tests/baselines/reference/unionTypeWithLeadingOperator.js
@@ -6,5 +6,15 @@ type B =
 
 type C = [| 0 | 1, | "foo" | "bar"];
 
+export type D = 
+  /*leading0*/
+  | /*leading1*/ 1 /*trailing1*/ 
+  | /*leading2*/ 2 /*trailing2*/;
 
 //// [unionTypeWithLeadingOperator.js]
+"use strict";
+exports.__esModule = true;
+
+
+//// [unionTypeWithLeadingOperator.d.ts]
+export declare type D = /*leading1*/ 1 | /*leading2*/ 2;

--- a/tests/baselines/reference/unionTypeWithLeadingOperator.symbols
+++ b/tests/baselines/reference/unionTypeWithLeadingOperator.symbols
@@ -14,3 +14,9 @@ type B =
 type C = [| 0 | 1, | "foo" | "bar"];
 >C : Symbol(C, Decl(unionTypeWithLeadingOperator.ts, 3, 26))
 
+export type D = 
+>D : Symbol(D, Decl(unionTypeWithLeadingOperator.ts, 5, 36))
+
+  /*leading0*/
+  | /*leading1*/ 1 /*trailing1*/ 
+  | /*leading2*/ 2 /*trailing2*/;

--- a/tests/baselines/reference/unionTypeWithLeadingOperator.types
+++ b/tests/baselines/reference/unionTypeWithLeadingOperator.types
@@ -14,3 +14,9 @@ type B =
 type C = [| 0 | 1, | "foo" | "bar"];
 >C : [0 | 1, "foo" | "bar"]
 
+export type D = 
+>D : D
+
+  /*leading0*/
+  | /*leading1*/ 1 /*trailing1*/ 
+  | /*leading2*/ 2 /*trailing2*/;

--- a/tests/cases/compiler/unionTypeWithLeadingOperator.ts
+++ b/tests/cases/compiler/unionTypeWithLeadingOperator.ts
@@ -1,6 +1,12 @@
+// @declaration: true
 type A = | string;
 type B =
   | { type: "INCREMENT" }
   | { type: "DECREMENT" };
 
 type C = [| 0 | 1, | "foo" | "bar"];
+
+export type D = 
+  /*leading0*/
+  | /*leading1*/ 1 /*trailing1*/ 
+  | /*leading2*/ 2 /*trailing2*/;


### PR DESCRIPTION
Fixes: #30995

A leading `|` or `&` is now part of the union/intersection type's range.
If there's a leading operator and only one constituent type, we still parse a union/intersection type.
