### PR TITLE
Fix es2019.string.d.ts

### DIFF
--- a/src/lib/es2019.string.d.ts
+++ b/src/lib/es2019.string.d.ts
@@ -5,9 +5,9 @@ interface String {
   /** Removes the leading white space and line terminator characters from a string. */
   trimStart(): string;
 
-  /** Removes the trailing white space and line terminator characters from a string. */
+  /** Removes the leading white space and line terminator characters from a string. */
   trimLeft(): string;
 
-  /** Removes the leading white space and line terminator characters from a string. */
+  /** Removes the trailing white space and line terminator characters from a string. */
   trimRight(): string;
 }


### PR DESCRIPTION
trimLeft and trimRight's comments are swapped.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31830
