### PR TITLE
A merged interface with an inherited member should satisfy an abstract base class member

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29319,7 +29319,7 @@ namespace ts {
 
             // NOTE: assignability is checked in checkClassDeclaration
             const baseProperties = getPropertiesOfType(baseType);
-            outer: for (const baseProperty of baseProperties) {
+            basePropertyCheck: for (const baseProperty of baseProperties) {
                 const base = getTargetSymbol(baseProperty);
 
                 if (base.flags & SymbolFlags.Prototype) {
@@ -29343,16 +29343,15 @@ namespace ts {
                     // If there is no declaration for the derived class (as in the case of class expressions),
                     // then the class cannot be declared abstract.
                     if (baseDeclarationFlags & ModifierFlags.Abstract && (!derivedClassDecl || !hasModifier(derivedClassDecl, ModifierFlags.Abstract))) {
-                        // getPropertyOfObjectType will return a single symbol even if the property can be found
-                        // on multiple declarations, so it’s possible for derived === base to be true even when
-                        // another base type introduced from declaration merging to contain the property as well,
-                        // which should satisfy the abstract member requirement.
+                        // Searches other base types for a declaration that would satisfy the inherited abstract member.
+                        // (The class may have more than one base type via declaration merging with an interface with the
+                        // same name.)
                         for (const otherBaseType of getBaseTypes(type)) {
                             if (otherBaseType === baseType) continue;
                             const baseSymbol = getPropertyOfObjectType(otherBaseType, base.escapedName);
                             const derivedElsewhere = baseSymbol && getTargetSymbol(baseSymbol);
                             if (derivedElsewhere && derivedElsewhere !== base) {
-                                continue outer;
+                                continue basePropertyCheck;
                             }
                         }
 

--- a/tests/baselines/reference/mergedInheritedMembersSatisfyAbstractBase.errors.txt
+++ b/tests/baselines/reference/mergedInheritedMembersSatisfyAbstractBase.errors.txt
@@ -1,0 +1,28 @@
+tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts(19,11): error TS2320: Interface 'IncorrectlyExtends' cannot simultaneously extend types 'BaseClass' and 'IncorrectGetters'.
+  Named property 'bar' of types 'BaseClass' and 'IncorrectGetters' are not identical.
+
+
+==== tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts (1 errors) ====
+    abstract class BaseClass {
+      abstract bar: number;
+    }
+    
+    class Broken extends BaseClass {}
+    
+    // declaration merging should satisfy abstract bar
+    interface IGetters {
+      bar: number;
+    }
+    interface Broken extends IGetters {}
+    
+    new Broken().bar
+    
+    class IncorrectlyExtends extends BaseClass {}
+    interface IncorrectGetters {
+      bar: string;
+    }
+    interface IncorrectlyExtends extends IncorrectGetters {}
+              ~~~~~~~~~~~~~~~~~~
+!!! error TS2320: Interface 'IncorrectlyExtends' cannot simultaneously extend types 'BaseClass' and 'IncorrectGetters'.
+!!! error TS2320:   Named property 'bar' of types 'BaseClass' and 'IncorrectGetters' are not identical.
+    

--- a/tests/baselines/reference/mergedInheritedMembersSatisfyAbstractBase.js
+++ b/tests/baselines/reference/mergedInheritedMembersSatisfyAbstractBase.js
@@ -1,0 +1,56 @@
+//// [mergedInheritedMembersSatisfyAbstractBase.ts]
+abstract class BaseClass {
+  abstract bar: number;
+}
+
+class Broken extends BaseClass {}
+
+// declaration merging should satisfy abstract bar
+interface IGetters {
+  bar: number;
+}
+interface Broken extends IGetters {}
+
+new Broken().bar
+
+class IncorrectlyExtends extends BaseClass {}
+interface IncorrectGetters {
+  bar: string;
+}
+interface IncorrectlyExtends extends IncorrectGetters {}
+
+
+//// [mergedInheritedMembersSatisfyAbstractBase.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var BaseClass = /** @class */ (function () {
+    function BaseClass() {
+    }
+    return BaseClass;
+}());
+var Broken = /** @class */ (function (_super) {
+    __extends(Broken, _super);
+    function Broken() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return Broken;
+}(BaseClass));
+new Broken().bar;
+var IncorrectlyExtends = /** @class */ (function (_super) {
+    __extends(IncorrectlyExtends, _super);
+    function IncorrectlyExtends() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return IncorrectlyExtends;
+}(BaseClass));

--- a/tests/baselines/reference/mergedInheritedMembersSatisfyAbstractBase.symbols
+++ b/tests/baselines/reference/mergedInheritedMembersSatisfyAbstractBase.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts ===
+abstract class BaseClass {
+>BaseClass : Symbol(BaseClass, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 0, 0))
+
+  abstract bar: number;
+>bar : Symbol(BaseClass.bar, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 0, 26))
+}
+
+class Broken extends BaseClass {}
+>Broken : Symbol(Broken, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 2, 1), Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 9, 1))
+>BaseClass : Symbol(BaseClass, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 0, 0))
+
+// declaration merging should satisfy abstract bar
+interface IGetters {
+>IGetters : Symbol(IGetters, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 4, 33))
+
+  bar: number;
+>bar : Symbol(IGetters.bar, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 7, 20))
+}
+interface Broken extends IGetters {}
+>Broken : Symbol(Broken, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 2, 1), Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 9, 1))
+>IGetters : Symbol(IGetters, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 4, 33))
+
+new Broken().bar
+>new Broken().bar : Symbol(BaseClass.bar, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 0, 26))
+>Broken : Symbol(Broken, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 2, 1), Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 9, 1))
+>bar : Symbol(BaseClass.bar, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 0, 26))
+
+class IncorrectlyExtends extends BaseClass {}
+>IncorrectlyExtends : Symbol(IncorrectlyExtends, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 12, 16), Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 17, 1))
+>BaseClass : Symbol(BaseClass, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 0, 0))
+
+interface IncorrectGetters {
+>IncorrectGetters : Symbol(IncorrectGetters, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 14, 45))
+
+  bar: string;
+>bar : Symbol(IncorrectGetters.bar, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 15, 28))
+}
+interface IncorrectlyExtends extends IncorrectGetters {}
+>IncorrectlyExtends : Symbol(IncorrectlyExtends, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 12, 16), Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 17, 1))
+>IncorrectGetters : Symbol(IncorrectGetters, Decl(mergedInheritedMembersSatisfyAbstractBase.ts, 14, 45))
+

