### PR TITLE
The Set.has() function should accepts any value type.

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -40,7 +40,7 @@ interface Set<T> {
     clear(): void;
     delete(value: T): boolean;
     forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void;
-    has(value: T): boolean;
+    has<U>(value: U): value is (T & U);
     readonly size: number;
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

For example
```ts
const digitsArray = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'] as const
type Digit = typeof digitsArray extends readonly (infer U)[] ? U : never

// digits type is Set<'0' | '1' | … '9'>
const digits = new Set(digitsArray)

const c: string = …
// Currently, this line produces an unexpected compilation error.
if (digits.has(c)) {
   // Currently, this code also produces a compilation error. But we would like to narrow the type of `c` here.
   const parsedDigit: Digit = c
}
```