### PR TITLE
Wrap es2015 classes

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -23,11 +23,10 @@ namespace ts {
         IsNamedExternalExport = 1 << 4,
         IsDefaultExternalExport = 1 << 5,
         IsDerivedClass = 1 << 6,
-        UseImmediatelyInvokedFunctionExpression = 1 << 7,
 
         HasAnyDecorators = HasConstructorDecorators | HasMemberDecorators,
         NeedsName = HasStaticInitializedProperties | HasMemberDecorators,
-        MayNeedImmediatelyInvokedFunctionExpression = HasAnyDecorators | HasStaticInitializedProperties,
+        UseImmediatelyInvokedFunctionExpression = HasAnyDecorators | HasStaticInitializedProperties,
         IsExported = IsExportOfNamespace | IsDefaultExternalExport | IsNamedExternalExport,
     }
 
@@ -587,7 +586,6 @@ namespace ts {
             if (isExportOfNamespace(node)) facts |= ClassFacts.IsExportOfNamespace;
             else if (isDefaultExternalModuleExport(node)) facts |= ClassFacts.IsDefaultExternalExport;
             else if (isNamedExternalModuleExport(node)) facts |= ClassFacts.IsNamedExternalExport;
-            if (languageVersion <= ScriptTarget.ES5 && (facts & ClassFacts.MayNeedImmediatelyInvokedFunctionExpression)) facts |= ClassFacts.UseImmediatelyInvokedFunctionExpression;
             return facts;
         }
 
@@ -666,7 +664,7 @@ namespace ts {
                             /*type*/ undefined,
                             iife
                         )
-                    ])
+                    ], languageVersion > ScriptTarget.ES5 ? NodeFlags.Let : undefined)
                 );
 
                 setOriginalNode(varStatement, node);

--- a/tests/baselines/reference/classDeclarationCheckUsedBeforeDefinitionInItself.js
+++ b/tests/baselines/reference/classDeclarationCheckUsedBeforeDefinitionInItself.js
@@ -4,6 +4,9 @@ class C3 {
 }
 
 //// [classDeclarationCheckUsedBeforeDefinitionInItself.js]
-class C3 {
-}
-C3.intance = new C3(); // ok
+let C3 = (() => {
+    class C3 {
+    }
+    C3.intance = new C3(); // ok
+    return C3;
+})();

--- a/tests/baselines/reference/computedPropertyNames12_ES6.js
+++ b/tests/baselines/reference/computedPropertyNames12_ES6.js
@@ -17,16 +17,19 @@ class C {
 }
 
 //// [computedPropertyNames12_ES6.js]
-var _a, _b, _c;
 var s;
 var n;
 var a;
