### PR TITLE
Improve multiple overloads error span

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21837,7 +21837,7 @@ namespace ts {
                             map(diags, d => typeof d.messageText === "string" ? (d as DiagnosticMessageChain) : d.messageText),
                             Diagnostics.No_overload_matches_this_call);
                         const related = flatMap(diags, d => (d as Diagnostic).relatedInformation) as DiagnosticRelatedInformation[];
-                        if(every(diags, d => d.start === diags[0].start && d.length === diags[0].length && d.file === diags[0].file)) {
+                        if (every(diags, d => d.start === diags[0].start && d.length === diags[0].length && d.file === diags[0].file)) {
                             const { file, start, length } = diags[0];
                             diagnostics.add({ file, start, length, code: chain.code, category: chain.category, messageText: chain, relatedInformation: related });
                         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21832,9 +21832,18 @@ namespace ts {
                         }
 
                         const diags = max > 1 ? allDiagnostics[minIndex] : flatten(allDiagnostics);
-                        const chain = map(diags, d => typeof d.messageText === "string" ? (d as DiagnosticMessageChain) : d.messageText);
+                        Debug.assert(diags.length > 0, "No errors reported for 3 or fewer overload signatures");
+                        const chain = chainDiagnosticMessages(
+                            map(diags, d => typeof d.messageText === "string" ? (d as DiagnosticMessageChain) : d.messageText),
+                            Diagnostics.No_overload_matches_this_call);
                         const related = flatMap(diags, d => (d as Diagnostic).relatedInformation) as DiagnosticRelatedInformation[];
-                        diagnostics.add(createDiagnosticForNodeFromMessageChain(node, chainDiagnosticMessages(chain, Diagnostics.No_overload_matches_this_call), related));
+                        if(every(diags, d => d.start === diags[0].start && d.length === diags[0].length && d.file === diags[0].file)) {
+                            const { file, start, length } = diags[0];
+                            diagnostics.add({ file, start, length, code: chain.code, category: chain.category, messageText: chain, relatedInformation: related });
+                        }
+                        else {
+                            diagnostics.add(createDiagnosticForNodeFromMessageChain(node, chain, related));
+                        }
                     }
                 }
                 else if (candidateForArgumentArityError) {

--- a/tests/baselines/reference/bigintWithLib.errors.txt
+++ b/tests/baselines/reference/bigintWithLib.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/bigintWithLib.ts(4,1): error TS2350: Only a void function can be called with the 'new' keyword.
-tests/cases/compiler/bigintWithLib.ts(16,15): error TS2769: No overload matches this call.
+tests/cases/compiler/bigintWithLib.ts(16,33): error TS2769: No overload matches this call.
   Overload 1 of 3, '(length?: number): BigInt64Array', gave the following error.
     Argument of type 'number[]' is not assignable to parameter of type 'number'.
   Overload 2 of 3, '(array: Iterable<bigint>): BigInt64Array', gave the following error.
@@ -17,7 +17,7 @@ tests/cases/compiler/bigintWithLib.ts(16,15): error TS2769: No overload matches 
     Argument of type 'number[]' is not assignable to parameter of type 'ArrayBuffer | SharedArrayBuffer'.
       Type 'number[]' is missing the following properties from type 'SharedArrayBuffer': byteLength, [Symbol.species], [Symbol.toStringTag]
 tests/cases/compiler/bigintWithLib.ts(21,13): error TS2540: Cannot assign to 'length' because it is a read-only property.
-tests/cases/compiler/bigintWithLib.ts(28,16): error TS2769: No overload matches this call.
+tests/cases/compiler/bigintWithLib.ts(28,35): error TS2769: No overload matches this call.
   Overload 1 of 3, '(length?: number): BigUint64Array', gave the following error.
     Argument of type 'number[]' is not assignable to parameter of type 'number'.
   Overload 2 of 3, '(array: Iterable<bigint>): BigUint64Array', gave the following error.
@@ -49,7 +49,7 @@ tests/cases/compiler/bigintWithLib.ts(43,26): error TS2345: Argument of type '12
     bigIntArray = new BigInt64Array(10);
     bigIntArray = new BigInt64Array([1n, 2n, 3n]);
     bigIntArray = new BigInt64Array([1, 2, 3]); // should error
-                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                    ~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(length?: number): BigInt64Array', gave the following error.
 !!! error TS2769:     Argument of type 'number[]' is not assignable to parameter of type 'number'.
@@ -81,7 +81,7 @@ tests/cases/compiler/bigintWithLib.ts(43,26): error TS2345: Argument of type '12
     bigUintArray = new BigUint64Array(10);
     bigUintArray = new BigUint64Array([1n, 2n, 3n]);
     bigUintArray = new BigUint64Array([1, 2, 3]); // should error
-                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                      ~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(length?: number): BigUint64Array', gave the following error.
 !!! error TS2769:     Argument of type 'number[]' is not assignable to parameter of type 'number'.

--- a/tests/baselines/reference/checkJsxChildrenCanBeTupleType.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenCanBeTupleType.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx(17,17): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx(17,18): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<ResizablePanelProps>): ResizablePanel', gave the following error.
     Type '{ children: [Element, Element, Element]; }' is not assignable to type 'Readonly<ResizablePanelProps>'.
       Types of property 'children' are incompatible.
@@ -29,7 +29,7 @@ tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx(17,17): error TS2
     </ResizablePanel>
     
     const testErr = <ResizablePanel>
-                    ~~~~~~~~~~~~~~~~
+                     ~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(props: Readonly<ResizablePanelProps>): ResizablePanel', gave the following error.
 !!! error TS2769:     Type '{ children: [Element, Element, Element]; }' is not assignable to type 'Readonly<ResizablePanelProps>'.

--- a/tests/baselines/reference/constructorOverloads1.errors.txt
+++ b/tests/baselines/reference/constructorOverloads1.errors.txt
@@ -2,12 +2,12 @@ tests/cases/compiler/constructorOverloads1.ts(2,5): error TS2392: Multiple const
 tests/cases/compiler/constructorOverloads1.ts(3,5): error TS2392: Multiple constructor implementations are not allowed.
 tests/cases/compiler/constructorOverloads1.ts(4,5): error TS2392: Multiple constructor implementations are not allowed.
 tests/cases/compiler/constructorOverloads1.ts(7,5): error TS2392: Multiple constructor implementations are not allowed.
-tests/cases/compiler/constructorOverloads1.ts(16,10): error TS2769: No overload matches this call.
+tests/cases/compiler/constructorOverloads1.ts(16,18): error TS2769: No overload matches this call.
   Overload 1 of 2, '(s: string): Foo', gave the following error.
     Argument of type 'Foo' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(n: number): Foo', gave the following error.
     Argument of type 'Foo' is not assignable to parameter of type 'number'.
-tests/cases/compiler/constructorOverloads1.ts(17,10): error TS2769: No overload matches this call.
+tests/cases/compiler/constructorOverloads1.ts(17,18): error TS2769: No overload matches this call.
   Overload 1 of 2, '(s: string): Foo', gave the following error.
     Argument of type 'any[]' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(n: number): Foo', gave the following error.
