### PR TITLE
Prioritize “property names” over punctuation in smart select

### DIFF
--- a/src/services/smartSelection.ts
+++ b/src/services/smartSelection.ts
@@ -17,7 +17,7 @@ namespace ts.SmartSelectionRange {
                     break outer;
                 }
 
-                if (positionShouldSnapToNode(pos, node, nextNode)) {
+                if (positionShouldSnapToNode(sourceFile, pos, node)) {
                     // 1. Blocks are effectively redundant with SyntaxLists.
                     // 2. TemplateSpans, along with the SyntaxLists containing them, are a somewhat unintuitive grouping
                     //    of things that should be considered independently.
@@ -97,12 +97,12 @@ namespace ts.SmartSelectionRange {
      * count too, unless that position belongs to the next node. In effect, makes
      * selections able to snap to preceding tokens when the cursor is on the tail
      * end of them with only whitespace ahead.
+     * @param sourceFile The source file containing the nodes.
      * @param pos The position to check.
      * @param node The candidate node to snap to.
      * @param nextNode The next sibling node in the tree.
-     * @param sourceFile The source file containing the nodes.
      */
-    function positionShouldSnapToNode(pos: number, node: Node, nextNode: Node | undefined) {
+    function positionShouldSnapToNode(sourceFile: SourceFile, pos: number, node: Node) {
         // Can’t use 'ts.positionBelongsToNode()' here because it cleverly accounts
         // for missing nodes, which can’t really be considered when deciding what
         // to select.
@@ -111,9 +111,8 @@ namespace ts.SmartSelectionRange {
             return true;
         }
         const nodeEnd = node.getEnd();
-        const nextNodeStart = nextNode && nextNode.getStart();
         if (nodeEnd === pos) {
-            return pos !== nextNodeStart;
+            return getTouchingPropertyName(sourceFile, pos).pos < node.end;
         }
         return false;
     }

--- a/src/services/smartSelection.ts
+++ b/src/services/smartSelection.ts
@@ -100,7 +100,6 @@ namespace ts.SmartSelectionRange {
      * @param sourceFile The source file containing the nodes.
      * @param pos The position to check.
      * @param node The candidate node to snap to.
-     * @param nextNode The next sibling node in the tree.
      */
     function positionShouldSnapToNode(sourceFile: SourceFile, pos: number, node: Node) {
         // Can’t use 'ts.positionBelongsToNode()' here because it cleverly accounts

--- a/tests/baselines/reference/smartSelection_emptyRanges.baseline
+++ b/tests/baselines/reference/smartSelection_emptyRanges.baseline
@@ -44,7 +44,10 @@ class HomePage {
 }
 
 
-                           )  
+                   username   
+
+
+        this.props.username   
 
 
     if (this.props.username) {

--- a/tests/baselines/reference/smartSelection_punctuationPriority.baseline
+++ b/tests/baselines/reference/smartSelection_punctuationPriority.baseline
@@ -1,0 +1,6 @@
+console/**/.log();
+
+console       
+console.log   
+console.log() 
+console.log();

--- a/tests/cases/fourslash/smartSelection_punctuationPriority.ts
+++ b/tests/cases/fourslash/smartSelection_punctuationPriority.ts
@@ -1,0 +1,5 @@
+/// <reference path="fourslash.ts" />
+
+////console/**/.log();
+
+verify.baselineSmartSelection();


### PR DESCRIPTION
Fixes #32159 

**Before**

![before](https://user-images.githubusercontent.com/3277153/62400482-3d20d700-b534-11e9-9b0c-f67b7ead5115.gif)

**After**

![after](https://user-images.githubusercontent.com/3277153/62400486-41e58b00-b534-11e9-9e64-34276bf1cacc.gif)
