### PR TITLE
Fall back to (Async)IterableIterator if (Async)Generator not found

### DIFF
--- a/tests/baselines/reference/castOfYield.errors.txt
+++ b/tests/baselines/reference/castOfYield.errors.txt
@@ -1,8 +1,8 @@
-error TS2318: Cannot find global type 'Generator'.
+error TS2318: Cannot find global type 'IterableIterator'.
 tests/cases/compiler/castOfYield.ts(4,14): error TS1109: Expression expected.
 
 
-!!! error TS2318: Cannot find global type 'Generator'.
+!!! error TS2318: Cannot find global type 'IterableIterator'.
 ==== tests/cases/compiler/castOfYield.ts (1 errors) ====
     function* f() {
         <number> (yield 0);

--- a/tests/baselines/reference/generatorReturnTypeFallback.1.symbols
+++ b/tests/baselines/reference/generatorReturnTypeFallback.1.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.1.ts ===
+// Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+function* f() {
+>f : Symbol(f, Decl(generatorReturnTypeFallback.1.ts, 0, 0))
+
+    yield 1;
+}

--- a/tests/baselines/reference/generatorReturnTypeFallback.1.types
+++ b/tests/baselines/reference/generatorReturnTypeFallback.1.types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.1.ts ===
+// Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+function* f() {
+>f : () => IterableIterator<number>
+
+    yield 1;
+>yield 1 : any
+>1 : 1
+}

--- a/tests/baselines/reference/generatorReturnTypeFallback.2.errors.txt
+++ b/tests/baselines/reference/generatorReturnTypeFallback.2.errors.txt
@@ -1,0 +1,10 @@
+error TS2318: Cannot find global type 'IterableIterator'.
+
+
+!!! error TS2318: Cannot find global type 'IterableIterator'.
+==== tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts (0 errors) ====
+    // Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+    // Report an error if IterableIterator cannot be found.
+    function* f() {
+        yield 1;
+    }

--- a/tests/baselines/reference/generatorReturnTypeFallback.2.symbols
+++ b/tests/baselines/reference/generatorReturnTypeFallback.2.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts ===
+// Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+// Report an error if IterableIterator cannot be found.
+function* f() {
+>f : Symbol(f, Decl(generatorReturnTypeFallback.2.ts, 0, 0))
+
+    yield 1;
+}

--- a/tests/baselines/reference/generatorReturnTypeFallback.2.types
+++ b/tests/baselines/reference/generatorReturnTypeFallback.2.types
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts ===
+// Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+// Report an error if IterableIterator cannot be found.
+function* f() {
+>f : () => {}
+
+    yield 1;
+>yield 1 : any
+>1 : 1
+}

--- a/tests/baselines/reference/generatorReturnTypeFallback.3.errors.txt
+++ b/tests/baselines/reference/generatorReturnTypeFallback.3.errors.txt
@@ -1,0 +1,10 @@
+error TS2318: Cannot find global type 'Generator'.
+
+
+!!! error TS2318: Cannot find global type 'Generator'.
+==== tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts (0 errors) ====
+    // Do not allow generators to fallback to IterableIterator while in strictNullChecks mode if they need a type for the sent value.
+    // NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+    function* f() {
+        const x: string = yield 1;
+    }

--- a/tests/baselines/reference/generatorReturnTypeFallback.3.symbols
+++ b/tests/baselines/reference/generatorReturnTypeFallback.3.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts ===
+// Do not allow generators to fallback to IterableIterator while in strictNullChecks mode if they need a type for the sent value.
+// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+function* f() {
+>f : Symbol(f, Decl(generatorReturnTypeFallback.3.ts, 0, 0))
+
+    const x: string = yield 1;
+>x : Symbol(x, Decl(generatorReturnTypeFallback.3.ts, 3, 9))
+}

--- a/tests/baselines/reference/generatorReturnTypeFallback.3.types
+++ b/tests/baselines/reference/generatorReturnTypeFallback.3.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts ===
+// Do not allow generators to fallback to IterableIterator while in strictNullChecks mode if they need a type for the sent value.
+// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+function* f() {
+>f : () => {}
+
+    const x: string = yield 1;
+>x : string
+>yield 1 : any
+>1 : 1
+}

--- a/tests/baselines/reference/generatorReturnTypeFallback.4.symbols
+++ b/tests/baselines/reference/generatorReturnTypeFallback.4.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts ===
+// Allow generators to fallback to IterableIterator if they are not in strictNullChecks mode
+// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+function* f() {
+>f : Symbol(f, Decl(generatorReturnTypeFallback.4.ts, 0, 0))
+
+    const x: string = yield 1;
+>x : Symbol(x, Decl(generatorReturnTypeFallback.4.ts, 3, 9))
+}

--- a/tests/baselines/reference/generatorReturnTypeFallback.4.types
+++ b/tests/baselines/reference/generatorReturnTypeFallback.4.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts ===
+// Allow generators to fallback to IterableIterator if they are not in strictNullChecks mode
+// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+function* f() {
+>f : () => IterableIterator<number>
+
+    const x: string = yield 1;
+>x : string
+>yield 1 : any
+>1 : 1
+}