@@ -43,14 +43,14 @@ tests/cases/compiler/constructorOverloads1.ts(17,10): error TS2769: No overload 
     var f1 = new Foo("hey");
     var f2 = new Foo(0);
     var f3 = new Foo(f1);
-             ~~~~~~~~~~~
+                     ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(s: string): Foo', gave the following error.
 !!! error TS2769:     Argument of type 'Foo' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 2, '(n: number): Foo', gave the following error.
 !!! error TS2769:     Argument of type 'Foo' is not assignable to parameter of type 'number'.
     var f4 = new Foo([f1,f2,f3]);
-             ~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(s: string): Foo', gave the following error.
 !!! error TS2769:     Argument of type 'any[]' is not assignable to parameter of type 'string'.

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
@@ -1,25 +1,25 @@
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,12): error TS2769: No overload matches this call.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,12): error TS2769: No overload matches this call.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
       Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,12): error TS2769: No overload matches this call.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ extra: true; goTo: string; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
     Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(30,12): error TS2769: No overload matches this call.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(30,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ goTo: string; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'goTo' does not exist on type 'IntrinsicAttributes & ButtonProps'.
@@ -60,7 +60,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): err
     }
     
     const b0 = <MainButton {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type "left" | "right"
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
@@ -69,7 +69,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): err
 !!! error TS2769:     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b2 = <MainButton onClick={(k)=>{console.log(k)}} extra />;  // k has type "left" | "right"
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
@@ -78,7 +78,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): err
 !!! error TS2769:     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2769:       Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b3 = <MainButton {...{goTo:"home"}} extra />;  // goTo has type"home" | "contact"
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ extra: true; goTo: string; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
@@ -87,7 +87,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): err
 !!! error TS2769:     Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b4 = <MainButton goTo="home" extra />;  // goTo has type "home" | "contact"
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ goTo: string; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.

--- a/tests/baselines/reference/controlFlowIterationErrors.errors.txt
+++ b/tests/baselines/reference/controlFlowIterationErrors.errors.txt
@@ -2,14 +2,14 @@ tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(11,17): error 
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(22,17): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'string'.
   Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(34,13): error TS2769: No overload matches this call.
+tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(34,17): error TS2769: No overload matches this call.
   Overload 1 of 2, '(x: string): number', gave the following error.
     Argument of type 'string | number' is not assignable to parameter of type 'string'.
       Type 'number' is not assignable to type 'string'.
   Overload 2 of 2, '(x: number): string', gave the following error.
     Argument of type 'string | number' is not assignable to parameter of type 'number'.
       Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(45,13): error TS2769: No overload matches this call.
+tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(45,17): error TS2769: No overload matches this call.
   Overload 1 of 2, '(x: string): number', gave the following error.
     Argument of type 'string | number' is not assignable to parameter of type 'string'.
       Type 'number' is not assignable to type 'string'.
