### PR TITLE
Fixed auto completion after a < token to return types not values.

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1239,6 +1239,9 @@ namespace ts.Completions {
                     case SyntaxKind.AsKeyword:
                         return parentKind === SyntaxKind.AsExpression;
 
+                    case SyntaxKind.LessThanToken:
+                        return parentKind === SyntaxKind.TypeReference;
+
                     case SyntaxKind.ExtendsKeyword:
                         return parentKind === SyntaxKind.TypeParameter;
                 }

--- a/tests/cases/fourslash/completionsAfterLessThanToken.ts
+++ b/tests/cases/fourslash/completionsAfterLessThanToken.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+//// function f() {
+//// 	const k: Record</**/
+//// }
+
+goTo.marker();
+verify.completions({
+    includes: [
+        { name: "string", sortText: completion.SortText.GlobalsOrKeywords }
+    ]
+});

--- a/tests/cases/fourslash/completionsIsPossiblyTypeArgumentPosition.ts
+++ b/tests/cases/fourslash/completionsIsPossiblyTypeArgumentPosition.ts
@@ -10,8 +10,8 @@
 ////x < {| "valueOnly": true |}
 ////f < {| "valueOnly": true |}
 ////g < {| "valueOnly": false |}
-////const something: C<{| "valueOnly": false |};
-////const something2: C<C<{| "valueOnly": false |};
+////const something: C<{| "typeOnly": true |};
+////const something2: C<C<{| "typeOnly": true |};
 ////new C<{| "valueOnly": false |};
 ////new C<C<{| "valueOnly": false |};
 ////
@@ -20,7 +20,10 @@
 ////new callAndConstruct<callAndConstruct</*callAndConstruct*/
 
 for (const marker of test.markers()) {
-    if (marker.data && marker.data.valueOnly) {
+    if (marker.data && marker.data.typeOnly) {
+        verify.completions({ marker, includes: "T", excludes: "x" });
+    }
+    else if (marker.data && marker.data.valueOnly) {
         verify.completions({ marker, includes: "x", excludes: "T" });
     }
     else {


### PR DESCRIPTION
Fixes #29769

Right now immediately after the `<` token the suggestions do not include types. This PR changes `isContextTokenTypeLocation` to recognize that if the `<` token is encountered inside a `TypeReference`, types should be suggested. 

Interestingly there is a test that specifically tested that values are included  in the suggestions for a type reference. I can't think of a case where this would be valid. This change removes values  from completions here. I would say this is an improvement but I am unsure what the original intent was.

```ts
const something: C<{| "valueOnly": false |}; // failed here, because of  missing values
const something2: C<C<{| "valueOnly": false |}; // failed here, because of  missing values
```
 