### PR TITLE
Fix error message regressed by #30916

### DIFF
--- a/tests/baselines/reference/assigningFunctionToTupleIssuesError.errors.txt
+++ b/tests/baselines/reference/assigningFunctionToTupleIssuesError.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/assigningFunctionToTupleIssuesError.ts(2,5): error TS2322: Type '() => void' is not assignable to type '[string]'.
+
+
+==== tests/cases/compiler/assigningFunctionToTupleIssuesError.ts (1 errors) ====
+    declare let a: () => void;
+    let b: [string] = a;
+        ~
+!!! error TS2322: Type '() => void' is not assignable to type '[string]'.

--- a/tests/baselines/reference/assigningFunctionToTupleIssuesError.js
+++ b/tests/baselines/reference/assigningFunctionToTupleIssuesError.js
@@ -1,0 +1,6 @@
+//// [assigningFunctionToTupleIssuesError.ts]
+declare let a: () => void;
+let b: [string] = a;
+
+//// [assigningFunctionToTupleIssuesError.js]
+var b = a;

--- a/tests/baselines/reference/assigningFunctionToTupleIssuesError.symbols
+++ b/tests/baselines/reference/assigningFunctionToTupleIssuesError.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/assigningFunctionToTupleIssuesError.ts ===
+declare let a: () => void;
+>a : Symbol(a, Decl(assigningFunctionToTupleIssuesError.ts, 0, 11))
+
+let b: [string] = a;
+>b : Symbol(b, Decl(assigningFunctionToTupleIssuesError.ts, 1, 3))
+>a : Symbol(a, Decl(assigningFunctionToTupleIssuesError.ts, 0, 11))
+

--- a/tests/baselines/reference/assigningFunctionToTupleIssuesError.types
+++ b/tests/baselines/reference/assigningFunctionToTupleIssuesError.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/assigningFunctionToTupleIssuesError.ts ===
+declare let a: () => void;
+>a : () => void
+
+let b: [string] = a;
+>b : [string]
+>a : () => void
+

--- a/tests/cases/compiler/assigningFunctionToTupleIssuesError.ts
+++ b/tests/cases/compiler/assigningFunctionToTupleIssuesError.ts
@@ -1,0 +1,2 @@
+declare let a: () => void;
+let b: [string] = a;


### PR DESCRIPTION
Fixes #31271

`overrideNextErrorInfo` is now, rather than a boolean, a union of a message chain or `undefined`, this way you can only actually set it when there's already a diagnostic message queue'd up, so the same small error introduced in #30916 (a previously exhaustive error-elaboration codepath became non-exhaustive) can't be reintroduced.