### PR TITLE
Introduce lazy loading for export expressions

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -1504,12 +1504,27 @@ namespace ts {
          */
         function createExportExpression(name: Identifier, value: Expression, location?: TextRange) {
             return setTextRange(
-                createAssignment(
+                createCall(
                     createPropertyAccess(
-                        createIdentifier("exports"),
-                        getSynthesizedClone(name)
+                        createIdentifier("Object"),
+                        "defineProperty"
                     ),
-                    value
+                    /*typeArguments*/ undefined,
+                    [
+                        createIdentifier("exports"),
+                        createLiteral(name),
+                        createObjectLiteral([
+                            createPropertyAssignment("enumerable", createLiteral(/*value*/ true)),
+                            createPropertyAssignment("get", createArrowFunction(
+                                /*modifiers*/ undefined,
+                                /*typeParameters*/ undefined,
+                                /*parameters*/ [],
+                                /*type*/ undefined,
+                                /*equalsGreaterThanToken*/ undefined,
+                                value
+                            ))
+                        ])
+                    ]
                 ),
                 location
             );


### PR DESCRIPTION
**This PR is meant as a basis for discussion, far from being ready to merge**

Currently, CommonJS modules are not exported via `Object.defineProperty` and lazy getters, but directly via explicit assignments to a file's `exports` property. This leads to indeterministic behavior when working with re-exports (#12522) and recursive imports (#13245), which are sometimes not necessary.

This is my first PR, so please be nice. The tests don't pass, but before investing a lot of time in fixing them I wanted to discuss whether this approach is viable. I just wanted to go ahead and start a fix on this really, really annoying issue.

It changes this:

``` ts
"use strict";
var a_1 = require("./a");
exports.a = a_1
var b_1 = require("./b");
exports.b = b_1
```

To this:

``` ts
"use strict";
var a_1 = require("./a");
Object.defineProperty(exports, "a", { enumerable: true, get: () => a_1.a });
var b_1 = require("./b");
Object.defineProperty(exports, "b", { enumerable: true, get: () => b_1.b });
```

My knowledge of the compiler code base is limited. I started successfully using the factory functions for code generation on another project some time ago, but have no knowledge of the transpilation architecture. Happy to collaborate!

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

