### PR TITLE
Union inferences from object and array literals 

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4089,19 +4089,20 @@ namespace ts {
         MarkerType       = 1 << 13, // Marker type used for variance probing
         JSLiteral        = 1 << 14, // Object type declared in JS - disables errors on read/write of nonexisting members
         FreshLiteral     = 1 << 15, // Fresh object literal
+        ArrayLiteral     = 1 << 16, // Originates in an array literal
         /* @internal */
-        PrimitiveUnion   = 1 << 16, // Union of only primitive types
+        PrimitiveUnion   = 1 << 17, // Union of only primitive types
         /* @internal */
-        ContainsWideningType = 1 << 17, // Type is or contains undefined or null widening type
+        ContainsWideningType = 1 << 18, // Type is or contains undefined or null widening type
         /* @internal */
-        ContainsObjectLiteral = 1 << 18, // Type is or contains object literal type
+        ContainsObjectOrArrayLiteral = 1 << 19, // Type is or contains object literal type
         /* @internal */
-        NonInferrableType = 1 << 19, // Type is or contains anyFunctionType or silentNeverType
+        NonInferrableType = 1 << 20, // Type is or contains anyFunctionType or silentNeverType
         ClassOrInterface = Class | Interface,
         /* @internal */
-        RequiresWidening = ContainsWideningType | ContainsObjectLiteral,
+        RequiresWidening = ContainsWideningType | ContainsObjectOrArrayLiteral,
         /* @internal */
-        PropagatingFlags = ContainsWideningType | ContainsObjectLiteral | NonInferrableType
+        PropagatingFlags = ContainsWideningType | ContainsObjectOrArrayLiteral | NonInferrableType
     }
 
     /* @internal */
