### PR TITLE
Use only immediately preceding JSDoc

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2201,13 +2201,13 @@ namespace ts {
         let result: (JSDoc | JSDocTag)[] | undefined;
         // Pull parameter comments from declaring function as well
         if (isVariableLike(hostNode) && hasInitializer(hostNode) && hasJSDocNodes(hostNode.initializer!)) {
-            result = addRange(result, (hostNode.initializer as HasJSDoc).jsDoc!);
+            result = append(result, last((hostNode.initializer as HasJSDoc).jsDoc!));
         }
 
         let node: Node | undefined = hostNode;
         while (node && node.parent) {
             if (hasJSDocNodes(node)) {
-                result = addRange(result, node.jsDoc!);
+                result = append(result, last(node.jsDoc!));
             }
 
             if (node.kind === SyntaxKind.Parameter) {

--- a/tests/baselines/reference/syntaxErrors.symbols
+++ b/tests/baselines/reference/syntaxErrors.symbols
@@ -17,12 +17,8 @@ function f(x, y, skipped) {
 >skipped : Symbol(skipped, Decl(badTypeArguments.js, 4, 16))
 
     return x.t + y.t;
->x.t : Symbol(C.t, Decl(dummyType.d.ts, 0, 20))
 >x : Symbol(x, Decl(badTypeArguments.js, 4, 11))
->t : Symbol(C.t, Decl(dummyType.d.ts, 0, 20))
->y.t : Symbol(C.t, Decl(dummyType.d.ts, 0, 20))
 >y : Symbol(y, Decl(badTypeArguments.js, 4, 13))
->t : Symbol(C.t, Decl(dummyType.d.ts, 0, 20))
 }
 var x = f({ t: 1000 }, { t: 3000 }, { t: 5000 });
 >x : Symbol(x, Decl(badTypeArguments.js, 7, 3))

--- a/tests/baselines/reference/syntaxErrors.types
+++ b/tests/baselines/reference/syntaxErrors.types
@@ -9,24 +9,24 @@ declare class C<T> { t: T }
 // @ts-ignore
 /** @param {C.<number,>} skipped */
 function f(x, y, skipped) {
->f : (x: C<any>, y: C<number>, skipped: C<number>) => any
->x : C<any>
->y : C<number>
+>f : (x: any, y: any, skipped: C<number>) => any
+>x : any
+>y : any
 >skipped : C<number>
 
     return x.t + y.t;
 >x.t + y.t : any
 >x.t : any
->x : C<any>
+>x : any
 >t : any
->y.t : number
->y : C<number>
->t : number
+>y.t : any
+>y : any
+>t : any
 }
 var x = f({ t: 1000 }, { t: 3000 }, { t: 5000 });
 >x : any
 >f({ t: 1000 }, { t: 3000 }, { t: 5000 }) : any
->f : (x: C<any>, y: C<number>, skipped: C<number>) => any
+>f : (x: any, y: any, skipped: C<number>) => any
 >{ t: 1000 } : { t: number; }
 >t : number
 >1000 : 1000

--- a/tests/cases/fourslash/commentsCommentParsing.ts
+++ b/tests/cases/fourslash/commentsCommentParsing.ts
@@ -26,7 +26,7 @@
 ////}
 ////jsDocM/*4q*/ultiLine(/*4*/);
 ////
-/////** this is multiple line jsdoc stule comment
+/////** multiple line jsdoc comments no longer merge
 ////*New line1
 ////*New Line2*/
 /////** Shoul mege this line as well
@@ -99,13 +99,13 @@
 ////    return /*18*/a + b;
 ////}
 /////*15*/s/*16q*/um(/*16*/10, /*17*/20);
-/////** This is multiplication function*/
-/////** @param */
-/////** @param a first number*/
-/////** @param b */
-/////** @param c {
-//// @param d @anotherTag*/
-/////** @param e LastParam @anotherTag*/
+/////** This is multiplication function
+//// * @param 
+//// * @param a first number
+//// * @param b
+//// * @param c {
+//// @param d @anotherTag
+//// * @param e LastParam @anotherTag*/
 ////function multiply(/*19aq*/a: number, /*20aq*/b: number, /*21aq*/c?: number, /*22aq*/d?, /*23aq*/e?) {
 ////}
 ////mult/*19q*/iply(/*19*/10,/*20*/ 20,/*21*/ 30, /*22*/40, /*23*/50);
@@ -214,26 +214,26 @@ verify.quickInfoAt("3q", "function jsDocSingleLine(): void", "this is eg of sing
 verify.signatureHelp({ marker: "4", docComment: "this is multiple line jsdoc stule comment\nNew line1\nNew Line2" });
 verify.quickInfoAt("4q", "function jsDocMultiLine(): void", "this is multiple line jsdoc stule comment\nNew line1\nNew Line2");
 
-verify.signatureHelp({ marker: "5", docComment: "this is multiple line jsdoc stule comment\nNew line1\nNew Line2\nShoul mege this line as well\nand this too\nAnother this one too" });
-verify.quickInfoAt("5q", "function jsDocMultiLineMerge(): void", "this is multiple line jsdoc stule comment\nNew line1\nNew Line2\nShoul mege this line as well\nand this too\nAnother this one too");
+verify.signatureHelp({ marker: "5", docComment: "Another this one too" });
+verify.quickInfoAt("5q", "function jsDocMultiLineMerge(): void", "Another this one too");
 
 verify.signatureHelp({ marker: "6", docComment: "jsdoc comment" });
 verify.quickInfoAt("6q", "function jsDocMixedComments1(): void", "jsdoc comment");
 
-verify.signatureHelp({ marker: "7", docComment: "jsdoc comment\nanother jsDocComment" });
-verify.quickInfoAt("7q", "function jsDocMixedComments2(): void", "jsdoc comment\nanother jsDocComment");
+verify.signatureHelp({ marker: "7", docComment: "another jsDocComment" });
+verify.quickInfoAt("7q", "function jsDocMixedComments2(): void", "another jsDocComment");
 
-verify.signatureHelp({ marker: "8", docComment: "jsdoc comment\n* triplestar jsDocComment" });
-verify.quickInfoAt("8q", "function jsDocMixedComments3(): void", "jsdoc comment\n* triplestar jsDocComment");
+verify.signatureHelp({ marker: "8", docComment: "* triplestar jsDocComment" });
+verify.quickInfoAt("8q", "function jsDocMixedComments3(): void", "* triplestar jsDocComment");
 
-verify.signatureHelp({ marker: "9", docComment: "jsdoc comment\nanother jsDocComment" });
-verify.quickInfoAt("9q", "function jsDocMixedComments4(): void", "jsdoc comment\nanother jsDocComment");
+verify.signatureHelp({ marker: "9", docComment: "another jsDocComment" });
+verify.quickInfoAt("9q", "function jsDocMixedComments4(): void", "another jsDocComment");
 
-verify.signatureHelp({ marker: "10", docComment: "jsdoc comment\nanother jsDocComment" });
-verify.quickInfoAt("10q", "function jsDocMixedComments5(): void", "jsdoc comment\nanother jsDocComment");
+verify.signatureHelp({ marker: "10", docComment: "another jsDocComment" });
+verify.quickInfoAt("10q", "function jsDocMixedComments5(): void", "another jsDocComment");
 
-verify.signatureHelp({ marker: "11", docComment: "another jsDocComment\njsdoc comment" });
-verify.quickInfoAt("11q", "function jsDocMixedComments6(): void", "another jsDocComment\njsdoc comment");
+verify.signatureHelp({ marker: "11", docComment: "jsdoc comment" });
+verify.quickInfoAt("11q", "function jsDocMixedComments6(): void", "jsdoc comment");
 
 verify.signatureHelp({ marker: "12", docComment: "" });
 verify.quickInfoAt("12q", "function noHelpComment1(): void");

--- a/tests/cases/fourslash/server/jsdocCallbackTag.ts
+++ b/tests/cases/fourslash/server/jsdocCallbackTag.ts
@@ -37,18 +37,15 @@ verify.signatureHelp({
     marker: '4',
     text: "t(eventName: string, eventName2: string | number, eventName3: any): number",
     parameterDocComment: "- So many words",
-    tags: [{ name: "callback", text: "FooHandler - A kind of magic" },
-           { name: "type", text: "{FooHandler} callback" }]
+    tags: [{ name: "type", text: "{FooHandler} callback" }]
 });
 verify.signatureHelp({
     marker: '5',
     parameterDocComment: "- Silence is golden",
-    tags: [{ name: "callback", text: "FooHandler - A kind of magic" },
-           { name: "type", text: "{FooHandler} callback" }]
+    tags: [{ name: "type", text: "{FooHandler} callback" }]
 });
 verify.signatureHelp({
     marker: '6',
     parameterDocComment: "- Osterreich mos def",
-    tags: [{ name: "callback", text: "FooHandler - A kind of magic" },
-           { name: "type", text: "{FooHandler} callback" }]
+    tags: [{ name: "type", text: "{FooHandler} callback" }]
 });


### PR DESCRIPTION
Now only the immediately preceding jsdoc of a node is retrieved by getJSDoc, although it still does the correct non-local lookup for nodes like ParameterDeclaration.

This doesn't change parsing or binding, which use the per-node Node.jsdoc property directly. But it does change everything that relies on getJSDoc, which includes the checker and language service.

Fixes #32062, which contains the analysis that justifies the change.