### PR TITLE
Property assignment uses parent type annotation

### DIFF
--- a/tests/baselines/reference/expandoFunctionContextualTypes.types
+++ b/tests/baselines/reference/expandoFunctionContextualTypes.types
@@ -12,7 +12,7 @@ interface StatelessComponent<P> {
 
 const MyComponent: StatelessComponent<MyComponentProps> = () => null as any;
 >MyComponent : StatelessComponent<MyComponentProps>
->() => null as any : { (): any; defaultProps: { color: "red"; }; }
+>() => null as any : { (): any; defaultProps: Partial<MyComponentProps>; }
 >null as any : any
 >null : null
 

--- a/tests/baselines/reference/expandoFunctionContextualTypesJs.types
+++ b/tests/baselines/reference/expandoFunctionContextualTypesJs.types
@@ -10,7 +10,7 @@
   */
 const MyComponent = () => /* @type {any} */(null);
 >MyComponent : { (): any; defaultProps?: Partial<{ color: "red" | "blue"; }>; }
->() => /* @type {any} */(null) : { (): any; defaultProps: { color: "red"; }; }
+>() => /* @type {any} */(null) : { (): any; defaultProps: Partial<{ color: "red" | "blue"; }>; }
 >(null) : null
 >null : null
 

--- a/tests/baselines/reference/propertyAssignmentUseParentType1.js
+++ b/tests/baselines/reference/propertyAssignmentUseParentType1.js
@@ -1,0 +1,26 @@
+//// [propertyAssignmentUseParentType1.ts]
+interface N {
+    (): boolean
+    num: 123;
+}
+export const interfaced: N = () => true;
+interfaced.num = 123;
+
+export const inlined: { (): boolean; nun: 456 } = () => true;
+inlined.nun = 456;
+
+export const ignoreJsdoc = () => true;
+/** @type {string} make sure to ignore jsdoc! */
+ignoreJsdoc.extra = 111
+
+
+//// [propertyAssignmentUseParentType1.js]
+"use strict";
+exports.__esModule = true;
+exports.interfaced = function () { return true; };
+exports.interfaced.num = 123;
+exports.inlined = function () { return true; };
+exports.inlined.nun = 456;
+exports.ignoreJsdoc = function () { return true; };
+/** @type {string} make sure to ignore jsdoc! */
+exports.ignoreJsdoc.extra = 111;

--- a/tests/baselines/reference/propertyAssignmentUseParentType1.symbols
+++ b/tests/baselines/reference/propertyAssignmentUseParentType1.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/conformance/salsa/propertyAssignmentUseParentType1.ts ===
+interface N {
+>N : Symbol(N, Decl(propertyAssignmentUseParentType1.ts, 0, 0))
+
+    (): boolean
+    num: 123;
+>num : Symbol(N.num, Decl(propertyAssignmentUseParentType1.ts, 1, 15))
+}
+export const interfaced: N = () => true;
+>interfaced : Symbol(interfaced, Decl(propertyAssignmentUseParentType1.ts, 4, 12), Decl(propertyAssignmentUseParentType1.ts, 4, 40))
+>N : Symbol(N, Decl(propertyAssignmentUseParentType1.ts, 0, 0))
+
+interfaced.num = 123;
+>interfaced.num : Symbol(N.num, Decl(propertyAssignmentUseParentType1.ts, 1, 15))
+>interfaced : Symbol(interfaced, Decl(propertyAssignmentUseParentType1.ts, 4, 12), Decl(propertyAssignmentUseParentType1.ts, 4, 40))
+>num : Symbol(N.num, Decl(propertyAssignmentUseParentType1.ts, 1, 15))
+
+export const inlined: { (): boolean; nun: 456 } = () => true;
+>inlined : Symbol(inlined, Decl(propertyAssignmentUseParentType1.ts, 7, 12), Decl(propertyAssignmentUseParentType1.ts, 7, 61))
+>nun : Symbol(nun, Decl(propertyAssignmentUseParentType1.ts, 7, 36))
+
+inlined.nun = 456;
+>inlined.nun : Symbol(nun, Decl(propertyAssignmentUseParentType1.ts, 7, 36))
+>inlined : Symbol(inlined, Decl(propertyAssignmentUseParentType1.ts, 7, 12), Decl(propertyAssignmentUseParentType1.ts, 7, 61))
+>nun : Symbol(nun, Decl(propertyAssignmentUseParentType1.ts, 7, 36))
+
+export const ignoreJsdoc = () => true;
+>ignoreJsdoc : Symbol(ignoreJsdoc, Decl(propertyAssignmentUseParentType1.ts, 10, 12), Decl(propertyAssignmentUseParentType1.ts, 10, 38))
+
+/** @type {string} make sure to ignore jsdoc! */
+ignoreJsdoc.extra = 111
+>ignoreJsdoc.extra : Symbol(ignoreJsdoc.extra, Decl(propertyAssignmentUseParentType1.ts, 10, 38))
+>ignoreJsdoc : Symbol(ignoreJsdoc, Decl(propertyAssignmentUseParentType1.ts, 10, 12), Decl(propertyAssignmentUseParentType1.ts, 10, 38))
+>extra : Symbol(ignoreJsdoc.extra, Decl(propertyAssignmentUseParentType1.ts, 10, 38))
+

--- a/tests/baselines/reference/propertyAssignmentUseParentType1.types
+++ b/tests/baselines/reference/propertyAssignmentUseParentType1.types
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/salsa/propertyAssignmentUseParentType1.ts ===
+interface N {
+    (): boolean
+    num: 123;
+>num : 123
+}
+export const interfaced: N = () => true;
+>interfaced : N
+>() => true : { (): true; num: 123; }
+>true : true
+
+interfaced.num = 123;
+>interfaced.num = 123 : 123
+>interfaced.num : 123
+>interfaced : N
+>num : 123
+>123 : 123
+
+export const inlined: { (): boolean; nun: 456 } = () => true;
+>inlined : { (): boolean; nun: 456; }
+>nun : 456
+>() => true : { (): true; nun: 456; }
+>true : true
+
+inlined.nun = 456;
+>inlined.nun = 456 : 456
+>inlined.nun : 456
+>inlined : { (): boolean; nun: 456; }
+>nun : 456
+>456 : 456
+
+export const ignoreJsdoc = () => true;
+>ignoreJsdoc : { (): boolean; extra: number; }
+>() => true : { (): boolean; extra: number; }
+>true : true
+
+/** @type {string} make sure to ignore jsdoc! */
+ignoreJsdoc.extra = 111
+>ignoreJsdoc.extra = 111 : 111
+>ignoreJsdoc.extra : number
+>ignoreJsdoc : { (): boolean; extra: number; }
+>extra : number
+>111 : 111
+

--- a/tests/baselines/reference/propertyAssignmentUseParentType2.errors.txt
+++ b/tests/baselines/reference/propertyAssignmentUseParentType2.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/conformance/salsa/propertyAssignmentUseParentType2.js(11,14): error TS2322: Type '{ (): boolean; nuo: 1000; }' is not assignable to type '{ (): boolean; nuo: 789; }'.
+  Types of property 'nuo' are incompatible.
+    Type '1000' is not assignable to type '789'.
+
+
+==== tests/cases/conformance/salsa/propertyAssignmentUseParentType2.js (1 errors) ====
+    /** @type {{ (): boolean; nuo: 789 }} */
+    export const inlined = () => true
+    inlined.nuo = 789
+    
+    /** @type {{ (): boolean; nuo: 789 }} */
+    export const duplicated = () => true
+    /** @type {789} */
+    duplicated.nuo = 789
+    
+    /** @type {{ (): boolean; nuo: 789 }} */
+    export const conflictingDuplicated = () => true
+                 ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ (): boolean; nuo: 1000; }' is not assignable to type '{ (): boolean; nuo: 789; }'.
+!!! error TS2322:   Types of property 'nuo' are incompatible.
+!!! error TS2322:     Type '1000' is not assignable to type '789'.
+    /** @type {1000} */
+    conflictingDuplicated.nuo = 789
+    