@@ -59,7 +59,7 @@ tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(45,13): error 
         x = "";
         while (cond) {
             x = foo(x);
-                ~~~~~~
+                    ~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(x: string): number', gave the following error.
 !!! error TS2769:     Argument of type 'string | number' is not assignable to parameter of type 'string'.
@@ -78,7 +78,7 @@ tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts(45,13): error 
         while (cond) {
             x;
             x = foo(x);
-                ~~~~~~
+                    ~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(x: string): number', gave the following error.
 !!! error TS2769:     Argument of type 'string | number' is not assignable to parameter of type 'string'.

--- a/tests/baselines/reference/destructuringTuple.errors.txt
+++ b/tests/baselines/reference/destructuringTuple.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/destructuringTuple.ts(11,8): error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
-tests/cases/compiler/destructuringTuple.ts(11,48): error TS2769: No overload matches this call.
+tests/cases/compiler/destructuringTuple.ts(11,60): error TS2769: No overload matches this call.
   Overload 1 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.
     Argument of type 'number' is not assignable to parameter of type 'ConcatArray<never>'.
   Overload 2 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.
@@ -20,7 +20,7 @@ tests/cases/compiler/destructuringTuple.ts(11,48): error TS2769: No overload mat
     const [oops1] = [1, 2, 3].reduce((accu, el) => accu.concat(el), []);
            ~~~~~
 !!! error TS2493: Tuple type '[]' of length '0' has no element at index '0'.
-                                                   ~~~~~~~~~~~~~~~
+                                                               ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(...items: ConcatArray<never>[]): never[]', gave the following error.
 !!! error TS2769:     Argument of type 'number' is not assignable to parameter of type 'ConcatArray<never>'.

--- a/tests/baselines/reference/functionOverloads2.errors.txt
+++ b/tests/baselines/reference/functionOverloads2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/functionOverloads2.ts(4,9): error TS2769: No overload matches this call.
+tests/cases/compiler/functionOverloads2.ts(4,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(bar: string): string', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(bar: number): number', gave the following error.
@@ -10,7 +10,7 @@ tests/cases/compiler/functionOverloads2.ts(4,9): error TS2769: No overload match
     function foo(bar: number): number;
     function foo(bar: any): any { return bar };
     var x = foo(true);
-            ~~~~~~~~~
+                ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(bar: string): string', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'string'.

--- a/tests/baselines/reference/functionOverloads40.errors.txt
+++ b/tests/baselines/reference/functionOverloads40.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/functionOverloads40.ts(4,9): error TS2769: No overload matches this call.
+tests/cases/compiler/functionOverloads40.ts(4,15): error TS2769: No overload matches this call.
   Overload 1 of 2, '(bar: { a: number; }[]): string', gave the following error.
     Type 'string' is not assignable to type 'number'.
   Overload 2 of 2, '(bar: { a: boolean; }[]): number', gave the following error.
@@ -10,7 +10,7 @@ tests/cases/compiler/functionOverloads40.ts(4,9): error TS2769: No overload matc
     function foo(bar:{a:boolean;}[]):number;
     function foo(bar:{a:any;}[]):any{ return bar }
     var x = foo([{a:'bar'}]);
-            ~~~~~~~~~~~~~~~~
+                  ~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(bar: { a: number; }[]): string', gave the following error.
 !!! error TS2769:     Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/functionOverloads41.errors.txt
+++ b/tests/baselines/reference/functionOverloads41.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/functionOverloads41.ts(4,9): error TS2769: No overload matches this call.
+tests/cases/compiler/functionOverloads41.ts(4,14): error TS2769: No overload matches this call.
   Overload 1 of 2, '(bar: { a: number; }[]): string', gave the following error.
     Property 'a' is missing in type '{}' but required in type '{ a: number; }'.
   Overload 2 of 2, '(bar: { a: boolean; }[]): number', gave the following error.
@@ -10,7 +10,7 @@ tests/cases/compiler/functionOverloads41.ts(4,9): error TS2769: No overload matc
     function foo(bar:{a:boolean;}[]):number;
     function foo(bar:{a:any;}[]):any{ return bar }
     var x = foo([{}]);
-            ~~~~~~~~~
+                 ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(bar: { a: number; }[]): string', gave the following error.
 !!! error TS2769:     Property 'a' is missing in type '{}' but required in type '{ a: number; }'.

--- a/tests/baselines/reference/genericCallToOverloadedMethodWithOverloadedArguments.errors.txt
+++ b/tests/baselines/reference/genericCallToOverloadedMethodWithOverloadedArguments.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts(23,38): error TS2345: Argument of type '{ (n: number): Promise<number>; (s: string): Promise<string>; }' is not assignable to parameter of type '(x: number) => Promise<string>'.
   Type 'Promise<number>' is not assignable to type 'Promise<string>'.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts(52,22): error TS2769: No overload matches this call.
+tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts(52,38): error TS2769: No overload matches this call.
   Overload 1 of 2, '(cb: (x: number) => Promise<string>): Promise<string>', gave the following error.
     Argument of type '{ (n: number): Promise<number>; (s: string): Promise<string>; }' is not assignable to parameter of type '(x: number) => Promise<string>'.
       Type 'Promise<number>' is not assignable to type 'Promise<string>'.
@@ -9,7 +9,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverl
   Overload 2 of 2, '(cb: (x: number) => Promise<string>, error?: (error: any) => Promise<string>): Promise<string>', gave the following error.
     Argument of type '{ (n: number): Promise<number>; (s: string): Promise<string>; }' is not assignable to parameter of type '(x: number) => Promise<string>'.
       Type 'Promise<number>' is not assignable to type 'Promise<string>'.
-tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts(68,22): error TS2769: No overload matches this call.
+tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts(68,38): error TS2769: No overload matches this call.
   Overload 1 of 3, '(cb: (x: number) => Promise<string>): Promise<string>', gave the following error.
     Argument of type '{ (n: number): Promise<number>; (s: string): Promise<string>; }' is not assignable to parameter of type '(x: number) => Promise<string>'.
       Type 'Promise<number>' is not assignable to type 'Promise<string>'.
@@ -20,7 +20,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverl
   Overload 3 of 3, '(cb: (x: number) => Promise<string>, error?: (error: any) => string, progress?: (preservation: any) => void): Promise<string>', gave the following error.
     Argument of type '{ (n: number): Promise<number>; (s: string): Promise<string>; }' is not assignable to parameter of type '(x: number) => Promise<string>'.
       Type 'Promise<number>' is not assignable to type 'Promise<string>'.
-tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts(84,22): error TS2769: No overload matches this call.
+tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts(84,38): error TS2769: No overload matches this call.
   Overload 1 of 2, '(cb: (x: number) => Promise<boolean>): Promise<boolean>', gave the following error.
     Argument of type '{ (n: number): Promise<number>; (s: string): Promise<string>; (b: boolean): Promise<boolean>; }' is not assignable to parameter of type '(x: number) => Promise<boolean>'.
       Type 'Promise<number>' is not assignable to type 'Promise<boolean>'.
@@ -87,7 +87,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverl
     
         var numPromise: Promise<number>;
         var newPromise = numPromise.then(testFunction);
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                         ~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(cb: (x: number) => Promise<string>): Promise<string>', gave the following error.
 !!! error TS2769:     Argument of type '{ (n: number): Promise<number>; (s: string): Promise<string>; }' is not assignable to parameter of type '(x: number) => Promise<string>'.
@@ -112,7 +112,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverl
     
         var numPromise: Promise<number>;
         var newPromise = numPromise.then(testFunction);
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                         ~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(cb: (x: number) => Promise<string>): Promise<string>', gave the following error.
 !!! error TS2769:     Argument of type '{ (n: number): Promise<number>; (s: string): Promise<string>; }' is not assignable to parameter of type '(x: number) => Promise<string>'.
@@ -140,7 +140,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverl
     
         var numPromise: Promise<number>;
         var newPromise = numPromise.then(testFunction);
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                         ~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(cb: (x: number) => Promise<boolean>): Promise<boolean>', gave the following error.
 !!! error TS2769:     Argument of type '{ (n: number): Promise<number>; (s: string): Promise<string>; (b: boolean): Promise<boolean>; }' is not assignable to parameter of type '(x: number) => Promise<boolean>'.

--- a/tests/baselines/reference/heterogeneousArrayAndOverloads.errors.txt
+++ b/tests/baselines/reference/heterogeneousArrayAndOverloads.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/heterogeneousArrayAndOverloads.ts(9,9): error TS2769: No overload matches this call.
+tests/cases/compiler/heterogeneousArrayAndOverloads.ts(9,26): error TS2769: No overload matches this call.
   Overload 1 of 2, '(arg1: number[]): any', gave the following error.
     Type 'string' is not assignable to type 'number'.
 
@@ -13,7 +13,7 @@ tests/cases/compiler/heterogeneousArrayAndOverloads.ts(9,9): error TS2769: No ov
             this.test(["hi"]);
             this.test([]);
             this.test([1, 2, "hi", 5]); // Error
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~
+                             ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(arg1: number[]): any', gave the following error.
 !!! error TS2769:     Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -9,7 +9,7 @@ tests/cases/compiler/incompatibleTypes.ts(26,12): error TS2416: Property 'p1' in
   Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/incompatibleTypes.ts(34,12): error TS2416: Property 'p1' in type 'C4' is not assignable to the same property in base type 'IFoo4'.
   Type '{ c: { b: string; }; d: string; }' is missing the following properties from type '{ a: { a: string; }; b: string; }': a, b
-tests/cases/compiler/incompatibleTypes.ts(42,1): error TS2769: No overload matches this call.
+tests/cases/compiler/incompatibleTypes.ts(42,5): error TS2769: No overload matches this call.
   Overload 1 of 2, '(i: IFoo1): void', gave the following error.
     Argument of type 'C1' is not assignable to parameter of type 'IFoo1'.
       Types of property 'p1' are incompatible.
@@ -20,7 +20,7 @@ tests/cases/compiler/incompatibleTypes.ts(42,1): error TS2769: No overload match
       Types of property 'p1' are incompatible.
         Type '() => string' is not assignable to type '(s: string) => number'.
           Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/incompatibleTypes.ts(49,1): error TS2769: No overload matches this call.
+tests/cases/compiler/incompatibleTypes.ts(49,7): error TS2769: No overload matches this call.
   Overload 1 of 2, '(n: { a: { a: string; }; b: string; }): number', gave the following error.
     Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ a: { a: string; }; b: string; }'.
       Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
@@ -91,7 +91,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     var c1: C1;
     var c2: C2;
     if1(c1);
-    ~~~~~~~
+        ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(i: IFoo1): void', gave the following error.
 !!! error TS2769:     Argument of type 'C1' is not assignable to parameter of type 'IFoo1'.
@@ -110,7 +110,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     function of1(a: any) { return null; }
     
     of1({ e: 0, f: 0 });
-    ~~~~~~~~~~~~~~~~~~~
+          ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(n: { a: { a: string; }; b: string; }): number', gave the following error.
 !!! error TS2769:     Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ a: { a: string; }; b: string; }'.

--- a/tests/baselines/reference/iteratorSpreadInArray6.errors.txt
+++ b/tests/baselines/reference/iteratorSpreadInArray6.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts(15,1): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts(15,14): error TS2769: No overload matches this call.
   Overload 1 of 2, '(...items: ConcatArray<number>[]): number[]', gave the following error.
     Argument of type 'symbol[]' is not assignable to parameter of type 'ConcatArray<number>'.
       Types of property 'slice' are incompatible.
@@ -26,7 +26,7 @@ tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts(15,1): error TS2769
     
     var array: number[] = [0, 1];
     array.concat([...new SymbolIterator]);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                 ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(...items: ConcatArray<number>[]): number[]', gave the following error.
 !!! error TS2769:     Argument of type 'symbol[]' is not assignable to parameter of type 'ConcatArray<number>'.

--- a/tests/baselines/reference/overloadResolution.errors.txt
+++ b/tests/baselines/reference/overloadResolution.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(27,1): error TS2769: No overload matches this call.
+tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(27,5): error TS2769: No overload matches this call.
   Overload 1 of 2, '(s: string): string', gave the following error.
     Argument of type '{}' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(s: number): number', gave the following error.
@@ -8,12 +8,12 @@ tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(63,5): e
 tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(70,21): error TS2345: Argument of type '3' is not assignable to parameter of type 'string'.
 tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(71,21): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
 tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(81,5): error TS2344: Type 'boolean' does not satisfy the constraint 'number'.
-tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(84,1): error TS2769: No overload matches this call.
+tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(84,5): error TS2769: No overload matches this call.
   Overload 1 of 2, '(n: string, m: any): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(n: number, m: any): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(85,1): error TS2769: No overload matches this call.
+tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(85,11): error TS2769: No overload matches this call.
   Overload 1 of 2, '(n: any, m: number): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 2, '(n: any, m: string): any', gave the following error.
@@ -50,7 +50,7 @@ tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(91,22): 
     
     // No candidate overloads found
     fn1({}); // Error
-    ~~~~~~~
+        ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(s: string): string', gave the following error.
 !!! error TS2769:     Argument of type '{}' is not assignable to parameter of type 'string'.
@@ -123,14 +123,14 @@ tests/cases/conformance/expressions/functionCalls/overloadResolution.ts(91,22): 
     
     // Generic overloads with constraints called without type arguments but with types that do not satisfy the constraints
     fn4(true, null); // Error
-    ~~~~~~~~~~~~~~~
+        ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(n: string, m: any): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 2, '(n: number, m: any): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.
     fn4(null, true); // Error
-    ~~~~~~~~~~~~~~~
+              ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(n: any, m: number): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.

--- a/tests/baselines/reference/overloadResolutionClassConstructors.errors.txt
+++ b/tests/baselines/reference/overloadResolutionClassConstructors.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(27,1): error TS2769: No overload matches this call.
+tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts(27,9): error TS2769: No overload matches this call.
   Overload 1 of 2, '(s: string): fn1', gave the following error.
     Argument of type '{}' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(s: number): fn1', gave the following error.
@@ -46,7 +46,7 @@ tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstru
     
     // No candidate overloads found
     new fn1({}); // Error
-    ~~~~~~~~~~~
+            ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(s: string): fn1', gave the following error.
 !!! error TS2769:     Argument of type '{}' is not assignable to parameter of type 'string'.

--- a/tests/baselines/reference/overloadResolutionConstructors.errors.txt
+++ b/tests/baselines/reference/overloadResolutionConstructors.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(27,1): error TS2769: No overload matches this call.
+tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(27,9): error TS2769: No overload matches this call.
   Overload 1 of 2, '(s: string): string', gave the following error.
     Argument of type '{}' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(s: number): number', gave the following error.
@@ -8,12 +8,12 @@ tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors
 tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(77,25): error TS2345: Argument of type '3' is not assignable to parameter of type 'string'.
 tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(78,25): error TS2345: Argument of type '""' is not assignable to parameter of type 'number'.
 tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(88,9): error TS2344: Type 'boolean' does not satisfy the constraint 'number'.
-tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(91,1): error TS2769: No overload matches this call.
+tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(91,9): error TS2769: No overload matches this call.
   Overload 1 of 2, '(n: string, m: any): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(n: number, m: any): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
-tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(92,1): error TS2769: No overload matches this call.
+tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts(92,15): error TS2769: No overload matches this call.
   Overload 1 of 2, '(n: any, m: number): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 2, '(n: any, m: string): any', gave the following error.
@@ -50,7 +50,7 @@ tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors
     
     // No candidate overloads found
     new fn1({}); // Error
-    ~~~~~~~~~~~
+            ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(s: string): string', gave the following error.
 !!! error TS2769:     Argument of type '{}' is not assignable to parameter of type 'string'.
@@ -130,14 +130,14 @@ tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors
     
     // Generic overloads with constraints called without type arguments but with types that do not satisfy the constraints
     new fn4(true, null); // Error
-    ~~~~~~~~~~~~~~~~~~~
+            ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(n: string, m: any): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 2, '(n: number, m: any): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.
     new fn4(null, true); // Error
-    ~~~~~~~~~~~~~~~~~~~
+                  ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(n: any, m: number): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.

--- a/tests/baselines/reference/overloadResolutionTest1.errors.txt
+++ b/tests/baselines/reference/overloadResolutionTest1.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/compiler/overloadResolutionTest1.ts(7,12): error TS2769: No overload matches this call.
+tests/cases/compiler/overloadResolutionTest1.ts(7,18): error TS2769: No overload matches this call.
   Overload 1 of 2, '(bar: { a: number; }[]): string', gave the following error.
     Type 'string' is not assignable to type 'number'.
   Overload 2 of 2, '(bar: { a: boolean; }[]): number', gave the following error.
     Type 'string' is not assignable to type 'boolean'.
-tests/cases/compiler/overloadResolutionTest1.ts(18,10): error TS2769: No overload matches this call.
+tests/cases/compiler/overloadResolutionTest1.ts(18,16): error TS2769: No overload matches this call.
   Overload 1 of 2, '(bar: { a: number; }): string', gave the following error.
     Type 'string' is not assignable to type 'number'.
   Overload 2 of 2, '(bar: { a: boolean; }): number', gave the following error.
     Type 'string' is not assignable to type 'boolean'.
-tests/cases/compiler/overloadResolutionTest1.ts(24,9): error TS2769: No overload matches this call.
+tests/cases/compiler/overloadResolutionTest1.ts(24,15): error TS2769: No overload matches this call.
   Overload 1 of 2, '(bar: { a: number; }): number', gave the following error.
     Type 'true' is not assignable to type 'number'.
   Overload 2 of 2, '(bar: { a: string; }): string', gave the following error.
@@ -23,7 +23,7 @@ tests/cases/compiler/overloadResolutionTest1.ts(24,9): error TS2769: No overload
     var x1 = foo([{a:true}]); // works
     var x11 = foo([{a:0}]); // works
     var x111 = foo([{a:"s"}]); // error - does not match any signature
-               ~~~~~~~~~~~~~~
+                     ~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(bar: { a: number; }[]): string', gave the following error.
 !!! error TS2769:     Type 'string' is not assignable to type 'number'.
@@ -42,7 +42,7 @@ tests/cases/compiler/overloadResolutionTest1.ts(24,9): error TS2769: No overload
     var x2 = foo2({a:0}); // works
     var x3 = foo2({a:true}); // works
     var x4 = foo2({a:"s"}); // error
-             ~~~~~~~~~~~~~
+                   ~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(bar: { a: number; }): string', gave the following error.
 !!! error TS2769:     Type 'string' is not assignable to type 'number'.
@@ -56,7 +56,7 @@ tests/cases/compiler/overloadResolutionTest1.ts(24,9): error TS2769: No overload
     function foo4(bar:{a:string;}):string;
     function foo4(bar:{a:any;}):any{ return bar };
     var x = foo4({a:true}); // error
-            ~~~~~~~~~~~~~~
+                  ~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(bar: { a: number; }): number', gave the following error.
 !!! error TS2769:     Type 'true' is not assignable to type 'number'.

--- a/tests/baselines/reference/overloadingOnConstants2.errors.txt
+++ b/tests/baselines/reference/overloadingOnConstants2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/overloadingOnConstants2.ts(9,10): error TS2394: This overload signature is not compatible with its implementation signature.
-tests/cases/compiler/overloadingOnConstants2.ts(15,9): error TS2769: No overload matches this call.
+tests/cases/compiler/overloadingOnConstants2.ts(15,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(x: "hi", items: string[]): D', gave the following error.
     Argument of type '"um"' is not assignable to parameter of type '"hi"'.
   Overload 2 of 2, '(x: "bye", items: string[]): E', gave the following error.
@@ -26,7 +26,7 @@ tests/cases/compiler/overloadingOnConstants2.ts(19,10): error TS2394: This overl
     var a: D = foo("hi", []); // D
     var b: E = foo("bye", []); // E 
     var c = foo("um", []); // error
-            ~~~~~~~~~~~~~
+                ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(x: "hi", items: string[]): D', gave the following error.
 !!! error TS2769:     Argument of type '"um"' is not assignable to parameter of type '"hi"'.

--- a/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.errors.txt
+++ b/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.errors.txt
@@ -3,7 +3,7 @@ tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(14,37):
   Property 'x' is missing in type 'D' but required in type 'A'.
 tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(16,5): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(16,38): error TS2344: Type 'D' does not satisfy the constraint 'A'.
-tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(18,23): error TS2769: No overload matches this call.
+tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(18,27): error TS2769: No overload matches this call.
   Overload 1 of 3, '(arg: (x: D) => number): string', gave the following error.
     Argument of type '(x: D) => G<D>' is not assignable to parameter of type '(x: D) => number'.
       Type 'G<D>' is not assignable to type 'number'.
@@ -47,15 +47,7 @@ tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(19,14):
 !!! error TS2344: Type 'D' does not satisfy the constraint 'A'.
     
     var result3: string = foo(x => { // x has type D
-                          ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        var y: G<typeof x>; // error that D does not satisfy constraint, y is of type G<D>, entire call to foo is an error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                 ~~~~~~~~
-!!! error TS2344: Type 'D' does not satisfy the constraint 'A'.
-        return y;
-    ~~~~~~~~~~~~~
-    });
-    ~~
+                              ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(arg: (x: D) => number): string', gave the following error.
 !!! error TS2769:     Argument of type '(x: D) => G<D>' is not assignable to parameter of type '(x: D) => number'.
@@ -70,4 +62,9 @@ tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(19,14):
 !!! error TS2769:         Property 'q' is missing in type 'B' but required in type 'D'.
 !!! related TS2728 tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts:4:15: 'q' is declared here.
 !!! related TS2728 tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts:4:15: 'q' is declared here.
+        var y: G<typeof x>; // error that D does not satisfy constraint, y is of type G<D>, entire call to foo is an error
+                 ~~~~~~~~
+!!! error TS2344: Type 'D' does not satisfy the constraint 'A'.
+        return y;
+    });
     

