### PR TITLE
Rework declaration emit visibility calculation for namespaces

### DIFF
--- a/tests/baselines/reference/aliasInaccessibleModule.js
+++ b/tests/baselines/reference/aliasInaccessibleModule.js
@@ -16,4 +16,5 @@ declare module M {
     module N {
     }
     export import X = N;
+    export {};
 }

--- a/tests/baselines/reference/aliasInaccessibleModule2.js
+++ b/tests/baselines/reference/aliasInaccessibleModule2.js
@@ -31,4 +31,5 @@ declare module M {
     }
     import R = N;
     export import X = R;
+    export {};
 }

--- a/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorAccessors.js
+++ b/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorAccessors.js
@@ -264,13 +264,13 @@ var m;
 declare module m {
     class private1 {
     }
-    class public1 {
+    export class public1 {
     }
     module m2 {
         class public2 {
         }
     }
-    class c {
+    export class c {
         readonly foo1: private1;
         readonly foo2: private1;
         foo3: private1;
@@ -287,4 +287,5 @@ declare module m {
         foo114: m2.public2;
         foo115: m2.public2;
     }
+    export {};
 }

--- a/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorParameterOfFunction.js
+++ b/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorParameterOfFunction.js
@@ -111,16 +111,17 @@ var m;
 declare module m {
     class private1 {
     }
-    class public1 {
+    export class public1 {
     }
-    function foo3(param: private1): void;
-    function foo4(param?: private1): void;
-    function foo13(param: public1): void;
-    function foo14(param?: public1): void;
+    export function foo3(param: private1): void;
+    export function foo4(param?: private1): void;
+    export function foo13(param: public1): void;
+    export function foo14(param?: public1): void;
     module m2 {
         class public2 {
         }
     }
-    function foo113(param: m2.public2): void;
-    function foo114(param?: m2.public2): void;
+    export function foo113(param: m2.public2): void;
+    export function foo114(param?: m2.public2): void;
+    export {};
 }

--- a/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorReturnTypeOfFunction.js
+++ b/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorReturnTypeOfFunction.js
@@ -129,16 +129,17 @@ var m;
 declare module m {
     class private1 {
     }
-    class public1 {
+    export class public1 {
     }
-    function foo3(): private1;
-    function foo4(): private1;
-    function foo13(): public1;
-    function foo14(): public1;
+    export function foo3(): private1;
+    export function foo4(): private1;
+    export function foo13(): public1;
+    export function foo14(): public1;
     module m2 {
         class public2 {
         }
     }
-    function foo113(): m2.public2;
-    function foo114(): m2.public2;
+    export function foo113(): m2.public2;
+    export function foo114(): m2.public2;
+    export {};
 }

--- a/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorTypeAlias.js
+++ b/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorTypeAlias.js
@@ -95,11 +95,12 @@ interface Window {
 }
 declare module M {
     type W = Window | string;
-    module N {
+    export module N {
         class Window {
         }
         var p: W;
     }
+    export {};
 }
 declare module M1 {
     type W = Window | string;
@@ -118,7 +119,8 @@ declare module M2 {
         class public1 {
         }
     }
-    type t2 = private1;
-    type t12 = public1;
-    type t112 = m3.public1;
+    export type t2 = private1;
+    export type t12 = public1;
+    export type t112 = m3.public1;
+    export {};
 }

--- a/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorTypeLiteral.js
+++ b/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorTypeLiteral.js
@@ -71,7 +71,7 @@ declare module m {
         class public1 {
         }
     }
-    var x: {
+    export var x: {
         x: private1;
         y: m2.public1;
         (): m2.public1[];
@@ -79,12 +79,12 @@ declare module m {
         [n: number]: private1;
         [s: string]: m2.public1;
     };
-    var x2: {
+    export var x2: {
         x: private1;
         y: m2.public1;
         method(): private1;
     };
-    var x3: {
+    export var x3: {
         (): m2.public1[];
         [s: string]: m2.public1;
         [n: number]: private1;
@@ -92,8 +92,9 @@ declare module m {
         y: m2.public1;
         method(): private1;
     };
-    var y: (a: private1) => m2.public1;
-    var y2: (a: private1) => m2.public1;
-    var z: new (a: private1) => m2.public1;
-    var z2: new (a: private1) => m2.public1;
+    export var y: (a: private1) => m2.public1;
+    export var y2: (a: private1) => m2.public1;
+    export var z: new (a: private1) => m2.public1;
+    export var z2: new (a: private1) => m2.public1;
+    export {};
 }

--- a/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorVariableDeclaration.js
+++ b/tests/baselines/reference/declFileTypeAnnotationVisibilityErrorVariableDeclaration.js
@@ -72,16 +72,17 @@ var m;
 declare module m {
     class private1 {
     }
-    class public1 {
+    export class public1 {
     }
-    var k: private1;
-    var l: private1;
-    var k2: public1;
-    var l2: public1;
+    export var k: private1;
+    export var l: private1;
+    export var k2: public1;
+    export var l2: public1;
     module m2 {
         class public2 {
         }
     }
-    var k3: m2.public2;
-    var l3: m2.public2;
+    export var k3: m2.public2;
+    export var l3: m2.public2;
+    export {};
 }

--- a/tests/baselines/reference/declInput-2.js
+++ b/tests/baselines/reference/declInput-2.js
@@ -54,13 +54,13 @@ var M;
 declare module M {
     class C {
     }
-    class E {
+    export class E {
     }
-    interface I1 {
+    export interface I1 {
     }
     interface I2 {
     }
-    class D {
+    export class D {
         private c;
         m1: number;
         m2: string;
@@ -75,4 +75,5 @@ declare module M {
         m262(i: I2): void;
         m3(): C;
     }
+    export {};
 }

--- a/tests/baselines/reference/declarationEmitDestructuringPrivacyError.js
+++ b/tests/baselines/reference/declarationEmitDestructuringPrivacyError.js
@@ -22,5 +22,6 @@ var m;
 declare module m {
     class c {
     }
-    var x: number, y: c, z: number;
+    export var x: number, y: c, z: number;
+    export {};
 }

--- a/tests/baselines/reference/declarationEmitExpressionInExtends5.js
+++ b/tests/baselines/reference/declarationEmitExpressionInExtends5.js
@@ -59,12 +59,13 @@ var Test;
 
 //// [declarationEmitExpressionInExtends5.d.ts]
 declare namespace Test {
-    interface IFace {
+    export interface IFace {
     }
-    class SomeClass implements IFace {
+    export class SomeClass implements IFace {
     }
     const Derived_base: new () => IFace;
-    class Derived extends Derived_base {
+    export class Derived extends Derived_base {
     }
-    function getClass<T>(): new () => T;
+    export function getClass<T>(): new () => T;
+    export {};
 }

--- a/tests/baselines/reference/declarationFunctionTypeNonlocalShouldNotBeAnError.js
+++ b/tests/baselines/reference/declarationFunctionTypeNonlocalShouldNotBeAnError.js
@@ -21,7 +21,8 @@ var foo;
 //// [declarationFunctionTypeNonlocalShouldNotBeAnError.d.ts]
 declare namespace foo {
     function bar(): void;
-    const obj: {
+    export const obj: {
         bar: typeof bar;
     };
+    export {};
 }

--- a/tests/baselines/reference/exportNamespaceDeclarationRetainsVisibility.js
+++ b/tests/baselines/reference/exportNamespaceDeclarationRetainsVisibility.js
@@ -1,0 +1,32 @@
+//// [exportNamespaceDeclarationRetainsVisibility.ts]
+namespace X {
+    interface A {
+        kind: 'a';
+    }
+
+    interface B {
+        kind: 'b';
+    }
+
+    export type C = A | B;
+}
+
+export = X;
+
+//// [exportNamespaceDeclarationRetainsVisibility.js]
+"use strict";
+exports.__esModule = true;
+
+
+//// [exportNamespaceDeclarationRetainsVisibility.d.ts]
+declare namespace X {
+    interface A {
+        kind: 'a';
+    }
+    interface B {
+        kind: 'b';
+    }
+    export type C = A | B;
+    export {};
+}
+export = X;

--- a/tests/baselines/reference/exportNamespaceDeclarationRetainsVisibility.symbols
+++ b/tests/baselines/reference/exportNamespaceDeclarationRetainsVisibility.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts ===
+namespace X {
+>X : Symbol(X, Decl(exportNamespaceDeclarationRetainsVisibility.ts, 0, 0))
+
+    interface A {
+>A : Symbol(A, Decl(exportNamespaceDeclarationRetainsVisibility.ts, 0, 13))
+
+        kind: 'a';
+>kind : Symbol(A.kind, Decl(exportNamespaceDeclarationRetainsVisibility.ts, 1, 17))
+    }
+
+    interface B {
+>B : Symbol(B, Decl(exportNamespaceDeclarationRetainsVisibility.ts, 3, 5))
+
+        kind: 'b';
+>kind : Symbol(B.kind, Decl(exportNamespaceDeclarationRetainsVisibility.ts, 5, 17))
+    }
+
+    export type C = A | B;
+>C : Symbol(C, Decl(exportNamespaceDeclarationRetainsVisibility.ts, 7, 5))
+>A : Symbol(A, Decl(exportNamespaceDeclarationRetainsVisibility.ts, 0, 13))
+>B : Symbol(B, Decl(exportNamespaceDeclarationRetainsVisibility.ts, 3, 5))
+}
+
+export = X;
+>X : Symbol(X, Decl(exportNamespaceDeclarationRetainsVisibility.ts, 0, 0))
+

--- a/tests/baselines/reference/exportNamespaceDeclarationRetainsVisibility.types
+++ b/tests/baselines/reference/exportNamespaceDeclarationRetainsVisibility.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts ===
+namespace X {
+    interface A {
+        kind: 'a';
+>kind : "a"
+    }
+
+    interface B {
+        kind: 'b';
+>kind : "b"
+    }
+
+    export type C = A | B;
+>C : C
+}
+
+export = X;
+>X : any
+

--- a/tests/baselines/reference/getEmitOutputWithEmitterErrors.baseline
+++ b/tests/baselines/reference/getEmitOutputWithEmitterErrors.baseline
@@ -15,6 +15,7 @@ FileName : /tests/cases/fourslash/inputFile.d.ts
 declare module M {
     class C {
     }
-    var foo: C;
+    export var foo: C;
+    export {};
 }
 

--- a/tests/baselines/reference/privacyAccessorDeclFile.js
+++ b/tests/baselines/reference/privacyAccessorDeclFile.js
@@ -3606,9 +3606,9 @@ export declare class publicClassWithPrivateModuleSetAccessorTypes {
 export declare module publicModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    class publicClassWithWithPrivateGetAccessorTypes {
+    export class publicClassWithWithPrivateGetAccessorTypes {
         static readonly myPublicStaticMethod: privateClass;
         private static readonly myPrivateStaticMethod;
         readonly myPublicMethod: privateClass;
@@ -3618,7 +3618,7 @@ export declare module publicModule {
         readonly myPublicMethod1: privateClass;
         private readonly myPrivateMethod1;
     }
-    class publicClassWithWithPublicGetAccessorTypes {
+    export class publicClassWithWithPublicGetAccessorTypes {
         static readonly myPublicStaticMethod: publicClass;
         private static readonly myPrivateStaticMethod;
         readonly myPublicMethod: publicClass;
@@ -3628,35 +3628,36 @@ export declare module publicModule {
         readonly myPublicMethod1: publicClass;
         private readonly myPrivateMethod1;
     }
-    class publicClassWithWithPrivateSetAccessorTypes {
+    export class publicClassWithWithPrivateSetAccessorTypes {
         static myPublicStaticMethod: privateClass;
         private static myPrivateStaticMethod;
         myPublicMethod: privateClass;
         private myPrivateMethod;
     }
-    class publicClassWithWithPublicSetAccessorTypes {
+    export class publicClassWithWithPublicSetAccessorTypes {
         static myPublicStaticMethod: publicClass;
         private static myPrivateStaticMethod;
         myPublicMethod: publicClass;
         private myPrivateMethod;
     }
-    class publicClassWithPrivateModuleGetAccessorTypes {
+    export class publicClassWithPrivateModuleGetAccessorTypes {
         static readonly myPublicStaticMethod: privateModule.publicClass;
         readonly myPublicMethod: privateModule.publicClass;
         static readonly myPublicStaticMethod1: privateModule.publicClass;
         readonly myPublicMethod1: privateModule.publicClass;
     }
-    class publicClassWithPrivateModuleSetAccessorTypes {
+    export class publicClassWithPrivateModuleSetAccessorTypes {
         static myPublicStaticMethod: privateModule.publicClass;
         myPublicMethod: privateModule.publicClass;
     }
+    export {};
 }
 declare module privateModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    class publicClassWithWithPrivateGetAccessorTypes {
+    export class publicClassWithWithPrivateGetAccessorTypes {
         static readonly myPublicStaticMethod: privateClass;
         private static readonly myPrivateStaticMethod;
         readonly myPublicMethod: privateClass;
@@ -3666,7 +3667,7 @@ declare module privateModule {
         readonly myPublicMethod1: privateClass;
         private readonly myPrivateMethod1;
     }
-    class publicClassWithWithPublicGetAccessorTypes {
+    export class publicClassWithWithPublicGetAccessorTypes {
         static readonly myPublicStaticMethod: publicClass;
         private static readonly myPrivateStaticMethod;
         readonly myPublicMethod: publicClass;
@@ -3676,28 +3677,29 @@ declare module privateModule {
         readonly myPublicMethod1: publicClass;
         private readonly myPrivateMethod1;
     }
-    class publicClassWithWithPrivateSetAccessorTypes {
+    export class publicClassWithWithPrivateSetAccessorTypes {
         static myPublicStaticMethod: privateClass;
         private static myPrivateStaticMethod;
         myPublicMethod: privateClass;
         private myPrivateMethod;
     }
-    class publicClassWithWithPublicSetAccessorTypes {
+    export class publicClassWithWithPublicSetAccessorTypes {
         static myPublicStaticMethod: publicClass;
         private static myPrivateStaticMethod;
         myPublicMethod: publicClass;
         private myPrivateMethod;
     }
-    class publicClassWithPrivateModuleGetAccessorTypes {
+    export class publicClassWithPrivateModuleGetAccessorTypes {
         static readonly myPublicStaticMethod: privateModule.publicClass;
         readonly myPublicMethod: privateModule.publicClass;
         static readonly myPublicStaticMethod1: publicClass;
         readonly myPublicMethod1: publicClass;
     }
-    class publicClassWithPrivateModuleSetAccessorTypes {
+    export class publicClassWithPrivateModuleSetAccessorTypes {
         static myPublicStaticMethod: privateModule.publicClass;
         myPublicMethod: privateModule.publicClass;
     }
+    export {};
 }
 export {};
 //// [privacyAccessorDeclFile_GlobalFile.d.ts]
@@ -3722,14 +3724,14 @@ declare class publicClassInGlobalWithWithPublicSetAccessorTypes {
 declare module publicModuleInGlobal {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
     module privateModule {
         class privateClass {
         }
-        class publicClass {
+        export class publicClass {
         }
-        class publicClassWithWithPrivateGetAccessorTypes {
+        export class publicClassWithWithPrivateGetAccessorTypes {
             static readonly myPublicStaticMethod: privateClass;
             private static readonly myPrivateStaticMethod;
             readonly myPublicMethod: privateClass;
@@ -3739,7 +3741,7 @@ declare module publicModuleInGlobal {
             readonly myPublicMethod1: privateClass;
             private readonly myPrivateMethod1;
         }
-        class publicClassWithWithPublicGetAccessorTypes {
+        export class publicClassWithWithPublicGetAccessorTypes {
             static readonly myPublicStaticMethod: publicClass;
             private static readonly myPrivateStaticMethod;
             readonly myPublicMethod: publicClass;
@@ -3749,30 +3751,31 @@ declare module publicModuleInGlobal {
             readonly myPublicMethod1: publicClass;
             private readonly myPrivateMethod1;
         }
-        class publicClassWithWithPrivateSetAccessorTypes {
+        export class publicClassWithWithPrivateSetAccessorTypes {
             static myPublicStaticMethod: privateClass;
             private static myPrivateStaticMethod;
             myPublicMethod: privateClass;
             private myPrivateMethod;
         }
-        class publicClassWithWithPublicSetAccessorTypes {
+        export class publicClassWithWithPublicSetAccessorTypes {
             static myPublicStaticMethod: publicClass;
             private static myPrivateStaticMethod;
             myPublicMethod: publicClass;
             private myPrivateMethod;
         }
-        class publicClassWithPrivateModuleGetAccessorTypes {
+        export class publicClassWithPrivateModuleGetAccessorTypes {
             static readonly myPublicStaticMethod: privateModule.publicClass;
             readonly myPublicMethod: privateModule.publicClass;
             static readonly myPublicStaticMethod1: publicClass;
             readonly myPublicMethod1: publicClass;
         }
-        class publicClassWithPrivateModuleSetAccessorTypes {
+        export class publicClassWithPrivateModuleSetAccessorTypes {
             static myPublicStaticMethod: privateModule.publicClass;
             myPublicMethod: privateModule.publicClass;
         }
+        export {};
     }
-    class publicClassWithWithPrivateGetAccessorTypes {
+    export class publicClassWithWithPrivateGetAccessorTypes {
         static readonly myPublicStaticMethod: privateClass;
         private static readonly myPrivateStaticMethod;
         readonly myPublicMethod: privateClass;
@@ -3782,7 +3785,7 @@ declare module publicModuleInGlobal {
         readonly myPublicMethod1: privateClass;
         private readonly myPrivateMethod1;
     }
-    class publicClassWithWithPublicGetAccessorTypes {
+    export class publicClassWithWithPublicGetAccessorTypes {
         static readonly myPublicStaticMethod: publicClass;
         private static readonly myPrivateStaticMethod;
         readonly myPublicMethod: publicClass;
@@ -3792,26 +3795,27 @@ declare module publicModuleInGlobal {
         readonly myPublicMethod1: publicClass;
         private readonly myPrivateMethod1;
     }
-    class publicClassWithWithPrivateSetAccessorTypes {
+    export class publicClassWithWithPrivateSetAccessorTypes {
         static myPublicStaticMethod: privateClass;
         private static myPrivateStaticMethod;
         myPublicMethod: privateClass;
         private myPrivateMethod;
     }
-    class publicClassWithWithPublicSetAccessorTypes {
+    export class publicClassWithWithPublicSetAccessorTypes {
         static myPublicStaticMethod: publicClass;
         private static myPrivateStaticMethod;
         myPublicMethod: publicClass;
         private myPrivateMethod;
     }
-    class publicClassWithPrivateModuleGetAccessorTypes {
+    export class publicClassWithPrivateModuleGetAccessorTypes {
         static readonly myPublicStaticMethod: privateModule.publicClass;
         readonly myPublicMethod: privateModule.publicClass;
         static readonly myPublicStaticMethod1: privateModule.publicClass;
         readonly myPublicMethod1: privateModule.publicClass;
     }
-    class publicClassWithPrivateModuleSetAccessorTypes {
+    export class publicClassWithPrivateModuleSetAccessorTypes {
         static myPublicStaticMethod: privateModule.publicClass;
         myPublicMethod: privateModule.publicClass;
     }
+    export {};
 }

--- a/tests/baselines/reference/privacyCheckTypeOfInvisibleModuleError.js
+++ b/tests/baselines/reference/privacyCheckTypeOfInvisibleModuleError.js
@@ -22,5 +22,6 @@ declare module Outer {
     module Inner {
         var m: typeof Inner;
     }
-    var f: typeof Inner;
+    export var f: typeof Inner;
+    export {};
 }

--- a/tests/baselines/reference/privacyCheckTypeOfInvisibleModuleNoError.js
+++ b/tests/baselines/reference/privacyCheckTypeOfInvisibleModuleNoError.js
@@ -22,5 +22,6 @@ declare module Outer {
     module Inner {
         var m: number;
     }
-    var f: typeof Inner;
+    export var f: typeof Inner;
+    export {};
 }

--- a/tests/baselines/reference/privacyClassExtendsClauseDeclFile.js
+++ b/tests/baselines/reference/privacyClassExtendsClauseDeclFile.js
@@ -368,30 +368,32 @@ var publicClassExtendingPublicClassInGlobal = /** @class */ (function (_super) {
 
 //// [privacyClassExtendsClauseDeclFile_externalModule.d.ts]
 export declare module publicModule {
-    class publicClassInPublicModule {
+    export class publicClassInPublicModule {
         private f1;
     }
     class privateClassInPublicModule {
     }
-    class publicClassExtendingPublicClassInModule extends publicClassInPublicModule {
+    export class publicClassExtendingPublicClassInModule extends publicClassInPublicModule {
     }
-    class publicClassExtendingPrivateClassInModule extends privateClassInPublicModule {
+    export class publicClassExtendingPrivateClassInModule extends privateClassInPublicModule {
     }
-    class publicClassExtendingFromPrivateModuleClass extends privateModule.publicClassInPrivateModule {
+    export class publicClassExtendingFromPrivateModuleClass extends privateModule.publicClassInPrivateModule {
     }
+    export {};
 }
 declare module privateModule {
-    class publicClassInPrivateModule {
+    export class publicClassInPrivateModule {
         private f1;
     }
     class privateClassInPrivateModule {
     }
-    class publicClassExtendingPublicClassInModule extends publicClassInPrivateModule {
+    export class publicClassExtendingPublicClassInModule extends publicClassInPrivateModule {
     }
-    class publicClassExtendingPrivateClassInModule extends privateClassInPrivateModule {
+    export class publicClassExtendingPrivateClassInModule extends privateClassInPrivateModule {
     }
-    class publicClassExtendingFromPrivateModuleClass extends privateModule.publicClassInPrivateModule {
+    export class publicClassExtendingFromPrivateModuleClass extends privateModule.publicClassInPrivateModule {
     }
+    export {};
 }
 export declare class publicClass {
     private f1;
@@ -407,15 +409,16 @@ export declare class publicClassExtendingFromPrivateModuleClass extends privateM
 export {};
 //// [privacyClassExtendsClauseDeclFile_GlobalFile.d.ts]
 declare module publicModuleInGlobal {
-    class publicClassInPublicModule {
+    export class publicClassInPublicModule {
         private f1;
     }
     class privateClassInPublicModule {
     }
-    class publicClassExtendingPublicClassInModule extends publicClassInPublicModule {
+    export class publicClassExtendingPublicClassInModule extends publicClassInPublicModule {
     }
-    class publicClassExtendingPrivateClassInModule extends privateClassInPublicModule {
+    export class publicClassExtendingPrivateClassInModule extends privateClassInPublicModule {
     }
+    export {};
 }
 declare class publicClassInGlobal {
 }

--- a/tests/baselines/reference/privacyClassImplementsClauseDeclFile.js
+++ b/tests/baselines/reference/privacyClassImplementsClauseDeclFile.js
@@ -242,30 +242,32 @@ var publicClassImplementingPublicInterfaceInGlobal = /** @class */ (function () 
 
 //// [privacyClassImplementsClauseDeclFile_externalModule.d.ts]
 export declare module publicModule {
-    interface publicInterfaceInPublicModule {
+    export interface publicInterfaceInPublicModule {
     }
     interface privateInterfaceInPublicModule {
     }
-    class publicClassImplementingPublicInterfaceInModule implements publicInterfaceInPublicModule {
+    export class publicClassImplementingPublicInterfaceInModule implements publicInterfaceInPublicModule {
     }
-    class publicClassImplementingPrivateInterfaceInModule implements privateInterfaceInPublicModule {
+    export class publicClassImplementingPrivateInterfaceInModule implements privateInterfaceInPublicModule {
     }
-    class publicClassImplementingFromPrivateModuleInterface implements privateModule.publicInterfaceInPrivateModule {
+    export class publicClassImplementingFromPrivateModuleInterface implements privateModule.publicInterfaceInPrivateModule {
     }
-    class publicClassImplementingPrivateAndPublicInterface implements privateInterfaceInPublicModule, publicInterfaceInPublicModule {
+    export class publicClassImplementingPrivateAndPublicInterface implements privateInterfaceInPublicModule, publicInterfaceInPublicModule {
     }
+    export {};
 }
 declare module privateModule {
-    interface publicInterfaceInPrivateModule {
+    export interface publicInterfaceInPrivateModule {
     }
     interface privateInterfaceInPrivateModule {
     }
-    class publicClassImplementingPublicInterfaceInModule implements publicInterfaceInPrivateModule {
+    export class publicClassImplementingPublicInterfaceInModule implements publicInterfaceInPrivateModule {
     }
-    class publicClassImplementingPrivateInterfaceInModule implements privateInterfaceInPrivateModule {
+    export class publicClassImplementingPrivateInterfaceInModule implements privateInterfaceInPrivateModule {
     }
-    class publicClassImplementingFromPrivateModuleInterface implements privateModule.publicInterfaceInPrivateModule {
+    export class publicClassImplementingFromPrivateModuleInterface implements privateModule.publicInterfaceInPrivateModule {
     }
+    export {};
 }
 export interface publicInterface {
 }
@@ -280,14 +282,15 @@ export declare class publicClassImplementingFromPrivateModuleInterface implement
 export {};
 //// [privacyClassImplementsClauseDeclFile_GlobalFile.d.ts]
 declare module publicModuleInGlobal {
-    interface publicInterfaceInPublicModule {
+    export interface publicInterfaceInPublicModule {
     }
     interface privateInterfaceInPublicModule {
     }
-    class publicClassImplementingPublicInterfaceInModule implements publicInterfaceInPublicModule {
+    export class publicClassImplementingPublicInterfaceInModule implements publicInterfaceInPublicModule {
     }
-    class publicClassImplementingPrivateInterfaceInModule implements privateInterfaceInPublicModule {
+    export class publicClassImplementingPrivateInterfaceInModule implements privateInterfaceInPublicModule {
     }
+    export {};
 }
 interface publicInterfaceInGlobal {
 }

--- a/tests/baselines/reference/privacyFunctionParameterDeclFile.js
+++ b/tests/baselines/reference/privacyFunctionParameterDeclFile.js
@@ -1334,19 +1334,19 @@ export declare function publicAmbientFunctionWithPrivateModuleParameterTypes(par
 export declare module publicModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    interface publicInterfaceWithPrivateParmeterTypes {
+    export interface publicInterfaceWithPrivateParmeterTypes {
         new (param: privateClass): publicClass;
         (param: privateClass): publicClass;
         myMethod(param: privateClass): void;
     }
-    interface publicInterfaceWithPublicParmeterTypes {
+    export interface publicInterfaceWithPublicParmeterTypes {
         new (param: publicClass): publicClass;
         (param: publicClass): publicClass;
         myMethod(param: publicClass): void;
     }
-    class publicClassWithWithPrivateParmeterTypes {
+    export class publicClassWithWithPrivateParmeterTypes {
         private param1;
         param2: privateClass;
         static myPublicStaticMethod(param: privateClass): void;
@@ -1355,7 +1355,7 @@ export declare module publicModule {
         private myPrivateMethod;
         constructor(param: privateClass, param1: privateClass, param2: privateClass);
     }
-    class publicClassWithWithPublicParmeterTypes {
+    export class publicClassWithWithPublicParmeterTypes {
         private param1;
         param2: publicClass;
         static myPublicStaticMethod(param: publicClass): void;
@@ -1364,41 +1364,42 @@ export declare module publicModule {
         private myPrivateMethod;
         constructor(param: publicClass, param1: publicClass, param2: publicClass);
     }
-    function publicFunctionWithPrivateParmeterTypes(param: privateClass): void;
-    function publicFunctionWithPublicParmeterTypes(param: publicClass): void;
-    function publicAmbientFunctionWithPrivateParmeterTypes(param: privateClass): void;
-    function publicAmbientFunctionWithPublicParmeterTypes(param: publicClass): void;
-    interface publicInterfaceWithPrivateModuleParameterTypes {
+    export function publicFunctionWithPrivateParmeterTypes(param: privateClass): void;
+    export function publicFunctionWithPublicParmeterTypes(param: publicClass): void;
+    export function publicAmbientFunctionWithPrivateParmeterTypes(param: privateClass): void;
+    export function publicAmbientFunctionWithPublicParmeterTypes(param: publicClass): void;
+    export interface publicInterfaceWithPrivateModuleParameterTypes {
         new (param: privateModule.publicClass): publicClass;
         (param: privateModule.publicClass): publicClass;
         myMethod(param: privateModule.publicClass): void;
     }
-    class publicClassWithPrivateModuleParameterTypes {
+    export class publicClassWithPrivateModuleParameterTypes {
         private param1;
         param2: privateModule.publicClass;
         static myPublicStaticMethod(param: privateModule.publicClass): void;
         myPublicMethod(param: privateModule.publicClass): void;
         constructor(param: privateModule.publicClass, param1: privateModule.publicClass, param2: privateModule.publicClass);
     }
-    function publicFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
-    function publicAmbientFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+    export function publicFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+    export function publicAmbientFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+    export {};
 }
 declare module privateModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    interface publicInterfaceWithPrivateParmeterTypes {
+    export interface publicInterfaceWithPrivateParmeterTypes {
         new (param: privateClass): publicClass;
         (param: privateClass): publicClass;
         myMethod(param: privateClass): void;
     }
-    interface publicInterfaceWithPublicParmeterTypes {
+    export interface publicInterfaceWithPublicParmeterTypes {
         new (param: publicClass): publicClass;
         (param: publicClass): publicClass;
         myMethod(param: publicClass): void;
     }
-    class publicClassWithWithPrivateParmeterTypes {
+    export class publicClassWithWithPrivateParmeterTypes {
         private param1;
         param2: privateClass;
         static myPublicStaticMethod(param: privateClass): void;
@@ -1407,7 +1408,7 @@ declare module privateModule {
         private myPrivateMethod;
         constructor(param: privateClass, param1: privateClass, param2: privateClass);
     }
-    class publicClassWithWithPublicParmeterTypes {
+    export class publicClassWithWithPublicParmeterTypes {
         private param1;
         param2: publicClass;
         static myPublicStaticMethod(param: publicClass): void;
@@ -1416,24 +1417,25 @@ declare module privateModule {
         private myPrivateMethod;
         constructor(param: publicClass, param1: publicClass, param2: publicClass);
     }
-    function publicFunctionWithPrivateParmeterTypes(param: privateClass): void;
-    function publicFunctionWithPublicParmeterTypes(param: publicClass): void;
-    function publicAmbientFunctionWithPrivateParmeterTypes(param: privateClass): void;
-    function publicAmbientFunctionWithPublicParmeterTypes(param: publicClass): void;
-    interface publicInterfaceWithPrivateModuleParameterTypes {
+    export function publicFunctionWithPrivateParmeterTypes(param: privateClass): void;
+    export function publicFunctionWithPublicParmeterTypes(param: publicClass): void;
+    export function publicAmbientFunctionWithPrivateParmeterTypes(param: privateClass): void;
+    export function publicAmbientFunctionWithPublicParmeterTypes(param: publicClass): void;
+    export interface publicInterfaceWithPrivateModuleParameterTypes {
         new (param: privateModule.publicClass): publicClass;
         (param: privateModule.publicClass): publicClass;
         myMethod(param: privateModule.publicClass): void;
     }
-    class publicClassWithPrivateModuleParameterTypes {
+    export class publicClassWithPrivateModuleParameterTypes {
         private param1;
         param2: privateModule.publicClass;
         static myPublicStaticMethod(param: privateModule.publicClass): void;
         myPublicMethod(param: privateModule.publicClass): void;
         constructor(param: privateModule.publicClass, param1: privateModule.publicClass, param2: privateModule.publicClass);
     }
-    function publicFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
-    function publicAmbientFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+    export function publicFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+    export function publicAmbientFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+    export {};
 }
 export {};
 //// [privacyFunctionParameterDeclFile_GlobalFile.d.ts]
@@ -1458,24 +1460,24 @@ declare function publicAmbientFunctionWithPublicParmeterTypesInGlobal(param: pub
 declare module publicModuleInGlobal {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
     module privateModule {
         class privateClass {
         }
-        class publicClass {
+        export class publicClass {
         }
-        interface publicInterfaceWithPrivateParmeterTypes {
+        export interface publicInterfaceWithPrivateParmeterTypes {
             new (param: privateClass): publicClass;
             (param: privateClass): publicClass;
             myMethod(param: privateClass): void;
         }
-        interface publicInterfaceWithPublicParmeterTypes {
+        export interface publicInterfaceWithPublicParmeterTypes {
             new (param: publicClass): publicClass;
             (param: publicClass): publicClass;
             myMethod(param: publicClass): void;
         }
-        class publicClassWithWithPrivateParmeterTypes {
+        export class publicClassWithWithPrivateParmeterTypes {
             private param1;
             param2: privateClass;
             static myPublicStaticMethod(param: privateClass): void;
@@ -1484,7 +1486,7 @@ declare module publicModuleInGlobal {
             private myPrivateMethod;
             constructor(param: privateClass, param1: privateClass, param2: privateClass);
         }
-        class publicClassWithWithPublicParmeterTypes {
+        export class publicClassWithWithPublicParmeterTypes {
             private param1;
             param2: publicClass;
             static myPublicStaticMethod(param: publicClass): void;
@@ -1493,36 +1495,37 @@ declare module publicModuleInGlobal {
             private myPrivateMethod;
             constructor(param: publicClass, param1: publicClass, param2: publicClass);
         }
-        function publicFunctionWithPrivateParmeterTypes(param: privateClass): void;
-        function publicFunctionWithPublicParmeterTypes(param: publicClass): void;
-        function publicAmbientFunctionWithPrivateParmeterTypes(param: privateClass): void;
-        function publicAmbientFunctionWithPublicParmeterTypes(param: publicClass): void;
-        interface publicInterfaceWithPrivateModuleParameterTypes {
+        export function publicFunctionWithPrivateParmeterTypes(param: privateClass): void;
+        export function publicFunctionWithPublicParmeterTypes(param: publicClass): void;
+        export function publicAmbientFunctionWithPrivateParmeterTypes(param: privateClass): void;
+        export function publicAmbientFunctionWithPublicParmeterTypes(param: publicClass): void;
+        export interface publicInterfaceWithPrivateModuleParameterTypes {
             new (param: privateModule.publicClass): publicClass;
             (param: privateModule.publicClass): publicClass;
             myMethod(param: privateModule.publicClass): void;
         }
-        class publicClassWithPrivateModuleParameterTypes {
+        export class publicClassWithPrivateModuleParameterTypes {
             private param1;
             param2: privateModule.publicClass;
             static myPublicStaticMethod(param: privateModule.publicClass): void;
             myPublicMethod(param: privateModule.publicClass): void;
             constructor(param: privateModule.publicClass, param1: privateModule.publicClass, param2: privateModule.publicClass);
         }
-        function publicFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
-        function publicAmbientFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+        export function publicFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+        export function publicAmbientFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+        export {};
     }
-    interface publicInterfaceWithPrivateParmeterTypes {
+    export interface publicInterfaceWithPrivateParmeterTypes {
         new (param: privateClass): publicClass;
         (param: privateClass): publicClass;
         myMethod(param: privateClass): void;
     }
-    interface publicInterfaceWithPublicParmeterTypes {
+    export interface publicInterfaceWithPublicParmeterTypes {
         new (param: publicClass): publicClass;
         (param: publicClass): publicClass;
         myMethod(param: publicClass): void;
     }
-    class publicClassWithWithPrivateParmeterTypes {
+    export class publicClassWithWithPrivateParmeterTypes {
         private param1;
         param2: privateClass;
         static myPublicStaticMethod(param: privateClass): void;
@@ -1531,7 +1534,7 @@ declare module publicModuleInGlobal {
         private myPrivateMethod;
         constructor(param: privateClass, param1: privateClass, param2: privateClass);
     }
-    class publicClassWithWithPublicParmeterTypes {
+    export class publicClassWithWithPublicParmeterTypes {
         private param1;
         param2: publicClass;
         static myPublicStaticMethod(param: publicClass): void;
@@ -1540,22 +1543,23 @@ declare module publicModuleInGlobal {
         private myPrivateMethod;
         constructor(param: publicClass, param1: publicClass, param2: publicClass);
     }
-    function publicFunctionWithPrivateParmeterTypes(param: privateClass): void;
-    function publicFunctionWithPublicParmeterTypes(param: publicClass): void;
-    function publicAmbientFunctionWithPrivateParmeterTypes(param: privateClass): void;
-    function publicAmbientFunctionWithPublicParmeterTypes(param: publicClass): void;
-    interface publicInterfaceWithPrivateModuleParameterTypes {
+    export function publicFunctionWithPrivateParmeterTypes(param: privateClass): void;
+    export function publicFunctionWithPublicParmeterTypes(param: publicClass): void;
+    export function publicAmbientFunctionWithPrivateParmeterTypes(param: privateClass): void;
+    export function publicAmbientFunctionWithPublicParmeterTypes(param: publicClass): void;
+    export interface publicInterfaceWithPrivateModuleParameterTypes {
         new (param: privateModule.publicClass): publicClass;
         (param: privateModule.publicClass): publicClass;
         myMethod(param: privateModule.publicClass): void;
     }
-    class publicClassWithPrivateModuleParameterTypes {
+    export class publicClassWithPrivateModuleParameterTypes {
         private param1;
         param2: privateModule.publicClass;
         static myPublicStaticMethod(param: privateModule.publicClass): void;
         myPublicMethod(param: privateModule.publicClass): void;
         constructor(param: privateModule.publicClass, param1: privateModule.publicClass, param2: privateModule.publicClass);
     }
-    function publicFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
-    function publicAmbientFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+    export function publicFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+    export function publicAmbientFunctionWithPrivateModuleParameterTypes(param: privateModule.publicClass): void;
+    export {};
 }

--- a/tests/baselines/reference/privacyFunctionReturnTypeDeclFile.js
+++ b/tests/baselines/reference/privacyFunctionReturnTypeDeclFile.js
@@ -2341,21 +2341,21 @@ export declare function publicAmbientFunctionWithPrivateModuleParameterTypes(): 
 export declare module publicModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    interface publicInterfaceWithPrivateParmeterTypes {
+    export interface publicInterfaceWithPrivateParmeterTypes {
         new (): privateClass;
         (): privateClass;
         [x: number]: privateClass;
         myMethod(): privateClass;
     }
-    interface publicInterfaceWithPublicParmeterTypes {
+    export interface publicInterfaceWithPublicParmeterTypes {
         new (): publicClass;
         (): publicClass;
         [x: number]: publicClass;
         myMethod(): publicClass;
     }
-    class publicClassWithWithPrivateParmeterTypes {
+    export class publicClassWithWithPrivateParmeterTypes {
         static myPublicStaticMethod(): privateClass;
         private static myPrivateStaticMethod;
         myPublicMethod(): privateClass;
@@ -2365,7 +2365,7 @@ export declare module publicModule {
         myPublicMethod1(): privateClass;
         private myPrivateMethod1;
     }
-    class publicClassWithWithPublicParmeterTypes {
+    export class publicClassWithWithPublicParmeterTypes {
         static myPublicStaticMethod(): publicClass;
         private static myPrivateStaticMethod;
         myPublicMethod(): publicClass;
@@ -2375,46 +2375,47 @@ export declare module publicModule {
         myPublicMethod1(): publicClass;
         private myPrivateMethod1;
     }
-    function publicFunctionWithPrivateParmeterTypes(): privateClass;
-    function publicFunctionWithPublicParmeterTypes(): publicClass;
-    function publicFunctionWithPrivateParmeterTypes1(): privateClass;
-    function publicFunctionWithPublicParmeterTypes1(): publicClass;
-    function publicAmbientFunctionWithPrivateParmeterTypes(): privateClass;
-    function publicAmbientFunctionWithPublicParmeterTypes(): publicClass;
-    interface publicInterfaceWithPrivateModuleParameterTypes {
+    export function publicFunctionWithPrivateParmeterTypes(): privateClass;
+    export function publicFunctionWithPublicParmeterTypes(): publicClass;
+    export function publicFunctionWithPrivateParmeterTypes1(): privateClass;
+    export function publicFunctionWithPublicParmeterTypes1(): publicClass;
+    export function publicAmbientFunctionWithPrivateParmeterTypes(): privateClass;
+    export function publicAmbientFunctionWithPublicParmeterTypes(): publicClass;
+    export interface publicInterfaceWithPrivateModuleParameterTypes {
         new (): privateModule.publicClass;
         (): privateModule.publicClass;
         [x: number]: privateModule.publicClass;
         myMethod(): privateModule.publicClass;
     }
-    class publicClassWithPrivateModuleParameterTypes {
+    export class publicClassWithPrivateModuleParameterTypes {
         static myPublicStaticMethod(): privateModule.publicClass;
         myPublicMethod(): privateModule.publicClass;
         static myPublicStaticMethod1(): privateModule.publicClass;
         myPublicMethod1(): privateModule.publicClass;
     }
-    function publicFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
-    function publicFunctionWithPrivateModuleParameterTypes1(): privateModule.publicClass;
-    function publicAmbientFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+    export function publicFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+    export function publicFunctionWithPrivateModuleParameterTypes1(): privateModule.publicClass;
+    export function publicAmbientFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+    export {};
 }
 declare module privateModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    interface publicInterfaceWithPrivateParmeterTypes {
+    export interface publicInterfaceWithPrivateParmeterTypes {
         new (): privateClass;
         (): privateClass;
         [x: number]: privateClass;
         myMethod(): privateClass;
     }
-    interface publicInterfaceWithPublicParmeterTypes {
+    export interface publicInterfaceWithPublicParmeterTypes {
         new (): publicClass;
         (): publicClass;
         [x: number]: publicClass;
         myMethod(): publicClass;
     }
-    class publicClassWithWithPrivateParmeterTypes {
+    export class publicClassWithWithPrivateParmeterTypes {
         static myPublicStaticMethod(): privateClass;
         private static myPrivateStaticMethod;
         myPublicMethod(): privateClass;
@@ -2424,7 +2425,7 @@ declare module privateModule {
         myPublicMethod1(): privateClass;
         private myPrivateMethod1;
     }
-    class publicClassWithWithPublicParmeterTypes {
+    export class publicClassWithWithPublicParmeterTypes {
         static myPublicStaticMethod(): publicClass;
         private static myPrivateStaticMethod;
         myPublicMethod(): publicClass;
@@ -2434,27 +2435,28 @@ declare module privateModule {
         myPublicMethod1(): publicClass;
         private myPrivateMethod1;
     }
-    function publicFunctionWithPrivateParmeterTypes(): privateClass;
-    function publicFunctionWithPublicParmeterTypes(): publicClass;
-    function publicFunctionWithPrivateParmeterTypes1(): privateClass;
-    function publicFunctionWithPublicParmeterTypes1(): publicClass;
-    function publicAmbientFunctionWithPrivateParmeterTypes(): privateClass;
-    function publicAmbientFunctionWithPublicParmeterTypes(): publicClass;
-    interface publicInterfaceWithPrivateModuleParameterTypes {
+    export function publicFunctionWithPrivateParmeterTypes(): privateClass;
+    export function publicFunctionWithPublicParmeterTypes(): publicClass;
+    export function publicFunctionWithPrivateParmeterTypes1(): privateClass;
+    export function publicFunctionWithPublicParmeterTypes1(): publicClass;
+    export function publicAmbientFunctionWithPrivateParmeterTypes(): privateClass;
+    export function publicAmbientFunctionWithPublicParmeterTypes(): publicClass;
+    export interface publicInterfaceWithPrivateModuleParameterTypes {
         new (): privateModule.publicClass;
         (): privateModule.publicClass;
         [x: number]: privateModule.publicClass;
         myMethod(): privateModule.publicClass;
     }
-    class publicClassWithPrivateModuleParameterTypes {
+    export class publicClassWithPrivateModuleParameterTypes {
         static myPublicStaticMethod(): privateModule.publicClass;
         myPublicMethod(): privateModule.publicClass;
         static myPublicStaticMethod1(): publicClass;
         myPublicMethod1(): publicClass;
     }
-    function publicFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
-    function publicFunctionWithPrivateModuleParameterTypes1(): publicClass;
-    function publicAmbientFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+    export function publicFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+    export function publicFunctionWithPrivateModuleParameterTypes1(): publicClass;
+    export function publicAmbientFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+    export {};
 }
 export {};
 //// [privacyFunctionReturnTypeDeclFile_GlobalFile.d.ts]
@@ -2482,26 +2484,26 @@ declare function publicAmbientFunctionWithPublicParmeterTypesInGlobal(): publicC
 declare module publicModuleInGlobal {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
     module privateModule {
         class privateClass {
         }
-        class publicClass {
+        export class publicClass {
         }
-        interface publicInterfaceWithPrivateParmeterTypes {
+        export interface publicInterfaceWithPrivateParmeterTypes {
             new (): privateClass;
             (): privateClass;
             [x: number]: privateClass;
             myMethod(): privateClass;
         }
-        interface publicInterfaceWithPublicParmeterTypes {
+        export interface publicInterfaceWithPublicParmeterTypes {
             new (): publicClass;
             (): publicClass;
             [x: number]: publicClass;
             myMethod(): publicClass;
         }
-        class publicClassWithWithPrivateParmeterTypes {
+        export class publicClassWithWithPrivateParmeterTypes {
             static myPublicStaticMethod(): privateClass;
             private static myPrivateStaticMethod;
             myPublicMethod(): privateClass;
@@ -2511,7 +2513,7 @@ declare module publicModuleInGlobal {
             myPublicMethod1(): privateClass;
             private myPrivateMethod1;
         }
-        class publicClassWithWithPublicParmeterTypes {
+        export class publicClassWithWithPublicParmeterTypes {
             static myPublicStaticMethod(): publicClass;
             private static myPrivateStaticMethod;
             myPublicMethod(): publicClass;
@@ -2521,41 +2523,42 @@ declare module publicModuleInGlobal {
             myPublicMethod1(): publicClass;
             private myPrivateMethod1;
         }
-        function publicFunctionWithPrivateParmeterTypes(): privateClass;
-        function publicFunctionWithPublicParmeterTypes(): publicClass;
-        function publicFunctionWithPrivateParmeterTypes1(): privateClass;
-        function publicFunctionWithPublicParmeterTypes1(): publicClass;
-        function publicAmbientFunctionWithPrivateParmeterTypes(): privateClass;
-        function publicAmbientFunctionWithPublicParmeterTypes(): publicClass;
-        interface publicInterfaceWithPrivateModuleParameterTypes {
+        export function publicFunctionWithPrivateParmeterTypes(): privateClass;
+        export function publicFunctionWithPublicParmeterTypes(): publicClass;
+        export function publicFunctionWithPrivateParmeterTypes1(): privateClass;
+        export function publicFunctionWithPublicParmeterTypes1(): publicClass;
+        export function publicAmbientFunctionWithPrivateParmeterTypes(): privateClass;
+        export function publicAmbientFunctionWithPublicParmeterTypes(): publicClass;
+        export interface publicInterfaceWithPrivateModuleParameterTypes {
             new (): privateModule.publicClass;
             (): privateModule.publicClass;
             [x: number]: privateModule.publicClass;
             myMethod(): privateModule.publicClass;
         }
-        class publicClassWithPrivateModuleParameterTypes {
+        export class publicClassWithPrivateModuleParameterTypes {
             static myPublicStaticMethod(): privateModule.publicClass;
             myPublicMethod(): privateModule.publicClass;
             static myPublicStaticMethod1(): publicClass;
             myPublicMethod1(): publicClass;
         }
-        function publicFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
-        function publicFunctionWithPrivateModuleParameterTypes1(): publicClass;
-        function publicAmbientFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+        export function publicFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+        export function publicFunctionWithPrivateModuleParameterTypes1(): publicClass;
+        export function publicAmbientFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+        export {};
     }
-    interface publicInterfaceWithPrivateParmeterTypes {
+    export interface publicInterfaceWithPrivateParmeterTypes {
         new (): privateClass;
         (): privateClass;
         [x: number]: privateClass;
         myMethod(): privateClass;
     }
-    interface publicInterfaceWithPublicParmeterTypes {
+    export interface publicInterfaceWithPublicParmeterTypes {
         new (): publicClass;
         (): publicClass;
         [x: number]: publicClass;
         myMethod(): publicClass;
     }
-    class publicClassWithWithPrivateParmeterTypes {
+    export class publicClassWithWithPrivateParmeterTypes {
         static myPublicStaticMethod(): privateClass;
         private static myPrivateStaticMethod;
         myPublicMethod(): privateClass;
@@ -2565,7 +2568,7 @@ declare module publicModuleInGlobal {
         myPublicMethod1(): privateClass;
         private myPrivateMethod1;
     }
-    class publicClassWithWithPublicParmeterTypes {
+    export class publicClassWithWithPublicParmeterTypes {
         static myPublicStaticMethod(): publicClass;
         private static myPrivateStaticMethod;
         myPublicMethod(): publicClass;
@@ -2575,25 +2578,26 @@ declare module publicModuleInGlobal {
         myPublicMethod1(): publicClass;
         private myPrivateMethod1;
     }
-    function publicFunctionWithPrivateParmeterTypes(): privateClass;
-    function publicFunctionWithPublicParmeterTypes(): publicClass;
-    function publicFunctionWithPrivateParmeterTypes1(): privateClass;
-    function publicFunctionWithPublicParmeterTypes1(): publicClass;
-    function publicAmbientFunctionWithPrivateParmeterTypes(): privateClass;
-    function publicAmbientFunctionWithPublicParmeterTypes(): publicClass;
-    interface publicInterfaceWithPrivateModuleParameterTypes {
+    export function publicFunctionWithPrivateParmeterTypes(): privateClass;
+    export function publicFunctionWithPublicParmeterTypes(): publicClass;
+    export function publicFunctionWithPrivateParmeterTypes1(): privateClass;
+    export function publicFunctionWithPublicParmeterTypes1(): publicClass;
+    export function publicAmbientFunctionWithPrivateParmeterTypes(): privateClass;
+    export function publicAmbientFunctionWithPublicParmeterTypes(): publicClass;
+    export interface publicInterfaceWithPrivateModuleParameterTypes {
         new (): privateModule.publicClass;
         (): privateModule.publicClass;
         [x: number]: privateModule.publicClass;
         myMethod(): privateModule.publicClass;
     }
-    class publicClassWithPrivateModuleParameterTypes {
+    export class publicClassWithPrivateModuleParameterTypes {
         static myPublicStaticMethod(): privateModule.publicClass;
         myPublicMethod(): privateModule.publicClass;
         static myPublicStaticMethod1(): privateModule.publicClass;
         myPublicMethod1(): privateModule.publicClass;
     }
-    function publicFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
-    function publicFunctionWithPrivateModuleParameterTypes1(): privateModule.publicClass;
-    function publicAmbientFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+    export function publicFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+    export function publicFunctionWithPrivateModuleParameterTypes1(): privateModule.publicClass;
+    export function publicAmbientFunctionWithPrivateModuleParameterTypes(): privateModule.publicClass;
+    export {};
 }

--- a/tests/baselines/reference/privacyGloImport.js
+++ b/tests/baselines/reference/privacyGloImport.js
@@ -265,7 +265,7 @@ var m2;
 
 //// [privacyGloImport.d.ts]
 declare module m1 {
-    module m1_M1_public {
+    export module m1_M1_public {
         class c1 {
         }
         function f1(): c1;
@@ -280,17 +280,18 @@ declare module m1 {
         var v2: c1;
     }
     import m1_im1_private = m1_M1_public;
-    var m1_im1_private_v1_public: typeof m1_im1_private.c1;
-    var m1_im1_private_v2_public: m1_im1_private.c1;
-    var m1_im1_private_v3_public: typeof m1_im1_private.f1;
-    var m1_im1_private_v4_public: m1_im1_private.c1;
+    export var m1_im1_private_v1_public: typeof m1_im1_private.c1;
+    export var m1_im1_private_v2_public: m1_im1_private.c1;
+    export var m1_im1_private_v3_public: typeof m1_im1_private.f1;
+    export var m1_im1_private_v4_public: m1_im1_private.c1;
     import m1_im2_private = m1_M2_private;
-    var m1_im2_private_v1_public: typeof m1_im2_private.c1;
-    var m1_im2_private_v2_public: m1_im2_private.c1;
-    var m1_im2_private_v3_public: typeof m1_im2_private.f1;
-    var m1_im2_private_v4_public: m1_im2_private.c1;
+    export var m1_im2_private_v1_public: typeof m1_im2_private.c1;
+    export var m1_im2_private_v2_public: m1_im2_private.c1;
+    export var m1_im2_private_v3_public: typeof m1_im2_private.f1;
+    export var m1_im2_private_v4_public: m1_im2_private.c1;
     export import m1_im1_public = m1_M1_public;
     export import m1_im2_public = m1_M2_private;
+    export {};
 }
 declare module glo_M1_public {
     class c1 {

--- a/tests/baselines/reference/privacyGloImportParseErrors.js
+++ b/tests/baselines/reference/privacyGloImportParseErrors.js
@@ -245,7 +245,7 @@ var m2;
 
 //// [privacyGloImportParseErrors.d.ts]
 declare module m1 {
-    module m1_M1_public {
+    export module m1_M1_public {
         class c1 {
         }
         function f1(): c1;
@@ -259,7 +259,7 @@ declare module m1 {
         var v1: typeof c1;
         var v2: c1;
     }
-    module "m1_M3_public" {
+    export module "m1_M3_public" {
         function f1(): any;
         class c1 {
         }
@@ -269,27 +269,28 @@ declare module m1 {
         var v2: c1;
     }
     import m1_im1_private = m1_M1_public;
-    var m1_im1_private_v1_public: typeof m1_im1_private.c1;
-    var m1_im1_private_v2_public: m1_im1_private.c1;
-    var m1_im1_private_v3_public: typeof m1_im1_private.f1;
-    var m1_im1_private_v4_public: m1_im1_private.c1;
+    export var m1_im1_private_v1_public: typeof m1_im1_private.c1;
+    export var m1_im1_private_v2_public: m1_im1_private.c1;
+    export var m1_im1_private_v3_public: typeof m1_im1_private.f1;
+    export var m1_im1_private_v4_public: m1_im1_private.c1;
     import m1_im2_private = m1_M2_private;
-    var m1_im2_private_v1_public: typeof m1_im2_private.c1;
-    var m1_im2_private_v2_public: m1_im2_private.c1;
-    var m1_im2_private_v3_public: typeof m1_im2_private.f1;
-    var m1_im2_private_v4_public: m1_im2_private.c1;
-    var m1_im3_private_v1_public: any;
-    var m1_im3_private_v2_public: any;
-    var m1_im3_private_v3_public: any;
-    var m1_im3_private_v4_public: any;
-    var m1_im4_private_v1_public: any;
-    var m1_im4_private_v2_public: any;
-    var m1_im4_private_v3_public: any;
-    var m1_im4_private_v4_public: any;
+    export var m1_im2_private_v1_public: typeof m1_im2_private.c1;
+    export var m1_im2_private_v2_public: m1_im2_private.c1;
+    export var m1_im2_private_v3_public: typeof m1_im2_private.f1;
+    export var m1_im2_private_v4_public: m1_im2_private.c1;
+    export var m1_im3_private_v1_public: any;
+    export var m1_im3_private_v2_public: any;
+    export var m1_im3_private_v3_public: any;
+    export var m1_im3_private_v4_public: any;
+    export var m1_im4_private_v1_public: any;
+    export var m1_im4_private_v2_public: any;
+    export var m1_im4_private_v3_public: any;
+    export var m1_im4_private_v4_public: any;
     export import m1_im1_public = m1_M1_public;
     export import m1_im2_public = m1_M2_private;
     export import m1_im3_public = require("m1_M3_public");
     export import m1_im4_public = require("m1_M4_private");
+    export {};
 }
 declare module glo_M1_public {
     class c1 {

--- a/tests/baselines/reference/privacyImport.js
+++ b/tests/baselines/reference/privacyImport.js
@@ -706,7 +706,7 @@ var m3;
 
 //// [privacyImport.d.ts]
 export declare module m1 {
-    module m1_M1_public {
+    export module m1_M1_public {
         class c1 {
         }
         function f1(): c1;
@@ -721,17 +721,18 @@ export declare module m1 {
         var v2: c1;
     }
     import m1_im1_private = m1_M1_public;
-    var m1_im1_private_v1_public: typeof m1_im1_private.c1;
-    var m1_im1_private_v2_public: m1_im1_private.c1;
-    var m1_im1_private_v3_public: typeof m1_im1_private.f1;
-    var m1_im1_private_v4_public: m1_im1_private.c1;
+    export var m1_im1_private_v1_public: typeof m1_im1_private.c1;
+    export var m1_im1_private_v2_public: m1_im1_private.c1;
+    export var m1_im1_private_v3_public: typeof m1_im1_private.f1;
+    export var m1_im1_private_v4_public: m1_im1_private.c1;
     import m1_im2_private = m1_M2_private;
-    var m1_im2_private_v1_public: typeof m1_im2_private.c1;
-    var m1_im2_private_v2_public: m1_im2_private.c1;
-    var m1_im2_private_v3_public: typeof m1_im2_private.f1;
-    var m1_im2_private_v4_public: m1_im2_private.c1;
+    export var m1_im2_private_v1_public: typeof m1_im2_private.c1;
+    export var m1_im2_private_v2_public: m1_im2_private.c1;
+    export var m1_im2_private_v3_public: typeof m1_im2_private.f1;
+    export var m1_im2_private_v4_public: m1_im2_private.c1;
     export import m1_im1_public = m1_M1_public;
     export import m1_im2_public = m1_M2_private;
+    export {};
 }
 export declare module glo_M1_public {
     class c1 {

--- a/tests/baselines/reference/privacyInterfaceExtendsClauseDeclFile.js
+++ b/tests/baselines/reference/privacyInterfaceExtendsClauseDeclFile.js
@@ -101,30 +101,32 @@ exports.__esModule = true;
 
 //// [privacyInterfaceExtendsClauseDeclFile_externalModule.d.ts]
 export declare module publicModule {
-    interface publicInterfaceInPublicModule {
+    export interface publicInterfaceInPublicModule {
     }
     interface privateInterfaceInPublicModule {
     }
-    interface publicInterfaceImplementingPublicInterfaceInModule extends publicInterfaceInPublicModule {
+    export interface publicInterfaceImplementingPublicInterfaceInModule extends publicInterfaceInPublicModule {
     }
-    interface publicInterfaceImplementingPrivateInterfaceInModule extends privateInterfaceInPublicModule {
+    export interface publicInterfaceImplementingPrivateInterfaceInModule extends privateInterfaceInPublicModule {
     }
-    interface publicInterfaceImplementingFromPrivateModuleInterface extends privateModule.publicInterfaceInPrivateModule {
+    export interface publicInterfaceImplementingFromPrivateModuleInterface extends privateModule.publicInterfaceInPrivateModule {
     }
-    interface publicInterfaceImplementingPrivateAndPublicInterface extends privateInterfaceInPublicModule, publicInterfaceInPublicModule {
+    export interface publicInterfaceImplementingPrivateAndPublicInterface extends privateInterfaceInPublicModule, publicInterfaceInPublicModule {
     }
+    export {};
 }
 declare module privateModule {
-    interface publicInterfaceInPrivateModule {
+    export interface publicInterfaceInPrivateModule {
     }
     interface privateInterfaceInPrivateModule {
     }
-    interface publicInterfaceImplementingPublicInterfaceInModule extends publicInterfaceInPrivateModule {
+    export interface publicInterfaceImplementingPublicInterfaceInModule extends publicInterfaceInPrivateModule {
     }
-    interface publicInterfaceImplementingPrivateInterfaceInModule extends privateInterfaceInPrivateModule {
+    export interface publicInterfaceImplementingPrivateInterfaceInModule extends privateInterfaceInPrivateModule {
     }
-    interface publicInterfaceImplementingFromPrivateModuleInterface extends privateModule.publicInterfaceInPrivateModule {
+    export interface publicInterfaceImplementingFromPrivateModuleInterface extends privateModule.publicInterfaceInPrivateModule {
     }
+    export {};
 }
 export interface publicInterface {
 }
@@ -139,14 +141,15 @@ export interface publicInterfaceImplementingFromPrivateModuleInterface extends p
 export {};
 //// [privacyInterfaceExtendsClauseDeclFile_GlobalFile.d.ts]
 declare module publicModuleInGlobal {
-    interface publicInterfaceInPublicModule {
+    export interface publicInterfaceInPublicModule {
     }
     interface privateInterfaceInPublicModule {
     }
-    interface publicInterfaceImplementingPublicInterfaceInModule extends publicInterfaceInPublicModule {
+    export interface publicInterfaceImplementingPublicInterfaceInModule extends publicInterfaceInPublicModule {
     }
-    interface publicInterfaceImplementingPrivateInterfaceInModule extends privateInterfaceInPublicModule {
+    export interface publicInterfaceImplementingPrivateInterfaceInModule extends privateInterfaceInPublicModule {
     }
+    export {};
 }
 interface publicInterfaceInGlobal {
 }

--- a/tests/baselines/reference/privacyTypeParameterOfFunctionDeclFile.js
+++ b/tests/baselines/reference/privacyTypeParameterOfFunctionDeclFile.js
@@ -872,95 +872,97 @@ export declare function publicFunctionWithPrivateMopduleTypeParameters<T extends
 export declare module publicModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    interface publicInterfaceWithPrivateTypeParameters {
+    export interface publicInterfaceWithPrivateTypeParameters {
         new <T extends privateClass>(): privateClass;
         <T extends privateClass>(): privateClass;
         myMethod<T extends privateClass>(): privateClass;
     }
-    interface publicInterfaceWithPublicTypeParameters {
+    export interface publicInterfaceWithPublicTypeParameters {
         new <T extends publicClass>(): publicClass;
         <T extends publicClass>(): publicClass;
         myMethod<T extends publicClass>(): publicClass;
     }
-    class publicClassWithWithPrivateTypeParameters {
+    export class publicClassWithWithPrivateTypeParameters {
         static myPublicStaticMethod<T extends privateClass>(): void;
         private static myPrivateStaticMethod;
         myPublicMethod<T extends privateClass>(): void;
         private myPrivateMethod;
     }
-    class publicClassWithWithPublicTypeParameters {
+    export class publicClassWithWithPublicTypeParameters {
         static myPublicStaticMethod<T extends publicClass>(): void;
         private static myPrivateStaticMethod;
         myPublicMethod<T extends publicClass>(): void;
         private myPrivateMethod;
     }
-    function publicFunctionWithPrivateTypeParameters<T extends privateClass>(): void;
-    function publicFunctionWithPublicTypeParameters<T extends publicClass>(): void;
-    interface publicInterfaceWithPublicTypeParametersWithoutExtends {
+    export function publicFunctionWithPrivateTypeParameters<T extends privateClass>(): void;
+    export function publicFunctionWithPublicTypeParameters<T extends publicClass>(): void;
+    export interface publicInterfaceWithPublicTypeParametersWithoutExtends {
         new <T>(): publicClass;
         <T>(): publicClass;
         myMethod<T>(): publicClass;
     }
-    class publicClassWithWithPublicTypeParametersWithoutExtends {
+    export class publicClassWithWithPublicTypeParametersWithoutExtends {
         static myPublicStaticMethod<T>(): void;
         private static myPrivateStaticMethod;
         myPublicMethod<T>(): void;
         private myPrivateMethod;
     }
-    function publicFunctionWithPublicTypeParametersWithoutExtends<T>(): void;
-    interface publicInterfaceWithPrivatModuleTypeParameters {
+    export function publicFunctionWithPublicTypeParametersWithoutExtends<T>(): void;
+    export interface publicInterfaceWithPrivatModuleTypeParameters {
         new <T extends privateModule.publicClass>(): privateModule.publicClass;
         <T extends privateModule.publicClass>(): privateModule.publicClass;
         myMethod<T extends privateModule.publicClass>(): privateModule.publicClass;
     }
-    class publicClassWithWithPrivateModuleTypeParameters {
+    export class publicClassWithWithPrivateModuleTypeParameters {
         static myPublicStaticMethod<T extends privateModule.publicClass>(): void;
         myPublicMethod<T extends privateModule.publicClass>(): void;
     }
-    function publicFunctionWithPrivateMopduleTypeParameters<T extends privateModule.publicClass>(): void;
+    export function publicFunctionWithPrivateMopduleTypeParameters<T extends privateModule.publicClass>(): void;
+    export {};
 }
 declare module privateModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    interface publicInterfaceWithPrivateTypeParameters {
+    export interface publicInterfaceWithPrivateTypeParameters {
         new <T extends privateClass>(): privateClass;
         <T extends privateClass>(): privateClass;
         myMethod<T extends privateClass>(): privateClass;
     }
-    interface publicInterfaceWithPublicTypeParameters {
+    export interface publicInterfaceWithPublicTypeParameters {
         new <T extends publicClass>(): publicClass;
         <T extends publicClass>(): publicClass;
         myMethod<T extends publicClass>(): publicClass;
     }
-    class publicClassWithWithPrivateTypeParameters {
+    export class publicClassWithWithPrivateTypeParameters {
         static myPublicStaticMethod<T extends privateClass>(): void;
         private static myPrivateStaticMethod;
         myPublicMethod<T extends privateClass>(): void;
         private myPrivateMethod;
     }
-    class publicClassWithWithPublicTypeParameters {
+    export class publicClassWithWithPublicTypeParameters {
         static myPublicStaticMethod<T extends publicClass>(): void;
         private static myPrivateStaticMethod;
         myPublicMethod<T extends publicClass>(): void;
         private myPrivateMethod;
     }
-    function publicFunctionWithPrivateTypeParameters<T extends privateClass>(): void;
-    function publicFunctionWithPublicTypeParameters<T extends publicClass>(): void;
-    interface publicInterfaceWithPublicTypeParametersWithoutExtends {
+    export function publicFunctionWithPrivateTypeParameters<T extends privateClass>(): void;
+    export function publicFunctionWithPublicTypeParameters<T extends publicClass>(): void;
+    export interface publicInterfaceWithPublicTypeParametersWithoutExtends {
         new <T>(): publicClass;
         <T>(): publicClass;
         myMethod<T>(): publicClass;
     }
-    class publicClassWithWithPublicTypeParametersWithoutExtends {
+    export class publicClassWithWithPublicTypeParametersWithoutExtends {
         static myPublicStaticMethod<T>(): void;
         private static myPrivateStaticMethod;
         myPublicMethod<T>(): void;
         private myPrivateMethod;
     }
-    function publicFunctionWithPublicTypeParametersWithoutExtends<T>(): void;
+    export function publicFunctionWithPublicTypeParametersWithoutExtends<T>(): void;
+    export {};
 }
 export {};

--- a/tests/baselines/reference/privacyTypeParametersOfClassDeclFile.js
+++ b/tests/baselines/reference/privacyTypeParametersOfClassDeclFile.js
@@ -405,34 +405,36 @@ export declare class publicClassWithTypeParametersFromPrivateModule<T extends pr
 export declare module publicModule {
     class privateClassInPublicModule {
     }
-    class publicClassInPublicModule {
+    export class publicClassInPublicModule {
     }
-    class publicClassWithPrivateTypeParameters<T extends privateClassInPublicModule> {
+    export class publicClassWithPrivateTypeParameters<T extends privateClassInPublicModule> {
         myMethod(val: T): T;
     }
-    class publicClassWithPublicTypeParameters<T extends publicClassInPublicModule> {
+    export class publicClassWithPublicTypeParameters<T extends publicClassInPublicModule> {
         myMethod(val: T): T;
     }
-    class publicClassWithPublicTypeParametersWithoutExtends<T> {
+    export class publicClassWithPublicTypeParametersWithoutExtends<T> {
         myMethod(val: T): T;
     }
-    class publicClassWithTypeParametersFromPrivateModule<T extends privateModule.publicClassInPrivateModule> {
+    export class publicClassWithTypeParametersFromPrivateModule<T extends privateModule.publicClassInPrivateModule> {
         myMethod(val: T): T;
     }
+    export {};
 }
 declare module privateModule {
     class privateClassInPrivateModule {
     }
-    class publicClassInPrivateModule {
+    export class publicClassInPrivateModule {
     }
-    class publicClassWithPrivateTypeParameters<T extends privateClassInPrivateModule> {
+    export class publicClassWithPrivateTypeParameters<T extends privateClassInPrivateModule> {
         myMethod(val: T): T;
     }
-    class publicClassWithPublicTypeParameters<T extends publicClassInPrivateModule> {
+    export class publicClassWithPublicTypeParameters<T extends publicClassInPrivateModule> {
         myMethod(val: T): T;
     }
-    class publicClassWithPublicTypeParametersWithoutExtends<T> {
+    export class publicClassWithPublicTypeParametersWithoutExtends<T> {
         myMethod(val: T): T;
     }
+    export {};
 }
 export {};

--- a/tests/baselines/reference/privacyTypeParametersOfInterfaceDeclFile.js
+++ b/tests/baselines/reference/privacyTypeParametersOfInterfaceDeclFile.js
@@ -301,13 +301,13 @@ export interface publicInterfaceWithPrivateModuleTypeParameterConstraints<T exte
 export declare module publicModule {
     class privateClassInPublicModule {
     }
-    class publicClassInPublicModule {
+    export class publicClassInPublicModule {
     }
     class privateClassInPublicModuleT<T> {
     }
-    class publicClassInPublicModuleT<T> {
+    export class publicClassInPublicModuleT<T> {
     }
-    interface publicInterfaceWithPrivateTypeParameters<T extends privateClassInPublicModule> {
+    export interface publicInterfaceWithPrivateTypeParameters<T extends privateClassInPublicModule> {
         myMethod(val: T): T;
         myMethod0(): publicClassInPublicModuleT<T>;
         myMethod1(): privateClassInPublicModuleT<privateClassInPublicModule>;
@@ -315,7 +315,7 @@ export declare module publicModule {
         myMethod3(): publicClassInPublicModuleT<privateClassInPublicModule>;
         myMethod4(): publicClassInPublicModuleT<publicClassInPublicModule>;
     }
-    interface publicInterfaceWithPublicTypeParameters<T extends publicClassInPublicModule> {
+    export interface publicInterfaceWithPublicTypeParameters<T extends publicClassInPublicModule> {
         myMethod(val: T): T;
         myMethod0(): publicClassInPublicModuleT<T>;
         myMethod1(): privateClassInPublicModuleT<privateClassInPublicModule>;
@@ -323,23 +323,24 @@ export declare module publicModule {
         myMethod3(): publicClassInPublicModuleT<privateClassInPublicModule>;
         myMethod4(): publicClassInPublicModuleT<publicClassInPublicModule>;
     }
-    interface publicInterfaceWithPublicTypeParametersWithoutExtends<T> {
+    export interface publicInterfaceWithPublicTypeParametersWithoutExtends<T> {
         myMethod(val: T): T;
         myMethod0(): publicClassInPublicModuleT<T>;
     }
-    interface publicInterfaceWithPrivateModuleTypeParameterConstraints<T extends privateModule.publicClassInPrivateModule> {
+    export interface publicInterfaceWithPrivateModuleTypeParameterConstraints<T extends privateModule.publicClassInPrivateModule> {
     }
+    export {};
 }
 declare module privateModule {
     class privateClassInPrivateModule {
     }
-    class publicClassInPrivateModule {
+    export class publicClassInPrivateModule {
     }
     class privateClassInPrivateModuleT<T> {
     }
-    class publicClassInPrivateModuleT<T> {
+    export class publicClassInPrivateModuleT<T> {
     }
-    interface publicInterfaceWithPrivateTypeParameters<T extends privateClassInPrivateModule> {
+    export interface publicInterfaceWithPrivateTypeParameters<T extends privateClassInPrivateModule> {
         myMethod(val: T): T;
         myMethod0(): publicClassInPrivateModuleT<T>;
         myMethod1(): privateClassInPrivateModuleT<privateClassInPrivateModule>;
@@ -347,7 +348,7 @@ declare module privateModule {
         myMethod3(): publicClassInPrivateModuleT<privateClassInPrivateModule>;
         myMethod4(): publicClassInPrivateModuleT<publicClassInPrivateModule>;
     }
-    interface publicInterfaceWithPublicTypeParameters<T extends publicClassInPrivateModule> {
+    export interface publicInterfaceWithPublicTypeParameters<T extends publicClassInPrivateModule> {
         myMethod(val: T): T;
         myMethod0(): publicClassInPrivateModuleT<T>;
         myMethod1(): privateClassInPrivateModuleT<privateClassInPrivateModule>;
@@ -355,9 +356,10 @@ declare module privateModule {
         myMethod3(): publicClassInPrivateModuleT<privateClassInPrivateModule>;
         myMethod4(): publicClassInPrivateModuleT<publicClassInPrivateModule>;
     }
-    interface publicInterfaceWithPublicTypeParametersWithoutExtends<T> {
+    export interface publicInterfaceWithPublicTypeParametersWithoutExtends<T> {
         myMethod(val: T): T;
         myMethod0(): publicClassInPrivateModuleT<T>;
     }
+    export {};
 }
 export {};

--- a/tests/baselines/reference/privacyVarDeclFile.js
+++ b/tests/baselines/reference/privacyVarDeclFile.js
@@ -727,76 +727,78 @@ export declare var publicAmbientVarWithPrivateModulePropertyTypes: privateModule
 export declare module publicModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    interface publicInterfaceWithPrivatePropertyTypes {
+    export interface publicInterfaceWithPrivatePropertyTypes {
         myProperty: privateClass;
     }
-    interface publicInterfaceWithPublicPropertyTypes {
+    export interface publicInterfaceWithPublicPropertyTypes {
         myProperty: publicClass;
     }
-    class publicClassWithWithPrivatePropertyTypes {
+    export class publicClassWithWithPrivatePropertyTypes {
         static myPublicStaticProperty: privateClass;
         private static myPrivateStaticProperty;
         myPublicProperty: privateClass;
         private myPrivateProperty;
     }
-    class publicClassWithWithPublicPropertyTypes {
+    export class publicClassWithWithPublicPropertyTypes {
         static myPublicStaticProperty: publicClass;
         private static myPrivateStaticProperty;
         myPublicProperty: publicClass;
         private myPrivateProperty;
     }
-    var publicVarWithPrivatePropertyTypes: privateClass;
-    var publicVarWithPublicPropertyTypes: publicClass;
-    var publicAmbientVarWithPrivatePropertyTypes: privateClass;
-    var publicAmbientVarWithPublicPropertyTypes: publicClass;
-    interface publicInterfaceWithPrivateModulePropertyTypes {
+    export var publicVarWithPrivatePropertyTypes: privateClass;
+    export var publicVarWithPublicPropertyTypes: publicClass;
+    export var publicAmbientVarWithPrivatePropertyTypes: privateClass;
+    export var publicAmbientVarWithPublicPropertyTypes: publicClass;
+    export interface publicInterfaceWithPrivateModulePropertyTypes {
         myProperty: privateModule.publicClass;
     }
-    class publicClassWithPrivateModulePropertyTypes {
+    export class publicClassWithPrivateModulePropertyTypes {
         static myPublicStaticProperty: privateModule.publicClass;
         myPublicProperty: privateModule.publicClass;
     }
-    var publicVarWithPrivateModulePropertyTypes: privateModule.publicClass;
-    var publicAmbientVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+    export var publicVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+    export var publicAmbientVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+    export {};
 }
 declare module privateModule {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
-    interface publicInterfaceWithPrivatePropertyTypes {
+    export interface publicInterfaceWithPrivatePropertyTypes {
         myProperty: privateClass;
     }
-    interface publicInterfaceWithPublicPropertyTypes {
+    export interface publicInterfaceWithPublicPropertyTypes {
         myProperty: publicClass;
     }
-    class publicClassWithWithPrivatePropertyTypes {
+    export class publicClassWithWithPrivatePropertyTypes {
         static myPublicStaticProperty: privateClass;
         private static myPrivateStaticProperty;
         myPublicProperty: privateClass;
         private myPrivateProperty;
     }
-    class publicClassWithWithPublicPropertyTypes {
+    export class publicClassWithWithPublicPropertyTypes {
         static myPublicStaticProperty: publicClass;
         private static myPrivateStaticProperty;
         myPublicProperty: publicClass;
         private myPrivateProperty;
     }
-    var publicVarWithPrivatePropertyTypes: privateClass;
-    var publicVarWithPublicPropertyTypes: publicClass;
-    var publicAmbientVarWithPrivatePropertyTypes: privateClass;
-    var publicAmbientVarWithPublicPropertyTypes: publicClass;
-    interface publicInterfaceWithPrivateModulePropertyTypes {
+    export var publicVarWithPrivatePropertyTypes: privateClass;
+    export var publicVarWithPublicPropertyTypes: publicClass;
+    export var publicAmbientVarWithPrivatePropertyTypes: privateClass;
+    export var publicAmbientVarWithPublicPropertyTypes: publicClass;
+    export interface publicInterfaceWithPrivateModulePropertyTypes {
         myProperty: privateModule.publicClass;
     }
-    class publicClassWithPrivateModulePropertyTypes {
+    export class publicClassWithPrivateModulePropertyTypes {
         static myPublicStaticProperty: privateModule.publicClass;
         myPublicProperty: privateModule.publicClass;
     }
-    var publicVarWithPrivateModulePropertyTypes: privateModule.publicClass;
-    var publicAmbientVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+    export var publicVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+    export var publicAmbientVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+    export {};
 }
 export {};
 //// [privacyVarDeclFile_GlobalFile.d.ts]
@@ -816,74 +818,76 @@ declare var publicAmbientVarWithPublicPropertyTypesInGlobal: publicClassInGlobal
 declare module publicModuleInGlobal {
     class privateClass {
     }
-    class publicClass {
+    export class publicClass {
     }
     module privateModule {
         class privateClass {
         }
-        class publicClass {
+        export class publicClass {
         }
-        interface publicInterfaceWithPrivatePropertyTypes {
+        export interface publicInterfaceWithPrivatePropertyTypes {
             myProperty: privateClass;
         }
-        interface publicInterfaceWithPublicPropertyTypes {
+        export interface publicInterfaceWithPublicPropertyTypes {
             myProperty: publicClass;
         }
-        class publicClassWithWithPrivatePropertyTypes {
+        export class publicClassWithWithPrivatePropertyTypes {
             static myPublicStaticProperty: privateClass;
             private static myPrivateStaticProperty;
             myPublicProperty: privateClass;
             private myPrivateProperty;
         }
-        class publicClassWithWithPublicPropertyTypes {
+        export class publicClassWithWithPublicPropertyTypes {
             static myPublicStaticProperty: publicClass;
             private static myPrivateStaticProperty;
             myPublicProperty: publicClass;
             private myPrivateProperty;
         }
-        var publicVarWithPrivatePropertyTypes: privateClass;
-        var publicVarWithPublicPropertyTypes: publicClass;
-        var publicAmbientVarWithPrivatePropertyTypes: privateClass;
-        var publicAmbientVarWithPublicPropertyTypes: publicClass;
-        interface publicInterfaceWithPrivateModulePropertyTypes {
+        export var publicVarWithPrivatePropertyTypes: privateClass;
+        export var publicVarWithPublicPropertyTypes: publicClass;
+        export var publicAmbientVarWithPrivatePropertyTypes: privateClass;
+        export var publicAmbientVarWithPublicPropertyTypes: publicClass;
+        export interface publicInterfaceWithPrivateModulePropertyTypes {
             myProperty: privateModule.publicClass;
         }
-        class publicClassWithPrivateModulePropertyTypes {
+        export class publicClassWithPrivateModulePropertyTypes {
             static myPublicStaticProperty: privateModule.publicClass;
             myPublicProperty: privateModule.publicClass;
         }
-        var publicVarWithPrivateModulePropertyTypes: privateModule.publicClass;
-        var publicAmbientVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+        export var publicVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+        export var publicAmbientVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+        export {};
     }
-    interface publicInterfaceWithPrivatePropertyTypes {
+    export interface publicInterfaceWithPrivatePropertyTypes {
         myProperty: privateClass;
     }
-    interface publicInterfaceWithPublicPropertyTypes {
+    export interface publicInterfaceWithPublicPropertyTypes {
         myProperty: publicClass;
     }
-    class publicClassWithWithPrivatePropertyTypes {
+    export class publicClassWithWithPrivatePropertyTypes {
         static myPublicStaticProperty: privateClass;
         private static myPrivateStaticProperty;
         myPublicProperty: privateClass;
         private myPrivateProperty;
     }
-    class publicClassWithWithPublicPropertyTypes {
+    export class publicClassWithWithPublicPropertyTypes {
         static myPublicStaticProperty: publicClass;
         private static myPrivateStaticProperty;
         myPublicProperty: publicClass;
         private myPrivateProperty;
     }
-    var publicVarWithPrivatePropertyTypes: privateClass;
-    var publicVarWithPublicPropertyTypes: publicClass;
-    var publicAmbientVarWithPrivatePropertyTypes: privateClass;
-    var publicAmbientVarWithPublicPropertyTypes: publicClass;
-    interface publicInterfaceWithPrivateModulePropertyTypes {
+    export var publicVarWithPrivatePropertyTypes: privateClass;
+    export var publicVarWithPublicPropertyTypes: publicClass;
+    export var publicAmbientVarWithPrivatePropertyTypes: privateClass;
+    export var publicAmbientVarWithPublicPropertyTypes: publicClass;
+    export interface publicInterfaceWithPrivateModulePropertyTypes {
         myProperty: privateModule.publicClass;
     }
-    class publicClassWithPrivateModulePropertyTypes {
+    export class publicClassWithPrivateModulePropertyTypes {
         static myPublicStaticProperty: privateModule.publicClass;
         myPublicProperty: privateModule.publicClass;
     }
-    var publicVarWithPrivateModulePropertyTypes: privateModule.publicClass;
-    var publicAmbientVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+    export var publicVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+    export var publicAmbientVarWithPrivateModulePropertyTypes: privateModule.publicClass;
+    export {};
 }

--- a/tests/baselines/reference/symbolDeclarationEmit12.js
+++ b/tests/baselines/reference/symbolDeclarationEmit12.js
@@ -31,11 +31,12 @@ var M;
 declare module M {
     interface I {
     }
-    class C {
+    export class C {
         [Symbol.iterator]: I;
         [Symbol.toPrimitive](x: I): void;
         [Symbol.isConcatSpreadable](): I;
         readonly [Symbol.toPrimitive]: any;
         [Symbol.toPrimitive]: I;
     }
+    export {};
 }

--- a/tests/baselines/reference/typeFromPropertyAssignment29.js
+++ b/tests/baselines/reference/typeFromPropertyAssignment29.js
@@ -219,7 +219,8 @@ declare namespace Ns {
     namespace ExpandoNamespace {
         var p6: number;
     }
-    function foo(): typeof ExpandoNamespace;
+    export function foo(): typeof ExpandoNamespace;
+    export {};
 }
 declare var ExpandoExpr2: (n: number) => string;
 declare var n: number;

--- a/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
+++ b/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
@@ -1,0 +1,14 @@
+// @declaration: true
+namespace X {
+    interface A {
+        kind: 'a';
+    }
+
+    interface B {
+        kind: 'b';
+    }
+
+    export type C = A | B;
+}
+
+export = X;


### PR DESCRIPTION
So that it emits `export {};` to retain privates, just like the top-level does.

Fixes #31487
