### PR TITLE
Failing test + Discussion for #31230

### DIFF
--- a/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
+++ b/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
@@ -1,0 +1,36 @@
+// @filename: graphql-compose.d.ts
+// @declaration: true
+export type ObjMapReadOnly<T> = Readonly<{ [key: string]: Readonly<T> }>;
+export type Thunk<T> = (() => T) | T;
+
+export type ComposeOutputTypeDefinition = Readonly<ObjectTypeComposer<any, any> | EnumTypeComposer>;
+
+export class EnumTypeComposer {
+  public setFields(fields: { [name: string]: { [key: string]: any } }): this;
+}
+
+export class ObjectTypeComposer<TSource, TContext> {
+  public setFields(fields: ObjMapReadOnly<Resolver>): this;
+
+  public addResolver<TResolverSource>(opts: { type?: Thunk<ComposeOutputTypeDefinition> }): this;
+}
+
+export class Resolver {
+  public wrapArgs<NewContext>(
+    cb: () => {
+      [argName: string]: Thunk<Readonly<EnumTypeComposer>>;
+    }
+  ): void;
+
+  public wrapType(cb: () => ComposeOutputTypeDefinition): void;
+}
+
+
+// @filename: app.ts
+import { ObjectTypeComposer } from './graphql-compose';
+
+declare const User: ObjectTypeComposer<any, any>;
+
+User.addResolver({
+  type: User, // `User as any` fix the problem
+});


### PR DESCRIPTION
Fixes #31230

What this looks like under the hood is that tsc gets stuck in an infinite loop between type narrowing and inferring types. It looks for related types, jumps into [recursiveTypeRelatedTo](https://github.com/orta/typescript/blob/74c6bc1f85c2ab36fdb789aa0ef6ee5dbde5afdd/src/compiler/checker.ts#L12636) finds itself needing to go back to finding related tasks ad infinitum.

@weswigham mentioned that it's quite likely in order to fix this we'll need to keep cache  onwhether a type is currently being inferred, which could allow a guard against the recurse. We think we'll need to chat with @ahejlsberg about it.