### PR TITLE
Improve error message on indexed access to private members of type parameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9987,8 +9987,8 @@ namespace ts {
             });
         }
 
-        function getLiteralTypeFromProperty(prop: Symbol, include: TypeFlags) {
-            if (!(getDeclarationModifierFlagsFromSymbol(prop) & ModifierFlags.NonPublicAccessibilityModifier)) {
+        function getLiteralTypeFromProperty(prop: Symbol, include: TypeFlags, includeNonPublic?: boolean) {
+            if (includeNonPublic || !(getDeclarationModifierFlagsFromSymbol(prop) & ModifierFlags.NonPublicAccessibilityModifier)) {
                 let type = getLateBoundSymbol(prop).nameType;
                 if (!type && !isKnownSymbol(prop)) {
                     if (prop.escapedName === InternalSymbolName.Default) {
@@ -10006,8 +10006,8 @@ namespace ts {
             return neverType;
         }
 
-        function getLiteralTypeFromProperties(type: Type, include: TypeFlags) {
-            return getUnionType(map(getPropertiesOfType(type), p => getLiteralTypeFromProperty(p, include)));
+        function getLiteralTypeFromProperties(type: Type, include: TypeFlags, includeNonPublic?: boolean) {
+            return getUnionType(map(getPropertiesOfType(type), p => getLiteralTypeFromProperty(p, include, includeNonPublic)));
         }
 
         function getNonEnumNumberIndexInfo(type: Type) {
@@ -10023,10 +10023,10 @@ namespace ts {
                 type === wildcardType ? wildcardType :
                 type.flags & TypeFlags.Unknown ? neverType :
                 type.flags & (TypeFlags.Any | TypeFlags.Never) ? keyofConstraintType :
-                stringsOnly ? !noIndexSignatures && getIndexInfoOfType(type, IndexKind.String) ? stringType : getLiteralTypeFromProperties(type, TypeFlags.StringLiteral) :
-                !noIndexSignatures && getIndexInfoOfType(type, IndexKind.String) ? getUnionType([stringType, numberType, getLiteralTypeFromProperties(type, TypeFlags.UniqueESSymbol)]) :
-                getNonEnumNumberIndexInfo(type) ? getUnionType([numberType, getLiteralTypeFromProperties(type, TypeFlags.StringLiteral | TypeFlags.UniqueESSymbol)]) :
-                getLiteralTypeFromProperties(type, TypeFlags.StringOrNumberLiteralOrUnique);
+                stringsOnly ? !noIndexSignatures && getIndexInfoOfType(type, IndexKind.String) ? stringType : getLiteralTypeFromProperties(type, TypeFlags.StringLiteral, /*includeNonPublic*/ true) :
+                !noIndexSignatures && getIndexInfoOfType(type, IndexKind.String) ? getUnionType([stringType, numberType, getLiteralTypeFromProperties(type, TypeFlags.UniqueESSymbol, /*includeNonPublic*/ true)]) :
+                getNonEnumNumberIndexInfo(type) ? getUnionType([numberType, getLiteralTypeFromProperties(type, TypeFlags.StringLiteral | TypeFlags.UniqueESSymbol, /*includeNonPublic*/ true)]) :
+                getLiteralTypeFromProperties(type, TypeFlags.StringOrNumberLiteralOrUnique, /*includeNonPublic*/ true);
         }
 
         function getExtractStringType(type: Type) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2963,6 +2963,10 @@
         "category": "Error",
         "code": 4104
     },
+    "Private or protected member '{0}' cannot be accessed on a type parameter.": {
+        "category": "Error",
+        "code": 4105
+    },
 
     "The current host does not support the '{0}' option.": {
         "category": "Error",

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.errors.txt
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.errors.txt
@@ -1,0 +1,27 @@
+tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts(9,24): error TS4105: Private or protected member 'a' cannot be accessed on a type parameter.
+tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts(9,32): error TS4105: Private or protected member 'a' cannot be accessed on a type parameter.
+tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts(10,27): error TS4105: Private or protected member 'a' cannot be accessed on a type parameter.
+tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts(11,27): error TS4105: Private or protected member 'a' cannot be accessed on a type parameter.
+
+
+==== tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts (4 errors) ====
+    class A {
+      private a: number;
+    }
+    
+    class B {
+      private a: string;
+    }
+    
+    type X<T extends A> = [T["a"], (T | B)["a"]];
+                           ~~~~~~
+!!! error TS4105: Private or protected member 'a' cannot be accessed on a type parameter.
+                                   ~~~~~~~~~~~~
+!!! error TS4105: Private or protected member 'a' cannot be accessed on a type parameter.
+    type Y<T extends A | B> = T["a"];
+                              ~~~~~~
+!!! error TS4105: Private or protected member 'a' cannot be accessed on a type parameter.
+    type Z<T extends A & B> = T["a"];
+                              ~~~~~~
+!!! error TS4105: Private or protected member 'a' cannot be accessed on a type parameter.
+    

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.js
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.js
@@ -7,10 +7,9 @@ class B {
   private a: string;
 }
 
-type X<T extends A> = T["a"];
+type X<T extends A> = [T["a"], (T | B)["a"]];
 type Y<T extends A | B> = T["a"];
 type Z<T extends A & B> = T["a"];
-
 
 
 //// [indexedAccessPrivateMemberOfGenericConstraint.js]

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.js
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.js
@@ -3,7 +3,14 @@ class A {
   private a: number;
 }
 
-type B<T extends A> = T["a"];
+class B {
+  private a: string;
+}
+
+type X<T extends A> = T["a"];
+type Y<T extends A | B> = T["a"];
+type Z<T extends A & B> = T["a"];
+
 
 
 //// [indexedAccessPrivateMemberOfGenericConstraint.js]
@@ -11,4 +18,9 @@ var A = /** @class */ (function () {
     function A() {
     }
     return A;
+}());
+var B = /** @class */ (function () {
+    function B() {
+    }
+    return B;
 }());

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.js
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.js
@@ -1,0 +1,14 @@
+//// [indexedAccessPrivateMemberOfGenericConstraint.ts]
+class A {
+  private a: number;
+}
+
+type B<T extends A> = T["a"];
+
+
+//// [indexedAccessPrivateMemberOfGenericConstraint.js]
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.symbols
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts ===
+class A {
+>A : Symbol(A, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 0))
+
+  private a: number;
+>a : Symbol(A.a, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 9))
+}
+
+type B<T extends A> = T["a"];
+>B : Symbol(B, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 2, 1))
+>T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 4, 7))
+>A : Symbol(A, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 0))
+>T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 4, 7))
+

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.symbols
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.symbols
@@ -13,14 +13,16 @@ class B {
 >a : Symbol(B.a, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 4, 9))
 }
 
