### PR TITLE
Support classification of triple-slash references

### DIFF
--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash1.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash1.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="./module.ts" />
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"./module.ts\""),
+    c.comment(" "),
+    c.punctuation("/>"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash10.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash10.ts
@@ -1,0 +1,13 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="./module.ts"
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"./module.ts\""));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash11.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash11.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="./module.ts" /
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"./module.ts\""),
+    c.comment(" "),
+    c.comment("/"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash12.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash12.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="./module.ts" bad types="node" />
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"./module.ts\""),
+    c.comment(" bad "),
+    c.jsxAttribute("types"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"node\""),
+    c.comment(" "),
+    c.punctuation("/>"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash13.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash13.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="./module.ts" /> trailing
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"./module.ts\""),
+    c.comment(" "),
+    c.punctuation("/>"),
+    c.comment(" trailing"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash14.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash14.ts
@@ -1,0 +1,7 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// nonElement
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// nonElement"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash15.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash15.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="./module1.ts" />
+//// /// <reference path="./module2.ts" />
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"./module1.ts\""),
+    c.comment(" "),
+    c.punctuation("/>"),
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"./module2.ts\""),
+    c.comment(" "),
+    c.punctuation("/>"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash16.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash16.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="./module.ts" />
+//// 1
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"./module.ts\""),
+    c.comment(" "),
+    c.punctuation("/>"),
+    c.numericLiteral("1"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash2.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash2.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts"/>
+
+//// ///<reference path = "./module.ts"/>
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("///"),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.comment(" "),
+    c.operator("="),
+    c.comment(" "),
+    c.jsxAttributeStringLiteralValue("\"./module.ts\""),
+    c.punctuation("/>"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash3.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash3.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="./module.ts" types="node" />
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" "),
+    c.jsxAttribute("path"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"./module.ts\""),
+    c.comment(" "),
+    c.jsxAttribute("types"),
+    c.operator("="),
+    c.jsxAttributeStringLiteralValue("\"node\""),
+    c.comment(" "),
+    c.punctuation("/>"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash4.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash4.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash5.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash5.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash6.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash6.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" path"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash7.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash7.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path=
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" path="));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash8.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash8.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" path=\""));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash9.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash9.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts"/>
+
+//// /// <reference path="./module.ts
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/// "),
+    c.punctuation("<"),
+    c.jsxSelfClosingTagName("reference"),
+    c.comment(" path=\"./module.ts"));


### PR DESCRIPTION
Note: not restricted to the element and attribute names that actually bind
Bonus: classifies (many) incomplete triple-slash references