### PR TITLE
Fix compiler crash with object rest in catch binding

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30162,12 +30162,17 @@ namespace ts {
             return undefined;
         }
 
+        function isSymbolOfDestructuredElementOfCatchBinding(symbol: Symbol) {
+            return isBindingElement(symbol.valueDeclaration)
+                && walkUpBindingElementsAndPatterns(symbol.valueDeclaration).parent.kind === SyntaxKind.CatchClause;
+        }
+
         function isSymbolOfDeclarationWithCollidingName(symbol: Symbol): boolean {
             if (symbol.flags & SymbolFlags.BlockScoped && !isSourceFile(symbol.valueDeclaration)) {
                 const links = getSymbolLinks(symbol);
                 if (links.isDeclarationWithCollidingName === undefined) {
                     const container = getEnclosingBlockScopeContainer(symbol.valueDeclaration);
-                    if (isStatementWithLocals(container)) {
+                    if (isStatementWithLocals(container) || isSymbolOfDestructuredElementOfCatchBinding(symbol)) {
                         const nodeLinks = getNodeLinks(symbol.valueDeclaration);
                         if (resolveName(container.parent, symbol.escapedName, SymbolFlags.Value, /*nameNotFoundMessage*/ undefined, /*nameArg*/ undefined, /*isUse*/ false)) {
                             // redeclaration - always should be renamed

--- a/tests/baselines/reference/objectRestCatchES5.js
+++ b/tests/baselines/reference/objectRestCatchES5.js
@@ -1,0 +1,21 @@
+//// [objectRestCatchES5.ts]
+let a = 1, b = 2;
+try {} catch ({ a, ...b }) {}
+
+//// [objectRestCatchES5.js]
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+var a = 1, b = 2;
+try { }
+catch (_a) {
+    var a_1 = _a.a, b_1 = __rest(_a, ["a"]);
+}

--- a/tests/baselines/reference/objectRestCatchES5.symbols
+++ b/tests/baselines/reference/objectRestCatchES5.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/types/rest/objectRestCatchES5.ts ===
+let a = 1, b = 2;
+>a : Symbol(a, Decl(objectRestCatchES5.ts, 0, 3))
+>b : Symbol(b, Decl(objectRestCatchES5.ts, 0, 10))
+
+try {} catch ({ a, ...b }) {}
+>a : Symbol(a, Decl(objectRestCatchES5.ts, 1, 15))
+>b : Symbol(b, Decl(objectRestCatchES5.ts, 1, 18))
+

--- a/tests/baselines/reference/objectRestCatchES5.types
+++ b/tests/baselines/reference/objectRestCatchES5.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/types/rest/objectRestCatchES5.ts ===
+let a = 1, b = 2;
+>a : number
+>1 : 1
+>b : number
+>2 : 2
+
+try {} catch ({ a, ...b }) {}
+>a : any
+>b : any
+

--- a/tests/cases/conformance/types/rest/objectRestCatchES5.ts
+++ b/tests/cases/conformance/types/rest/objectRestCatchES5.ts
@@ -1,0 +1,2 @@
+let a = 1, b = 2;
+try {} catch ({ a, ...b }) {}


### PR DESCRIPTION
Fixes a crash when transforming the following to ES5:
```ts
try {} catch ({ a, ...b }) {}
```

~This also relocates some of our `Debug` code because we had some duplicative code across different files, which I discovered while adding some additional debug info while diagnosing the issue.~ (moving this to a separate PR)

Fixes #30627
