### PR TITLE
Make it easier to read multi-line exceptions

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -948,7 +948,7 @@ namespace FourSlash {
 
             const actual = checker.typeToString(type);
             if (actual !== expected) {
-                this.raiseError(`Expected: '${expected}', actual: '${actual}'`);
+                this.raiseError(displayExpectedAndActualString(expected, actual));
             }
         }
 
@@ -1024,9 +1024,7 @@ namespace FourSlash {
         private assertObjectsEqual<T>(fullActual: T, fullExpected: T, msgPrefix = ""): void {
             const recur = <U>(actual: U, expected: U, path: string) => {
                 const fail = (msg: string) => {
-                    this.raiseError(`${msgPrefix} At ${path}: ${msg}
-Expected: ${stringify(fullExpected)}
-Actual: ${stringify(fullActual)}`);
+                    this.raiseError(`${msgPrefix} At ${path}: ${msg} ${displayExpectedAndActualString(stringify(fullExpected), stringify(fullActual))}`);
                 };
 
                 if ((actual === undefined) !== (expected === undefined)) {
@@ -1058,9 +1056,7 @@ Actual: ${stringify(fullActual)}`);
                 if (fullActual === fullExpected) {
                     return;
                 }
-                this.raiseError(`${msgPrefix}
-Expected: ${stringify(fullExpected)}
-Actual: ${stringify(fullActual)}`);
+                this.raiseError(`${msgPrefix} ${displayExpectedAndActualString(stringify(fullExpected), stringify(fullActual))}`);
             }
             recur(fullActual, fullExpected, "");
 
@@ -2111,9 +2107,7 @@ Actual: ${stringify(fullActual)}`);
         public verifyCurrentLineContent(text: string) {
             const actual = this.getCurrentLineContent();
             if (actual !== text) {
-                throw new Error("verifyCurrentLineContent\n" +
-                    "\tExpected: \"" + text + "\"\n" +
-                    "\t  Actual: \"" + actual + "\"");
+                throw new Error("verifyCurrentLineContent\n" + displayExpectedAndActualString(text, actual, /* quoted */ true));
             }
         }
 
@@ -2139,25 +2133,19 @@ Actual: ${stringify(fullActual)}`);
         public verifyTextAtCaretIs(text: string) {
             const actual = this.getFileContent(this.activeFile.fileName).substring(this.currentCaretPosition, this.currentCaretPosition + text.length);
             if (actual !== text) {
-                throw new Error("verifyTextAtCaretIs\n" +
-                    "\tExpected: \"" + text + "\"\n" +
-                    "\t  Actual: \"" + actual + "\"");
+                throw new Error("verifyTextAtCaretIs\n" + displayExpectedAndActualString(text, actual, /* quoted */ true));
             }
         }
 
         public verifyCurrentNameOrDottedNameSpanText(text: string) {
             const span = this.languageService.getNameOrDottedNameSpan(this.activeFile.fileName, this.currentCaretPosition, this.currentCaretPosition);
             if (!span) {
-                return this.raiseError("verifyCurrentNameOrDottedNameSpanText\n" +
-                    "\tExpected: \"" + text + "\"\n" +
-                    "\t  Actual: undefined");
+                return this.raiseError("verifyCurrentNameOrDottedNameSpanText\n" + displayExpectedAndActualString("\"" + text + "\"", "undefined"));
             }
 
             const actual = this.getFileContent(this.activeFile.fileName).substring(span.start, ts.textSpanEnd(span));
             if (actual !== text) {
-                this.raiseError("verifyCurrentNameOrDottedNameSpanText\n" +
-                    "\tExpected: \"" + text + "\"\n" +
-                    "\t  Actual: \"" + actual + "\"");
+                this.raiseError("verifyCurrentNameOrDottedNameSpanText\n" + displayExpectedAndActualString(text, actual, /* quoted */ true));
             }
         }
 
@@ -3690,7 +3678,7 @@ ${code}
             expected = makeWhitespaceVisible(expected);
             actual = makeWhitespaceVisible(actual);
         }
-        return `Expected:\n${expected}\nActual:\n${actual}`;
+        return displayExpectedAndActualString(expected, actual);
     }
 
     function differOnlyByWhitespace(a: string, b: string) {
@@ -3709,6 +3697,14 @@ ${code}
                 }
             }
         }
+    }
+
+    function displayExpectedAndActualString(expected: string, actual: string, quoted = false) {
+        const expectMsg = "\x1b[1mExpected\x1b[0m\x1b[31m";
+        const actualMsg = "\x1b[1mActual\x1b[0m\x1b[31m";
+        const expectedString = quoted ? "\"" + expected + "\"" : expected;
+        const actualString = quoted ? "\"" + actual + "\"" : actual;
+        return `\n${expectMsg}:\n${expectedString}\n\n${actualMsg}:\n${actualString}`;
     }
 }
 


### PR DESCRIPTION
This PR improves multi-line error messages from within fourslash:

- Adds newlines
- Bolds the titles to make it easy to see where the reported strings start/end

![Screen Shot 2019-07-16 at 11 38 59 AM](https://user-images.githubusercontent.com/49038/61310063-84cc0280-a7c1-11e9-8fc4-4bdc551ee7b4.png)