-class C {
-    constructor() {
-        this[_a] = n;
-        this[_b] = 2;
-        this[`hello bye`] = 0;
+let C = (() => {
+    var _a, _b, _c;
+    class C {
+        constructor() {
+            this[_a] = n;
+            this[_b] = 2;
+            this[`hello bye`] = 0;
+        }
     }
-}
-_a = n, s + s, _b = s + n, +s, _c = `hello ${a} bye`;
-C[_c] = 0;
+    _a = n, s + s, _b = s + n, +s, _c = `hello ${a} bye`;
+    C[_c] = 0;
+    return C;
+})();

--- a/tests/baselines/reference/computedPropertyNamesWithStaticProperty.js
+++ b/tests/baselines/reference/computedPropertyNamesWithStaticProperty.js
@@ -11,13 +11,16 @@ class C {
 }
 
 //// [computedPropertyNamesWithStaticProperty.js]
-class C {
-    get [C.staticProp]() {
-        return "hello";
+let C = (() => {
+    class C {
+        get [C.staticProp]() {
+            return "hello";
+        }
+        set [C.staticProp](x) {
+            var y = x;
+        }
+        [C.staticProp]() { }
     }
-    set [C.staticProp](x) {
-        var y = x;
-    }
-    [C.staticProp]() { }
-}
-C.staticProp = 10;
+    C.staticProp = 10;
+    return C;
+})();

--- a/tests/baselines/reference/decoratedClassExportsCommonJS1.js
+++ b/tests/baselines/reference/decoratedClassExportsCommonJS1.js
@@ -14,12 +14,15 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var Testing123_1;
 Object.defineProperty(exports, "__esModule", { value: true });
-let Testing123 = Testing123_1 = class Testing123 {
-};
-Testing123.prop1 = Testing123_1.prop0;
-Testing123 = Testing123_1 = __decorate([
-    Something({ v: () => Testing123_1 })
-], Testing123);
+let Testing123 = (() => {
+    var Testing123_1;
+    let Testing123 = Testing123_1 = class Testing123 {
+    };
+    Testing123.prop1 = Testing123_1.prop0;
+    Testing123 = Testing123_1 = __decorate([
+        Something({ v: () => Testing123_1 })
+    ], Testing123);
+    return Testing123;
+})();
 exports.Testing123 = Testing123;

--- a/tests/baselines/reference/decoratedClassExportsCommonJS2.js
+++ b/tests/baselines/reference/decoratedClassExportsCommonJS2.js
@@ -12,11 +12,14 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var Testing123_1;
 Object.defineProperty(exports, "__esModule", { value: true });
-let Testing123 = Testing123_1 = class Testing123 {
-};
-Testing123 = Testing123_1 = __decorate([
-    Something({ v: () => Testing123_1 })
-], Testing123);
+let Testing123 = (() => {
+    var Testing123_1;
+    let Testing123 = Testing123_1 = class Testing123 {
+    };
+    Testing123 = Testing123_1 = __decorate([
+        Something({ v: () => Testing123_1 })
+    ], Testing123);
+    return Testing123;
+})();
 exports.Testing123 = Testing123;

--- a/tests/baselines/reference/decoratedClassExportsSystem1.js
+++ b/tests/baselines/reference/decoratedClassExportsSystem1.js
@@ -16,17 +16,21 @@ System.register([], function (exports_1, context_1) {
         else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
         return c > 3 && r && Object.defineProperty(target, key, r), r;
     };
-    var Testing123_1, Testing123;
+    var Testing123;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [],
         execute: function () {
-            Testing123 = Testing123_1 = class Testing123 {
-            };
-            Testing123.prop1 = Testing123_1.prop0;
-            Testing123 = Testing123_1 = __decorate([
-                Something({ v: () => Testing123_1 })
-            ], Testing123);
+            Testing123 = (() => {
+                var Testing123_1;
+                let Testing123 = Testing123_1 = class Testing123 {
+                };
+                Testing123.prop1 = Testing123_1.prop0;
+                Testing123 = Testing123_1 = __decorate([
+                    Something({ v: () => Testing123_1 })
+                ], Testing123);
+                return Testing123;
+            })();
             exports_1("Testing123", Testing123);
         }
     };

--- a/tests/baselines/reference/decoratedClassExportsSystem2.js
+++ b/tests/baselines/reference/decoratedClassExportsSystem2.js
@@ -13,16 +13,20 @@ System.register([], function (exports_1, context_1) {
         else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
         return c > 3 && r && Object.defineProperty(target, key, r), r;
     };
-    var Testing123_1, Testing123;
+    var Testing123;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [],
         execute: function () {
-            Testing123 = Testing123_1 = class Testing123 {
-            };
-            Testing123 = Testing123_1 = __decorate([
-                Something({ v: () => Testing123_1 })
-            ], Testing123);
+            Testing123 = (() => {
+                var Testing123_1;
+                let Testing123 = Testing123_1 = class Testing123 {
+                };
+                Testing123 = Testing123_1 = __decorate([
+                    Something({ v: () => Testing123_1 })
+                ], Testing123);
+                return Testing123;
+            })();
             exports_1("Testing123", Testing123);
         }
     };

--- a/tests/baselines/reference/decoratedClassFromExternalModule.js
+++ b/tests/baselines/reference/decoratedClassFromExternalModule.js
@@ -17,10 +17,13 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 function decorate(target) { }
-let Decorated = class Decorated {
-};
-Decorated = __decorate([
-    decorate
-], Decorated);
+let Decorated = (() => {
+    let Decorated = class Decorated {
+    };
+    Decorated = __decorate([
+        decorate
+    ], Decorated);
+    return Decorated;
+})();
 export default Decorated;
 //// [undecorated.js]

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.js
@@ -24,11 +24,14 @@ define(["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var decorator;
-    let Foo = class Foo {
-    };
-    Foo = __decorate([
-        decorator
-    ], Foo);
+    let Foo = (() => {
+        let Foo = class Foo {
+        };
+        Foo = __decorate([
+            decorator
+        ], Foo);
+        return Foo;
+    })();
     exports.default = Foo;
 });
 //// [b.js]
@@ -42,10 +45,13 @@ define(["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var decorator;
-    let default_1 = class {
-    };
-    default_1 = __decorate([
-        decorator
-    ], default_1);
+    let default_1 = (() => {
+        let default_1 = class {
+        };
+        default_1 = __decorate([
+            decorator
+        ], default_1);
+        return default_1;
+    })();
     exports.default = default_1;
 });

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.js
@@ -23,11 +23,14 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 var decorator;
-let Foo = class Foo {
-};
-Foo = __decorate([
-    decorator
-], Foo);
+let Foo = (() => {
+    let Foo = class Foo {
+    };
+    Foo = __decorate([
+        decorator
+    ], Foo);
+    return Foo;
+})();
 exports.default = Foo;
 //// [b.js]
 "use strict";
@@ -39,9 +42,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 var decorator;
-let default_1 = class {
-};
-default_1 = __decorate([
-    decorator
-], default_1);
+let default_1 = (() => {
+    let default_1 = class {
+    };
+    default_1 = __decorate([
+        decorator
+    ], default_1);
+    return default_1;
+})();
 exports.default = default_1;

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
@@ -26,11 +26,14 @@ System.register([], function (exports_1, context_1) {
     return {
         setters: [],
         execute: function () {
-            Foo = class Foo {
-            };
-            Foo = __decorate([
-                decorator
-            ], Foo);
+            Foo = (() => {
+                let Foo = class Foo {
+                };
+                Foo = __decorate([
+                    decorator
+                ], Foo);
+                return Foo;
+            })();
             exports_1("default", Foo);
         }
     };
@@ -49,11 +52,14 @@ System.register([], function (exports_1, context_1) {
     return {
         setters: [],
         execute: function () {
-            default_1 = class {
-            };
-            default_1 = __decorate([
-                decorator
-            ], default_1);
+            default_1 = (() => {
+                let default_1 = class {
+                };
+                default_1 = __decorate([
+                    decorator
+                ], default_1);
+                return default_1;
+            })();
             exports_1("default", default_1);
         }
     };

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.js
@@ -32,11 +32,14 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var decorator;
-    let Foo = class Foo {
-    };
-    Foo = __decorate([
-        decorator
-    ], Foo);
+    let Foo = (() => {
+        let Foo = class Foo {
+        };
+        Foo = __decorate([
+            decorator
+        ], Foo);
+        return Foo;
+    })();
     exports.default = Foo;
 });
 //// [b.js]
@@ -58,10 +61,13 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
     var decorator;
-    let default_1 = class {
-    };
-    default_1 = __decorate([
-        decorator
-    ], default_1);
+    let default_1 = (() => {
+        let default_1 = class {
+        };
+        default_1 = __decorate([
+            decorator
+        ], default_1);
+        return default_1;
+    })();
     exports.default = default_1;
 });

--- a/tests/baselines/reference/decoratorMetadataPromise.js
+++ b/tests/baselines/reference/decoratorMetadataPromise.js
@@ -29,30 +29,33 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-class A {
-    foo() {
-        return __awaiter(this, void 0, void 0, function* () { });
+let A = (() => {
+    class A {
+        foo() {
+            return __awaiter(this, void 0, void 0, function* () { });
+        }
+        bar() {
+            return __awaiter(this, void 0, void 0, function* () { return 0; });
+        }
+        baz(n) { return n; }
     }
-    bar() {
-        return __awaiter(this, void 0, void 0, function* () { return 0; });
-    }
-    baz(n) { return n; }
-}
-__decorate([
-    decorator,
-    __metadata("design:type", Function),
-    __metadata("design:paramtypes", []),
-    __metadata("design:returntype", Promise)
-], A.prototype, "foo", null);
-__decorate([
-    decorator,
-    __metadata("design:type", Function),
-    __metadata("design:paramtypes", []),
-    __metadata("design:returntype", Promise)
-], A.prototype, "bar", null);
-__decorate([
-    decorator,
-    __metadata("design:type", Function),
-    __metadata("design:paramtypes", [Promise]),
-    __metadata("design:returntype", Promise)
-], A.prototype, "baz", null);
+    __decorate([
+        decorator,
+        __metadata("design:type", Function),
+        __metadata("design:paramtypes", []),
+        __metadata("design:returntype", Promise)
+    ], A.prototype, "foo", null);
+    __decorate([
+        decorator,
+        __metadata("design:type", Function),
+        __metadata("design:paramtypes", []),
+        __metadata("design:returntype", Promise)
+    ], A.prototype, "bar", null);
+    __decorate([
+        decorator,
+        __metadata("design:type", Function),
+        __metadata("design:paramtypes", [Promise]),
+        __metadata("design:returntype", Promise)
+    ], A.prototype, "baz", null);
+    return A;
+})();

--- a/tests/baselines/reference/decoratorOnClass1.es6.js
+++ b/tests/baselines/reference/decoratorOnClass1.es6.js
@@ -14,9 +14,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-let C = class C {
-};
-C = __decorate([
-    dec
-], C);
+let C = (() => {
+    let C = class C {
+    };
+    C = __decorate([
+        dec
+    ], C);
+    return C;
+})();
 let c = new C();

--- a/tests/baselines/reference/decoratorOnClass2.es6.js
+++ b/tests/baselines/reference/decoratorOnClass2.es6.js
@@ -14,10 +14,13 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-let C = class C {
-};
-C = __decorate([
-    dec
-], C);
+let C = (() => {
+    let C = class C {
+    };
+    C = __decorate([
+        dec
+    ], C);
+    return C;
+})();
 export { C };
 let c = new C();

--- a/tests/baselines/reference/decoratorOnClass3.es6.js
+++ b/tests/baselines/reference/decoratorOnClass3.es6.js
@@ -14,10 +14,13 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-let C = class C {
-};
-C = __decorate([
-    dec
-], C);
+let C = (() => {
+    let C = class C {
+    };
+    C = __decorate([
+        dec
+    ], C);
+    return C;
+})();
 export default C;
 let c = new C();

--- a/tests/baselines/reference/decoratorOnClass4.es6.js
+++ b/tests/baselines/reference/decoratorOnClass4.es6.js
@@ -12,9 +12,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-let default_1 = class {
-};
-default_1 = __decorate([
-    dec
-], default_1);
+let default_1 = (() => {
+    let default_1 = class {
+    };
+    default_1 = __decorate([
+        dec
+    ], default_1);
+    return default_1;
+})();
 export default default_1;

--- a/tests/baselines/reference/decoratorOnClass5.es6.js
+++ b/tests/baselines/reference/decoratorOnClass5.es6.js
@@ -16,12 +16,15 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var C_1;
-let C = C_1 = class C {
-    static x() { return C_1.y; }
-};
-C.y = 1;
-C = C_1 = __decorate([
-    dec
-], C);
+let C = (() => {
+    var C_1;
+    let C = C_1 = class C {
+        static x() { return C_1.y; }
+    };
+    C.y = 1;
+    C = C_1 = __decorate([
+        dec
+    ], C);
+    return C;
+})();
 let c = new C();

--- a/tests/baselines/reference/decoratorOnClass6.es6.js
+++ b/tests/baselines/reference/decoratorOnClass6.es6.js
@@ -16,13 +16,16 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var C_1;
-let C = C_1 = class C {
-    static x() { return C_1.y; }
-};
-C.y = 1;
-C = C_1 = __decorate([
-    dec
-], C);
+let C = (() => {
+    var C_1;
+    let C = C_1 = class C {
+        static x() { return C_1.y; }
+    };
+    C.y = 1;
+    C = C_1 = __decorate([
+        dec
+    ], C);
+    return C;
+})();
 export { C };
 let c = new C();

--- a/tests/baselines/reference/decoratorOnClass7.es6.js
+++ b/tests/baselines/reference/decoratorOnClass7.es6.js
@@ -16,13 +16,16 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var C_1;
-let C = C_1 = class C {
-    static x() { return C_1.y; }
-};
-C.y = 1;
-C = C_1 = __decorate([
-    dec
-], C);
+let C = (() => {
+    var C_1;
+    let C = C_1 = class C {
+        static x() { return C_1.y; }
+    };
+    C.y = 1;
+    C = C_1 = __decorate([
+        dec
+    ], C);
+    return C;
+})();
 export default C;
 let c = new C();

--- a/tests/baselines/reference/decoratorOnClass8.es6.js
+++ b/tests/baselines/reference/decoratorOnClass8.es6.js
@@ -13,10 +13,13 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-let default_1 = class default_1 {
-};
-default_1.y = 1;
-default_1 = __decorate([
-    dec
-], default_1);
+let default_1 = (() => {
+    let default_1 = class default_1 {
+    };
+    default_1.y = 1;
+    default_1 = __decorate([
+        dec
+    ], default_1);
+    return default_1;
+})();
 export default default_1;

--- a/tests/baselines/reference/decoratorOnClassAccessor1.es6.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor1.es6.js
@@ -12,9 +12,13 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-export default class default_1 {
-    get accessor() { return 1; }
-}
-__decorate([
-    dec
-], default_1.prototype, "accessor", null);
+let default_1 = (() => {
+    class default_1 {
+        get accessor() { return 1; }
+    }
+    __decorate([
+        dec
+    ], default_1.prototype, "accessor", null);
+    return default_1;
+})();
+export default default_1;

--- a/tests/baselines/reference/decoratorOnClassMethod1.es6.js
+++ b/tests/baselines/reference/decoratorOnClassMethod1.es6.js
@@ -12,9 +12,13 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-export default class default_1 {
-    method() { }
-}
-__decorate([
-    dec
-], default_1.prototype, "method", null);
+let default_1 = (() => {
+    class default_1 {
+        method() { }
+    }
+    __decorate([
+        dec
+    ], default_1.prototype, "method", null);
+    return default_1;
+})();
+export default default_1;

--- a/tests/baselines/reference/decoratorOnClassMethod13.js
+++ b/tests/baselines/reference/decoratorOnClassMethod13.js
@@ -13,13 +13,16 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-class C {
-    ["1"]() { }
-    ["b"]() { }
-}
-__decorate([
-    dec
-], C.prototype, "1", null);
-__decorate([
-    dec
-], C.prototype, "b", null);
+let C = (() => {
+    class C {
+        ["1"]() { }
+        ["b"]() { }
+    }
+    __decorate([
+        dec
+    ], C.prototype, "1", null);
+    __decorate([
+        dec
+    ], C.prototype, "b", null);
+    return C;
+})();

--- a/tests/baselines/reference/decoratorOnClassMethod4.js
+++ b/tests/baselines/reference/decoratorOnClassMethod4.js
@@ -12,9 +12,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-class C {
-    ["method"]() { }
-}
-__decorate([
-    dec
-], C.prototype, "method", null);
+let C = (() => {
+    class C {
+        ["method"]() { }
+    }
+    __decorate([
+        dec
+    ], C.prototype, "method", null);
+    return C;
+})();

--- a/tests/baselines/reference/decoratorOnClassMethod5.js
+++ b/tests/baselines/reference/decoratorOnClassMethod5.js
@@ -12,9 +12,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-class C {
-    ["method"]() { }
-}
-__decorate([
-    dec()
-], C.prototype, "method", null);
+let C = (() => {
+    class C {
+        ["method"]() { }
+    }
+    __decorate([
+        dec()
+    ], C.prototype, "method", null);
+    return C;
+})();

--- a/tests/baselines/reference/decoratorOnClassMethod6.js
+++ b/tests/baselines/reference/decoratorOnClassMethod6.js
@@ -12,9 +12,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-class C {
-    ["method"]() { }
-}
-__decorate([
-    dec
-], C.prototype, "method", null);
+let C = (() => {
+    class C {
+        ["method"]() { }
+    }
+    __decorate([
+        dec
+    ], C.prototype, "method", null);
+    return C;
+})();

--- a/tests/baselines/reference/decoratorOnClassMethod7.js
+++ b/tests/baselines/reference/decoratorOnClassMethod7.js
@@ -12,9 +12,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-class C {
-    ["method"]() { }
-}
-__decorate([
-    dec
-], C.prototype, "method", null);
+let C = (() => {
+    class C {
+        ["method"]() { }
+    }
+    __decorate([
+        dec
+    ], C.prototype, "method", null);
+    return C;
+})();

--- a/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.js
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.js
@@ -15,9 +15,13 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __param = (this && this.__param) || function (paramIndex, decorator) {
     return function (target, key) { decorator(target, key, paramIndex); }
 };
-export default class default_1 {
-    method(p) { }
-}
-__decorate([
-    __param(0, dec)
-], default_1.prototype, "method", null);
+let default_1 = (() => {
+    class default_1 {
+        method(p) { }
+    }
+    __decorate([
+        __param(0, dec)
+    ], default_1.prototype, "method", null);
+    return default_1;
+})();
+export default default_1;

--- a/tests/baselines/reference/decoratorOnClassProperty1.es6.js
+++ b/tests/baselines/reference/decoratorOnClassProperty1.es6.js
@@ -12,8 +12,12 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-export default class default_1 {
-}
-__decorate([
-    dec
-], default_1.prototype, "prop", void 0);
+let default_1 = (() => {
+    class default_1 {
+    }
+    __decorate([
+        dec
+    ], default_1.prototype, "prop", void 0);
+    return default_1;
+})();
+export default default_1;

--- a/tests/baselines/reference/decoratorsOnComputedProperties.js
+++ b/tests/baselines/reference/decoratorsOnComputedProperties.js
@@ -197,262 +197,282 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 var _a, _b, _c, _d;
-var _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18, _19, _20, _21;
+var _e, _f, _g, _h, _j, _k, _l, _m, _o, _p, _q, _r, _s, _t, _u, _v, _w, _x, _y, _z, _0;
 function x(o, k) { }
 let i = 0;
 function foo() { return ++i + ""; }
 const fieldNameA = "fieldName1";
 const fieldNameB = "fieldName2";
 const fieldNameC = "fieldName3";
-class A {
-    constructor() {
-        this["property2"] = 2;
-        this[Symbol.iterator] = null;
-        this["property4"] = 2;
-        this[Symbol.match] = null;
-        this[_f] = null;
-        this[_h] = null;
+let A = (() => {
+    var _a, _b, _c, _d;
+    class A {
+        constructor() {
+            this["property2"] = 2;
+            this[Symbol.iterator] = null;
+            this["property4"] = 2;
+            this[Symbol.match] = null;
+            this[_b] = null;
+            this[_d] = null;
+        }
     }
-}
-foo(), _e = foo(), _f = foo(), _g = fieldNameB, _h = fieldNameC;
-__decorate([
-    x
-], A.prototype, "property", void 0);
-__decorate([
-    x
-], A.prototype, Symbol.toStringTag, void 0);
-__decorate([
-    x
-], A.prototype, "property2", void 0);
-__decorate([
-    x
-], A.prototype, Symbol.iterator, void 0);
-__decorate([
-    x
-], A.prototype, _e, void 0);
-__decorate([
-    x
-], A.prototype, _f, void 0);
-__decorate([
-    x
-], A.prototype, _g, void 0);
-__decorate([
-    x
-], A.prototype, _h, void 0);
+    foo(), _a = foo(), _b = foo(), _c = fieldNameB, _d = fieldNameC;
+    __decorate([
+        x
+    ], A.prototype, "property", void 0);
+    __decorate([
+        x
+    ], A.prototype, Symbol.toStringTag, void 0);
+    __decorate([
+        x
+    ], A.prototype, "property2", void 0);
+    __decorate([
+        x
+    ], A.prototype, Symbol.iterator, void 0);
+    __decorate([
+        x
+    ], A.prototype, _a, void 0);
+    __decorate([
+        x
+    ], A.prototype, _b, void 0);
+    __decorate([
+        x
+    ], A.prototype, _c, void 0);
+    __decorate([
+        x
+    ], A.prototype, _d, void 0);
+    return A;
+})();
 void (_a = class B {
         constructor() {
             this["property2"] = 2;
             this[Symbol.iterator] = null;
             this["property4"] = 2;
             this[Symbol.match] = null;
-            this[_k] = null;
-            this[_m] = null;
+            this[_f] = null;
+            this[_h] = null;
         }
     },
     foo(),
-    _j = foo(),
-    _k = foo(),
-    _l = fieldNameB,
-    _m = fieldNameC,
+    _e = foo(),
+    _f = foo(),
+    _g = fieldNameB,
+    _h = fieldNameC,
     _a);
-class C {
-    constructor() {
-        this["property2"] = 2;
-        this[Symbol.iterator] = null;
-        this["property4"] = 2;
-        this[Symbol.match] = null;
-        this[_p] = null;
-        this[_r] = null;
+let C = (() => {
+    var _a, _b, _c, _d;
+    class C {
+        constructor() {
+            this["property2"] = 2;
+            this[Symbol.iterator] = null;
+            this["property4"] = 2;
+            this[Symbol.match] = null;
+            this[_b] = null;
+            this[_d] = null;
+        }
+        [(foo(), _a = foo(), _b = foo(), _c = fieldNameB, _d = fieldNameC, "some" + "method")]() { }
     }
-    [(foo(), _o = foo(), _p = foo(), _q = fieldNameB, _r = fieldNameC, "some" + "method")]() { }
-}
-__decorate([
-    x
-], C.prototype, "property", void 0);
-__decorate([
-    x
-], C.prototype, Symbol.toStringTag, void 0);
-__decorate([
-    x
-], C.prototype, "property2", void 0);
-__decorate([
-    x
-], C.prototype, Symbol.iterator, void 0);
-__decorate([
-    x
-], C.prototype, _o, void 0);
-__decorate([
-    x
-], C.prototype, _p, void 0);
-__decorate([
-    x
-], C.prototype, _q, void 0);
-__decorate([
-    x
-], C.prototype, _r, void 0);
+    __decorate([
+        x
+    ], C.prototype, "property", void 0);
+    __decorate([
+        x
+    ], C.prototype, Symbol.toStringTag, void 0);
+    __decorate([
+        x
+    ], C.prototype, "property2", void 0);
+    __decorate([
+        x
+    ], C.prototype, Symbol.iterator, void 0);
+    __decorate([
+        x
+    ], C.prototype, _a, void 0);
+    __decorate([
+        x
+    ], C.prototype, _b, void 0);
+    __decorate([
+        x
+    ], C.prototype, _c, void 0);
+    __decorate([
+        x
+    ], C.prototype, _d, void 0);
+    return C;
+})();
 void class D {
     constructor() {
         this["property2"] = 2;
         this[Symbol.iterator] = null;
         this["property4"] = 2;
         this[Symbol.match] = null;
-        this[_t] = null;
-        this[_v] = null;
+        this[_k] = null;
+        this[_m] = null;
     }
-    [(foo(), _s = foo(), _t = foo(), _u = fieldNameB, _v = fieldNameC, "some" + "method")]() { }
+    [(foo(), _j = foo(), _k = foo(), _l = fieldNameB, _m = fieldNameC, "some" + "method")]() { }
 };
-class E {
-    constructor() {
-        this["property2"] = 2;
-        this[Symbol.iterator] = null;
-        this["property4"] = 2;
-        this[Symbol.match] = null;
-        this[_x] = null;
-        this[_z] = null;
+let E = (() => {
+    var _a, _b, _c, _d;
+    class E {
+        constructor() {
+            this["property2"] = 2;
+            this[Symbol.iterator] = null;
+            this["property4"] = 2;
+            this[Symbol.match] = null;
+            this[_b] = null;
+            this[_d] = null;
+        }
+        [(foo(), _a = foo(), _b = foo(), "some" + "method")]() { }
     }
-    [(foo(), _w = foo(), _x = foo(), "some" + "method")]() { }
-}
-_y = fieldNameB, _z = fieldNameC;
-__decorate([
-    x
-], E.prototype, "property", void 0);
-__decorate([
-    x
-], E.prototype, Symbol.toStringTag, void 0);
-__decorate([
-    x
-], E.prototype, "property2", void 0);
-__decorate([
-    x
-], E.prototype, Symbol.iterator, void 0);
-__decorate([
-    x
-], E.prototype, _w, void 0);
-__decorate([
-    x
-], E.prototype, _x, void 0);
-__decorate([
-    x
-], E.prototype, _y, void 0);
-__decorate([
-    x
-], E.prototype, _z, void 0);
+    _c = fieldNameB, _d = fieldNameC;
+    __decorate([
+        x
+    ], E.prototype, "property", void 0);
+    __decorate([
+        x
+    ], E.prototype, Symbol.toStringTag, void 0);
+    __decorate([
+        x
+    ], E.prototype, "property2", void 0);
+    __decorate([
+        x
+    ], E.prototype, Symbol.iterator, void 0);
+    __decorate([
+        x
+    ], E.prototype, _a, void 0);
+    __decorate([
+        x
+    ], E.prototype, _b, void 0);
+    __decorate([
+        x
+    ], E.prototype, _c, void 0);
+    __decorate([
+        x
+    ], E.prototype, _d, void 0);
+    return E;
+})();
 void (_b = class F {
         constructor() {
             this["property2"] = 2;
             this[Symbol.iterator] = null;
             this["property4"] = 2;
             this[Symbol.match] = null;
-            this[_1] = null;
-            this[_3] = null;
+            this[_p] = null;
+            this[_r] = null;
         }
-        [(foo(), _0 = foo(), _1 = foo(), "some" + "method")]() { }
+        [(foo(), _o = foo(), _p = foo(), "some" + "method")]() { }
     },
-    _2 = fieldNameB,
-    _3 = fieldNameC,
+    _q = fieldNameB,
+    _r = fieldNameC,
     _b);
-class G {
-    constructor() {
-        this["property2"] = 2;
-        this[Symbol.iterator] = null;
-        this["property4"] = 2;
-        this[Symbol.match] = null;
-        this[_5] = null;
-        this[_7] = null;
+let G = (() => {
+    var _a, _b, _c, _d;
+    class G {
+        constructor() {
+            this["property2"] = 2;
+            this[Symbol.iterator] = null;
+            this["property4"] = 2;
+            this[Symbol.match] = null;
+            this[_b] = null;
+            this[_d] = null;
+        }
+        [(foo(), _a = foo(), _b = foo(), "some" + "method")]() { }
+        [(_c = fieldNameB, "some" + "method2")]() { }
     }
-    [(foo(), _4 = foo(), _5 = foo(), "some" + "method")]() { }
-    [(_6 = fieldNameB, "some" + "method2")]() { }
-}
-_7 = fieldNameC;
-__decorate([
-    x
-], G.prototype, "property", void 0);
-__decorate([
-    x
-], G.prototype, Symbol.toStringTag, void 0);
-__decorate([
-    x
-], G.prototype, "property2", void 0);
-__decorate([
-    x
-], G.prototype, Symbol.iterator, void 0);
-__decorate([
-    x
-], G.prototype, _4, void 0);
-__decorate([
-    x
-], G.prototype, _5, void 0);
-__decorate([
-    x
-], G.prototype, _6, void 0);
-__decorate([
-    x
-], G.prototype, _7, void 0);
+    _d = fieldNameC;
+    __decorate([
+        x
+    ], G.prototype, "property", void 0);
+    __decorate([
+        x
+    ], G.prototype, Symbol.toStringTag, void 0);
+    __decorate([
+        x
+    ], G.prototype, "property2", void 0);
+    __decorate([
+        x
+    ], G.prototype, Symbol.iterator, void 0);
+    __decorate([
+        x
+    ], G.prototype, _a, void 0);
+    __decorate([
+        x
+    ], G.prototype, _b, void 0);
+    __decorate([
+        x
+    ], G.prototype, _c, void 0);
+    __decorate([
+        x
+    ], G.prototype, _d, void 0);
+    return G;
+})();
 void (_c = class H {
         constructor() {
             this["property2"] = 2;
             this[Symbol.iterator] = null;
             this["property4"] = 2;
             this[Symbol.match] = null;
-            this[_9] = null;
-            this[_11] = null;
+            this[_t] = null;
+            this[_v] = null;
         }
-        [(foo(), _8 = foo(), _9 = foo(), "some" + "method")]() { }
-        [(_10 = fieldNameB, "some" + "method2")]() { }
+        [(foo(), _s = foo(), _t = foo(), "some" + "method")]() { }
+        [(_u = fieldNameB, "some" + "method2")]() { }
     },
-    _11 = fieldNameC,
+    _v = fieldNameC,
     _c);
-class I {
-    constructor() {
-        this["property2"] = 2;
-        this[Symbol.iterator] = null;
-        this["property4"] = 2;
-        this[Symbol.match] = null;
-        this[_13] = null;
-        this[_16] = null;
+let I = (() => {
+    var _a, _b, _c, _d, _e;
+    class I {
+        constructor() {
+            this["property2"] = 2;
+            this[Symbol.iterator] = null;
+            this["property4"] = 2;
+            this[Symbol.match] = null;
+            this[_b] = null;
+            this[_e] = null;
+        }
+        [(foo(), _a = foo(), _b = foo(), _c = "some" + "method")]() { }
+        [(_d = fieldNameB, "some" + "method2")]() { }
     }
-    [(foo(), _12 = foo(), _13 = foo(), _14 = "some" + "method")]() { }
-    [(_15 = fieldNameB, "some" + "method2")]() { }
-}
-_16 = fieldNameC;
-__decorate([
-    x
-], I.prototype, "property", void 0);
-__decorate([
-    x
-], I.prototype, Symbol.toStringTag, void 0);
-__decorate([
-    x
-], I.prototype, "property2", void 0);
-__decorate([
-    x
-], I.prototype, Symbol.iterator, void 0);
-__decorate([
-    x
-], I.prototype, _12, void 0);
-__decorate([
-    x
-], I.prototype, _13, void 0);
-__decorate([
-    x
-], I.prototype, _14, null);
-__decorate([
-    x
-], I.prototype, _15, void 0);
-__decorate([
-    x
-], I.prototype, _16, void 0);
+    _e = fieldNameC;
+    __decorate([
+        x
+    ], I.prototype, "property", void 0);
+    __decorate([
+        x
+    ], I.prototype, Symbol.toStringTag, void 0);
+    __decorate([
+        x
+    ], I.prototype, "property2", void 0);
+    __decorate([
+        x
+    ], I.prototype, Symbol.iterator, void 0);
+    __decorate([
+        x
+    ], I.prototype, _a, void 0);
+    __decorate([
+        x
+    ], I.prototype, _b, void 0);
+    __decorate([
+        x
+    ], I.prototype, _c, null);
+    __decorate([
+        x
+    ], I.prototype, _d, void 0);
+    __decorate([
+        x
+    ], I.prototype, _e, void 0);
+    return I;
+})();
 void (_d = class J {
         constructor() {
             this["property2"] = 2;
             this[Symbol.iterator] = null;
             this["property4"] = 2;
             this[Symbol.match] = null;
-            this[_18] = null;
-            this[_21] = null;
+            this[_x] = null;
+            this[_0] = null;
         }
-        [(foo(), _17 = foo(), _18 = foo(), _19 = "some" + "method")]() { }
-        [(_20 = fieldNameB, "some" + "method2")]() { }
+        [(foo(), _w = foo(), _x = foo(), _y = "some" + "method")]() { }
+        [(_z = fieldNameB, "some" + "method2")]() { }
     },
-    _21 = fieldNameC,
+    _0 = fieldNameC,
     _d);

--- a/tests/baselines/reference/emitClassDeclarationWithLiteralPropertyNameInES6.js
+++ b/tests/baselines/reference/emitClassDeclarationWithLiteralPropertyNameInES6.js
@@ -15,19 +15,22 @@ class B {
 }
 
 //// [emitClassDeclarationWithLiteralPropertyNameInES6.js]
-class B {
-    constructor() {
-        this["hello"] = 10;
-        this[0b110] = "world";
-        this[0o23534] = "WORLD";
-        this[20] = "twenty";
+let B = (() => {
+    class B {
+        constructor() {
+            this["hello"] = 10;
+            this[0b110] = "world";
+            this[0o23534] = "WORLD";
+            this[20] = "twenty";
+        }
+        "foo"() { }
+        0b1110() { }
+        11() { }
+        interface() { }
     }
-    "foo"() { }
-    0b1110() { }
-    11() { }
-    interface() { }
-}
-B["hi"] = 10000;
-B[22] = "twenty-two";
-B[0b101] = "binary";
-B[0o3235] = "octal";
+    B["hi"] = 10000;
+    B[22] = "twenty-two";
+    B[0b101] = "binary";
+    B[0o3235] = "octal";
+    return B;
+})();

--- a/tests/baselines/reference/emitClassDeclarationWithStaticPropertyAssignmentInES6.js
+++ b/tests/baselines/reference/emitClassDeclarationWithStaticPropertyAssignmentInES6.js
@@ -10,12 +10,18 @@ class D {
 
 
 //// [emitClassDeclarationWithStaticPropertyAssignmentInES6.js]
-class C {
-}
-C.z = "Foo";
-class D {
-    constructor() {
-        this.x = 20000;
+let C = (() => {
+    class C {
     }
-}
-D.b = true;
+    C.z = "Foo";
+    return C;
+})();
+let D = (() => {
+    class D {
+        constructor() {
+            this.x = 20000;
+        }
+    }
+    D.b = true;
+    return D;
+})();

--- a/tests/baselines/reference/es6ModuleClassDeclaration.js
+++ b/tests/baselines/reference/es6ModuleClassDeclaration.js
@@ -113,75 +113,88 @@ module m2 {
 }
 
 //// [es6ModuleClassDeclaration.js]
-export class c {
-    constructor() {
-        this.x = 10;
-        this.y = 30;
+let c = (() => {
+    class c {
+        constructor() {
+            this.x = 10;
+            this.y = 30;
+        }
+        method1() {
+        }
+        method2() {
+        }
+        static method3() {
+        }
+        static method4() {
+        }
     }
-    method1() {
+    c.k = 20;
+    c.l = 30;
+    return c;
+})();
+export { c };
+let c2 = (() => {
+    class c2 {
+        constructor() {
+            this.x = 10;
+            this.y = 30;
+        }
+        method1() {
+        }
+        method2() {
+        }
+        static method3() {
+        }
+        static method4() {
+        }
     }
-    method2() {
-    }
-    static method3() {
-    }
-    static method4() {
-    }
-}
-c.k = 20;
-c.l = 30;
-class c2 {
-    constructor() {
-        this.x = 10;
-        this.y = 30;
-    }
-    method1() {
-    }
-    method2() {
-    }
-    static method3() {
-    }
-    static method4() {
-    }
-}
-c2.k = 20;
-c2.l = 30;
+    c2.k = 20;
+    c2.l = 30;
+    return c2;
+})();
 new c();
 new c2();
 export var m1;
 (function (m1) {
-    class c3 {
-        constructor() {
-            this.x = 10;
-            this.y = 30;
+    let c3 = (() => {
+        class c3 {
+            constructor() {
+                this.x = 10;
+                this.y = 30;
+            }
+            method1() {
+            }
+            method2() {
+            }
+            static method3() {
+            }
+            static method4() {
+            }
         }
-        method1() {
-        }
-        method2() {
-        }
-        static method3() {
-        }
-        static method4() {
-        }
-    }
-    c3.k = 20;
-    c3.l = 30;
+        c3.k = 20;
+        c3.l = 30;
+        return c3;
+    })();
     m1.c3 = c3;
-    class c4 {
-        constructor() {
-            this.x = 10;
-            this.y = 30;
+    let c4 = (() => {
+        class c4 {
+            constructor() {
+                this.x = 10;
+                this.y = 30;
+            }
+            method1() {
+            }
+            method2() {
+            }
+            static method3() {
+            }
+            static method4() {
+            }
         }
-        method1() {
-        }
-        method2() {
-        }
-        static method3() {
-        }
-        static method4() {
-        }
-    }
-    c4.k = 20;
-    c4.l = 30;
+        c4.k = 20;
+        c4.l = 30;
+        return c4;
+    })();
     new c();
     new c2();
     new c3();
@@ -189,39 +202,45 @@ export var m1;
 })(m1 || (m1 = {}));
 var m2;
 (function (m2) {
-    class c3 {
-        constructor() {
-            this.x = 10;
-            this.y = 30;
+    let c3 = (() => {
+        class c3 {
+            constructor() {
+                this.x = 10;
+                this.y = 30;
+            }
+            method1() {
+            }
+            method2() {
+            }
+            static method3() {
+            }
+            static method4() {
+            }
         }
-        method1() {
-        }
-        method2() {
-        }
-        static method3() {
-        }
-        static method4() {
-        }
-    }
-    c3.k = 20;
-    c3.l = 30;
+        c3.k = 20;
+        c3.l = 30;
+        return c3;
+    })();
     m2.c3 = c3;
-    class c4 {
-        constructor() {
-            this.x = 10;
-            this.y = 30;
+    let c4 = (() => {
+        class c4 {
+            constructor() {
+                this.x = 10;
+                this.y = 30;
+            }
+            method1() {
+            }
+            method2() {
+            }
+            static method3() {
+            }
+            static method4() {
+            }
         }
-        method1() {
-        }
-        method2() {
-        }
-        static method3() {
-        }
-        static method4() {
-        }
-    }
-    c4.k = 20;
-    c4.l = 30;
+        c4.k = 20;
+        c4.l = 30;
+        return c4;
+    })();
     new c();
     new c2();
     new c3();

--- a/tests/baselines/reference/exportDefaultClassWithStaticPropertyAssignmentsInES6.js
+++ b/tests/baselines/reference/exportDefaultClassWithStaticPropertyAssignmentsInES6.js
@@ -4,6 +4,10 @@ export default class {
 }
 
 //// [exportDefaultClassWithStaticPropertyAssignmentsInES6.js]
-export default class default_1 {
-}
-default_1.z = "Foo";
+let default_1 = (() => {
+    class default_1 {
+    }
+    default_1.z = "Foo";
+    return default_1;
+})();
+export default default_1;

--- a/tests/baselines/reference/generatorTypeCheck39.js
+++ b/tests/baselines/reference/generatorTypeCheck39.js
@@ -20,12 +20,15 @@ function decorator(x) {
     return y => { };
 }
 function* g() {
-    let C = class C {
-        constructor() {
-            this.x = yield 0;
-        }
-    };
-    C = __decorate([
-        decorator(yield 0)
-    ], C);
+    let C = (() => {
+        let C = class C {
+            constructor() {
+                this.x = yield 0;
+            }
+        };
+        C = __decorate([
+            decorator(yield 0)
+        ], C);
+        return C;
+    })();
 }

--- a/tests/baselines/reference/generatorTypeCheck58.js
+++ b/tests/baselines/reference/generatorTypeCheck58.js
@@ -7,8 +7,11 @@ function* g() {
 
 //// [generatorTypeCheck58.js]
 function* g() {
-    class C {
-    }
-    C.x = yield 0;
+    let C = (() => {
+        class C {
+        }
+        C.x = yield 0;
+        return C;
+    })();
     ;
 }

--- a/tests/baselines/reference/generatorTypeCheck59.js
+++ b/tests/baselines/reference/generatorTypeCheck59.js
@@ -14,11 +14,14 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 function* g() {
-    class C {
-        m() { }
-    }
-    __decorate([
-        (yield "")
-    ], C.prototype, "m", null);
+    let C = (() => {
+        class C {
+            m() { }
+        }
+        __decorate([
+            (yield "")
+        ], C.prototype, "m", null);
+        return C;
+    })();
     ;
 }

--- a/tests/baselines/reference/generatorTypeCheck61.js
+++ b/tests/baselines/reference/generatorTypeCheck61.js
@@ -12,10 +12,13 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
 function* g() {
-    let C = class C {
-    };
-    C = __decorate([
-        (yield 0)
-    ], C);
+    let C = (() => {
+        let C = class C {
+        };
+        C = __decorate([
+            (yield 0)
+        ], C);
+        return C;
+    })();
     ;
 }

--- a/tests/baselines/reference/importHelpersES6.js
+++ b/tests/baselines/reference/importHelpersES6.js
@@ -19,11 +19,14 @@ export declare function __awaiter(thisArg: any, _arguments: any, P: Function, ge
 
 //// [a.js]
 import * as tslib_1 from "tslib";
-let A = class A {
-};
-A = tslib_1.__decorate([
-    dec
-], A);
+let A = (() => {
+    let A = class A {
+    };
+    A = tslib_1.__decorate([
+        dec
+    ], A);
+    return A;
+})();
 export { A };
 const o = { a: 1 };
 const y = Object.assign({}, o);

--- a/tests/baselines/reference/invalidNewTarget.es6.js
+++ b/tests/baselines/reference/invalidNewTarget.es6.js
@@ -27,20 +27,23 @@ const O = {
 //// [invalidNewTarget.es6.js]
 const a = new.target;
 const b = () => new.target;
-class C {
-    constructor() {
-        this.f = () => new.target;
+let C = (() => {
+    class C {
+        constructor() {
+            this.f = () => new.target;
+        }
+        [new.target]() { }
+        c() { return new.target; }
+        get d() { return new.target; }
+        set e(_) { _ = new.target; }
+        static [new.target]() { }
+        static g() { return new.target; }
+        static get h() { return new.target; }
+        static set i(_) { _ = new.target; }
     }
-    [new.target]() { }
-    c() { return new.target; }
-    get d() { return new.target; }
-    set e(_) { _ = new.target; }
-    static [new.target]() { }
-    static g() { return new.target; }
-    static get h() { return new.target; }
-    static set i(_) { _ = new.target; }
-}
-C.j = () => new.target;
+    C.j = () => new.target;
+    return C;
+})();
 const O = {
     [new.target]: undefined,
     k() { return new.target; },

--- a/tests/baselines/reference/newTarget.es6.js
+++ b/tests/baselines/reference/newTarget.es6.js
@@ -33,14 +33,17 @@ const O = {
 
 
 //// [newTarget.es6.js]
-class A {
-    constructor() {
-        this.d = function () { return new.target; };
-        const a = new.target;
-        const b = () => new.target;
+let A = (() => {
+    class A {
+        constructor() {
+            this.d = function () { return new.target; };
+            const a = new.target;
+            const b = () => new.target;
+        }
     }
-}
-A.c = function () { return new.target; };
+    A.c = function () { return new.target; };
+    return A;
+})();
 class B extends A {
     constructor() {
         super();

--- a/tests/baselines/reference/potentiallyUncalledDecorators.js
+++ b/tests/baselines/reference/potentiallyUncalledDecorators.js
@@ -85,105 +85,135 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-class FooComponent {
-}
-__decorate([
-    Input
-], FooComponent.prototype, "foo", void 0);
-class Person {
-}
-__decorate([
-    tracked
-], Person.prototype, "person", void 0);
-class MultiplyByTwo {
-    get multiplied() {
-        return this.args.number * 2;
+let FooComponent = (() => {
+    class FooComponent {
     }
-}
-__decorate([
-    tracked('args')
-], MultiplyByTwo.prototype, "multiplied", null);
-let A = class A {
-    bar() { }
-};
-__decorate([
-    noArgs
-], A.prototype, "foo", void 0);
-__decorate([
-    noArgs
-], A.prototype, "bar", null);
-A = __decorate([
-    noArgs
-], A);
-let B = class B {
-    bar() { }
-};
-__decorate([
-    allRest
-], B.prototype, "foo", void 0);
-__decorate([
-    allRest
-], B.prototype, "bar", null);
-B = __decorate([
-    allRest
-], B);
-let C = class C {
-    bar() { }
-};
-__decorate([
-    oneOptional
-], C.prototype, "foo", void 0);
-__decorate([
-    oneOptional
-], C.prototype, "bar", null);
-C = __decorate([
-    oneOptional
-], C);
-let D = class D {
-    bar() { }
-};
-__decorate([
-    twoOptional
-], D.prototype, "foo", void 0);
-__decorate([
-    twoOptional
-], D.prototype, "bar", null);
-D = __decorate([
-    twoOptional
-], D);
-let E = class E {
-    bar() { }
-};
-__decorate([
-    threeOptional
-], E.prototype, "foo", void 0);
-__decorate([
-    threeOptional
-], E.prototype, "bar", null);
-E = __decorate([
-    threeOptional
-], E);
-let F = class F {
-    bar() { }
-};
-__decorate([
-    oneOptionalWithRest
-], F.prototype, "foo", void 0);
-__decorate([
-    oneOptionalWithRest
-], F.prototype, "bar", null);
-F = __decorate([
-    oneOptionalWithRest
-], F);
-let G = class G {
-    bar() { }
-};
-__decorate([
-    anyDec
-], G.prototype, "foo", void 0);
-__decorate([
-    anyDec
-], G.prototype, "bar", null);
-G = __decorate([
-    anyDec
-], G);
+    __decorate([
+        Input
+    ], FooComponent.prototype, "foo", void 0);
+    return FooComponent;
+})();
+let Person = (() => {
+    class Person {
+    }
+    __decorate([
+        tracked
+    ], Person.prototype, "person", void 0);
+    return Person;
+})();
+let MultiplyByTwo = (() => {
+    class MultiplyByTwo {
+        get multiplied() {
+            return this.args.number * 2;
+        }
+    }
+    __decorate([
+        tracked('args')
+    ], MultiplyByTwo.prototype, "multiplied", null);
+    return MultiplyByTwo;
+})();
+let A = (() => {
+    let A = class A {
+        bar() { }
+    };
+    __decorate([
+        noArgs
+    ], A.prototype, "foo", void 0);
+    __decorate([
+        noArgs
+    ], A.prototype, "bar", null);
+    A = __decorate([
+        noArgs
+    ], A);
+    return A;
+})();
+let B = (() => {
+    let B = class B {
+        bar() { }
+    };
+    __decorate([
+        allRest
+    ], B.prototype, "foo", void 0);
+    __decorate([
+        allRest
+    ], B.prototype, "bar", null);
+    B = __decorate([
+        allRest
+    ], B);
+    return B;
+})();
+let C = (() => {
+    let C = class C {
+        bar() { }
+    };
+    __decorate([
+        oneOptional
+    ], C.prototype, "foo", void 0);
+    __decorate([
+        oneOptional
+    ], C.prototype, "bar", null);
+    C = __decorate([
+        oneOptional
+    ], C);
+    return C;
+})();
+let D = (() => {
+    let D = class D {
+        bar() { }
+    };
+    __decorate([
+        twoOptional
+    ], D.prototype, "foo", void 0);
+    __decorate([
+        twoOptional
+    ], D.prototype, "bar", null);
+    D = __decorate([
+        twoOptional
+    ], D);
+    return D;
+})();
+let E = (() => {
+    let E = class E {
+        bar() { }
+    };
+    __decorate([
+        threeOptional
+    ], E.prototype, "foo", void 0);
+    __decorate([
+        threeOptional
+    ], E.prototype, "bar", null);
+    E = __decorate([
+        threeOptional
+    ], E);
+    return E;
+})();
+let F = (() => {
+    let F = class F {
+        bar() { }
+    };
+    __decorate([
+        oneOptionalWithRest
+    ], F.prototype, "foo", void 0);
+    __decorate([
+        oneOptionalWithRest
+    ], F.prototype, "bar", null);
+    F = __decorate([
+        oneOptionalWithRest
+    ], F);
+    return F;
+})();
+let G = (() => {
+    let G = class G {
+        bar() { }
+    };
+    __decorate([
+        anyDec
+    ], G.prototype, "foo", void 0);
+    __decorate([
+        anyDec
+    ], G.prototype, "bar", null);
+    G = __decorate([
+        anyDec
+    ], G);
+    return G;
+})();

--- a/tests/baselines/reference/symbolDeclarationEmit11.js
+++ b/tests/baselines/reference/symbolDeclarationEmit11.js
@@ -7,12 +7,15 @@ class C {
 }
 
 //// [symbolDeclarationEmit11.js]
-class C {
-    static [Symbol.isConcatSpreadable]() { }
-    static get [Symbol.toPrimitive]() { return ""; }
-    static set [Symbol.toPrimitive](x) { }
-}
-C[Symbol.iterator] = 0;
+let C = (() => {
+    class C {
+        static [Symbol.isConcatSpreadable]() { }
+        static get [Symbol.toPrimitive]() { return ""; }
+        static set [Symbol.toPrimitive](x) { }
+    }
+    C[Symbol.iterator] = 0;
+    return C;
+})();
 
 
 //// [symbolDeclarationEmit11.d.ts]

--- a/tests/baselines/reference/systemModuleTargetES6.js
+++ b/tests/baselines/reference/systemModuleTargetES6.js
@@ -32,11 +32,14 @@ System.register([], function (exports_1, context_1) {
             MyClass = class MyClass {
             };
             exports_1("MyClass", MyClass);
-            MyClass2 = class MyClass2 {
-                static getInstance() { return MyClass2.value; }
-            };
+            MyClass2 = (() => {
+                class MyClass2 {
+                    static getInstance() { return MyClass2.value; }
+                }
+                MyClass2.value = 42;
+                return MyClass2;
+            })();
             exports_1("MyClass2", MyClass2);
-            MyClass2.value = 42;
         }
     };
 });

--- a/tests/baselines/reference/transformApi/transformsCorrectly.rewrittenNamespaceFollowingClass.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.rewrittenNamespaceFollowingClass.js
@@ -1,9 +1,12 @@
-class C {
-    constructor() {
-        this.foo = 10;
+let C = (() => {
+    class C {
+        constructor() {
+            this.foo = 10;
+        }
     }
-}
-C.bar = 20;
+    C.bar = 20;
+    return C;
+})();
 (function (C) {
     C.x = 10;
 })(C || (C = {}));

--- a/tests/baselines/reference/transformApi/transformsCorrectly.transformAddCommentToProperties.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.transformAddCommentToProperties.js
@@ -1,12 +1,16 @@
 /*comment*/
-class Clazz {
+let Clazz = (() => {
     /*comment*/
-    constructor(/*comment*/
-    field = 1) {
-        this.field = field;
+    class Clazz {
         /*comment*/
-        this.instanceProp = 2;
+        constructor(/*comment*/
+        field = 1) {
+            this.field = field;
+            /*comment*/
+            this.instanceProp = 2;
+        }
     }
-}
-/*comment*/
-Clazz.staticProp = 1;
+    /*comment*/
+    Clazz.staticProp = 1;
+    return Clazz;
+})();

--- a/tests/baselines/reference/uniqueSymbols.js
+++ b/tests/baselines/reference/uniqueSymbols.js
@@ -314,15 +314,18 @@ async function* asyncGenFuncYieldConstCall() { yield constCall; }
 async function* asyncGenFuncYieldLetCall() { yield letCall; }
 async function* asyncGenFuncYieldVarCall() { yield varCall; }
 // classes
-class C {
-    constructor() {
-        this.readonlyCall = Symbol();
-        this.readwriteCall = Symbol();
+let C = (() => {
+    class C {
+        constructor() {
+            this.readonlyCall = Symbol();
+            this.readwriteCall = Symbol();
+        }
     }
-}
-C.readonlyStaticCall = Symbol();
-C.readonlyStaticTypeAndCall = Symbol();
-C.readwriteStaticCall = Symbol();
+    C.readonlyStaticCall = Symbol();
+    C.readonlyStaticTypeAndCall = Symbol();
+    C.readwriteStaticCall = Symbol();
+    return C;
+})();
 const constInitToCReadonlyStaticCall = C.readonlyStaticCall;
 const constInitToCReadonlyStaticType = C.readonlyStaticType;
 const constInitToCReadonlyStaticTypeAndCall = C.readonlyStaticTypeAndCall;
@@ -370,27 +373,30 @@ const o2 = {
     method5(p = s) { return p; },
 };
 // property initializers
-class C0 {
-    constructor() {
-        this.a = s;
-        this.b = N.s;
-        this.c = N["s"];
-        this.d = s;
-        this.e = N.s;
-        this.f = N["s"];
+let C0 = (() => {
+    class C0 {
+        constructor() {
+            this.a = s;
+            this.b = N.s;
+            this.c = N["s"];
+            this.d = s;
+            this.e = N.s;
+            this.f = N["s"];
+        }
+        method1() { return s; }
+        async method2() { return s; }
+        async *method3() { yield s; }
+        *method4() { yield s; }
+        method5(p = s) { return p; }
     }
-    method1() { return s; }
-    async method2() { return s; }
-    async *method3() { yield s; }
-    *method4() { yield s; }
-    method5(p = s) { return p; }
-}
-C0.a = s;
-C0.b = N.s;
-C0.c = N["s"];
-C0.d = s;
-C0.e = N.s;
-C0.f = N["s"];
+    C0.a = s;
+    C0.b = N.s;
+    C0.c = N["s"];
+    C0.d = s;
+    C0.e = N.s;
+    C0.f = N["s"];
+    return C0;
+})();
 // non-widening positions
 // element access
 o[s];

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.js
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.js
@@ -282,15 +282,18 @@ async function* asyncGenFuncYieldConstCall() { yield constCall; }
 async function* asyncGenFuncYieldLetCall() { yield letCall; }
 async function* asyncGenFuncYieldVarCall() { yield varCall; }
 // classes
-class C {
-    constructor() {
-        this.readonlyCall = Symbol();
-        this.readwriteCall = Symbol();
+let C = (() => {
+    class C {
+        constructor() {
+            this.readonlyCall = Symbol();
+            this.readwriteCall = Symbol();
+        }
     }
-}
-C.readonlyStaticCall = Symbol();
-C.readonlyStaticTypeAndCall = Symbol();
-C.readwriteStaticCall = Symbol();
+    C.readonlyStaticCall = Symbol();
+    C.readonlyStaticTypeAndCall = Symbol();
+    C.readwriteStaticCall = Symbol();
+    return C;
+})();
 const constInitToCReadonlyStaticCall = C.readonlyStaticCall;
 const constInitToCReadonlyStaticType = C.readonlyStaticType;
 const constInitToCReadonlyStaticTypeAndCall = C.readonlyStaticTypeAndCall;
@@ -338,27 +341,30 @@ const o2 = {
     method5(p = s) { return p; }
 };
 // property initializers
-class C0 {
-    constructor() {
-        this.a = s;
-        this.b = N.s;
-        this.c = N["s"];
-        this.d = s;
-        this.e = N.s;
-        this.f = N["s"];
+let C0 = (() => {
+    class C0 {
+        constructor() {
+            this.a = s;
+            this.b = N.s;
+            this.c = N["s"];
+            this.d = s;
+            this.e = N.s;
+            this.f = N["s"];
+        }
+        method1() { return s; }
+        async method2() { return s; }
+        async *method3() { yield s; }
+        *method4() { yield s; }
+        method5(p = s) { return p; }
     }
-    method1() { return s; }
-    async method2() { return s; }
-    async *method3() { yield s; }
-    *method4() { yield s; }
-    method5(p = s) { return p; }
-}
-C0.a = s;
-C0.b = N.s;
-C0.c = N["s"];
-C0.d = s;
-C0.e = N.s;
-C0.f = N["s"];
+    C0.a = s;
+    C0.b = N.s;
+    C0.c = N["s"];
+    C0.d = s;
+    C0.e = N.s;
+    C0.f = N["s"];
+    return C0;
+})();
 // non-widening positions
 // element access
 o[s];

--- a/tests/baselines/reference/useBeforeDeclaration_jsx.js
+++ b/tests/baselines/reference/useBeforeDeclaration_jsx.js
@@ -16,13 +16,16 @@ class C {
 
 
 //// [useBeforeDeclaration_jsx.jsx]
-class C {
-}
-C.a = <C.z></C.z>;
-C.b = <C.z />;
-C.c = <span {...C.x}></span>;
-C.d = <span id={C.y}></span>;
-C.e = <span>{C.y}</span>;
-C.x = {};
-C.y = '';
-C.z = () => <b></b>;
+let C = (() => {
+    class C {
+    }
+    C.a = <C.z></C.z>;
+    C.b = <C.z />;
+    C.c = <span {...C.x}></span>;
+    C.d = <span id={C.y}></span>;
+    C.e = <span>{C.y}</span>;
+    C.x = {};
+    C.y = '';
+    C.z = () => <b></b>;
+    return C;
+})();

--- a/tests/baselines/reference/useBeforeDeclaration_propertyAssignment.js
+++ b/tests/baselines/reference/useBeforeDeclaration_propertyAssignment.js
@@ -25,13 +25,16 @@ export class C {
         this.c = { c: this.b };
     }
 }
-class D {
-}
-D.A = class extends D.B {
-    [D.D]() { } // should be an error
-};
-D.B = class {
-};
-D.C = Object.assign({ [D.D]: 1 }, { get [D.D]() { return 0; } } // should be an error
-);
-D.D = '';
+let D = (() => {
+    class D {
+    }
+    D.A = class extends D.B {
+        [D.D]() { } // should be an error
+    };
+    D.B = class {
+    };
+    D.C = Object.assign({ [D.D]: 1 }, { get [D.D]() { return 0; } } // should be an error
+    );
+    D.D = '';
+    return D;
+})();


### PR DESCRIPTION
Currently only script targets less than or equal to ES5 will wrap classes.  However, the wrapping is also crucial to file size optimizations for ES2015+ as well.  Without the IIFE wrapper, minification tools do not elide the class.  This is due to references to the class being present within the downlevelled decorator and static property code.
This change represents the full completion of issue #15857