### PR TITLE
Fix tuple and array comparisons during identity checking

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13321,7 +13321,14 @@ namespace ts {
                         }
                     }
                     else if (isReadonlyArrayType(target) ? isArrayType(source) || isTupleType(source) : isArrayType(target) && isTupleType(source) && !source.target.readonly) {
-                        return isRelatedTo(getIndexTypeOfType(source, IndexKind.Number) || anyType, getIndexTypeOfType(target, IndexKind.Number) || anyType, reportErrors);
+                        if (relation !== identityRelation) {
+                            return isRelatedTo(getIndexTypeOfType(source, IndexKind.Number) || anyType, getIndexTypeOfType(target, IndexKind.Number) || anyType, reportErrors);
+                        }
+                        else {
+                            // By flags alone, we know that the `target` is a readonly array while the source is a normal array or tuple
+                            // or `target` is an array and source is a tuple - in both cases the types cannot be identical, by construction
+                            return Ternary.False;
+                        }
                     }
                     // Consider a fresh empty object literal type "closed" under the subtype relationship - this way `{} <- {[idx: string]: any} <- fresh({})`
                     // and not `{} <- fresh({}) <- {[idx: string]: any}`

--- a/tests/cases/fourslash/quickinfoExpressionTypeNotChangedViaDeletion.ts
+++ b/tests/cases/fourslash/quickinfoExpressionTypeNotChangedViaDeletion.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+////type TypeEq<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+////
+////const /*2*/test1: TypeEq<number[], [number, ...number[]]> = false;
+////
+////declare const foo: [number, ...number[]];
+////declare const bar: number[];
+////
+////const /*1*/test2: TypeEq<typeof foo, typeof bar> = false;
+
+goTo.marker("1");
+verify.quickInfoIs("const test2: false");
+
+goTo.marker("2");
+verify.quickInfoIs("const test1: false");


### PR DESCRIPTION
Fixes #31967

We cache `isTypeIdenticalTo` assuming it is reflexive. We had a bug where `[number, ...number[]]` compared with `number[]` returned `true`, while `number[]` compared with `[number, ...number[]]` returned `false` (that is to say, the result was based on their assignability relationship and not their identity) - so whichever got run first got cached. With this change we now appropriately return `false` in both cases.