### PR TITLE
Don't let the additional property setting on an object show up as a definition to tsserver

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -26,7 +26,7 @@ namespace ts.GoToDefinition {
         if (!symbol) {
             return getDefinitionInfoForIndexSignatures(node, typeChecker);
         }
-
+        
         const calledDeclaration = tryGetSignatureDeclaration(typeChecker, node);
         // Don't go to the component constructor definition for a JSX element, just go to the component definition.
         if (calledDeclaration && !(isJsxOpeningLikeElement(node.parent) && isConstructorLike(calledDeclaration))) {
@@ -233,20 +233,24 @@ namespace ts.GoToDefinition {
     }
 
     function getDefinitionFromSymbol(typeChecker: TypeChecker, symbol: Symbol, node: Node): DefinitionInfo[] | undefined {
-        return getConstructSignatureDefinition() || getCallSignatureDefinition() || map(symbol.declarations, declaration => createDefinitionInfo(declaration, typeChecker, symbol, node));
+        // There are cases when you extend a function by adding properties to it afterwards,
+        // we want to strip those extra properties
+        const filteredDeclarations = symbol.declarations.filter(d =>  !ts.isAssignmentDeclaration(d) || d === symbol.valueDeclaration)
+
+        return getConstructSignatureDefinition() || getCallSignatureDefinition() || map(filteredDeclarations, declaration => createDefinitionInfo(declaration, typeChecker, symbol, node));
 
         function getConstructSignatureDefinition(): DefinitionInfo[] | undefined {
             // Applicable only if we are in a new expression, or we are on a constructor declaration
             // and in either case the symbol has a construct signature definition, i.e. class
             if (symbol.flags & SymbolFlags.Class && (isNewExpressionTarget(node) || node.kind === SyntaxKind.ConstructorKeyword)) {
-                const cls = find(symbol.declarations, isClassLike) || Debug.fail("Expected declaration to have at least one class-like declaration");
+                const cls = find(filteredDeclarations, isClassLike) || Debug.fail("Expected declaration to have at least one class-like declaration");
                 return getSignatureDefinition(cls.members, /*selectConstructors*/ true);
             }
         }
 
         function getCallSignatureDefinition(): DefinitionInfo[] | undefined {
             return isCallOrNewExpressionTarget(node) || isNameOfFunctionDeclaration(node)
-                ? getSignatureDefinition(symbol.declarations, /*selectConstructors*/ false)
+                ? getSignatureDefinition(filteredDeclarations, /*selectConstructors*/ false)
                 : undefined;
         }
 

--- a/tests/cases/fourslash/goToDefinitionPropertyAssignment.ts
+++ b/tests/cases/fourslash/goToDefinitionPropertyAssignment.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+//// export const /*FunctionResult*/Component = () => { return "OK"}
+//// Component./*PropertyResult*/displayName = 'Component'
+////
+//// [|/*FunctionClick*/Component|]
+////
+//// Component.[|/*PropertyClick*/displayName|]
+
+verify.goToDefinition("FunctionClick", "FunctionResult")
+
+verify.goToDefinition("PropertyClick", "PropertyResult")
+
+// export const Component = () => { return "OK"}
+// Component.displayName = 'Component'
+


### PR DESCRIPTION
Fixes #30246 by filtering out property setters. but also making sure that you can still jump to those field 
 definitions when the symbol you clicked on is specifically  targeted

Prior to this change, clicking on `Component` would show`const Component...` and `Component.displayName`. An initially over-eager implementation didn't allow for clicking the `displayName` - so I included a test for that too.

![30246](https://user-images.githubusercontent.com/49038/59635435-1afb0300-9106-11e9-8f2d-cb77cbd801ad.gif)