### PR TITLE
Checking RWC/DT impact of disallowing 'keyof T' where T is known primitive

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10048,7 +10048,11 @@ namespace ts {
             if (!links.resolvedType) {
                 switch (node.operator) {
                     case SyntaxKind.KeyOfKeyword:
-                        links.resolvedType = getIndexType(getTypeFromTypeNode(node.type));
+                        const operandType = getTypeFromTypeNode(node.type);
+                        if (operandType.flags & TypeFlags.Primitive) {
+                            error(node, Diagnostics.Cannot_directly_use_keyof_operator_on_primitive_0_Are_you_missing_a_typeof, typeToString(operandType));
+                        }
+                        links.resolvedType = getIndexType(operandType);
                         break;
                     case SyntaxKind.UniqueKeyword:
                         links.resolvedType = node.type.kind === SyntaxKind.SymbolKeyword

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2963,6 +2963,10 @@
         "category": "Error",
         "code": 4104
     },
+    "Cannot directly use 'keyof' operator on primitive '{0}'. Are you missing a 'typeof' ?": {
+        "category": "Error",
+        "code": 4106
+    },
 
     "The current host does not support the '{0}' option.": {
         "category": "Error",

--- a/tests/baselines/reference/mappedTypes1.errors.txt
+++ b/tests/baselines/reference/mappedTypes1.errors.txt
@@ -1,0 +1,63 @@
+tests/cases/conformance/types/mapped/mappedTypes1.ts(17,20): error TS4106: Cannot directly use 'keyof' operator on primitive 'string'. Are you missing a 'typeof' ?
+tests/cases/conformance/types/mapped/mappedTypes1.ts(18,20): error TS4106: Cannot directly use 'keyof' operator on primitive 'number'. Are you missing a 'typeof' ?
+tests/cases/conformance/types/mapped/mappedTypes1.ts(19,20): error TS4106: Cannot directly use 'keyof' operator on primitive 'boolean'. Are you missing a 'typeof' ?
+tests/cases/conformance/types/mapped/mappedTypes1.ts(20,20): error TS4106: Cannot directly use 'keyof' operator on primitive 'undefined'. Are you missing a 'typeof' ?
+tests/cases/conformance/types/mapped/mappedTypes1.ts(21,20): error TS4106: Cannot directly use 'keyof' operator on primitive 'null'. Are you missing a 'typeof' ?
+tests/cases/conformance/types/mapped/mappedTypes1.ts(22,20): error TS4106: Cannot directly use 'keyof' operator on primitive 'void'. Are you missing a 'typeof' ?
+tests/cases/conformance/types/mapped/mappedTypes1.ts(23,20): error TS4106: Cannot directly use 'keyof' operator on primitive 'symbol'. Are you missing a 'typeof' ?
+
+
+==== tests/cases/conformance/types/mapped/mappedTypes1.ts (7 errors) ====
+    type Item = { a: string, b: number, c: boolean };
+    
+    type T00 = { [P in "x" | "y"]: number };
+    type T01 = { [P in "x" | "y"]: P };
+    type T02 = { [P in "a" | "b"]: Item[P]; }
+    type T03 = { [P in keyof Item]: Date };
+    
+    type T10 = { [P in keyof Item]: Item[P] };
+    type T11 = { [P in keyof Item]?: Item[P] };
+    type T12 = { readonly [P in keyof Item]: Item[P] };
+    type T13 = { readonly [P in keyof Item]?: Item[P] };
+    
+    type T20 = { [P in keyof Item]: Item[P] | null };
+    type T21 = { [P in keyof Item]: Array<Item[P]> };
+    
+    type T30 = { [P in keyof any]: void };
+    type T31 = { [P in keyof string]: void };
+                       ~~~~~~~~~~~~
+!!! error TS4106: Cannot directly use 'keyof' operator on primitive 'string'. Are you missing a 'typeof' ?
+    type T32 = { [P in keyof number]: void };
+                       ~~~~~~~~~~~~
+!!! error TS4106: Cannot directly use 'keyof' operator on primitive 'number'. Are you missing a 'typeof' ?
+    type T33 = { [P in keyof boolean]: void };
+                       ~~~~~~~~~~~~~
+!!! error TS4106: Cannot directly use 'keyof' operator on primitive 'boolean'. Are you missing a 'typeof' ?
+    type T34 = { [P in keyof undefined]: void };
+                       ~~~~~~~~~~~~~~~
+!!! error TS4106: Cannot directly use 'keyof' operator on primitive 'undefined'. Are you missing a 'typeof' ?
+    type T35 = { [P in keyof null]: void };
+                       ~~~~~~~~~~
+!!! error TS4106: Cannot directly use 'keyof' operator on primitive 'null'. Are you missing a 'typeof' ?
+    type T36 = { [P in keyof void]: void };
+                       ~~~~~~~~~~
+!!! error TS4106: Cannot directly use 'keyof' operator on primitive 'void'. Are you missing a 'typeof' ?
+    type T37 = { [P in keyof symbol]: void };
+                       ~~~~~~~~~~~~
+!!! error TS4106: Cannot directly use 'keyof' operator on primitive 'symbol'. Are you missing a 'typeof' ?
+    type T38 = { [P in keyof never]: void };
+    
+    type T40 = { [P in string]: void };
+    type T43 = { [P in "a" | "b"]: void };
+    type T44 = { [P in "a" | "b" | "0" | "1"]: void };
+    type T47 = { [P in string | "a" | "b" | "0" | "1"]: void };
+    
+    declare function f1<T1>(): { [P in keyof T1]: void };
+    declare function f2<T1 extends string>(): { [P in keyof T1]: void };
+    declare function f3<T1 extends number>(): { [P in keyof T1]: void };
+    declare function f4<T1 extends Number>(): { [P in keyof T1]: void };
+    
+    let x1 = f1();
+    let x2 = f2();
+    let x3 = f3();
+    let x4 = f4();


### PR DESCRIPTION
From #31620 