--- a/tests/baselines/reference/promiseTypeInference.errors.txt
+++ b/tests/baselines/reference/promiseTypeInference.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/promiseTypeInference.ts(10,11): error TS2769: No overload matches this call.
+tests/cases/compiler/promiseTypeInference.ts(10,39): error TS2769: No overload matches this call.
   Overload 1 of 2, '(success?: (value: string) => Promise<unknown>): Promise<unknown>', gave the following error.
     Property 'catch' is missing in type 'IPromise<number>' but required in type 'Promise<unknown>'.
   Overload 2 of 2, '(onfulfilled?: (value: string) => number | PromiseLike<number>, onrejected?: (reason: any) => PromiseLike<never>): Promise<number>', gave the following error.
@@ -22,7 +22,7 @@ tests/cases/compiler/promiseTypeInference.ts(10,11): error TS2769: No overload m
     declare function convert(s: string): IPromise<number>;
     
     var $$x = load("something").then(s => convert(s));
-              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                          ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(success?: (value: string) => Promise<unknown>): Promise<unknown>', gave the following error.
 !!! error TS2769:     Property 'catch' is missing in type 'IPromise<number>' but required in type 'Promise<unknown>'.

--- a/tests/baselines/reference/reactDefaultPropsInferenceSuccess.errors.txt
+++ b/tests/baselines/reference/reactDefaultPropsInferenceSuccess.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(27,21): error TS2769: No overload matches this call.
+tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(27,36): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<Props>): FieldFeedback<Props>', gave the following error.
     Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
       Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
