### PR TITLE
Improve error messages for potentially missing 'await'

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21453,6 +21453,10 @@ namespace ts {
 
             function maybeAddMissingAwaitInfo(errorNode: Node | undefined, source: Type, target: Type) {
                 if (errorNode && reportErrors && errorOutputContainer.errors && errorOutputContainer.errors.length) {
+                    // Bail if target is Promise-like---something else is wrong
+                    if (getAwaitedTypeOfPromise(target)) {
+                        return;
+                    }
                     const awaitedTypeOfSource = getAwaitedTypeOfPromise(source);
                     if (awaitedTypeOfSource && isTypeRelatedTo(awaitedTypeOfSource, target, relation)) {
                         addRelatedInfo(errorOutputContainer.errors[0], createDiagnosticForNode(errorNode, Diagnostics.Did_you_forget_to_use_await));

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24537,7 +24537,9 @@ namespace ts {
                 if (awaitedTypesAreCompatible) {
                     const awaitedLeftType = getAwaitedType(leftType);
                     const awaitedRightType = getAwaitedType(rightType);
-                    wouldWorkWithAwait = !!(awaitedLeftType && awaitedRightType) && awaitedTypesAreCompatible(awaitedLeftType, awaitedRightType);
+                    wouldWorkWithAwait = !(awaitedLeftType === leftType && awaitedRightType === rightType)
+                        && !!(awaitedLeftType && awaitedRightType)
+                        && awaitedTypesAreCompatible(awaitedLeftType, awaitedRightType);
                 }
 
                 if (!tryGiveBetterPrimaryError(errNode, wouldWorkWithAwait, leftStr, rightStr)) {
@@ -24558,11 +24560,11 @@ namespace ts {
                 switch (operatorToken.kind) {
                     case SyntaxKind.EqualsEqualsEqualsToken:
                     case SyntaxKind.EqualsEqualsToken:
-                        typeName = "true";
+                        typeName = "false";
                         break;
                     case SyntaxKind.ExclamationEqualsEqualsToken:
                     case SyntaxKind.ExclamationEqualsToken:
-                        typeName = "false";
+                        typeName = "true";
                 }
 
                 if (typeName) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22342,6 +22342,8 @@ namespace ts {
         function invocationErrorDetails(apparentType: Type, kind: SignatureKind): DiagnosticMessageChain {
             let errorInfo: DiagnosticMessageChain | undefined;
             const isCall = kind === SignatureKind.Call;
+            const awaitedType = getAwaitedType(apparentType);
+            const mightWorkWithAwait = awaitedType && getSignaturesOfType(awaitedType, kind).length > 0;
             if (apparentType.flags & TypeFlags.Union) {
                 const types = (apparentType as UnionType).types;
                 let hasSignatures = false;
@@ -22408,9 +22410,9 @@ namespace ts {
             }
             return chainDiagnosticMessages(
                 errorInfo,
-                isCall ?
-                    Diagnostics.This_expression_is_not_callable :
-                    Diagnostics.This_expression_is_not_constructable
+                mightWorkWithAwait
+                    ? isCall ? Diagnostics.This_expression_is_not_callable_Did_you_forget_to_use_await : Diagnostics.This_expression_is_not_constructable_Did_you_forget_to_use_await
+                    : isCall ? Diagnostics.This_expression_is_not_callable : Diagnostics.This_expression_is_not_constructable
             );
         }
         function invocationError(errorTarget: Node, apparentType: Type, kind: SignatureKind, relatedInformation?: DiagnosticRelatedInformation) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2655,7 +2655,8 @@
     },
     "Cannot iterate value because the 'next' method of its iterator expects type '{1}', but for-of will always send '{0}'.": {
         "category": "Error",
-        "code": 77   },
+        "code": 2673
+    },
     "Cannot iterate value because the 'next' method of its iterator expects type '{1}', but array spread will always send '{0}'.": {
         "category": "Error",
         "code": 2764
@@ -2692,73 +2693,9 @@
         "category": "Error",
         "code": 2772
     },
-    "Operator '{0}' cannot be applied to types '{1}' and '{2}'. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2773
-    },
-    "An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2774
-    },
-    "The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2775
-    },
-    "This expression is not callable. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2776
-    },
-    "This expression is not constructable. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2777
-    },
-    "The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2778
-    },
-    "Type '{0}' must have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2779
-    },
-    "Type '{0}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2780
-    },
-    "Type '{0}' is not an array type. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2781
-    },
-    "Type '{0}' is not an array type or a string type. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2782
-    },
-    "Type '{0}' is not an array type or does not have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2783
-    },
-    "Type '{0}' is not an array type or a string type or does not have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2784
-    },
-    "Argument of type '{0}' is not assignable to parameter of type '{1}'. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2785
-    },
-    "Type '{0}' has no call signatures. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2786
-    },
-    "Type '{0}' has no construct signatures. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2787
-    },
-    "This condition will always return '{0}' since the types '{1}' and '{2}' have no overlap. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2788
-    },
     "Did you forget to use 'await'?": {
         "category": "Error",
-        "code": 2789
+        "code": 2773
     },
 
     "Import declaration '{0}' is using private name '{1}'.": {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2655,8 +2655,7 @@
     },
     "Cannot iterate value because the 'next' method of its iterator expects type '{1}', but for-of will always send '{0}'.": {
         "category": "Error",
-        "code": 2763
-    },
+        "code": 77   },
     "Cannot iterate value because the 'next' method of its iterator expects type '{1}', but array spread will always send '{0}'.": {
         "category": "Error",
         "code": 2764

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2713,25 +2713,41 @@
         "category": "Error",
         "code": 2777
     },
