### PR TITLE
Update errors for missing property in union type involving index signature

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20353,7 +20353,7 @@ namespace ts {
             let relatedInfo: Diagnostic | undefined;
             if (containingType.flags & TypeFlags.Union && !(containingType.flags & TypeFlags.Primitive)) {
                 for (const subtype of (containingType as UnionType).types) {
-                    if (!getPropertyOfType(subtype, propNode.escapedText)) {
+                    if (!getPropertyOfType(subtype, propNode.escapedText) && !getIndexInfoOfType(subtype, IndexKind.String)) {
                         errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1, declarationNameToString(propNode), typeToString(subtype));
                         break;
                     }

--- a/tests/baselines/reference/unionTypeWithIndexSignature.errors.txt
+++ b/tests/baselines/reference/unionTypeWithIndexSignature.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(11,3): error TS2339: Property 'bar' does not exist on type 'Missing'.
-  Property 'bar' does not exist on type '{ [s: string]: string; }'.
+  Property 'bar' does not exist on type '{ foo: boolean; }'.
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(14,4): error TS2540: Cannot assign to 'foo' because it is a read-only property.
 tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(24,1): error TS7053: Element implicitly has an 'any' type because expression of type '1' can't be used to index type 'Both'.
   Property '1' does not exist on type 'Both'.
@@ -22,7 +22,7 @@ tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts(26,1): error 
     m.bar
       ~~~
 !!! error TS2339: Property 'bar' does not exist on type 'Missing'.
-!!! error TS2339:   Property 'bar' does not exist on type '{ [s: string]: string; }'.
+!!! error TS2339:   Property 'bar' does not exist on type '{ foo: boolean; }'.
     type RO = { foo: number } | { readonly [s: string]: string }
     declare var ro: RO
     ro.foo = 'not allowed'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

When looking for what error to output in the reportNonexistentProperty function in the checker.ts file, the method did not take into account the fact that the subtype could be a Record<string, ...>. This meant that errors related to missing properties on types were outputting: `Property 'foo' does not exist on type 'Record<string, ...>'` instead of  `Property 'foo' does not exist on type '{ prop: number; }'` for example. The fix is simply to check the subtype with the getIndexInfoOfType method.

Fixes #31306
