### PR TITLE
add completion for promise context

### DIFF
--- a/tests/cases/fourslash/completionOfAwaitPromise1.ts
+++ b/tests/cases/fourslash/completionOfAwaitPromise1.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts'/>
+
+//// async function foo(x: Promise<string>) {
+////    [|x./**/|]
+//// }
+
+const replacementSpan = test.ranges()[0]
+verify.completions({
+    marker: "",
+    includes: [
+        "then",
+        { name: "trim", insertText: '(await x).trim', replacementSpan },
+    ],
+    preferences: {
+        includeInsertTextCompletions: true,
+    },
+});

--- a/tests/cases/fourslash/completionOfAwaitPromise2.ts
+++ b/tests/cases/fourslash/completionOfAwaitPromise2.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts'/>
+
+//// interface Foo { foo: string }
+//// async function foo(x: Promise<Foo>) {
+////    [|x./**/|]
+//// }
+
+const replacementSpan = test.ranges()[0]
+verify.completions({
+    marker: "",
+    includes: [
+        "then",
+        { name: "foo", insertText: '(await x).foo', replacementSpan },
+    ],
+    preferences: {
+        includeInsertTextCompletions: true,
+    },
+});

--- a/tests/cases/fourslash/completionOfAwaitPromise3.ts
+++ b/tests/cases/fourslash/completionOfAwaitPromise3.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts'/>
+
+//// interface Foo { ["foo-foo"]: string }
+//// async function foo(x: Promise<Foo>) {
+////    [|x./**/|]
+//// }
+
+const replacementSpan = test.ranges()[0]
+verify.completions({
+    marker: "",
+    includes: [
+        "then",
+        { name: "foo-foo", insertText: '(await x)["foo-foo"]', replacementSpan,  },
+    ],
+    preferences: {
+        includeInsertTextCompletions: true,
+    },
+});

--- a/tests/cases/fourslash/completionOfAwaitPromise4.ts
+++ b/tests/cases/fourslash/completionOfAwaitPromise4.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts'/>
+
+//// function foo(x: Promise<string>) {
+////    [|x./**/|]
+//// }
+
+const replacementSpan = test.ranges()[0]
+verify.completions({
+    marker: "",
+    includes: ["then"],
+    excludes: ["trim"],
+    preferences: {
+        includeInsertTextCompletions: true,
+    },
+});

--- a/tests/cases/fourslash/completionOfAwaitPromise5.ts
+++ b/tests/cases/fourslash/completionOfAwaitPromise5.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts'/>
+
+//// interface Foo { foo: string }
+//// async function foo(x: (a: number) => Promise<Foo>) {
+////    [|x(1)./**/|]
+//// }
+
+const replacementSpan = test.ranges()[0]
+verify.completions({
+    marker: "",
+    includes: [
+        "then",
+        { name: "foo", insertText: '(await x(1)).foo', replacementSpan },
+    ],
+    preferences: {
+        includeInsertTextCompletions: true,
+    },
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31450 

This PR added a new `SymbolOriginInfo` for Promise and create await on `createCompletionEntry`  if the node is in `AwaitContext`.
I'm not sure the current insertText behavior is totally correct, and as the result of `completionOfAwaitPromise3.ts`, everything seems ok, but I cannot do it in my local vscode

unsupported: 
- add `async` modifier to container function
- top level await