### PR TITLE
Check for parse errors in emitted JS

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1311,6 +1311,13 @@ namespace Harness {
                 if (jsCode.length && jsCode.charCodeAt(jsCode.length - 1) !== ts.CharacterCodes.lineFeed) {
                     jsCode += "\r\n";
                 }
+                if (!result.diagnostics.length && !ts.endsWith(file.file, ts.Extension.Json)) {
+                    const fileParseResult = ts.createSourceFile(file.file, file.text, options.target || ts.ScriptTarget.ES3, /*parentNodes*/ false, ts.endsWith(file.file, "x") ? ts.ScriptKind.JSX : ts.ScriptKind.JS);
+                    if (ts.length(fileParseResult.parseDiagnostics)) {
+                        jsCode += getErrorBaseline([file.asTestFile()], fileParseResult.parseDiagnostics);
+                        return;
+                    }
+                }
                 jsCode += fileOutput(file, harnessSettings);
             });
 

--- a/tests/baselines/reference/emitBOM.js
+++ b/tests/baselines/reference/emitBOM.js
@@ -2,10 +2,18 @@
 // JS and d.ts output should have a BOM but not the sourcemap
 var x;
 
-//// [emitBOM.js]
-ï»¿// JS and d.ts output should have a BOM but not the sourcemap
-var x;
-//# sourceMappingURL=emitBOM.js.map
+tests/cases/compiler/emitBOM.js(1,2): error TS1127: Invalid character.
+tests/cases/compiler/emitBOM.js(1,3): error TS1127: Invalid character.
+
+
+==== tests/cases/compiler/emitBOM.js (2 errors) ====
+    ï»¿// JS and d.ts output should have a BOM but not the sourcemap
+     
+!!! error TS1127: Invalid character.
+      
+!!! error TS1127: Invalid character.
+    var x;
+    //# sourceMappingURL=emitBOM.js.map
 
 //// [emitBOM.d.ts]
 ï»¿declare var x: any;


### PR DESCRIPTION
(When the input is error-free)

Fixes #2818

We have two tests which produce output JS with errors, which probably indicate bugs which need fixing.

There is a small cost to doing this validation, but not too much in aggregate since our parser is fast - only about 5% longer test times. (ofc, if a test is marked `@noEmit: true` we won't be doing it for that test - so tests where the emit doesn't matter should probably use that option more aggressively). And it already found some bugs, so clearly it is a good thing to check.