-    "Type '{0}' is not an array type or a string type. Did you forget to use 'await'?": {
+    "Type '{0}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2778
     },
-    "Argument of type '{0}' is not assignable to parameter of type '{1}'. Did you forget to use 'await'?": {
+    "Type '{0}' is not an array type. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2779
     },
-    "Type '{0}' has no call signatures. Did you forget to use 'await'?": {
+    "Type '{0}' is not an array type or a string type. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2780
     },
-    "Type '{0}' has no construct signatures. Did you forget to use 'await'?": {
+    "Type '{0}' is not an array type or does not have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2781
     },
-    "This condition will always return '{0}' since the types '{1}' and '{2}' have no overlap. Did you forget to use 'await'?": {
+    "Type '{0}' is not an array type or a string type or does not have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2782
+    },
+    "Argument of type '{0}' is not assignable to parameter of type '{1}'. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2783
+    },
+    "Type '{0}' has no call signatures. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2784
+    },
+    "Type '{0}' has no construct signatures. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2785
+    },
+    "This condition will always return '{0}' since the types '{1}' and '{2}' have no overlap. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2786
     },
 
     "Import declaration '{0}' is using private name '{1}'.": {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2693,6 +2693,46 @@
         "category": "Error",
         "code": 2772
     },
+    "Operator '{0}' cannot be applied to types '{1}' and '{2}'. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2773
+    },
+    "An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2774
+    },
+    "The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2775
+    },
+    "The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2777
+    },
+    "Type '{0}' must have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2777
+    },
+    "Type '{0}' is not an array type or a string type. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2778
+    },
+    "Argument of type '{0}' is not assignable to parameter of type '{1}'. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2779
+    },
+    "Type '{0}' has no call signatures. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2780
+    },
+    "Type '{0}' has no construct signatures. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2781
+    },
+    "This condition will always return '{0}' since the types '{1}' and '{2}' have no overlap. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2782
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2705,49 +2705,57 @@
         "category": "Error",
         "code": 2775
     },
+    "This expression is not callable. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2776
+    },
+    "This expression is not constructable. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2777
+    },
     "The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2777
-    },
-    "Type '{0}' must have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
-        "category": "Error",
-        "code": 2777
-    },
-    "Type '{0}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2778
     },
-    "Type '{0}' is not an array type. Did you forget to use 'await'?": {
+    "Type '{0}' must have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2779
     },
-    "Type '{0}' is not an array type or a string type. Did you forget to use 'await'?": {
+    "Type '{0}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2780
     },
-    "Type '{0}' is not an array type or does not have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
+    "Type '{0}' is not an array type. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2781
     },
-    "Type '{0}' is not an array type or a string type or does not have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
+    "Type '{0}' is not an array type or a string type. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2782
     },
-    "Argument of type '{0}' is not assignable to parameter of type '{1}'. Did you forget to use 'await'?": {
+    "Type '{0}' is not an array type or does not have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2783
     },
-    "Type '{0}' has no call signatures. Did you forget to use 'await'?": {
+    "Type '{0}' is not an array type or a string type or does not have a '[Symbol.iterator]()' method that returns an iterator. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2784
     },
-    "Type '{0}' has no construct signatures. Did you forget to use 'await'?": {
+    "Argument of type '{0}' is not assignable to parameter of type '{1}'. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2785
     },
-    "This condition will always return '{0}' since the types '{1}' and '{2}' have no overlap. Did you forget to use 'await'?": {
+    "Type '{0}' has no call signatures. Did you forget to use 'await'?": {
         "category": "Error",
         "code": 2786
+    },
+    "Type '{0}' has no construct signatures. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2787
+    },
+    "This condition will always return '{0}' since the types '{1}' and '{2}' have no overlap. Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2788
     },
 
     "Import declaration '{0}' is using private name '{1}'.": {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2757,6 +2757,10 @@
         "category": "Error",
         "code": 2788
     },
