### PR TITLE
Elide the exact node version rush complains about from the docker output

### DIFF
--- a/src/testRunner/externalCompileRunner.ts
+++ b/src/testRunner/externalCompileRunner.ts
@@ -201,7 +201,7 @@ function sanitizeTimestamps(result: string): string {
 function sanitizeVersionSpecifiers(result: string): string {
     return result
         .replace(/\d+.\d+.\d+-insiders.\d\d\d\d\d\d\d\d/g, "X.X.X-insiders.xxxxxxxx")
-        .replace(/([@v])\d+\.\d+\.\d+/g, "$1X.X.X");
+        .replace(/([@v\()])\d+\.\d+\.\d+/g, "$1X.X.X");
 }
 
 /**

--- a/tests/baselines/reference/docker/azure-sdk.log
+++ b/tests/baselines/reference/docker/azure-sdk.log
@@ -82,7 +82,7 @@ rush rebuild - Errors! ( ? seconds)
 
 
 Standard error:
-Your version of Node.js (12.4.0) has not been tested with this release of Rush. The Rush team will not accept issue reports for it. Please consider upgrading Rush or downgrading Node.js.
+Your version of Node.js (X.X.X) has not been tested with this release of Rush. The Rush team will not accept issue reports for it. Please consider upgrading Rush or downgrading Node.js.
 XX of XX: [@azure/service-bus] completed with warnings in ? seconds
 XX of XX: [@azure/core-amqp] failed to build!
 XX of XX: [@azure/event-hubs] blocked by [@azure/core-amqp]!

--- a/tests/baselines/reference/docker/office-ui-fabric.log
+++ b/tests/baselines/reference/docker/office-ui-fabric.log
@@ -311,7 +311,7 @@ rush rebuild - Errors! ( ? seconds)
 
 
 Standard error:
-Your version of Node.js (12.4.0) has not been tested with this release of Rush. The Rush team will not accept issue reports for it. Please consider upgrading Rush or downgrading Node.js.
+Your version of Node.js (X.X.X) has not been tested with this release of Rush. The Rush team will not accept issue reports for it. Please consider upgrading Rush or downgrading Node.js.
 XX of XX: [@uifabric/codepen-loader] completed with warnings in ? seconds
 XX of XX: [@uifabric/set-version] completed with warnings in ? seconds
 XX of XX: [@uifabric/merge-styles] completed with warnings in ? seconds


### PR DESCRIPTION
Replaces the docker test changes from [here](https://github.com/microsoft/TypeScript/pull/32195/files) with a `X.X.X` so the test output is less sensitive to minor node releases.
