### PR TITLE
Ensure that the filePaths in compiler options are absolute before getting relative path to buildInfo directory

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -612,7 +612,8 @@ namespace ts {
      */
     function getProgramBuildInfo(state: Readonly<ReusableBuilderProgramState>, getCanonicalFileName: GetCanonicalFileName): ProgramBuildInfo | undefined {
         if (state.compilerOptions.outFile || state.compilerOptions.out) return undefined;
-        const buildInfoDirectory = getDirectoryPath(getNormalizedAbsolutePath(getOutputPathForBuildInfo(state.compilerOptions)!, Debug.assertDefined(state.program).getCurrentDirectory()));
+        const currentDirectory = Debug.assertDefined(state.program).getCurrentDirectory();
+        const buildInfoDirectory = getDirectoryPath(getNormalizedAbsolutePath(getOutputPathForBuildInfo(state.compilerOptions)!, currentDirectory));
         const fileInfos: MapLike<BuilderState.FileInfo> = {};
         state.fileInfos.forEach((value, key) => {
             const signature = state.currentAffectedFilesSignatures && state.currentAffectedFilesSignatures.get(key);
@@ -621,7 +622,7 @@ namespace ts {
 
         const result: ProgramBuildInfo = {
             fileInfos,
-            options: convertToReusableCompilerOptions(state.compilerOptions, relativeToBuildInfo)
+            options: convertToReusableCompilerOptions(state.compilerOptions, relativeToBuildInfoEnsuringAbsolutePath)
         };
         if (state.referencedMap) {
             const referencedMap: MapLike<string[]> = {};
@@ -660,6 +661,10 @@ namespace ts {
         }
 
         return result;
+
+        function relativeToBuildInfoEnsuringAbsolutePath(path: string) {
+            return relativeToBuildInfo(getNormalizedAbsolutePath(path, currentDirectory));
+        }
 
         function relativeToBuildInfo(path: string) {
             return ensurePathIsNonModuleName(getRelativePathFromDirectory(buildInfoDirectory, path, getCanonicalFileName));

--- a/src/testRunner/unittests/tscWatch/helpers.ts
+++ b/src/testRunner/unittests/tscWatch/helpers.ts
@@ -35,8 +35,8 @@ namespace ts.tscWatch {
         close(): void;
     }
 
-    export function createWatchOfConfigFile(configFileName: string, host: WatchedSystem, maxNumberOfFilesToIterateForInvalidation?: number) {
-        const compilerHost = createWatchCompilerHostOfConfigFile(configFileName, {}, host);
+    export function createWatchOfConfigFile(configFileName: string, host: WatchedSystem, optionsToExtend?: CompilerOptions, maxNumberOfFilesToIterateForInvalidation?: number) {
+        const compilerHost = createWatchCompilerHostOfConfigFile(configFileName, optionsToExtend || {}, host);
         compilerHost.maxNumberOfFilesToIterateForInvalidation = maxNumberOfFilesToIterateForInvalidation;
         const watch = createWatchProgram(compilerHost);
         const result = (() => watch.getCurrentProgram().getProgram()) as Watch;

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -931,7 +931,7 @@ namespace ts.tscWatch {
                     content: generateTSConfig(options, emptyArray, "\n")
                 };
                 const host = createWatchedSystem([file1, file2, libFile, tsconfig], { currentDirectory: proj });
-                const watch = createWatchOfConfigFile(tsconfig.path, host, /*maxNumberOfFilesToIterateForInvalidation*/1);
+                const watch = createWatchOfConfigFile(tsconfig.path, host, /*optionsToExtend*/ undefined, /*maxNumberOfFilesToIterateForInvalidation*/1);
                 checkProgramActualFiles(watch(), [file1.path, file2.path, libFile.path]);
 
                 outputFiles.forEach(f => host.fileExists(f));


### PR DESCRIPTION
Fixes #32353
