### PR TITLE
Allow JS with isolated modules

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -655,7 +655,7 @@
         "category": "Error",
         "code": 1207
     },
-    "Cannot compile namespaces when the '--isolatedModules' flag is provided.": {
+    "All files must be modules when the '--isolatedModules' flag is provided.": {
         "category": "Error",
         "code": 1208
     },

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2855,10 +2855,10 @@ namespace ts {
                     createDiagnosticForOptionName(Diagnostics.Option_isolatedModules_can_only_be_used_when_either_option_module_is_provided_or_option_target_is_ES2015_or_higher, "isolatedModules", "target");
                 }
 
-                const firstNonExternalModuleSourceFile = find(files, f => !isExternalModule(f) && !f.isDeclarationFile && f.scriptKind !== ScriptKind.JSON);
+                const firstNonExternalModuleSourceFile = find(files, f => !isExternalModule(f) && !isSourceFileJS(f) && !f.isDeclarationFile && f.scriptKind !== ScriptKind.JSON);
                 if (firstNonExternalModuleSourceFile) {
                     const span = getErrorSpanForNode(firstNonExternalModuleSourceFile, firstNonExternalModuleSourceFile);
-                    programDiagnostics.add(createFileDiagnostic(firstNonExternalModuleSourceFile, span.start, span.length, Diagnostics.Cannot_compile_namespaces_when_the_isolatedModules_flag_is_provided));
+                    programDiagnostics.add(createFileDiagnostic(firstNonExternalModuleSourceFile, span.start, span.length, Diagnostics.All_files_must_be_modules_when_the_isolatedModules_flag_is_provided));
                 }
             }
             else if (firstNonAmbientExternalModuleSourceFile && languageVersion < ScriptTarget.ES2015 && options.module === ModuleKind.None) {

--- a/tests/baselines/reference/commonJsIsolatedModules.js
+++ b/tests/baselines/reference/commonJsIsolatedModules.js
@@ -1,0 +1,8 @@
+//// [index.js]
+module.exports = {}
+var x = 1
+
+
+//// [index.js]
+module.exports = {};
+var x = 1;

--- a/tests/baselines/reference/commonJsIsolatedModules.symbols
+++ b/tests/baselines/reference/commonJsIsolatedModules.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/index.js ===
+module.exports = {}
+>module.exports : Symbol("tests/cases/compiler/index", Decl(index.js, 0, 0))
+>module : Symbol(module, Decl(index.js, 0, 0))
+>exports : Symbol("tests/cases/compiler/index", Decl(index.js, 0, 0))
+
+var x = 1
+>x : Symbol(x, Decl(index.js, 1, 3))
+

--- a/tests/baselines/reference/commonJsIsolatedModules.types
+++ b/tests/baselines/reference/commonJsIsolatedModules.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/index.js ===
+module.exports = {}
+>module.exports = {} : typeof import("tests/cases/compiler/index")
+>module.exports : typeof import("tests/cases/compiler/index")
+>module : { "tests/cases/compiler/index": typeof import("tests/cases/compiler/index"); }
+>exports : typeof import("tests/cases/compiler/index")
+>{} : {}
+
+var x = 1
+>x : number
+>1 : 1
+

--- a/tests/baselines/reference/importHelpersInIsolatedModules.errors.txt
+++ b/tests/baselines/reference/importHelpersInIsolatedModules.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/script.ts(1,1): error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+tests/cases/compiler/script.ts(1,1): error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
 
 
 ==== tests/cases/compiler/external.ts (0 errors) ====
@@ -16,7 +16,7 @@ tests/cases/compiler/script.ts(1,1): error TS1208: Cannot compile namespaces whe
 ==== tests/cases/compiler/script.ts (1 errors) ====
     class A { }
     ~~~~~
-!!! error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+!!! error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
     class B extends A { }
     
     declare var dec: any;

--- a/tests/baselines/reference/isolatedModulesNoExternalModule.errors.txt
+++ b/tests/baselines/reference/isolatedModulesNoExternalModule.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/compiler/file1.ts(1,1): error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+tests/cases/compiler/file1.ts(1,1): error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
 
 
 ==== tests/cases/compiler/file1.ts (1 errors) ====
     var x;
     ~~~
-!!! error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+!!! error TS1208: All files must be modules when the '--isolatedModules' flag is provided.

--- a/tests/baselines/reference/isolatedModulesOut.errors.txt
+++ b/tests/baselines/reference/isolatedModulesOut.errors.txt
@@ -1,6 +1,6 @@
 error TS5053: Option 'out' cannot be specified with option 'isolatedModules'.
 tests/cases/compiler/file1.ts(1,1): error TS6131: Cannot compile modules using option 'out' unless the '--module' flag is 'amd' or 'system'.
-tests/cases/compiler/file2.ts(1,1): error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+tests/cases/compiler/file2.ts(1,1): error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
 
 
 !!! error TS5053: Option 'out' cannot be specified with option 'isolatedModules'.
@@ -11,4 +11,4 @@ tests/cases/compiler/file2.ts(1,1): error TS1208: Cannot compile namespaces when
 ==== tests/cases/compiler/file2.ts (1 errors) ====
     var y;
     ~~~
-!!! error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+!!! error TS1208: All files must be modules when the '--isolatedModules' flag is provided.

--- a/tests/baselines/reference/isolatedModulesPlainFile-AMD.errors.txt
+++ b/tests/baselines/reference/isolatedModulesPlainFile-AMD.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/isolatedModulesPlainFile-AMD.ts(1,1): error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+tests/cases/compiler/isolatedModulesPlainFile-AMD.ts(1,1): error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
 
 
 ==== tests/cases/compiler/isolatedModulesPlainFile-AMD.ts (1 errors) ====
     declare function run(a: number): void;
     ~~~~~~~
-!!! error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+!!! error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
     run(1);
     

--- a/tests/baselines/reference/isolatedModulesPlainFile-CommonJS.errors.txt
+++ b/tests/baselines/reference/isolatedModulesPlainFile-CommonJS.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/isolatedModulesPlainFile-CommonJS.ts(1,1): error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+tests/cases/compiler/isolatedModulesPlainFile-CommonJS.ts(1,1): error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
 
 
 ==== tests/cases/compiler/isolatedModulesPlainFile-CommonJS.ts (1 errors) ====
     declare function run(a: number): void;
     ~~~~~~~
-!!! error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+!!! error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
     run(1);
     

--- a/tests/baselines/reference/isolatedModulesPlainFile-ES6.errors.txt
+++ b/tests/baselines/reference/isolatedModulesPlainFile-ES6.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/isolatedModulesPlainFile-ES6.ts(1,1): error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+tests/cases/compiler/isolatedModulesPlainFile-ES6.ts(1,1): error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
 
 
 ==== tests/cases/compiler/isolatedModulesPlainFile-ES6.ts (1 errors) ====
     declare function run(a: number): void;
     ~~~~~~~
-!!! error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+!!! error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
     run(1);
     

--- a/tests/baselines/reference/isolatedModulesPlainFile-System.errors.txt
+++ b/tests/baselines/reference/isolatedModulesPlainFile-System.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/isolatedModulesPlainFile-System.ts(1,1): error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+tests/cases/compiler/isolatedModulesPlainFile-System.ts(1,1): error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
 
 
 ==== tests/cases/compiler/isolatedModulesPlainFile-System.ts (1 errors) ====
     declare function run(a: number): void;
     ~~~~~~~
-!!! error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+!!! error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
     run(1);
     

--- a/tests/baselines/reference/isolatedModulesPlainFile-UMD.errors.txt
+++ b/tests/baselines/reference/isolatedModulesPlainFile-UMD.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/isolatedModulesPlainFile-UMD.ts(1,1): error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+tests/cases/compiler/isolatedModulesPlainFile-UMD.ts(1,1): error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
 
 
 ==== tests/cases/compiler/isolatedModulesPlainFile-UMD.ts (1 errors) ====
     declare function run(a: number): void;
     ~~~~~~~
-!!! error TS1208: Cannot compile namespaces when the '--isolatedModules' flag is provided.
+!!! error TS1208: All files must be modules when the '--isolatedModules' flag is provided.
     run(1);
     

--- a/tests/cases/compiler/commonJsIsolatedModules.ts
+++ b/tests/cases/compiler/commonJsIsolatedModules.ts
@@ -1,0 +1,12 @@
+// @Filename: tsconfig.json
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "noEmit": true,
+    "isolatedModules": true,
+  }
+}
+
+// @Filename: index.js
+module.exports = {}
+var x = 1

--- a/tests/cases/compiler/commonJsIsolatedModules.ts
+++ b/tests/cases/compiler/commonJsIsolatedModules.ts
@@ -2,7 +2,7 @@
 {
   "compilerOptions": {
     "allowJs": true,
-    "noEmit": true,
+    "outDir": "foo",
     "isolatedModules": true,
   }
 }


### PR DESCRIPTION
Previously legacy JS code was not allowed; it was required to use ES6 module syntax. Unfortunately, the check happens after parsing but before binding, and the commonjs module indicator isn't set until binding because it's not syntactically simple like the ES6 module indicator, which is set during parsing.

So I decided that JS should be allowed during isolatedModules unconditionally. We're not going to be transforming it anyway.

I also improved the error message, which mentions namespaces when most erroneous code it encounters will just be global scripts.

Fixes #29087