### PR TITLE
Suppress console.log & others inside the TS Server runtime so that language service plugins don't accidentally use them and kill the server

### DIFF
--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -975,7 +975,7 @@ namespace ts.server {
     // the log. This is so that language service plugins which use
     // console.log don't break the message passing between tsserver
     // and the client
-    console.log = (msg) => logger.msg(msg, Msg.Info);
-    console.warn = (msg) => logger.msg(msg, Msg.Err);
-    console.error = (msg) => logger.msg(msg, Msg.Err);
+    console.log = (...args) => logger.msg(args.length === 1 ? args[0] : args.join(", "), Msg.Info);
+    console.warn = (...args) => logger.msg(args.length === 1 ? args[0] : args.join(", "), Msg.Err);
+    console.error = (...args) => logger.msg(args.length === 1 ? args[0] : args.join(", "), Msg.Err);
 }

--- a/src/tsserver/server.ts
+++ b/src/tsserver/server.ts
@@ -970,4 +970,12 @@ namespace ts.server {
     if (ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
         ts.sys.tryEnableSourceMapsForHost();
     }
+
+    // Overwrites the current console messages to instead write to
+    // the log. This is so that language service plugins which use
+    // console.log don't break the message passing between tsserver
+    // and the client
+    console.log = (msg) => logger.msg(msg, Msg.Info);
+    console.warn = (msg) => logger.msg(msg, Msg.Err);
+    console.error = (msg) => logger.msg(msg, Msg.Err);
 }


### PR DESCRIPTION
Fixes #31209 (where most of the discussion is)

This should probably hold till 3.7 