### PR TITLE
When checking sourceFile is from external library, use sourceFile.resolvedPath since thats how the source files are queried and thats the real path

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1395,7 +1395,7 @@ namespace ts {
                 const filePath = newSourceFile.path;
                 addFileToFilesByName(newSourceFile, filePath, newSourceFile.resolvedPath);
                 // Set the file as found during node modules search if it was found that way in old progra,
-                if (oldProgram.isSourceFileFromExternalLibrary(oldProgram.getSourceFileByPath(filePath)!)) {
+                if (oldProgram.isSourceFileFromExternalLibrary(oldProgram.getSourceFileByPath(newSourceFile.resolvedPath)!)) {
                     sourceFilesFoundSearchingNodeModules.set(filePath, true);
                 }
             }


### PR DESCRIPTION
Fixes #32086
