### PR TITLE
Add 'Remove unnecessary await' suggestion and fix

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26403,7 +26403,11 @@ namespace ts {
          * The runtime behavior of the `await` keyword.
          */
         function checkAwaitedType(type: Type, errorNode: Node, diagnosticMessage: DiagnosticMessage, arg0?: string | number): Type {
-            return getAwaitedType(type, errorNode, diagnosticMessage, arg0) || errorType;
+            const awaitedType = getAwaitedType(type, errorNode, diagnosticMessage, arg0);
+            if (awaitedType === type) {
+                addErrorOrSuggestion(/*isError*/ false, createDiagnosticForNode(errorNode, Diagnostics.await_has_no_effect_on_the_type_of_this_expression));
+            }
+            return awaitedType || errorType;
         }
 
         function getAwaitedType(type: Type, errorNode?: Node, diagnosticMessage?: DiagnosticMessage, arg0?: string | number): Type | undefined {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26404,7 +26404,7 @@ namespace ts {
          */
         function checkAwaitedType(type: Type, errorNode: Node, diagnosticMessage: DiagnosticMessage, arg0?: string | number): Type {
             const awaitedType = getAwaitedType(type, errorNode, diagnosticMessage, arg0);
-            if (awaitedType === type) {
+            if (awaitedType === type && !(type.flags & TypeFlags.AnyOrUnknown)) {
                 addErrorOrSuggestion(/*isError*/ false, createDiagnosticForNode(errorNode, Diagnostics.await_has_no_effect_on_the_type_of_this_expression));
             }
             return awaitedType || errorType;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4635,6 +4635,11 @@
         "category": "Suggestion",
         "code": 80006
     },
+    "'await' has no effect on the type of this expression.": {
+        "category": "Suggestion",
+        "code": 80007
+    },
+
     "Add missing 'super()' call": {
         "category": "Message",
         "code": 90001
@@ -5094,6 +5099,14 @@
     "Fix all expressions possibly missing 'await'": {
         "category": "Message",
         "code": 95085
+    },
+    "Remove unnecessary 'await'": {
+        "category": "Message",
+        "code": 95086
+    },
+    "Remove all unnecessary uses of 'await'": {
+        "category": "Message",
+        "code": 95087
     },
 
     "No value exists in scope for the shorthand property '{0}'. Either declare one or provide an initializer.": {

--- a/src/services/codefixes/removeUnnecessaryAwait.ts
+++ b/src/services/codefixes/removeUnnecessaryAwait.ts
@@ -27,34 +27,7 @@ namespace ts.codefix {
         }
 
         const parenthesizedExpression = tryCast(awaitExpression.parent, isParenthesizedExpression);
-        const preserveParens = parenthesizedExpression && (
-            // (await 0).toFixed() should keep its parens (or add an extra dot for 0..toFixed())
-            isPropertyAccessExpression(parenthesizedExpression.parent) && isDecimalIntegerLiteral(awaitExpression.expression, sourceFile) ||
-            // new (await c).Class()
-            isPropertyAccessExpressionInNewExpression(parenthesizedExpression.parent) ||
-            // (await new C).foo
-            isNewExpressionWithoutParens(awaitExpression.expression)
-        );
-
-        if (preserveParens) {
-            changeTracker.replaceNode(sourceFile, awaitExpression, awaitExpression.expression);
-        }
-        else {
-            changeTracker.replaceNode(sourceFile, parenthesizedExpression || awaitExpression, awaitExpression.expression);
-        }
-    }
-
-    function isPropertyAccessExpressionInNewExpression(expression: Node) {
-        return isPropertyAccessExpression(expression) && !!findAncestor(expression, ancestor => {
-            return isPropertyAccessExpression(ancestor)
-                ? false
-                : isNewExpression(ancestor)
-                    ? true
-                    : "quit";
-        });
-    }
-
-    function isNewExpressionWithoutParens(expression: Node) {
-        return isNewExpression(expression) && expression.getLastToken() === expression.expression;
+        const removeParens = parenthesizedExpression && (isIdentifier(awaitExpression.expression) || isCallExpression(awaitExpression.expression));
+        changeTracker.replaceNode(sourceFile, removeParens ? parenthesizedExpression || awaitExpression : awaitExpression, awaitExpression.expression);
     }
 }

--- a/src/services/codefixes/removeUnnecessaryAwait.ts
+++ b/src/services/codefixes/removeUnnecessaryAwait.ts
@@ -1,0 +1,32 @@
+/* @internal */
+namespace ts.codefix {
+    const fixId = "removeUnnecessaryAwait";
+    const errorCodes = [
+        Diagnostics.await_has_no_effect_on_the_type_of_this_expression.code,
+    ];
+
+    registerCodeFix({
+        errorCodes,
+        getCodeActions: (context) => {
+            const changes = textChanges.ChangeTracker.with(context, t => makeChange(t, context.sourceFile, context.span));
+            if (changes.length > 0) {
+                return [createCodeFixAction(fixId, changes, Diagnostics.Remove_unnecessary_await, fixId, Diagnostics.Remove_all_unnecessary_uses_of_await)];
+            }
+        },
+        fixIds: [fixId],
+        getAllCodeActions: context => {
+            return codeFixAll(context, errorCodes, (changes, diag) => makeChange(changes, diag.file, diag));
+        },
+    });
+
+    function makeChange(changeTracker: textChanges.ChangeTracker, sourceFile: SourceFile, span: TextSpan) {
+        const awaitKeyword = tryCast(getTokenAtPosition(sourceFile, span.start), (node): node is AwaitKeywordToken => node.kind === SyntaxKind.AwaitKeyword);
+        const awaitExpression = awaitKeyword && tryCast(awaitKeyword.parent, isAwaitExpression);
+        if (!awaitExpression) {
+            return;
+        }
+
+        const parenthesizedExpression = awaitExpression && tryCast(awaitExpression.parent, isParenthesizedExpression);
+        changeTracker.replaceNode(sourceFile, parenthesizedExpression || awaitExpression, awaitExpression.expression);
+    }
+}

--- a/src/services/codefixes/removeUnnecessaryAwait.ts
+++ b/src/services/codefixes/removeUnnecessaryAwait.ts
@@ -26,7 +26,13 @@ namespace ts.codefix {
             return;
         }
 
-        const parenthesizedExpression = awaitExpression && tryCast(awaitExpression.parent, isParenthesizedExpression);
-        changeTracker.replaceNode(sourceFile, parenthesizedExpression || awaitExpression, awaitExpression.expression);
+        const parenthesizedExpression = tryCast(awaitExpression.parent, isParenthesizedExpression);
+        // (await 0).toFixed() should keep its parens (or add an extra dot for 0..toFixed())
+        if (parenthesizedExpression && isPropertyAccessExpression(parenthesizedExpression.parent) && isDecimalIntegerLiteral(awaitExpression.expression)) {
+            changeTracker.replaceNode(sourceFile, awaitExpression, awaitExpression.expression);
+        }
+        else {
+            changeTracker.replaceNode(sourceFile, parenthesizedExpression || awaitExpression, awaitExpression.expression);
+        }
     }
 }

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -80,6 +80,7 @@
         "codefixes/useDefaultImport.ts",
         "codefixes/fixAddModuleReferTypeMissingTypeof.ts",
         "codefixes/convertToMappedObjectType.ts",
+        "codefixes/removeUnnecessaryAwait.ts",
         "refactors/convertExport.ts",
         "refactors/convertImport.ts",
         "refactors/extractSymbol.ts",

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1992,6 +1992,10 @@ namespace ts {
         return typeIsAccessible ? res : undefined;
     }
 
+    export function isDecimalIntegerLiteral(node: Node): node is NumericLiteral {
+        return isNumericLiteral(node) && /^\d+$/.test(node.text);
+    }
+
     export function syntaxUsuallyHasTrailingSemicolon(kind: SyntaxKind) {
         return kind === SyntaxKind.VariableStatement
             || kind === SyntaxKind.ExpressionStatement

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1992,10 +1992,6 @@ namespace ts {
         return typeIsAccessible ? res : undefined;
     }
 
-    export function isDecimalIntegerLiteral(node: Node, sourceFile: SourceFile): node is NumericLiteral {
-        return isNumericLiteral(node) && /^\d+$/.test(node.getText(sourceFile));
-    }
-
     export function syntaxUsuallyHasTrailingSemicolon(kind: SyntaxKind) {
         return kind === SyntaxKind.VariableStatement
             || kind === SyntaxKind.ExpressionStatement

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1992,8 +1992,8 @@ namespace ts {
         return typeIsAccessible ? res : undefined;
     }
 
-    export function isDecimalIntegerLiteral(node: Node): node is NumericLiteral {
-        return isNumericLiteral(node) && /^\d+$/.test(node.text);
+    export function isDecimalIntegerLiteral(node: Node, sourceFile: SourceFile): node is NumericLiteral {
+        return isNumericLiteral(node) && /^\d+$/.test(node.getText(sourceFile));
     }
 
     export function syntaxUsuallyHasTrailingSemicolon(kind: SyntaxKind) {

--- a/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
+++ b/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
@@ -2,6 +2,7 @@
 ////async function f() {
 ////  await "";
 ////  await 0;
+////  (await "").toLowerCase();
 ////}
 
 verify.codeFix({
@@ -11,6 +12,7 @@ verify.codeFix({
 `async function f() {
   "";
   await 0;
+  (await "").toLowerCase();
 }`
 });
 
@@ -21,5 +23,6 @@ verify.codeFixAll({
 `async function f() {
   "";
   0;
+  "".toLowerCase();
 }`
 });

--- a/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
+++ b/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
@@ -1,14 +1,12 @@
 /// <reference path="fourslash.ts" />
 ////declare class C { foo(): void }
-////declare function getC(): { foo: { Class: C } }
+////declare function foo(): string;
 ////async function f() {
 ////  await "";
 ////  await 0;
-////  (await "").toLowerCase();
+////  (await foo()).toLowerCase();
 ////  (await 0).toFixed();
-////  (await 3.2).toFixed();
 ////  (await new C).foo();
-////  new (await getC()).foo.Class();
 ////}
 
 verify.codeFix({
@@ -16,15 +14,13 @@ verify.codeFix({
   index: 0,
   newFileContent:
 `declare class C { foo(): void }
-declare function getC(): { foo: { Class: C } }
+declare function foo(): string;
 async function f() {
   "";
   await 0;
-  (await "").toLowerCase();
+  (await foo()).toLowerCase();
   (await 0).toFixed();
-  (await 3.2).toFixed();
   (await new C).foo();
-  new (await getC()).foo.Class();
 }`
 });
 
@@ -33,14 +29,12 @@ verify.codeFixAll({
   fixId: "removeUnnecessaryAwait",
   newFileContent:
 `declare class C { foo(): void }
-declare function getC(): { foo: { Class: C } }
+declare function foo(): string;
 async function f() {
   "";
   0;
-  "".toLowerCase();
+  foo().toLowerCase();
   (0).toFixed();
-  3.2.toFixed();
   (new C).foo();
-  new (getC()).foo.Class();
 }`
 });

--- a/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
+++ b/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+////async function f() {
+////  await "";
+////  await 0;
+////}
+
+verify.codeFix({
+  description: ts.Diagnostics.Remove_unnecessary_await.message,
+  index: 0,
+  newFileContent:
+`async function f() {
+  "";
+  await 0;
+}`
+});
+
+verify.codeFixAll({
+  fixAllDescription: ts.Diagnostics.Remove_all_unnecessary_uses_of_await.message,
+  fixId: "removeUnnecessaryAwait",
+  newFileContent:
+`async function f() {
+  "";
+  0;
+}`
+});

--- a/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
+++ b/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
@@ -3,6 +3,8 @@
 ////  await "";
 ////  await 0;
 ////  (await "").toLowerCase();
+////  (await 0).toFixed();
+////  (await 3.2).toFixed();
 ////}
 
 verify.codeFix({
@@ -13,6 +15,8 @@ verify.codeFix({
   "";
   await 0;
   (await "").toLowerCase();
+  (await 0).toFixed();
+  (await 3.2).toFixed();
 }`
 });
 
@@ -24,5 +28,7 @@ verify.codeFixAll({
   "";
   0;
   "".toLowerCase();
+  (0).toFixed();
+  3.2.toFixed();
 }`
 });

--- a/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
+++ b/tests/cases/fourslash/codeFixRemoveUnnecessaryAwait.ts
@@ -1,22 +1,30 @@
 /// <reference path="fourslash.ts" />
+////declare class C { foo(): void }
+////declare function getC(): { foo: { Class: C } }
 ////async function f() {
 ////  await "";
 ////  await 0;
 ////  (await "").toLowerCase();
 ////  (await 0).toFixed();
 ////  (await 3.2).toFixed();
+////  (await new C).foo();
+////  new (await getC()).foo.Class();
 ////}
 
 verify.codeFix({
   description: ts.Diagnostics.Remove_unnecessary_await.message,
   index: 0,
   newFileContent:
-`async function f() {
+`declare class C { foo(): void }
+declare function getC(): { foo: { Class: C } }
+async function f() {
   "";
   await 0;
   (await "").toLowerCase();
   (await 0).toFixed();
   (await 3.2).toFixed();
+  (await new C).foo();
+  new (await getC()).foo.Class();
 }`
 });
 
@@ -24,11 +32,15 @@ verify.codeFixAll({
   fixAllDescription: ts.Diagnostics.Remove_all_unnecessary_uses_of_await.message,
   fixId: "removeUnnecessaryAwait",
   newFileContent:
-`async function f() {
+`declare class C { foo(): void }
+declare function getC(): { foo: { Class: C } }
+async function f() {
   "";
   0;
   "".toLowerCase();
   (0).toFixed();
   3.2.toFixed();
+  (new C).foo();
+  new (getC()).foo.Class();
 }`
 });

--- a/tests/cases/fourslash/convertFunctionToEs6Class_asyncMethods.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class_asyncMethods.ts
@@ -2,13 +2,14 @@
 
 // @allowNonTsExtensions: true
 // @Filename: test123.js
+// @lib: es5
 ////export function /**/MyClass() {
 ////}
 ////MyClass.prototype.foo = async function() {
-////    await 2;
+////    await Promise.resolve();
 ////}
 ////MyClass.bar = async function() {
-////    await 3;
+////    await Promise.resolve();
 ////}
 
 verify.codeFix({
@@ -18,10 +19,10 @@ verify.codeFix({
     constructor() {
     }
     async foo() {
-        await 2;
+        await Promise.resolve();
     }
     static async bar() {
-        await 3;
+        await Promise.resolve();
     }
 }
 `,


### PR DESCRIPTION
Also related to #30646 

I hesitated to use the word “unnecessary” since your program _could_ be relying on bizarre side effects of the asynchrony introduced by awaiting something sync’ly available, and indeed the message I wrote for the checker suggestion speaks only of _types_:

> 'await' has no effect on the type of this expression. ts(80007)

But, it was just too awkward to try to write a code fix message that tries to dance around the issue—so it simply says

> Remove unnecessary 'await'

<details>
  <summary><strong>Screen capture 🎥 </strong></summary>

![remove-await](https://user-images.githubusercontent.com/3277153/61086645-3943de00-a3e8-11e9-8ca4-a2a7e626d5d6.gif)

</summary>