### PR TITLE
Fix type annotations originating in property initializers being emitted in constructor

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -916,7 +916,7 @@ namespace ts {
                 );
 
                 const parameters = transformConstructorParameters(constructor);
-                const body = transformConstructorBody(node.members, constructor, parametersWithPropertyAssignments);
+                const body = transformConstructorBody(existingMembers, constructor, parametersWithPropertyAssignments);
                 members.push(startOnNewLine(
                     setOriginalNode(
                         setTextRange(

--- a/tests/baselines/reference/instanceMemberInitialization.js
+++ b/tests/baselines/reference/instanceMemberInitialization.js
@@ -8,6 +8,13 @@ c.x = 3;
 var c2 = new C();
 var r = c.x === c2.x;
 
+// #31792
+class MyMap<K, V> {
+	constructor(private readonly Map_: { new<K, V>(): any }) {}
+	private readonly store = new this.Map_<K, V>();
+}
+
+
 //// [instanceMemberInitialization.js]
 var C = /** @class */ (function () {
     function C() {
@@ -19,3 +26,11 @@ var c = new C();
 c.x = 3;
 var c2 = new C();
 var r = c.x === c2.x;
+// #31792
+var MyMap = /** @class */ (function () {
+    function MyMap(Map_) {
+        this.Map_ = Map_;
+        this.store = new this.Map_();
+    }
+    return MyMap;
+}());

--- a/tests/baselines/reference/instanceMemberInitialization.symbols
+++ b/tests/baselines/reference/instanceMemberInitialization.symbols
@@ -28,3 +28,23 @@ var r = c.x === c2.x;
 >c2 : Symbol(c2, Decl(instanceMemberInitialization.ts, 6, 3))
 >x : Symbol(C.x, Decl(instanceMemberInitialization.ts, 0, 9))
 
+// #31792
+class MyMap<K, V> {
+>MyMap : Symbol(MyMap, Decl(instanceMemberInitialization.ts, 7, 21))
+>K : Symbol(K, Decl(instanceMemberInitialization.ts, 10, 12))
+>V : Symbol(V, Decl(instanceMemberInitialization.ts, 10, 14))
+
+	constructor(private readonly Map_: { new<K, V>(): any }) {}
+>Map_ : Symbol(MyMap.Map_, Decl(instanceMemberInitialization.ts, 11, 13))
+>K : Symbol(K, Decl(instanceMemberInitialization.ts, 11, 42))
+>V : Symbol(V, Decl(instanceMemberInitialization.ts, 11, 44))
+
+	private readonly store = new this.Map_<K, V>();
+>store : Symbol(MyMap.store, Decl(instanceMemberInitialization.ts, 11, 60))
+>this.Map_ : Symbol(MyMap.Map_, Decl(instanceMemberInitialization.ts, 11, 13))
+>this : Symbol(MyMap, Decl(instanceMemberInitialization.ts, 7, 21))
+>Map_ : Symbol(MyMap.Map_, Decl(instanceMemberInitialization.ts, 11, 13))
+>K : Symbol(K, Decl(instanceMemberInitialization.ts, 10, 12))
+>V : Symbol(V, Decl(instanceMemberInitialization.ts, 10, 14))
+}
+

--- a/tests/baselines/reference/instanceMemberInitialization.types
+++ b/tests/baselines/reference/instanceMemberInitialization.types
@@ -34,3 +34,18 @@ var r = c.x === c2.x;
 >c2 : C
 >x : number
 
+// #31792
+class MyMap<K, V> {
+>MyMap : MyMap<K, V>
+
+	constructor(private readonly Map_: { new<K, V>(): any }) {}
+>Map_ : new <K, V>() => any
+
+	private readonly store = new this.Map_<K, V>();
+>store : any
+>new this.Map_<K, V>() : any
+>this.Map_ : new <K, V>() => any
+>this : this
+>Map_ : new <K, V>() => any
+}
+

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberInitialization.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberInitialization.ts
@@ -6,3 +6,9 @@ var c = new C();
 c.x = 3;
 var c2 = new C();
 var r = c.x === c2.x;
+
+// #31792
+export class MyMap<K, V> {
+	constructor(private readonly Map_: typeof Map = Map) {}
+	private readonly store = new this.Map_<K, V>();
+}

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberInitialization.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberInitialization.ts
@@ -8,7 +8,7 @@ var c2 = new C();
 var r = c.x === c2.x;
 
 // #31792
-export class MyMap<K, V> {
-	constructor(private readonly Map_: typeof Map = Map) {}
+class MyMap<K, V> {
+	constructor(private readonly Map_: { new<K, V>(): any }) {}
 	private readonly store = new this.Map_<K, V>();
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31792 
