### PR TITLE
Prevent infinite recursion resolving nested conditional types with import types in them

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -516,6 +516,7 @@ namespace ts {
         const noConstraintType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, undefined, undefined);
         const circularConstraintType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, undefined, undefined);
         const resolvingDefaultType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, undefined, undefined);
+        const resolvingConditionalType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, undefined, undefined);
 
         const markerSuperType = createTypeParameter();
         const markerSubType = createTypeParameter();
@@ -10715,6 +10716,7 @@ namespace ts {
         function getTypeFromConditionalTypeNode(node: ConditionalTypeNode): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
+                links.resolvedType = resolvingConditionalType;
                 const checkType = getTypeFromTypeNode(node.checkType);
                 const aliasSymbol = getAliasSymbolForTypeNode(node);
                 const aliasTypeArguments = getTypeArgumentsForAliasSymbol(aliasSymbol);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -788,7 +788,6 @@ namespace ts {
 
         const enum TypeSystemPropertyName {
             Type,
-            ResolvedType,
             ResolvedBaseConstructorType,
             DeclaredType,
             ResolvedReturnType,
@@ -5020,8 +5019,6 @@ namespace ts {
             switch (propertyName) {
                 case TypeSystemPropertyName.Type:
                     return !!getSymbolLinks(<Symbol>target).type;
-                case TypeSystemPropertyName.ResolvedType:
-                    return !!getNodeLinks(target as Node).resolvedType;
                 case TypeSystemPropertyName.EnumTagType:
                     return !!(getNodeLinks(target as JSDocEnumTag).resolvedEnumType);
                 case TypeSystemPropertyName.DeclaredType:
@@ -10738,8 +10735,7 @@ namespace ts {
                     aliasSymbol,
                     aliasTypeArguments
                 };
-                const resolvedType = getConditionalType(root, /*mapper*/ undefined);
-                links.resolvedType = resolvedType;
+                links.resolvedType = getConditionalType(root, /*mapper*/ undefined);
                 if (outerTypeParameters) {
                     root.instantiations = createMap<Type>();
                     root.instantiations.set(getTypeListId(outerTypeParameters), links.resolvedType);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2693,6 +2693,10 @@
         "category": "Error",
         "code": 2773
     },
+    "Conditional type circularly references itself.": {
+        "category":"Error",
+        "code": 2774
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2693,10 +2693,6 @@
         "category": "Error",
         "code": 2773
     },
-    "Conditional type circularly references itself.": {
-        "category":"Error",
-        "code": 2774
-    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/nestedGenericConditionalTypeWithGenericImportType.js
+++ b/tests/baselines/reference/nestedGenericConditionalTypeWithGenericImportType.js
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts] ////
+
+//// [name.ts]
+// #31824
+
+export type Name<T> = any;
+
+//// [index.ts]
+type T<X> = any extends ((any extends any ? any : string) extends any ? import("./name").Name<X> : any)
+  ? any
+  : any;
+
+
+//// [name.js]
+"use strict";
+// #31824
+exports.__esModule = true;
+//// [index.js]

--- a/tests/baselines/reference/nestedGenericConditionalTypeWithGenericImportType.symbols
+++ b/tests/baselines/reference/nestedGenericConditionalTypeWithGenericImportType.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/name.ts ===
+// #31824
+
+export type Name<T> = any;
+>Name : Symbol(Name, Decl(name.ts, 0, 0))
+>T : Symbol(T, Decl(name.ts, 2, 17))
+
+=== tests/cases/compiler/index.ts ===
+type T<X> = any extends ((any extends any ? any : string) extends any ? import("./name").Name<X> : any)
+>T : Symbol(T, Decl(index.ts, 0, 0))
+>X : Symbol(X, Decl(index.ts, 0, 7))
+>Name : Symbol(Name, Decl(name.ts, 0, 0))
+>X : Symbol(X, Decl(index.ts, 0, 7))
+
+  ? any
+  : any;
+

--- a/tests/baselines/reference/nestedGenericConditionalTypeWithGenericImportType.types
+++ b/tests/baselines/reference/nestedGenericConditionalTypeWithGenericImportType.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/name.ts ===
+// #31824
+
+export type Name<T> = any;
+>Name : any
+
+=== tests/cases/compiler/index.ts ===
+type T<X> = any extends ((any extends any ? any : string) extends any ? import("./name").Name<X> : any)
+>T : any
+
+  ? any
+  : any;
+

--- a/tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts
+++ b/tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts
@@ -1,0 +1,9 @@
+// #31824
+
+// @filename: name.ts
+export type Name<T> = any;
+
+// @filename: index.ts
+type T<X> = any extends ((any extends any ? any : string) extends any ? import("./name").Name<X> : any)
+  ? any
+  : any;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31824 

In the provided repro, a large circular code path something like this occurs:

```
getTypeFromConditionalTypeNode
  -> isTypeParameterPossiblyReferenced
  -> [deep forEachChild down to a type alias Name<k>]
  -> [try to get the type of k]
  -> getConstrainedTypeVariable
  -> [walk up the parse tree until a conditional type is found]
  -> getImpliedConstraint
  -> [some uninteresting stuff]
  -> getTypeFromConditionalTypeNode
```

~Unfortunately, I’m unable to figure out logically what’s happening because the declaration emit is [so huge and convoluted that no human can understand it](https://unpkg.com/type-mapping@1.1.2/dist/fluent-lib/index.d.ts). As such, I have no idea where to begin to try writing a test for this, but the repro no longer crashes and existing tests pass ¯\\_(ツ)_/¯~

---

### UPDATE, I FIGURED IT OUT

The issue occurs under these exact circumstances:

- You have a conditional type inside a conditional type, the outer of which contains an outer type parameter
- One of the types in the outer conditional type is or contains an import type with a qualifier and a type argument of the aforementioned outer type parameter:

```ts
type T<X> = any extends ((any extends any ? any : string) extends any ? import("./name").Name<X> : any)
  ? any
  : any;
```

The reason is that we weren’t properly short circuiting when trying to determine whether `Name` itself is a reference to `X`. In trying to figure that out, we ask for the type of `Name`, which ends up asking for the type of the whole `import("./name").Name<X>`, which tries to get the type of of `X`, which tries to resolve the type of `T<X>`, which we were already doing. _Q.E.D. Drops mic. 🎤_ 