### PR TITLE
Ensure that the comma is removed when all named imports are removed via moveToFile 

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2430,7 +2430,7 @@ namespace FourSlash {
                     const oldText = this.tryGetFileContent(change.fileName);
                     ts.Debug.assert(!!change.isNewFile === (oldText === undefined));
                     const newContent = change.isNewFile ? ts.first(change.textChanges).newText : ts.textChanges.applyChanges(oldText!, change.textChanges);
-                    assert.equal(newContent, expectedNewContent);
+                    assert.equal(newContent, expectedNewContent, `String mis-matched in file ${change.fileName}`);
                 }
                 for (const newFileName in newFileContent) {
                     ts.Debug.assert(changes.some(c => c.fileName === newFileName), "No change in file", () => newFileName);

--- a/src/services/refactors/moveToNewFile.ts
+++ b/src/services/refactors/moveToNewFile.ts
@@ -350,7 +350,11 @@ namespace ts.refactor {
             }
             if (namedBindings) {
                 if (namedBindingsUnused) {
-                    changes.delete(sourceFile, namedBindings);
+                    changes.replaceNode(
+                        sourceFile,
+                        importDecl.importClause,
+                        updateImportClause(importDecl.importClause, name, /*namedBindings*/ undefined)
+                    );
                 }
                 else if (namedBindings.kind === SyntaxKind.NamedImports) {
                     for (const element of namedBindings.elements) {

--- a/tests/cases/fourslash/moveToNewFile_cleanUpLastNamedImport.ts
+++ b/tests/cases/fourslash/moveToNewFile_cleanUpLastNamedImport.ts
@@ -1,0 +1,27 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /has-exports.ts
+////
+//// export interface Exported { }
+//// const defaultExport = ""
+//// export default defaultExport
+
+// @Filename: /31195.ts
+////
+////import defaultExport, { Exported } from "./has-exports"
+////console.log(defaultExport)
+////[|export const bar = (logger: Exported) => 0;|]
+
+verify.moveToNewFile({
+  newFileContents: {
+    "/31195.ts": `
+import defaultExport from "./has-exports"
+console.log(defaultExport)
+`,
+
+    "/bar.ts": 
+    `import { Exported } from "./has-exports";
+export const bar = (logger: Exported) => 0;
+`,
+  }
+});


### PR DESCRIPTION
Fixes #31195

This one *feels* like I'm taking a shortcut, but it was definitely doing the right thing before. When I looked [in ast-explorer](https://astexplorer.net/#/gist/da52a3557b1ea5fc617f5514a6e7dd18/b137573b1f8a92a85ff3d6c49a4fea1937505e17) what `import defaultD, from "./has-exports";` looks, like the comma comes from a `NamedImports` with no elements inside a `ImportClause`- removing the comma completely removes the `NamedImports` node.

This AST change is actually happening in the current refactor as-is, however, deleting just that node doesn't include the comma (maybe the fix is instead to make the span for that node different?) but this will remove the comma either way. I don't believe there are ever cases where you need that comma.

