### PR TITLE
Fix incorrect noImplicitAny error on contextual union function signature

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19095,7 +19095,9 @@ namespace ts {
                 }
             }
             // Result is union of signatures collected (return type is union of return types of this signature set)
-            return signatureList && createUnionSignature(signatureList[0], signatureList);
+            if (signatureList) {
+                return signatureList.length === 1 ? signatureList[0] : createUnionSignature(signatureList[0], signatureList);
+            }
         }
 
         function checkSpreadExpression(node: SpreadElement, checkMode?: CheckMode): Type {

--- a/tests/baselines/reference/functionExpressionContextualTyping3.js
+++ b/tests/baselines/reference/functionExpressionContextualTyping3.js
@@ -1,0 +1,8 @@
+//// [functionExpressionContextualTyping3.ts]
+// #31114
+declare function f<T>(value: T | number): void;
+f((a: any) => "")
+
+
+//// [functionExpressionContextualTyping3.js]
+f(function (a) { return ""; });

--- a/tests/baselines/reference/functionExpressionContextualTyping3.symbols
+++ b/tests/baselines/reference/functionExpressionContextualTyping3.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts ===
+// #31114
+declare function f<T>(value: T | number): void;
+>f : Symbol(f, Decl(functionExpressionContextualTyping3.ts, 0, 0))
+>T : Symbol(T, Decl(functionExpressionContextualTyping3.ts, 1, 19))
+>value : Symbol(value, Decl(functionExpressionContextualTyping3.ts, 1, 22))
+>T : Symbol(T, Decl(functionExpressionContextualTyping3.ts, 1, 19))
+
+f((a: any) => "")
+>f : Symbol(f, Decl(functionExpressionContextualTyping3.ts, 0, 0))
+>a : Symbol(a, Decl(functionExpressionContextualTyping3.ts, 2, 3))
+

--- a/tests/baselines/reference/functionExpressionContextualTyping3.types
+++ b/tests/baselines/reference/functionExpressionContextualTyping3.types
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts ===
+// #31114
+declare function f<T>(value: T | number): void;
+>f : <T>(value: number | T) => void
+>value : number | T
+
+f((a: any) => "")
+>f((a: any) => "") : void
+>f : <T>(value: number | T) => void
+>(a: any) => "" : (a: any) => ""
+>a : any
+>"" : ""
+

--- a/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts
+++ b/tests/cases/conformance/expressions/contextualTyping/functionExpressionContextualTyping3.ts
@@ -1,0 +1,5 @@
+// @noImplicitAny: true
+
+// #31114
+declare function f<T>(value: T | number): void;
+f((a: any) => "")


### PR DESCRIPTION
For a very strange sounding bug, this is a pleasantly uninteresting fix.

Fixes #31114 
