### PR TITLE
Port #31685 to release-3.5

### DIFF
--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -54,6 +54,7 @@ namespace ts {
         writeLog(s: string): void;
         maxNumberOfFilesToIterateForInvalidation?: number;
         getCurrentProgram(): Program | undefined;
+        fileIsOpen(filePath: Path): boolean;
     }
 
     interface DirectoryWatchesOfFailedLookup {
@@ -697,6 +698,11 @@ namespace ts {
             else {
                 // If something to do with folder/file starting with "." in node_modules folder, skip it
                 if (isPathIgnored(fileOrDirectoryPath)) return false;
+
+                // prevent saving an open file from over-eagerly triggering invalidation
+                if (resolutionHost.fileIsOpen(fileOrDirectoryPath)) {
+                    return false;
+                }
 
                 // Some file or directory in the watching directory is created
                 // Return early if it does not have any of the watching extension or not the custom failed lookup path

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -691,6 +691,7 @@ namespace ts {
             hasChangedAutomaticTypeDirectiveNames = true;
             scheduleProgramUpdate();
         };
+        compilerHost.fileIsOpen = returnFalse;
         compilerHost.maxNumberOfFilesToIterateForInvalidation = host.maxNumberOfFilesToIterateForInvalidation;
         compilerHost.getCurrentProgram = getCurrentProgram;
         compilerHost.writeLog = writeLog;

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1003,6 +1003,12 @@ namespace ts.server {
                 fileOrDirectory => {
                     const fileOrDirectoryPath = this.toPath(fileOrDirectory);
                     project.getCachedDirectoryStructureHost().addOrDeleteFileOrDirectory(fileOrDirectory, fileOrDirectoryPath);
+
+                    // don't trigger callback on open, existing files
+                    if (project.fileIsOpen(fileOrDirectoryPath)) {
+                        return;
+                    }
+
                     if (isPathIgnored(fileOrDirectoryPath)) return;
                     const configFilename = project.getConfigFilePath();
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -458,6 +458,11 @@ namespace ts.server {
         }
 
         /*@internal*/
+        fileIsOpen(filePath: Path) {
+            return this.projectService.openFiles.has(filePath);
+        }
+
+        /*@internal*/
         writeLog(s: string) {
             this.projectService.logger.info(s);
         }

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -1341,6 +1341,26 @@ var x = 10;`
             }
         });
 
+        it("no project structure update on directory watch invoke on open file save", () => {
+            const projectRootPath = "/users/username/projects/project";
+            const file1: File = {
+                path: `${projectRootPath}/a.ts`,
+                content: "export const a = 10;"
+            };
+            const config: File = {
+                path: `${projectRootPath}/tsconfig.json`,
+                content: "{}"
+            };
+            const files = [file1, config];
+            const host = createServerHost(files);
+            const service = createProjectService(host);
+            service.openClientFile(file1.path);
+            checkNumberOfProjects(service, { configuredProjects: 1 });
+
+            host.modifyFile(file1.path, file1.content, { invokeFileDeleteCreateAsPartInsteadOfChange: true });
+            host.checkTimeoutQueueLength(0);
+        });
+
         it("handles delayed directory watch invoke on file creation", () => {
             const projectRootPath = "/users/username/projects/project";
             const fileB: File = {

--- a/src/testRunner/unittests/tsserver/syntaxOperations.ts
+++ b/src/testRunner/unittests/tsserver/syntaxOperations.ts
@@ -60,13 +60,14 @@ describe("Test Suite 1", () => {
 
             const navBarResultUnitTest1 = navBarFull(session, unitTest1);
             host.deleteFile(unitTest1.path);
-            host.checkTimeoutQueueLengthAndRun(2);
-            checkProjectActualFiles(project, expectedFilesWithoutUnitTest1);
+            host.checkTimeoutQueueLengthAndRun(0);
+            checkProjectActualFiles(project, expectedFilesWithUnitTest1);
 
             session.executeCommandSeq<protocol.CloseRequest>({
                 command: protocol.CommandTypes.Close,
                 arguments: { file: unitTest1.path }
             });
+            host.checkTimeoutQueueLengthAndRun(2);
             checkProjectActualFiles(project, expectedFilesWithoutUnitTest1);
 
             const unitTest1WithChangedContent: File = {


### PR DESCRIPTION
Stop invalidating module resolution cache when saving an open file

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

