### PR TITLE
Fix for computed properties in instance initializers

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4527,6 +4527,8 @@ namespace ts {
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:
                     return generateNameForMethodOrAccessor(<MethodDeclaration | AccessorDeclaration>node);
+                case SyntaxKind.ComputedPropertyName:
+                    return makeTempVariableName(TempFlags.Auto, /*reserveInNestedScopes*/ true);
                 default:
                     return makeTempVariableName(TempFlags.Auto);
             }

--- a/tests/baselines/reference/instanceMemberWithComputedPropertyName.js
+++ b/tests/baselines/reference/instanceMemberWithComputedPropertyName.js
@@ -1,0 +1,22 @@
+//// [instanceMemberWithComputedPropertyName.ts]
+// https://github.com/microsoft/TypeScript/issues/30953
+const x = 1;
+class C {
+    [x] = true;
+    constructor() {
+        const { a, b } = { a: 1, b: 2 };
+    }
+}
+
+//// [instanceMemberWithComputedPropertyName.js]
+var _a;
+// https://github.com/microsoft/TypeScript/issues/30953
+var x = 1;
+var C = /** @class */ (function () {
+    function C() {
+        this[_a] = true;
+        var _b = { a: 1, b: 2 }, a = _b.a, b = _b.b;
+    }
+    return C;
+}());
+_a = x;

--- a/tests/baselines/reference/instanceMemberWithComputedPropertyName.symbols
+++ b/tests/baselines/reference/instanceMemberWithComputedPropertyName.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName.ts ===
+// https://github.com/microsoft/TypeScript/issues/30953
+const x = 1;
+>x : Symbol(x, Decl(instanceMemberWithComputedPropertyName.ts, 1, 5))
+
+class C {
+>C : Symbol(C, Decl(instanceMemberWithComputedPropertyName.ts, 1, 12))
+
+    [x] = true;
+>[x] : Symbol(C[x], Decl(instanceMemberWithComputedPropertyName.ts, 2, 9))
+>x : Symbol(x, Decl(instanceMemberWithComputedPropertyName.ts, 1, 5))
+
+    constructor() {
+        const { a, b } = { a: 1, b: 2 };
+>a : Symbol(a, Decl(instanceMemberWithComputedPropertyName.ts, 5, 15))
+>b : Symbol(b, Decl(instanceMemberWithComputedPropertyName.ts, 5, 18))
+>a : Symbol(a, Decl(instanceMemberWithComputedPropertyName.ts, 5, 26))
+>b : Symbol(b, Decl(instanceMemberWithComputedPropertyName.ts, 5, 32))
+    }
+}

--- a/tests/baselines/reference/instanceMemberWithComputedPropertyName.types
+++ b/tests/baselines/reference/instanceMemberWithComputedPropertyName.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName.ts ===
+// https://github.com/microsoft/TypeScript/issues/30953
+const x = 1;
+>x : 1
+>1 : 1
+
+class C {
+>C : C
+
+    [x] = true;
+>[x] : boolean
+>x : 1
+>true : true
+
+    constructor() {
+        const { a, b } = { a: 1, b: 2 };
+>a : number
+>b : number
+>{ a: 1, b: 2 } : { a: number; b: number; }
+>a : number
+>1 : 1
+>b : number
+>2 : 2
+    }
+}

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName.ts
@@ -1,0 +1,8 @@
+// https://github.com/microsoft/TypeScript/issues/30953
+const x = 1;
+class C {
+    [x] = true;
+    constructor() {
+        const { a, b } = { a: 1, b: 2 };
+    }
+}


### PR DESCRIPTION
This change ensures we always reserve the temporary variable name in nested scopes for a computed property name so other temporary variable declarations don't collide with it.

Fixes #30953