--- a/tests/baselines/reference/generatorReturnTypeFallback.5.symbols
+++ b/tests/baselines/reference/generatorReturnTypeFallback.5.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts ===
+// Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+function* f(): IterableIterator<number> {
+>f : Symbol(f, Decl(generatorReturnTypeFallback.5.ts, 0, 0))
+>IterableIterator : Symbol(IterableIterator, Decl(lib.es2015.iterable.d.ts, --, --))
+
+    yield 1;
+}

--- a/tests/baselines/reference/generatorReturnTypeFallback.5.types
+++ b/tests/baselines/reference/generatorReturnTypeFallback.5.types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts ===
+// Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+function* f(): IterableIterator<number> {
+>f : () => IterableIterator<number>
+
+    yield 1;
+>yield 1 : undefined
+>1 : 1
+}

--- a/tests/baselines/reference/spreadOfParamsFromGeneratorMakesRequiredParams.errors.txt
+++ b/tests/baselines/reference/spreadOfParamsFromGeneratorMakesRequiredParams.errors.txt
@@ -1,8 +1,8 @@
-error TS2318: Cannot find global type 'Generator'.
+error TS2318: Cannot find global type 'IterableIterator'.
 tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts(6,1): error TS2554: Expected 2 arguments, but got 1.
 
 
-!!! error TS2318: Cannot find global type 'Generator'.
+!!! error TS2318: Cannot find global type 'IterableIterator'.
 ==== tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts (1 errors) ====
     declare function call<Fn extends (...args: any[]) => any>(
         fn: Fn,

--- a/tests/baselines/reference/templateStringWithEmbeddedYieldKeyword.errors.txt
+++ b/tests/baselines/reference/templateStringWithEmbeddedYieldKeyword.errors.txt
@@ -1,8 +1,8 @@
-error TS2318: Cannot find global type 'Generator'.
+error TS2318: Cannot find global type 'IterableIterator'.
 tests/cases/conformance/es6/templates/templateStringWithEmbeddedYieldKeyword.ts(1,15): error TS1005: '(' expected.
 
 
-!!! error TS2318: Cannot find global type 'Generator'.
+!!! error TS2318: Cannot find global type 'IterableIterator'.
 ==== tests/cases/conformance/es6/templates/templateStringWithEmbeddedYieldKeyword.ts (1 errors) ====
     function* gen {
                   ~

--- a/tests/baselines/reference/types.forAwait.es2018.3.errors.txt
+++ b/tests/baselines/reference/types.forAwait.es2018.3.errors.txt
@@ -1,11 +1,11 @@
-error TS2318: Cannot find global type 'AsyncGenerator'.
+error TS2318: Cannot find global type 'AsyncIterableIterator'.
 tests/cases/conformance/types/forAwait/types.forAwait.es2018.3.ts(3,27): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/forAwait/types.forAwait.es2018.3.ts(5,21): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/forAwait/types.forAwait.es2018.3.ts(10,27): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/forAwait/types.forAwait.es2018.3.ts(12,21): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 
 
-!!! error TS2318: Cannot find global type 'AsyncGenerator'.
+!!! error TS2318: Cannot find global type 'AsyncIterableIterator'.
 ==== tests/cases/conformance/types/forAwait/types.forAwait.es2018.3.ts (4 errors) ====
     async function f1() {
         let y: number;

--- a/tests/cases/conformance/generators/generatorReturnTypeFallback.1.ts
+++ b/tests/cases/conformance/generators/generatorReturnTypeFallback.1.ts
@@ -1,0 +1,9 @@
+// @target: esnext
+// @lib: es5,es2015.iterable
+// @noemit: true
+// @strict: true
+
+// Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+function* f() {
+    yield 1;
+}

--- a/tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts
+++ b/tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts
@@ -1,0 +1,10 @@
+// @target: esnext
+// @lib: es5
+// @noemit: true
+// @strict: true
+
+// Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+// Report an error if IterableIterator cannot be found.
+function* f() {
+    yield 1;
+}

--- a/tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts
+++ b/tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts
@@ -1,0 +1,10 @@
+// @target: esnext
+// @lib: es5,es2015.iterable
+// @noemit: true
+// @strict: true
+
+// Do not allow generators to fallback to IterableIterator while in strictNullChecks mode if they need a type for the sent value.
+// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+function* f() {
+    const x: string = yield 1;
+}

--- a/tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts
+++ b/tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts
@@ -1,0 +1,10 @@
+// @target: esnext
+// @lib: es5,es2015.iterable
+// @noemit: true
+// @strict: false
+
+// Allow generators to fallback to IterableIterator if they are not in strictNullChecks mode
+// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+function* f() {
+    const x: string = yield 1;
+}

--- a/tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts
+++ b/tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts
@@ -1,0 +1,9 @@
+// @target: esnext
+// @lib: es5,es2015.iterable
+// @noemit: true
+// @strict: true
+
+// Allow generators to fallback to IterableIterator if they do not need a type for the sent value while in strictNullChecks mode.
+function* f(): IterableIterator<number> {
+    yield 1;
+}


### PR DESCRIPTION
Allow generator return type inference to fall back to `IterableIterator` if `Generator` can't be found and the `return` and `next` types of the generator are compatible with the expected `return` and `next` types of `IterableIterator`.

This improves backwards compatibility for existing generators that may not have the `es2015.generators` lib included.

Fixes https://github.com/microsoft/TypeScript/pull/32244/files#diff-601ae163618e1a582913605ac0b1b7c1R107