### PR TITLE
Add affectsEmit to module and esModuleInterop options

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -245,6 +245,7 @@ namespace ts {
                 esnext: ModuleKind.ESNext
             }),
             affectsModuleResolution: true,
+            affectsEmit: true,
             paramType: Diagnostics.KIND,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Basic_Options,
@@ -590,6 +591,7 @@ namespace ts {
             name: "esModuleInterop",
             type: "boolean",
             affectsSemanticDiagnostics: true,
+            affectsEmit: true,
             showInSimplifiedHelpView: true,
             category: Diagnostics.Module_Resolution_Options,
             description: Diagnostics.Enables_emit_interoperability_between_CommonJS_and_ES_Modules_via_creation_of_namespace_objects_for_all_imports_Implies_allowSyntheticDefaultImports

--- a/src/testRunner/unittests/tsbuild/sample.ts
+++ b/src/testRunner/unittests/tsbuild/sample.ts
@@ -982,34 +982,40 @@ class someClass { }`),
                 lastProjectOutputJs: "/src/tests/index.js",
                 initialBuild: {
                     modifyFs: fs => fs.writeFileSync("/src/tests/tsconfig.json", `{
+    "references": [
+        { "path": "../core" },
+        { "path": "../logic" }
+    ],
+    "files": ["index.ts"],
     "compilerOptions": {
-        "incremental": true,
-        "module": "commonjs",
+        "composite": true,
+        "declaration": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipDefaultLibCheck": true,
         "esModuleInterop": false
     }
 }`),
                     expectedDiagnostics: [
-                        getExpectedDiagnosticForProjectsInBuild("src/tests/tsconfig.json"),
+                        getExpectedDiagnosticForProjectsInBuild("src/core/tsconfig.json", "src/logic/tsconfig.json", "src/tests/tsconfig.json"),
+                        [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/core/tsconfig.json", "src/core/anotherModule.js"],
+                        [Diagnostics.Building_project_0, "/src/core/tsconfig.json"],
+                        [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/logic/tsconfig.json", "src/logic/index.js"],
+                        [Diagnostics.Building_project_0, "/src/logic/tsconfig.json"],
                         [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/tests/tsconfig.json", "src/tests/index.js"],
-                        [Diagnostics.Building_project_0, "/src/tests/tsconfig.json"],
+                        [Diagnostics.Building_project_0, "/src/tests/tsconfig.json"]
                     ]
                 },
                 incrementalDtsChangedBuild: {
                     modifyFs: fs => replaceText(fs, "/src/tests/tsconfig.json", `"esModuleInterop": false`, `"esModuleInterop": true`),
                     expectedDiagnostics: [
-                        getExpectedDiagnosticForProjectsInBuild("src/tests/tsconfig.json"),
+                        getExpectedDiagnosticForProjectsInBuild("src/core/tsconfig.json", "src/logic/tsconfig.json", "src/tests/tsconfig.json"),
+                        [Diagnostics.Project_0_is_up_to_date_because_newest_input_1_is_older_than_oldest_output_2, "src/core/tsconfig.json", "src/core/anotherModule.ts", "src/core/anotherModule.js"],
+                        [Diagnostics.Project_0_is_up_to_date_because_newest_input_1_is_older_than_oldest_output_2, "src/logic/tsconfig.json", "src/logic/index.ts", "src/logic/index.js"],
                         [Diagnostics.Project_0_is_out_of_date_because_oldest_output_1_is_older_than_newest_input_2, "src/tests/tsconfig.json", "src/tests/index.js", "src/tests/tsconfig.json"],
                         [Diagnostics.Building_project_0, "/src/tests/tsconfig.json"]
                     ]
                 },
-                outputFiles: [
-                    "/src/core/anotherModule.js",
-                    "/src/core/index.js",
-                    "/src/logic/index.js",
-                    "/src/tests/index.js",
-                    "/src/tests/tsconfig.json",
-                    "/src/tests/tsconfig.tsbuildinfo"
-                ],
+                outputFiles: [],
                 baselineOnly: true,
                 verifyDiagnostics: true
             });

--- a/src/testRunner/unittests/tsbuild/sample.ts
+++ b/src/testRunner/unittests/tsbuild/sample.ts
@@ -906,7 +906,7 @@ class someClass { }`),
         "target": "esnext",
     }
 }`);
-                            },
+                    },
                     expectedDiagnostics: [
                         getExpectedDiagnosticForProjectsInBuild("src/core/tsconfig.json"),
                         [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/core/tsconfig.json", "src/core/anotherModule.js"],
@@ -927,6 +927,88 @@ class someClass { }`),
                     "/src/core/index.js",
                     "/src/core/index.d.ts",
                     "/src/core/tsconfig.tsbuildinfo",
