### PR TITLE
Improve excess property checking for intersections

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12810,7 +12810,7 @@ namespace ts {
                 const isPerformingCommonPropertyChecks = relation !== comparableRelation && !isIntersectionConstituent &&
                     source.flags & (TypeFlags.Primitive | TypeFlags.Object | TypeFlags.Intersection) && source !== globalObjectType &&
                     target.flags & (TypeFlags.Object | TypeFlags.Intersection) && isWeakType(target) &&
-                    (getPropertiesOfType(source).length > 0 || typeHasCallOrConstructSignatures(source))
+                    (getPropertiesOfType(source).length > 0 || typeHasCallOrConstructSignatures(source));
                 if (isPerformingCommonPropertyChecks && !hasCommonProperties(source, target, isComparingJsxAttributes)) {
                     if (reportErrors) {
                         const calls = getSignaturesOfType(source, SignatureKind.Call);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12605,7 +12605,6 @@ namespace ts {
             let expandingFlags = ExpandingFlags.None;
             let overflow = false;
             let overrideNextErrorInfo: DiagnosticMessageChain | undefined;
-            let isIntersectionConstituent = false;
 
             Debug.assert(relation !== identityRelation || !errorNode, "no error reporting in identity checking");
 
@@ -12748,7 +12747,7 @@ namespace ts {
              * * Ternary.Maybe if they are related with assumptions of other relationships, or
              * * Ternary.False if they are not related.
              */
-            function isRelatedTo(source: Type, target: Type, reportErrors = false, headMessage?: DiagnosticMessage): Ternary {
+            function isRelatedTo(source: Type, target: Type, reportErrors = false, headMessage?: DiagnosticMessage, isApparentIntersectionConstituent?: boolean): Ternary {
                 if (isFreshLiteralType(source)) {
                     source = (<FreshableType>source).regularType;
                 }
@@ -12796,7 +12795,7 @@ namespace ts {
                     isSimpleTypeRelatedTo(source, target, relation, reportErrors ? reportError : undefined)) return Ternary.True;
 
                 const isComparingJsxAttributes = !!(getObjectFlags(source) & ObjectFlags.JsxAttributes);
-                const isPerformingExcessPropertyChecks = !isIntersectionConstituent && (isObjectLiteralType(source) && getObjectFlags(source) & ObjectFlags.FreshLiteral);
+                const isPerformingExcessPropertyChecks = !isApparentIntersectionConstituent && (isObjectLiteralType(source) && getObjectFlags(source) & ObjectFlags.FreshLiteral);
                 if (isPerformingExcessPropertyChecks) {
                     const discriminantType = target.flags & TypeFlags.Union ? findMatchingDiscriminantType(source, target as UnionType) : undefined;
                     if (hasExcessProperties(<FreshObjectLiteralType>source, target, discriminantType, reportErrors)) {
@@ -12807,7 +12806,7 @@ namespace ts {
                     }
                 }
 
-                const isPerformingCommonPropertyChecks = relation !== comparableRelation && !isIntersectionConstituent &&
+                const isPerformingCommonPropertyChecks = relation !== comparableRelation && !isApparentIntersectionConstituent &&
                     source.flags & (TypeFlags.Primitive | TypeFlags.Object | TypeFlags.Intersection) && source !== globalObjectType &&
                     target.flags & (TypeFlags.Object | TypeFlags.Intersection) && isWeakType(target) &&
                     (getPropertiesOfType(source).length > 0 || typeHasCallOrConstructSignatures(source));
@@ -12828,6 +12827,7 @@ namespace ts {
 
                 let result = Ternary.False;
                 const saveErrorInfo = errorInfo;
+                let isIntersectionConstituent = !!isApparentIntersectionConstituent;
 
                 // Note that these checks are specifically ordered to produce correct results. In particular,
                 // we need to deconstruct unions before intersections (because unions are always at the top),
@@ -12843,21 +12843,19 @@ namespace ts {
                         if (result && (isPerformingExcessPropertyChecks || isPerformingCommonPropertyChecks)) {
                             // Validate against excess props using the original `source`
                             const discriminantType = findMatchingDiscriminantType(source, target as UnionType) || filterPrimitivesIfContainsNonPrimitive(target as UnionType);
-                            if (!propertiesRelatedTo(source, discriminantType, reportErrors, /*excludedProperties*/ undefined)) {
+                            if (!propertiesRelatedTo(source, discriminantType, reportErrors, /*excludedProperties*/ undefined, isIntersectionConstituent)) {
                                 return Ternary.False;
                             }
                         }
                     }
                     else if (target.flags & TypeFlags.Intersection) {
+                        isIntersectionConstituent = true; // set here to affect the following trio of checks
                         result = typeRelatedToEachType(getRegularTypeOfObjectLiteral(source), target as IntersectionType, reportErrors);
                         if (result && (isPerformingExcessPropertyChecks || isPerformingCommonPropertyChecks)) {
                             // Validate against excess props using the original `source`
-                            const saveIsInt = isIntersectionConstituent;
-                            isIntersectionConstituent = false;
-                            if (!propertiesRelatedTo(source, target, reportErrors, /*excludedProperties*/ undefined)) {
+                            if (!propertiesRelatedTo(source, target, reportErrors, /*excludedProperties*/ undefined, /*isIntersectionConstituent*/ false)) {
                                 return Ternary.False;
                             }
-                            isIntersectionConstituent = saveIsInt;
                         }
                     }
                     else if (source.flags & TypeFlags.Intersection) {
@@ -12877,7 +12875,7 @@ namespace ts {
                         result = someTypeRelatedToType(<IntersectionType>source, target, /*reportErrors*/ false);
                     }
                     if (!result && (source.flags & TypeFlags.StructuredOrInstantiable || target.flags & TypeFlags.StructuredOrInstantiable)) {
-                        if (result = recursiveTypeRelatedTo(source, target, reportErrors)) {
+                        if (result = recursiveTypeRelatedTo(source, target, reportErrors, isIntersectionConstituent)) {
                             errorInfo = saveErrorInfo;
                         }
                     }
@@ -12894,7 +12892,7 @@ namespace ts {
                     // 'string & number | number & number' which reduces to just 'number'.
                     const constraint = getUnionConstraintOfIntersection(<IntersectionType>source, !!(target.flags & TypeFlags.Union));
                     if (constraint) {
-                        if (result = isRelatedTo(constraint, target, reportErrors)) {
+                        if (result = isRelatedTo(constraint, target, reportErrors, /*headMessage*/ undefined, isIntersectionConstituent)) {
                             errorInfo = saveErrorInfo;
                         }
                     }
@@ -12939,11 +12937,7 @@ namespace ts {
                 let result: Ternary;
                 const flags = source.flags & target.flags;
                 if (flags & TypeFlags.Object || flags & TypeFlags.IndexedAccess || flags & TypeFlags.Conditional || flags & TypeFlags.Index || flags & TypeFlags.Substitution) {
-                    const saveIsInt = isIntersectionConstituent;
-                    isIntersectionConstituent = false;
-                    const r = recursiveTypeRelatedTo(source, target, /*reportErrors*/ false);
-                    isIntersectionConstituent = saveIsInt;
-                    return r;
+                    return recursiveTypeRelatedTo(source, target, /*reportErrors*/ false, /*isIntersectionConstituent*/ false);
                 }
                 if (flags & (TypeFlags.Union | TypeFlags.Intersection)) {
                     if (result = eachTypeRelatedToSomeType(<UnionOrIntersectionType>source, <UnionOrIntersectionType>target)) {
@@ -13148,10 +13142,7 @@ namespace ts {
                 let result = Ternary.True;
                 const targetTypes = target.types;
                 for (const targetType of targetTypes) {
-                    const saveIsInt = isIntersectionConstituent;
-                    isIntersectionConstituent = true;
-                    const related = isRelatedTo(source, targetType, reportErrors);
-                    isIntersectionConstituent = saveIsInt;
+                    const related = isRelatedTo(source, targetType, reportErrors, /*headMessage*/ undefined, /*isIntersectionConstituent*/ true);
                     if (!related) {
                         return Ternary.False;
                     }
@@ -13188,7 +13179,7 @@ namespace ts {
                 return result;
             }
 
-            function typeArgumentsRelatedTo(sources: ReadonlyArray<Type> = emptyArray, targets: ReadonlyArray<Type> = emptyArray, variances: ReadonlyArray<VarianceFlags> = emptyArray, reportErrors: boolean): Ternary {
+            function typeArgumentsRelatedTo(sources: ReadonlyArray<Type> = emptyArray, targets: ReadonlyArray<Type> = emptyArray, variances: ReadonlyArray<VarianceFlags> = emptyArray, reportErrors: boolean, isIntersectionConstituent: boolean): Ternary {
                 if (sources.length !== targets.length && relation === identityRelation) {
                     return Ternary.False;
                 }
@@ -13212,10 +13203,10 @@ namespace ts {
                             related = relation === identityRelation ? isRelatedTo(s, t, /*reportErrors*/ false) : compareTypesIdentical(s, t);
                         }
                         else if (variance === VarianceFlags.Covariant) {
-                            related = isRelatedTo(s, t, reportErrors);
+                            related = isRelatedTo(s, t, reportErrors, /*headMessage*/ undefined, isIntersectionConstituent);
                         }
                         else if (variance === VarianceFlags.Contravariant) {
-                            related = isRelatedTo(t, s, reportErrors);
+                            related = isRelatedTo(t, s, reportErrors, /*headMessage*/ undefined, isIntersectionConstituent);
                         }
                         else if (variance === VarianceFlags.Bivariant) {
                             // In the bivariant case we first compare contravariantly without reporting
@@ -13224,16 +13215,16 @@ namespace ts {
                             // which is generally easier to reason about.
                             related = isRelatedTo(t, s, /*reportErrors*/ false);
                             if (!related) {
-                                related = isRelatedTo(s, t, reportErrors);
+                                related = isRelatedTo(s, t, reportErrors, /*headMessage*/ undefined, isIntersectionConstituent);
                             }
                         }
                         else {
                             // In the invariant case we first compare covariantly, and only when that
                             // succeeds do we proceed to compare contravariantly. Thus, error elaboration
                             // will typically be based on the covariant check.
-                            related = isRelatedTo(s, t, reportErrors);
+                            related = isRelatedTo(s, t, reportErrors, /*headMessage*/ undefined, isIntersectionConstituent);
                             if (related) {
-                                related &= isRelatedTo(t, s, reportErrors);
+                                related &= isRelatedTo(t, s, reportErrors, /*headMessage*/ undefined, isIntersectionConstituent);
                             }
                         }
                         if (!related) {
@@ -13262,7 +13253,7 @@ namespace ts {
             // Third, check if both types are part of deeply nested chains of generic type instantiations and if so assume the types are
             // equal and infinitely expanding. Fourth, if we have reached a depth of 100 nested comparisons, assume we have runaway recursion
             // and issue an error. Otherwise, actually compare the structure of the two types.
-            function recursiveTypeRelatedTo(source: Type, target: Type, reportErrors: boolean): Ternary {
+            function recursiveTypeRelatedTo(source: Type, target: Type, reportErrors: boolean, isIntersectionConstituent: boolean): Ternary {
                 if (overflow) {
                     return Ternary.False;
                 }
@@ -13313,7 +13304,7 @@ namespace ts {
                 const saveExpandingFlags = expandingFlags;
                 if (!(expandingFlags & ExpandingFlags.Source) && isDeeplyNestedType(source, sourceStack, depth)) expandingFlags |= ExpandingFlags.Source;
                 if (!(expandingFlags & ExpandingFlags.Target) && isDeeplyNestedType(target, targetStack, depth)) expandingFlags |= ExpandingFlags.Target;
-                const result = expandingFlags !== ExpandingFlags.Both ? structuredTypeRelatedTo(source, target, reportErrors) : Ternary.Maybe;
+                const result = expandingFlags !== ExpandingFlags.Both ? structuredTypeRelatedTo(source, target, reportErrors, isIntersectionConstituent) : Ternary.Maybe;
                 expandingFlags = saveExpandingFlags;
                 depth--;
                 if (result) {
@@ -13334,7 +13325,7 @@ namespace ts {
                 return result;
             }
 
-            function structuredTypeRelatedTo(source: Type, target: Type, reportErrors: boolean): Ternary {
+            function structuredTypeRelatedTo(source: Type, target: Type, reportErrors: boolean, isIntersectionConstituent: boolean): Ternary {
                 const flags = source.flags & target.flags;
                 if (relation === identityRelation && !(flags & TypeFlags.Object)) {
                     if (flags & TypeFlags.Index) {
@@ -13379,7 +13370,7 @@ namespace ts {
                     source.aliasTypeArguments && source.aliasSymbol === target.aliasSymbol &&
                     !(source.aliasTypeArgumentsContainsMarker || target.aliasTypeArgumentsContainsMarker)) {
                     const variances = getAliasVariances(source.aliasSymbol);
-                    const varianceResult = relateVariances(source.aliasTypeArguments, target.aliasTypeArguments, variances);
+                    const varianceResult = relateVariances(source.aliasTypeArguments, target.aliasTypeArguments, variances, isIntersectionConstituent);
                     if (varianceResult !== undefined) {
                         return varianceResult;
                     }
@@ -13488,12 +13479,12 @@ namespace ts {
                             }
                         }
                         // hi-speed no-this-instantiation check (less accurate, but avoids costly `this`-instantiation when the constraint will suffice), see #28231 for report on why this is needed
-                        else if (result = isRelatedTo(constraint, target, /*reportErrors*/ false)) {
+                        else if (result = isRelatedTo(constraint, target, /*reportErrors*/ false, /*headMessage*/ undefined, isIntersectionConstituent)) {
                             errorInfo = saveErrorInfo;
                             return result;
                         }
                         // slower, fuller, this-instantiated check (necessary when comparing raw `this` types from base classes), see `subclassWithPolymorphicThisIsAssignable.ts` test for example
-                        else if (result = isRelatedTo(getTypeWithThisArgument(constraint, source), target, reportErrors)) {
+                        else if (result = isRelatedTo(getTypeWithThisArgument(constraint, source), target, reportErrors, /*headMessage*/ undefined, isIntersectionConstituent)) {
                             errorInfo = saveErrorInfo;
                             return result;
                         }
@@ -13565,7 +13556,7 @@ namespace ts {
                         // type references (which are intended by be compared structurally). Obtain the variance
                         // information for the type parameters and relate the type arguments accordingly.
                         const variances = getVariances((<TypeReference>source).target);
-                        const varianceResult = relateVariances((<TypeReference>source).typeArguments, (<TypeReference>target).typeArguments, variances);
+                        const varianceResult = relateVariances((<TypeReference>source).typeArguments, (<TypeReference>target).typeArguments, variances, isIntersectionConstituent);
                         if (varianceResult !== undefined) {
                             return varianceResult;
                         }
@@ -13593,7 +13584,7 @@ namespace ts {
                     if (source.flags & (TypeFlags.Object | TypeFlags.Intersection) && target.flags & TypeFlags.Object) {
                         // Report structural errors only if we haven't reported any errors yet
                         const reportStructuralErrors = reportErrors && errorInfo === saveErrorInfo && !sourceIsPrimitive;
-                        result = propertiesRelatedTo(source, target, reportStructuralErrors, /*excludedProperties*/ undefined);
+                        result = propertiesRelatedTo(source, target, reportStructuralErrors, /*excludedProperties*/ undefined, isIntersectionConstituent);
                         if (result) {
                             result &= signaturesRelatedTo(source, target, SignatureKind.Call, reportStructuralErrors);
                             if (result) {
@@ -13629,8 +13620,8 @@ namespace ts {
                 }
                 return Ternary.False;
 
-                function relateVariances(sourceTypeArguments: ReadonlyArray<Type> | undefined, targetTypeArguments: ReadonlyArray<Type> | undefined, variances: VarianceFlags[]) {
-                    if (result = typeArgumentsRelatedTo(sourceTypeArguments, targetTypeArguments, variances, reportErrors)) {
+                function relateVariances(sourceTypeArguments: ReadonlyArray<Type> | undefined, targetTypeArguments: ReadonlyArray<Type> | undefined, variances: VarianceFlags[], isIntersectionConstituent: boolean) {
+                    if (result = typeArgumentsRelatedTo(sourceTypeArguments, targetTypeArguments, variances, reportErrors, isIntersectionConstituent)) {
                         return result;
                     }
                     if (some(variances, v => !!(v & VarianceFlags.AllowsStructuralFallback))) {
@@ -13758,10 +13749,7 @@ namespace ts {
                             if (!targetProperty) continue outer;
                             if (sourceProperty === targetProperty) continue;
                             // We compare the source property to the target in the context of a single discriminant type.
-                            const saveIsInt = isIntersectionConstituent;
-                            isIntersectionConstituent = false;
-                            const related = propertyRelatedTo(source, target, sourceProperty, targetProperty, _ => combination[i], /*reportErrors*/ false);
-                            isIntersectionConstituent = saveIsInt;
+                            const related = propertyRelatedTo(source, target, sourceProperty, targetProperty, _ => combination[i], /*reportErrors*/ false, /*isIntersectionConstituent*/ false);
                             // If the target property could not be found, or if the properties were not related,
                             // then this constituent is not a match.
                             if (!related) {
@@ -13780,7 +13768,7 @@ namespace ts {
                 // Compare the remaining non-discriminant properties of each match.
                 let result = Ternary.True;
                 for (const type of matchingTypes) {
-                    result &= propertiesRelatedTo(source, type, /*reportErrors*/ false, excludedProperties);
+                    result &= propertiesRelatedTo(source, type, /*reportErrors*/ false, excludedProperties, /*isIntersectionConstituent*/ false);
                     if (result) {
                         result &= signaturesRelatedTo(source, type, SignatureKind.Call, /*reportStructuralErrors*/ false);
                         if (result) {
@@ -13816,7 +13804,7 @@ namespace ts {
                 return result || properties;
             }
 
-            function isPropertySymbolTypeRelated(sourceProp: Symbol, targetProp: Symbol, getTypeOfSourceProperty: (sym: Symbol) => Type, reportErrors: boolean): Ternary {
+            function isPropertySymbolTypeRelated(sourceProp: Symbol, targetProp: Symbol, getTypeOfSourceProperty: (sym: Symbol) => Type, reportErrors: boolean, isIntersectionConstituent: boolean): Ternary {
                 const targetIsOptional = strictNullChecks && !!(getCheckFlags(targetProp) & CheckFlags.Partial);
                 const source = getTypeOfSourceProperty(sourceProp);
                 if (getCheckFlags(targetProp) & CheckFlags.DeferredType && !getSymbolLinks(targetProp).type) {
@@ -13828,10 +13816,7 @@ namespace ts {
                     let result = unionParent ? Ternary.False : Ternary.True;
                     const targetTypes = links.deferralConstituents!;
                     for (const targetType of targetTypes) {
-                        const saveIsInt = isIntersectionConstituent;
-                        isIntersectionConstituent = !unionParent;
-                        const related = isRelatedTo(source, targetType, /*reportErrors*/ false);
-                        isIntersectionConstituent = saveIsInt;
+                        const related = isRelatedTo(source, targetType, /*reportErrors*/ false, /*headMessage*/ undefined, /*isIntersectionConstituent*/ !unionParent);
                         if (!unionParent) {
                             if (!related) {
                                 // Can't assign to a target individually - have to fallback to assigning to the _whole_ intersection (which forces normalization)
@@ -13858,11 +13843,11 @@ namespace ts {
                     return result;
                 }
                 else {
-                    return isRelatedTo(source, addOptionality(getTypeOfSymbol(targetProp), targetIsOptional), reportErrors);
+                    return isRelatedTo(source, addOptionality(getTypeOfSymbol(targetProp), targetIsOptional), reportErrors, /*headMessage*/ undefined, isIntersectionConstituent);
                 }
             }
 
-            function propertyRelatedTo(source: Type, target: Type, sourceProp: Symbol, targetProp: Symbol, getTypeOfSourceProperty: (sym: Symbol) => Type, reportErrors: boolean): Ternary {
+            function propertyRelatedTo(source: Type, target: Type, sourceProp: Symbol, targetProp: Symbol, getTypeOfSourceProperty: (sym: Symbol) => Type, reportErrors: boolean, isIntersectionConstituent: boolean): Ternary {
                 const sourcePropFlags = getDeclarationModifierFlagsFromSymbol(sourceProp);
                 const targetPropFlags = getDeclarationModifierFlagsFromSymbol(targetProp);
                 if (sourcePropFlags & ModifierFlags.Private || targetPropFlags & ModifierFlags.Private) {
@@ -13904,7 +13889,7 @@ namespace ts {
                     return Ternary.False;
                 }
                 // If the target comes from a partial union prop, allow `undefined` in the target type
-                const related = isPropertySymbolTypeRelated(sourceProp, targetProp, getTypeOfSourceProperty, reportErrors);
+                const related = isPropertySymbolTypeRelated(sourceProp, targetProp, getTypeOfSourceProperty, reportErrors, isIntersectionConstituent);
                 if (!related) {
                     if (reportErrors) {
                         reportError(Diagnostics.Types_of_property_0_are_incompatible, symbolToString(targetProp));
@@ -13929,7 +13914,7 @@ namespace ts {
                 return related;
             }
 
-            function propertiesRelatedTo(source: Type, target: Type, reportErrors: boolean, excludedProperties: UnderscoreEscapedMap<true> | undefined): Ternary {
+            function propertiesRelatedTo(source: Type, target: Type, reportErrors: boolean, excludedProperties: UnderscoreEscapedMap<true> | undefined, isIntersectionConstituent: boolean): Ternary {
                 if (relation === identityRelation) {
                     return propertiesIdenticalTo(source, target, excludedProperties);
                 }
@@ -14016,7 +14001,7 @@ namespace ts {
                     if (!(targetProp.flags & SymbolFlags.Prototype)) {
                         const sourceProp = getPropertyOfType(source, targetProp.escapedName);
                         if (sourceProp && sourceProp !== targetProp) {
-                            const related = propertyRelatedTo(source, target, sourceProp, targetProp, getTypeOfSymbol, reportErrors);
+                            const related = propertyRelatedTo(source, target, sourceProp, targetProp, getTypeOfSymbol, reportErrors, isIntersectionConstituent);
                             if (!related) {
                                 return Ternary.False;
                             }
@@ -27741,7 +27726,7 @@ namespace ts {
                         (initializer.properties.length === 0 || isPrototypeAccess(node.name)) &&
                         hasEntries(symbol.exports);
                     if (!isJSObjectLiteralInitializer && node.parent.parent.kind !== SyntaxKind.ForInStatement) {
-                        checkTypeAssignableToAndOptionallyElaborate(checkExpressionCached(initializer), type, node, initializer);
+                        checkTypeAssignableToAndOptionallyElaborate(checkExpressionCached(initializer), type, node, initializer, /*headMessage*/ undefined);
                     }
                 }
                 if (symbol.declarations.length > 1) {
@@ -27761,7 +27746,7 @@ namespace ts {
                     errorNextVariableOrPropertyDeclarationMustHaveSameType(symbol.valueDeclaration, type, node, declarationType);
                 }
                 if (node.initializer) {
-                    checkTypeAssignableToAndOptionallyElaborate(checkExpressionCached(node.initializer), declarationType, node, node.initializer);
+                    checkTypeAssignableToAndOptionallyElaborate(checkExpressionCached(node.initializer), declarationType, node, node.initializer, /*headMessage*/ undefined);
                 }
                 if (!areDeclarationFlagsIdentical(node, symbol.valueDeclaration)) {
                     error(node.name, Diagnostics.All_declarations_of_0_must_have_identical_modifiers, declarationNameToString(node.name));
@@ -28814,7 +28799,7 @@ namespace ts {
                     }
                     if (!isTypeEqualityComparableTo(comparedExpressionType, caseType)) {
                         // expressionType is not comparable to caseType, try the reversed check and report errors if it fails
-                        checkTypeComparableTo(caseType, comparedExpressionType, clause.expression);
+                        checkTypeComparableTo(caseType, comparedExpressionType, clause.expression, /*headMessage*/ undefined);
                     }
                 }
                 forEach(clause.statements, checkSourceElement);
@@ -29602,7 +29587,7 @@ namespace ts {
             }
             else {
                 // Only here do we need to check that the initializer is assignable to the enum type.
-                checkTypeAssignableTo(checkExpression(initializer), getDeclaredTypeOfSymbol(getSymbolOfNode(member.parent)), initializer);
+                checkTypeAssignableTo(checkExpression(initializer), getDeclaredTypeOfSymbol(getSymbolOfNode(member.parent)), initializer, /*headMessage*/ undefined);
             }
             return value;
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13759,7 +13759,7 @@ namespace ts {
                             if (sourceProperty === targetProperty) continue;
                             // We compare the source property to the target in the context of a single discriminant type.
                             const saveIsInt = isIntersectionConstituent;
-                            isIntersectionConstituent = false; // TODOOOOO: Probably not needed
+                            isIntersectionConstituent = false;
                             const related = propertyRelatedTo(source, target, sourceProperty, targetProperty, _ => combination[i], /*reportErrors*/ false);
                             isIntersectionConstituent = saveIsInt;
                             // If the target property could not be found, or if the properties were not related,

--- a/tests/baselines/reference/excessPropertyCheckWithNestedArrayIntersection.js
+++ b/tests/baselines/reference/excessPropertyCheckWithNestedArrayIntersection.js
@@ -1,0 +1,34 @@
+//// [excessPropertyCheckWithNestedArrayIntersection.ts]
+interface ValueOnlyFields {
+    fields: Array<{
+        value: number | null;
+    }>;
+}
+interface ValueAndKeyFields {
+    fields: Array<{
+        key: string | null;
+        value: number | null;
+    }>;
+}
+interface BugRepro {
+  dataType: ValueAndKeyFields & ValueOnlyFields;
+}
+const repro: BugRepro = {
+  dataType: {
+    fields: [{
+      key: 'bla', // should be OK: Not excess
+      value: null,
+    }],
+  }
+}
+
+
+//// [excessPropertyCheckWithNestedArrayIntersection.js]
+var repro = {
+    dataType: {
+        fields: [{
+                key: 'bla',
+                value: null
+            }]
+    }
+};

--- a/tests/baselines/reference/excessPropertyCheckWithNestedArrayIntersection.symbols
+++ b/tests/baselines/reference/excessPropertyCheckWithNestedArrayIntersection.symbols
@@ -1,0 +1,56 @@
+=== tests/cases/compiler/excessPropertyCheckWithNestedArrayIntersection.ts ===
+interface ValueOnlyFields {
+>ValueOnlyFields : Symbol(ValueOnlyFields, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 0, 0))
+
+    fields: Array<{
+>fields : Symbol(ValueOnlyFields.fields, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 0, 27))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+        value: number | null;
+>value : Symbol(value, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 1, 19))
+
+    }>;
+}
+interface ValueAndKeyFields {
+>ValueAndKeyFields : Symbol(ValueAndKeyFields, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 4, 1))
+
+    fields: Array<{
+>fields : Symbol(ValueAndKeyFields.fields, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 5, 29))
+>Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+        key: string | null;
+>key : Symbol(key, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 6, 19))
+
+        value: number | null;
+>value : Symbol(value, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 7, 27))
+
+    }>;
+}
+interface BugRepro {
+>BugRepro : Symbol(BugRepro, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 10, 1))
+
+  dataType: ValueAndKeyFields & ValueOnlyFields;
+>dataType : Symbol(BugRepro.dataType, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 11, 20))
+>ValueAndKeyFields : Symbol(ValueAndKeyFields, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 4, 1))
+>ValueOnlyFields : Symbol(ValueOnlyFields, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 0, 0))
+}
+const repro: BugRepro = {
+>repro : Symbol(repro, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 14, 5))
+>BugRepro : Symbol(BugRepro, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 10, 1))
+
+  dataType: {
+>dataType : Symbol(dataType, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 14, 25))
+
+    fields: [{
+>fields : Symbol(fields, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 15, 13))
+
+      key: 'bla', // should be OK: Not excess
+>key : Symbol(key, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 16, 14))
+
+      value: null,
+>value : Symbol(value, Decl(excessPropertyCheckWithNestedArrayIntersection.ts, 17, 17))
+
+    }],
+  }
+}
+

--- a/tests/baselines/reference/excessPropertyCheckWithNestedArrayIntersection.types
+++ b/tests/baselines/reference/excessPropertyCheckWithNestedArrayIntersection.types
@@ -1,0 +1,54 @@
+=== tests/cases/compiler/excessPropertyCheckWithNestedArrayIntersection.ts ===
+interface ValueOnlyFields {
+    fields: Array<{
+>fields : { value: number; }[]
+
+        value: number | null;
+>value : number
+>null : null
+
+    }>;
+}
+interface ValueAndKeyFields {
+    fields: Array<{
+>fields : { key: string; value: number; }[]
+
+        key: string | null;
+>key : string
+>null : null
+
+        value: number | null;
+>value : number
+>null : null
+
+    }>;
+}
+interface BugRepro {
+  dataType: ValueAndKeyFields & ValueOnlyFields;
+>dataType : ValueAndKeyFields & ValueOnlyFields
+}
+const repro: BugRepro = {
+>repro : BugRepro
+>{  dataType: {    fields: [{      key: 'bla', // should be OK: Not excess      value: null,    }],  }} : { dataType: { fields: { key: string; value: null; }[]; }; }
+
+  dataType: {
+>dataType : { fields: { key: string; value: null; }[]; }
+>{    fields: [{      key: 'bla', // should be OK: Not excess      value: null,    }],  } : { fields: { key: string; value: null; }[]; }
+
+    fields: [{
+>fields : { key: string; value: null; }[]
+>[{      key: 'bla', // should be OK: Not excess      value: null,    }] : { key: string; value: null; }[]
+>{      key: 'bla', // should be OK: Not excess      value: null,    } : { key: string; value: null; }
+
+      key: 'bla', // should be OK: Not excess
+>key : string
+>'bla' : "bla"
+
+      value: null,
+>value : null
+>null : null
+
+    }],
+  }
+}
+

--- a/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.errors.txt
+++ b/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.errors.txt
@@ -47,7 +47,7 @@ tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts(70,50): erro
                       ~
 !!! error TS2322: Type 'number' is not assignable to type 'string'.
 !!! related TS6500 tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts:4:5: The expected type comes from property 'x' which is declared here on type 'A'
-    let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // should be an error
+    let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // error - y does not exist in type A
                                   ~~~~
 !!! error TS2322: Type '{ x: string; y: number; }' is not assignable to type 'A'.
 !!! error TS2322:   Object literal may only specify known properties, and 'y' does not exist in type 'A'.

--- a/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.js
+++ b/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.js
@@ -21,7 +21,7 @@ let c: B = { a: { x: 'hello', y: 2 } }; // error - y does not exist in type A
 
 let d: D = { a: { x: 'hello' }, c: 5 }; // ok
 let e: D = { a: { x: 2 }, c: 5 }; // error - types of property x are incompatible
-let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // should be an error
+let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // error - y does not exist in type A
 
 // https://github.com/Microsoft/TypeScript/issues/18075
 
@@ -80,7 +80,7 @@ var b = { a: { x: 2 } }; // error - types of property x are incompatible
 var c = { a: { x: 'hello', y: 2 } }; // error - y does not exist in type A
 var d = { a: { x: 'hello' }, c: 5 }; // ok
 var e = { a: { x: 2 }, c: 5 }; // error - types of property x are incompatible
-var f = { a: { x: 'hello', y: 2 }, c: 5 }; // should be an error
+var f = { a: { x: 'hello', y: 2 }, c: 5 }; // error - y does not exist in type A
 exports.photo = {
     id: 1,
     url: '',

--- a/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.symbols
+++ b/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.symbols
@@ -61,7 +61,7 @@ let e: D = { a: { x: 2 }, c: 5 }; // error - types of property x are incompatibl
 >x : Symbol(x, Decl(excessPropertyChecksWithNestedIntersections.ts, 21, 17))
 >c : Symbol(c, Decl(excessPropertyChecksWithNestedIntersections.ts, 21, 25))
 
-let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // should be an error
+let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // error - y does not exist in type A
 >f : Symbol(f, Decl(excessPropertyChecksWithNestedIntersections.ts, 22, 3))
 >D : Symbol(D, Decl(excessPropertyChecksWithNestedIntersections.ts, 12, 1))
 >a : Symbol(a, Decl(excessPropertyChecksWithNestedIntersections.ts, 22, 12))

--- a/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.types
+++ b/tests/baselines/reference/excessPropertyChecksWithNestedIntersections.types
@@ -65,7 +65,7 @@ let e: D = { a: { x: 2 }, c: 5 }; // error - types of property x are incompatibl
 >c : number
 >5 : 5
 
-let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // should be an error
+let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // error - y does not exist in type A
 >f : D
 >{ a: { x: 'hello', y: 2 }, c: 5 } : { a: { x: string; y: number; }; c: number; }
 >a : { x: string; y: number; }

--- a/tests/baselines/reference/weakType.errors.txt
+++ b/tests/baselines/reference/weakType.errors.txt
@@ -5,10 +5,8 @@ tests/cases/compiler/weakType.ts(18,13): error TS2559: Type '12' has no properti
 tests/cases/compiler/weakType.ts(19,13): error TS2559: Type '"completely wrong"' has no properties in common with type 'Settings'.
 tests/cases/compiler/weakType.ts(20,13): error TS2559: Type 'false' has no properties in common with type 'Settings'.
 tests/cases/compiler/weakType.ts(37,18): error TS2559: Type '{ error?: number; }' has no properties in common with type 'ChangeOptions'.
-tests/cases/compiler/weakType.ts(62,5): error TS2322: Type '{ properties: { wrong: string; }; }' is not assignable to type 'Weak & Spoiler'.
-  Type '{ properties: { wrong: string; }; }' is not assignable to type 'Weak'.
-    Types of property 'properties' are incompatible.
-      Type '{ wrong: string; }' has no properties in common with type '{ b?: number; }'.
+tests/cases/compiler/weakType.ts(62,5): error TS2326: Types of property 'properties' are incompatible.
+  Type '{ wrong: string; }' has no properties in common with type '{ b?: number; }'.
 
 
 ==== tests/cases/compiler/weakType.ts (8 errors) ====
@@ -85,16 +83,14 @@ tests/cases/compiler/weakType.ts(62,5): error TS2322: Type '{ properties: { wron
             b?: number
         }
     }
-    declare let unknown: {
+    declare let propertiesWrong: {
         properties: {
             wrong: string
         }
     }
-    let weak: Weak & Spoiler = unknown
+    let weak: Weak & Spoiler = propertiesWrong
         ~~~~
-!!! error TS2322: Type '{ properties: { wrong: string; }; }' is not assignable to type 'Weak & Spoiler'.
-!!! error TS2322:   Type '{ properties: { wrong: string; }; }' is not assignable to type 'Weak'.
-!!! error TS2322:     Types of property 'properties' are incompatible.
-!!! error TS2322:       Type '{ wrong: string; }' has no properties in common with type '{ b?: number; }'.
+!!! error TS2326: Types of property 'properties' are incompatible.
+!!! error TS2326:   Type '{ wrong: string; }' has no properties in common with type '{ b?: number; }'.
     
     

--- a/tests/baselines/reference/weakType.js
+++ b/tests/baselines/reference/weakType.js
@@ -55,12 +55,12 @@ type Weak = {
         b?: number
     }
 }
-declare let unknown: {
+declare let propertiesWrong: {
     properties: {
         wrong: string
     }
 }
-let weak: Weak & Spoiler = unknown
+let weak: Weak & Spoiler = propertiesWrong
 
 
 
@@ -89,4 +89,4 @@ var K = /** @class */ (function () {
     return K;
 }());
 var ctor = K;
-var weak = unknown;
+var weak = propertiesWrong;

--- a/tests/baselines/reference/weakType.symbols
+++ b/tests/baselines/reference/weakType.symbols
@@ -144,20 +144,20 @@ type Weak = {
 >b : Symbol(b, Decl(weakType.ts, 52, 18))
     }
 }
-declare let unknown: {
->unknown : Symbol(unknown, Decl(weakType.ts, 56, 11))
+declare let propertiesWrong: {
+>propertiesWrong : Symbol(propertiesWrong, Decl(weakType.ts, 56, 11))
 
     properties: {
->properties : Symbol(properties, Decl(weakType.ts, 56, 22))
+>properties : Symbol(properties, Decl(weakType.ts, 56, 30))
 
         wrong: string
 >wrong : Symbol(wrong, Decl(weakType.ts, 57, 17))
     }
 }
-let weak: Weak & Spoiler = unknown
+let weak: Weak & Spoiler = propertiesWrong
 >weak : Symbol(weak, Decl(weakType.ts, 61, 3))
 >Weak : Symbol(Weak, Decl(weakType.ts, 49, 32))
 >Spoiler : Symbol(Spoiler, Decl(weakType.ts, 47, 18))
->unknown : Symbol(unknown, Decl(weakType.ts, 56, 11))
+>propertiesWrong : Symbol(propertiesWrong, Decl(weakType.ts, 56, 11))
 
 

--- a/tests/baselines/reference/weakType.types
+++ b/tests/baselines/reference/weakType.types
@@ -147,8 +147,8 @@ type Weak = {
 >b : number
     }
 }
-declare let unknown: {
->unknown : { properties: { wrong: string; }; }
+declare let propertiesWrong: {
+>propertiesWrong : { properties: { wrong: string; }; }
 
     properties: {
 >properties : { wrong: string; }
@@ -157,8 +157,8 @@ declare let unknown: {
 >wrong : string
     }
 }
-let weak: Weak & Spoiler = unknown
+let weak: Weak & Spoiler = propertiesWrong
 >weak : Weak & Spoiler
->unknown : { properties: { wrong: string; }; }
+>propertiesWrong : { properties: { wrong: string; }; }
 
 

--- a/tests/cases/compiler/excessPropertyCheckWithNestedArrayIntersection.ts
+++ b/tests/cases/compiler/excessPropertyCheckWithNestedArrayIntersection.ts
@@ -1,0 +1,22 @@
+interface ValueOnlyFields {
+    fields: Array<{
+        value: number | null;
+    }>;
+}
+interface ValueAndKeyFields {
+    fields: Array<{
+        key: string | null;
+        value: number | null;
+    }>;
+}
+interface BugRepro {
+  dataType: ValueAndKeyFields & ValueOnlyFields;
+}
+const repro: BugRepro = {
+  dataType: {
+    fields: [{
+      key: 'bla', // should be OK: Not excess
+      value: null,
+    }],
+  }
+}

--- a/tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts
+++ b/tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts
@@ -20,7 +20,7 @@ let c: B = { a: { x: 'hello', y: 2 } }; // error - y does not exist in type A
 
 let d: D = { a: { x: 'hello' }, c: 5 }; // ok
 let e: D = { a: { x: 2 }, c: 5 }; // error - types of property x are incompatible
-let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // should be an error
+let f: D = { a: { x: 'hello', y: 2 }, c: 5 }; // error - y does not exist in type A
 
 // https://github.com/Microsoft/TypeScript/issues/18075
 

--- a/tests/cases/compiler/weakType.ts
+++ b/tests/cases/compiler/weakType.ts
@@ -54,10 +54,10 @@ type Weak = {
         b?: number
     }
 }
-declare let unknown: {
+declare let propertiesWrong: {
     properties: {
         wrong: string
     }
 }
-let weak: Weak & Spoiler = unknown
+let weak: Weak & Spoiler = propertiesWrong
 


### PR DESCRIPTION
Excess property checking incorrectly applies to half of an intersection when nested deeply enough because `isIntersectionConstituent` is not sufficiently threaded through the `checkTypeRelatedTo` code. This PR threads `isIntersectionConstituent` through several more places.

I may scope `isIntersectionConstituent` to the entirety of `checkTypeRelatedTo` and mutate it in a dynamically scoped way. The fix works as-is, but I think it would be simpler to mutate a variable instead of adding parameters.

Fixes #30715
