### PR TITLE
Fix emit for object rest on a module export

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -436,10 +436,10 @@ task("runtests-parallel").flags = {
     "   --shardId": "1-based ID of this shard (default: 1)",
 };
 
-task("diff", () => exec(getDiffTool(), [refBaseline, localBaseline], { ignoreExitCode: true }));
+task("diff", () => exec(getDiffTool(), [refBaseline, localBaseline], { ignoreExitCode: true, waitForExit: false }));
 task("diff").description = "Diffs the compiler baselines using the diff tool specified by the 'DIFF' environment variable";
 
-task("diff-rwc", () => exec(getDiffTool(), [refRwcBaseline, localRwcBaseline], { ignoreExitCode: true }));
+task("diff-rwc", () => exec(getDiffTool(), [refRwcBaseline, localRwcBaseline], { ignoreExitCode: true, waitForExit: false }));
 task("diff-rwc").description = "Diffs the RWC baselines using the diff tool specified by the 'DIFF' environment variable";
 
 /**

--- a/scripts/build/utils.js
+++ b/scripts/build/utils.js
@@ -37,7 +37,7 @@ function exec(cmd, args, options = {}) {
         const command = isWindows ? [possiblyQuote(cmd), ...args] : [`${cmd} ${args.join(" ")}`];
 
         if (!options.hidePrompt) log(`> ${chalk.green(cmd)} ${args.join(" ")}`);
-        const proc = spawn(isWindows ? "cmd" : "/bin/sh", [subshellFlag, ...command], { stdio: "inherit", windowsVerbatimArguments: true });
+        const proc = spawn(isWindows ? "cmd" : "/bin/sh", [subshellFlag, ...command], { stdio: waitForExit ? "inherit" : "ignore", windowsVerbatimArguments: true });
         const registration = cancelToken.register(() => {
             log(`${chalk.red("killing")} '${chalk.green(cmd)} ${args.join(" ")}'...`);
             proc.kill("SIGINT");
@@ -61,7 +61,8 @@ function exec(cmd, args, options = {}) {
         }
         else {
             proc.unref();
-            resolve({ exitCode: undefined });
+            // wait a short period in order to allow the process to start successfully before Node exits.
+            setTimeout(() => resolve({ exitCode: undefined }), 100);
         }
     }));
 }

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -726,6 +726,7 @@ namespace Harness {
             includeBuiltFile?: string;
             baselineFile?: string;
             libFiles?: string;
+            noTypesAndSymbols?: boolean;
         }
 
         // Additional options not already in ts.optionDeclarations
@@ -742,6 +743,7 @@ namespace Harness {
             { name: "currentDirectory", type: "string" },
             { name: "symlink", type: "string" },
             { name: "link", type: "string" },
+            { name: "noTypesAndSymbols", type: "boolean" },
             // Emitted js baseline will print full paths for every output file
             { name: "fullEmitPaths", type: "boolean" }
         ];

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=amd,target=es5).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=amd,target=es5).js
@@ -1,0 +1,10 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var _a;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports._b = _a = [];
+});

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=amd,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=amd,target=esnext).js
@@ -1,0 +1,10 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var _a;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    _a = [];
+});

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=commonjs,target=es5).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=commonjs,target=es5).js
@@ -1,0 +1,8 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+"use strict";
+var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports._b = _a = [];

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=commonjs,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=commonjs,target=esnext).js
@@ -1,0 +1,8 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+"use strict";
+var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
+_a = [];

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=es2015,target=es5).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=es2015,target=es5).js
@@ -1,0 +1,6 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+var _a;
+export var _b = _a = [];

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=es2015,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=es2015,target=esnext).js
@@ -1,0 +1,5 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+export const [] = [];

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=esnext,target=es5).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=esnext,target=es5).js
@@ -1,0 +1,6 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+var _a;
+export var _b = _a = [];

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=esnext,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=esnext,target=esnext).js
@@ -1,0 +1,5 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+export const [] = [];

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=system,target=es5).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=system,target=es5).js
@@ -1,0 +1,15 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var _a, _b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("_b", _b = _a = []);
+        }
+    };
+});

--- a/tests/baselines/reference/exportEmptyArrayBindingPattern(module=system,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyArrayBindingPattern(module=system,target=esnext).js
@@ -1,0 +1,15 @@
+//// [exportEmptyArrayBindingPattern.ts]
+export const [] = [];
+
+//// [exportEmptyArrayBindingPattern.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var _a;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            _a = [];
+        }
+    };
+});

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=amd,target=es5).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=amd,target=es5).js
@@ -1,0 +1,10 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var _a;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports._b = _a = {};
+});

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=amd,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=amd,target=esnext).js
@@ -1,0 +1,10 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var _a;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    _a = {};
+});

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=commonjs,target=es5).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=commonjs,target=es5).js
@@ -1,0 +1,8 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+"use strict";
+var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports._b = _a = {};

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=commonjs,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=commonjs,target=esnext).js
@@ -1,0 +1,8 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+"use strict";
+var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
+_a = {};

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=es2015,target=es5).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=es2015,target=es5).js
@@ -1,0 +1,6 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+var _a;
+export var _b = _a = {};

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=es2015,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=es2015,target=esnext).js
@@ -1,0 +1,5 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+export const {} = {};

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=esnext,target=es5).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=esnext,target=es5).js
@@ -1,0 +1,6 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+var _a;
+export var _b = _a = {};

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=esnext,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=esnext,target=esnext).js
@@ -1,0 +1,5 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+export const {} = {};

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=system,target=es5).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=system,target=es5).js
@@ -1,0 +1,15 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var _a, _b;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("_b", _b = _a = {});
+        }
+    };
+});

--- a/tests/baselines/reference/exportEmptyObjectBindingPattern(module=system,target=esnext).js
+++ b/tests/baselines/reference/exportEmptyObjectBindingPattern(module=system,target=esnext).js
@@ -1,0 +1,15 @@
+//// [exportEmptyObjectBindingPattern.ts]
+export const {} = {};
+
+//// [exportEmptyObjectBindingPattern.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var _a;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            _a = {};
+        }
+    };
+});

--- a/tests/baselines/reference/exportObjectRest(module=amd,target=es5).js
+++ b/tests/baselines/reference/exportObjectRest(module=amd,target=es5).js
@@ -1,0 +1,10 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var _a;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    exports.x = (_a = { x: 'x', y: 'y' }, _a).x, exports.rest = __rest(_a, ["x"]);
+});

--- a/tests/baselines/reference/exportObjectRest(module=amd,target=esnext).js
+++ b/tests/baselines/reference/exportObjectRest(module=amd,target=esnext).js
@@ -1,0 +1,10 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var _a;
+    Object.defineProperty(exports, "__esModule", { value: true });
+    _a = { x: 'x', y: 'y' }, exports.x = _a.x, exports.rest = __rest(_a, ["x"]);
+});

--- a/tests/baselines/reference/exportObjectRest(module=commonjs,target=es5).js
+++ b/tests/baselines/reference/exportObjectRest(module=commonjs,target=es5).js
@@ -1,0 +1,8 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+"use strict";
+var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.x = (_a = { x: 'x', y: 'y' }, _a).x, exports.rest = __rest(_a, ["x"]);

--- a/tests/baselines/reference/exportObjectRest(module=commonjs,target=esnext).js
+++ b/tests/baselines/reference/exportObjectRest(module=commonjs,target=esnext).js
@@ -1,0 +1,8 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+"use strict";
+var _a;
+Object.defineProperty(exports, "__esModule", { value: true });
+_a = { x: 'x', y: 'y' }, exports.x = _a.x, exports.rest = __rest(_a, ["x"]);

--- a/tests/baselines/reference/exportObjectRest(module=es2015,target=es5).js
+++ b/tests/baselines/reference/exportObjectRest(module=es2015,target=es5).js
@@ -1,0 +1,6 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+var _a;
+export var x = (_a = { x: 'x', y: 'y' }, _a).x, rest = __rest(_a, ["x"]);

--- a/tests/baselines/reference/exportObjectRest(module=es2015,target=esnext).js
+++ b/tests/baselines/reference/exportObjectRest(module=es2015,target=esnext).js
@@ -1,0 +1,5 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+export const { x, ...rest } = { x: 'x', y: 'y' };

--- a/tests/baselines/reference/exportObjectRest(module=esnext,target=es5).js
+++ b/tests/baselines/reference/exportObjectRest(module=esnext,target=es5).js
@@ -1,0 +1,6 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+var _a;
+export var x = (_a = { x: 'x', y: 'y' }, _a).x, rest = __rest(_a, ["x"]);

--- a/tests/baselines/reference/exportObjectRest(module=esnext,target=esnext).js
+++ b/tests/baselines/reference/exportObjectRest(module=esnext,target=esnext).js
@@ -1,0 +1,5 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+export const { x, ...rest } = { x: 'x', y: 'y' };

--- a/tests/baselines/reference/exportObjectRest(module=system,target=es5).js
+++ b/tests/baselines/reference/exportObjectRest(module=system,target=es5).js
@@ -1,0 +1,15 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var _a, x, rest;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            exports_1("x", x = (_a = { x: 'x', y: 'y' }, _a).x), exports_1("rest", rest = __rest(_a, ["x"]));
+        }
+    };
+});

--- a/tests/baselines/reference/exportObjectRest(module=system,target=esnext).js
+++ b/tests/baselines/reference/exportObjectRest(module=system,target=esnext).js
@@ -1,0 +1,15 @@
+//// [exportObjectRest.ts]
+export const { x, ...rest } = { x: 'x', y: 'y' };
+
+//// [exportObjectRest.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var _a, x, rest;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            _a = { x: 'x', y: 'y' }, exports_1("x", x = _a.x), exports_1("rest", rest = __rest(_a, ["x"]));
+        }
+    };
+});

--- a/tests/cases/compiler/exportEmptyArrayBindingPattern.ts
+++ b/tests/cases/compiler/exportEmptyArrayBindingPattern.ts
@@ -1,0 +1,5 @@
+// @module: commonjs,amd,system,es2015,esnext
+// @target: esnext,es5
+// @noEmitHelpers: true
+// @noTypesAndSymbols: true
+export const [] = [];

--- a/tests/cases/compiler/exportEmptyObjectBindingPattern.ts
+++ b/tests/cases/compiler/exportEmptyObjectBindingPattern.ts
@@ -1,0 +1,5 @@
+// @module: commonjs,amd,system,es2015,esnext
+// @target: esnext,es5
+// @noEmitHelpers: true
+// @noTypesAndSymbols: true
+export const {} = {};

--- a/tests/cases/compiler/exportObjectRest.ts
+++ b/tests/cases/compiler/exportObjectRest.ts
@@ -1,0 +1,5 @@
+// @module: commonjs,amd,system,es2015,esnext
+// @target: esnext,es5
+// @noEmitHelpers: true
+// @noTypesAndSymbols: true
+export const { x, ...rest } = { x: 'x', y: 'y' };


### PR DESCRIPTION
Fixes the emit for object rest binding patterns on exported variables. 

Also fixes a few other small tooling bugs:
-  Fixes a bug in vary-by test configurations to allow running conformance/compiler tests against multiple module/target configurations.
- `gulp diff` and `gulp diff-rwc` no longer block until your diff tool is closed.
- You can add `// @noTypesAndSymbols: true` to the top of a test to skip .types and .symbols baselines if they're not relevant to the test.

Fixes #32656