--- a/tests/baselines/reference/propertyAssignmentUseParentType2.symbols
+++ b/tests/baselines/reference/propertyAssignmentUseParentType2.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/conformance/salsa/propertyAssignmentUseParentType2.js ===
+/** @type {{ (): boolean; nuo: 789 }} */
+export const inlined = () => true
+>inlined : Symbol(inlined, Decl(propertyAssignmentUseParentType2.js, 1, 12), Decl(propertyAssignmentUseParentType2.js, 1, 33))
+
+inlined.nuo = 789
+>inlined.nuo : Symbol(nuo, Decl(propertyAssignmentUseParentType2.js, 0, 25))
+>inlined : Symbol(inlined, Decl(propertyAssignmentUseParentType2.js, 1, 12), Decl(propertyAssignmentUseParentType2.js, 1, 33))
+>nuo : Symbol(nuo, Decl(propertyAssignmentUseParentType2.js, 0, 25))
+
+/** @type {{ (): boolean; nuo: 789 }} */
+export const duplicated = () => true
+>duplicated : Symbol(duplicated, Decl(propertyAssignmentUseParentType2.js, 5, 12), Decl(propertyAssignmentUseParentType2.js, 5, 36))
+
+/** @type {789} */
+duplicated.nuo = 789
+>duplicated.nuo : Symbol(nuo, Decl(propertyAssignmentUseParentType2.js, 4, 25))
+>duplicated : Symbol(duplicated, Decl(propertyAssignmentUseParentType2.js, 5, 12), Decl(propertyAssignmentUseParentType2.js, 5, 36))
+>nuo : Symbol(nuo, Decl(propertyAssignmentUseParentType2.js, 4, 25))
+
+/** @type {{ (): boolean; nuo: 789 }} */
+export const conflictingDuplicated = () => true
+>conflictingDuplicated : Symbol(conflictingDuplicated, Decl(propertyAssignmentUseParentType2.js, 10, 12), Decl(propertyAssignmentUseParentType2.js, 10, 47))
+
+/** @type {1000} */
+conflictingDuplicated.nuo = 789
+>conflictingDuplicated.nuo : Symbol(nuo, Decl(propertyAssignmentUseParentType2.js, 9, 25))
+>conflictingDuplicated : Symbol(conflictingDuplicated, Decl(propertyAssignmentUseParentType2.js, 10, 12), Decl(propertyAssignmentUseParentType2.js, 10, 47))
+>nuo : Symbol(nuo, Decl(propertyAssignmentUseParentType2.js, 9, 25))
+

