### PR TITLE
Incorrect evaluation example

### DIFF
--- a/tests/baselines/reference/unknownType1.js
+++ b/tests/baselines/reference/unknownType1.js
@@ -17,7 +17,7 @@ type T12 = unknown | null | undefined;  // unknown
 type T13 = unknown | string;  // unknown
 type T14 = unknown | string[];  // unknown
 type T15 = unknown | unknown;  // unknown
-type T16 = unknown | any;  // any
+type T16 = unknown | any;  // unknown
 
 // Type variable and unknown in union and intersection
 


### PR DESCRIPTION
The documentation says that in a union an unknown absorbs everything, but that is not what was reflected in the documentation.

This updates the documentation to fix the evaluation example.