### PR TITLE
Use optional module "@microsoft/typescript-etw" for ETW logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,8 @@
     "browser": {
         "fs": false,
         "os": false,
-        "path": false
+        "path": false,
+        "@microsoft/typescript-etw": false
     },
     "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "@types/gulp-sourcemaps": "0.0.32",
         "@types/jake": "latest",
         "@types/merge2": "latest",
+        "@types/microsoft__typescript-etw": "latest",
         "@types/minimatch": "latest",
         "@types/minimist": "latest",
         "@types/mkdirp": "latest",

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -105,10 +105,15 @@ namespace ts {
     const binder = createBinder();
 
     export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
-        performance.mark("beforeBind");
-        binder(file, options);
-        performance.mark("afterBind");
-        performance.measure("Bind", "beforeBind", "afterBind");
+        try {
+            performance.mark("beforeBind");
+            if (etwLogger) etwLogger.logStartBindFile("" + file.fileName);
+            binder(file, options);
+        } finally {
+            if (etwLogger) etwLogger.logStopBindFile();
+            performance.mark("afterBind");
+            performance.measure("Bind", "beforeBind", "afterBind");
+        }
     }
 
     function createBinder(): (file: SourceFile, options: CompilerOptions) => void {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -107,10 +107,10 @@ namespace ts {
     export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
         try {
             performance.mark("beforeBind");
-            if (etwLogger) etwLogger.logStartBindFile("" + file.fileName);
+            perfLogger.logStartBindFile("" + file.fileName);
             binder(file, options);
         } finally {
-            if (etwLogger) etwLogger.logStopBindFile();
+            perfLogger.logStopBindFile();
             performance.mark("afterBind");
             performance.measure("Bind", "beforeBind", "afterBind");
         }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -105,15 +105,12 @@ namespace ts {
     const binder = createBinder();
 
     export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
-        try {
-            performance.mark("beforeBind");
-            perfLogger.logStartBindFile("" + file.fileName);
-            binder(file, options);
-        } finally {
-            perfLogger.logStopBindFile();
-            performance.mark("afterBind");
-            performance.measure("Bind", "beforeBind", "afterBind");
-        }
+        performance.mark("beforeBind");
+        perfLogger.logStartBindFile("" + file.fileName);
+        binder(file, options);
+        perfLogger.logStopBindFile();
+        performance.mark("afterBind");
+        performance.measure("Bind", "beforeBind", "afterBind");
     }
 
     function createBinder(): (file: SourceFile, options: CompilerOptions) => void {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -4,6 +4,24 @@ namespace ts {
     export const versionMajorMinor = "3.6";
     /** The version of the TypeScript compiler release */
     export const version = `${versionMajorMinor}.0-dev`;
+
+    // Load optional module to enable Event Tracing for Windows
+    // See https://github.com/microsoft/typescript-etw for more information
+    let etwModule;
+    try {
+        // tslint:disable-next-line:no-implicit-dependencies
+        etwModule = require("@microsoft/typescript-etw");
+    }
+    catch (e) {
+        // Optional module not installed
+        etwModule = undefined;
+    }
+
+    /* @internal */
+    // tslint:disable-next-line:no-implicit-dependencies
+    export const etwLogger: typeof import("@microsoft/typescript-etw") | undefined = etwModule;
+
+    if (etwLogger) etwLogger.logInfoEvent(`Starting TypeScript v${versionMajorMinor} with command line: ${JSON.stringify(process.argv)}`);
 }
 
 namespace ts {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -4,8 +4,6 @@ namespace ts {
     export const versionMajorMinor = "3.6";
     /** The version of the TypeScript compiler release */
     export const version = `${versionMajorMinor}.0-dev`;
-
-    perfLogger.logInfoEvent(`Starting TypeScript v${versionMajorMinor} with command line: ${JSON.stringify(process.argv)}`);
 }
 
 namespace ts {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -5,23 +5,7 @@ namespace ts {
     /** The version of the TypeScript compiler release */
     export const version = `${versionMajorMinor}.0-dev`;
 
-    // Load optional module to enable Event Tracing for Windows
-    // See https://github.com/microsoft/typescript-etw for more information
-    let etwModule;
-    try {
-        // tslint:disable-next-line:no-implicit-dependencies
-        etwModule = require("@microsoft/typescript-etw");
-    }
-    catch (e) {
-        // Optional module not installed
-        etwModule = undefined;
-    }
-
-    /* @internal */
-    // tslint:disable-next-line:no-implicit-dependencies
-    export const etwLogger: typeof import("@microsoft/typescript-etw") | undefined = etwModule;
-
-    if (etwLogger) etwLogger.logInfoEvent(`Starting TypeScript v${versionMajorMinor} with command line: ${JSON.stringify(process.argv)}`);
+    perfLogger.logInfoEvent(`Starting TypeScript v${versionMajorMinor} with command line: ${JSON.stringify(process.argv)}`);
 }
 
 namespace ts {

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -666,7 +666,7 @@ namespace ts {
             }
 
             try {
-                if (etwLogger) etwLogger.logStartResolveModule(moduleName /* , containingFile, ModuleResolutionKind[moduleResolution]*/);
+                perfLogger.logStartResolveModule(moduleName /* , containingFile, ModuleResolutionKind[moduleResolution]*/);
                 switch (moduleResolution) {
                     case ModuleResolutionKind.NodeJs:
                         result = nodeModuleNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
@@ -679,8 +679,8 @@ namespace ts {
                 }
             }
             finally {
-                if (etwLogger && result && result.resolvedModule) etwLogger.logInfoEvent(`Module "${moduleName}" resolved to "${result.resolvedModule.resolvedFileName}"`);
-                if (etwLogger) etwLogger.logStopResolveModule((result && result.resolvedModule) ? "" + result.resolvedModule.resolvedFileName : "null");
+                if (result && result.resolvedModule) perfLogger.logInfoEvent(`Module "${moduleName}" resolved to "${result.resolvedModule.resolvedFileName}"`);
+                perfLogger.logStopResolveModule((result && result.resolvedModule) ? "" + result.resolvedModule.resolvedFileName : "null");
              }
 
             if (perFolderCache) {

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -665,16 +665,23 @@ namespace ts {
                 }
             }
 
-            switch (moduleResolution) {
-                case ModuleResolutionKind.NodeJs:
-                    result = nodeModuleNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
-                    break;
-                case ModuleResolutionKind.Classic:
-                    result = classicNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
-                    break;
-                default:
-                    return Debug.fail(`Unexpected moduleResolution: ${moduleResolution}`);
+            try {
+                if (etwLogger) etwLogger.logStartResolveModule(moduleName /* , containingFile, ModuleResolutionKind[moduleResolution]*/);
+                switch (moduleResolution) {
+                    case ModuleResolutionKind.NodeJs:
+                        result = nodeModuleNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
+                        break;
+                    case ModuleResolutionKind.Classic:
+                        result = classicNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
+                        break;
+                    default:
+                        return Debug.fail(`Unexpected moduleResolution: ${moduleResolution}`);
+                }
             }
+            finally {
+                if (etwLogger && result && result.resolvedModule) etwLogger.logInfoEvent(`Module "${moduleName}" resolved to "${result.resolvedModule.resolvedFileName}"`);
+                if (etwLogger) etwLogger.logStopResolveModule((result && result.resolvedModule) ? "" + result.resolvedModule.resolvedFileName : "null");
+             }
 
             if (perFolderCache) {
                 perFolderCache.set(moduleName, result);

--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -665,23 +665,19 @@ namespace ts {
                 }
             }
 
-            try {
-                perfLogger.logStartResolveModule(moduleName /* , containingFile, ModuleResolutionKind[moduleResolution]*/);
-                switch (moduleResolution) {
-                    case ModuleResolutionKind.NodeJs:
-                        result = nodeModuleNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
-                        break;
-                    case ModuleResolutionKind.Classic:
-                        result = classicNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
-                        break;
-                    default:
-                        return Debug.fail(`Unexpected moduleResolution: ${moduleResolution}`);
-                }
+            perfLogger.logStartResolveModule(moduleName /* , containingFile, ModuleResolutionKind[moduleResolution]*/);
+            switch (moduleResolution) {
+                case ModuleResolutionKind.NodeJs:
+                    result = nodeModuleNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
+                    break;
+                case ModuleResolutionKind.Classic:
+                    result = classicNameResolver(moduleName, containingFile, compilerOptions, host, cache, redirectedReference);
+                    break;
+                default:
+                    return Debug.fail(`Unexpected moduleResolution: ${moduleResolution}`);
             }
-            finally {
-                if (result && result.resolvedModule) perfLogger.logInfoEvent(`Module "${moduleName}" resolved to "${result.resolvedModule.resolvedFileName}"`);
-                perfLogger.logStopResolveModule((result && result.resolvedModule) ? "" + result.resolvedModule.resolvedFileName : "null");
-             }
+            if (result && result.resolvedModule) perfLogger.logInfoEvent(`Module "${moduleName}" resolved to "${result.resolvedModule.resolvedFileName}"`);
+            perfLogger.logStopResolveModule((result && result.resolvedModule) ? "" + result.resolvedModule.resolvedFileName : "null");
 
             if (perFolderCache) {
                 perFolderCache.set(moduleName, result);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -512,12 +512,19 @@ namespace ts {
     export function createSourceFile(fileName: string, sourceText: string, languageVersion: ScriptTarget, setParentNodes = false, scriptKind?: ScriptKind): SourceFile {
         performance.mark("beforeParse");
         let result: SourceFile;
-        if (languageVersion === ScriptTarget.JSON) {
-            result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, ScriptKind.JSON);
+        try {
+            if (etwLogger) etwLogger.logStartParseSourceFile(fileName);
+            if (languageVersion === ScriptTarget.JSON) {
+                result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, ScriptKind.JSON);
+            }
+            else {
+                result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind);
+            }
         }
-        else {
-            result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind);
+        finally {
+            if (etwLogger) etwLogger.logStopParseSourceFile();
         }
+
         performance.mark("afterParse");
         performance.measure("Parse", "beforeParse", "afterParse");
         return result;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -513,7 +513,7 @@ namespace ts {
         performance.mark("beforeParse");
         let result: SourceFile;
         try {
-            if (etwLogger) etwLogger.logStartParseSourceFile(fileName);
+            perfLogger.logStartParseSourceFile(fileName);
             if (languageVersion === ScriptTarget.JSON) {
                 result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, ScriptKind.JSON);
             }
@@ -522,7 +522,7 @@ namespace ts {
             }
         }
         finally {
-            if (etwLogger) etwLogger.logStopParseSourceFile();
+            perfLogger.logStopParseSourceFile();
         }
 
         performance.mark("afterParse");

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -512,18 +512,15 @@ namespace ts {
     export function createSourceFile(fileName: string, sourceText: string, languageVersion: ScriptTarget, setParentNodes = false, scriptKind?: ScriptKind): SourceFile {
         performance.mark("beforeParse");
         let result: SourceFile;
-        try {
-            perfLogger.logStartParseSourceFile(fileName);
-            if (languageVersion === ScriptTarget.JSON) {
-                result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, ScriptKind.JSON);
-            }
-            else {
-                result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind);
-            }
+
+        perfLogger.logStartParseSourceFile(fileName);
+        if (languageVersion === ScriptTarget.JSON) {
+            result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, ScriptKind.JSON);
         }
-        finally {
-            perfLogger.logStopParseSourceFile();
+        else {
+            result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind);
         }
+        perfLogger.logStopParseSourceFile();
 
         performance.mark("afterParse");
         performance.measure("Parse", "beforeParse", "afterParse");

--- a/src/compiler/perfLogger.ts
+++ b/src/compiler/perfLogger.ts
@@ -1,69 +1,28 @@
 /* @internal */
 namespace ts {
-    export type PerfLogger = typeof import("@microsoft/typescript-etw"); // tslint:disable-line:no-implicit-dependencies
-
-    export class NullLogger implements PerfLogger {
-        logEvent(_msg: string): void {
-            return;
-        }
-        logErrEvent(_msg: string): void {
-            return;
-        }
-        logPerfEvent(_msg: string): void {
-            return;
-        }
-        logInfoEvent(_msg: string): void {
-            return;
-        }
-        logStartCommand(_command: string, _msg: string): void {
-            return;
-        }
-        logStopCommand(_command: string, _msg: string): void {
-            return;
-        }
-        logStartUpdateProgram(_msg: string): void {
-            return;
-        }
-        logStopUpdateProgram(_msg: string): void {
-            return;
-        }
-        logStartUpdateGraph(): void {
-            return;
-        }
-        logStopUpdateGraph(): void {
-            return;
-        }
-        logStartResolveModule(_name: string): void {
-            return;
-        }
-        logStopResolveModule(_success: string): void {
-            return;
-        }
-        logStartParseSourceFile(_filename: string): void {
-            return;
-        }
-        logStopParseSourceFile(): void {
-            return;
-        }
-        logStartReadFile(_filename: string): void {
-            return;
-        }
-        logStopReadFile(): void {
-            return;
-        }
-        logStartBindFile(_filename: string): void {
-            return;
-        }
-        logStopBindFile(): void {
-            return;
-        }
-        logStartScheduledOperation(_operationId: string): void {
-            return;
-        }
-        logStopScheduledOperation(): void {
-            return;
-        }
-    }
+    type PerfLogger = typeof import("@microsoft/typescript-etw"); // tslint:disable-line:no-implicit-dependencies
+    const nullLogger: PerfLogger = {
+        logEvent: noop,
+        logErrEvent: noop,
+        logPerfEvent: noop,
+        logInfoEvent: noop,
+        logStartCommand: noop,
+        logStopCommand: noop,
+        logStartUpdateProgram: noop,
+        logStopUpdateProgram: noop,
+        logStartUpdateGraph: noop,
+        logStopUpdateGraph: noop,
+        logStartResolveModule: noop,
+        logStopResolveModule: noop,
+        logStartParseSourceFile: noop,
+        logStopParseSourceFile: noop,
+        logStartReadFile: noop,
+        logStopReadFile: noop,
+        logStartBindFile: noop,
+        logStopBindFile: noop,
+        logStartScheduledOperation: noop,
+        logStopScheduledOperation: noop,
+    };
 
     // Load optional module to enable Event Tracing for Windows
     // See https://github.com/microsoft/typescript-etw for more information
@@ -77,5 +36,8 @@ namespace ts {
         etwModule = undefined;
     }
 
-    export const perfLogger: PerfLogger = etwModule ? etwModule : new NullLogger();
+    /** Performance logger that will generate ETW events if possible */
+    export const perfLogger: PerfLogger = etwModule ? etwModule : nullLogger;
+
+    perfLogger.logInfoEvent(`Starting TypeScript v${versionMajorMinor} with command line: ${JSON.stringify(process.argv)}`);
 }

--- a/src/compiler/perfLogger.ts
+++ b/src/compiler/perfLogger.ts
@@ -1,0 +1,81 @@
+/* @internal */
+namespace ts {
+    export type PerfLogger = typeof import("@microsoft/typescript-etw"); // tslint:disable-line:no-implicit-dependencies
+
+    export class NullLogger implements PerfLogger {
+        logEvent(_msg: string): void {
+            return;
+        }
+        logErrEvent(_msg: string): void {
+            return;
+        }
+        logPerfEvent(_msg: string): void {
+            return;
+        }
+        logInfoEvent(_msg: string): void {
+            return;
+        }
+        logStartCommand(_command: string, _msg: string): void {
+            return;
+        }
+        logStopCommand(_command: string, _msg: string): void {
+            return;
+        }
+        logStartUpdateProgram(_msg: string): void {
+            return;
+        }
+        logStopUpdateProgram(_msg: string): void {
+            return;
+        }
+        logStartUpdateGraph(): void {
+            return;
+        }
+        logStopUpdateGraph(): void {
+            return;
+        }
+        logStartResolveModule(_name: string): void {
+            return;
+        }
+        logStopResolveModule(_success: string): void {
+            return;
+        }
+        logStartParseSourceFile(_filename: string): void {
+            return;
+        }
+        logStopParseSourceFile(): void {
+            return;
+        }
+        logStartReadFile(_filename: string): void {
+            return;
+        }
+        logStopReadFile(): void {
+            return;
+        }
+        logStartBindFile(_filename: string): void {
+            return;
+        }
+        logStopBindFile(): void {
+            return;
+        }
+        logStartScheduledOperation(_operationId: string): void {
+            return;
+        }
+        logStopScheduledOperation(): void {
+            return;
+        }
+    }
+
+    // Load optional module to enable Event Tracing for Windows
+    // See https://github.com/microsoft/typescript-etw for more information
+    let etwModule;
+    try {
+        // require() will throw an exception if the module is not installed
+        // It may also return undefined if not installed properly
+        etwModule = require("@microsoft/typescript-etw"); // tslint:disable-line:no-implicit-dependencies
+    }
+    catch (e) {
+        etwModule = undefined;
+    }
+
+    export const perfLogger: PerfLogger = etwModule ? etwModule : new NullLogger();
+}

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1088,7 +1088,7 @@ namespace ts {
 
             function readFile(fileName: string, _encoding?: string): string | undefined {
                 try {
-                    if (etwLogger) etwLogger.logStartReadFile(fileName);
+                    perfLogger.logStartReadFile(fileName);
                     if (!fileExists(fileName)) {
                         return undefined;
                     }
@@ -1116,12 +1116,12 @@ namespace ts {
                     // Default is UTF-8 with no byte order mark
                     return buffer.toString("utf8");
                 } finally {
-                    if (etwLogger) etwLogger.logStopReadFile();
+                    perfLogger.logStopReadFile();
                 }
             }
 
             function writeFile(fileName: string, data: string, writeByteOrderMark?: boolean): void {
-                if (etwLogger) etwLogger.logEvent("WriteFile: " + fileName);
+                perfLogger.logEvent("WriteFile: " + fileName);
                 // If a BOM is required, emit one
                 if (writeByteOrderMark) {
                     data = byteOrderMarkIndicator + data;
@@ -1141,7 +1141,7 @@ namespace ts {
             }
 
             function getAccessibleFileSystemEntries(path: string): FileSystemEntries {
-                if (etwLogger) etwLogger.logEvent("ReadDir: " + (path || "."));
+                perfLogger.logEvent("ReadDir: " + (path || "."));
                 try {
                     const entries = _fs.readdirSync(path || ".").sort();
                     const files: string[] = [];
@@ -1203,7 +1203,7 @@ namespace ts {
             }
 
             function getDirectories(path: string): string[] {
-                if (etwLogger) etwLogger.logEvent("ReadDir: " + path);
+                perfLogger.logEvent("ReadDir: " + path);
                 return filter<string>(_fs.readdirSync(path), dir => fileSystemEntryExists(combinePaths(path, dir), FileSystemEntryKind.Directory));
             }
 

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1087,35 +1087,41 @@ namespace ts {
             }
 
             function readFile(fileName: string, _encoding?: string): string | undefined {
-                if (!fileExists(fileName)) {
-                    return undefined;
-                }
-                const buffer = _fs.readFileSync(fileName);
-                let len = buffer.length;
-                if (len >= 2 && buffer[0] === 0xFE && buffer[1] === 0xFF) {
-                    // Big endian UTF-16 byte order mark detected. Since big endian is not supported by node.js,
-                    // flip all byte pairs and treat as little endian.
-                    len &= ~1; // Round down to a multiple of 2
-                    for (let i = 0; i < len; i += 2) {
-                        const temp = buffer[i];
-                        buffer[i] = buffer[i + 1];
-                        buffer[i + 1] = temp;
+                try {
+                    if (etwLogger) etwLogger.logStartReadFile(fileName);
+                    if (!fileExists(fileName)) {
+                        return undefined;
                     }
-                    return buffer.toString("utf16le", 2);
+                    const buffer = _fs.readFileSync(fileName);
+                    let len = buffer.length;
+                    if (len >= 2 && buffer[0] === 0xFE && buffer[1] === 0xFF) {
+                        // Big endian UTF-16 byte order mark detected. Since big endian is not supported by node.js,
+                        // flip all byte pairs and treat as little endian.
+                        len &= ~1; // Round down to a multiple of 2
+                        for (let i = 0; i < len; i += 2) {
+                            const temp = buffer[i];
+                            buffer[i] = buffer[i + 1];
+                            buffer[i + 1] = temp;
+                        }
+                        return buffer.toString("utf16le", 2);
+                    }
+                    if (len >= 2 && buffer[0] === 0xFF && buffer[1] === 0xFE) {
+                        // Little endian UTF-16 byte order mark detected
+                        return buffer.toString("utf16le", 2);
+                    }
+                    if (len >= 3 && buffer[0] === 0xEF && buffer[1] === 0xBB && buffer[2] === 0xBF) {
+                        // UTF-8 byte order mark detected
+                        return buffer.toString("utf8", 3);
+                    }
+                    // Default is UTF-8 with no byte order mark
+                    return buffer.toString("utf8");
+                } finally {
+                    if (etwLogger) etwLogger.logStopReadFile();
                 }
-                if (len >= 2 && buffer[0] === 0xFF && buffer[1] === 0xFE) {
-                    // Little endian UTF-16 byte order mark detected
-                    return buffer.toString("utf16le", 2);
-                }
-                if (len >= 3 && buffer[0] === 0xEF && buffer[1] === 0xBB && buffer[2] === 0xBF) {
-                    // UTF-8 byte order mark detected
-                    return buffer.toString("utf8", 3);
-                }
-                // Default is UTF-8 with no byte order mark
-                return buffer.toString("utf8");
             }
 
             function writeFile(fileName: string, data: string, writeByteOrderMark?: boolean): void {
+                if (etwLogger) etwLogger.logEvent("WriteFile: " + fileName);
                 // If a BOM is required, emit one
                 if (writeByteOrderMark) {
                     data = byteOrderMarkIndicator + data;
@@ -1135,6 +1141,7 @@ namespace ts {
             }
 
             function getAccessibleFileSystemEntries(path: string): FileSystemEntries {
+                if (etwLogger) etwLogger.logEvent("ReadDir: " + (path || "."));
                 try {
                     const entries = _fs.readdirSync(path || ".").sort();
                     const files: string[] = [];
@@ -1196,6 +1203,7 @@ namespace ts {
             }
 
             function getDirectories(path: string): string[] {
+                if (etwLogger) etwLogger.logEvent("ReadDir: " + path);
                 return filter<string>(_fs.readdirSync(path), dir => fileSystemEntryExists(combinePaths(path, dir), FileSystemEntryKind.Directory));
             }
 

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -7,6 +7,7 @@
     "references": [],
 
     "files": [
+        "perfLogger.ts",
         "core.ts",
         "debug.ts",
         "performance.ts",

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -7,10 +7,10 @@
     "references": [],
 
     "files": [
-        "perfLogger.ts",
         "core.ts",
         "debug.ts",
         "performance.ts",
+        "perfLogger.ts",
         "semver.ts",
 
         "types.ts",

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -1003,22 +1003,21 @@ namespace ts {
             timerToUpdateProgram = undefined;
             reportWatchDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation);
 
-            try {
-                switch (reloadLevel) {
-                    case ConfigFileProgramReloadLevel.Partial:
-                        perfLogger.logStartUpdateProgram("PartialConfigReload");
-                        return reloadFileNamesFromConfigFile();
-                    case ConfigFileProgramReloadLevel.Full:
-                        perfLogger.logStartUpdateProgram("FullConfigReload");
-                        return reloadConfigFile();
-                    default:
-                        perfLogger.logStartUpdateProgram("SynchronizeProgram");
-                        synchronizeProgram();
-                        return;
-                }
-            } finally {
-                perfLogger.logStopUpdateProgram("Done");
+            switch (reloadLevel) {
+                case ConfigFileProgramReloadLevel.Partial:
+                    perfLogger.logStartUpdateProgram("PartialConfigReload");
+                    reloadFileNamesFromConfigFile();
+                    break;
+                case ConfigFileProgramReloadLevel.Full:
+                    perfLogger.logStartUpdateProgram("FullConfigReload");
+                    reloadConfigFile();
+                    break;
+                default:
+                    perfLogger.logStartUpdateProgram("SynchronizeProgram");
+                    synchronizeProgram();
+                    break;
             }
+            perfLogger.logStopUpdateProgram("Done");
         }
 
         function reloadFileNamesFromConfigFile() {

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -1006,18 +1006,18 @@ namespace ts {
             try {
                 switch (reloadLevel) {
                     case ConfigFileProgramReloadLevel.Partial:
-                        if (etwLogger) etwLogger.logStartUpdateProgram("PartialConfigReload");
+                        perfLogger.logStartUpdateProgram("PartialConfigReload");
                         return reloadFileNamesFromConfigFile();
                     case ConfigFileProgramReloadLevel.Full:
-                        if (etwLogger) etwLogger.logStartUpdateProgram("FullConfigReload");
+                        perfLogger.logStartUpdateProgram("FullConfigReload");
                         return reloadConfigFile();
                     default:
-                        if (etwLogger) etwLogger.logStartUpdateProgram("SynchronizeProgram");
+                        perfLogger.logStartUpdateProgram("SynchronizeProgram");
                         synchronizeProgram();
                         return;
                 }
             } finally {
-                if (etwLogger) etwLogger.logStopUpdateProgram("Done");
+                perfLogger.logStopUpdateProgram("Done");
             }
         }
 

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -1003,14 +1003,21 @@ namespace ts {
             timerToUpdateProgram = undefined;
             reportWatchDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation);
 
-            switch (reloadLevel) {
-                case ConfigFileProgramReloadLevel.Partial:
-                    return reloadFileNamesFromConfigFile();
-                case ConfigFileProgramReloadLevel.Full:
-                    return reloadConfigFile();
-                default:
-                    synchronizeProgram();
-                    return;
+            try {
+                switch (reloadLevel) {
+                    case ConfigFileProgramReloadLevel.Partial:
+                        if (etwLogger) etwLogger.logStartUpdateProgram("PartialConfigReload");
+                        return reloadFileNamesFromConfigFile();
+                    case ConfigFileProgramReloadLevel.Full:
+                        if (etwLogger) etwLogger.logStartUpdateProgram("FullConfigReload");
+                        return reloadConfigFile();
+                    default:
+                        if (etwLogger) etwLogger.logStartUpdateProgram("SynchronizeProgram");
+                        synchronizeProgram();
+                        return;
+                }
+            } finally {
+                if (etwLogger) etwLogger.logStopUpdateProgram("Done");
             }
         }
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -852,46 +852,43 @@ namespace ts.server {
          */
         updateGraph(): boolean {
             perfLogger.logStartUpdateGraph();
-            try {
-                this.resolutionCache.startRecordingFilesWithChangedResolutions();
+            this.resolutionCache.startRecordingFilesWithChangedResolutions();
 
-                const hasNewProgram = this.updateGraphWorker();
-                const hasAddedorRemovedFiles = this.hasAddedorRemovedFiles;
-                this.hasAddedorRemovedFiles = false;
+            const hasNewProgram = this.updateGraphWorker();
+            const hasAddedorRemovedFiles = this.hasAddedorRemovedFiles;
+            this.hasAddedorRemovedFiles = false;
 
-                const changedFiles: ReadonlyArray<Path> = this.resolutionCache.finishRecordingFilesWithChangedResolutions() || emptyArray;
+            const changedFiles: ReadonlyArray<Path> = this.resolutionCache.finishRecordingFilesWithChangedResolutions() || emptyArray;
 
-                for (const file of changedFiles) {
-                    // delete cached information for changed files
-                    this.cachedUnresolvedImportsPerFile.delete(file);
-                }
-
-                // update builder only if language service is enabled
-                // otherwise tell it to drop its internal state
-                if (this.languageServiceEnabled) {
-                    // 1. no changes in structure, no changes in unresolved imports - do nothing
-                    // 2. no changes in structure, unresolved imports were changed - collect unresolved imports for all files
-                    // (can reuse cached imports for files that were not changed)
-                    // 3. new files were added/removed, but compilation settings stays the same - collect unresolved imports for all new/modified files
-                    // (can reuse cached imports for files that were not changed)
-                    // 4. compilation settings were changed in the way that might affect module resolution - drop all caches and collect all data from the scratch
-                    if (hasNewProgram || changedFiles.length) {
-                        this.lastCachedUnresolvedImportsList = getUnresolvedImports(this.program!, this.cachedUnresolvedImportsPerFile);
-                    }
-
-                    this.projectService.typingsCache.enqueueInstallTypingsForProject(this, this.lastCachedUnresolvedImportsList, hasAddedorRemovedFiles);
-                }
-                else {
-                    this.lastCachedUnresolvedImportsList = undefined;
-                }
-
-                if (hasNewProgram) {
-                    this.projectProgramVersion++;
-                }
-                return !hasNewProgram;
-            } finally {
-                perfLogger.logStopUpdateGraph();
+            for (const file of changedFiles) {
+                // delete cached information for changed files
+                this.cachedUnresolvedImportsPerFile.delete(file);
             }
+
+            // update builder only if language service is enabled
+            // otherwise tell it to drop its internal state
+            if (this.languageServiceEnabled) {
+                // 1. no changes in structure, no changes in unresolved imports - do nothing
+                // 2. no changes in structure, unresolved imports were changed - collect unresolved imports for all files
+                // (can reuse cached imports for files that were not changed)
+                // 3. new files were added/removed, but compilation settings stays the same - collect unresolved imports for all new/modified files
+                // (can reuse cached imports for files that were not changed)
+                // 4. compilation settings were changed in the way that might affect module resolution - drop all caches and collect all data from the scratch
+                if (hasNewProgram || changedFiles.length) {
+                    this.lastCachedUnresolvedImportsList = getUnresolvedImports(this.program!, this.cachedUnresolvedImportsPerFile);
+                }
+
+                this.projectService.typingsCache.enqueueInstallTypingsForProject(this, this.lastCachedUnresolvedImportsList, hasAddedorRemovedFiles);
+            }
+            else {
+                this.lastCachedUnresolvedImportsList = undefined;
+            }
+
+            if (hasNewProgram) {
+                this.projectProgramVersion++;
+            }
+            perfLogger.logStopUpdateGraph();
+            return !hasNewProgram;
         }
 
         /*@internal*/

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -851,7 +851,7 @@ namespace ts.server {
          * @returns: true if set of files in the project stays the same and false - otherwise.
          */
         updateGraph(): boolean {
-            if (etwLogger) etwLogger.logStartUpdateGraph();
+            perfLogger.logStartUpdateGraph();
             try {
                 this.resolutionCache.startRecordingFilesWithChangedResolutions();
 
@@ -890,7 +890,7 @@ namespace ts.server {
                 }
                 return !hasNewProgram;
             } finally {
-                if (etwLogger) etwLogger.logStopUpdateGraph();
+                perfLogger.logStopUpdateGraph();
             }
         }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -731,7 +731,9 @@ namespace ts.server {
                 }
                 return;
             }
-            this.host.write(formatMessage(msg, this.logger, this.byteLength, this.host.newLine));
+            const msgText = formatMessage(msg, this.logger, this.byteLength, this.host.newLine);
+            if (etwLogger) etwLogger.logEvent(`Response message size: ${msgText.length}`);
+            this.host.write(msgText);
         }
 
         public event<T extends object>(body: T, eventName: string): void {
@@ -2506,9 +2508,12 @@ namespace ts.server {
 
             let request: protocol.Request | undefined;
             let relevantFile: protocol.FileRequestArgs | undefined;
+            let commandSucceeded = false;
             try {
                 request = <protocol.Request>JSON.parse(message);
                 relevantFile = request.arguments && (request as protocol.FileRequest).arguments.file ? (request as protocol.FileRequest).arguments : undefined;
+
+                if (etwLogger) etwLogger.logStartCommand("" + request.command, message.substring(0, 100));
                 const { response, responseRequired } = this.executeCommand(request);
 
                 if (this.logger.hasLevel(LogLevel.requestTime)) {
@@ -2521,6 +2526,10 @@ namespace ts.server {
                     }
                 }
 
+                // Note: Log before writing the response, else the editor can complete its activity before the server does
+                // Set 'commandSucceded' flag to ensure logStopCommand doesn't get called twice (e.g. if doOutput throws)
+                commandSucceeded = true;
+                if (etwLogger) etwLogger.logStopCommand("" + request.command, "Success");
                 if (response) {
                     this.doOutput(response, request.command, request.seq, /*success*/ true);
                 }
@@ -2531,10 +2540,14 @@ namespace ts.server {
             catch (err) {
                 if (err instanceof OperationCanceledException) {
                     // Handle cancellation exceptions
+                    if (etwLogger && !commandSucceeded) etwLogger.logStopCommand("" + (request && request.command), "Canceled: " + err);
                     this.doOutput({ canceled: true }, request!.command, request!.seq, /*success*/ true);
                     return;
                 }
+
                 this.logErrorWorker(err, message, relevantFile);
+                if (etwLogger && !commandSucceeded) etwLogger.logStopCommand("" + (request && request.command), "Error: " + err);
+
                 this.doOutput(
                     /*info*/ undefined,
                     request ? request.command : CommandNames.Unknown,

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -151,14 +151,14 @@ namespace ts.server {
 
         private static run(self: ThrottledOperations, operationId: string, cb: () => void) {
             try {
-                if (etwLogger) etwLogger.logStartScheduledOperation(operationId);
+                perfLogger.logStartScheduledOperation(operationId);
                 self.pendingTimeouts.delete(operationId);
                 if (self.logger) {
                     self.logger.info(`Running: ${operationId}`);
                 }
                 cb();
             } finally {
-                if (etwLogger) etwLogger.logStopScheduledOperation();
+                perfLogger.logStopScheduledOperation();
             }
         }
     }
@@ -180,7 +180,7 @@ namespace ts.server {
             self.timerId = undefined;
 
             try {
-                if (etwLogger) etwLogger.logStartScheduledOperation("GC collect");
+                perfLogger.logStartScheduledOperation("GC collect");
                 const log = self.logger.hasLevel(LogLevel.requestTime);
                 const before = log && self.host.getMemoryUsage!(); // TODO: GH#18217
 
@@ -190,7 +190,7 @@ namespace ts.server {
                     self.logger.perftrc(`GC::before ${before}, after ${after}`);
                 }
             } finally {
-                if (etwLogger) etwLogger.logStopScheduledOperation();
+                perfLogger.logStopScheduledOperation();
             }
         }
     }

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -150,16 +150,13 @@ namespace ts.server {
         }
 
         private static run(self: ThrottledOperations, operationId: string, cb: () => void) {
-            try {
-                perfLogger.logStartScheduledOperation(operationId);
-                self.pendingTimeouts.delete(operationId);
-                if (self.logger) {
-                    self.logger.info(`Running: ${operationId}`);
-                }
-                cb();
-            } finally {
-                perfLogger.logStopScheduledOperation();
+            perfLogger.logStartScheduledOperation(operationId);
+            self.pendingTimeouts.delete(operationId);
+            if (self.logger) {
+                self.logger.info(`Running: ${operationId}`);
             }
+            cb();
+            perfLogger.logStopScheduledOperation();
         }
     }
 
@@ -179,19 +176,16 @@ namespace ts.server {
         private static run(self: GcTimer) {
             self.timerId = undefined;
 
-            try {
-                perfLogger.logStartScheduledOperation("GC collect");
-                const log = self.logger.hasLevel(LogLevel.requestTime);
-                const before = log && self.host.getMemoryUsage!(); // TODO: GH#18217
+            perfLogger.logStartScheduledOperation("GC collect");
+            const log = self.logger.hasLevel(LogLevel.requestTime);
+            const before = log && self.host.getMemoryUsage!(); // TODO: GH#18217
 
-                self.host.gc!(); // TODO: GH#18217
-                if (log) {
-                    const after = self.host.getMemoryUsage!(); // TODO: GH#18217
-                    self.logger.perftrc(`GC::before ${before}, after ${after}`);
-                }
-            } finally {
-                perfLogger.logStopScheduledOperation();
+            self.host.gc!(); // TODO: GH#18217
+            if (log) {
+                const after = self.host.getMemoryUsage!(); // TODO: GH#18217
+                self.logger.perftrc(`GC::before ${before}, after ${after}`);
             }
+            perfLogger.logStopScheduledOperation();
         }
     }
 

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -180,19 +180,18 @@ namespace ts.server {
         }
 
         msg(s: string, type: Msg = Msg.Err) {
-            if (etwLogger) {
-                switch (type) {
-                    case Msg.Info:
-                    etwLogger.logInfoEvent(s);
-                    break;
-                    case Msg.Perf:
-                    etwLogger.logPerfEvent(s);
-                    break;
-                    default: // Msg.Err
-                    etwLogger.logErrEvent(s);
-                    break;
-                }
+            switch (type) {
+                case Msg.Info:
+                    perfLogger.logInfoEvent(s);
+                break;
+                case Msg.Perf:
+                    perfLogger.logPerfEvent(s);
+                break;
+                default: // Msg.Err
+                    perfLogger.logErrEvent(s);
+                break;
             }
+
             if (!this.canWrite) return;
 
             s = `[${nowString()}] ${s}\n`;

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -180,6 +180,19 @@ namespace ts.server {
         }
 
         msg(s: string, type: Msg = Msg.Err) {
+            if (etwLogger) {
+                switch (type) {
+                    case Msg.Info:
+                    etwLogger.logInfoEvent(s);
+                    break;
+                    case Msg.Perf:
+                    etwLogger.logPerfEvent(s);
+                    break;
+                    default: // Msg.Err
+                    etwLogger.logErrEvent(s);
+                    break;
+                }
+            }
             if (!this.canWrite) return;
 
             s = `[${nowString()}] ${s}\n`;


### PR DESCRIPTION
Use the [@microsoft/typescript-etw](https://www.npmjs.com/package/@microsoft/typescript-etw) native module for ETW logging.

[@microsoft/typescript-etw](https://www.npmjs.com/package/@microsoft/typescript-etw) (and ETW in general) are only supported on Windows, so it is not a good idea to add it to the "dependencies" in package.json. Even on Windows we still do not want this module installed by default. Consumers who are interested (such as Visual Studio) should have to opt in. Therefore ETW logging will only be supported if [@microsoft/typescript-etw](https://www.npmjs.com/package/@microsoft/typescript-etw) is installed manually. The code will work if the module is found, otherwise it will do nothing.

Types are added from [@types/microsoft__typescript-etw](https://www.npmjs.com/package/@types/microsoft__typescript-etw) so that we can have type checking even if the actual package is not installed.