### PR TITLE
Set the ScriptTarget of ESNext to be 99 so it doesn't change between releases

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4760,7 +4760,7 @@ namespace ts {
         UMD = 3,
         System = 4,
         ES2015 = 5,
-        ESNext = 6
+        ESNext = 99
     }
 
     export const enum JsxEmit {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4808,7 +4808,7 @@ namespace ts {
         ES2018 = 5,
         ES2019 = 6,
         ES2020 = 7,
-        ESNext = 8,
+        ESNext = 99,
         JSON = 100,
         Latest = ESNext,
     }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2600,7 +2600,7 @@ declare namespace ts {
         UMD = 3,
         System = 4,
         ES2015 = 5,
-        ESNext = 6
+        ESNext = 99
     }
     enum JsxEmit {
         None = 0,
@@ -2640,9 +2640,9 @@ declare namespace ts {
         ES2018 = 5,
         ES2019 = 6,
         ES2020 = 7,
-        ESNext = 8,
+        ESNext = 99,
         JSON = 100,
-        Latest = 8
+        Latest = 99
     }
     enum LanguageVariant {
         Standard = 0,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2600,7 +2600,7 @@ declare namespace ts {
         UMD = 3,
         System = 4,
         ES2015 = 5,
-        ESNext = 6
+        ESNext = 99
     }
     enum JsxEmit {
         None = 0,
@@ -2640,9 +2640,9 @@ declare namespace ts {
         ES2018 = 5,
         ES2019 = 6,
         ES2020 = 7,
-        ESNext = 8,
+        ESNext = 99,
         JSON = 100,
-        Latest = 8
+        Latest = 99
     }
     enum LanguageVariant {
         Standard = 0,

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-target-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-target-option-changes.js
@@ -70,7 +70,7 @@ export function multiply(a, b) { return a * b; }
       "incremental": true,
       "listFiles": true,
       "listEmittedFiles": true,
-      "target": 8,
+      "target": 99,
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {},


### PR DESCRIPTION
@andrewbranch spotted a bug in the playground where ESNext wasn't being recognized, this turned out to be because [this code](https://github.com/microsoft/monaco-typescript/blob/f39458d794a6157ee1645552d17d4cf013919b68/src/monaco.contribution.ts#L166-L176) replicates the entire set of targets in monaco-typescript, but ESNext is wrong in 3.5.1 because of `ES2019` and `ES2020`.

This makes it much harder for the UI to go out of sync with the data, missing 2019/2020 isn't critical, but it's a bit more annoying for ESNext to go out of sync.