### PR TITLE
Improve error messages when indexing into a type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10046,7 +10046,7 @@ namespace ts {
             return false;
         }
 
-        function getPropertyTypeForIndexType(originalObjectType: Type, objectType: Type, indexType: Type, accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression | undefined, accessFlags: AccessFlags) {
+        function getPropertyTypeForIndexType(originalObjectType: Type, objectType: Type, indexType: Type, fullIndexType: Type, accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression | undefined, accessFlags: AccessFlags) {
             const accessExpression = accessNode && accessNode.kind === SyntaxKind.ElementAccessExpression ? accessNode : undefined;
             const propName = isTypeUsableAsPropertyName(indexType) ?
                 getPropertyNameFromType(indexType) :
@@ -10145,7 +10145,16 @@ namespace ts {
                                     error(accessExpression, Diagnostics.Element_implicitly_has_an_any_type_because_type_0_has_no_index_signature_Did_you_mean_to_call_1, typeToString(objectType), suggestion);
                                 }
                                 else {
-                                    error(accessExpression, Diagnostics.Element_implicitly_has_an_any_type_because_type_0_has_no_index_signature, typeToString(objectType));
+                                    let errorInfo =
+                                        (indexType.flags & TypeFlags.StringLiteral) ? chainDiagnosticMessages(/* details */ undefined, Diagnostics.Property_0_does_not_exist_on_type_1, (indexType as StringLiteralType).value, typeToString(objectType)) :
+                                        (indexType.flags & TypeFlags.NumberLiteral) ? chainDiagnosticMessages(/* details */ undefined, Diagnostics.Property_0_does_not_exist_on_type_1, (indexType as NumberLiteralType).value, typeToString(objectType)) :
+                                        undefined;
+
+                                    errorInfo = chainDiagnosticMessages(
+                                        errorInfo,
+                                        Diagnostics.Element_implicitly_has_an_any_type_because_expression_of_type_0_can_t_be_used_to_index_type_1, typeToString(fullIndexType), typeToString(objectType)
+                                    );
+                                    diagnostics.add(createDiagnosticForNodeFromMessageChain(accessExpression, errorInfo));
                                 }
                             }
                         }
@@ -10300,7 +10309,7 @@ namespace ts {
                 const propTypes: Type[] = [];
                 let wasMissingProp = false;
                 for (const t of (<UnionType>indexType).types) {
-                    const propType = getPropertyTypeForIndexType(objectType, apparentObjectType, t, accessNode, accessFlags);
+                    const propType = getPropertyTypeForIndexType(objectType, apparentObjectType, t, indexType, accessNode, accessFlags);
                     if (propType) {
                         propTypes.push(propType);
                     }
@@ -10318,7 +10327,7 @@ namespace ts {
                 }
                 return accessFlags & AccessFlags.Writing ? getIntersectionType(propTypes) : getUnionType(propTypes);
             }
-            return getPropertyTypeForIndexType(objectType, apparentObjectType, indexType, accessNode, accessFlags | AccessFlags.CacheSymbol);
+            return getPropertyTypeForIndexType(objectType, apparentObjectType, indexType, indexType, accessNode, accessFlags | AccessFlags.CacheSymbol);
         }
 
         function getTypeFromIndexedAccessTypeNode(node: IndexedAccessTypeNode) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10046,7 +10046,7 @@ namespace ts {
             return false;
         }
 
