### PR TITLE
Adds support for class completions after ASI inserted class property definition

### DIFF
--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -892,7 +892,7 @@ namespace ts {
     }
 
     export interface CompletionInfo {
-        /** Not true for all glboal completions. This will be true if the enclosing scope matches a few syntax kinds. See `isSnippetScope`. */
+        /** Not true for all global completions. This will be true if the enclosing scope matches a few syntax kinds. See `isSnippetScope`. */
         isGlobalCompletion: boolean;
         isMemberCompletion: boolean;
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5398,7 +5398,7 @@ declare namespace ts {
         argumentCount: number;
     }
     interface CompletionInfo {
-        /** Not true for all glboal completions. This will be true if the enclosing scope matches a few syntax kinds. See `isSnippetScope`. */
+        /** Not true for all global completions. This will be true if the enclosing scope matches a few syntax kinds. See `isSnippetScope`. */
         isGlobalCompletion: boolean;
         isMemberCompletion: boolean;
         /**

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5398,7 +5398,7 @@ declare namespace ts {
         argumentCount: number;
     }
     interface CompletionInfo {
-        /** Not true for all glboal completions. This will be true if the enclosing scope matches a few syntax kinds. See `isSnippetScope`. */
+        /** Not true for all global completions. This will be true if the enclosing scope matches a few syntax kinds. See `isSnippetScope`. */
         isGlobalCompletion: boolean;
         isMemberCompletion: boolean;
         /**

--- a/tests/cases/fourslash/completionEntryAfterASIExpressionInClass.ts
+++ b/tests/cases/fourslash/completionEntryAfterASIExpressionInClass.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts'/>
+
+//// class Parent {
+////   protected shouldWork() {
+////       console.log();
+////   }
+//// }
+//// 
+//// class Child extends Parent {
+////             // this assumes ASI, but on next line wants to  
+////   x = () => 1
+////   shoul/*insideid*/ 
+//// }
+////
+//// class ChildTwo extends Parent {
+////             // this assumes ASI, but on next line wants to  
+////   x = () => 1
+////   /*root*/ //nothing
+//// }
+
+verify.completions({ marker: ["insideid", "root"], includes: "shouldWork", isNewIdentifierLocation: true });


### PR DESCRIPTION
Fixes #30536 - handles both the case where you start writing on a newline directly, and when you are continuing to write inside an identifier. 