### PR TITLE
Fix crash when checking invalid object rest

### DIFF
--- a/tests/baselines/reference/objectRestPropertyMustBeLast.errors.txt
+++ b/tests/baselines/reference/objectRestPropertyMustBeLast.errors.txt
@@ -1,0 +1,21 @@
+tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts(1,9): error TS2462: A rest element must be last in a destructuring pattern.
+tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts(2,3): error TS2462: A rest element must be last in a destructuring pattern.
+tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts(4,9): error TS2462: A rest element must be last in a destructuring pattern.
+tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts(5,3): error TS2462: A rest element must be last in a destructuring pattern.
+
+
+==== tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts (4 errors) ====
+    var {...a, x } = { x: 1 };    // Error, rest must be last property
+            ~
+!!! error TS2462: A rest element must be last in a destructuring pattern.
+    ({...a, x } = { x: 1 });      // Error, rest must be last property
+      ~~~~
+!!! error TS2462: A rest element must be last in a destructuring pattern.
+    
+    var {...a, x, ...b } = { x: 1 };    // Error, rest must be last property
+            ~
+!!! error TS2462: A rest element must be last in a destructuring pattern.
+    ({...a, x, ...b } = { x: 1 });      // Error, rest must be last property
+      ~~~~
+!!! error TS2462: A rest element must be last in a destructuring pattern.
+    

--- a/tests/baselines/reference/objectRestPropertyMustBeLast.js
+++ b/tests/baselines/reference/objectRestPropertyMustBeLast.js
@@ -1,0 +1,25 @@
+//// [objectRestPropertyMustBeLast.ts]
+var {...a, x } = { x: 1 };    // Error, rest must be last property
+({...a, x } = { x: 1 });      // Error, rest must be last property
+
+var {...a, x, ...b } = { x: 1 };    // Error, rest must be last property
+({...a, x, ...b } = { x: 1 });      // Error, rest must be last property
+
+
+//// [objectRestPropertyMustBeLast.js]
+var __rest = (this && this.__rest) || function (s, e) {
+    var t = {};
+    for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
+        t[p] = s[p];
+    if (s != null && typeof Object.getOwnPropertySymbols === "function")
+        for (var i = 0, p = Object.getOwnPropertySymbols(s); i < p.length; i++) {
+            if (e.indexOf(p[i]) < 0 && Object.prototype.propertyIsEnumerable.call(s, p[i]))
+                t[p[i]] = s[p[i]];
+        }
+    return t;
+};
+var _a, _b;
+var _c = { x: 1 }, x = _c.x; // Error, rest must be last property
+(_a = { x: 1 }, (x = _a.x, _a)); // Error, rest must be last property
+var _d = { x: 1 }, x = _d.x, b = __rest(_d, ["a", "x"]); // Error, rest must be last property
+(_b = { x: 1 }, (x = _b.x, _b), b = __rest(_b, ["x"])); // Error, rest must be last property

--- a/tests/baselines/reference/objectRestPropertyMustBeLast.symbols
+++ b/tests/baselines/reference/objectRestPropertyMustBeLast.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts ===
+var {...a, x } = { x: 1 };    // Error, rest must be last property
+>a : Symbol(a, Decl(objectRestPropertyMustBeLast.ts, 0, 5), Decl(objectRestPropertyMustBeLast.ts, 3, 5))
+>x : Symbol(x, Decl(objectRestPropertyMustBeLast.ts, 0, 10), Decl(objectRestPropertyMustBeLast.ts, 3, 10))
+>x : Symbol(x, Decl(objectRestPropertyMustBeLast.ts, 0, 18))
+
+({...a, x } = { x: 1 });      // Error, rest must be last property
+>a : Symbol(a, Decl(objectRestPropertyMustBeLast.ts, 0, 5), Decl(objectRestPropertyMustBeLast.ts, 3, 5))
+>x : Symbol(x, Decl(objectRestPropertyMustBeLast.ts, 1, 7))
+>x : Symbol(x, Decl(objectRestPropertyMustBeLast.ts, 1, 15))
+
+var {...a, x, ...b } = { x: 1 };    // Error, rest must be last property
+>a : Symbol(a, Decl(objectRestPropertyMustBeLast.ts, 0, 5), Decl(objectRestPropertyMustBeLast.ts, 3, 5))
+>x : Symbol(x, Decl(objectRestPropertyMustBeLast.ts, 0, 10), Decl(objectRestPropertyMustBeLast.ts, 3, 10))
+>b : Symbol(b, Decl(objectRestPropertyMustBeLast.ts, 3, 13))
+>x : Symbol(x, Decl(objectRestPropertyMustBeLast.ts, 3, 24))
+
+({...a, x, ...b } = { x: 1 });      // Error, rest must be last property
+>a : Symbol(a, Decl(objectRestPropertyMustBeLast.ts, 0, 5), Decl(objectRestPropertyMustBeLast.ts, 3, 5))
+>x : Symbol(x, Decl(objectRestPropertyMustBeLast.ts, 4, 7))
+>b : Symbol(b, Decl(objectRestPropertyMustBeLast.ts, 3, 13))
+>x : Symbol(x, Decl(objectRestPropertyMustBeLast.ts, 4, 21))
+

--- a/tests/baselines/reference/objectRestPropertyMustBeLast.types
+++ b/tests/baselines/reference/objectRestPropertyMustBeLast.types
@@ -1,0 +1,37 @@
+=== tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts ===
+var {...a, x } = { x: 1 };    // Error, rest must be last property
+>a : {}
+>x : number
+>{ x: 1 } : { x: number; }
+>x : number
+>1 : 1
+
+({...a, x } = { x: 1 });      // Error, rest must be last property
+>({...a, x } = { x: 1 }) : { x: number; }
+>{...a, x } = { x: 1 } : { x: number; }
+>{...a, x } : { x: number; }
+>a : {}
+>x : number
+>{ x: 1 } : { x: number; }
+>x : number
+>1 : 1
+
+var {...a, x, ...b } = { x: 1 };    // Error, rest must be last property
+>a : {}
+>x : number
+>b : {}
+>{ x: 1 } : { x: number; }
+>x : number
+>1 : 1
+
+({...a, x, ...b } = { x: 1 });      // Error, rest must be last property
+>({...a, x, ...b } = { x: 1 }) : { x: number; }
+>{...a, x, ...b } = { x: 1 } : { x: number; }
+>{...a, x, ...b } : { x: number; }
+>a : {}
+>x : number
+>b : {}
+>{ x: 1 } : { x: number; }
+>x : number
+>1 : 1
+

--- a/tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts
+++ b/tests/cases/conformance/types/rest/objectRestPropertyMustBeLast.ts
@@ -1,0 +1,5 @@
+var {...a, x } = { x: 1 };    // Error, rest must be last property
+({...a, x } = { x: 1 });      // Error, rest must be last property
+
+var {...a, x, ...b } = { x: 1 };    // Error, rest must be last property
+({...a, x, ...b } = { x: 1 });      // Error, rest must be last property


### PR DESCRIPTION
We were not checking whether a `SpreadAssignment` was in a valid place in an object destructuring assignment, and just assumed all properties except the last one were valid. This change ensures we do not crash and properly report an error.

Fixes #29610
