### PR TITLE
Stop invalidating module resolution cache when saving an open file

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -54,6 +54,7 @@ namespace ts {
         writeLog(s: string): void;
         maxNumberOfFilesToIterateForInvalidation?: number;
         getCurrentProgram(): Program | undefined;
+        fileIsOpen(filePath: Path): boolean;
     }
 
     interface DirectoryWatchesOfFailedLookup {
@@ -712,6 +713,10 @@ namespace ts {
                 else {
                     if (!isPathWithDefaultFailedLookupExtension(fileOrDirectoryPath) && !customFailedLookupPaths.has(fileOrDirectoryPath)) {
                         return false;
+                    }
+                    // prevent saving an open file from over-eagerly triggering invalidation
+                    if (resolutionHost.fileIsOpen(fileOrDirectoryPath)) {
+                        return;
                     }
                     // Ignore emits from the program
                     if (isEmittedFileOfProgram(resolutionHost.getCurrentProgram(), fileOrDirectoryPath)) {

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -716,7 +716,7 @@ namespace ts {
                     }
                     // prevent saving an open file from over-eagerly triggering invalidation
                     if (resolutionHost.fileIsOpen(fileOrDirectoryPath)) {
-                        return;
+                        return false;
                     }
                     // Ignore emits from the program
                     if (isEmittedFileOfProgram(resolutionHost.getCurrentProgram(), fileOrDirectoryPath)) {

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -699,6 +699,11 @@ namespace ts {
                 // If something to do with folder/file starting with "." in node_modules folder, skip it
                 if (isPathIgnored(fileOrDirectoryPath)) return false;
 
+                // prevent saving an open file from over-eagerly triggering invalidation
+                if (resolutionHost.fileIsOpen(fileOrDirectoryPath)) {
+                    return false;
+                }
+
                 // Some file or directory in the watching directory is created
                 // Return early if it does not have any of the watching extension or not the custom failed lookup path
                 const dirOfFileOrDirectory = getDirectoryPath(fileOrDirectoryPath);
@@ -712,10 +717,6 @@ namespace ts {
                 }
                 else {
                     if (!isPathWithDefaultFailedLookupExtension(fileOrDirectoryPath) && !customFailedLookupPaths.has(fileOrDirectoryPath)) {
-                        return false;
-                    }
-                    // prevent saving an open file from over-eagerly triggering invalidation
-                    if (resolutionHost.fileIsOpen(fileOrDirectoryPath)) {
                         return false;
                     }
                     // Ignore emits from the program

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -691,7 +691,7 @@ namespace ts {
             hasChangedAutomaticTypeDirectiveNames = true;
             scheduleProgramUpdate();
         };
-        compilerHost.fileIsOpen = () => false;
+        compilerHost.fileIsOpen = returnFalse;
         compilerHost.maxNumberOfFilesToIterateForInvalidation = host.maxNumberOfFilesToIterateForInvalidation;
         compilerHost.getCurrentProgram = getCurrentProgram;
         compilerHost.writeLog = writeLog;

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -691,6 +691,7 @@ namespace ts {
             hasChangedAutomaticTypeDirectiveNames = true;
             scheduleProgramUpdate();
         };
+        compilerHost.fileIsOpen = () => false;
         compilerHost.maxNumberOfFilesToIterateForInvalidation = host.maxNumberOfFilesToIterateForInvalidation;
         compilerHost.getCurrentProgram = getCurrentProgram;
         compilerHost.writeLog = writeLog;

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1002,7 +1002,13 @@ namespace ts.server {
                 directory,
                 fileOrDirectory => {
                     const fileOrDirectoryPath = this.toPath(fileOrDirectory);
-                    project.getCachedDirectoryStructureHost().addOrDeleteFileOrDirectory(fileOrDirectory, fileOrDirectoryPath);
+                    const fileSystemResult = project.getCachedDirectoryStructureHost().addOrDeleteFileOrDirectory(fileOrDirectory, fileOrDirectoryPath);
+
+                    // don't trigger callback on open, existing files
+                    if (project.fileIsOpen(fileOrDirectoryPath) && fileSystemResult && fileSystemResult.fileExists) {
+                        return;
+                    }
+
                     if (isPathIgnored(fileOrDirectoryPath)) return;
                     const configFilename = project.getConfigFilePath();
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1002,10 +1002,10 @@ namespace ts.server {
                 directory,
                 fileOrDirectory => {
                     const fileOrDirectoryPath = this.toPath(fileOrDirectory);
-                    const fileSystemResult = project.getCachedDirectoryStructureHost().addOrDeleteFileOrDirectory(fileOrDirectory, fileOrDirectoryPath);
+                    project.getCachedDirectoryStructureHost().addOrDeleteFileOrDirectory(fileOrDirectory, fileOrDirectoryPath);
 
                     // don't trigger callback on open, existing files
-                    if (project.fileIsOpen(fileOrDirectoryPath) && fileSystemResult && fileSystemResult.fileExists) {
+                    if (project.fileIsOpen(fileOrDirectoryPath)) {
                         return;
                     }
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -458,6 +458,11 @@ namespace ts.server {
         }
 
         /*@internal*/
+        fileIsOpen(filePath: Path) {
+            return this.projectService.openFiles.has(filePath);
+        }
+
+        /*@internal*/
         writeLog(s: string) {
             this.projectService.logger.info(s);
         }

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -1341,6 +1341,26 @@ var x = 10;`
             }
         });
 
+        it("no project structure update on directory watch invoke on open file save", () => {
+            const projectRootPath = "/users/username/projects/project";
+            const fileA: File = {
+                path: `${projectRootPath}/a.ts`,
+                content: "export const a = 10;"
+            };
+            const config: File = {
+                path: `${projectRootPath}/tsconfig.json`,
+                content: "{}"
+            };
+            const files = [fileA, config];
+            const host = createServerHost(files);
+            const service = createProjectService(host);
+            service.openClientFile(fileA.path);
+            checkNumberOfProjects(service, { configuredProjects: 1 });
+
+            host.invokeWatchedDirectoriesRecursiveCallback(projectRootPath, "a.ts");
+            host.checkTimeoutQueueLength(0);
+        });
+
         it("handles delayed directory watch invoke on file creation", () => {
             const projectRootPath = "/users/username/projects/project";
             const fileB: File = {

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -1343,7 +1343,7 @@ var x = 10;`
 
         it("no project structure update on directory watch invoke on open file save", () => {
             const projectRootPath = "/users/username/projects/project";
-            const fileA: File = {
+            const file1: File = {
                 path: `${projectRootPath}/a.ts`,
                 content: "export const a = 10;"
             };
@@ -1351,13 +1351,13 @@ var x = 10;`
                 path: `${projectRootPath}/tsconfig.json`,
                 content: "{}"
             };
-            const files = [fileA, config];
+            const files = [file1, config];
             const host = createServerHost(files);
             const service = createProjectService(host);
-            service.openClientFile(fileA.path);
+            service.openClientFile(file1.path);
             checkNumberOfProjects(service, { configuredProjects: 1 });
 
-            host.invokeWatchedDirectoriesRecursiveCallback(projectRootPath, "a.ts");
+            host.modifyFile(file1.path, file1.content, { invokeFileDeleteCreateAsPartInsteadOfChange: true });
             host.checkTimeoutQueueLength(0);
         });
 

--- a/src/testRunner/unittests/tsserver/resolutionCache.ts
+++ b/src/testRunner/unittests/tsserver/resolutionCache.ts
@@ -975,5 +975,33 @@ export const x = 10;`
                 host.checkTimeoutQueueLength(0);
             });
         });
+
+        describe("avoid unnecessary invalidation", () => {
+            it("failed lookup invalidation", () => {
+                const expectedNonRelativeDirectories = [`${projectLocation}/node_modules`, `${projectLocation}/src`];
+                const module1Name = "module1";
+                const module2Name = "module2";
+                const fileContent = `import { module1 } from "${module1Name}";import { module2 } from "${module2Name}";`;
+                const file1: File = {
+                    path: `${projectLocation}/src/file1.ts`,
+                    content: fileContent
+                };
+                const { module1, module2 } = getModules(`${projectLocation}/src/node_modules/module1/index.ts`, `${projectLocation}/node_modules/module2/index.ts`);
+                const files = [module1, module2, file1, configFile, libFile];
+                const host = createServerHost(files);
+                const resolutionTrace = createHostModuleResolutionTrace(host);
+                const service = createProjectService(host);
+                service.openClientFile(file1.path);
+                const project = service.configuredProjects.get(configFile.path)!;
+                (project as ResolutionCacheHost).maxNumberOfFilesToIterateForInvalidation = 1;
+                const expectedTrace = getExpectedNonRelativeModuleResolutionTrace(host, file1, module1, module1Name);
+                getExpectedNonRelativeModuleResolutionTrace(host, file1, module2, module2Name, expectedTrace);
+                verifyTrace(resolutionTrace, expectedTrace);
+                verifyWatchesWithConfigFile(host, files, file1, expectedNonRelativeDirectories);
+
+                host.invokeWatchedDirectoriesRecursiveCallback(projectLocation + "/src", "file1.ts");
+                host.checkTimeoutQueueLengthAndRun(0);
+            });
+        });
     });
 }

--- a/src/testRunner/unittests/tsserver/resolutionCache.ts
+++ b/src/testRunner/unittests/tsserver/resolutionCache.ts
@@ -977,7 +977,7 @@ export const x = 10;`
         });
 
         describe("avoid unnecessary invalidation", () => {
-            it("failed lookup invalidation", () => {
+            it("unnecessary lookup invalidation on save", () => {
                 const expectedNonRelativeDirectories = [`${projectLocation}/node_modules`, `${projectLocation}/src`];
                 const module1Name = "module1";
                 const module2Name = "module2";
@@ -999,6 +999,7 @@ export const x = 10;`
                 verifyTrace(resolutionTrace, expectedTrace);
                 verifyWatchesWithConfigFile(host, files, file1, expectedNonRelativeDirectories);
 
+                // invoke callback to simulate saving
                 host.invokeWatchedDirectoriesRecursiveCallback(projectLocation + "/src", "file1.ts");
                 host.checkTimeoutQueueLengthAndRun(0);
             });

--- a/src/testRunner/unittests/tsserver/resolutionCache.ts
+++ b/src/testRunner/unittests/tsserver/resolutionCache.ts
@@ -1000,7 +1000,7 @@ export const x = 10;`
                 verifyWatchesWithConfigFile(host, files, file1, expectedNonRelativeDirectories);
 
                 // invoke callback to simulate saving
-                host.invokeWatchedDirectoriesRecursiveCallback(projectLocation + "/src", "file1.ts");
+                host.modifyFile(file1.path, file1.content, { invokeFileDeleteCreateAsPartInsteadOfChange: true });
                 host.checkTimeoutQueueLengthAndRun(0);
             });
         });

--- a/src/testRunner/unittests/tsserver/syntaxOperations.ts
+++ b/src/testRunner/unittests/tsserver/syntaxOperations.ts
@@ -60,13 +60,14 @@ describe("Test Suite 1", () => {
 
             const navBarResultUnitTest1 = navBarFull(session, unitTest1);
             host.deleteFile(unitTest1.path);
-            host.checkTimeoutQueueLengthAndRun(2);
-            checkProjectActualFiles(project, expectedFilesWithoutUnitTest1);
+            host.checkTimeoutQueueLengthAndRun(0);
+            checkProjectActualFiles(project, expectedFilesWithUnitTest1);
 
             session.executeCommandSeq<protocol.CloseRequest>({
                 command: protocol.CommandTypes.Close,
                 arguments: { file: unitTest1.path }
             });
+            host.checkTimeoutQueueLengthAndRun(2);
             checkProjectActualFiles(project, expectedFilesWithoutUnitTest1);
 
             const unitTest1WithChangedContent: File = {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

In Visual Studio, we currently trigger directory watchers when saving an open file.
In projects with sufficiently large dependencies (i.e., the ASP.NET Core Angular template), this causes the module resolution cache to be entirely invalidated, thereby triggering a seconds-long `updateGraph` operation to occur.
This change aims to prevent this scenario by checking if the file whose change triggered the directory watcher is still open and, if so, not invalidating the cache.
