### PR TITLE
 Allow to omit the begin parameter of %TypedArray%.prototype.subarray

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1887,7 +1887,7 @@ interface Int8Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Int8Array;
+    subarray(begin?: number, end?: number): Int8Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -2162,7 +2162,7 @@ interface Uint8Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Uint8Array;
+    subarray(begin?: number, end?: number): Uint8Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -2437,7 +2437,7 @@ interface Uint8ClampedArray {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Uint8ClampedArray;
+    subarray(begin?: number, end?: number): Uint8ClampedArray;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -2710,7 +2710,7 @@ interface Int16Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Int16Array;
+    subarray(begin?: number, end?: number): Int16Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -2986,7 +2986,7 @@ interface Uint16Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Uint16Array;
+    subarray(begin?: number, end?: number): Uint16Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -3261,7 +3261,7 @@ interface Int32Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Int32Array;
+    subarray(begin?: number, end?: number): Int32Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -3535,7 +3535,7 @@ interface Uint32Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Uint32Array;
+    subarray(begin?: number, end?: number): Uint32Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -3810,7 +3810,7 @@ interface Float32Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Float32Array;
+    subarray(begin?: number, end?: number): Float32Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -4086,7 +4086,7 @@ interface Float64Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Float64Array;
+    subarray(begin?: number, end?: number): Float64Array;
 
     /**
       * Converts a number to a string by using the current locale.

--- a/src/lib/esnext.bigint.d.ts
+++ b/src/lib/esnext.bigint.d.ts
@@ -260,7 +260,7 @@ interface BigInt64Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): BigInt64Array;
+    subarray(begin?: number, end?: number): BigInt64Array;
 
     /** Converts the array to a string by using the current locale. */
     toLocaleString(): string;
@@ -529,7 +529,7 @@ interface BigUint64Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): BigUint64Array;
+    subarray(begin?: number, end?: number): BigUint64Array;
 
     /** Converts the array to a string by using the current locale. */
     toLocaleString(): string;

