### PR TITLE
Reset error record in downlevel for-of

### DIFF
--- a/tests/baselines/reference/ES5For-of37.js
+++ b/tests/baselines/reference/ES5For-of37.js
@@ -1,0 +1,64 @@
+//// [ES5For-of37.ts]
+// https://github.com/microsoft/TypeScript/issues/30083
+
+for (const i of [0, 1, 2, 3, 4]) {
+    try {
+        // Ensure catch binding for the following loop is reset per iteration:
+        for (const j of [1, 2, 3]) {
+            if (i === 2) {
+                throw new Error('ERR');
+            }
+        }
+        console.log(i);
+    } catch (err) {
+        console.log('E %s %s', i, err);
+    }
+}
+
+//// [ES5For-of37.js]
+// https://github.com/microsoft/TypeScript/issues/30083
+var __values = (this && this.__values) || function (o) {
+    var m = typeof Symbol === "function" && o[Symbol.iterator], i = 0;
+    if (m) return m.call(o);
+    return {
+        next: function () {
+            if (o && i >= o.length) o = void 0;
+            return { value: o && o[i++], done: !o };
+        }
+    };
+};
+var e_1, _a, e_2, _b;
+try {
+    for (var _c = __values([0, 1, 2, 3, 4]), _d = _c.next(); !_d.done; _d = _c.next()) {
+        var i = _d.value;
+        try {
+            try {
+                // Ensure catch binding for the following loop is reset per iteration:
+                for (var _e = (e_2 = void 0, __values([1, 2, 3])), _f = _e.next(); !_f.done; _f = _e.next()) {
+                    var j = _f.value;
+                    if (i === 2) {
+                        throw new Error('ERR');
+                    }
+                }
+            }
+            catch (e_2_1) { e_2 = { error: e_2_1 }; }
+            finally {
+                try {
+                    if (_f && !_f.done && (_b = _e["return"])) _b.call(_e);
+                }
+                finally { if (e_2) throw e_2.error; }
+            }
+            console.log(i);
+        }
+        catch (err) {
+            console.log('E %s %s', i, err);
+        }
+    }
+}
+catch (e_1_1) { e_1 = { error: e_1_1 }; }
+finally {
+    try {
+        if (_d && !_d.done && (_a = _c["return"])) _a.call(_c);
+    }
+    finally { if (e_1) throw e_1.error; }
+}

--- a/tests/baselines/reference/ES5For-of37.symbols
+++ b/tests/baselines/reference/ES5For-of37.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/conformance/statements/for-ofStatements/ES5For-of37.ts ===
+// https://github.com/microsoft/TypeScript/issues/30083
+
+for (const i of [0, 1, 2, 3, 4]) {
+>i : Symbol(i, Decl(ES5For-of37.ts, 2, 10))
+
+    try {
+        // Ensure catch binding for the following loop is reset per iteration:
+        for (const j of [1, 2, 3]) {
+>j : Symbol(j, Decl(ES5For-of37.ts, 5, 18))
+
+            if (i === 2) {
+>i : Symbol(i, Decl(ES5For-of37.ts, 2, 10))
+
+                throw new Error('ERR');
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+            }
+        }
+        console.log(i);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>i : Symbol(i, Decl(ES5For-of37.ts, 2, 10))
+
+    } catch (err) {
+>err : Symbol(err, Decl(ES5For-of37.ts, 11, 13))
+
+        console.log('E %s %s', i, err);
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>i : Symbol(i, Decl(ES5For-of37.ts, 2, 10))
+>err : Symbol(err, Decl(ES5For-of37.ts, 11, 13))
+    }
+}

--- a/tests/baselines/reference/ES5For-of37.types
+++ b/tests/baselines/reference/ES5For-of37.types
@@ -1,0 +1,52 @@
+=== tests/cases/conformance/statements/for-ofStatements/ES5For-of37.ts ===
+// https://github.com/microsoft/TypeScript/issues/30083
+
+for (const i of [0, 1, 2, 3, 4]) {
+>i : number
+>[0, 1, 2, 3, 4] : number[]
+>0 : 0
+>1 : 1
+>2 : 2
+>3 : 3
+>4 : 4
+
+    try {
+        // Ensure catch binding for the following loop is reset per iteration:
+        for (const j of [1, 2, 3]) {
+>j : number
+>[1, 2, 3] : number[]
+>1 : 1
+>2 : 2
+>3 : 3
+
+            if (i === 2) {
+>i === 2 : boolean
+>i : number
+>2 : 2
+
+                throw new Error('ERR');
+>new Error('ERR') : Error
+>Error : ErrorConstructor
+>'ERR' : "ERR"
+            }
+        }
+        console.log(i);
+>console.log(i) : void
+>console.log : (message?: any, ...optionalParams: any[]) => void
+>console : Console
+>log : (message?: any, ...optionalParams: any[]) => void
+>i : number
+
+    } catch (err) {
+>err : any
+
+        console.log('E %s %s', i, err);
+>console.log('E %s %s', i, err) : void
+>console.log : (message?: any, ...optionalParams: any[]) => void
+>console : Console
+>log : (message?: any, ...optionalParams: any[]) => void
+>'E %s %s' : "E %s %s"
+>i : number
+>err : any
+    }
+}

--- a/tests/cases/conformance/statements/for-ofStatements/ES5For-of37.ts
+++ b/tests/cases/conformance/statements/for-ofStatements/ES5For-of37.ts
@@ -1,0 +1,16 @@
+// @downlevelIteration: true
+// https://github.com/microsoft/TypeScript/issues/30083
+
+for (const i of [0, 1, 2, 3, 4]) {
+    try {
+        // Ensure catch binding for the following loop is reset per iteration:
+        for (const j of [1, 2, 3]) {
+            if (i === 2) {
+                throw new Error('ERR');
+            }
+        }
+        console.log(i);
+    } catch (err) {
+        console.log('E %s %s', i, err);
+    }
+}


### PR DESCRIPTION
This ensures we reset the `errorRecord` temp variable we generate for downlevel `for..of` when the `for..of` statement is enclosed in another iteration statement.

Fixes #30083
