### PR TITLE
Prefer default imports over import = when auto-fixing with esModuleInterop being on 

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -7289,6 +7289,10 @@ namespace ts {
             moduleKind === ModuleKind.System;
     }
 
+    export function getEsModuleInterop(compilerOptions: CompilerOptions) {
+        return compilerOptions.esModuleInterop;
+    }
+
     export function getEmitDeclarations(compilerOptions: CompilerOptions): boolean {
         return !!(compilerOptions.declaration || compilerOptions.composite);
     }

--- a/tests/cases/fourslash/importNameCodeFix_ESModuleInterop.ts
+++ b/tests/cases/fourslash/importNameCodeFix_ESModuleInterop.ts
@@ -1,0 +1,21 @@
+/// <reference path="fourslash.ts" />
+// #29038
+
+// @allowJs: true
+// @checkJs: true
+// @esModuleInterop: true
+// @moduleResolution: node
+
+// @Filename: /node_modules/moment.d.ts
+////declare function moment(): void;
+////export = moment;
+
+// @Filename: /b.js
+////[|moment;|]
+
+goTo.file("/b.js");
+verify.importFixAtPosition([
+`import moment from "moment";
+
+moment;`,
+]);


### PR DESCRIPTION
Fixes #29038 by short-circuiting the import equals with a default instead.