--- a/tests/baselines/reference/propertyAssignmentUseParentType2.types
+++ b/tests/baselines/reference/propertyAssignmentUseParentType2.types
@@ -1,0 +1,42 @@
+=== tests/cases/conformance/salsa/propertyAssignmentUseParentType2.js ===
+/** @type {{ (): boolean; nuo: 789 }} */
+export const inlined = () => true
+>inlined : { (): boolean; nuo: 789; }
+>() => true : { (): boolean; nuo: 789; }
+>true : true
+
+inlined.nuo = 789
+>inlined.nuo = 789 : 789
+>inlined.nuo : 789
+>inlined : { (): boolean; nuo: 789; }
+>nuo : 789
+>789 : 789
+
+/** @type {{ (): boolean; nuo: 789 }} */
+export const duplicated = () => true
+>duplicated : { (): boolean; nuo: 789; }
+>() => true : { (): boolean; nuo: 789; }
+>true : true
+
+/** @type {789} */
+duplicated.nuo = 789
+>duplicated.nuo = 789 : 789
+>duplicated.nuo : 789
+>duplicated : { (): boolean; nuo: 789; }
+>nuo : 789
+>789 : 789
+
+/** @type {{ (): boolean; nuo: 789 }} */
+export const conflictingDuplicated = () => true
+>conflictingDuplicated : { (): boolean; nuo: 789; }
+>() => true : { (): boolean; nuo: 1000; }
+>true : true
+
+/** @type {1000} */
+conflictingDuplicated.nuo = 789
+>conflictingDuplicated.nuo = 789 : 789
+>conflictingDuplicated.nuo : 789
+>conflictingDuplicated : { (): boolean; nuo: 789; }
+>nuo : 789
+>789 : 789
+

--- a/tests/cases/conformance/salsa/propertyAssignmentUseParentType1.ts
+++ b/tests/cases/conformance/salsa/propertyAssignmentUseParentType1.ts
@@ -1,0 +1,13 @@
+interface N {
+    (): boolean
+    num: 123;
+}
+export const interfaced: N = () => true;
+interfaced.num = 123;
+
+export const inlined: { (): boolean; nun: 456 } = () => true;
+inlined.nun = 456;
+
+export const ignoreJsdoc = () => true;
+/** @type {string} make sure to ignore jsdoc! */
+ignoreJsdoc.extra = 111

--- a/tests/cases/conformance/salsa/propertyAssignmentUseParentType2.ts
+++ b/tests/cases/conformance/salsa/propertyAssignmentUseParentType2.ts
@@ -1,0 +1,18 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: propertyAssignmentUseParentType2.js
+
+/** @type {{ (): boolean; nuo: 789 }} */
+export const inlined = () => true
+inlined.nuo = 789
+
+/** @type {{ (): boolean; nuo: 789 }} */
+export const duplicated = () => true
+/** @type {789} */
+duplicated.nuo = 789
+
+/** @type {{ (): boolean; nuo: 789 }} */
+export const conflictingDuplicated = () => true
+/** @type {1000} */
+conflictingDuplicated.nuo = 789


### PR DESCRIPTION
1. A property assignment declaration can get its type from a type annotation directly on the assignment, or from a type annotation on its parent. Since this is an assignment, you might assume that the parent's type would be available as a contextual type, but declarations are not contextually typed, even assignment declarations. This PR explicitly checks the parent's declaration for a type annotation. Fixes #28492
1. Property assignment declarations previously assumed only JSDoc. Now they use the standard function, getEffectiveTypeAnnotationNode, to look for type annotations. The name of the calling function is now getAnnotatedTypeForAssignmentDeclaration to reflect that.
2. getWidenedType**From**AssignmentDeclaration is now getWidenedType**For**AssignmentDeclaration. Finally!
3. I always search for `Whoa` instead of `getApparentTypeOfContextualType`, but it was spelled `Woah`.