### PR TITLE
Remove "Did you forget to use await" for unary arithmetic expressions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23713,9 +23713,9 @@ namespace ts {
             }
         }
 
-        function checkArithmeticOperandType(operand: Node, type: Type, diagnostic: DiagnosticMessage): boolean {
+        function checkArithmeticOperandType(operand: Node, type: Type, diagnostic: DiagnosticMessage, tryAwait = false): boolean {
             if (!isTypeAssignableTo(type, numberOrBigIntType)) {
-                const awaitedType = getAwaitedType(type);
+                const awaitedType = tryAwait && getAwaitedTypeOfPromise(type);
                 errorAndMaybeSuggestAwait(
                     operand,
                     !!awaitedType && isTypeAssignableTo(awaitedType, numberOrBigIntType),
@@ -24327,8 +24327,8 @@ namespace ts {
                     }
                     else {
                         // otherwise just check each operand separately and report errors as normal
-                        const leftOk = checkArithmeticOperandType(left, leftType, Diagnostics.The_left_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type);
-                        const rightOk = checkArithmeticOperandType(right, rightType, Diagnostics.The_right_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type);
+                        const leftOk = checkArithmeticOperandType(left, leftType, Diagnostics.The_left_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type, /*tryAwait*/ true);
+                        const rightOk = checkArithmeticOperandType(right, rightType, Diagnostics.The_right_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type, /*tryAwait*/ true);
                         let resultType: Type;
                         // If both are any or unknown, allow operation; assume it will resolve to number
                         if ((isTypeAssignableToKind(leftType, TypeFlags.AnyOrUnknown) && isTypeAssignableToKind(rightType, TypeFlags.AnyOrUnknown)) ||

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23713,9 +23713,9 @@ namespace ts {
             }
         }
 
-        function checkArithmeticOperandType(operand: Node, type: Type, diagnostic: DiagnosticMessage, tryAwait = false): boolean {
+        function checkArithmeticOperandType(operand: Node, type: Type, diagnostic: DiagnosticMessage, isAwaitValid = false): boolean {
             if (!isTypeAssignableTo(type, numberOrBigIntType)) {
-                const awaitedType = tryAwait && getAwaitedTypeOfPromise(type);
+                const awaitedType = isAwaitValid && getAwaitedTypeOfPromise(type);
                 errorAndMaybeSuggestAwait(
                     operand,
                     !!awaitedType && isTypeAssignableTo(awaitedType, numberOrBigIntType),
@@ -24327,8 +24327,8 @@ namespace ts {
                     }
                     else {
                         // otherwise just check each operand separately and report errors as normal
-                        const leftOk = checkArithmeticOperandType(left, leftType, Diagnostics.The_left_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type, /*tryAwait*/ true);
-                        const rightOk = checkArithmeticOperandType(right, rightType, Diagnostics.The_right_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type, /*tryAwait*/ true);
+                        const leftOk = checkArithmeticOperandType(left, leftType, Diagnostics.The_left_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type, /*isAwaitValid*/ true);
+                        const rightOk = checkArithmeticOperandType(right, rightType, Diagnostics.The_right_hand_side_of_an_arithmetic_operation_must_be_of_type_any_number_bigint_or_an_enum_type, /*isAwaitValid*/ true);
                         let resultType: Type;
                         // If both are any or unknown, allow operation; assume it will resolve to number
                         if ((isTypeAssignableToKind(leftType, TypeFlags.AnyOrUnknown) && isTypeAssignableToKind(rightType, TypeFlags.AnyOrUnknown)) ||

--- a/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
+++ b/tests/baselines/reference/operationsAvailableOnPromisedType.errors.txt
@@ -51,11 +51,9 @@ tests/cases/compiler/operationsAvailableOnPromisedType.ts(27,5): error TS2349: T
         b++;
         ~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
-!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:15:5: Did you forget to use 'await'?
         --b;
           ~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number', 'bigint' or an enum type.
-!!! related TS2773 tests/cases/compiler/operationsAvailableOnPromisedType.ts:16:7: Did you forget to use 'await'?
         a === b;
         ~~~~~~~
 !!! error TS2367: This condition will always return 'false' since the types 'number' and 'Promise<number>' have no overlap.


### PR DESCRIPTION
Um, so in #32239, one of the ones I added was

```ts
declare var x: Promise<number>;
x++; // Did you forget to use 'await'?
--x; // Did you forget to use 'await'?
```

🤦‍♂ 

_Did_ you forget to use 'await'? _Did you really?_

```ts
// Obviously nonsense
(await x)++;
--(await x);
```

![image](https://user-images.githubusercontent.com/3277153/61002364-42647a80-a316-11e9-8f93-7474dab369d9.png)