-        function getPropertyTypeForIndexType(originalObjectType: Type, objectType: Type, indexType: Type, fullIndexType: Type, supressNoImplicitAnyError: boolean, accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression | undefined, accessFlags: AccessFlags) {
+        function getPropertyTypeForIndexType(originalObjectType: Type, objectType: Type, indexType: Type, fullIndexType: Type, suppressNoImplicitAnyError: boolean, accessNode: ElementAccessExpression | IndexedAccessTypeNode | PropertyName | BindingName | SyntheticExpression | undefined, accessFlags: AccessFlags) {
             const accessExpression = accessNode && accessNode.kind === SyntaxKind.ElementAccessExpression ? accessNode : undefined;
             const propName = isTypeUsableAsPropertyName(indexType) ?
                 getPropertyNameFromType(indexType) :
@@ -10125,7 +10125,7 @@ namespace ts {
                     if (objectType.symbol === globalThisSymbol && propName !== undefined && globalThisSymbol.exports!.has(propName) && (globalThisSymbol.exports!.get(propName)!.flags & SymbolFlags.BlockScoped)) {
                         error(accessExpression, Diagnostics.Property_0_does_not_exist_on_type_1, unescapeLeadingUnderscores(propName), typeToString(objectType));
                     }
-                    else if (noImplicitAny && !compilerOptions.suppressImplicitAnyIndexErrors && !supressNoImplicitAnyError) {
+                    else if (noImplicitAny && !compilerOptions.suppressImplicitAnyIndexErrors && !suppressNoImplicitAnyError) {
                         if (propName !== undefined && typeHasStaticProperty(propName, objectType)) {
                             error(accessExpression, Diagnostics.Property_0_is_a_static_member_of_type_1, propName as string, typeToString(objectType));
                         }
@@ -10160,7 +10160,7 @@ namespace ts {
                                         errorInfo = chainDiagnosticMessages(/* details */ undefined, Diagnostics.Property_0_does_not_exist_on_type_1, (indexType as NumberLiteralType).value, typeToString(objectType));
                                     }
                                     else if (indexType.flags & (TypeFlags.Number | TypeFlags.String)) {
-                                        errorInfo = chainDiagnosticMessages(/* details */ undefined, Diagnostics.No_index_with_a_parameter_of_type_0_was_found_on_type_1, typeToString(indexType), typeToString(objectType));
+                                        errorInfo = chainDiagnosticMessages(/* details */ undefined, Diagnostics.No_index_signature_with_a_parameter_of_type_0_was_found_on_type_1, typeToString(indexType), typeToString(objectType));
                                     }
 
                                     errorInfo = chainDiagnosticMessages(

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4284,6 +4284,10 @@
         "category": "Error",
         "code": 7052
     },
+    "Element implicitly has an 'any' type because expression of type '{0}' can't be used to index type '{1}'.": {
+        "category": "Error",
+        "code": 7053
+    },
     "You cannot rename this element.": {
         "category": "Error",
         "code": 8000

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4288,7 +4288,7 @@
         "category": "Error",
         "code": 7053
     },    
-    "No index with a parameter of type '{0}' was found on type '{1}'.": {
+    "No index signature with a parameter of type '{0}' was found on type '{1}'.": {
         "category": "Error",
         "code": 7054
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4287,6 +4287,10 @@
     "Element implicitly has an 'any' type because expression of type '{0}' can't be used to index type '{1}'.": {
         "category": "Error",
         "code": 7053
+    },    
+    "No index with a parameter of type '{0}' was found on type '{1}'.": {
+        "category": "Error",
+        "code": 7054
     },
     "You cannot rename this element.": {
         "category": "Error",

--- a/tests/baselines/reference/globalThisUnknownNoImplicitAny.errors.txt
+++ b/tests/baselines/reference/globalThisUnknownNoImplicitAny.errors.txt
@@ -2,8 +2,10 @@ tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts(4,5): error TS2
 tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts(5,6): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
 tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts(6,12): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
 tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts(8,5): error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'.
-tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts(9,1): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
-tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts(10,1): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts(9,1): error TS7053: Element implicitly has an 'any' type because expression of type '"hi"' can't be used to index type 'typeof globalThis'.
+  Property 'hi' does not exist on type 'typeof globalThis'.
+tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts(10,1): error TS7053: Element implicitly has an 'any' type because expression of type '"hi"' can't be used to index type 'typeof globalThis'.
+  Property 'hi' does not exist on type 'typeof globalThis'.
 
 
 ==== tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts (6 errors) ====
@@ -25,8 +27,10 @@ tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts(10,1): error TS
 !!! error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'.
     this['hi']
     ~~~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"hi"' can't be used to index type 'typeof globalThis'.
+!!! error TS7053:   Property 'hi' does not exist on type 'typeof globalThis'.
     globalThis['hi']
     ~~~~~~~~~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"hi"' can't be used to index type 'typeof globalThis'.
+!!! error TS7053:   Property 'hi' does not exist on type 'typeof globalThis'.
     

--- a/tests/baselines/reference/keyofAndIndexedAccess2.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccess2.errors.txt
@@ -16,7 +16,7 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(27,5): error TS232
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(31,5): error TS2322: Type '{ [key: string]: number; }' is not assignable to type '{ [P in K]: number; }'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(38,5): error TS2322: Type '{ [x: string]: number; }' is not assignable to type '{ [P in K]: number; }'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(50,3): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Item'.
-  No index with a parameter of type 'string' was found on type 'Item'.
+  No index signature with a parameter of type 'string' was found on type 'Item'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(51,3): error TS2322: Type '123' is not assignable to type 'string & number'.
   Type '123' is not assignable to type 'string'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(52,3): error TS2322: Type '123' is not assignable to type 'T[keyof T]'.
@@ -114,7 +114,7 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(108,5): error TS23
       obj[k1] = 123;  // Error
       ~~~~~~~
 !!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Item'.
-!!! error TS7053:   No index with a parameter of type 'string' was found on type 'Item'.
+!!! error TS7053:   No index signature with a parameter of type 'string' was found on type 'Item'.
       obj[k2] = 123;  // Error
       ~~~~~~~
 !!! error TS2322: Type '123' is not assignable to type 'string & number'.

--- a/tests/baselines/reference/keyofAndIndexedAccess2.errors.txt
+++ b/tests/baselines/reference/keyofAndIndexedAccess2.errors.txt
@@ -15,7 +15,8 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(26,7): error TS233
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(27,5): error TS2322: Type '1' is not assignable to type 'T[keyof T]'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(31,5): error TS2322: Type '{ [key: string]: number; }' is not assignable to type '{ [P in K]: number; }'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(38,5): error TS2322: Type '{ [x: string]: number; }' is not assignable to type '{ [P in K]: number; }'.
-tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(50,3): error TS7017: Element implicitly has an 'any' type because type 'Item' has no index signature.
+tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(50,3): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Item'.
+  No index with a parameter of type 'string' was found on type 'Item'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(51,3): error TS2322: Type '123' is not assignable to type 'string & number'.
   Type '123' is not assignable to type 'string'.
 tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(52,3): error TS2322: Type '123' is not assignable to type 'T[keyof T]'.
@@ -112,7 +113,8 @@ tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts(108,5): error TS23
     function f10<T extends Item, K extends keyof T>(obj: T, k1: string, k2: keyof Item, k3: keyof T, k4: K) {
       obj[k1] = 123;  // Error
       ~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type 'Item' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'Item'.
+!!! error TS7053:   No index with a parameter of type 'string' was found on type 'Item'.
       obj[k2] = 123;  // Error
       ~~~~~~~
 !!! error TS2322: Type '123' is not assignable to type 'string & number'.

--- a/tests/baselines/reference/noImplicitAnyForIn.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyForIn.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/noImplicitAnyForIn.ts(7,18): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-  No index with a parameter of type 'string' was found on type '{}'.
+  No index signature with a parameter of type 'string' was found on type '{}'.
 tests/cases/compiler/noImplicitAnyForIn.ts(14,18): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-  No index with a parameter of type 'string' was found on type '{}'.
+  No index signature with a parameter of type 'string' was found on type '{}'.
 tests/cases/compiler/noImplicitAnyForIn.ts(28,5): error TS7005: Variable 'n' implicitly has an 'any[][]' type.
 tests/cases/compiler/noImplicitAnyForIn.ts(30,6): error TS2405: The left-hand side of a 'for...in' statement must be of type 'string' or 'any'.
 
@@ -16,7 +16,7 @@ tests/cases/compiler/noImplicitAnyForIn.ts(30,6): error TS2405: The left-hand si
             var _j = x[i][j];
                      ~~~~~~~
 !!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-!!! error TS7053:   No index with a parameter of type 'string' was found on type '{}'.
+!!! error TS7053:   No index signature with a parameter of type 'string' was found on type '{}'.
         }
     
         for (var k in x[0]) {
@@ -26,7 +26,7 @@ tests/cases/compiler/noImplicitAnyForIn.ts(30,6): error TS2405: The left-hand si
             var k2 = k1[k];
                      ~~~~~
 !!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-!!! error TS7053:   No index with a parameter of type 'string' was found on type '{}'.
+!!! error TS7053:   No index signature with a parameter of type 'string' was found on type '{}'.
         }
     }
     

--- a/tests/baselines/reference/noImplicitAnyForIn.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyForIn.errors.txt
@@ -1,5 +1,7 @@
-tests/cases/compiler/noImplicitAnyForIn.ts(7,18): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
-tests/cases/compiler/noImplicitAnyForIn.ts(14,18): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+tests/cases/compiler/noImplicitAnyForIn.ts(7,18): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+  No index with a parameter of type 'string' was found on type '{}'.
+tests/cases/compiler/noImplicitAnyForIn.ts(14,18): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+  No index with a parameter of type 'string' was found on type '{}'.
 tests/cases/compiler/noImplicitAnyForIn.ts(28,5): error TS7005: Variable 'n' implicitly has an 'any[][]' type.
 tests/cases/compiler/noImplicitAnyForIn.ts(30,6): error TS2405: The left-hand side of a 'for...in' statement must be of type 'string' or 'any'.
 
@@ -13,7 +15,8 @@ tests/cases/compiler/noImplicitAnyForIn.ts(30,6): error TS2405: The left-hand si
             //Should yield an implicit 'any' error
             var _j = x[i][j];
                      ~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+!!! error TS7053:   No index with a parameter of type 'string' was found on type '{}'.
         }
     
         for (var k in x[0]) {
@@ -22,7 +25,8 @@ tests/cases/compiler/noImplicitAnyForIn.ts(30,6): error TS2405: The left-hand si
             //Should yield an implicit 'any' error
             var k2 = k1[k];
                      ~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+!!! error TS7053:   No index with a parameter of type 'string' was found on type '{}'.
         }
     }
     

--- a/tests/baselines/reference/noImplicitAnyIndexing.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyIndexing.errors.txt
@@ -1,7 +1,9 @@
 tests/cases/compiler/noImplicitAnyIndexing.ts(12,37): error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'.
-tests/cases/compiler/noImplicitAnyIndexing.ts(19,9): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
-tests/cases/compiler/noImplicitAnyIndexing.ts(22,9): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
-tests/cases/compiler/noImplicitAnyIndexing.ts(30,10): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+tests/cases/compiler/noImplicitAnyIndexing.ts(19,9): error TS7053: Element implicitly has an 'any' type because expression of type '"hi"' can't be used to index type '{}'.
+  Property 'hi' does not exist on type '{}'.
+tests/cases/compiler/noImplicitAnyIndexing.ts(22,9): error TS7053: Element implicitly has an 'any' type because expression of type '10' can't be used to index type '{}'.
+  Property '10' does not exist on type '{}'.
+tests/cases/compiler/noImplicitAnyIndexing.ts(30,10): error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
 
 
 ==== tests/cases/compiler/noImplicitAnyIndexing.ts (4 errors) ====
@@ -27,12 +29,14 @@ tests/cases/compiler/noImplicitAnyIndexing.ts(30,10): error TS7017: Element impl
     // Should report an implicit 'any'.
     var x = {}["hi"];
             ~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"hi"' can't be used to index type '{}'.
+!!! error TS7053:   Property 'hi' does not exist on type '{}'.
     
     // Should report an implicit 'any'.
     var y = {}[10];
             ~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '10' can't be used to index type '{}'.
+!!! error TS7053:   Property '10' does not exist on type '{}'.
     
     
     var hi: any = "hi";
@@ -42,7 +46,7 @@ tests/cases/compiler/noImplicitAnyIndexing.ts(30,10): error TS7017: Element impl
     // Should report an implicit 'any'.
     var z1 = emptyObj[hi];
              ~~~~~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'any' can't be used to index type '{}'.
     var z2 = (<any>emptyObj)[hi];
     
     interface MyMap<T> {

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.errors.txt
@@ -1,16 +1,29 @@
-tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(1,9): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(1,9): error TS7053: Element implicitly has an 'any' type because expression of type '"hello"' can't be used to index type '{}'.
+  Property 'hello' does not exist on type '{}'.
 tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(7,1): error TS7052: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'get' ?
 tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(8,13): error TS7052: Element implicitly has an 'any' type because type '{ get: (key: string) => string; }' has no index signature. Did you mean to call 'get' ?
-tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(13,13): error TS7017: Element implicitly has an 'any' type because type '{ set: (key: string) => string; }' has no index signature.
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(13,13): error TS7053: Element implicitly has an 'any' type because expression of type '"hello"' can't be used to index type '{ set: (key: string) => string; }'.
+  Property 'hello' does not exist on type '{ set: (key: string) => string; }'.
 tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(19,1): error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
 tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(20,1): error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
 tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(21,1): error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(26,1): error TS7053: Element implicitly has an 'any' type because expression of type '"a" | "b" | "c"' can't be used to index type '{ a: number; }'.
+  Property 'b' does not exist on type '{ a: number; }'.
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(30,1): error TS7053: Element implicitly has an 'any' type because expression of type '"c"' can't be used to index type '{ a: number; }'.
+  Property 'c' does not exist on type '{ a: number; }'.
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(33,1): error TS7053: Element implicitly has an 'any' type because expression of type 'unique symbol' can't be used to index type '{ a: number; }'.
+  Property '[sym]' does not exist on type '{ a: number; }'.
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(37,1): error TS7053: Element implicitly has an 'any' type because expression of type 'NumEnum' can't be used to index type '{ a: number; }'.
+  Property '[NumEnum.a]' does not exist on type '{ a: number; }'.
+tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(42,1): error TS7053: Element implicitly has an 'any' type because expression of type 'StrEnum' can't be used to index type '{ a: number; }'.
+  Property '[StrEnum.b]' does not exist on type '{ a: number; }'.
 
 
-==== tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts (7 errors) ====
+==== tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts (12 errors) ====
     var a = {}["hello"];
             ~~~~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"hello"' can't be used to index type '{}'.
+!!! error TS7053:   Property 'hello' does not exist on type '{}'.
     var b: string = { '': 'foo' }[''];
     
     var c = {
@@ -28,7 +41,8 @@ tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(21,1): error TS7052: 
     };
     const bar = d['hello'];
                 ~~~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{ set: (key: string) => string; }' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"hello"' can't be used to index type '{ set: (key: string) => string; }'.
+!!! error TS7053:   Property 'hello' does not exist on type '{ set: (key: string) => string; }'.
     
     var e = {
       set: (key: string) => 'foobar',
@@ -44,4 +58,39 @@ tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts(21,1): error TS7052: 
     ~~~~~~~~~~
 !!! error TS7052: Element implicitly has an 'any' type because type '{ set: (key: string) => string; get: (key: string) => string; }' has no index signature. Did you mean to call 'set' ?
     
+    const o = { a: 0 };
+    
+    declare const k: "a" | "b" | "c";
+    o[k];
+    ~~~~
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"a" | "b" | "c"' can't be used to index type '{ a: number; }'.
+!!! error TS7053:   Property 'b' does not exist on type '{ a: number; }'.
+    
+    
+    declare const k2: "c";
+    o[k2];
+    ~~~~~
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"c"' can't be used to index type '{ a: number; }'.
+!!! error TS7053:   Property 'c' does not exist on type '{ a: number; }'.
+    
+    declare const sym : unique symbol;
+    o[sym];
+    ~~~~~~
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'unique symbol' can't be used to index type '{ a: number; }'.
+!!! error TS7053:   Property '[sym]' does not exist on type '{ a: number; }'.
+    
+    enum NumEnum { a, b }
+    let numEnumKey: NumEnum;
+    o[numEnumKey];
+    ~~~~~~~~~~~~~
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'NumEnum' can't be used to index type '{ a: number; }'.
+!!! error TS7053:   Property '[NumEnum.a]' does not exist on type '{ a: number; }'.
+    
+    
+    enum StrEnum { a = "a", b = "b" }
+    let strEnumKey: StrEnum;
+    o[strEnumKey];
+    ~~~~~~~~~~~~~
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'StrEnum' can't be used to index type '{ a: number; }'.
+!!! error TS7053:   Property '[StrEnum.b]' does not exist on type '{ a: number; }'.
     

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.js
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.js
@@ -21,6 +21,26 @@ e['hello'] = 'modified';
 e['hello'] += 1;
 e['hello'] ++;
 
+const o = { a: 0 };
+
+declare const k: "a" | "b" | "c";
+o[k];
+
+
+declare const k2: "c";
+o[k2];
+
+declare const sym : unique symbol;
+o[sym];
+
+enum NumEnum { a, b }
+let numEnumKey: NumEnum;
+o[numEnumKey];
+
+
+enum StrEnum { a = "a", b = "b" }
+let strEnumKey: StrEnum;
+o[strEnumKey];
 
 
 //// [noImplicitAnyStringIndexerOnObject.js]
@@ -42,3 +62,21 @@ var e = {
 e['hello'] = 'modified';
 e['hello'] += 1;
 e['hello']++;
+var o = { a: 0 };
+o[k];
+o[k2];
+o[sym];
+var NumEnum;
+(function (NumEnum) {
+    NumEnum[NumEnum["a"] = 0] = "a";
+    NumEnum[NumEnum["b"] = 1] = "b";
+})(NumEnum || (NumEnum = {}));
+var numEnumKey;
+o[numEnumKey];
+var StrEnum;
+(function (StrEnum) {
+    StrEnum["a"] = "a";
+    StrEnum["b"] = "b";
+})(StrEnum || (StrEnum = {}));
+var strEnumKey;
+o[strEnumKey];

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.symbols
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.symbols
@@ -55,4 +55,56 @@ e['hello'] += 1;
 e['hello'] ++;
 >e : Symbol(e, Decl(noImplicitAnyStringIndexerOnObject.ts, 14, 3))
 
+const o = { a: 0 };
+>o : Symbol(o, Decl(noImplicitAnyStringIndexerOnObject.ts, 22, 5))
+>a : Symbol(a, Decl(noImplicitAnyStringIndexerOnObject.ts, 22, 11))
+
+declare const k: "a" | "b" | "c";
+>k : Symbol(k, Decl(noImplicitAnyStringIndexerOnObject.ts, 24, 13))
+
+o[k];
+>o : Symbol(o, Decl(noImplicitAnyStringIndexerOnObject.ts, 22, 5))
+>k : Symbol(k, Decl(noImplicitAnyStringIndexerOnObject.ts, 24, 13))
+
+
+declare const k2: "c";
+>k2 : Symbol(k2, Decl(noImplicitAnyStringIndexerOnObject.ts, 28, 13))
+
+o[k2];
+>o : Symbol(o, Decl(noImplicitAnyStringIndexerOnObject.ts, 22, 5))
+>k2 : Symbol(k2, Decl(noImplicitAnyStringIndexerOnObject.ts, 28, 13))
+
+declare const sym : unique symbol;
+>sym : Symbol(sym, Decl(noImplicitAnyStringIndexerOnObject.ts, 31, 13))
+
+o[sym];
+>o : Symbol(o, Decl(noImplicitAnyStringIndexerOnObject.ts, 22, 5))
+>sym : Symbol(sym, Decl(noImplicitAnyStringIndexerOnObject.ts, 31, 13))
+
+enum NumEnum { a, b }
+>NumEnum : Symbol(NumEnum, Decl(noImplicitAnyStringIndexerOnObject.ts, 32, 7))
+>a : Symbol(NumEnum.a, Decl(noImplicitAnyStringIndexerOnObject.ts, 34, 14))
+>b : Symbol(NumEnum.b, Decl(noImplicitAnyStringIndexerOnObject.ts, 34, 17))
+
+let numEnumKey: NumEnum;
+>numEnumKey : Symbol(numEnumKey, Decl(noImplicitAnyStringIndexerOnObject.ts, 35, 3))
+>NumEnum : Symbol(NumEnum, Decl(noImplicitAnyStringIndexerOnObject.ts, 32, 7))
+
+o[numEnumKey];
+>o : Symbol(o, Decl(noImplicitAnyStringIndexerOnObject.ts, 22, 5))
+>numEnumKey : Symbol(numEnumKey, Decl(noImplicitAnyStringIndexerOnObject.ts, 35, 3))
+
+
+enum StrEnum { a = "a", b = "b" }
+>StrEnum : Symbol(StrEnum, Decl(noImplicitAnyStringIndexerOnObject.ts, 36, 14))
+>a : Symbol(StrEnum.a, Decl(noImplicitAnyStringIndexerOnObject.ts, 39, 14))
+>b : Symbol(StrEnum.b, Decl(noImplicitAnyStringIndexerOnObject.ts, 39, 23))
+
+let strEnumKey: StrEnum;
+>strEnumKey : Symbol(strEnumKey, Decl(noImplicitAnyStringIndexerOnObject.ts, 40, 3))
+>StrEnum : Symbol(StrEnum, Decl(noImplicitAnyStringIndexerOnObject.ts, 36, 14))
+
+o[strEnumKey];
+>o : Symbol(o, Decl(noImplicitAnyStringIndexerOnObject.ts, 22, 5))
+>strEnumKey : Symbol(strEnumKey, Decl(noImplicitAnyStringIndexerOnObject.ts, 40, 3))
 

--- a/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.types
+++ b/tests/baselines/reference/noImplicitAnyStringIndexerOnObject.types
@@ -89,4 +89,63 @@ e['hello'] ++;
 >e : { set: (key: string) => string; get: (key: string) => string; }
 >'hello' : "hello"
 
+const o = { a: 0 };
+>o : { a: number; }
+>{ a: 0 } : { a: number; }
+>a : number
+>0 : 0
+
+declare const k: "a" | "b" | "c";
+>k : "a" | "b" | "c"
+
+o[k];
+>o[k] : any
+>o : { a: number; }
+>k : "a" | "b" | "c"
+
+
+declare const k2: "c";
+>k2 : "c"
+
+o[k2];
+>o[k2] : any
+>o : { a: number; }
+>k2 : "c"
+
+declare const sym : unique symbol;
+>sym : unique symbol
+
+o[sym];
+>o[sym] : any
+>o : { a: number; }
+>sym : unique symbol
+
+enum NumEnum { a, b }
+>NumEnum : NumEnum
+>a : NumEnum.a
+>b : NumEnum.b
+
+let numEnumKey: NumEnum;
+>numEnumKey : NumEnum
+
+o[numEnumKey];
+>o[numEnumKey] : any
+>o : { a: number; }
+>numEnumKey : NumEnum
+
+
+enum StrEnum { a = "a", b = "b" }
+>StrEnum : StrEnum
+>a : StrEnum.a
+>"a" : "a"
+>b : StrEnum.b
+>"b" : "b"
+
+let strEnumKey: StrEnum;
+>strEnumKey : StrEnum
+
+o[strEnumKey];
+>o[strEnumKey] : any
+>o : { a: number; }
+>strEnumKey : StrEnum
 

--- a/tests/baselines/reference/nonPrimitiveIndexingWithForInNoImplicitAny.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveIndexingWithForInNoImplicitAny.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplicitAny.ts(4,17): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-  No index with a parameter of type 'string' was found on type '{}'.
+  No index signature with a parameter of type 'string' was found on type '{}'.
 
 
 ==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplicitAny.ts (1 errors) ====
@@ -9,6 +9,6 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplic
         var value = a[key]; // error
                     ~~~~~~
 !!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-!!! error TS7053:   No index with a parameter of type 'string' was found on type '{}'.
+!!! error TS7053:   No index signature with a parameter of type 'string' was found on type '{}'.
     }
     

--- a/tests/baselines/reference/nonPrimitiveIndexingWithForInNoImplicitAny.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveIndexingWithForInNoImplicitAny.errors.txt
@@ -1,4 +1,5 @@
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplicitAny.ts(4,17): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplicitAny.ts(4,17): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+  No index with a parameter of type 'string' was found on type '{}'.
 
 
 ==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplicitAny.ts (1 errors) ====
@@ -7,6 +8,7 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplic
     for (var key in a) {
         var value = a[key]; // error
                     ~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+!!! error TS7053:   No index with a parameter of type 'string' was found on type '{}'.
     }
     

--- a/tests/baselines/reference/objectSpreadIndexSignature.errors.txt
+++ b/tests/baselines/reference/objectSpreadIndexSignature.errors.txt
@@ -1,4 +1,5 @@
-tests/cases/conformance/types/spread/objectSpreadIndexSignature.ts(6,1): error TS7017: Element implicitly has an 'any' type because type '{ b: number; a: number; }' has no index signature.
+tests/cases/conformance/types/spread/objectSpreadIndexSignature.ts(6,1): error TS7053: Element implicitly has an 'any' type because expression of type '101' can't be used to index type '{ b: number; a: number; }'.
+  Property '101' does not exist on type '{ b: number; a: number; }'.
 
 
 ==== tests/cases/conformance/types/spread/objectSpreadIndexSignature.ts (1 errors) ====
@@ -9,7 +10,8 @@ tests/cases/conformance/types/spread/objectSpreadIndexSignature.ts(6,1): error T
     // only indexed has indexer, so i[101]: any
     i[101];
     ~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{ b: number; a: number; }' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '101' can't be used to index type '{ b: number; a: number; }'.
+!!! error TS7053:   Property '101' does not exist on type '{ b: number; a: number; }'.
     let ii = { ...indexed1, ...indexed2 };
     // both have indexer, so i[1001]: number | boolean
     ii[1001];

--- a/tests/baselines/reference/propertyAccessStringIndexSignatureNoImplicitAny.errors.txt
+++ b/tests/baselines/reference/propertyAccessStringIndexSignatureNoImplicitAny.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/conformance/expressions/propertyAccess/propertyAccessStringIndexSignatureNoImplicitAny.ts(10,7): error TS2339: Property 'nope' does not exist on type 'Empty'.
-tests/cases/conformance/expressions/propertyAccess/propertyAccessStringIndexSignatureNoImplicitAny.ts(11,1): error TS7017: Element implicitly has an 'any' type because type 'Empty' has no index signature.
+tests/cases/conformance/expressions/propertyAccess/propertyAccessStringIndexSignatureNoImplicitAny.ts(11,1): error TS7053: Element implicitly has an 'any' type because expression of type '"not allowed either"' can't be used to index type 'Empty'.
+  Property 'not allowed either' does not exist on type 'Empty'.
 
 
 ==== tests/cases/conformance/expressions/propertyAccess/propertyAccessStringIndexSignatureNoImplicitAny.ts (2 errors) ====
@@ -17,5 +18,6 @@ tests/cases/conformance/expressions/propertyAccess/propertyAccessStringIndexSign
 !!! error TS2339: Property 'nope' does not exist on type 'Empty'.
     empty["not allowed either"];
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type 'Empty' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '"not allowed either"' can't be used to index type 'Empty'.
+!!! error TS7053:   Property 'not allowed either' does not exist on type 'Empty'.
     

--- a/tests/baselines/reference/typeFromPrototypeAssignment3.errors.txt
+++ b/tests/baselines/reference/typeFromPrototypeAssignment3.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/salsa/bug26885.js(2,5): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
 tests/cases/conformance/salsa/bug26885.js(11,16): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-  No index with a parameter of type 'string' was found on type '{}'.
+  No index signature with a parameter of type 'string' was found on type '{}'.
 
 
 ==== tests/cases/conformance/salsa/bug26885.js (2 errors) ====
@@ -19,7 +19,7 @@ tests/cases/conformance/salsa/bug26885.js(11,16): error TS7053: Element implicit
             return this._map[key + ''];
                    ~~~~~~~~~~~~~~~~~~~
 !!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
-!!! error TS7053:   No index with a parameter of type 'string' was found on type '{}'.
+!!! error TS7053:   No index signature with a parameter of type 'string' was found on type '{}'.
         }
     }
     

--- a/tests/baselines/reference/typeFromPrototypeAssignment3.errors.txt
+++ b/tests/baselines/reference/typeFromPrototypeAssignment3.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/conformance/salsa/bug26885.js(2,5): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
-tests/cases/conformance/salsa/bug26885.js(11,16): error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+tests/cases/conformance/salsa/bug26885.js(11,16): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+  No index with a parameter of type 'string' was found on type '{}'.
 
 
 ==== tests/cases/conformance/salsa/bug26885.js (2 errors) ====
@@ -17,7 +18,8 @@ tests/cases/conformance/salsa/bug26885.js(11,16): error TS7017: Element implicit
         get(key) {
             return this._map[key + ''];
                    ~~~~~~~~~~~~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type '{}' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type '{}'.
+!!! error TS7053:   No index with a parameter of type 'string' was found on type '{}'.
         }
     }
     

--- a/tests/baselines/reference/unionTypeWithIndexSignature.errors.txt
+++ b/tests/baselines/reference/unionTypeWithIndexSignature.errors.txt
@@ -1,9 +1,11 @@
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(11,3): error TS2339: Property 'bar' does not exist on type 'Missing'.
   Property 'bar' does not exist on type '{ [s: string]: string; }'.
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(14,4): error TS2540: Cannot assign to 'foo' because it is a read-only property.
-tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(24,1): error TS7017: Element implicitly has an 'any' type because type 'Both' has no index signature.
+tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(24,1): error TS7053: Element implicitly has an 'any' type because expression of type '1' can't be used to index type 'Both'.
+  Property '1' does not exist on type 'Both'.
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(25,1): error TS2322: Type '"not ok"' is not assignable to type 'number'.
-tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(26,1): error TS7017: Element implicitly has an 'any' type because type 'Both' has no index signature.
+tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(26,1): error TS7053: Element implicitly has an 'any' type because expression of type 'unique symbol' can't be used to index type 'Both'.
+  Property '[sym]' does not exist on type 'Both'.
 
 
 ==== tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts (5 errors) ====
@@ -37,11 +39,13 @@ tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(26,1): error 
     both[0] = 1
     both[1] = 0 // not ok
     ~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type 'Both' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type '1' can't be used to index type 'Both'.
+!!! error TS7053:   Property '1' does not exist on type 'Both'.
     both[0] = 'not ok'
     ~~~~~~~
 !!! error TS2322: Type '"not ok"' is not assignable to type 'number'.
     both[sym] = 'not ok'
     ~~~~~~~~~
-!!! error TS7017: Element implicitly has an 'any' type because type 'Both' has no index signature.
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'unique symbol' can't be used to index type 'Both'.
+!!! error TS7053:   Property '[sym]' does not exist on type 'Both'.
     

--- a/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
+++ b/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
@@ -22,3 +22,23 @@ e['hello'] = 'modified';
 e['hello'] += 1;
 e['hello'] ++;
 
+const o = { a: 0 };
+
+declare const k: "a" | "b" | "c";
+o[k];
+
+
+declare const k2: "c";
+o[k2];
+
+declare const sym : unique symbol;
+o[sym];
+
+enum NumEnum { a, b }
+let numEnumKey: NumEnum;
+o[numEnumKey];
+
+
+enum StrEnum { a = "a", b = "b" }
+let strEnumKey: StrEnum;
+o[strEnumKey];


### PR DESCRIPTION
Fixes #30241

This PR introduces more explicit error messages when trying to index into a type without an index signature.
Rules:
- When the index argument is a string literal, number literal or unique symbol, but the target object does not have the corresponding property the error will be:
```
Element implicitly has an 'any' type because expression of type 'LITERAL_TYPE' can't be used to index type 'TARGET_TYPE'.
  Property 'PROP_NAME' does not exist on type 'TARGET_TYPE'
```
- When the index argument is a union of literals, the error message will contain the union used to index, and will contain the first property in the union that is not found in the type:
```
Element implicitly has an 'any' type because expression of type 'UNION_OF_LITERAL_TYPES' can't be used to index type 'TARGET_TYPE'.
  Property 'FIRST_MISSING_PROP_NAME' does not exist on type 'TARGET_TYPE'
```
- When the index argument is `string` or `number` the error will warn about the missing index on the target type:
```
Element implicitly has an 'any' type because expression of type 'STRING_OR_NUMBER' can't be used to index type 'TARGET_TYPE'.
  No index with a parameter of type 'STRING_OR_NUMBER' was found on type 'TARGET_TYPE'
```
Examples:

```ts
const o = { a: 0 };

declare const k:"b";
o[k]; // rule 1
// Element implicitly has an 'any' type because expression of type '"b"' can't be used to index type '{ a: number; }'.
//   Property 'b' does not exist on type '{ a: number; }'

declare const k2: "b" | "c";
o[k2]; // rule 2
// Element implicitly has an 'any' type because expression of type '"b" | "c"' can't be used to index type '{ a: number; }'.
//   Property 'b' does not exist on type '{ a: number; }'.

declare const nIndex: number;
o[nIndex] // rule 3
// Element implicitly has an 'any' type because expression of type 'number' can't be used to index type '{ a: number; }'.
//   No index with a parameter of type 'number' was found on type '{ a: number; }'
```