### PR TITLE
Make import fix for 'export =' respect module target and allowSyntheticDefaultImports/esModuleInterop

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2328,7 +2328,10 @@ Actual: ${stringify(fullActual)}`);
         public applyCodeActionFromCompletion(markerName: string, options: FourSlashInterface.VerifyCompletionActionOptions) {
             this.goToMarker(markerName);
 
-            const details = this.getCompletionEntryDetails(options.name, options.source, options.preferences)!;
+            const details = this.getCompletionEntryDetails(options.name, options.source, options.preferences);
+            if (!details) {
+                return this.raiseError(`No completions were found for the given name, source, and preferences.`);
+            }
             const codeActions = details.codeActions!;
             if (codeActions.length !== 1) {
                 this.raiseError(`Expected one code action, got ${codeActions.length}`);

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -435,13 +435,9 @@ namespace ts.codefix {
     }
 
     function getImportKindForExportEquals(compilerOptions: CompilerOptions): ImportKind {
-        if (getAllowSyntheticDefaultImports(compilerOptions)) {
-            return ImportKind.Default;
-        }
-        if (getEmitModuleKind(compilerOptions) >= ModuleKind.ES2015) {
-            return ImportKind.Namespace;
-        }
-        return ImportKind.Equals;
+        return getAllowSyntheticDefaultImports(compilerOptions)
+            ? ImportKind.Default
+            : ImportKind.Equals;
     }
 
     function getDefaultExportInfoWorker(defaultExport: Symbol, moduleSymbol: Symbol, checker: TypeChecker, compilerOptions: CompilerOptions): { readonly symbolForMeaning: Symbol, readonly name: string } | undefined {

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -435,7 +435,7 @@ namespace ts.codefix {
     }
 
     function getImportKindForExportEquals(compilerOptions: CompilerOptions): ImportKind {
-        return getAllowSyntheticDefaultImports(compilerOptions)
+        return getAllowSyntheticDefaultImports(compilerOptions) && getEmitModuleKind(compilerOptions) >= ModuleKind.ES2015
             ? ImportKind.Default
             : ImportKind.Equals;
     }

--- a/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESModuleInterop.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESModuleInterop.ts
@@ -14,6 +14,6 @@
 goTo.marker('');
 verify.getAndApplyCodeFix(2304, 0);
 verify.currentFileContentIs(
-`import foo from './a';
+`import foo from "foo";
 
 foo`);

--- a/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESModuleInterop.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESModuleInterop.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @EsModuleInterop: true
+
+// @Filename: /foo.d.ts
+////declare module "foo" {
+////  const _default: number;
+////  export = _default;
+////}
+
+// @Filename: /index.ts
+////foo/**/
+
+goTo.marker('');
+verify.getAndApplyCodeFix(2304, 0);
+verify.currentFileContentIs(
+`import foo from './a';
+
+foo`);

--- a/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESModuleInterop.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESModuleInterop.ts
@@ -1,6 +1,7 @@
 /// <reference path="fourslash.ts" />
 
 // @EsModuleInterop: true
+// @Module: es2015
 
 // @Filename: /foo.d.ts
 ////declare module "foo" {

--- a/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESNext.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESNext.ts
@@ -14,6 +14,6 @@
 goTo.marker('');
 verify.getAndApplyCodeFix(2304, 0);
 verify.currentFileContentIs(
-`import * as foo from "foo";
+`import foo = require("foo");
 
 foo`);

--- a/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESNext.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESNext.ts
@@ -14,6 +14,6 @@
 goTo.marker('');
 verify.getAndApplyCodeFix(2304, 0);
 verify.currentFileContentIs(
-`import * as foo from './a';
+`import * as foo from "foo";
 
 foo`);

--- a/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESNext.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESNext.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @Module: esnext
+
+// @Filename: /foo.d.ts
+////declare module "foo" {
+////  const _default: number;
+////  export = _default;
+////}
+
+// @Filename: /index.ts
+////foo/**/
+
+goTo.marker('');
+verify.getAndApplyCodeFix(2304, 0);
+verify.currentFileContentIs(
+`import * as foo from './a';
+
+foo`);

--- a/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsJavaScript.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsJavaScript.ts
@@ -1,0 +1,20 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+
+// @Filename: /foo.d.ts
+////declare module "foo" {
+////  const _default: number;
+////  export = _default;
+////}
+
+// @Filename: /index.js
+////foo/**/
+
+goTo.marker('');
+verify.getAndApplyCodeFix(2304, 0);
+verify.currentFileContentIs(
+`import foo from "foo";
+
+foo`);

--- a/tests/cases/fourslash/importNameCodeFixUMDGlobalJavaScript.ts
+++ b/tests/cases/fourslash/importNameCodeFixUMDGlobalJavaScript.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+
+// @AllowSyntheticDefaultImports: false
+// @Module: commonjs
+// @CheckJs: true
+// @AllowJs: true
+
+// @Filename: a/f1.js
+//// [|export function test() { };
+//// bar1/*0*/.bar;|]
+
+// @Filename: a/foo.d.ts
+//// export declare function bar(): number;
+//// export as namespace bar1; 
+
+verify.importFixAtPosition([
+`import bar1 from "./foo";
+
+export function test() { };
+bar1.bar;`
+]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31219 

The change here is super simple. For an export assignment (`export = foo`):

- if you have allowSyntheticDefaultImport or esModuleInterop enabled, prefer `import foo from "foo"`
- ~~else if your module target is ES2015+, prefer `import * as foo from "foo"`. (This is invalid, but so is literally anything else with this combination of export form and compiler options, and this one gives the best error message.)~~
- else, continue using `import foo = require("foo")` (what previously happened for all cases)

It is possible to use `import * as foo from "foo"` for some additional cases, but I wanted to get clarified feedback on exactly which cases. My understanding is that, **assuming `allowSyntheticDefaultImport`/`esModuleInterop` is disabled**,  export assignments roughly fall into three logical categories:

1. Things that can _only_ be imported with `import foo = require("foo")`: includes classes, interfaces, types, enums. (From reading old docs, it sounds like this _used_ to be the _only_ category—`export =` mandated `import foo =`, bar none.)
2. Things that can be imported with `import * as foo from "foo"` within ES module spec compliance: includes values that are not callable/constructable.
3. Things that can be imported with `import * as foo from "foo"` but apparently violates ES module spec: values that are callable/constructable. (E.g. `import * as express from "express"; express()` works today, but I think it didn’t at some point in the past, because it‘s technically wrong?)

There’s a lot of history here that’s not particularly well-documented as far as I can find—calling on @DanielRosenwasser to help unearth the archives and advise.