+    "Did you forget to use 'await'?": {
+        "category": "Error",
+        "code": 2789
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2655,7 +2655,7 @@
     },
     "Cannot iterate value because the 'next' method of its iterator expects type '{1}', but for-of will always send '{0}'.": {
         "category": "Error",
-        "code": 2673
+        "code": 2763
     },
     "Cannot iterate value because the 'next' method of its iterator expects type '{1}', but array spread will always send '{0}'.": {
         "category": "Error",

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
@@ -1,21 +1,21 @@
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(11,9): error TS2766: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(12,5): error TS2765: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(13,5): error TS2763: Operator '+' cannot be applied to types 'number' and 'Promise<number>'. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(14,5): error TS2763: Operator '>' cannot be applied to types 'number' and 'Promise<number>'. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(15,5): error TS2764: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(16,7): error TS2764: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(17,5): error TS2776: This condition will always return 'false' since the types 'number' and 'Promise<number>' have no overlap. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(18,9): error TS2769: Type 'Promise<string[]>' is not an array type. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(19,21): error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(11,9): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(12,5): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(13,5): error TS2365: Operator '+' cannot be applied to types 'number' and 'Promise<number>'.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(14,5): error TS2365: Operator '>' cannot be applied to types 'number' and 'Promise<number>'.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(15,5): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(16,7): error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(17,5): error TS2367: This condition will always return 'false' since the types 'number' and 'Promise<number>' have no overlap.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(18,9): error TS2461: Type 'Promise<string[]>' is not an array type.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(19,21): error TS2495: Type 'Promise<string[]>' is not an array type or a string type.
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(20,12): error TS2345: Argument of type 'Promise<number>' is not assignable to parameter of type 'number'.
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(21,11): error TS2570: Property 'prop' does not exist on type 'Promise<{ prop: string; }>'. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(23,27): error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(24,5): error TS2774: This expression is not callable. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(23,27): error TS2495: Type 'Promise<string[]>' is not an array type or a string type.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(24,5): error TS2349: This expression is not callable.
   Type 'Promise<() => void>' has no call signatures.
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(25,5): error TS2774: This expression is not callable. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(25,5): error TS2349: This expression is not callable.
   Not all constituents of type 'Promise<() => void> | (() => void)' are callable.
     Type 'Promise<() => void>' has no call signatures.
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(26,9): error TS2775: This expression is not constructable. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(26,9): error TS2351: This expression is not constructable.
   Type 'Promise<new () => any>' has no construct signatures.
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(27,5): error TS2349: This expression is not callable.
   Type 'Promise<number>' has no call signatures.
@@ -34,55 +34,68 @@ tests/cases/compiler/operationsAvailableOnPromisedType.ts(27,5): error TS2349: T
         // All errors
         a | b;
             ~
-!!! error TS2766: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:11:9: Did you forget to use 'await'?
         b | a;
         ~
-!!! error TS2765: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:12:5: Did you forget to use 'await'?
         a + b;
         ~~~~~
-!!! error TS2763: Operator '+' cannot be applied to types 'number' and 'Promise<number>'. Did you forget to use 'await'?
+!!! error TS2365: Operator '+' cannot be applied to types 'number' and 'Promise<number>'.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:13:5: Did you forget to use 'await'?
         a > b;
         ~~~~~
-!!! error TS2763: Operator '>' cannot be applied to types 'number' and 'Promise<number>'. Did you forget to use 'await'?
+!!! error TS2365: Operator '>' cannot be applied to types 'number' and 'Promise<number>'.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:14:5: Did you forget to use 'await'?
         b++;
         ~
-!!! error TS2764: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:15:5: Did you forget to use 'await'?
         --b;
           ~
-!!! error TS2764: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:16:7: Did you forget to use 'await'?
         a === b;
         ~~~~~~~
-!!! error TS2776: This condition will always return 'false' since the types 'number' and 'Promise<number>' have no overlap. Did you forget to use 'await'?
+!!! error TS2367: This condition will always return 'false' since the types 'number' and 'Promise<number>' have no overlap.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:17:5: Did you forget to use 'await'?
         [...c];
             ~
-!!! error TS2769: Type 'Promise<string[]>' is not an array type. Did you forget to use 'await'?
+!!! error TS2461: Type 'Promise<string[]>' is not an array type.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:18:9: Did you forget to use 'await'?
         for (const s of c) {
                         ~
-!!! error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
+!!! error TS2495: Type 'Promise<string[]>' is not an array type or a string type.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:19:21: Did you forget to use 'await'?
             fn(b, b, c, d, e, f, g);
                ~
 !!! error TS2345: Argument of type 'Promise<number>' is not assignable to parameter of type 'number'.
-!!! related TS2777 tests/cases/compiler/operationsAvailableOnPromisedType.ts:20:12: Did you forget to use 'await'?
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:20:12: Did you forget to use 'await'?
             d.prop;
               ~~~~
 !!! error TS2570: Property 'prop' does not exist on type 'Promise<{ prop: string; }>'. Did you forget to use 'await'?
         }
         for await (const s of c) {}
                               ~
-!!! error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
+!!! error TS2495: Type 'Promise<string[]>' is not an array type or a string type.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:23:27: Did you forget to use 'await'?
         e();
         ~
-!!! error TS2774: This expression is not callable. Did you forget to use 'await'?
-!!! error TS2774:   Type 'Promise<() => void>' has no call signatures.
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Type 'Promise<() => void>' has no call signatures.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:24:5: Did you forget to use 'await'?
         f();
         ~
-!!! error TS2774: This expression is not callable. Did you forget to use 'await'?
-!!! error TS2774:   Not all constituents of type 'Promise<() => void> | (() => void)' are callable.
-!!! error TS2774:     Type 'Promise<() => void>' has no call signatures.
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Not all constituents of type 'Promise<() => void> | (() => void)' are callable.
+!!! error TS2349:     Type 'Promise<() => void>' has no call signatures.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:25:5: Did you forget to use 'await'?
         new g();
             ~
-!!! error TS2775: This expression is not constructable. Did you forget to use 'await'?
-!!! error TS2775:   Type 'Promise<new () => any>' has no construct signatures.
+!!! error TS2351: This expression is not constructable.
+!!! error TS2351:   Type 'Promise<new () => any>' has no construct signatures.
+!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:26:9: Did you forget to use 'await'?
         b();
         ~
 !!! error TS2349: This expression is not callable.

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
@@ -1,0 +1,91 @@
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(11,9): error TS2766: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(12,5): error TS2765: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(13,5): error TS2763: Operator '+' cannot be applied to types 'number' and 'Promise<number>'. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(14,5): error TS2763: Operator '>' cannot be applied to types 'number' and 'Promise<number>'. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(15,5): error TS2764: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(16,7): error TS2764: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(17,5): error TS2776: This condition will always return 'false' since the types 'number' and 'Promise<number>' have no overlap. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(18,9): error TS2769: Type 'Promise<string[]>' is not an array type. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(19,21): error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(20,9): error TS2554: Expected 7 arguments, but got 4.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(21,11): error TS2570: Property 'prop' does not exist on type 'Promise<{ prop: string; }>'. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(23,27): error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(24,5): error TS2774: This expression is not callable. Did you forget to use 'await'?
+  Type 'Promise<() => void>' has no call signatures.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(25,5): error TS2774: This expression is not callable. Did you forget to use 'await'?
+  Not all constituents of type 'Promise<() => void> | (() => void)' are callable.
+    Type 'Promise<() => void>' has no call signatures.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(26,9): error TS2775: This expression is not constructable. Did you forget to use 'await'?
+  Type 'Promise<new () => any>' has no construct signatures.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(27,5): error TS2349: This expression is not callable.
+  Type 'Promise<number>' has no call signatures.
+
+
+==== tests/cases/compiler/operationsAvailableOnPromisedType.ts (16 errors) ====
+    async function fn(
+        a: number,
+        b: Promise<number>,
+        c: Promise<string[]>,
+        d: Promise<{ prop: string }>,
+        e: Promise<() => void>,
+        f: Promise<() => void> | (() => void),
+        g: Promise<{ new(): any }>
+    ) {
+        // All errors
+        a | b;
+            ~
+!!! error TS2766: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+        b | a;
+        ~
+!!! error TS2765: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+        a + b;
+        ~~~~~
+!!! error TS2763: Operator '+' cannot be applied to types 'number' and 'Promise<number>'. Did you forget to use 'await'?
+        a > b;
+        ~~~~~
+!!! error TS2763: Operator '>' cannot be applied to types 'number' and 'Promise<number>'. Did you forget to use 'await'?
+        b++;
+        ~
+!!! error TS2764: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+        --b;
+          ~
+!!! error TS2764: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type. Did you forget to use 'await'?
+        a === b;
+        ~~~~~~~
+!!! error TS2776: This condition will always return 'false' since the types 'number' and 'Promise<number>' have no overlap. Did you forget to use 'await'?
+        [...c];
+            ~
+!!! error TS2769: Type 'Promise<string[]>' is not an array type. Did you forget to use 'await'?
+        for (const s of c) {
+                        ~
+!!! error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
+            fn(b, b, c, d);
+            ~~~~~~~~~~~~~~
+!!! error TS2554: Expected 7 arguments, but got 4.
+!!! related TS6210 tests/cases/compiler/operationsAvailableOnPromisedType.ts:6:5: An argument for 'e' was not provided.
+            d.prop;
+              ~~~~
+!!! error TS2570: Property 'prop' does not exist on type 'Promise<{ prop: string; }>'. Did you forget to use 'await'?
+        }
+        for await (const s of c) {}
+                              ~
+!!! error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
+        e();
+        ~
+!!! error TS2774: This expression is not callable. Did you forget to use 'await'?
+!!! error TS2774:   Type 'Promise<() => void>' has no call signatures.
+        f();
+        ~
+!!! error TS2774: This expression is not callable. Did you forget to use 'await'?
+!!! error TS2774:   Not all constituents of type 'Promise<() => void> | (() => void)' are callable.
+!!! error TS2774:     Type 'Promise<() => void>' has no call signatures.
+        new g();
+            ~
+!!! error TS2775: This expression is not constructable. Did you forget to use 'await'?
+!!! error TS2775:   Type 'Promise<new () => any>' has no construct signatures.
+        b();
+        ~
+!!! error TS2349: This expression is not callable.
+!!! error TS2349:   Type 'Promise<number>' has no call signatures.
+    }
+    

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
@@ -35,43 +35,43 @@ tests/cases/compiler/operationsAvailableOnPromisedType.ts(27,5): error TS2349: T
         a | b;
             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:11:9: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:11:9: Did you forget to use 'await'?
         b | a;
         ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:12:5: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:12:5: Did you forget to use 'await'?
         a + b;
         ~~~~~
 !!! error TS2365: Operator '+' cannot be applied to types 'number' and 'Promise<number>'.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:13:5: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:13:5: Did you forget to use 'await'?
         a > b;
         ~~~~~
 !!! error TS2365: Operator '>' cannot be applied to types 'number' and 'Promise<number>'.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:14:5: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:14:5: Did you forget to use 'await'?
         b++;
         ~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:15:5: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:15:5: Did you forget to use 'await'?
         --b;
           ~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:16:7: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:16:7: Did you forget to use 'await'?
         a === b;
         ~~~~~~~
 !!! error TS2367: This condition will always return 'false' since the types 'number' and 'Promise<number>' have no overlap.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:17:5: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:17:5: Did you forget to use 'await'?
         [...c];
             ~
 !!! error TS2461: Type 'Promise<string[]>' is not an array type.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:18:9: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:18:9: Did you forget to use 'await'?
         for (const s of c) {
                         ~
 !!! error TS2495: Type 'Promise<string[]>' is not an array type or a string type.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:19:21: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:19:21: Did you forget to use 'await'?
             fn(b, b, c, d, e, f, g);
                ~
 !!! error TS2345: Argument of type 'Promise<number>' is not assignable to parameter of type 'number'.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:20:12: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:20:12: Did you forget to use 'await'?
             d.prop;
               ~~~~
 !!! error TS2570: Property 'prop' does not exist on type 'Promise<{ prop: string; }>'. Did you forget to use 'await'?
@@ -79,23 +79,23 @@ tests/cases/compiler/operationsAvailableOnPromisedType.ts(27,5): error TS2349: T
         for await (const s of c) {}
                               ~
 !!! error TS2495: Type 'Promise<string[]>' is not an array type or a string type.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:23:27: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:23:27: Did you forget to use 'await'?
         e();
         ~
 !!! error TS2349: This expression is not callable.
 !!! error TS2349:   Type 'Promise<() => void>' has no call signatures.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:24:5: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:24:5: Did you forget to use 'await'?
         f();
         ~
 !!! error TS2349: This expression is not callable.
 !!! error TS2349:   Not all constituents of type 'Promise<() => void> | (() => void)' are callable.
 !!! error TS2349:     Type 'Promise<() => void>' has no call signatures.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:25:5: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:25:5: Did you forget to use 'await'?
         new g();
             ~
 !!! error TS2351: This expression is not constructable.
 !!! error TS2351:   Type 'Promise<new () => any>' has no construct signatures.
-!!! related TS2763 tests/cases/compiler/operationsAvailableOnPromisedType.ts:26:9: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:26:9: Did you forget to use 'await'?
         b();
         ~
 !!! error TS2349: This expression is not callable.

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
@@ -7,7 +7,7 @@ tests/cases/compiler/operationsAvailableOnPromisedType.ts(16,7): error TS2764: A
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(17,5): error TS2776: This condition will always return 'false' since the types 'number' and 'Promise<number>' have no overlap. Did you forget to use 'await'?
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(18,9): error TS2769: Type 'Promise<string[]>' is not an array type. Did you forget to use 'await'?
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(19,21): error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
-tests/cases/compiler/operationsAvailableOnPromisedType.ts(20,9): error TS2554: Expected 7 arguments, but got 4.
+tests/cases/compiler/operationsAvailableOnPromisedType.ts(20,12): error TS2345: Argument of type 'Promise<number>' is not assignable to parameter of type 'number'.
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(21,11): error TS2570: Property 'prop' does not exist on type 'Promise<{ prop: string; }>'. Did you forget to use 'await'?
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(23,27): error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
 tests/cases/compiler/operationsAvailableOnPromisedType.ts(24,5): error TS2774: This expression is not callable. Did you forget to use 'await'?
@@ -59,10 +59,10 @@ tests/cases/compiler/operationsAvailableOnPromisedType.ts(27,5): error TS2349: T
         for (const s of c) {
                         ~
 !!! error TS2770: Type 'Promise<string[]>' is not an array type or a string type. Did you forget to use 'await'?
-            fn(b, b, c, d);
-            ~~~~~~~~~~~~~~
-!!! error TS2554: Expected 7 arguments, but got 4.
-!!! related TS6210 tests/cases/compiler/operationsAvailableOnPromisedType.ts:6:5: An argument for 'e' was not provided.
+            fn(b, b, c, d, e, f, g);
+               ~
+!!! error TS2345: Argument of type 'Promise<number>' is not assignable to parameter of type 'number'.
+!!! related TS2777 tests/cases/compiler/operationsAvailableOnPromisedType.ts:20:12: Did you forget to use 'await'?
             d.prop;
               ~~~~
 !!! error TS2570: Property 'prop' does not exist on type 'Promise<{ prop: string; }>'. Did you forget to use 'await'?

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.js
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.js
@@ -1,0 +1,141 @@
+//// [operationsAvailableOnPromisedType.ts]
+async function fn(
+    a: number,
+    b: Promise<number>,
+    c: Promise<string[]>,
+    d: Promise<{ prop: string }>,
+    e: Promise<() => void>,
+    f: Promise<() => void> | (() => void),
+    g: Promise<{ new(): any }>
+) {
+    // All errors
+    a | b;
+    b | a;
+    a + b;
+    a > b;
+    b++;
+    --b;
+    a === b;
+    [...c];
+    for (const s of c) {
+        fn(b, b, c, d);
+        d.prop;
+    }
+    for await (const s of c) {}
+    e();
+    f();
+    new g();
+    b();
+}
+
+
+//// [operationsAvailableOnPromisedType.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __asyncValues = (this && this.__asyncValues) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator], i;
+    return m ? m.call(o) : (o = typeof __values === "function" ? __values(o) : o[Symbol.iterator](), i = {}, verb("next"), verb("throw"), verb("return"), i[Symbol.asyncIterator] = function () { return this; }, i);
+    function verb(n) { i[n] = o[n] && function (v) { return new Promise(function (resolve, reject) { v = o[n](v), settle(resolve, reject, v.done, v.value); }); }; }
+    function settle(resolve, reject, d, v) { Promise.resolve(v).then(function(v) { resolve({ value: v, done: d }); }, reject); }
+};
+var __spreadArrays = (this && this.__spreadArrays) || function () {
+    for (var s = 0, i = 0, il = arguments.length; i < il; i++) s += arguments[i].length;
+    for (var r = Array(s), k = 0, i = 0; i < il; i++)
+        for (var a = arguments[i], j = 0, jl = a.length; j < jl; j++, k++)
+            r[k] = a[j];
+    return r;
+};
+function fn(a, b, c, d, e, f, g) {
+    var c_1, c_1_1;
+    var e_1, _a;
+    return __awaiter(this, void 0, void 0, function () {
+        var _i, c_2, s, s, e_1_1;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
+                case 0:
+                    // All errors
+                    a | b;
+                    b | a;
+                    a + b;
+                    a > b;
+                    b++;
+                    --b;
+                    a === b;
+                    __spreadArrays(c);
+                    for (_i = 0, c_2 = c; _i < c_2.length; _i++) {
+                        s = c_2[_i];
+                        fn(b, b, c, d);
+                        d.prop;
+                    }
+                    _b.label = 1;
+                case 1:
+                    _b.trys.push([1, 6, 7, 12]);
+                    c_1 = __asyncValues(c);
+                    _b.label = 2;
+                case 2: return [4 /*yield*/, c_1.next()];
+                case 3:
+                    if (!(c_1_1 = _b.sent(), !c_1_1.done)) return [3 /*break*/, 5];
+                    s = c_1_1.value;
+                    _b.label = 4;
+                case 4: return [3 /*break*/, 2];
+                case 5: return [3 /*break*/, 12];
+                case 6:
+                    e_1_1 = _b.sent();
+                    e_1 = { error: e_1_1 };
+                    return [3 /*break*/, 12];
+                case 7:
+                    _b.trys.push([7, , 10, 11]);
+                    if (!(c_1_1 && !c_1_1.done && (_a = c_1["return"]))) return [3 /*break*/, 9];
+                    return [4 /*yield*/, _a.call(c_1)];
+                case 8:
+                    _b.sent();
+                    _b.label = 9;
+                case 9: return [3 /*break*/, 11];
+                case 10:
+                    if (e_1) throw e_1.error;
+                    return [7 /*endfinally*/];
+                case 11: return [7 /*endfinally*/];
+                case 12:
+                    e();
+                    f();
+                    new g();
+                    b();
+                    return [2 /*return*/];
+            }
+        });
+    });
+}

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.js
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.js
@@ -18,7 +18,7 @@ async function fn(
     a === b;
     [...c];
     for (const s of c) {
-        fn(b, b, c, d);
+        fn(b, b, c, d, e, f, g);
         d.prop;
     }
     for await (const s of c) {}
@@ -98,7 +98,7 @@ function fn(a, b, c, d, e, f, g) {
                     __spreadArrays(c);
                     for (_i = 0, c_2 = c; _i < c_2.length; _i++) {
                         s = c_2[_i];
-                        fn(b, b, c, d);
+                        fn(b, b, c, d, e, f, g);
                         d.prop;
                     }
                     _b.label = 1;

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.symbols
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.symbols
@@ -65,12 +65,15 @@ async function fn(
 >s : Symbol(s, Decl(operationsAvailableOnPromisedType.ts, 18, 14))
 >c : Symbol(c, Decl(operationsAvailableOnPromisedType.ts, 2, 23))
 
-        fn(b, b, c, d);
+        fn(b, b, c, d, e, f, g);
 >fn : Symbol(fn, Decl(operationsAvailableOnPromisedType.ts, 0, 0))
 >b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
 >b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
 >c : Symbol(c, Decl(operationsAvailableOnPromisedType.ts, 2, 23))
 >d : Symbol(d, Decl(operationsAvailableOnPromisedType.ts, 3, 25))
+>e : Symbol(e, Decl(operationsAvailableOnPromisedType.ts, 4, 33))
+>f : Symbol(f, Decl(operationsAvailableOnPromisedType.ts, 5, 27))
+>g : Symbol(g, Decl(operationsAvailableOnPromisedType.ts, 6, 42))
 
         d.prop;
 >d : Symbol(d, Decl(operationsAvailableOnPromisedType.ts, 3, 25))

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.symbols
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.symbols
@@ -1,0 +1,94 @@
+=== tests/cases/compiler/operationsAvailableOnPromisedType.ts ===
+async function fn(
+>fn : Symbol(fn, Decl(operationsAvailableOnPromisedType.ts, 0, 0))
+
+    a: number,
+>a : Symbol(a, Decl(operationsAvailableOnPromisedType.ts, 0, 18))
+
+    b: Promise<number>,
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+
+    c: Promise<string[]>,
+>c : Symbol(c, Decl(operationsAvailableOnPromisedType.ts, 2, 23))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+
+    d: Promise<{ prop: string }>,
+>d : Symbol(d, Decl(operationsAvailableOnPromisedType.ts, 3, 25))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>prop : Symbol(prop, Decl(operationsAvailableOnPromisedType.ts, 4, 16))
+
+    e: Promise<() => void>,
+>e : Symbol(e, Decl(operationsAvailableOnPromisedType.ts, 4, 33))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+
+    f: Promise<() => void> | (() => void),
+>f : Symbol(f, Decl(operationsAvailableOnPromisedType.ts, 5, 27))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+
+    g: Promise<{ new(): any }>
+>g : Symbol(g, Decl(operationsAvailableOnPromisedType.ts, 6, 42))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+
+) {
+    // All errors
+    a | b;
+>a : Symbol(a, Decl(operationsAvailableOnPromisedType.ts, 0, 18))
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+
+    b | a;
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+>a : Symbol(a, Decl(operationsAvailableOnPromisedType.ts, 0, 18))
+
+    a + b;
+>a : Symbol(a, Decl(operationsAvailableOnPromisedType.ts, 0, 18))
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+
+    a > b;
+>a : Symbol(a, Decl(operationsAvailableOnPromisedType.ts, 0, 18))
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+
+    b++;
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+
+    --b;
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+
+    a === b;
+>a : Symbol(a, Decl(operationsAvailableOnPromisedType.ts, 0, 18))
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+
+    [...c];
+>c : Symbol(c, Decl(operationsAvailableOnPromisedType.ts, 2, 23))
+
+    for (const s of c) {
+>s : Symbol(s, Decl(operationsAvailableOnPromisedType.ts, 18, 14))
+>c : Symbol(c, Decl(operationsAvailableOnPromisedType.ts, 2, 23))
+
+        fn(b, b, c, d);
+>fn : Symbol(fn, Decl(operationsAvailableOnPromisedType.ts, 0, 0))
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+>c : Symbol(c, Decl(operationsAvailableOnPromisedType.ts, 2, 23))
+>d : Symbol(d, Decl(operationsAvailableOnPromisedType.ts, 3, 25))
+
+        d.prop;
+>d : Symbol(d, Decl(operationsAvailableOnPromisedType.ts, 3, 25))
+    }
+    for await (const s of c) {}
+>s : Symbol(s, Decl(operationsAvailableOnPromisedType.ts, 22, 20))
+>c : Symbol(c, Decl(operationsAvailableOnPromisedType.ts, 2, 23))
+
+    e();
+>e : Symbol(e, Decl(operationsAvailableOnPromisedType.ts, 4, 33))
+
+    f();
+>f : Symbol(f, Decl(operationsAvailableOnPromisedType.ts, 5, 27))
+
+    new g();
+>g : Symbol(g, Decl(operationsAvailableOnPromisedType.ts, 6, 42))
+
+    b();
+>b : Symbol(b, Decl(operationsAvailableOnPromisedType.ts, 1, 14))
+}
+

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.types
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.types
@@ -1,0 +1,104 @@
+=== tests/cases/compiler/operationsAvailableOnPromisedType.ts ===
+async function fn(
+>fn : (a: number, b: Promise<number>, c: Promise<string[]>, d: Promise<{ prop: string; }>, e: Promise<() => void>, f: Promise<() => void> | (() => void), g: Promise<new () => any>) => Promise<void>
+
+    a: number,
+>a : number
+
+    b: Promise<number>,
+>b : Promise<number>
+
+    c: Promise<string[]>,
+>c : Promise<string[]>
+
+    d: Promise<{ prop: string }>,
+>d : Promise<{ prop: string; }>
+>prop : string
+
+    e: Promise<() => void>,
+>e : Promise<() => void>
+
+    f: Promise<() => void> | (() => void),
+>f : Promise<() => void> | (() => void)
+
+    g: Promise<{ new(): any }>
+>g : Promise<new () => any>
+
+) {
+    // All errors
+    a | b;
+>a | b : number
+>a : number
+>b : Promise<number>
+
+    b | a;
+>b | a : number
+>b : Promise<number>
+>a : number
+
+    a + b;
+>a + b : any
+>a : number
+>b : Promise<number>
+
+    a > b;
+>a > b : boolean
+>a : number
+>b : Promise<number>
+
+    b++;
+>b++ : number
+>b : Promise<number>
+
+    --b;
+>--b : number
+>b : Promise<number>
+
+    a === b;
+>a === b : boolean
+>a : number
+>b : Promise<number>
+
+    [...c];
+>[...c] : any[]
+>...c : any
+>c : Promise<string[]>
+
+    for (const s of c) {
+>s : any
+>c : Promise<string[]>
+
+        fn(b, b, c, d);
+>fn(b, b, c, d) : Promise<void>
+>fn : (a: number, b: Promise<number>, c: Promise<string[]>, d: Promise<{ prop: string; }>, e: Promise<() => void>, f: Promise<() => void> | (() => void), g: Promise<new () => any>) => Promise<void>
+>b : Promise<number>
+>b : Promise<number>
+>c : Promise<string[]>
+>d : Promise<{ prop: string; }>
+
+        d.prop;
+>d.prop : any
+>d : Promise<{ prop: string; }>
+>prop : any
+    }
+    for await (const s of c) {}
+>s : any
+>c : Promise<string[]>
+
+    e();
+>e() : any
+>e : Promise<() => void>
+
+    f();
+>f() : any
+>f : Promise<() => void> | (() => void)
+
+    new g();
+>new g() : any
+>g : Promise<new () => any>
+
+    b();
+>b() : any
+>b : Promise<number>
+}
+

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.types
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.types
@@ -68,13 +68,16 @@ async function fn(
 >s : any
 >c : Promise<string[]>
 
-        fn(b, b, c, d);
->fn(b, b, c, d) : Promise<void>
+        fn(b, b, c, d, e, f, g);
+>fn(b, b, c, d, e, f, g) : Promise<void>
 >fn : (a: number, b: Promise<number>, c: Promise<string[]>, d: Promise<{ prop: string; }>, e: Promise<() => void>, f: Promise<() => void> | (() => void), g: Promise<new () => any>) => Promise<void>
 >b : Promise<number>
 >b : Promise<number>
 >c : Promise<string[]>
 >d : Promise<{ prop: string; }>
+>e : Promise<() => void>
+>f : Promise<() => void> | (() => void)
+>g : Promise<new () => any>
 
         d.prop;
 >d.prop : any

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(2,12): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(8,12): error TS2780: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator. Did you forget to use 'await'?
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(8,12): error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(10,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
     Types of property 'next' are incompatible.
@@ -71,7 +71,8 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     async function * inferReturnType3() {
         yield* Promise.resolve([1, 2]);
                ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2780: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator. Did you forget to use 'await'?
+!!! error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! related TS2789 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts:8:12: Did you forget to use 'await'?
     }
     const assignability1: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(2,12): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(8,12): error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(8,12): error TS2780: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator. Did you forget to use 'await'?
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(10,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
     Types of property 'next' are incompatible.
@@ -71,7 +71,7 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     async function * inferReturnType3() {
         yield* Promise.resolve([1, 2]);
                ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+!!! error TS2780: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator. Did you forget to use 'await'?
     }
     const assignability1: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
@@ -72,7 +72,7 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
         yield* Promise.resolve([1, 2]);
                ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-!!! related TS2789 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts:8:12: Did you forget to use 'await'?
+!!! related TS2773 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts:8:12: Did you forget to use 'await'?
     }
     const assignability1: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~

--- a/tests/cases/compiler/nonexistentPropertyAvailableOnPromisedType.ts
+++ b/tests/cases/compiler/nonexistentPropertyAvailableOnPromisedType.ts
@@ -1,3 +1,0 @@
-function f(x: Promise<string>) {
-    x.toLowerCase();
-}

--- a/tests/cases/compiler/operationsAvailableOnPromisedType.ts
+++ b/tests/cases/compiler/operationsAvailableOnPromisedType.ts
@@ -1,0 +1,25 @@
+function fn(
+    a: number,
+    b: Promise<number>,
+    c: Promise<string[]>,
+    d: Promise<{ prop: string }>,
+    e: Promise<() => void>,
+    f: Promise<() => void> | (() => void),
+    g: Promise<{ new(): any }>
+) {
+    // All errors
+    a | b;
+    b | a;
+    a + b;
+    a > b;
+    b++;
+    --b;
+    a === b;
+    for (const s of c) {
+        fn(b, b, c, d);
+        d.prop;
+    }
+    e();
+    f();
+    new g();
+}

--- a/tests/cases/compiler/operationsAvailableOnPromisedType.ts
+++ b/tests/cases/compiler/operationsAvailableOnPromisedType.ts
@@ -17,7 +17,7 @@ async function fn(
     a === b;
     [...c];
     for (const s of c) {
-        fn(b, b, c, d);
+        fn(b, b, c, d, e, f, g);
         d.prop;
     }
     for await (const s of c) {}

--- a/tests/cases/compiler/operationsAvailableOnPromisedType.ts
+++ b/tests/cases/compiler/operationsAvailableOnPromisedType.ts
@@ -24,4 +24,5 @@ async function fn(
     e();
     f();
     new g();
+    b();
 }

--- a/tests/cases/compiler/operationsAvailableOnPromisedType.ts
+++ b/tests/cases/compiler/operationsAvailableOnPromisedType.ts
@@ -1,4 +1,4 @@
-function fn(
+async function fn(
     a: number,
     b: Promise<number>,
     c: Promise<string[]>,
@@ -15,10 +15,12 @@ function fn(
     b++;
     --b;
     a === b;
+    [...c];
     for (const s of c) {
         fn(b, b, c, d);
         d.prop;
     }
+    for await (const s of c) {}
     e();
     f();
     new g();


### PR DESCRIPTION
This is a partial fix for #30646. The rest of the fix will be enabling some quick fixes triggered by these errors where appropriate (some cases are already covered in #32101).

The conformance test file I added shows one or more instances of every error I added. To summarize them here (operators shown in examples aren’t exhaustive, but the particular types of errors enumerated are):

- `x++` when `x` is a Promise of `bigint` or `number`
- `a | b` when `a` or `b` is a Promise of `bigint` or `number`
- `a > b` when `await a > await b` would check successfully
- `a === b` when `await a === await b` would check successfully
- `f(x)` when the parameter type in `f` is not a Promise and `f(await x)` would check successfully
- `for (const _ of x)` when `x` is a Promise
- `for await (const _ of x)` when `x` is a Promise
- `x()` when `x` has no call signatures but `await x` does
- `new C()` when `C` has no construct signatures but `await C` does

Already existed:

- `x.foo` when `x` is a Promise that resolves to something with a `foo` property

Note: I followed suit with the existing property access error and **did not** predicate these error messages on being in an `async` context. I think this makes sense, because often times I begin writing a function as non-async `function f()`, and only when I get to the first time I need to await do I go back and add `async` to my function declaration. (I even think enabling a quick fix in a non-async function is ok, as another quick fix to add 'async' will appear directly after. I think having those as two separate steps, but readily available, is a pretty good UX—it's a middle ground where we make extra sure you’re really ok with changing your function to async, but we still fix up your code with very few keystrokes. But, we can dig into that in a future PR.)

/cc @bterlson for review as well, if you like.