### PR TITLE
Update setTimeout and setInterval signatures

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -17144,8 +17144,10 @@ interface WindowOrWorkerGlobalScope {
     createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number): Promise<ImageBitmap>;
     fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
     queueMicrotask(callback: Function): void;
-    setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-    setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
+    setInterval<A extends any[]>(handler: (...args: A) => void, timeout?: number, ...arguments: A): number;
+    setInterval(handler: string, timeout?: number, ...arguments: any[]): number;
+    setTimeout<A extends any[]>(handler: (...args: A) => void, timeout?: number, ...arguments: A): number;
+    setTimeout(handler: string, timeout?: number, ...arguments: any[]): number;
 }
 
 interface WindowSessionStorage {
@@ -18232,8 +18234,10 @@ declare function createImageBitmap(image: ImageBitmapSource): Promise<ImageBitma
 declare function createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number): Promise<ImageBitmap>;
 declare function fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
 declare function queueMicrotask(callback: Function): void;
-declare function setInterval(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
-declare function setTimeout(handler: TimerHandler, timeout?: number, ...arguments: any[]): number;
+declare function setInterval<A extends any[]>(handler: (...args: A) => void, timeout?: number, ...arguments: A): number;
+declare function setInterval(handler: string, timeout?: number, ...arguments: any[]): number;
+declare function setTimeout<A extends any[]>(handler: (...args: A) => void, timeout?: number, ...arguments: A): number;
+declare function setTimeout(handler: string, timeout?: number, ...arguments: any[]): number;
 declare var sessionStorage: Storage;
 declare var localStorage: Storage;
 declare var onafterprint: ((this: Window, ev: Event) => any) | null;


### PR DESCRIPTION
#32186 
The original signatures of `setTimeout` and `setInterval` may allow wrongly typed additional parameters passed to handler function.
This update fixes the issue without introducing any other changes
With this update, typescript can correctly reject wrongly typed additional parameters.

@fatcerberus is the author of the `setTimeout` signaure.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
