### PR TITLE
Collect _all_ symlinks a file may have witnessed when attempting to generate specifiers

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -175,9 +175,9 @@ namespace ts.moduleSpecifiers {
 
     function discoverProbableSymlinks(files: ReadonlyArray<SourceFile>, getCanonicalFileName: GetCanonicalFileName, cwd: string): ReadonlyMap<string> {
         const result = createMap<string>();
-        const symlinks = mapDefined(files, sf =>
-            sf.resolvedModules && firstDefinedIterator(sf.resolvedModules.values(), res =>
-                res && res.originalPath && res.resolvedFileName !== res.originalPath ? [res.resolvedFileName, res.originalPath] : undefined));
+        const symlinks = flatten<readonly [string, string]>(mapDefined(files, sf =>
+            sf.resolvedModules && compact(arrayFrom(mapIterator(sf.resolvedModules.values(), res =>
+                res && res.originalPath && res.resolvedFileName !== res.originalPath ? [res.resolvedFileName, res.originalPath] as const : undefined)))));
         for (const [resolvedPath, originalPath] of symlinks) {
             const [commonResolved, commonOriginal] = guessDirectorySymlink(resolvedPath, originalPath, cwd, getCanonicalFileName);
             result.set(commonOriginal, commonResolved);

--- a/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink.js
+++ b/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink.js
@@ -1,0 +1,45 @@
+//// [tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts] ////
+
+//// [impl.d.ts]
+export function getA(): A;
+export enum A {
+    Val
+}
+//// [index.d.ts]
+export * from "./src/impl";
+//// [package.json]
+{
+    "name": "typescript-fsa",
+    "version": "1.0.0"
+}
+//// [impl.d.ts]
+export function getA(): A;
+export enum A {
+    Val
+}
+//// [index.d.ts]
+export * from "./src/impl";
+//// [package.json]
+{
+    "name": "typescript-fsa",
+    "version": "1.0.0"
+}
+//// [index.ts]
+import * as _whatever from "p2";
+import { getA } from "typescript-fsa";
+
+export const a = getA();
+//// [index.d.ts]
+export const a: import("typescript-fsa").A;
+
+
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var typescript_fsa_1 = require("typescript-fsa");
+exports.a = typescript_fsa_1.getA();
+
+
+//// [index.d.ts]
+export declare const a: import("typescript-fsa").A;

--- a/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink.symbols
+++ b/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink.symbols
@@ -1,0 +1,43 @@
+=== /p1/node_modules/typescript-fsa/src/impl.d.ts ===
+export function getA(): A;
+>getA : Symbol(getA, Decl(impl.d.ts, 0, 0))
+>A : Symbol(A, Decl(impl.d.ts, 0, 26))
+
+export enum A {
+>A : Symbol(A, Decl(impl.d.ts, 0, 26))
+
+    Val
+>Val : Symbol(A.Val, Decl(impl.d.ts, 1, 15))
+}
+=== /p1/node_modules/typescript-fsa/index.d.ts ===
+export * from "./src/impl";
+No type information for this code.=== /p2/node_modules/typescript-fsa/src/impl.d.ts ===
+export function getA(): A;
+>getA : Symbol(getA, Decl(impl.d.ts, 0, 0))
+>A : Symbol(A, Decl(impl.d.ts, 0, 26))
+
+export enum A {
+>A : Symbol(A, Decl(impl.d.ts, 0, 26))
+
+    Val
+>Val : Symbol(A.Val, Decl(impl.d.ts, 1, 15))
+}
+=== /p2/node_modules/typescript-fsa/index.d.ts ===
+export * from "./src/impl";
+No type information for this code.=== /p1/index.ts ===
+import * as _whatever from "p2";
+>_whatever : Symbol(_whatever, Decl(index.ts, 0, 6))
+
+import { getA } from "typescript-fsa";
+>getA : Symbol(getA, Decl(index.ts, 1, 8))
+
+export const a = getA();
+>a : Symbol(a, Decl(index.ts, 3, 12))
+>getA : Symbol(getA, Decl(index.ts, 1, 8))
+
+=== /p2/index.d.ts ===
+export const a: import("typescript-fsa").A;
+>a : Symbol(a, Decl(index.d.ts, 0, 12))
+>A : Symbol(A, Decl(impl.d.ts, 0, 26))
+
+

--- a/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink.types
+++ b/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink.types
@@ -1,0 +1,41 @@
+=== /p1/node_modules/typescript-fsa/src/impl.d.ts ===
+export function getA(): A;
+>getA : () => A
+
+export enum A {
+>A : A
+
+    Val
+>Val : A
+}
+=== /p1/node_modules/typescript-fsa/index.d.ts ===
+export * from "./src/impl";
+No type information for this code.=== /p2/node_modules/typescript-fsa/src/impl.d.ts ===
+export function getA(): A;
+>getA : () => A
+
+export enum A {
+>A : A
+
+    Val
+>Val : A
+}
+=== /p2/node_modules/typescript-fsa/index.d.ts ===
+export * from "./src/impl";
+No type information for this code.=== /p1/index.ts ===
+import * as _whatever from "p2";
+>_whatever : typeof _whatever
+
+import { getA } from "typescript-fsa";
+>getA : () => import("/p1/node_modules/typescript-fsa/index").A
+
+export const a = getA();
+>a : import("/p1/node_modules/typescript-fsa/index").A
+>getA() : import("/p1/node_modules/typescript-fsa/index").A
+>getA : () => import("/p1/node_modules/typescript-fsa/index").A
+
+=== /p2/index.d.ts ===
+export const a: import("typescript-fsa").A;
+>a : import("/p2/node_modules/typescript-fsa/index").A
+
+

--- a/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink2.js
+++ b/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink2.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts] ////
+
+//// [impl.d.ts]
+export function getA(): A;
+export enum A {
+    Val
+}
+//// [index.d.ts]
+export * from "./src/impl";
+//// [package.json]
+{
+    "name": "typescript-fsa",
+    "version": "1.0.0"
+}
+//// [index.ts]
+import * as _whatever from "p2";
+import { getA } from "typescript-fsa";
+
+export const a = getA();
+//// [index.d.ts]
+export const a: import("typescript-fsa").A;
+
+
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var typescript_fsa_1 = require("typescript-fsa");
+exports.a = typescript_fsa_1.getA();
+
+
+//// [index.d.ts]
+export declare const a: import("typescript-fsa").A;

--- a/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink2.symbols
+++ b/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink2.symbols
@@ -1,0 +1,30 @@
+=== /cache/typescript-fsa/src/impl.d.ts ===
+export function getA(): A;
+>getA : Symbol(getA, Decl(impl.d.ts, 0, 0))
+>A : Symbol(A, Decl(impl.d.ts, 0, 26))
+
+export enum A {
+>A : Symbol(A, Decl(impl.d.ts, 0, 26))
+
+    Val
+>Val : Symbol(A.Val, Decl(impl.d.ts, 1, 15))
+}
+=== /cache/typescript-fsa/index.d.ts ===
+export * from "./src/impl";
+No type information for this code.=== /p1/index.ts ===
+import * as _whatever from "p2";
+>_whatever : Symbol(_whatever, Decl(index.ts, 0, 6))
+
+import { getA } from "typescript-fsa";
+>getA : Symbol(getA, Decl(index.ts, 1, 8))
+
+export const a = getA();
+>a : Symbol(a, Decl(index.ts, 3, 12))
+>getA : Symbol(getA, Decl(index.ts, 1, 8))
+
+=== /p2/index.d.ts ===
+export const a: import("typescript-fsa").A;
+>a : Symbol(a, Decl(index.d.ts, 0, 12))
+>A : Symbol(A, Decl(impl.d.ts, 0, 26))
+
+

--- a/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink2.types
+++ b/tests/baselines/reference/declarationEmitForGlobalishSpecifierSymlink2.types
@@ -1,0 +1,29 @@
+=== /cache/typescript-fsa/src/impl.d.ts ===
+export function getA(): A;
+>getA : () => A
+
+export enum A {
+>A : A
+
+    Val
+>Val : A
+}
+=== /cache/typescript-fsa/index.d.ts ===
+export * from "./src/impl";
+No type information for this code.=== /p1/index.ts ===
+import * as _whatever from "p2";
+>_whatever : typeof _whatever
+
+import { getA } from "typescript-fsa";
+>getA : () => import("/cache/typescript-fsa/index").A
+
+export const a = getA();
+>a : import("/cache/typescript-fsa/index").A
+>getA() : import("/cache/typescript-fsa/index").A
+>getA : () => import("/cache/typescript-fsa/index").A
+
+=== /p2/index.d.ts ===
+export const a: import("typescript-fsa").A;
+>a : import("/cache/typescript-fsa/index").A
+
+

--- a/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
+++ b/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
@@ -1,0 +1,35 @@
+// @useCaseSensitiveFilenames: true
+// @declaration: true
+// @filename: /p1/node_modules/typescript-fsa/src/impl.d.ts
+export function getA(): A;
+export enum A {
+    Val
+}
+// @filename: /p1/node_modules/typescript-fsa/index.d.ts
+export * from "./src/impl";
+// @filename: /p1/node_modules/typescript-fsa/package.json
+{
+    "name": "typescript-fsa",
+    "version": "1.0.0"
+}
+// @filename: /p2/node_modules/typescript-fsa/src/impl.d.ts
+export function getA(): A;
+export enum A {
+    Val
+}
+// @filename: /p2/node_modules/typescript-fsa/index.d.ts
+export * from "./src/impl";
+// @filename: /p2/node_modules/typescript-fsa/package.json
+{
+    "name": "typescript-fsa",
+    "version": "1.0.0"
+}
+// @filename: /p1/index.ts
+import * as _whatever from "p2";
+import { getA } from "typescript-fsa";
+
+export const a = getA();
+// @filename: /p2/index.d.ts
+export const a: import("typescript-fsa").A;
+
+// @link: /p2 -> /p1/node_modules/p2

--- a/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
+++ b/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
@@ -1,0 +1,25 @@
+// @useCaseSensitiveFilenames: true
+// @declaration: true
+// @filename: /cache/typescript-fsa/src/impl.d.ts
+export function getA(): A;
+export enum A {
+    Val
+}
+// @filename: /cache/typescript-fsa/index.d.ts
+export * from "./src/impl";
+// @filename: /cache/typescript-fsa/package.json
+{
+    "name": "typescript-fsa",
+    "version": "1.0.0"
+}
+// @filename: /p1/index.ts
+import * as _whatever from "p2";
+import { getA } from "typescript-fsa";
+
+export const a = getA();
+// @filename: /p2/index.d.ts
+export const a: import("typescript-fsa").A;
+
+// @link: /p2 -> /p1/node_modules/p2
+// @link: /cache/typescript-fsa -> /p1/node_modules/typescript-fsa
+// @link: /cache/typescript-fsa -> /p2/node_modules/typescript-fsa


### PR DESCRIPTION
Fixes an issue brought up by @simonfox in [this comment](https://github.com/microsoft/TypeScript/issues/29808#issuecomment-487811832).

Also fixes [this comment](https://github.com/microsoft/TypeScript/issues/29221#issuecomment-473245901)

Fixes #29221, probably - the repro from the OP has had a bit of bitrot and doesn't really compile clean.

The issue was essentially that `importHelpers` synthesizes an `import` entry in every file, which in turn makes a new `moduleResolution` - and we were then only inspecting the first `moduleResolution` for possible symlinks, rather than all of them (so the `tslib` import would prevent us from finding any symlinks).