### PR TITLE
Fix a typo in the error message around language service plugins

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1275,7 +1275,7 @@ namespace ts.server {
         private enableProxy(pluginModuleFactory: PluginModuleFactory, configEntry: PluginImport) {
             try {
                 if (typeof pluginModuleFactory !== "function") {
-                    this.projectService.logger.info(`Skipped loading plugin ${configEntry.name} because it did expose a proper factory function`);
+                    this.projectService.logger.info(`Skipped loading plugin ${configEntry.name} because it did not expose a proper factory function`);
                     return;
                 }
 


### PR DESCRIPTION
Fixes #32655 