### PR TITLE
 Fix containsPrecedingToken for tokens whose preceding token is a missing node

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1208,7 +1208,7 @@ Actual: ${stringify(fullActual)}`);
             }
         }
 
-        public verifySignatureHelpPresence(expectPresent: boolean, triggerReason: ts.SignatureHelpTriggerReason | undefined, markers: ReadonlyArray<string>) {
+        public verifySignatureHelpPresence(expectPresent: boolean, triggerReason: ts.SignatureHelpTriggerReason | undefined, markers: ReadonlyArray<string | Marker>) {
             if (markers.length) {
                 for (const marker of markers) {
                     this.goToMarker(marker);
@@ -3768,15 +3768,15 @@ namespace FourSlashInterface {
             assert(ranges.length !== 0, "Array of ranges is expected to be non-empty");
         }
 
-        public noSignatureHelp(...markers: string[]): void {
+        public noSignatureHelp(...markers: (string | FourSlash.Marker)[]): void {
             this.state.verifySignatureHelpPresence(/*expectPresent*/ false, /*triggerReason*/ undefined, markers);
         }
 
-        public noSignatureHelpForTriggerReason(reason: ts.SignatureHelpTriggerReason, ...markers: string[]): void {
+        public noSignatureHelpForTriggerReason(reason: ts.SignatureHelpTriggerReason, ...markers: (string | FourSlash.Marker)[]): void {
             this.state.verifySignatureHelpPresence(/*expectPresent*/ false, reason, markers);
         }
 
-        public signatureHelpPresentForTriggerReason(reason: ts.SignatureHelpTriggerReason, ...markers: string[]): void {
+        public signatureHelpPresentForTriggerReason(reason: ts.SignatureHelpTriggerReason, ...markers: (string | FourSlash.Marker)[]): void {
             this.state.verifySignatureHelpPresence(/*expectPresent*/ true, reason, markers);
         }
 
@@ -5124,7 +5124,7 @@ namespace FourSlashInterface {
     }
 
     export interface VerifySignatureHelpOptions {
-        readonly marker?: ArrayOrSingle<string>;
+        readonly marker?: ArrayOrSingle<string | FourSlash.Marker>;
         /** @default 1 */
         readonly overloadsCount?: number;
         /** @default undefined */

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -232,9 +232,9 @@ declare namespace FourSlashInterface {
         rangesWithSameTextAreRenameLocations(): void;
         rangesAreRenameLocations(options?: Range[] | { findInStrings?: boolean, findInComments?: boolean, ranges?: Range[] });
         findReferencesDefinitionDisplayPartsAtCaretAre(expected: ts.SymbolDisplayPart[]): void;
-        noSignatureHelp(...markers: string[]): void;
-        noSignatureHelpForTriggerReason(triggerReason: SignatureHelpTriggerReason, ...markers: string[]): void
-        signatureHelpPresentForTriggerReason(triggerReason: SignatureHelpTriggerReason, ...markers: string[]): void
+        noSignatureHelp(...markers: (string | Marker)[]): void;
+        noSignatureHelpForTriggerReason(triggerReason: SignatureHelpTriggerReason, ...markers: (string | Marker)[]): void
+        signatureHelpPresentForTriggerReason(triggerReason: SignatureHelpTriggerReason, ...markers: (string | Marker)[]): void
         signatureHelp(...options: VerifySignatureHelpOptions[], ): void;
         // Checks that there are no compile errors.
         noErrors(): void;
@@ -538,7 +538,7 @@ declare namespace FourSlashInterface {
     }
 
     interface VerifySignatureHelpOptions {
-        marker?: ArrayOrSingle<string>;
+        marker?: ArrayOrSingle<string | Marker>;
         /** @default 1 */
         overloadsCount?: number;
         docComment?: string;

--- a/tests/cases/fourslash/signatureHelpJSX.ts
+++ b/tests/cases/fourslash/signatureHelpJSX.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+//@Filename: test.tsx
+//@jsx: react
+////declare var React: any;
+////const z = <div>{[].map(x => </**/
+
+// This test exists because it used to crash: #31347
+goTo.marker();
+verify.noSignatureHelpForTriggerReason({ kind: "characterTyped", triggerCharacter: "<" });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31347 
