### PR TITLE
Ignore drive letters when comparing casings of the files with forceConsistentCasingInFileNames

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2232,7 +2232,10 @@ namespace ts {
                     if (isRedirect) {
                         inputName = getProjectReferenceRedirect(fileName) || fileName;
                     }
-                    if (getNormalizedAbsolutePath(checkedName, currentDirectory) !== getNormalizedAbsolutePath(inputName, currentDirectory)) {
+                    // Check if it differs only in drive letters its ok to ignore that error:
+                    const checkedAbsolutePath = getNormalizedAbsolutePathWithoutRoot(checkedName, currentDirectory);
+                    const inputAbsolutePath = getNormalizedAbsolutePathWithoutRoot(inputName, currentDirectory);
+                    if (checkedAbsolutePath !== inputAbsolutePath) {
                         reportFileNamesDifferOnlyInCasingError(inputName, checkedName, refFile, refPos, refEnd);
                     }
                 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7646,6 +7646,14 @@ namespace ts {
         return root + pathComponents.slice(1).join(directorySeparator);
     }
 
+    export function getNormalizedAbsolutePathWithoutRoot(fileName: string, currentDirectory: string | undefined) {
+        return getPathWithoutRoot(getNormalizedPathComponents(fileName, currentDirectory));
+    }
+
+    function getPathWithoutRoot(pathComponents: ReadonlyArray<string>) {
+        if (pathComponents.length === 0) return "";
+        return pathComponents.slice(1).join(directorySeparator);
+    }
 }
 
 /* @internal */

--- a/src/testRunner/unittests/moduleResolution.ts
+++ b/src/testRunner/unittests/moduleResolution.ts
@@ -530,7 +530,7 @@ export = C;
         });
     });
 
-    describe("unittests:: moduleResolution:: Files with different casing", () => {
+    describe("unittests:: moduleResolution:: Files with different casing with forceConsistentCasingInFileNames", () => {
         let library: SourceFile;
         function test(files: Map<string>, options: CompilerOptions, currentDirectory: string, useCaseSensitiveFileNames: boolean, rootFiles: string[], diagnosticCodes: number[]): void {
             const getCanonicalFileName = createGetCanonicalFileName(useCaseSensitiveFileNames);
@@ -648,6 +648,22 @@ import b = require("./moduleB");
                 `
             });
             test(files, { module: ModuleKind.CommonJS, forceConsistentCasingInFileNames: true }, "/a/B/c", /*useCaseSensitiveFileNames*/ false, ["moduleD.ts"], []);
+        });
+
+        it("should succeed when the two files in program differ only in drive letter in their names", () => {
+            const files = createMapFromTemplate({
+                "d:/someFolder/moduleA.ts": `import a = require("D:/someFolder/moduleC")`,
+                "d:/someFolder/moduleB.ts": `import a = require("./moduleC")`,
+                "D:/someFolder/moduleC.ts": "export const x = 10",
+            });
+            test(
+                files,
+                { module: ModuleKind.CommonJS, forceConsistentCasingInFileNames: true },
+                "d:/someFolder",
+                /*useCaseSensitiveFileNames*/ false,
+                ["d:/someFolder/moduleA.ts", "d:/someFolder/moduleB.ts"],
+                []
+            );
         });
     });
 


### PR DESCRIPTION
Fixes #31327