-type X<T extends A> = T["a"];
+type X<T extends A> = [T["a"], (T | B)["a"]];
 >X : Symbol(X, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 6, 1))
 >T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 8, 7))
 >A : Symbol(A, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 0))
 >T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 8, 7))
+>T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 8, 7))
+>B : Symbol(B, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 2, 1))
 
 type Y<T extends A | B> = T["a"];
->Y : Symbol(Y, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 8, 29))
+>Y : Symbol(Y, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 8, 45))
 >T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 9, 7))
 >A : Symbol(A, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 0))
 >B : Symbol(B, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 2, 1))
@@ -32,5 +34,4 @@ type Z<T extends A & B> = T["a"];
 >A : Symbol(A, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 0))
 >B : Symbol(B, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 2, 1))
 >T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 10, 7))
-
 

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.symbols
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.symbols
@@ -6,9 +6,31 @@ class A {
 >a : Symbol(A.a, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 9))
 }
 
-type B<T extends A> = T["a"];
+class B {
 >B : Symbol(B, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 2, 1))
->T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 4, 7))
+
+  private a: string;
+>a : Symbol(B.a, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 4, 9))
+}
+
+type X<T extends A> = T["a"];
+>X : Symbol(X, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 6, 1))
+>T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 8, 7))
 >A : Symbol(A, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 0))
->T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 4, 7))
+>T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 8, 7))
+
+type Y<T extends A | B> = T["a"];
+>Y : Symbol(Y, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 8, 29))
+>T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 9, 7))
+>A : Symbol(A, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 0))
+>B : Symbol(B, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 2, 1))
+>T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 9, 7))
+
+type Z<T extends A & B> = T["a"];
+>Z : Symbol(Z, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 9, 33))
+>T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 10, 7))
+>A : Symbol(A, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 0, 0))
+>B : Symbol(B, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 2, 1))
+>T : Symbol(T, Decl(indexedAccessPrivateMemberOfGenericConstraint.ts, 10, 7))
+
 

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.types
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.types
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts ===
+class A {
+>A : A
+
+  private a: number;
+>a : number
+}
+
+type B<T extends A> = T["a"];
+>B : T["a"]
+

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.types
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.types
@@ -6,6 +6,20 @@ class A {
 >a : number
 }
 
-type B<T extends A> = T["a"];
->B : T["a"]
+class B {
+>B : B
+
+  private a: string;
+>a : string
+}
+
+type X<T extends A> = T["a"];
+>X : T["a"]
+
+type Y<T extends A | B> = T["a"];
+>Y : T["a"]
+
+type Z<T extends A & B> = T["a"];
+>Z : T["a"]
+
 

--- a/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.types
+++ b/tests/baselines/reference/indexedAccessPrivateMemberOfGenericConstraint.types
@@ -13,13 +13,12 @@ class B {
 >a : string
 }
 
-type X<T extends A> = T["a"];
->X : T["a"]
+type X<T extends A> = [T["a"], (T | B)["a"]];
+>X : [T["a"], (B | T)["a"]]
 
 type Y<T extends A | B> = T["a"];
 >Y : T["a"]
 
 type Z<T extends A & B> = T["a"];
 >Z : T["a"]
-
 

--- a/tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts
+++ b/tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts
@@ -2,4 +2,11 @@ class A {
   private a: number;
 }
 
-type B<T extends A> = T["a"];
+class B {
+  private a: string;
+}
+
+type X<T extends A> = T["a"];
+type Y<T extends A | B> = T["a"];
+type Z<T extends A & B> = T["a"];
+

--- a/tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts
+++ b/tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts
@@ -1,0 +1,5 @@
+class A {
+  private a: number;
+}
+
+type B<T extends A> = T["a"];

--- a/tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts
+++ b/tests/cases/compiler/indexedAccessPrivateMemberOfGenericConstraint.ts
@@ -6,7 +6,6 @@ class B {
   private a: string;
 }
 
-type X<T extends A> = T["a"];
+type X<T extends A> = [T["a"], (T | B)["a"]];
 type Y<T extends A | B> = T["a"];
 type Z<T extends A & B> = T["a"];
-


### PR DESCRIPTION
~Fixes #30882, assuming it's a bug. Noticing that this works (has always worked?):~

```ts
class A {
  private a: string;
}

type X = A["a"]; // indexed access can access private members
```

~I assumed that there’s no reason why the same shouldn’t work when `A` is the constraint of a type parameter:~

```ts
type X<T extends A> = A["a"];
```

---

**EDIT**: #30882 is not a bug, as @weswigham explains below. This PR now just improves the error message.