### PR TITLE
Prevent type parameter printing from recuring on the same symbol

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4302,6 +4302,11 @@ namespace ts {
             function lookupTypeParameterNodes(chain: Symbol[], index: number, context: NodeBuilderContext) {
                 Debug.assert(chain && 0 <= index && index < chain.length);
                 const symbol = chain[index];
+                const symbolId = "" + getSymbolId(symbol);
+                if (context.typeParameterSymbolList && context.typeParameterSymbolList.get(symbolId)) {
+                    return undefined;
+                }
+                (context.typeParameterSymbolList || (context.typeParameterSymbolList = createMap())).set(symbolId, true);
                 let typeParameterNodes: ReadonlyArray<TypeNode> | ReadonlyArray<TypeParameterDeclaration> | undefined;
                 if (context.flags & NodeBuilderFlags.WriteTypeParametersInQualifiedName && index < (chain.length - 1)) {
                     const parentSymbol = symbol;
@@ -4628,6 +4633,7 @@ namespace ts {
             inferTypeParameters: TypeParameter[] | undefined;
             approximateLength: number;
             truncating?: boolean;
+            typeParameterSymbolList?: Map<true>;
         }
 
         function isDefaultBindingContext(location: Node) {

--- a/tests/cases/fourslash/quickinfoForNamespaceMergeWithClassConstrainedToSelf.ts
+++ b/tests/cases/fourslash/quickinfoForNamespaceMergeWithClassConstrainedToSelf.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+
+//// declare namespace AMap {
+////     namespace MassMarks {
+////         interface Data {
+////             style?: number;
+////         }
+////     }
+////     class MassMarks<D extends MassMarks.Data = MassMarks.Data> {
+////         constructor(data: D[] | string);
+////         clear(): void;
+////     }
+//// }
+////
+//// interface MassMarksCustomData extends AMap.MassMarks./*1*/Data {
+////     name: string;
+////     id: string;
+//// }
+
+verify.quickInfoAt("1", "interface AMap.MassMarks<D extends AMap.MassMarks.Data = AMap.MassMarks.Data>.Data");


### PR DESCRIPTION
Fixes #30583


Related: I'd personally prefer if it printed as `interface AMap.MassMarks.Data` (without mentioning the parameter at all), since the type parameter is only relevant to the instance side and we're talking about a namespace member; but that isn't reeeealy something we currently distinguish.