### PR TITLE
Organize imports: don’t delete import declarations used for module augmentation

### DIFF
--- a/src/testRunner/unittests/services/organizeImports.ts
+++ b/src/testRunner/unittests/services/organizeImports.ts
@@ -343,6 +343,19 @@ import { } from "lib";
                 },
                 libFile);
 
+            testOrganizeImports("Unused_false_positive_module_augmentation",
+            {
+                path: "/test.d.ts",
+                content: `
+import { Caseless } from 'caseless';
+
+declare module 'caseless' {
+    interface Caseless {
+        test(name: KeyType): boolean;
+    }
+}`
+            });
+
             testOrganizeImports("Unused_false_positive_shorthand_assignment",
             {
                     path: "/test.ts",

--- a/src/testRunner/unittests/services/organizeImports.ts
+++ b/src/testRunner/unittests/services/organizeImports.ts
@@ -358,6 +358,21 @@ declare module 'caseless' {
 }`
             });
 
+            testOrganizeImports("Unused_preserve_imports_for_module_augmentation_in_non_declaration_file",
+            {
+                path: "/test.ts",
+                content: `
+import foo from 'foo';
+import { Caseless } from 'caseless';
+
+declare module 'foo' {}
+declare module 'caseless' {
+    interface Caseless {
+        test(name: KeyType): boolean;
+    }
+}`
+            });
+
             testOrganizeImports("Unused_false_positive_shorthand_assignment",
             {
                     path: "/test.ts",

--- a/src/testRunner/unittests/services/organizeImports.ts
+++ b/src/testRunner/unittests/services/organizeImports.ts
@@ -1,5 +1,5 @@
 namespace ts {
-    describe("unittests:: services:: Organize imports", () => {
+    describe("unittests:: services:: organizeImports", () => {
         describe("Sort imports", () => {
             it("Sort - non-relative vs non-relative", () => {
                 assertSortsBefore(
@@ -347,8 +347,10 @@ import { } from "lib";
             {
                 path: "/test.d.ts",
                 content: `
+import foo from 'foo';
 import { Caseless } from 'caseless';
 
+declare module 'foo' {}
 declare module 'caseless' {
     interface Caseless {
         test(name: KeyType): boolean;

--- a/tests/baselines/reference/organizeImports/Unused_false_positive_module_augmentation.ts
+++ b/tests/baselines/reference/organizeImports/Unused_false_positive_module_augmentation.ts
@@ -1,0 +1,22 @@
+// ==ORIGINAL==
+
+import foo from 'foo';
+import { Caseless } from 'caseless';
+
+declare module 'foo' {}
+declare module 'caseless' {
+    interface Caseless {
+        test(name: KeyType): boolean;
+    }
+}
+// ==ORGANIZED==
+
+import 'caseless';
+import 'foo';
+
+declare module 'foo' {}
+declare module 'caseless' {
+    interface Caseless {
+        test(name: KeyType): boolean;
+    }
+}

--- a/tests/baselines/reference/organizeImports/Unused_preserve_imports_for_module_augmentation_in_non_declaration_file.ts
+++ b/tests/baselines/reference/organizeImports/Unused_preserve_imports_for_module_augmentation_in_non_declaration_file.ts
@@ -1,0 +1,22 @@
+// ==ORIGINAL==
+
+import foo from 'foo';
+import { Caseless } from 'caseless';
+
+declare module 'foo' {}
+declare module 'caseless' {
+    interface Caseless {
+        test(name: KeyType): boolean;
+    }
+}
+// ==ORGANIZED==
+
+import { Caseless } from 'caseless';
+import foo from 'foo';
+
+declare module 'foo' {}
+declare module 'caseless' {
+    interface Caseless {
+        test(name: KeyType): boolean;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31338 

Import clauses are removed, e.g.

```ts
import { Caseless } from 'caseless';

declare module 'caseless' {
  interface Caseless {
    test(name: KeyType): boolean;
  }
}
```

now becomes

```ts
import 'caseless';

declare module 'caseless' {
  interface Caseless {
    test(name: KeyType): boolean;
  }
}
```

(Previously, the whole import declaration was deleted.)