@@ -4154,6 +4155,8 @@ namespace ts {
     export interface TypeReference extends ObjectType {
         target: GenericType;    // Type reference target
         typeArguments?: ReadonlyArray<Type>;  // Type reference type arguments (undefined if none)
+        /* @internal */
+        literalType?: TypeReference;  // Clone of type with ObjectFlags.ArrayLiteral set
     }
 
     /* @internal */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2303,6 +2303,7 @@ declare namespace ts {
         MarkerType = 8192,
         JSLiteral = 16384,
         FreshLiteral = 32768,
+        ArrayLiteral = 65536,
         ClassOrInterface = 3,
     }
     interface ObjectType extends Type {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2303,6 +2303,7 @@ declare namespace ts {
         MarkerType = 8192,
         JSLiteral = 16384,
         FreshLiteral = 32768,
+        ArrayLiteral = 65536,
         ClassOrInterface = 3,
     }
     interface ObjectType extends Type {

--- a/tests/baselines/reference/arrayLiteralInference.js
+++ b/tests/baselines/reference/arrayLiteralInference.js
@@ -1,0 +1,65 @@
+//// [arrayLiteralInference.ts]
+// Repro from #31204
+
+export enum AppType {
+    HeaderDetail = 'HeaderDetail',
+    HeaderMultiDetail = 'HeaderMultiDetail',
+    AdvancedList = 'AdvancedList',
+    Standard = 'Standard',
+    Relationship = 'Relationship',
+    Report = 'Report',
+    Composite = 'Composite',
+    ListOnly = 'ListOnly',
+    ModuleSettings = 'ModuleSettings'
+}
+
+export enum AppStyle {
+    Tree,
+    TreeEntity,
+    Standard,
+    MiniApp,
+    PivotTable
+}
+
+const appTypeStylesWithError: Map<AppType, Array<AppStyle>> = new Map([
+    [AppType.Standard, [AppStyle.Standard, AppStyle.MiniApp]],
+    [AppType.Relationship, [AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity]],
+    [AppType.AdvancedList, [AppStyle.Standard, AppStyle.MiniApp]]
+]);
+
+// Repro from #31204
+
+declare function foo<T>(...args: T[]): T[];
+let b1: { x: boolean }[] = foo({ x: true }, { x: false });
+let b2: boolean[][] = foo([true], [false]);
+
+
+//// [arrayLiteralInference.js]
+// Repro from #31204
+export var AppType;
+(function (AppType) {
+    AppType["HeaderDetail"] = "HeaderDetail";
+    AppType["HeaderMultiDetail"] = "HeaderMultiDetail";
+    AppType["AdvancedList"] = "AdvancedList";
+    AppType["Standard"] = "Standard";
+    AppType["Relationship"] = "Relationship";
+    AppType["Report"] = "Report";
+    AppType["Composite"] = "Composite";
+    AppType["ListOnly"] = "ListOnly";
+    AppType["ModuleSettings"] = "ModuleSettings";
+})(AppType || (AppType = {}));
+export var AppStyle;
+(function (AppStyle) {
+    AppStyle[AppStyle["Tree"] = 0] = "Tree";
+    AppStyle[AppStyle["TreeEntity"] = 1] = "TreeEntity";
+    AppStyle[AppStyle["Standard"] = 2] = "Standard";
+    AppStyle[AppStyle["MiniApp"] = 3] = "MiniApp";
+    AppStyle[AppStyle["PivotTable"] = 4] = "PivotTable";
+})(AppStyle || (AppStyle = {}));
+const appTypeStylesWithError = new Map([
+    [AppType.Standard, [AppStyle.Standard, AppStyle.MiniApp]],
+    [AppType.Relationship, [AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity]],
+    [AppType.AdvancedList, [AppStyle.Standard, AppStyle.MiniApp]]
+]);
+let b1 = foo({ x: true }, { x: false });
+let b2 = foo([true], [false]);

--- a/tests/baselines/reference/arrayLiteralInference.symbols
+++ b/tests/baselines/reference/arrayLiteralInference.symbols
@@ -1,0 +1,119 @@
+=== tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts ===
+// Repro from #31204
+
+export enum AppType {
+>AppType : Symbol(AppType, Decl(arrayLiteralInference.ts, 0, 0))
+
+    HeaderDetail = 'HeaderDetail',
+>HeaderDetail : Symbol(AppType.HeaderDetail, Decl(arrayLiteralInference.ts, 2, 21))
+
+    HeaderMultiDetail = 'HeaderMultiDetail',
+>HeaderMultiDetail : Symbol(AppType.HeaderMultiDetail, Decl(arrayLiteralInference.ts, 3, 34))
+
+    AdvancedList = 'AdvancedList',
+>AdvancedList : Symbol(AppType.AdvancedList, Decl(arrayLiteralInference.ts, 4, 44))
+
+    Standard = 'Standard',
+>Standard : Symbol(AppType.Standard, Decl(arrayLiteralInference.ts, 5, 34))
+
+    Relationship = 'Relationship',
+>Relationship : Symbol(AppType.Relationship, Decl(arrayLiteralInference.ts, 6, 26))
+
+    Report = 'Report',
+>Report : Symbol(AppType.Report, Decl(arrayLiteralInference.ts, 7, 34))
+
+    Composite = 'Composite',
+>Composite : Symbol(AppType.Composite, Decl(arrayLiteralInference.ts, 8, 22))
+
+    ListOnly = 'ListOnly',
+>ListOnly : Symbol(AppType.ListOnly, Decl(arrayLiteralInference.ts, 9, 28))
+
+    ModuleSettings = 'ModuleSettings'
+>ModuleSettings : Symbol(AppType.ModuleSettings, Decl(arrayLiteralInference.ts, 10, 26))
+}
+
+export enum AppStyle {
+>AppStyle : Symbol(AppStyle, Decl(arrayLiteralInference.ts, 12, 1))
+
+    Tree,
+>Tree : Symbol(AppStyle.Tree, Decl(arrayLiteralInference.ts, 14, 22))
+
+    TreeEntity,
+>TreeEntity : Symbol(AppStyle.TreeEntity, Decl(arrayLiteralInference.ts, 15, 9))
+
+    Standard,
+>Standard : Symbol(AppStyle.Standard, Decl(arrayLiteralInference.ts, 16, 15))
+
+    MiniApp,
+>MiniApp : Symbol(AppStyle.MiniApp, Decl(arrayLiteralInference.ts, 17, 13))
+
+    PivotTable
+>PivotTable : Symbol(AppStyle.PivotTable, Decl(arrayLiteralInference.ts, 18, 12))
+}
+
+const appTypeStylesWithError: Map<AppType, Array<AppStyle>> = new Map([
+>appTypeStylesWithError : Symbol(appTypeStylesWithError, Decl(arrayLiteralInference.ts, 22, 5))
+>Map : Symbol(Map, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>AppType : Symbol(AppType, Decl(arrayLiteralInference.ts, 0, 0))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>AppStyle : Symbol(AppStyle, Decl(arrayLiteralInference.ts, 12, 1))
+>Map : Symbol(Map, Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.collection.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+
+    [AppType.Standard, [AppStyle.Standard, AppStyle.MiniApp]],
+>AppType.Standard : Symbol(AppType.Standard, Decl(arrayLiteralInference.ts, 5, 34))
+>AppType : Symbol(AppType, Decl(arrayLiteralInference.ts, 0, 0))
+>Standard : Symbol(AppType.Standard, Decl(arrayLiteralInference.ts, 5, 34))
+>AppStyle.Standard : Symbol(AppStyle.Standard, Decl(arrayLiteralInference.ts, 16, 15))
+>AppStyle : Symbol(AppStyle, Decl(arrayLiteralInference.ts, 12, 1))
+>Standard : Symbol(AppStyle.Standard, Decl(arrayLiteralInference.ts, 16, 15))
+>AppStyle.MiniApp : Symbol(AppStyle.MiniApp, Decl(arrayLiteralInference.ts, 17, 13))
+>AppStyle : Symbol(AppStyle, Decl(arrayLiteralInference.ts, 12, 1))
+>MiniApp : Symbol(AppStyle.MiniApp, Decl(arrayLiteralInference.ts, 17, 13))
+
+    [AppType.Relationship, [AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity]],
+>AppType.Relationship : Symbol(AppType.Relationship, Decl(arrayLiteralInference.ts, 6, 26))
+>AppType : Symbol(AppType, Decl(arrayLiteralInference.ts, 0, 0))
+>Relationship : Symbol(AppType.Relationship, Decl(arrayLiteralInference.ts, 6, 26))
+>AppStyle.Standard : Symbol(AppStyle.Standard, Decl(arrayLiteralInference.ts, 16, 15))
+>AppStyle : Symbol(AppStyle, Decl(arrayLiteralInference.ts, 12, 1))
+>Standard : Symbol(AppStyle.Standard, Decl(arrayLiteralInference.ts, 16, 15))
+>AppStyle.Tree : Symbol(AppStyle.Tree, Decl(arrayLiteralInference.ts, 14, 22))
+>AppStyle : Symbol(AppStyle, Decl(arrayLiteralInference.ts, 12, 1))
+>Tree : Symbol(AppStyle.Tree, Decl(arrayLiteralInference.ts, 14, 22))
+>AppStyle.TreeEntity : Symbol(AppStyle.TreeEntity, Decl(arrayLiteralInference.ts, 15, 9))
+>AppStyle : Symbol(AppStyle, Decl(arrayLiteralInference.ts, 12, 1))
+>TreeEntity : Symbol(AppStyle.TreeEntity, Decl(arrayLiteralInference.ts, 15, 9))
+
+    [AppType.AdvancedList, [AppStyle.Standard, AppStyle.MiniApp]]
+>AppType.AdvancedList : Symbol(AppType.AdvancedList, Decl(arrayLiteralInference.ts, 4, 44))
+>AppType : Symbol(AppType, Decl(arrayLiteralInference.ts, 0, 0))
+>AdvancedList : Symbol(AppType.AdvancedList, Decl(arrayLiteralInference.ts, 4, 44))
+>AppStyle.Standard : Symbol(AppStyle.Standard, Decl(arrayLiteralInference.ts, 16, 15))
+>AppStyle : Symbol(AppStyle, Decl(arrayLiteralInference.ts, 12, 1))
+>Standard : Symbol(AppStyle.Standard, Decl(arrayLiteralInference.ts, 16, 15))
+>AppStyle.MiniApp : Symbol(AppStyle.MiniApp, Decl(arrayLiteralInference.ts, 17, 13))
+>AppStyle : Symbol(AppStyle, Decl(arrayLiteralInference.ts, 12, 1))
+>MiniApp : Symbol(AppStyle.MiniApp, Decl(arrayLiteralInference.ts, 17, 13))
+
+]);
+
+// Repro from #31204
+
+declare function foo<T>(...args: T[]): T[];
+>foo : Symbol(foo, Decl(arrayLiteralInference.ts, 26, 3))
+>T : Symbol(T, Decl(arrayLiteralInference.ts, 30, 21))
+>args : Symbol(args, Decl(arrayLiteralInference.ts, 30, 24))
+>T : Symbol(T, Decl(arrayLiteralInference.ts, 30, 21))
+>T : Symbol(T, Decl(arrayLiteralInference.ts, 30, 21))
+
+let b1: { x: boolean }[] = foo({ x: true }, { x: false });
+>b1 : Symbol(b1, Decl(arrayLiteralInference.ts, 31, 3))
+>x : Symbol(x, Decl(arrayLiteralInference.ts, 31, 9))
+>foo : Symbol(foo, Decl(arrayLiteralInference.ts, 26, 3))
+>x : Symbol(x, Decl(arrayLiteralInference.ts, 31, 32))
+>x : Symbol(x, Decl(arrayLiteralInference.ts, 31, 45))
+
+let b2: boolean[][] = foo([true], [false]);
+>b2 : Symbol(b2, Decl(arrayLiteralInference.ts, 32, 3))
+>foo : Symbol(foo, Decl(arrayLiteralInference.ts, 26, 3))
+

--- a/tests/baselines/reference/arrayLiteralInference.types
+++ b/tests/baselines/reference/arrayLiteralInference.types
@@ -1,0 +1,139 @@
+=== tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts ===
+// Repro from #31204
+
+export enum AppType {
+>AppType : AppType
+
+    HeaderDetail = 'HeaderDetail',
+>HeaderDetail : AppType.HeaderDetail
+>'HeaderDetail' : "HeaderDetail"
+
+    HeaderMultiDetail = 'HeaderMultiDetail',
+>HeaderMultiDetail : AppType.HeaderMultiDetail
+>'HeaderMultiDetail' : "HeaderMultiDetail"
+
+    AdvancedList = 'AdvancedList',
+>AdvancedList : AppType.AdvancedList
+>'AdvancedList' : "AdvancedList"
+
+    Standard = 'Standard',
+>Standard : AppType.Standard
+>'Standard' : "Standard"
+
+    Relationship = 'Relationship',
+>Relationship : AppType.Relationship
+>'Relationship' : "Relationship"
+
+    Report = 'Report',
+>Report : AppType.Report
+>'Report' : "Report"
+
+    Composite = 'Composite',
+>Composite : AppType.Composite
+>'Composite' : "Composite"
+
+    ListOnly = 'ListOnly',
+>ListOnly : AppType.ListOnly
+>'ListOnly' : "ListOnly"
+
+    ModuleSettings = 'ModuleSettings'
+>ModuleSettings : AppType.ModuleSettings
+>'ModuleSettings' : "ModuleSettings"
+}
+
+export enum AppStyle {
+>AppStyle : AppStyle
+
+    Tree,
+>Tree : AppStyle.Tree
+
+    TreeEntity,
+>TreeEntity : AppStyle.TreeEntity
+
+    Standard,
+>Standard : AppStyle.Standard
+
+    MiniApp,
+>MiniApp : AppStyle.MiniApp
+
+    PivotTable
+>PivotTable : AppStyle.PivotTable
+}
+
+const appTypeStylesWithError: Map<AppType, Array<AppStyle>> = new Map([
+>appTypeStylesWithError : Map<AppType, AppStyle[]>
+>new Map([    [AppType.Standard, [AppStyle.Standard, AppStyle.MiniApp]],    [AppType.Relationship, [AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity]],    [AppType.AdvancedList, [AppStyle.Standard, AppStyle.MiniApp]]]) : Map<AppType.AdvancedList | AppType.Standard | AppType.Relationship, (AppStyle.Standard | AppStyle.MiniApp)[] | (AppStyle.Tree | AppStyle.TreeEntity | AppStyle.Standard)[]>
+>Map : MapConstructor
+>[    [AppType.Standard, [AppStyle.Standard, AppStyle.MiniApp]],    [AppType.Relationship, [AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity]],    [AppType.AdvancedList, [AppStyle.Standard, AppStyle.MiniApp]]] : ([AppType.Standard, (AppStyle.Standard | AppStyle.MiniApp)[]] | [AppType.Relationship, (AppStyle.Tree | AppStyle.TreeEntity | AppStyle.Standard)[]] | [AppType.AdvancedList, (AppStyle.Standard | AppStyle.MiniApp)[]])[]
+
+    [AppType.Standard, [AppStyle.Standard, AppStyle.MiniApp]],
+>[AppType.Standard, [AppStyle.Standard, AppStyle.MiniApp]] : [AppType.Standard, (AppStyle.Standard | AppStyle.MiniApp)[]]
+>AppType.Standard : AppType.Standard
+>AppType : typeof AppType
+>Standard : AppType.Standard
+>[AppStyle.Standard, AppStyle.MiniApp] : (AppStyle.Standard | AppStyle.MiniApp)[]
+>AppStyle.Standard : AppStyle.Standard
+>AppStyle : typeof AppStyle
+>Standard : AppStyle.Standard
+>AppStyle.MiniApp : AppStyle.MiniApp
+>AppStyle : typeof AppStyle
+>MiniApp : AppStyle.MiniApp
+
+    [AppType.Relationship, [AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity]],
+>[AppType.Relationship, [AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity]] : [AppType.Relationship, (AppStyle.Tree | AppStyle.TreeEntity | AppStyle.Standard)[]]
+>AppType.Relationship : AppType.Relationship
+>AppType : typeof AppType
+>Relationship : AppType.Relationship
+>[AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity] : (AppStyle.Tree | AppStyle.TreeEntity | AppStyle.Standard)[]
+>AppStyle.Standard : AppStyle.Standard
+>AppStyle : typeof AppStyle
+>Standard : AppStyle.Standard
+>AppStyle.Tree : AppStyle.Tree
+>AppStyle : typeof AppStyle
+>Tree : AppStyle.Tree
+>AppStyle.TreeEntity : AppStyle.TreeEntity
+>AppStyle : typeof AppStyle
+>TreeEntity : AppStyle.TreeEntity
+
+    [AppType.AdvancedList, [AppStyle.Standard, AppStyle.MiniApp]]
+>[AppType.AdvancedList, [AppStyle.Standard, AppStyle.MiniApp]] : [AppType.AdvancedList, (AppStyle.Standard | AppStyle.MiniApp)[]]
+>AppType.AdvancedList : AppType.AdvancedList
+>AppType : typeof AppType
+>AdvancedList : AppType.AdvancedList
+>[AppStyle.Standard, AppStyle.MiniApp] : (AppStyle.Standard | AppStyle.MiniApp)[]
+>AppStyle.Standard : AppStyle.Standard
+>AppStyle : typeof AppStyle
+>Standard : AppStyle.Standard
+>AppStyle.MiniApp : AppStyle.MiniApp
+>AppStyle : typeof AppStyle
+>MiniApp : AppStyle.MiniApp
+
+]);
+
+// Repro from #31204
+
+declare function foo<T>(...args: T[]): T[];
+>foo : <T>(...args: T[]) => T[]
+>args : T[]
+
+let b1: { x: boolean }[] = foo({ x: true }, { x: false });
+>b1 : { x: boolean; }[]
+>x : boolean
+>foo({ x: true }, { x: false }) : ({ x: true; } | { x: false; })[]
+>foo : <T>(...args: T[]) => T[]
+>{ x: true } : { x: true; }
+>x : true
+>true : true
+>{ x: false } : { x: false; }
+>x : false
+>false : false
+
+let b2: boolean[][] = foo([true], [false]);
+>b2 : boolean[][]
+>foo([true], [false]) : (true[] | false[])[]
+>foo : <T>(...args: T[]) => T[]
+>[true] : true[]
+>true : true
+>[false] : false[]
+>false : false
+

--- a/tests/baselines/reference/contextualTypeWithTuple.errors.txt
+++ b/tests/baselines/reference/contextualTypeWithTuple.errors.txt
@@ -2,6 +2,8 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(3,5): error TS232
   Types of property 'length' are incompatible.
     Type '3' is not assignable to type '2'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(15,1): error TS2322: Type '[number, string, boolean]' is not assignable to type '[number, string]'.
+  Types of property 'length' are incompatible.
+    Type '3' is not assignable to type '2'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(18,17): error TS2741: Property 'a' is missing in type '{}' but required in type '{ a: string; }'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(19,1): error TS2741: Property '2' is missing in type '[number, string]' but required in type '[number, string, boolean]'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(20,5): error TS2322: Type '[string, string, number]' is not assignable to type '[string, string]'.
@@ -38,6 +40,8 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(25,1): error TS23
     numStrTuple = numStrBoolTuple;
     ~~~~~~~~~~~
 !!! error TS2322: Type '[number, string, boolean]' is not assignable to type '[number, string]'.
+!!! error TS2322:   Types of property 'length' are incompatible.
+!!! error TS2322:     Type '3' is not assignable to type '2'.
     
     // error
     objNumTuple = [ {}, 5];

--- a/tests/baselines/reference/objectLiteralNormalization.errors.txt
+++ b/tests/baselines/reference/objectLiteralNormalization.errors.txt
@@ -9,9 +9,11 @@ tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
       Type 'string' is not assignable to type 'undefined'.
 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(18,1): error TS2322: Type '{ a: number; }' is not assignable to type '{ a: number; b: number; } | { a: string; b?: undefined; } | { a?: undefined; b?: undefined; }'.
   Property 'b' is missing in type '{ a: number; }' but required in type '{ a: number; b: number; }'.
+tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(48,20): error TS2322: Type '2' is not assignable to type '1'.
+tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts(49,14): error TS2322: Type '2' is not assignable to type '1'.
 
 
-==== tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts (5 errors) ====
+==== tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts (7 errors) ====
     // Object literals in unions are normalized upon widening
     let a1 = [{ a: 0 }, { a: 1, b: "x" }, { a: 2, b: "y", c: true }][0];
     a1.a;  // number
@@ -78,5 +80,11 @@ tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
     let e1 = f({ a: 1, b: 2 }, { a: "abc" }, {});
     let e2 = f({}, { a: "abc" }, { a: 1, b: 2 });
     let e3 = f(data, { a: 2 });
+                       ~
+!!! error TS2322: Type '2' is not assignable to type '1'.
+!!! related TS6500 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts:43:21: The expected type comes from property 'a' which is declared here on type '{ a: 1; b: "abc"; c: true; }'
     let e4 = f({ a: 2 }, data);
+                 ~
+!!! error TS2322: Type '2' is not assignable to type '1'.
+!!! related TS6500 tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts:43:21: The expected type comes from property 'a' which is declared here on type '{ a: 1; b: "abc"; c: true; }'
     

--- a/tests/baselines/reference/objectLiteralNormalization.js
+++ b/tests/baselines/reference/objectLiteralNormalization.js
@@ -227,9 +227,5 @@ declare let e2: {
     a: number;
     b: number;
 };
-declare let e3: {
-    a: number;
-};
-declare let e4: {
-    a: number;
-};
+declare let e3: any;
+declare let e4: any;

--- a/tests/baselines/reference/objectLiteralNormalization.types
+++ b/tests/baselines/reference/objectLiteralNormalization.types
@@ -304,8 +304,8 @@ let e2 = f({}, { a: "abc" }, { a: 1, b: 2 });
 >2 : 2
 
 let e3 = f(data, { a: 2 });
->e3 : { a: number; }
->f(data, { a: 2 }) : { a: number; }
+>e3 : any
+>f(data, { a: 2 }) : any
 >f : <T>(...items: T[]) => T
 >data : { a: 1; b: "abc"; c: true; }
 >{ a: 2 } : { a: number; }
@@ -313,8 +313,8 @@ let e3 = f(data, { a: 2 });
 >2 : 2
 
 let e4 = f({ a: 2 }, data);
->e4 : { a: number; }
->f({ a: 2 }, data) : { a: number; }
+>e4 : any
+>f({ a: 2 }, data) : any
 >f : <T>(...items: T[]) => T
 >{ a: 2 } : { a: number; }
 >a : number

--- a/tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts
+++ b/tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts
@@ -1,0 +1,36 @@
+// @strict: true
+// @target: es2015
+
+// Repro from #31204
+
+export enum AppType {
+    HeaderDetail = 'HeaderDetail',
+    HeaderMultiDetail = 'HeaderMultiDetail',
+    AdvancedList = 'AdvancedList',
+    Standard = 'Standard',
+    Relationship = 'Relationship',
+    Report = 'Report',
+    Composite = 'Composite',
+    ListOnly = 'ListOnly',
+    ModuleSettings = 'ModuleSettings'
+}
+
+export enum AppStyle {
+    Tree,
+    TreeEntity,
+    Standard,
+    MiniApp,
+    PivotTable
+}
+
+const appTypeStylesWithError: Map<AppType, Array<AppStyle>> = new Map([
+    [AppType.Standard, [AppStyle.Standard, AppStyle.MiniApp]],
+    [AppType.Relationship, [AppStyle.Standard, AppStyle.Tree, AppStyle.TreeEntity]],
+    [AppType.AdvancedList, [AppStyle.Standard, AppStyle.MiniApp]]
+]);
+
+// Repro from #31204
+
+declare function foo<T>(...args: T[]): T[];
+let b1: { x: boolean }[] = foo({ x: true }, { x: false });
+let b2: boolean[][] = foo([true], [false]);


### PR DESCRIPTION
In type inference it is safe to union together all inferences made from object and array literals to a particular type parameter because it is known that the object and array literals are not aliased. We already performed such unioning for object literals. This PR adds the same behavior for array literals.

Fixes #31204.