### PR TITLE
Escape apparent substitution in synthesized NoSubstitutionTemplateLiterals

### DIFF
--- a/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_templateLiteral.ts
+++ b/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_templateLiteral.ts
@@ -1,0 +1,26 @@
+/// <reference path='fourslash.ts' />
+
+////function /*a*/insert/*b*/(template: string, overwriteBefore = 0) {}
+////insert(`
+////  <head>
+////    <meta charset="UTF-8">
+////    <meta http-equiv="X-UA-Compatible" content="\${5:ie=edge}">
+////  </head>
+////`);
+
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Convert parameters to destructured object",
+    actionName: "Convert parameters to destructured object",
+    actionDescription: "Convert parameters to destructured object",
+    newContent: `function insert(template: string, overwriteBefore = 0) {}
+insert({
+  template: \`
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="\${5:ie=edge}">
+  </head>
+\`
+});`
+});

--- a/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_templateLiteral.ts
+++ b/tests/cases/fourslash/refactorConvertParamsToDestructuredObject_templateLiteral.ts
@@ -1,12 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 ////function /*a*/insert/*b*/(template: string, overwriteBefore = 0) {}
-////insert(`
-////  <head>
-////    <meta charset="UTF-8">
-////    <meta http-equiv="X-UA-Compatible" content="\${5:ie=edge}">
-////  </head>
-////`);
+////insert(`this is \${not} a substitution`);
 
 
 goTo.select("a", "b");
@@ -14,13 +9,8 @@ edit.applyRefactor({
     refactorName: "Convert parameters to destructured object",
     actionName: "Convert parameters to destructured object",
     actionDescription: "Convert parameters to destructured object",
-    newContent: `function insert(template: string, overwriteBefore = 0) {}
-insert({
-  template: \`
-  <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="X-UA-Compatible" content="\${5:ie=edge}">
-  </head>
-\`
-});`
+    newContent: [
+      'function insert({ template, overwriteBefore = 0 }: { template: string; overwriteBefore?: number; }) {}',
+      'insert({ template: `this is \\${not} a substitution` });'
+    ].join('\n')
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #32515 

The issue was in re-printing a NoSubstitutionTemplateLiteral with an escaped would-be substitution in it: `` `this is \${not} a substitution` ``. The node text simply becomes `this is ${not} a substitution`, and when we were re-writing that to a new node, we were printing that text as-is, when we needed to insert a backslash before the `${`.