### PR TITLE
Ignore identifier declarations when calculating symbol visibility

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3265,7 +3265,7 @@ namespace ts {
 
         function hasVisibleDeclarations(symbol: Symbol, shouldComputeAliasToMakeVisible: boolean): SymbolVisibilityResult | undefined {
             let aliasesToMakeVisible: LateVisibilityPaintedStatement[] | undefined;
-            if (!every(symbol.declarations, getIsDeclarationVisible)) {
+            if (!every(filter(symbol.declarations, d => d.kind !== SyntaxKind.Identifier), getIsDeclarationVisible)) {
                 return undefined;
             }
             return { accessibility: SymbolAccessibility.Accessible, aliasesToMakeVisible };

--- a/tests/baselines/reference/declarationEmitExpandoWithGenericConstraint.js
+++ b/tests/baselines/reference/declarationEmitExpandoWithGenericConstraint.js
@@ -1,0 +1,38 @@
+//// [declarationEmitExpandoWithGenericConstraint.ts]
+export interface Point {
+    readonly x: number;
+    readonly y: number;
+}
+
+export interface Rect<p extends Point> {
+    readonly a: p;
+    readonly b: p;
+}
+
+export const Point = (x: number, y: number): Point => ({ x, y });
+export const Rect = <p extends Point>(a: p, b: p): Rect<p> => ({ a, b });
+
+Point.zero = (): Point => Point(0, 0);
+
+//// [declarationEmitExpandoWithGenericConstraint.js]
+"use strict";
+exports.__esModule = true;
+exports.Point = function (x, y) { return ({ x: x, y: y }); };
+exports.Rect = function (a, b) { return ({ a: a, b: b }); };
+exports.Point.zero = function () { return exports.Point(0, 0); };
+
+
+//// [declarationEmitExpandoWithGenericConstraint.d.ts]
+export interface Point {
+    readonly x: number;
+    readonly y: number;
+}
+export interface Rect<p extends Point> {
+    readonly a: p;
+    readonly b: p;
+}
+export declare const Point: {
+    (x: number, y: number): Point;
+    zero(): Point;
+};
+export declare const Rect: <p extends Point>(a: p, b: p) => Rect<p>;

--- a/tests/baselines/reference/declarationEmitExpandoWithGenericConstraint.symbols
+++ b/tests/baselines/reference/declarationEmitExpandoWithGenericConstraint.symbols
@@ -1,0 +1,53 @@
+=== tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts ===
+export interface Point {
+>Point : Symbol(Point, Decl(declarationEmitExpandoWithGenericConstraint.ts, 0, 0), Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 12), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+
+    readonly x: number;
+>x : Symbol(Point.x, Decl(declarationEmitExpandoWithGenericConstraint.ts, 0, 24))
+
+    readonly y: number;
+>y : Symbol(Point.y, Decl(declarationEmitExpandoWithGenericConstraint.ts, 1, 23))
+}
+
+export interface Rect<p extends Point> {
+>Rect : Symbol(Rect, Decl(declarationEmitExpandoWithGenericConstraint.ts, 3, 1), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 12))
+>p : Symbol(p, Decl(declarationEmitExpandoWithGenericConstraint.ts, 5, 22))
+>Point : Symbol(Point, Decl(declarationEmitExpandoWithGenericConstraint.ts, 0, 0), Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 12), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+
+    readonly a: p;
+>a : Symbol(Rect.a, Decl(declarationEmitExpandoWithGenericConstraint.ts, 5, 40))
+>p : Symbol(p, Decl(declarationEmitExpandoWithGenericConstraint.ts, 5, 22))
+
+    readonly b: p;
+>b : Symbol(Rect.b, Decl(declarationEmitExpandoWithGenericConstraint.ts, 6, 18))
+>p : Symbol(p, Decl(declarationEmitExpandoWithGenericConstraint.ts, 5, 22))
+}
+
+export const Point = (x: number, y: number): Point => ({ x, y });
+>Point : Symbol(Point, Decl(declarationEmitExpandoWithGenericConstraint.ts, 0, 0), Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 12), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+>x : Symbol(x, Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 22))
+>y : Symbol(y, Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 32))
+>Point : Symbol(Point, Decl(declarationEmitExpandoWithGenericConstraint.ts, 0, 0), Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 12), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+>x : Symbol(x, Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 56))
+>y : Symbol(y, Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 59))
+
+export const Rect = <p extends Point>(a: p, b: p): Rect<p> => ({ a, b });
+>Rect : Symbol(Rect, Decl(declarationEmitExpandoWithGenericConstraint.ts, 3, 1), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 12))
+>p : Symbol(p, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 21))
+>Point : Symbol(Point, Decl(declarationEmitExpandoWithGenericConstraint.ts, 0, 0), Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 12), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+>a : Symbol(a, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 38))
+>p : Symbol(p, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 21))
+>b : Symbol(b, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 43))
+>p : Symbol(p, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 21))
+>Rect : Symbol(Rect, Decl(declarationEmitExpandoWithGenericConstraint.ts, 3, 1), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 12))
+>p : Symbol(p, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 21))
+>a : Symbol(a, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 64))
+>b : Symbol(b, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 67))
+
+Point.zero = (): Point => Point(0, 0);
+>Point.zero : Symbol(Point.zero, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+>Point : Symbol(Point, Decl(declarationEmitExpandoWithGenericConstraint.ts, 0, 0), Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 12), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+>zero : Symbol(Point.zero, Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+>Point : Symbol(Point, Decl(declarationEmitExpandoWithGenericConstraint.ts, 0, 0), Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 12), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+>Point : Symbol(Point, Decl(declarationEmitExpandoWithGenericConstraint.ts, 0, 0), Decl(declarationEmitExpandoWithGenericConstraint.ts, 10, 12), Decl(declarationEmitExpandoWithGenericConstraint.ts, 11, 73))
+

--- a/tests/baselines/reference/declarationEmitExpandoWithGenericConstraint.types
+++ b/tests/baselines/reference/declarationEmitExpandoWithGenericConstraint.types
@@ -1,0 +1,48 @@
+=== tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts ===
+export interface Point {
+    readonly x: number;
+>x : number
+
+    readonly y: number;
+>y : number
+}
+
+export interface Rect<p extends Point> {
+    readonly a: p;
+>a : p
+
+    readonly b: p;
+>b : p
+}
+
+export const Point = (x: number, y: number): Point => ({ x, y });
+>Point : { (x: number, y: number): Point; zero(): Point; }
+>(x: number, y: number): Point => ({ x, y }) : { (x: number, y: number): Point; zero(): Point; }
+>x : number
+>y : number
+>({ x, y }) : { x: number; y: number; }
+>{ x, y } : { x: number; y: number; }
+>x : number
+>y : number
+
+export const Rect = <p extends Point>(a: p, b: p): Rect<p> => ({ a, b });
+>Rect : <p extends Point>(a: p, b: p) => Rect<p>
+><p extends Point>(a: p, b: p): Rect<p> => ({ a, b }) : <p extends Point>(a: p, b: p) => Rect<p>
+>a : p
+>b : p
+>({ a, b }) : { a: p; b: p; }
+>{ a, b } : { a: p; b: p; }
+>a : p
+>b : p
+
+Point.zero = (): Point => Point(0, 0);
+>Point.zero = (): Point => Point(0, 0) : () => Point
+>Point.zero : () => Point
+>Point : { (x: number, y: number): Point; zero(): Point; }
+>zero : () => Point
+>(): Point => Point(0, 0) : () => Point
+>Point(0, 0) : Point
+>Point : { (x: number, y: number): Point; zero(): Point; }
+>0 : 0
+>0 : 0
+

--- a/tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts
+++ b/tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts
@@ -1,0 +1,15 @@
+// @declaration: true
+export interface Point {
+    readonly x: number;
+    readonly y: number;
+}
+
+export interface Rect<p extends Point> {
+    readonly a: p;
+    readonly b: p;
+}
+
+export const Point = (x: number, y: number): Point => ({ x, y });
+export const Rect = <p extends Point>(a: p, b: p): Rect<p> => ({ a, b });
+
+Point.zero = (): Point => Point(0, 0);


### PR DESCRIPTION
Since they correspond to expando declarations whose visibility is inherited from the other declarations of the symbol.

Fixes #31803
