### PR TITLE
Handle making sure that two less thans are never converted into >>

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -229,6 +229,7 @@ namespace ts.formatting {
 
             rule("NoSpaceBeforeNonNullAssertionOperator", anyToken, SyntaxKind.ExclamationToken, [isNonJsxSameLineTokenContext, isNonNullAssertionContext], RuleAction.Delete),
             rule("NoSpaceAfterNewKeywordOnConstructorSignature", SyntaxKind.NewKeyword, SyntaxKind.OpenParenToken, [isNonJsxSameLineTokenContext, isConstructorSignatureContext], RuleAction.Delete),
+            rule("SpaceLessThanAndNonJSXTypeAnnotation", SyntaxKind.LessThanToken, SyntaxKind.LessThanToken, [isNonJsxSameLineTokenContext], RuleAction.Space),
         ];
 
         // These rules are applied after high priority
@@ -349,6 +350,18 @@ namespace ts.formatting {
         ];
     }
 
+    /**
+     * A rule takes a two tokens (left/right) and a particular context
+     * for which you're meant to look at them. You then declare what should the
+     * whitespace annotation be between these tokens via the action param.
+     *
+     * @param debugName Name to print
+     * @param left The left side of the comparison
+     * @param right The right side of the comparison
+     * @param context A set of filters to narrow down the space in which this formatter rule applies
+     * @param action a declaration of the expected whitespace
+     * @param flags whether the rule deletes a line or not, defaults to no-op
+     */
     function rule(
         debugName: string,
         left: SyntaxKind | ReadonlyArray<SyntaxKind> | TokenRange,

--- a/tests/cases/fourslash/formattingDoubleLessThan.ts
+++ b/tests/cases/fourslash/formattingDoubleLessThan.ts
@@ -1,0 +1,8 @@
+///<reference path="fourslash.ts"/>
+// https://github.com/microsoft/TypeScript/issues/14589
+
+/////*1*/if (<number>foo < <number>bar) {}
+
+format.document();
+goTo.marker("1")
+verify.currentLineContentIs(`if (<number>foo < <number>bar) { }`)


### PR DESCRIPTION
Fixes #32068 

Should make sure that two `<` tokens always have whitespace between them.