@@ -6,7 +6,7 @@ tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(27,21): error TS2769:
   Overload 2 of 2, '(props: Props, context?: any): FieldFeedback<Props>', gave the following error.
     Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
       Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
-tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(43,22): error TS2769: No overload matches this call.
+tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(43,41): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<Props>): FieldFeedbackBeta<Props>', gave the following error.
     Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
       Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
@@ -14,7 +14,7 @@ tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(43,22): error TS2769:
   Overload 2 of 2, '(props: Props, context?: any): FieldFeedbackBeta<Props>', gave the following error.
     Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
       Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
-tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(64,21): error TS2769: No overload matches this call.
+tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(64,37): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<MyPropsProps>): FieldFeedback2<MyPropsProps>', gave the following error.
     Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.
       Type 'void' is not assignable to type 'boolean'.
@@ -50,7 +50,7 @@ tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(64,21): error TS2769:
     
     // Error: Void not assignable to boolean
     const Test2 = () => <FieldFeedback when={value => console.log(value)} />;
-                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                       ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(props: Readonly<Props>): FieldFeedback<Props>', gave the following error.
 !!! error TS2769:     Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
@@ -77,7 +77,7 @@ tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(64,21): error TS2769:
     
     // Error: Void not assignable to boolean
     const Test2a = () => <FieldFeedbackBeta when={value => console.log(value)} error>Hah</FieldFeedbackBeta>;
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                            ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(props: Readonly<Props>): FieldFeedbackBeta<Props>', gave the following error.
 !!! error TS2769:     Type '(value: string) => void' is not assignable to type '"a" | "b" | ((value: string) => boolean) | undefined'.
@@ -109,7 +109,7 @@ tests/cases/compiler/reactDefaultPropsInferenceSuccess.tsx(64,21): error TS2769:
     
     // Error: Void not assignable to boolean
     const Test4 = () => <FieldFeedback2 when={value => console.log(value)} />;
