### PR TITLE
Test docCommentTemplate for prototype methods

### DIFF
--- a/tests/cases/fourslash/docCommentTemplatePrototypeMethod.ts
+++ b/tests/cases/fourslash/docCommentTemplatePrototypeMethod.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+// @Filename: foo.js
+
+/////** @class */
+////function C() { }
+/////*above*/
+////C.prototype.method = /*next*/ function (p) {}
+
+for (const marker of test.markerNames()) {
+    verify.docCommentTemplateAt(marker, 8,
+`/**
+ * 
+ * @param {any} p
+ */`);
+}


### PR DESCRIPTION
This works in 3.5, but didn't in 3.2. Adding a test to make sure this stays working in the language service.

Fixes #27638