+                ],
+                baselineOnly: true,
+                verifyDiagnostics: true
+            });
+
+            verifyTsbuildOutput({
+                scenario: "when module option changes",
+                projFs: () => projFs,
+                time,
+                tick,
+                proj: "sample1",
+                rootNames: ["/src/core"],
+                expectedMapFileNames: emptyArray,
+                lastProjectOutputJs: "/src/core/index.js",
+                initialBuild: {
+                    modifyFs: fs => fs.writeFileSync("/src/core/tsconfig.json", `{
+    "compilerOptions": {
+        "incremental": true,
+        "module": "commonjs"
+    }
+}`),
+                    expectedDiagnostics: [
+                        getExpectedDiagnosticForProjectsInBuild("src/core/tsconfig.json"),
+                        [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/core/tsconfig.json", "src/core/anotherModule.js"],
+                        [Diagnostics.Building_project_0, "/src/core/tsconfig.json"],
+                    ]
+                },
+                incrementalDtsChangedBuild: {
+                    modifyFs: fs => replaceText(fs, "/src/core/tsconfig.json", `"module": "commonjs"`, `"module": "amd"`),
+                    expectedDiagnostics: [
+                        getExpectedDiagnosticForProjectsInBuild("src/core/tsconfig.json"),
+                        [Diagnostics.Project_0_is_out_of_date_because_oldest_output_1_is_older_than_newest_input_2, "src/core/tsconfig.json", "src/core/anotherModule.js", "src/core/tsconfig.json"],
+                        [Diagnostics.Building_project_0, "/src/core/tsconfig.json"]
+                    ]
+                },
+                outputFiles: [
+                    "/src/core/anotherModule.js",
+                    "/src/core/index.js",
+                    "/src/core/tsconfig.tsbuildinfo",
+                ],
+                baselineOnly: true,
+                verifyDiagnostics: true
+            });
+
+            verifyTsbuildOutput({
+                scenario: "when esModuleInterop option changes",
+                projFs: () => projFs,
+                time,
+                tick,
+                proj: "sample1",
+                rootNames: ["/src/tests"],
+                expectedMapFileNames: emptyArray,
+                lastProjectOutputJs: "/src/tests/index.js",
+                initialBuild: {
+                    modifyFs: fs => fs.writeFileSync("/src/tests/tsconfig.json", `{
+    "compilerOptions": {
+        "incremental": true,
+        "module": "commonjs",
+        "esModuleInterop": false
+    }
+}`),
+                    expectedDiagnostics: [
+                        getExpectedDiagnosticForProjectsInBuild("src/tests/tsconfig.json"),
+                        [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/tests/tsconfig.json", "src/tests/index.js"],
+                        [Diagnostics.Building_project_0, "/src/tests/tsconfig.json"],
+                    ]
+                },
+                incrementalDtsChangedBuild: {
+                    modifyFs: fs => replaceText(fs, "/src/tests/tsconfig.json", `"esModuleInterop": false`, `"esModuleInterop": true`),
+                    expectedDiagnostics: [
+                        getExpectedDiagnosticForProjectsInBuild("src/tests/tsconfig.json"),
+                        [Diagnostics.Project_0_is_out_of_date_because_oldest_output_1_is_older_than_newest_input_2, "src/tests/tsconfig.json", "src/tests/index.js", "src/tests/tsconfig.json"],
+                        [Diagnostics.Building_project_0, "/src/tests/tsconfig.json"]
+                    ]
+                },
+                outputFiles: [
+                    "/src/core/anotherModule.js",
+                    "/src/core/index.js",
+                    "/src/logic/index.js",
+                    "/src/tests/index.js",
+                    "/src/tests/tsconfig.json",
+                    "/src/tests/tsconfig.tsbuildinfo"
                 ],
                 baselineOnly: true,
                 verifyDiagnostics: true

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-esModuleInterop-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-esModuleInterop-option-changes.js
@@ -1,0 +1,107 @@
+//// [/src/logic/index.js]
+"use strict";
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+exports.__esModule = true;
+var c = __importStar(require("../core/index"));
+function getSecondsInDay() {
+    return c.multiply(10, 15);
+}
+exports.getSecondsInDay = getSecondsInDay;
+var mod = __importStar(require("../core/anotherModule"));
+exports.m = mod;
+
+
+//// [/src/tests/index.js]
+"use strict";
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
+    result["default"] = mod;
+    return result;
+};
+exports.__esModule = true;
+var c = __importStar(require("../core/index"));
+var logic = __importStar(require("../logic/index"));
+c.leftPad("", 10);
+logic.getSecondsInDay();
+var mod = __importStar(require("../core/anotherModule"));
+exports.m = mod;
+
+
+//// [/src/tests/tsconfig.json]
+{
+    "compilerOptions": {
+        "incremental": true,
+        "module": "commonjs",
+        "esModuleInterop": true
+    }
+}
+
+//// [/src/tests/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "-15964756381",
+        "signature": "-15964756381"
+      },
+      "../core/index.ts": {
+        "version": "-18749805970",
+        "signature": "1874987148"
+      },
+      "../core/anothermodule.ts": {
+        "version": "-2676574883",
+        "signature": "-8396256275"
+      },
+      "../logic/index.ts": {
+        "version": "-5786964698",
+        "signature": "-6548680073"
+      },
+      "./index.ts": {
+        "version": "12336236525",
+        "signature": "-9209611"
+      }
+    },
+    "options": {
+      "incremental": true,
+      "module": 1,
+      "esModuleInterop": true,
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {
+      "../logic/index.ts": [
+        "../core/anothermodule.ts",
+        "../core/index.ts"
+      ],
+      "./index.ts": [
+        "../core/anothermodule.ts",
+        "../core/index.ts",
+        "../logic/index.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "../logic/index.ts": [
+        "../core/anothermodule.ts"
+      ],
+      "./index.ts": [
+        "../core/anothermodule.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../core/anothermodule.ts",
+      "../core/index.ts",
+      "../logic/index.ts",
+      "./index.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-esModuleInterop-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-esModuleInterop-option-changes.js
@@ -1,22 +1,3 @@
-//// [/src/logic/index.js]
-"use strict";
-var __importStar = (this && this.__importStar) || function (mod) {
-    if (mod && mod.__esModule) return mod;
-    var result = {};
-    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) result[k] = mod[k];
-    result["default"] = mod;
-    return result;
-};
-exports.__esModule = true;
-var c = __importStar(require("../core/index"));
-function getSecondsInDay() {
-    return c.multiply(10, 15);
-}
-exports.getSecondsInDay = getSecondsInDay;
-var mod = __importStar(require("../core/anotherModule"));
-exports.m = mod;
-
-
 //// [/src/tests/index.js]
 "use strict";
 var __importStar = (this && this.__importStar) || function (mod) {
@@ -37,9 +18,16 @@ exports.m = mod;
 
 //// [/src/tests/tsconfig.json]
 {
+    "references": [
+        { "path": "../core" },
+        { "path": "../logic" }
+    ],
+    "files": ["index.ts"],
     "compilerOptions": {
-        "incremental": true,
-        "module": "commonjs",
+        "composite": true,
+        "declaration": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipDefaultLibCheck": true,
         "esModuleInterop": true
     }
 }
@@ -53,15 +41,15 @@ exports.m = mod;
         "signature": "-15964756381"
       },
       "../core/index.ts": {
-        "version": "-18749805970",
-        "signature": "1874987148"
+        "version": "-13851440507",
+        "signature": "-13851440507"
       },
       "../core/anothermodule.ts": {
-        "version": "-2676574883",
-        "signature": "-8396256275"
+        "version": "7652028357",
+        "signature": "7652028357"
       },
       "../logic/index.ts": {
-        "version": "-5786964698",
+        "version": "-6548680073",
         "signature": "-6548680073"
       },
       "./index.ts": {
@@ -70,28 +58,29 @@ exports.m = mod;
       }
     },
     "options": {
-      "incremental": true,
-      "module": 1,
+      "composite": true,
+      "declaration": true,
+      "forceConsistentCasingInFileNames": true,
+      "skipDefaultLibCheck": true,
       "esModuleInterop": true,
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
       "../logic/index.ts": [
-        "../core/anothermodule.ts",
-        "../core/index.ts"
+        "../core/anothermodule.d.ts"
       ],
       "./index.ts": [
-        "../core/anothermodule.ts",
-        "../core/index.ts",
-        "../logic/index.ts"
+        "../core/anothermodule.d.ts",
+        "../core/index.d.ts",
+        "../logic/index.d.ts"
       ]
     },
     "exportedModulesMap": {
       "../logic/index.ts": [
-        "../core/anothermodule.ts"
+        "../core/anothermodule.d.ts"
       ],
       "./index.ts": [
-        "../core/anothermodule.ts"
+        "../core/anothermodule.d.ts"
       ]
     },
     "semanticDiagnosticsPerFile": [

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-module-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-module-option-changes.js
@@ -1,0 +1,66 @@
+//// [/src/core/anotherModule.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+    exports.World = "hello";
+});
+
+
+//// [/src/core/index.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.__esModule = true;
+    exports.someString = "HELLO WORLD";
+    function leftPad(s, n) { return s + n; }
+    exports.leftPad = leftPad;
+    function multiply(a, b) { return a * b; }
+    exports.multiply = multiply;
+});
+
+
+//// [/src/core/tsconfig.json]
+{
+    "compilerOptions": {
+        "incremental": true,
+        "module": "amd"
+    }
+}
+
+//// [/src/core/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "-15964756381",
+        "signature": "-15964756381"
+      },
+      "./anothermodule.ts": {
+        "version": "-2676574883",
+        "signature": "-8396256275"
+      },
+      "./index.ts": {
+        "version": "-18749805970",
+        "signature": "1874987148"
+      },
+      "./some_decl.d.ts": {
+        "version": "-9253692965",
+        "signature": "-9253692965"
+      }
+    },
+    "options": {
+      "incremental": true,
+      "module": 2,
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "./anothermodule.ts",
+      "./index.ts",
+      "./some_decl.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-esModuleInterop-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-esModuleInterop-option-changes.js
@@ -1,8 +1,24 @@
+//// [/src/core/anotherModule.d.ts]
+export declare const World = "hello";
+//# sourceMappingURL=anotherModule.d.ts.map
+
+//// [/src/core/anotherModule.d.ts.map]
+{"version":3,"file":"anotherModule.d.ts","sourceRoot":"","sources":["anotherModule.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,KAAK,UAAU,CAAC"}
+
 //// [/src/core/anotherModule.js]
 "use strict";
 exports.__esModule = true;
 exports.World = "hello";
 
+
+//// [/src/core/index.d.ts]
+export declare const someString: string;
+export declare function leftPad(s: string, n: number): string;
+export declare function multiply(a: number, b: number): number;
+//# sourceMappingURL=index.d.ts.map
+
+//// [/src/core/index.d.ts.map]
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,UAAU,EAAE,MAAsB,CAAC;AAChD,wBAAgB,OAAO,CAAC,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,UAAmB;AAC/D,wBAAgB,QAAQ,CAAC,CAAC,EAAE,MAAM,EAAE,CAAC,EAAE,MAAM,UAAmB"}
 
 //// [/src/core/index.js]
 "use strict";
@@ -12,6 +28,52 @@ function leftPad(s, n) { return s + n; }
 exports.leftPad = leftPad;
 function multiply(a, b) { return a * b; }
 exports.multiply = multiply;
+
+
+//// [/src/core/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "-15964756381",
+        "signature": "-15964756381"
+      },
+      "./anothermodule.ts": {
+        "version": "-2676574883",
+        "signature": "25219880154"
+      },
+      "./index.ts": {
+        "version": "-18749805970",
+        "signature": "11051732871"
+      },
+      "./some_decl.d.ts": {
+        "version": "-9253692965",
+        "signature": "-9253692965"
+      }
+    },
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "declarationMap": true,
+      "skipDefaultLibCheck": true,
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "./anothermodule.ts",
+      "./index.ts",
+      "./some_decl.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+
+//// [/src/logic/index.d.ts]
+export declare function getSecondsInDay(): number;
+import * as mod from '../core/anotherModule';
+export declare const m: typeof mod;
 
 
 //// [/src/logic/index.js]
