### PR TITLE
Trivially expose getEncodedSyntacticClassifications

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -777,6 +777,7 @@ namespace ts.server.protocol {
     /**
      * Arguments for EncodedSyntacticClassificationsRequest request.
      */
+    /** @internal */
     export interface EncodedSyntacticClassificationsRequestArgs extends FileRequestArgs {
         /**
          * Start position of the span.
@@ -799,6 +800,7 @@ namespace ts.server.protocol {
     /**
      * Arguments for EncodedSemanticClassificationsRequest request.
      */
+    /** @internal */
     export interface EncodedSemanticClassificationsRequestArgs extends FileRequestArgs {
         /**
          * Start position of the span.

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -94,6 +94,8 @@ namespace ts.server.protocol {
         ApplyChangedToOpenFiles = "applyChangedToOpenFiles",
         UpdateOpen = "updateOpen",
         /* @internal */
+        EncodedSyntacticClassificationsFull = "encodedSyntacticClassifications-full",
+        /* @internal */
         EncodedSemanticClassificationsFull = "encodedSemanticClassifications-full",
         /* @internal */
         Cleanup = "cleanup",
@@ -762,6 +764,28 @@ namespace ts.server.protocol {
          * List of error codes supported by the server.
          */
         body?: string[];
+    }
+
+    /**
+     * A request to get encoded Syntactic classifications for a span in the file
+     */
+    /** @internal */
+    export interface EncodedSyntacticClassificationsRequest extends FileRequest {
+        arguments: EncodedSyntacticClassificationsRequestArgs;
+    }
+
+    /**
+     * Arguments for EncodedSyntacticClassificationsRequest request.
+     */
+    export interface EncodedSyntacticClassificationsRequestArgs extends FileRequestArgs {
+        /**
+         * Start position of the span.
+         */
+        start: number;
+        /**
+         * Length of the span.
+         */
+        length: number;
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -882,8 +882,8 @@ namespace ts.server {
         }
 
         private getEncodedSyntacticClassifications(args: protocol.EncodedSyntacticClassificationsRequestArgs) {
-            const { file, project } = this.getFileAndProject(args);
-            return project.getLanguageService().getEncodedSyntacticClassifications(file, args);
+            const { file, languageService } = this.getFileAndLanguageServiceForSyntacticOperation(args);
+            return languageService.getEncodedSyntacticClassifications(file, args);
         }
 
         private getEncodedSemanticClassifications(args: protocol.EncodedSemanticClassificationsRequestArgs) {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -881,6 +881,11 @@ namespace ts.server {
             }
         }
 
+        private getEncodedSyntacticClassifications(args: protocol.EncodedSyntacticClassificationsRequestArgs) {
+            const { file, project } = this.getFileAndProject(args);
+            return project.getLanguageService().getEncodedSyntacticClassifications(file, args);
+        }
+
         private getEncodedSemanticClassifications(args: protocol.EncodedSemanticClassificationsRequestArgs) {
             const { file, project } = this.getFileAndProject(args);
             return project.getLanguageService().getEncodedSemanticClassifications(file, args);
@@ -2298,6 +2303,9 @@ namespace ts.server {
             },
             [CommandNames.CompilerOptionsDiagnosticsFull]: (request: protocol.CompilerOptionsDiagnosticsRequest) => {
                 return this.requiredResponse(this.getCompilerOptionsDiagnostics(request.arguments));
+            },
+            [CommandNames.EncodedSyntacticClassificationsFull]: (request: protocol.EncodedSyntacticClassificationsRequest) => {
+                return this.requiredResponse(this.getEncodedSyntacticClassifications(request.arguments));
             },
             [CommandNames.EncodedSemanticClassificationsFull]: (request: protocol.EncodedSemanticClassificationsRequest) => {
                 return this.requiredResponse(this.getEncodedSemanticClassifications(request.arguments));

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6415,32 +6415,6 @@ declare namespace ts.server.protocol {
         body?: string[];
     }
     /**
-     * Arguments for EncodedSyntacticClassificationsRequest request.
-     */
-    interface EncodedSyntacticClassificationsRequestArgs extends FileRequestArgs {
-        /**
-         * Start position of the span.
-         */
-        start: number;
-        /**
-         * Length of the span.
-         */
-        length: number;
-    }
-    /**
-     * Arguments for EncodedSemanticClassificationsRequest request.
-     */
-    interface EncodedSemanticClassificationsRequestArgs extends FileRequestArgs {
-        /**
-         * Start position of the span.
-         */
-        start: number;
-        /**
-         * Length of the span.
-         */
-        length: number;
-    }
-    /**
      * Arguments in document highlight request; include: filesToSearch, file,
      * line, offset.
      */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6415,6 +6415,19 @@ declare namespace ts.server.protocol {
         body?: string[];
     }
     /**
+     * Arguments for EncodedSyntacticClassificationsRequest request.
+     */
+    interface EncodedSyntacticClassificationsRequestArgs extends FileRequestArgs {
+        /**
+         * Start position of the span.
+         */
+        start: number;
+        /**
+         * Length of the span.
+         */
+        length: number;
+    }
+    /**
      * Arguments for EncodedSemanticClassificationsRequest request.
      */
     interface EncodedSemanticClassificationsRequestArgs extends FileRequestArgs {
@@ -9075,6 +9088,7 @@ declare namespace ts.server {
         private updateErrorCheck;
         private cleanProjects;
         private cleanup;
+        private getEncodedSyntacticClassifications;
         private getEncodedSemanticClassifications;
         private getProject;
         private getConfigFileAndProject;


### PR DESCRIPTION
Visual Studio would like to use it to make a quick first pass before TextMate comes in with the real classifications.