### PR TITLE
  When resolving from typings cache, handle node code modules

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -51,6 +51,7 @@ namespace ts {
         getCachedDirectoryStructureHost(): CachedDirectoryStructureHost | undefined;
         projectName?: string;
         getGlobalCache?(): string | undefined;
+        globalCacheResolutionModuleName?(externalModuleName: string): string;
         writeLog(s: string): void;
         maxNumberOfFilesToIterateForInvalidation?: number;
         getCurrentProgram(): Program | undefined;
@@ -235,7 +236,12 @@ namespace ts {
             if (globalCache !== undefined && !isExternalModuleNameRelative(moduleName) && !(primaryResult.resolvedModule && extensionIsTS(primaryResult.resolvedModule.extension))) {
                 // create different collection of failed lookup locations for second pass
                 // if it will fail and we've already found something during the first pass - we don't want to pollute its results
-                const { resolvedModule, failedLookupLocations } = loadModuleFromGlobalCache(moduleName, resolutionHost.projectName, compilerOptions, host, globalCache);
+                const { resolvedModule, failedLookupLocations } = loadModuleFromGlobalCache(
+                    Debug.assertDefined(resolutionHost.globalCacheResolutionModuleName)(moduleName),
+                    resolutionHost.projectName,
+                    compilerOptions,
+                    host,
+                    globalCache);
                 if (resolvedModule) {
                     return { resolvedModule, failedLookupLocations: addRange(primaryResult.failedLookupLocations as string[], failedLookupLocations) };
                 }

--- a/src/jsTyping/jsTyping.ts
+++ b/src/jsTyping/jsTyping.ts
@@ -70,6 +70,10 @@ namespace ts.JsTyping {
 
     export const nodeCoreModules = arrayToSet(nodeCoreModuleList);
 
+    export function nonRelativeModuleNameForTypingCache(moduleName: string) {
+        return nodeCoreModules.has(moduleName) ? "node" : moduleName;
+    }
+
     /**
      * A map of loose file names to library names that we are confident require typings
      */
@@ -150,7 +154,7 @@ namespace ts.JsTyping {
         // add typings for unresolved imports
         if (unresolvedImports) {
             const module = deduplicate<string>(
-                unresolvedImports.map(moduleId => nodeCoreModules.has(moduleId) ? "node" : moduleId),
+                unresolvedImports.map(nonRelativeModuleNameForTypingCache),
                 equateStringsCaseSensitive,
                 compareStringsCaseSensitive);
             addInferredTypings(module, "Inferred typings from unresolved imports");

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -458,6 +458,9 @@ namespace ts.server {
         }
 
         /*@internal*/
+        globalCacheResolutionModuleName = JsTyping.nonRelativeModuleNameForTypingCache;
+
+        /*@internal*/
         fileIsOpen(filePath: Path) {
             return this.projectService.openFiles.has(filePath);
         }

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -1831,9 +1831,11 @@ declare module "stream" {
             checkProjectActualFiles(proj, [file.path, libFile.path, nodeTyping.path]);
 
             // Here, since typings doesnt contain node typings and resolution fails and
-            // node typings go out of project
+            // node typings go out of project,
+            // but because we handle core node modules when resolving from typings cache
+            // node typings are included in the project
             host.checkTimeoutQueueLengthAndRun(2);
-            checkProjectActualFiles(proj, [file.path, libFile.path]);
+            checkProjectActualFiles(proj, [file.path, libFile.path, nodeTyping.path]);
         });
     });
 

--- a/src/testRunner/unittests/tsserver/typingsInstaller.ts
+++ b/src/testRunner/unittests/tsserver/typingsInstaller.ts
@@ -1773,6 +1773,68 @@ namespace ts.projectSystem {
                     import * as c from "foo/a/c";
             `, ["foo"], [fooAA, fooAB, fooAC]);
         });
+
+        it("should handle node core modules", () => {
+            const file: TestFSWithWatch.File = {
+                path: "/a/b/app.js",
+                content: `// @ts-check
+
+const net = require("net");
+const stream = require("stream");`
+            };
+            const nodeTyping: TestFSWithWatch.File = {
+                path: `${globalTypingsCacheLocation}/node_modules/node/index.d.ts`,
+                content: `
+declare module "net" {
+    export type n = number;
+}
+declare module "stream" {
+    export type s = string;
+}`,
+            };
+
+            const host = createServerHost([file, libFile]);
+            const installer = new (class extends Installer {
+                constructor() {
+                    super(host, { globalTypingsCacheLocation, typesRegistry: createTypesRegistry("node") });
+                }
+                installWorker(_requestId: number, _args: string[], _cwd: string, cb: TI.RequestCompletedAction) {
+                    executeCommand(this, host, ["node"], [nodeTyping], cb);
+                }
+            })();
+            const projectService = createProjectService(host, { typingsInstaller: installer });
+            projectService.openClientFile(file.path);
+            projectService.checkNumberOfProjects({ inferredProjects: 1 });
+
+            const proj = projectService.inferredProjects[0];
+            checkProjectActualFiles(proj, [file.path, libFile.path]);
+            installer.installAll(/*expectedCount*/ 1);
+            host.checkTimeoutQueueLengthAndRun(2);
+            checkProjectActualFiles(proj, [file.path, libFile.path, nodeTyping.path]);
+            projectService.applyChangesInOpenFiles(
+                /*openFiles*/ undefined,
+                arrayIterator([{
+                    fileName: file.path,
+                    changes: arrayIterator([{
+                        span: {
+                            start: file.content.indexOf(`"stream"`) + 2,
+                            length: 0
+                        },
+                        newText: " "
+                    }])
+                }]),
+                /*closedFiles*/ undefined
+            );
+            // Below timeout Updates the typings to empty array because of "s tream" as unsresolved import
+            // and schedules the update graph because of this.
+            host.checkTimeoutQueueLengthAndRun(2);
+            checkProjectActualFiles(proj, [file.path, libFile.path, nodeTyping.path]);
+
+            // Here, since typings doesnt contain node typings and resolution fails and
+            // node typings go out of project
+            host.checkTimeoutQueueLengthAndRun(2);
+            checkProjectActualFiles(proj, [file.path, libFile.path]);
+        });
     });
 
     describe("unittests:: tsserver:: typingsInstaller:: tsserver:: with inferred Project", () => {


### PR DESCRIPTION
Earlier when first time we resolved things like "net", "stream" they would get added to the unresolved imports and typings installer would install the typing for node and project would get updated with it.
After this if one added import that doesn't resolve, we sent request to typings installer with unresolvedImport as that one and say it was invalid import, that would mean that the typings would come back as empty. At this point project would be invalidated and while resolving existing say "net" import in typings cache location we would lookup for "net.d.ts" and other such files which offcourse wont be there. That means now we have error resolving "net" import. But if this was another typing say like lodash it will resolve since it would find `lodash/index.d.ts` or some such file. So problem arises with these node core modules. 
The fix is to identify these module and lookup for "node" instead of "net" just like we do when we install typings when "net" is unresolved import.

Fixes #29865