-                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                        ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(props: Readonly<MyPropsProps>): FieldFeedback2<MyPropsProps>', gave the following error.
 !!! error TS2769:     Type '(value: string) => void' is not assignable to type '(value: string) => boolean'.

--- a/tests/baselines/reference/recursiveFunctionTypes.errors.txt
+++ b/tests/baselines/reference/recursiveFunctionTypes.errors.txt
@@ -11,7 +11,7 @@ tests/cases/compiler/recursiveFunctionTypes.ts(30,10): error TS2394: This overlo
 tests/cases/compiler/recursiveFunctionTypes.ts(33,8): error TS2554: Expected 0-1 arguments, but got 2.
 tests/cases/compiler/recursiveFunctionTypes.ts(34,4): error TS2345: Argument of type '""' is not assignable to parameter of type '{ (): typeof f6; (a: typeof f6): () => number; }'.
 tests/cases/compiler/recursiveFunctionTypes.ts(42,8): error TS2554: Expected 0-1 arguments, but got 2.
-tests/cases/compiler/recursiveFunctionTypes.ts(43,1): error TS2769: No overload matches this call.
+tests/cases/compiler/recursiveFunctionTypes.ts(43,4): error TS2769: No overload matches this call.
   Overload 1 of 4, '(a: { (): typeof f7; (a: typeof f7): () => number; (a: number): number; (a?: typeof f7): typeof f7; }): () => number', gave the following error.
     Argument of type '""' is not assignable to parameter of type '{ (): typeof f7; (a: typeof f7): () => number; (a: number): number; (a?: typeof f7): typeof f7; }'.
   Overload 2 of 4, '(a: number): number', gave the following error.
@@ -90,7 +90,7 @@ tests/cases/compiler/recursiveFunctionTypes.ts(43,1): error TS2769: No overload 
            ~
 !!! error TS2554: Expected 0-1 arguments, but got 2.
     f7(""); // ok (function takes an any param)
-    ~~~~~~
+       ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(a: { (): typeof f7; (a: typeof f7): () => number; (a: number): number; (a?: typeof f7): typeof f7; }): () => number', gave the following error.
 !!! error TS2769:     Argument of type '""' is not assignable to parameter of type '{ (): typeof f7; (a: typeof f7): () => number; (a: number): number; (a?: typeof f7): typeof f7; }'.

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1.errors.txt
@@ -1,23 +1,23 @@
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(9,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
   Property 'raw' is missing in type 'undefined[]' but required in type 'TemplateStringsArray'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(10,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(11,9): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(11,13): error TS2769: No overload matches this call.
   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(12,9): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(12,13): error TS2769: No overload matches this call.
   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(13,9): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(13,13): error TS2769: No overload matches this call.
   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(14,23): error TS2554: Expected 1-3 arguments, but got 4.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(19,9): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1.ts(19,20): error TS2769: No overload matches this call.
   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
@@ -43,21 +43,21 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
                 ~~
 !!! error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
     var c = foo([], 1, 2);       // boolean
-            ~~~~~~~~~~~~~
+                ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
     var d = foo([], 1, true);    // boolean (with error)
-            ~~~~~~~~~~~~~~~~
+                ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
     var e = foo([], 1, "2");     // {}
-            ~~~~~~~~~~~~~~~
+                ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
@@ -71,7 +71,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     var v = foo `${1}`;          // string
     var w = foo `${1}${2}`;      // boolean
     var x = foo `${1}${true}`;   // boolean (with error)
-            ~~~~~~~~~~~~~~~~~
+                       ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1_ES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution1_ES6.errors.txt
@@ -1,23 +1,23 @@
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(9,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
   Property 'raw' is missing in type 'undefined[]' but required in type 'TemplateStringsArray'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(10,13): error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(11,9): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(11,13): error TS2769: No overload matches this call.
   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(12,9): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(12,13): error TS2769: No overload matches this call.
   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(13,9): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(13,13): error TS2769: No overload matches this call.
   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(14,23): error TS2554: Expected 1-3 arguments, but got 4.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(19,9): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution1_ES6.ts(19,20): error TS2769: No overload matches this call.
   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
@@ -43,21 +43,21 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
                 ~~
 !!! error TS2345: Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
     var c = foo([], 1, 2);       // boolean
-            ~~~~~~~~~~~~~
+                ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
     var d = foo([], 1, true);    // boolean (with error)
-            ~~~~~~~~~~~~~~~~
+                ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
 !!! error TS2769:   Overload 2 of 4, '(strs: TemplateStringsArray, x: number, y: string): {}', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
     var e = foo([], 1, "2");     // {}
-            ~~~~~~~~~~~~~~~
+                ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
 !!! error TS2769:     Argument of type 'undefined[]' is not assignable to parameter of type 'TemplateStringsArray'.
@@ -71,7 +71,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     var v = foo `${1}`;          // string
     var w = foo `${1}${2}`;      // boolean
     var x = foo `${1}${true}`;   // boolean (with error)
-            ~~~~~~~~~~~~~~~~~
+                       ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 4, '(strs: TemplateStringsArray, x: number, y: number): boolean', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(9,1): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(9,9): error TS2769: No overload matches this call.
   Overload 1 of 2, '(strs: TemplateStringsArray, s: string): string', gave the following error.
     Argument of type '{}' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(strs: TemplateStringsArray, n: number): number', gave the following error.
     Argument of type '{}' is not assignable to parameter of type 'number'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(18,4): error TS2339: Property 'foo' does not exist on type 'Date'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(44,1): error TS2554: Expected 2-4 arguments, but got 1.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(62,1): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(62,9): error TS2769: No overload matches this call.
   Overload 1 of 3, '(strs: TemplateStringsArray, n: string, m: any): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'string'.
   Overload 2 of 3, '(strs: TemplateStringsArray, n: number, m: any): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(63,1): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3.ts(63,18): error TS2769: No overload matches this call.
   Overload 1 of 3, '(strs: TemplateStringsArray, n: any, m: number): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 3, '(strs: TemplateStringsArray, n: any, m: string): any', gave the following error.
@@ -28,7 +28,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     
     // No candidate overloads found
     fn1 `${ {} }`; // Error
-    ~~~~~~~~~~~~~
+            ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(strs: TemplateStringsArray, s: string): string', gave the following error.
 !!! error TS2769:     Argument of type '{}' is not assignable to parameter of type 'string'.
@@ -92,14 +92,14 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     
     // Generic overloads with constraints called without type arguments but with types that do not satisfy the constraints
     fn4 `${ true }${ null }`;
-    ~~~~~~~~~~~~~~~~~~~~~~~~
+            ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(strs: TemplateStringsArray, n: string, m: any): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 3, '(strs: TemplateStringsArray, n: number, m: any): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.
     fn4 `${ null }${ true }`;
-    ~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(strs: TemplateStringsArray, n: any, m: number): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(9,1): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(9,9): error TS2769: No overload matches this call.
   Overload 1 of 2, '(strs: TemplateStringsArray, s: string): string', gave the following error.
     Argument of type '{}' is not assignable to parameter of type 'string'.
   Overload 2 of 2, '(strs: TemplateStringsArray, n: number): number', gave the following error.
     Argument of type '{}' is not assignable to parameter of type 'number'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(18,4): error TS2339: Property 'foo' does not exist on type 'Date'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(44,1): error TS2554: Expected 2-4 arguments, but got 1.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(62,1): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(62,9): error TS2769: No overload matches this call.
   Overload 1 of 3, '(strs: TemplateStringsArray, n: string, m: any): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'string'.
   Overload 2 of 3, '(strs: TemplateStringsArray, n: number, m: any): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(63,1): error TS2769: No overload matches this call.
+tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolution3_ES6.ts(63,18): error TS2769: No overload matches this call.
   Overload 1 of 3, '(strs: TemplateStringsArray, n: any, m: number): any', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 3, '(strs: TemplateStringsArray, n: any, m: string): any', gave the following error.
@@ -28,7 +28,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     
     // No candidate overloads found
     fn1 `${ {} }`; // Error
-    ~~~~~~~~~~~~~
+            ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(strs: TemplateStringsArray, s: string): string', gave the following error.
 !!! error TS2769:     Argument of type '{}' is not assignable to parameter of type 'string'.
@@ -92,14 +92,14 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsWithOverloadResolutio
     
     // Generic overloads with constraints called without type arguments but with types that do not satisfy the constraints
     fn4 `${ true }${ null }`;
-    ~~~~~~~~~~~~~~~~~~~~~~~~
+            ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(strs: TemplateStringsArray, n: string, m: any): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'string'.
 !!! error TS2769:   Overload 2 of 3, '(strs: TemplateStringsArray, n: number, m: any): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.
     fn4 `${ null }${ true }`;
-    ~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(strs: TemplateStringsArray, n: any, m: number): any', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.

--- a/tests/baselines/reference/tsxElementResolution9.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution9.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/conformance/jsx/file.tsx(11,1): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(11,2): error TS2769: No overload matches this call.
   Overload 1 of 2, '(n: string): { x: number; }', gave the following error.
     Type '{}' is not assignable to type 'string'.
   Overload 2 of 2, '(n: number): { y: string; }', gave the following error.
     Type '{}' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(18,1): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(18,2): error TS2769: No overload matches this call.
   Overload 1 of 2, '(n: string): { x: number; }', gave the following error.
     Type '{}' is not assignable to type 'string'.
   Overload 2 of 2, '(n: number): { y: string; }', gave the following error.
     Type '{}' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(25,1): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(25,2): error TS2769: No overload matches this call.
   Overload 1 of 2, '(n: string): { x: number; }', gave the following error.
     Type '{ x: number; }' is not assignable to type 'string'.
   Overload 2 of 2, '(n: number): { x: number; y: string; }', gave the following error.
@@ -27,7 +27,7 @@ tests/cases/conformance/jsx/file.tsx(25,1): error TS2769: No overload matches th
     }
     var Obj1: Obj1;
     <Obj1 />; // Error, return type is not an object type
-    ~~~~~~~~
+     ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(n: string): { x: number; }', gave the following error.
 !!! error TS2769:     Type '{}' is not assignable to type 'string'.
@@ -40,7 +40,7 @@ tests/cases/conformance/jsx/file.tsx(25,1): error TS2769: No overload matches th
     }
     var Obj2: Obj2;
     <Obj2 />; // Error, return type is not an object type
-    ~~~~~~~~
+     ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(n: string): { x: number; }', gave the following error.
 !!! error TS2769:     Type '{}' is not assignable to type 'string'.
@@ -53,7 +53,7 @@ tests/cases/conformance/jsx/file.tsx(25,1): error TS2769: No overload matches th
     }
     var Obj3: Obj3;
     <Obj3 x={42} />; // OK
