### PR TITLE
Use defaults for transpileModule

### DIFF
--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -26,7 +26,15 @@ namespace ts {
     export function transpileModule(input: string, transpileOptions: TranspileOptions): TranspileOutput {
         const diagnostics: Diagnostic[] = [];
 
-        const options: CompilerOptions = transpileOptions.compilerOptions ? fixupCompilerOptions(transpileOptions.compilerOptions, diagnostics) : getDefaultCompilerOptions();
+        const options: CompilerOptions = transpileOptions.compilerOptions ? fixupCompilerOptions(transpileOptions.compilerOptions, diagnostics) : {};
+
+        // mix in default options
+        const defaultOptions = getDefaultCompilerOptions();
+        for (const key in defaultOptions) {
+            if (hasProperty(defaultOptions, key) && options[key] === undefined) {
+                options[key] = defaultOptions[key];
+            }
+        }
 
         options.isolatedModules = true;
 

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -17,7 +17,10 @@ namespace ts {
 
                 transpileOptions = testSettings.options || {};
                 if (!transpileOptions.compilerOptions) {
-                    transpileOptions.compilerOptions = {};
+                    transpileOptions.compilerOptions = { };
+                }
+                if (transpileOptions.compilerOptions.target === undefined) {
+                    transpileOptions.compilerOptions.target = ScriptTarget.ES3;
                 }
 
                 if (transpileOptions.compilerOptions.newLine === undefined) {


### PR DESCRIPTION
This change fills in the default compiler options for `transpileModule` so that `transpileModule(text, {})` and `transpileModule(text, { compilerOptions: {} })` result in the same output.

@DanielRosenwasser, @RyanCavanaugh: This could be considered a breaking change and thus we may want to consider postponing this until 3.6.

Fixes #28874