--- a/tests/baselines/reference/mergedInheritedMembersSatisfyAbstractBase.types
+++ b/tests/baselines/reference/mergedInheritedMembersSatisfyAbstractBase.types
@@ -1,0 +1,35 @@
+=== tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts ===
+abstract class BaseClass {
+>BaseClass : BaseClass
+
+  abstract bar: number;
+>bar : number
+}
+
+class Broken extends BaseClass {}
+>Broken : Broken
+>BaseClass : BaseClass
+
+// declaration merging should satisfy abstract bar
+interface IGetters {
+  bar: number;
+>bar : number
+}
+interface Broken extends IGetters {}
+
+new Broken().bar
+>new Broken().bar : number
+>new Broken() : Broken
+>Broken : typeof Broken
+>bar : number
+
+class IncorrectlyExtends extends BaseClass {}
+>IncorrectlyExtends : IncorrectlyExtends
+>BaseClass : BaseClass
+
+interface IncorrectGetters {
+  bar: string;
+>bar : string
+}
+interface IncorrectlyExtends extends IncorrectGetters {}
+

--- a/tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts
+++ b/tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts
@@ -1,0 +1,19 @@
+abstract class BaseClass {
+  abstract bar: number;
+}
+
+class Broken extends BaseClass {}
+
+// declaration merging should satisfy abstract bar
+interface IGetters {
+  bar: number;
+}
+interface Broken extends IGetters {}
+
+new Broken().bar
+
+class IncorrectlyExtends extends BaseClass {}
+interface IncorrectGetters {
+  bar: string;
+}
+interface IncorrectlyExtends extends IncorrectGetters {}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31905

I kind of expected this to be fixed by a single insertion of `getMergedSymbol` somewhere, but it seems that `resolveObjectTypeMembers` (which is called by `getPropertyOfType`), when copying members from base types, just skips over any member with the same name as one that has already been resolved. In the linked issue / test case, the `abstract BaseClass` is closer than `IGetters`, so its members get copied to the type, and then when `IGetters`’ members get copied, it’s a no-op because `bar` already exists. So—is there an existing function that says “get me all the symbols that represent this property,” rather than just the closest?