### PR TITLE
Fix newlines in smartSelection baselines to not be platform dependent

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1503,7 +1503,7 @@ Actual: ${stringify(fullActual)}`);
         }
 
         public baselineSmartSelection() {
-            const n = ts.sys.newLine;
+            const n = "\n";
             const baselineFile = this.getBaselineFileName();
             const markers = this.getMarkers();
             const fileContent = this.activeFile.content;


### PR DESCRIPTION
The smartSelection baselines in fourslash were causing test failures on Windows because the line-terminator was platform dependent.