-    ~~~~~~~~~~~~~~~
+     ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(n: string): { x: number; }', gave the following error.
 !!! error TS2769:     Type '{ x: number; }' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxNotUsingApparentTypeOfSFC.errors.txt
+++ b/tests/baselines/reference/tsxNotUsingApparentTypeOfSFC.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx(14,14): error TS2322: Type '{}' is not assignable to type 'P'.
   '{}' is assignable to the constraint of type 'P', but 'P' could be instantiated with a different subtype of constraint '{}'.
-tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx(15,13): error TS2769: No overload matches this call.
+tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx(15,14): error TS2769: No overload matches this call.
   Overload 1 of 2, '(props: Readonly<P>): MyComponent', gave the following error.
     Type '{}' is not assignable to type 'Readonly<P>'.
   Overload 2 of 2, '(props: P, context?: any): MyComponent', gave the following error.
@@ -26,7 +26,7 @@ tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx(15,13): error TS2769: No o
 !!! error TS2322: Type '{}' is not assignable to type 'P'.
 !!! error TS2322:   '{}' is assignable to the constraint of type 'P', but 'P' could be instantiated with a different subtype of constraint '{}'.
         let y = <MyComponent />;  // should error
-                ~~~~~~~~~~~~~~~
+                 ~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(props: Readonly<P>): MyComponent', gave the following error.
 !!! error TS2769:     Type '{}' is not assignable to type 'Readonly<P>'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/jsx/file.tsx(12,12): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(12,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes'.
       Property 'extraProp' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
       Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-tests/cases/conformance/jsx/file.tsx(13,12): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(13,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
     Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes'.
       Property 'yy' does not exist on type 'IntrinsicAttributes'.
@@ -17,14 +17,14 @@ tests/cases/conformance/jsx/file.tsx(14,12): error TS2769: No overload matches t
       Property 'yy1' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
     Type 'true' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(16,12): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(16,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
     Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes'.
       Property 'y1' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
     Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
       Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-tests/cases/conformance/jsx/file.tsx(17,12): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(17,13): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
     Type '{ yy: boolean; yy1: string; }' has no properties in common with type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
@@ -89,7 +89,7 @@ tests/cases/conformance/jsx/file.tsx(36,12): error TS2769: No overload matches t
     
     // Error
     const c0 = <OneThing extraProp />;  // extra property;
-               ~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
 !!! error TS2769:     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes'.
@@ -98,7 +98,7 @@ tests/cases/conformance/jsx/file.tsx(36,12): error TS2769: No overload matches t
 !!! error TS2769:     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 !!! error TS2769:       Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
     const c1 = <OneThing yy={10}/>;  // missing property;
-               ~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
 !!! error TS2769:     Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes'.
@@ -117,7 +117,7 @@ tests/cases/conformance/jsx/file.tsx(36,12): error TS2769: No overload matches t
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:3:43: The expected type comes from property 'yy1' which is declared here on type 'IntrinsicAttributes & { yy: number; yy1: string; }'
     const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  //  This is OK becuase all attribute are spread
     const c4 = <OneThing {...obj} y1={10000} />;  // extra property;
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
 !!! error TS2769:     Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes'.
@@ -126,7 +126,7 @@ tests/cases/conformance/jsx/file.tsx(36,12): error TS2769: No overload matches t
 !!! error TS2769:     Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 !!! error TS2769:       Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
     const c5 = <OneThing {...obj} {...{yy: true}} />;  // type incompatible;
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
 !!! error TS2769:     Type '{ yy: boolean; yy1: string; }' has no properties in common with type 'IntrinsicAttributes'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(48,12): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(48,13): error TS2769: No overload matches this call.
   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'to' does not exist on type 'IntrinsicAttributes & ButtonProps'.
@@ -8,14 +8,14 @@ tests/cases/conformance/jsx/file.tsx(48,12): error TS2769: No overload matches t
   Overload 3 of 3, '(hyphenProps: HyphenProps): Element', gave the following error.
     Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
       Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
-tests/cases/conformance/jsx/file.tsx(54,12): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(54,51): error TS2769: No overload matches this call.
   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
     Type 'number' is not assignable to type 'string'.
   Overload 2 of 3, '(linkProps: LinkProps): Element', gave the following error.
     Type 'number' is not assignable to type 'string'.
   Overload 3 of 3, '(hyphenProps: HyphenProps): Element', gave the following error.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(55,12): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(55,68): error TS2769: No overload matches this call.
   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
     Type 'true' is not assignable to type 'string'.
   Overload 2 of 3, '(linkProps: LinkProps): Element', gave the following error.
@@ -80,7 +80,7 @@ tests/cases/conformance/jsx/file.tsx(56,12): error TS2769: No overload matches t
     
     // Error
     const b0 = <MainButton to='/some/path' onClick={(e)=>{}}>GO</MainButton>;  // extra property;
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
@@ -97,7 +97,7 @@ tests/cases/conformance/jsx/file.tsx(56,12): error TS2769: No overload matches t
     const b4 = <MainButton {...obj3} to />;  // Should error because Incorrect type; but attributes are any so everything is allowed
     const b5 = <MainButton {...{ onClick(e: any) { } }} {...obj0} />;  // Spread retain method declaration (see GitHub #13365), so now there is an extra attributes
     const b6 = <MainButton {...{ onClick(e: any){} }} children={10} />;  // incorrect type for optional attribute
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                      ~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type 'number' is not assignable to type 'string'.
@@ -109,7 +109,7 @@ tests/cases/conformance/jsx/file.tsx(56,12): error TS2769: No overload matches t
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:4:5: The expected type comes from property 'children' which is declared here on type 'IntrinsicAttributes & LinkProps'
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:4:5: The expected type comes from property 'children' which is declared here on type 'IntrinsicAttributes & HyphenProps'
     const b7 = <MainButton {...{ onClick(e: any){} }} children="hello" className />;  // incorrect type for optional attribute
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                                       ~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type 'true' is not assignable to type 'string'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentsWithTypeArguments4.errors.txt
@@ -6,7 +6,7 @@ tests/cases/conformance/jsx/file.tsx(9,14): error TS2769: No overload matches th
     Type 'number' is not assignable to type 'string'.
   Overload 3 of 3, '(attr: { b: unknown; a: number; }): Element', gave the following error.
     Property 'b' is missing in type '{ a: number; }' but required in type '{ b: unknown; a: number; }'.
-tests/cases/conformance/jsx/file.tsx(10,14): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(10,15): error TS2769: No overload matches this call.
   Overload 1 of 3, '(): Element', gave the following error.
     Type 'T & { ignore-prop: true; }' has no properties in common with type 'IntrinsicAttributes'.
   Overload 2 of 3, '(attr: { b: unknown; a: string; "ignore-prop": boolean; }): Element', gave the following error.
@@ -39,7 +39,7 @@ tests/cases/conformance/jsx/file.tsx(10,14): error TS2769: No overload matches t
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:4:52: The expected type comes from property 'a' which is declared here on type 'IntrinsicAttributes & { b: unknown; a: string; "ignore-prop": boolean; }'
 !!! related TS2728 tests/cases/conformance/jsx/file.tsx:5:49: 'b' is declared here.
         let a2 = <OverloadComponent {...arg1} ignore-prop />  // missing a
-                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(): Element', gave the following error.
 !!! error TS2769:     Type 'T & { ignore-prop: true; }' has no properties in common with type 'IntrinsicAttributes'.

--- a/tests/baselines/reference/unionTypeCallSignatures.errors.txt
+++ b/tests/baselines/reference/unionTypeCallSignatures.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(9,43): error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'number'.
-tests/cases/conformance/types/union/unionTypeCallSignatures.ts(10,1): error TS2769: No overload matches this call.
+tests/cases/conformance/types/union/unionTypeCallSignatures.ts(10,29): error TS2769: No overload matches this call.
   Overload 1 of 2, '(a: number): number | Date', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 2, '(a: string): string | boolean', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'string'.
-tests/cases/conformance/types/union/unionTypeCallSignatures.ts(15,1): error TS2769: No overload matches this call.
+tests/cases/conformance/types/union/unionTypeCallSignatures.ts(15,29): error TS2769: No overload matches this call.
   Overload 1 of 2, '(a: number): number | Date', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 2, '(a: string): string | boolean', gave the following error.
@@ -48,7 +48,7 @@ tests/cases/conformance/types/union/unionTypeCallSignatures.ts(73,12): error TS2
                                               ~~~~~~~
 !!! error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'number'.
     unionOfDifferentReturnType1(true); // error in type of parameter
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(a: number): number | Date', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.
@@ -59,7 +59,7 @@ tests/cases/conformance/types/union/unionTypeCallSignatures.ts(73,12): error TS2
     numOrDate = unionOfDifferentReturnType1(10);
     strOrBoolean = unionOfDifferentReturnType1("hello");
     unionOfDifferentReturnType1(true); // error in type of parameter
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(a: number): number | Date', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.

--- a/tests/baselines/reference/unionTypeConstructSignatures.errors.txt
+++ b/tests/baselines/reference/unionTypeConstructSignatures.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(9,47): error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'number'.
-tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(10,1): error TS2769: No overload matches this call.
+tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(10,33): error TS2769: No overload matches this call.
   Overload 1 of 2, '(a: number): number | Date', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 2, '(a: string): string | boolean', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'string'.
-tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(15,1): error TS2769: No overload matches this call.
+tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(15,33): error TS2769: No overload matches this call.
   Overload 1 of 2, '(a: number): number | Date', gave the following error.
     Argument of type 'true' is not assignable to parameter of type 'number'.
   Overload 2 of 2, '(a: string): string | boolean', gave the following error.
@@ -47,7 +47,7 @@ tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(70,12): erro
                                                   ~~~~~~~
 !!! error TS2345: Argument of type '"hello"' is not assignable to parameter of type 'number'.
     new unionOfDifferentReturnType1(true); // error in type of parameter
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                    ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(a: number): number | Date', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.
@@ -58,7 +58,7 @@ tests/cases/conformance/types/union/unionTypeConstructSignatures.ts(70,12): erro
     numOrDate = new unionOfDifferentReturnType1(10);
     strOrBoolean = new unionOfDifferentReturnType1("hello");
     new unionOfDifferentReturnType1(true); // error in type of parameter
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                    ~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(a: number): number | Date', gave the following error.
 !!! error TS2769:     Argument of type 'true' is not assignable to parameter of type 'number'.


### PR DESCRIPTION
When all errors for a multiple-overload error refer to the same span, use that span instead of the one for the entire call.

This situation is quite common for 2-overload sets in React.