### PR TITLE
Don't add extra indentation for objects inside function parameters

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -490,7 +490,7 @@ namespace ts.formatting {
                 else if (SmartIndenter.childStartsOnTheSameLineWithElseInIfStatement(parent, node, startLine, sourceFile)) {
                     return { indentation: parentDynamicIndentation.getIndentation(), delta };
                 }
-                else if (SmartIndenter.childStartsInlineWithPreviousObject(parent, node, startLine, sourceFile)) {
+                else if (SmartIndenter.argumentStartsOnSameLineAsPreviousArgument(parent, node, startLine, sourceFile)) {
                     return { indentation: parentDynamicIndentation.getIndentation(), delta };
                 }
                 else {

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -490,6 +490,9 @@ namespace ts.formatting {
                 else if (SmartIndenter.childStartsOnTheSameLineWithElseInIfStatement(parent, node, startLine, sourceFile)) {
                     return { indentation: parentDynamicIndentation.getIndentation(), delta };
                 }
+                else if (SmartIndenter.childStartsInlineWithPreviousObject(parent, node, startLine, sourceFile)) {
+                    return { indentation: parentDynamicIndentation.getIndentation(), delta };
+                }
                 else {
                     return { indentation: parentDynamicIndentation.getIndentation() + parentDynamicIndentation.getDelta(node), delta };
                 }

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -482,7 +482,6 @@ namespace ts.formatting {
                 case SyntaxKind.ArrayLiteralExpression:
                 case SyntaxKind.Block:
                 case SyntaxKind.ModuleBlock:
-                case SyntaxKind.ObjectLiteralExpression:
                 case SyntaxKind.TypeLiteral:
                 case SyntaxKind.MappedType:
                 case SyntaxKind.TupleType:
@@ -524,6 +523,8 @@ namespace ts.formatting {
                         return rangeIsOnOneLine(sourceFile, child!);
                     }
                     return true;
+                case SyntaxKind.CallExpression:
+                    return childKind !== SyntaxKind.ObjectLiteralExpression
                 case SyntaxKind.DoStatement:
                 case SyntaxKind.WhileStatement:
                 case SyntaxKind.ForInStatement:

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -322,16 +322,15 @@ namespace ts.formatting {
             return false;
         }
 
-        export function childStartsInlineWithPreviousObject(parent: Node, child: TextRangeWithKind, childStartLine: number, sourceFile: SourceFileLike): boolean {
-            if (parent.kind === SyntaxKind.CallExpression) {
-                const parentCallExpression = <CallExpression>parent;
-                const currentNode = find(parentCallExpression.arguments, arg => arg.pos === child.pos);
-                if (!currentNode) return false; // Shouldn't happen
+        export function argumentStartsOnSameLineAsPreviousArgument(parent: Node, child: TextRangeWithKind, childStartLine: number, sourceFile: SourceFileLike): boolean {
+            if (isCallOrNewExpression(parent)) {
+                if (!parent.arguments) return false;
 
-                const currentIndex = parentCallExpression.arguments.indexOf(currentNode);
+                const currentNode = Debug.assertDefined(find(parent.arguments, arg => arg.pos === child.pos));
+                const currentIndex = parent.arguments.indexOf(currentNode);
                 if (currentIndex === 0) return false; // Can't look at previous node if first
 
-                const previousNode = parentCallExpression.arguments[currentIndex - 1];
+                const previousNode = parent.arguments[currentIndex - 1];
                 const lineOfPreviousNode = getLineAndCharacterOfPosition(sourceFile, previousNode.getEnd()).line;
 
                 if (childStartLine === lineOfPreviousNode) {

--- a/tests/cases/fourslash/consistenceOnIndentionsOfObjectsInAListAfterFormatting.ts
+++ b/tests/cases/fourslash/consistenceOnIndentionsOfObjectsInAListAfterFormatting.ts
@@ -8,4 +8,4 @@ format.document();
 goTo.marker("1");
 verify.currentLineContentIs("}, {");
 goTo.marker("2");
-verify.currentLineContentIs("    });");
+verify.currentLineContentIs("});");

--- a/tests/cases/fourslash/formatMultipleFunctionArguments.ts
+++ b/tests/cases/fourslash/formatMultipleFunctionArguments.ts
@@ -11,6 +11,15 @@
 ////    prop5: 5,
 ////    prop6: 6
 ////  });
+////
+////  someRandomFunction(
+////      { prop7: 1, prop8: 2 },
+////      { prop9: 3, prop10: 4 },
+////      {
+////        prop11: 5,
+////        prop2: 6
+////      }
+////  );
 
 format.document();
 verify.currentFileContentIs(`
@@ -23,4 +32,13 @@ someRandomFunction({
 }, {
     prop5: 5,
     prop6: 6
-});`);
+});
+
+someRandomFunction(
+    { prop7: 1, prop8: 2 },
+    { prop9: 3, prop10: 4 },
+    {
+        prop11: 5,
+        prop2: 6
+    }
+);`);

--- a/tests/cases/fourslash/formatMultipleFunctionArguments.ts
+++ b/tests/cases/fourslash/formatMultipleFunctionArguments.ts
@@ -1,0 +1,26 @@
+/// <reference path="fourslash.ts"/>
+
+////
+////  someRandomFunction({
+////    prop1: 1,
+////    prop2: 2
+////  }, {
+////    prop3: 3,
+////    prop4: 4
+////  }, {
+////    prop5: 5,
+////    prop6: 6
+////  });
+
+format.document();
+verify.currentFileContentIs(`
+someRandomFunction({
+    prop1: 1,
+    prop2: 2
+}, {
+    prop3: 3,
+    prop4: 4
+}, {
+    prop5: 5,
+    prop6: 6
+});`);


### PR DESCRIPTION
Fixes #14589

There was a test of the old behavior, but I think the new behavior is better, so I fixed that test.