@@ -24,6 +86,64 @@ function getSecondsInDay() {
 exports.getSecondsInDay = getSecondsInDay;
 var mod = require("../core/anotherModule");
 exports.m = mod;
+//# sourceMappingURL=index.js.map
+
+//// [/src/logic/index.js.map]
+{"version":3,"file":"index.js","sourceRoot":"","sources":["index.ts"],"names":[],"mappings":";;AAAA,iCAAmC;AACnC,SAAgB,eAAe;IAC3B,OAAO,CAAC,CAAC,QAAQ,CAAC,EAAE,EAAE,EAAE,CAAC,CAAC;AAC9B,CAAC;AAFD,0CAEC;AACD,2CAA6C;AAChC,QAAA,CAAC,GAAG,GAAG,CAAC"}
+
+//// [/src/logic/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "-15964756381",
+        "signature": "-15964756381"
+      },
+      "../core/index.ts": {
+        "version": "-13851440507",
+        "signature": "-13851440507"
+      },
+      "../core/anothermodule.ts": {
+        "version": "7652028357",
+        "signature": "7652028357"
+      },
+      "./index.ts": {
+        "version": "-5786964698",
+        "signature": "-6548680073"
+      }
+    },
+    "options": {
+      "composite": true,
+      "declaration": true,
+      "sourceMap": true,
+      "forceConsistentCasingInFileNames": true,
+      "skipDefaultLibCheck": true,
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {
+      "./index.ts": [
+        "../core/anothermodule.d.ts",
+        "../core/index.d.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "./index.ts": [
+        "../core/anothermodule.d.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../core/anothermodule.ts",
+      "../core/index.ts",
+      "./index.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+
+//// [/src/tests/index.d.ts]
+import * as mod from '../core/anotherModule';
+export declare const m: typeof mod;
 
 
 //// [/src/tests/index.js]
@@ -39,9 +159,16 @@ exports.m = mod;
 
 //// [/src/tests/tsconfig.json]
 {
+    "references": [
+        { "path": "../core" },
+        { "path": "../logic" }
+    ],
+    "files": ["index.ts"],
     "compilerOptions": {
-        "incremental": true,
-        "module": "commonjs",
+        "composite": true,
+        "declaration": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipDefaultLibCheck": true,
         "esModuleInterop": false
     }
 }
@@ -55,15 +182,15 @@ exports.m = mod;
         "signature": "-15964756381"
       },
       "../core/index.ts": {
-        "version": "-18749805970",
-        "signature": "1874987148"
+        "version": "-13851440507",
+        "signature": "-13851440507"
       },
       "../core/anothermodule.ts": {
-        "version": "-2676574883",
-        "signature": "-8396256275"
+        "version": "7652028357",
+        "signature": "7652028357"
       },
       "../logic/index.ts": {
-        "version": "-5786964698",
+        "version": "-6548680073",
         "signature": "-6548680073"
       },
       "./index.ts": {
@@ -72,28 +199,29 @@ exports.m = mod;
       }
     },
     "options": {
-      "incremental": true,
-      "module": 1,
+      "composite": true,
+      "declaration": true,
+      "forceConsistentCasingInFileNames": true,
+      "skipDefaultLibCheck": true,
       "esModuleInterop": false,
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
       "../logic/index.ts": [
-        "../core/anothermodule.ts",
-        "../core/index.ts"
+        "../core/anothermodule.d.ts"
       ],
       "./index.ts": [
-        "../core/anothermodule.ts",
-        "../core/index.ts",
-        "../logic/index.ts"
+        "../core/anothermodule.d.ts",
+        "../core/index.d.ts",
+        "../logic/index.d.ts"
       ]
     },
     "exportedModulesMap": {
       "../logic/index.ts": [
-        "../core/anothermodule.ts"
+        "../core/anothermodule.d.ts"
       ],
       "./index.ts": [
-        "../core/anothermodule.ts"
+        "../core/anothermodule.d.ts"
       ]
     },
     "semanticDiagnosticsPerFile": [

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-esModuleInterop-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-esModuleInterop-option-changes.js
@@ -1,0 +1,109 @@
+//// [/src/core/anotherModule.js]
+"use strict";
+exports.__esModule = true;
+exports.World = "hello";
+
+
+//// [/src/core/index.js]
+"use strict";
+exports.__esModule = true;
+exports.someString = "HELLO WORLD";
+function leftPad(s, n) { return s + n; }
+exports.leftPad = leftPad;
+function multiply(a, b) { return a * b; }
+exports.multiply = multiply;
+
+
+//// [/src/logic/index.js]
+"use strict";
+exports.__esModule = true;
+var c = require("../core/index");
+function getSecondsInDay() {
+    return c.multiply(10, 15);
+}
+exports.getSecondsInDay = getSecondsInDay;
+var mod = require("../core/anotherModule");
+exports.m = mod;
+
+
+//// [/src/tests/index.js]
+"use strict";
+exports.__esModule = true;
+var c = require("../core/index");
+var logic = require("../logic/index");
+c.leftPad("", 10);
+logic.getSecondsInDay();
+var mod = require("../core/anotherModule");
+exports.m = mod;
+
+
+//// [/src/tests/tsconfig.json]
+{
+    "compilerOptions": {
+        "incremental": true,
+        "module": "commonjs",
+        "esModuleInterop": false
+    }
+}
+
+//// [/src/tests/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "-15964756381",
+        "signature": "-15964756381"
+      },
+      "../core/index.ts": {
+        "version": "-18749805970",
+        "signature": "1874987148"
+      },
+      "../core/anothermodule.ts": {
+        "version": "-2676574883",
+        "signature": "-8396256275"
+      },
+      "../logic/index.ts": {
+        "version": "-5786964698",
+        "signature": "-6548680073"
+      },
+      "./index.ts": {
+        "version": "12336236525",
+        "signature": "-9209611"
+      }
+    },
+    "options": {
+      "incremental": true,
+      "module": 1,
+      "esModuleInterop": false,
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {
+      "../logic/index.ts": [
+        "../core/anothermodule.ts",
+        "../core/index.ts"
+      ],
+      "./index.ts": [
+        "../core/anothermodule.ts",
+        "../core/index.ts",
+        "../logic/index.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "../logic/index.ts": [
+        "../core/anothermodule.ts"
+      ],
+      "./index.ts": [
+        "../core/anothermodule.ts"
+      ]
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../core/anothermodule.ts",
+      "../core/index.ts",
+      "../logic/index.ts",
+      "./index.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-module-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-module-option-changes.js
@@ -1,0 +1,62 @@
+//// [/src/core/anotherModule.js]
+"use strict";
+exports.__esModule = true;
+exports.World = "hello";
+
+
+//// [/src/core/index.js]
+"use strict";
+exports.__esModule = true;
+exports.someString = "HELLO WORLD";
+function leftPad(s, n) { return s + n; }
+exports.leftPad = leftPad;
+function multiply(a, b) { return a * b; }
+exports.multiply = multiply;
+
+
+//// [/src/core/tsconfig.json]
+{
+    "compilerOptions": {
+        "incremental": true,
+        "module": "commonjs"
+    }
+}
+
+//// [/src/core/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "-15964756381",
+        "signature": "-15964756381"
+      },
+      "./anothermodule.ts": {
+        "version": "-2676574883",
+        "signature": "-8396256275"
+      },
+      "./index.ts": {
+        "version": "-18749805970",
+        "signature": "1874987148"
+      },
+      "./some_decl.d.ts": {
+        "version": "-9253692965",
+        "signature": "-9253692965"
+      }
+    },
+    "options": {
+      "incremental": true,
+      "module": 1,
+      "configFilePath": "./tsconfig.json"
+    },
+    "referencedMap": {},
+    "exportedModulesMap": {},
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "./anothermodule.ts",
+      "./index.ts",
+      "./some_decl.d.ts"
+    ]
+  },
+  "version": "FakeTSVersion"
+}
+


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31233

Just adds the `affectsEmit` flag to the `module` and `esModuleInterop` options.

~I'm not sure how to go about adding automated tests for this so some help with that would be appreciated if they're necessary.~ Think I got it.

Thanks!