--- a/tests/baselines/reference/bigint64ArraySubarray.js
+++ b/tests/baselines/reference/bigint64ArraySubarray.js
@@ -1,0 +1,16 @@
+//// [bigint64ArraySubarray.ts]
+function bigInt64ArraySubarray() {
+    var arr = new BigInt64Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+
+//// [bigint64ArraySubarray.js]
+function bigInt64ArraySubarray() {
+    var arr = new BigInt64Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}

--- a/tests/baselines/reference/bigint64ArraySubarray.symbols
+++ b/tests/baselines/reference/bigint64ArraySubarray.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/bigint64ArraySubarray.ts ===
+function bigInt64ArraySubarray() {
+>bigInt64ArraySubarray : Symbol(bigInt64ArraySubarray, Decl(bigint64ArraySubarray.ts, 0, 0))
+
+    var arr = new BigInt64Array(10);
+>arr : Symbol(arr, Decl(bigint64ArraySubarray.ts, 1, 7))
+>BigInt64Array : Symbol(BigInt64Array, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(BigInt64Array.subarray, Decl(lib.esnext.bigint.d.ts, --, --))
+>arr : Symbol(arr, Decl(bigint64ArraySubarray.ts, 1, 7))
+>subarray : Symbol(BigInt64Array.subarray, Decl(lib.esnext.bigint.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(BigInt64Array.subarray, Decl(lib.esnext.bigint.d.ts, --, --))
+>arr : Symbol(arr, Decl(bigint64ArraySubarray.ts, 1, 7))
+>subarray : Symbol(BigInt64Array.subarray, Decl(lib.esnext.bigint.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(BigInt64Array.subarray, Decl(lib.esnext.bigint.d.ts, --, --))
+>arr : Symbol(arr, Decl(bigint64ArraySubarray.ts, 1, 7))
+>subarray : Symbol(BigInt64Array.subarray, Decl(lib.esnext.bigint.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/bigint64ArraySubarray.types
+++ b/tests/baselines/reference/bigint64ArraySubarray.types
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/bigint64ArraySubarray.ts ===
+function bigInt64ArraySubarray() {
+>bigInt64ArraySubarray : () => void
+
+    var arr = new BigInt64Array(10);
+>arr : BigInt64Array
+>new BigInt64Array(10) : BigInt64Array
+>BigInt64Array : BigInt64ArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : BigInt64Array
+>arr.subarray : (begin?: number, end?: number) => BigInt64Array
+>arr : BigInt64Array
+>subarray : (begin?: number, end?: number) => BigInt64Array
+
+    arr.subarray(0);
+>arr.subarray(0) : BigInt64Array
+>arr.subarray : (begin?: number, end?: number) => BigInt64Array
+>arr : BigInt64Array
+>subarray : (begin?: number, end?: number) => BigInt64Array
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : BigInt64Array
+>arr.subarray : (begin?: number, end?: number) => BigInt64Array
+>arr : BigInt64Array
+>subarray : (begin?: number, end?: number) => BigInt64Array
+>0 : 0
+>10 : 10
+}
+

--- a/tests/baselines/reference/typedArraysSubarray.js
+++ b/tests/baselines/reference/typedArraysSubarray.js
@@ -1,0 +1,120 @@
+//// [typedArraysSubarray.ts]
+function int8ArraySubarray() {
+    var arr = new Int8Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function uint8ArraySubarray() {
+    var arr = new Uint8Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function uint8ClampedArraySubarray() {
+    var arr = new Uint8ClampedArray(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function int16ArraySubarray() {
+    var arr = new Int16Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function uint16ArraySubarray() {
+    var arr = new Uint16Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function int32ArraySubarray() {
+    var arr = new Int32Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function uint32ArraySubarray() {
+    var arr = new Uint32Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function float32ArraySubarray() {
+    var arr = new Float32Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function float64ArraySubarray() {
+    var arr = new Float64Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+
+//// [typedArraysSubarray.js]
+function int8ArraySubarray() {
+    var arr = new Int8Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+function uint8ArraySubarray() {
+    var arr = new Uint8Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+function uint8ClampedArraySubarray() {
+    var arr = new Uint8ClampedArray(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+function int16ArraySubarray() {
+    var arr = new Int16Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+function uint16ArraySubarray() {
+    var arr = new Uint16Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+function int32ArraySubarray() {
+    var arr = new Int32Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+function uint32ArraySubarray() {
+    var arr = new Uint32Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+function float32ArraySubarray() {
+    var arr = new Float32Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+function float64ArraySubarray() {
+    var arr = new Float64Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}

--- a/tests/baselines/reference/typedArraysSubarray.symbols
+++ b/tests/baselines/reference/typedArraysSubarray.symbols
@@ -1,0 +1,208 @@
+=== tests/cases/compiler/typedArraysSubarray.ts ===
+function int8ArraySubarray() {
+>int8ArraySubarray : Symbol(int8ArraySubarray, Decl(typedArraysSubarray.ts, 0, 0))
+
+    var arr = new Int8Array(10);
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 1, 7))
+>Int8Array : Symbol(Int8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(Int8Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 1, 7))
+>subarray : Symbol(Int8Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(Int8Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 1, 7))
+>subarray : Symbol(Int8Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(Int8Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 1, 7))
+>subarray : Symbol(Int8Array.subarray, Decl(lib.es5.d.ts, --, --))
+}
+
+function uint8ArraySubarray() {
+>uint8ArraySubarray : Symbol(uint8ArraySubarray, Decl(typedArraysSubarray.ts, 5, 1))
+
+    var arr = new Uint8Array(10);
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 8, 7))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(Uint8Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 8, 7))
+>subarray : Symbol(Uint8Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(Uint8Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 8, 7))
+>subarray : Symbol(Uint8Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(Uint8Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 8, 7))
+>subarray : Symbol(Uint8Array.subarray, Decl(lib.es5.d.ts, --, --))
+}
+
+function uint8ClampedArraySubarray() {
+>uint8ClampedArraySubarray : Symbol(uint8ClampedArraySubarray, Decl(typedArraysSubarray.ts, 12, 1))
+
+    var arr = new Uint8ClampedArray(10);
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 15, 7))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(Uint8ClampedArray.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 15, 7))
+>subarray : Symbol(Uint8ClampedArray.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(Uint8ClampedArray.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 15, 7))
+>subarray : Symbol(Uint8ClampedArray.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(Uint8ClampedArray.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 15, 7))
+>subarray : Symbol(Uint8ClampedArray.subarray, Decl(lib.es5.d.ts, --, --))
+}
+
+function int16ArraySubarray() {
+>int16ArraySubarray : Symbol(int16ArraySubarray, Decl(typedArraysSubarray.ts, 19, 1))
+
+    var arr = new Int16Array(10);
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 22, 7))
+>Int16Array : Symbol(Int16Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(Int16Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 22, 7))
+>subarray : Symbol(Int16Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(Int16Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 22, 7))
+>subarray : Symbol(Int16Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(Int16Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 22, 7))
+>subarray : Symbol(Int16Array.subarray, Decl(lib.es5.d.ts, --, --))
+}
+
+function uint16ArraySubarray() {
+>uint16ArraySubarray : Symbol(uint16ArraySubarray, Decl(typedArraysSubarray.ts, 26, 1))
+
+    var arr = new Uint16Array(10);
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 29, 7))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(Uint16Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 29, 7))
+>subarray : Symbol(Uint16Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(Uint16Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 29, 7))
+>subarray : Symbol(Uint16Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(Uint16Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 29, 7))
+>subarray : Symbol(Uint16Array.subarray, Decl(lib.es5.d.ts, --, --))
+}
+
+function int32ArraySubarray() {
+>int32ArraySubarray : Symbol(int32ArraySubarray, Decl(typedArraysSubarray.ts, 33, 1))
+
+    var arr = new Int32Array(10);
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 36, 7))
+>Int32Array : Symbol(Int32Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(Int32Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 36, 7))
+>subarray : Symbol(Int32Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(Int32Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 36, 7))
+>subarray : Symbol(Int32Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(Int32Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 36, 7))
+>subarray : Symbol(Int32Array.subarray, Decl(lib.es5.d.ts, --, --))
+}
+
+function uint32ArraySubarray() {
+>uint32ArraySubarray : Symbol(uint32ArraySubarray, Decl(typedArraysSubarray.ts, 40, 1))
+
+    var arr = new Uint32Array(10);
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 43, 7))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(Uint32Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 43, 7))
+>subarray : Symbol(Uint32Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(Uint32Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 43, 7))
+>subarray : Symbol(Uint32Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(Uint32Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 43, 7))
+>subarray : Symbol(Uint32Array.subarray, Decl(lib.es5.d.ts, --, --))
+}
+
+function float32ArraySubarray() {
+>float32ArraySubarray : Symbol(float32ArraySubarray, Decl(typedArraysSubarray.ts, 47, 1))
+
+    var arr = new Float32Array(10);
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 50, 7))
+>Float32Array : Symbol(Float32Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(Float32Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 50, 7))
+>subarray : Symbol(Float32Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(Float32Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 50, 7))
+>subarray : Symbol(Float32Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(Float32Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 50, 7))
+>subarray : Symbol(Float32Array.subarray, Decl(lib.es5.d.ts, --, --))
+}
+
+function float64ArraySubarray() {
+>float64ArraySubarray : Symbol(float64ArraySubarray, Decl(typedArraysSubarray.ts, 54, 1))
+
+    var arr = new Float64Array(10);
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 57, 7))
+>Float64Array : Symbol(Float64Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray();
+>arr.subarray : Symbol(Float64Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 57, 7))
+>subarray : Symbol(Float64Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0);
+>arr.subarray : Symbol(Float64Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 57, 7))
+>subarray : Symbol(Float64Array.subarray, Decl(lib.es5.d.ts, --, --))
+
+    arr.subarray(0, 10);
+>arr.subarray : Symbol(Float64Array.subarray, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(typedArraysSubarray.ts, 57, 7))
+>subarray : Symbol(Float64Array.subarray, Decl(lib.es5.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/typedArraysSubarray.types
+++ b/tests/baselines/reference/typedArraysSubarray.types
@@ -1,0 +1,280 @@
+=== tests/cases/compiler/typedArraysSubarray.ts ===
+function int8ArraySubarray() {
+>int8ArraySubarray : () => void
+
+    var arr = new Int8Array(10);
+>arr : Int8Array
+>new Int8Array(10) : Int8Array
+>Int8Array : Int8ArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : Int8Array
+>arr.subarray : (begin?: number, end?: number) => Int8Array
+>arr : Int8Array
+>subarray : (begin?: number, end?: number) => Int8Array
+
+    arr.subarray(0);
+>arr.subarray(0) : Int8Array
+>arr.subarray : (begin?: number, end?: number) => Int8Array
+>arr : Int8Array
+>subarray : (begin?: number, end?: number) => Int8Array
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : Int8Array
+>arr.subarray : (begin?: number, end?: number) => Int8Array
+>arr : Int8Array
+>subarray : (begin?: number, end?: number) => Int8Array
+>0 : 0
+>10 : 10
+}
+
+function uint8ArraySubarray() {
+>uint8ArraySubarray : () => void
+
+    var arr = new Uint8Array(10);
+>arr : Uint8Array
+>new Uint8Array(10) : Uint8Array
+>Uint8Array : Uint8ArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : Uint8Array
+>arr.subarray : (begin?: number, end?: number) => Uint8Array
+>arr : Uint8Array
+>subarray : (begin?: number, end?: number) => Uint8Array
+
+    arr.subarray(0);
+>arr.subarray(0) : Uint8Array
+>arr.subarray : (begin?: number, end?: number) => Uint8Array
+>arr : Uint8Array
+>subarray : (begin?: number, end?: number) => Uint8Array
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : Uint8Array
+>arr.subarray : (begin?: number, end?: number) => Uint8Array
+>arr : Uint8Array
+>subarray : (begin?: number, end?: number) => Uint8Array
+>0 : 0
+>10 : 10
+}
+
+function uint8ClampedArraySubarray() {
+>uint8ClampedArraySubarray : () => void
+
+    var arr = new Uint8ClampedArray(10);
+>arr : Uint8ClampedArray
+>new Uint8ClampedArray(10) : Uint8ClampedArray
+>Uint8ClampedArray : Uint8ClampedArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : Uint8ClampedArray
+>arr.subarray : (begin?: number, end?: number) => Uint8ClampedArray
+>arr : Uint8ClampedArray
+>subarray : (begin?: number, end?: number) => Uint8ClampedArray
+
+    arr.subarray(0);
+>arr.subarray(0) : Uint8ClampedArray
+>arr.subarray : (begin?: number, end?: number) => Uint8ClampedArray
+>arr : Uint8ClampedArray
+>subarray : (begin?: number, end?: number) => Uint8ClampedArray
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : Uint8ClampedArray
+>arr.subarray : (begin?: number, end?: number) => Uint8ClampedArray
+>arr : Uint8ClampedArray
+>subarray : (begin?: number, end?: number) => Uint8ClampedArray
+>0 : 0
+>10 : 10
+}
+
+function int16ArraySubarray() {
+>int16ArraySubarray : () => void
+
+    var arr = new Int16Array(10);
+>arr : Int16Array
+>new Int16Array(10) : Int16Array
+>Int16Array : Int16ArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : Int16Array
+>arr.subarray : (begin?: number, end?: number) => Int16Array
+>arr : Int16Array
+>subarray : (begin?: number, end?: number) => Int16Array
+
+    arr.subarray(0);
+>arr.subarray(0) : Int16Array
+>arr.subarray : (begin?: number, end?: number) => Int16Array
+>arr : Int16Array
+>subarray : (begin?: number, end?: number) => Int16Array
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : Int16Array
+>arr.subarray : (begin?: number, end?: number) => Int16Array
+>arr : Int16Array
+>subarray : (begin?: number, end?: number) => Int16Array
+>0 : 0
+>10 : 10
+}
+
+function uint16ArraySubarray() {
+>uint16ArraySubarray : () => void
+
+    var arr = new Uint16Array(10);
+>arr : Uint16Array
+>new Uint16Array(10) : Uint16Array
+>Uint16Array : Uint16ArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : Uint16Array
+>arr.subarray : (begin?: number, end?: number) => Uint16Array
+>arr : Uint16Array
+>subarray : (begin?: number, end?: number) => Uint16Array
+
+    arr.subarray(0);
+>arr.subarray(0) : Uint16Array
+>arr.subarray : (begin?: number, end?: number) => Uint16Array
+>arr : Uint16Array
+>subarray : (begin?: number, end?: number) => Uint16Array
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : Uint16Array
+>arr.subarray : (begin?: number, end?: number) => Uint16Array
+>arr : Uint16Array
+>subarray : (begin?: number, end?: number) => Uint16Array
+>0 : 0
+>10 : 10
+}
+
+function int32ArraySubarray() {
+>int32ArraySubarray : () => void
+
+    var arr = new Int32Array(10);
+>arr : Int32Array
+>new Int32Array(10) : Int32Array
+>Int32Array : Int32ArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : Int32Array
+>arr.subarray : (begin?: number, end?: number) => Int32Array
+>arr : Int32Array
+>subarray : (begin?: number, end?: number) => Int32Array
+
+    arr.subarray(0);
+>arr.subarray(0) : Int32Array
+>arr.subarray : (begin?: number, end?: number) => Int32Array
+>arr : Int32Array
+>subarray : (begin?: number, end?: number) => Int32Array
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : Int32Array
+>arr.subarray : (begin?: number, end?: number) => Int32Array
+>arr : Int32Array
+>subarray : (begin?: number, end?: number) => Int32Array
+>0 : 0
+>10 : 10
+}
+
+function uint32ArraySubarray() {
+>uint32ArraySubarray : () => void
+
+    var arr = new Uint32Array(10);
+>arr : Uint32Array
+>new Uint32Array(10) : Uint32Array
+>Uint32Array : Uint32ArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : Uint32Array
+>arr.subarray : (begin?: number, end?: number) => Uint32Array
+>arr : Uint32Array
+>subarray : (begin?: number, end?: number) => Uint32Array
+
+    arr.subarray(0);
+>arr.subarray(0) : Uint32Array
+>arr.subarray : (begin?: number, end?: number) => Uint32Array
+>arr : Uint32Array
+>subarray : (begin?: number, end?: number) => Uint32Array
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : Uint32Array
+>arr.subarray : (begin?: number, end?: number) => Uint32Array
+>arr : Uint32Array
+>subarray : (begin?: number, end?: number) => Uint32Array
+>0 : 0
+>10 : 10
+}
+
+function float32ArraySubarray() {
+>float32ArraySubarray : () => void
+
+    var arr = new Float32Array(10);
+>arr : Float32Array
+>new Float32Array(10) : Float32Array
+>Float32Array : Float32ArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : Float32Array
+>arr.subarray : (begin?: number, end?: number) => Float32Array
+>arr : Float32Array
+>subarray : (begin?: number, end?: number) => Float32Array
+
+    arr.subarray(0);
+>arr.subarray(0) : Float32Array
+>arr.subarray : (begin?: number, end?: number) => Float32Array
+>arr : Float32Array
+>subarray : (begin?: number, end?: number) => Float32Array
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : Float32Array
+>arr.subarray : (begin?: number, end?: number) => Float32Array
+>arr : Float32Array
+>subarray : (begin?: number, end?: number) => Float32Array
+>0 : 0
+>10 : 10
+}
+
+function float64ArraySubarray() {
+>float64ArraySubarray : () => void
+
+    var arr = new Float64Array(10);
+>arr : Float64Array
+>new Float64Array(10) : Float64Array
+>Float64Array : Float64ArrayConstructor
+>10 : 10
+
+    arr.subarray();
+>arr.subarray() : Float64Array
+>arr.subarray : (begin?: number, end?: number) => Float64Array
+>arr : Float64Array
+>subarray : (begin?: number, end?: number) => Float64Array
+
+    arr.subarray(0);
+>arr.subarray(0) : Float64Array
+>arr.subarray : (begin?: number, end?: number) => Float64Array
+>arr : Float64Array
+>subarray : (begin?: number, end?: number) => Float64Array
+>0 : 0
+
+    arr.subarray(0, 10);
+>arr.subarray(0, 10) : Float64Array
+>arr.subarray : (begin?: number, end?: number) => Float64Array
+>arr : Float64Array
+>subarray : (begin?: number, end?: number) => Float64Array
+>0 : 0
+>10 : 10
+}
+

--- a/tests/cases/compiler/bigint64ArraySubarray.ts
+++ b/tests/cases/compiler/bigint64ArraySubarray.ts
@@ -1,0 +1,8 @@
+// @target: esnext
+
+function bigInt64ArraySubarray() {
+    var arr = new BigInt64Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}

--- a/tests/cases/compiler/typedArraysSubarray.ts
+++ b/tests/cases/compiler/typedArraysSubarray.ts
@@ -1,0 +1,62 @@
+function int8ArraySubarray() {
+    var arr = new Int8Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function uint8ArraySubarray() {
+    var arr = new Uint8Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function uint8ClampedArraySubarray() {
+    var arr = new Uint8ClampedArray(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function int16ArraySubarray() {
+    var arr = new Int16Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function uint16ArraySubarray() {
+    var arr = new Uint16Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function int32ArraySubarray() {
+    var arr = new Int32Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function uint32ArraySubarray() {
+    var arr = new Uint32Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function float32ArraySubarray() {
+    var arr = new Float32Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}
+
+function float64ArraySubarray() {
+    var arr = new Float64Array(10);
+    arr.subarray();
+    arr.subarray(0);
+    arr.subarray(0, 10);
+}

--- a/tests/lib/lib.d.ts
+++ b/tests/lib/lib.d.ts
@@ -1622,7 +1622,7 @@ interface Int8Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Int8Array;
+    subarray(begin?: number, end?: number): Int8Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -1895,7 +1895,7 @@ interface Uint8Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Uint8Array;
+    subarray(begin?: number, end?: number): Uint8Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -2169,7 +2169,7 @@ interface Uint8ClampedArray {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Uint8ClampedArray;
+    subarray(begin?: number, end?: number): Uint8ClampedArray;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -2442,7 +2442,7 @@ interface Int16Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Int16Array;
+    subarray(begin?: number, end?: number): Int16Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -2716,7 +2716,7 @@ interface Uint16Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Uint16Array;
+    subarray(begin?: number, end?: number): Uint16Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -2989,7 +2989,7 @@ interface Int32Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Int32Array;
+    subarray(begin?: number, end?: number): Int32Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -3262,7 +3262,7 @@ interface Uint32Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Uint32Array;
+    subarray(begin?: number, end?: number): Uint32Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -3535,7 +3535,7 @@ interface Float32Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Float32Array;
+    subarray(begin?: number, end?: number): Float32Array;
 
     /**
       * Converts a number to a string by using the current locale.
@@ -3809,7 +3809,7 @@ interface Float64Array {
       * @param begin The index of the beginning of the array.
       * @param end The index of the end of the array.
       */
-    subarray(begin: number, end?: number): Float64Array;
+    subarray(begin?: number, end?: number): Float64Array;
 
     /**
       * Converts a number to a string by using the current locale.


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31174
