### PR TITLE
parseProjectReferenceConfigFile: always set SourceFile.path

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2688,6 +2688,7 @@ namespace ts {
                     return undefined;
                 }
                 sourceFile = Debug.assertDefined(commandLine.options.configFile);
+                Debug.assert(!sourceFile.path || sourceFile.path === sourceFilePath);
                 addFileToFilesByName(sourceFile, sourceFilePath, /*redirectedPath*/ undefined);
             }
             else {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2699,11 +2699,12 @@ namespace ts {
                     projectReferenceRedirects.set(sourceFilePath, false);
                     return undefined;
                 }
-                sourceFile.path = sourceFilePath;
-                sourceFile.resolvedPath = sourceFilePath;
-                sourceFile.originalFileName = refPath;
                 commandLine = parseJsonSourceFileConfigFileContent(sourceFile, configParsingHost, basePath, /*existingOptions*/ undefined, refPath);
             }
+            sourceFile.path = sourceFilePath;
+            sourceFile.resolvedPath = sourceFilePath;
+            sourceFile.originalFileName = refPath;
+
             const resolvedRef: ResolvedProjectReference = { commandLine, sourceFile };
             projectReferenceRedirects.set(sourceFilePath, resolvedRef);
             if (commandLine.projectReferences) {


### PR DESCRIPTION
Fixes: #31218

Is this the correct fix for the issue?
And what's the best way to test this? Create a unittest that basically contains https://github.com/ajafff/ts-31218