### PR TITLE
Fix inferred TNext of generator to use TNext of contextual return type

### DIFF
--- a/tests/baselines/reference/generatorTypeCheck28.types
+++ b/tests/baselines/reference/generatorTypeCheck28.types
@@ -5,10 +5,10 @@ function* g(): IterableIterator<(x: string) => number> {
 
     yield * {
 >yield * {        *[Symbol.iterator]() {            yield x => x.length;        }    } : void
->{        *[Symbol.iterator]() {            yield x => x.length;        }    } : { [Symbol.iterator](): Generator<(x: string) => number, void, unknown>; }
+>{        *[Symbol.iterator]() {            yield x => x.length;        }    } : { [Symbol.iterator](): Generator<(x: string) => number, void, undefined>; }
 
         *[Symbol.iterator]() {
->[Symbol.iterator] : () => Generator<(x: string) => number, void, unknown>
+>[Symbol.iterator] : () => Generator<(x: string) => number, void, undefined>
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
 >iterator : symbol

--- a/tests/baselines/reference/generatorTypeCheck45.types
+++ b/tests/baselines/reference/generatorTypeCheck45.types
@@ -11,7 +11,7 @@ foo("", function* () { yield x => x.length }, p => undefined); // T is fixed, sh
 >foo("", function* () { yield x => x.length }, p => undefined) : string
 >foo : <T, U>(x: T, fun: () => Iterator<(x: T) => U, any, undefined>, fun2: (y: U) => T) => T
 >"" : ""
->function* () { yield x => x.length } : () => Generator<(x: string) => number, void, unknown>
+>function* () { yield x => x.length } : () => Generator<(x: string) => number, void, undefined>
 >yield x => x.length : undefined
 >x => x.length : (x: string) => number
 >x : string

--- a/tests/baselines/reference/generatorTypeCheck46.types
+++ b/tests/baselines/reference/generatorTypeCheck46.types
@@ -11,14 +11,14 @@ foo("", function* () {
 >foo("", function* () {    yield* {        *[Symbol.iterator]() {            yield x => x.length        }    }}, p => undefined) : string
 >foo : <T, U>(x: T, fun: () => Iterable<(x: T) => U>, fun2: (y: U) => T) => T
 >"" : ""
->function* () {    yield* {        *[Symbol.iterator]() {            yield x => x.length        }    }} : () => Generator<(x: string) => number, void, unknown>
+>function* () {    yield* {        *[Symbol.iterator]() {            yield x => x.length        }    }} : () => Generator<(x: string) => number, void, undefined>
 
     yield* {
 >yield* {        *[Symbol.iterator]() {            yield x => x.length        }    } : void
->{        *[Symbol.iterator]() {            yield x => x.length        }    } : { [Symbol.iterator](): Generator<(x: string) => number, void, unknown>; }
+>{        *[Symbol.iterator]() {            yield x => x.length        }    } : { [Symbol.iterator](): Generator<(x: string) => number, void, undefined>; }
 
         *[Symbol.iterator]() {
->[Symbol.iterator] : () => Generator<(x: string) => number, void, unknown>
+>[Symbol.iterator] : () => Generator<(x: string) => number, void, undefined>
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
 >iterator : symbol

--- a/tests/baselines/reference/generatorTypeCheck62.types
+++ b/tests/baselines/reference/generatorTypeCheck62.types
@@ -12,7 +12,7 @@ export function strategy<T extends StrategicState>(stratName: string, gen: (a: T
 >a : T
 
     return function*(state) {
->function*(state) {        for (const next of gen(state)) {            if (next) {                next.lastStrategyApplied = stratName;            }            yield next;        }    } : (state: T) => Generator<T, void, unknown>
+>function*(state) {        for (const next of gen(state)) {            if (next) {                next.lastStrategyApplied = stratName;            }            yield next;        }    } : (state: T) => Generator<T, void, undefined>
 >state : T
 
         for (const next of gen(state)) {
@@ -53,7 +53,7 @@ export const Nothing1: Strategy<State> = strategy("Nothing", function*(state: St
 >strategy("Nothing", function*(state: State) {    return state;}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function*(state: State) {    return state;} : (state: State) => Generator<never, State, unknown>
+>function*(state: State) {    return state;} : (state: State) => Generator<never, State, undefined>
 >state : State
 
     return state;
@@ -66,7 +66,7 @@ export const Nothing2: Strategy<State> = strategy("Nothing", function*(state: St
 >strategy("Nothing", function*(state: State) {    yield state;}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function*(state: State) {    yield state;} : (state: State) => Generator<State, void, unknown>
+>function*(state: State) {    yield state;} : (state: State) => Generator<State, void, undefined>
 >state : State
 
     yield state;
@@ -80,7 +80,7 @@ export const Nothing3: Strategy<State> = strategy("Nothing", function* (state: S
 >strategy("Nothing", function* (state: State) {    yield ;    return state;}) : (a: any) => IterableIterator<any>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {    yield ;    return state;} : (state: State) => Generator<any, State, unknown>
+>function* (state: State) {    yield ;    return state;} : (state: State) => Generator<any, State, undefined>
 >state : State
 
     yield ;

--- a/tests/baselines/reference/generatorTypeCheck63.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck63.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(24,61): error TS2345: Argument of type '(state: State) => Generator<number, State, unknown>' is not assignable to parameter of type '(a: State) => IterableIterator<State>'.
-  Type 'Generator<number, State, unknown>' is not assignable to type 'IterableIterator<State>'.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(24,61): error TS2345: Argument of type '(state: State) => Generator<number, State, undefined>' is not assignable to parameter of type '(a: State) => IterableIterator<State>'.
+  Type 'Generator<number, State, undefined>' is not assignable to type 'IterableIterator<State>'.
     Types of property 'next' are incompatible.
-      Type '(...args: [] | [unknown]) => IteratorResult<number, State>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<State, any>'.
+      Type '(...args: [] | [undefined]) => IteratorResult<number, State>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<State, any>'.
         Type 'IteratorResult<number, State>' is not assignable to type 'IteratorResult<State, any>'.
           Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<State, any>'.
             Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<State>'.
@@ -34,10 +34,10 @@ tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(24,61): err
     
     export const Nothing: Strategy<State> = strategy("Nothing", function* (state: State) {
                                                                 ~~~~~~~~
-!!! error TS2345: Argument of type '(state: State) => Generator<number, State, unknown>' is not assignable to parameter of type '(a: State) => IterableIterator<State>'.
-!!! error TS2345:   Type 'Generator<number, State, unknown>' is not assignable to type 'IterableIterator<State>'.
+!!! error TS2345: Argument of type '(state: State) => Generator<number, State, undefined>' is not assignable to parameter of type '(a: State) => IterableIterator<State>'.
+!!! error TS2345:   Type 'Generator<number, State, undefined>' is not assignable to type 'IterableIterator<State>'.
 !!! error TS2345:     Types of property 'next' are incompatible.
-!!! error TS2345:       Type '(...args: [] | [unknown]) => IteratorResult<number, State>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<State, any>'.
+!!! error TS2345:       Type '(...args: [] | [undefined]) => IteratorResult<number, State>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<State, any>'.
 !!! error TS2345:         Type 'IteratorResult<number, State>' is not assignable to type 'IteratorResult<State, any>'.
 !!! error TS2345:           Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<State, any>'.
 !!! error TS2345:             Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<State>'.

--- a/tests/baselines/reference/generatorTypeCheck63.types
+++ b/tests/baselines/reference/generatorTypeCheck63.types
@@ -12,7 +12,7 @@ export function strategy<T extends StrategicState>(stratName: string, gen: (a: T
 >a : T
 
     return function*(state) {
->function*(state) {        for (const next of gen(state)) {            if (next) {                next.lastStrategyApplied = stratName;            }            yield next;        }    } : (state: T) => Generator<T, void, unknown>
+>function*(state) {        for (const next of gen(state)) {            if (next) {                next.lastStrategyApplied = stratName;            }            yield next;        }    } : (state: T) => Generator<T, void, undefined>
 >state : T
 
         for (const next of gen(state)) {
@@ -53,7 +53,7 @@ export const Nothing: Strategy<State> = strategy("Nothing", function* (state: St
 >strategy("Nothing", function* (state: State) {    yield 1;    return state;}) : any
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {    yield 1;    return state;} : (state: State) => Generator<number, State, unknown>
+>function* (state: State) {    yield 1;    return state;} : (state: State) => Generator<number, State, undefined>
 >state : State
 
     yield 1;
@@ -70,7 +70,7 @@ export const Nothing1: Strategy<State> = strategy("Nothing", function* (state: S
 >strategy("Nothing", function* (state: State) {}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {} : (state: State) => Generator<never, void, unknown>
+>function* (state: State) {} : (state: State) => Generator<never, void, undefined>
 >state : State
 
 });
@@ -80,7 +80,7 @@ export const Nothing2: Strategy<State> = strategy("Nothing", function* (state: S
 >strategy("Nothing", function* (state: State) {    return 1;}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {    return 1;} : (state: State) => Generator<never, number, unknown>
+>function* (state: State) {    return 1;} : (state: State) => Generator<never, number, undefined>
 >state : State
 
     return 1;
@@ -93,7 +93,7 @@ export const Nothing3: Strategy<State> = strategy("Nothing", function* (state: S
 >strategy("Nothing", function* (state: State) {    yield state;    return 1;}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {    yield state;    return 1;} : (state: State) => Generator<State, number, unknown>
+>function* (state: State) {    yield state;    return 1;} : (state: State) => Generator<State, number, undefined>
 >state : State
 
     yield state;

--- a/tests/baselines/reference/generatorYieldContextualType.types
+++ b/tests/baselines/reference/generatorYieldContextualType.types
@@ -6,7 +6,7 @@ declare function f1<T, R, S>(gen: () => Generator<R, T, S>): void;
 f1<0, 0, 1>(function* () {
 >f1<0, 0, 1>(function* () {	const a = yield 0;	return 0;}) : void
 >f1 : <T, R, S>(gen: () => Generator<R, T, S>) => void
->function* () {	const a = yield 0;	return 0;} : () => Generator<0, 0, unknown>
+>function* () {	const a = yield 0;	return 0;} : () => Generator<0, 0, 1>
 
 	const a = yield 0;
 >a : 1
@@ -25,7 +25,7 @@ declare function f2<T, R, S>(gen: () => Generator<R, T, S> | AsyncGenerator<R, T
 f2<0, 0, 1>(async function* () {
 >f2<0, 0, 1>(async function* () {	const a = yield 0;	return 0;}) : void
 >f2 : <T, R, S>(gen: () => Generator<R, T, S> | AsyncGenerator<R, T, S>) => void
->async function* () {	const a = yield 0;	return 0;} : () => AsyncGenerator<0, 0, unknown>
+>async function* () {	const a = yield 0;	return 0;} : () => AsyncGenerator<0, 0, 1>
 
 	const a = yield 0;
 >a : 1

--- a/tests/baselines/reference/types.asyncGenerators.es2018.1.types
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.1.types
@@ -75,7 +75,7 @@ async function * inferReturnType8() {
 }
 const assignability1: () => AsyncIterableIterator<number> = async function * () {
 >assignability1 : () => AsyncIterableIterator<number>
->async function * () {    yield 1;} : () => AsyncGenerator<number, void, unknown>
+>async function * () {    yield 1;} : () => AsyncGenerator<number, void, undefined>
 
     yield 1;
 >yield 1 : undefined
@@ -84,7 +84,7 @@ const assignability1: () => AsyncIterableIterator<number> = async function * () 
 };
 const assignability2: () => AsyncIterableIterator<number> = async function * () {
 >assignability2 : () => AsyncIterableIterator<number>
->async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, unknown>
+>async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, undefined>
 
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
@@ -135,7 +135,7 @@ const assignability5: () => AsyncIterableIterator<number> = async function * () 
 };
 const assignability6: () => AsyncIterable<number> = async function * () {
 >assignability6 : () => AsyncIterable<number>
->async function * () {    yield 1;} : () => AsyncGenerator<number, void, unknown>
+>async function * () {    yield 1;} : () => AsyncGenerator<number, void, undefined>
 
     yield 1;
 >yield 1 : undefined
@@ -144,7 +144,7 @@ const assignability6: () => AsyncIterable<number> = async function * () {
 };
 const assignability7: () => AsyncIterable<number> = async function * () {
 >assignability7 : () => AsyncIterable<number>
->async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, unknown>
+>async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, undefined>
 
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
@@ -195,7 +195,7 @@ const assignability10: () => AsyncIterable<number> = async function * () {
 };
 const assignability11: () => AsyncIterator<number> = async function * () {
 >assignability11 : () => AsyncIterator<number, any, undefined>
->async function * () {    yield 1;} : () => AsyncGenerator<number, void, unknown>
+>async function * () {    yield 1;} : () => AsyncGenerator<number, void, undefined>
 
     yield 1;
 >yield 1 : undefined
@@ -204,7 +204,7 @@ const assignability11: () => AsyncIterator<number> = async function * () {
 };
 const assignability12: () => AsyncIterator<number> = async function * () {
 >assignability12 : () => AsyncIterator<number, any, undefined>
->async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, unknown>
+>async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, undefined>
 
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(2,12): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(8,12): error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(10,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
-  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(10,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
+  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
     Types of property 'next' are incompatible.
-      Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
+      Type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
         Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
           Type 'IteratorResult<string, void>' is not assignable to type 'IteratorResult<number, any>'.
             Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorResult<number, any>'.
@@ -11,20 +11,12 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
                 Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(13,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
-    Types of property 'next' are incompatible.
-      Type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
-        Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(16,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(19,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
-  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
-    Types of property '[Symbol.asyncIterator]' are incompatible.
-      Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-        Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
-          Types of property 'next' are incompatible.
-            Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
-              Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(22,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
+    Types of property 'next' are incompatible.
+      Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
+        Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(19,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
     Types of property '[Symbol.asyncIterator]' are incompatible.
       Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
@@ -32,10 +24,18 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
           Types of property 'next' are incompatible.
             Type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
               Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(22,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
+  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(25,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(28,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+    Types of property '[Symbol.asyncIterator]' are incompatible.
+      Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
+        Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+          Types of property 'next' are incompatible.
+            Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
+              Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(28,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
+  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(31,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(34,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
@@ -76,10 +76,10 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     }
     const assignability1: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
 !!! error TS2322:     Types of property 'next' are incompatible.
-!!! error TS2322:       Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
+!!! error TS2322:       Type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
 !!! error TS2322:         Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
 !!! error TS2322:           Type 'IteratorResult<string, void>' is not assignable to type 'IteratorResult<number, any>'.
 !!! error TS2322:             Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorResult<number, any>'.
@@ -91,30 +91,18 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
           ~~~~~~~~~~~~~~
 !!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
 !!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
-!!! error TS2322:     Types of property 'next' are incompatible.
-!!! error TS2322:       Type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
-!!! error TS2322:         Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         yield* ["a", "b"];
     };
     const assignability3: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
 !!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
 !!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
+!!! error TS2322:     Types of property 'next' are incompatible.
+!!! error TS2322:       Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
+!!! error TS2322:         Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         yield* (async function * () { yield "a"; })();
     };
     const assignability4: () => AsyncIterable<number> = async function * () {
-          ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
-!!! error TS2322:     Types of property '[Symbol.asyncIterator]' are incompatible.
-!!! error TS2322:       Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-!!! error TS2322:         Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
-!!! error TS2322:           Types of property 'next' are incompatible.
-!!! error TS2322:             Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
-!!! error TS2322:               Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
-        yield "a";
-    };
-    const assignability5: () => AsyncIterable<number> = async function * () {
           ~~~~~~~~~~~~~~
 !!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
 !!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
@@ -124,18 +112,30 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
 !!! error TS2322:           Types of property 'next' are incompatible.
 !!! error TS2322:             Type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
 !!! error TS2322:               Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
+        yield "a";
+    };
+    const assignability5: () => AsyncIterable<number> = async function * () {
+          ~~~~~~~~~~~~~~
+!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
         yield* ["a", "b"];
     };
     const assignability6: () => AsyncIterable<number> = async function * () {
           ~~~~~~~~~~~~~~
 !!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
 !!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
+!!! error TS2322:     Types of property '[Symbol.asyncIterator]' are incompatible.
+!!! error TS2322:       Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
+!!! error TS2322:         Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+!!! error TS2322:           Types of property 'next' are incompatible.
+!!! error TS2322:             Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [PromiseLike<undefined>]) => Promise<IteratorResult<number, any>>'.
+!!! error TS2322:               Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         yield* (async function * () { yield "a"; })();
     };
     const assignability7: () => AsyncIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
         yield "a";
     };
     const assignability8: () => AsyncIterator<number> = async function * () {

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.types
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.types
@@ -29,7 +29,7 @@ async function * inferReturnType3() {
 }
 const assignability1: () => AsyncIterableIterator<number> = async function * () {
 >assignability1 : () => AsyncIterableIterator<number>
->async function * () {    yield "a";} : () => AsyncGenerator<string, void, unknown>
+>async function * () {    yield "a";} : () => AsyncGenerator<string, void, undefined>
 
     yield "a";
 >yield "a" : undefined
@@ -62,7 +62,7 @@ const assignability3: () => AsyncIterableIterator<number> = async function * () 
 };
 const assignability4: () => AsyncIterable<number> = async function * () {
 >assignability4 : () => AsyncIterable<number>
->async function * () {    yield "a";} : () => AsyncGenerator<string, void, unknown>
+>async function * () {    yield "a";} : () => AsyncGenerator<string, void, undefined>
 
     yield "a";
 >yield "a" : undefined
@@ -95,7 +95,7 @@ const assignability6: () => AsyncIterable<number> = async function * () {
 };
 const assignability7: () => AsyncIterator<number> = async function * () {
 >assignability7 : () => AsyncIterator<number, any, undefined>
->async function * () {    yield "a";} : () => AsyncGenerator<string, void, unknown>
+>async function * () {    yield "a";} : () => AsyncGenerator<string, void, undefined>
 
     yield "a";
 >yield "a" : undefined

--- a/tests/baselines/reference/uniqueSymbols.types
+++ b/tests/baselines/reference/uniqueSymbols.types
@@ -819,7 +819,7 @@ interface Context {
 
 const o3: Context = {
 >o3 : Context
->{    method1() {        return s; // return type should not widen due to contextual type    },    async method2() {        return s; // return type should not widen due to contextual type    },    async * method3() {        yield s; // yield type should not widen due to contextual type    },    * method4() {        yield s; // yield type should not widen due to contextual type    },    method5(p = s) { // parameter should not widen due to contextual type        return p;    },} : { method1(): unique symbol; method2(): Promise<unique symbol>; method3(): AsyncGenerator<unique symbol, void, unknown>; method4(): Generator<unique symbol, void, unknown>; method5(p?: unique symbol): unique symbol; }
+>{    method1() {        return s; // return type should not widen due to contextual type    },    async method2() {        return s; // return type should not widen due to contextual type    },    async * method3() {        yield s; // yield type should not widen due to contextual type    },    * method4() {        yield s; // yield type should not widen due to contextual type    },    method5(p = s) { // parameter should not widen due to contextual type        return p;    },} : { method1(): unique symbol; method2(): Promise<unique symbol>; method3(): AsyncGenerator<unique symbol, void, undefined>; method4(): Generator<unique symbol, void, undefined>; method5(p?: unique symbol): unique symbol; }
 
     method1() {
 >method1 : () => unique symbol
@@ -836,7 +836,7 @@ const o3: Context = {
 
     },
     async * method3() {
->method3 : () => AsyncGenerator<unique symbol, void, unknown>
+>method3 : () => AsyncGenerator<unique symbol, void, undefined>
 
         yield s; // yield type should not widen due to contextual type
 >yield s : undefined
@@ -844,7 +844,7 @@ const o3: Context = {
 
     },
     * method4() {
->method4 : () => Generator<unique symbol, void, unknown>
+>method4 : () => Generator<unique symbol, void, undefined>
 
         yield s; // yield type should not widen due to contextual type
 >yield s : undefined

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.types
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.types
@@ -812,7 +812,7 @@ interface Context {
 
 const o4: Context = {
 >o4 : Context
->{    method1() {        return s; // return type should not widen due to contextual type    },    async method2() {        return s; // return type should not widen due to contextual type    },    async * method3() {        yield s; // yield type should not widen due to contextual type    },    * method4() {        yield s; // yield type should not widen due to contextual type    },    method5(p = s) { // parameter should not widen due to contextual type        return p;    }} : { method1(): unique symbol; method2(): Promise<unique symbol>; method3(): AsyncGenerator<unique symbol, void, unknown>; method4(): Generator<unique symbol, void, unknown>; method5(p?: unique symbol): unique symbol; }
+>{    method1() {        return s; // return type should not widen due to contextual type    },    async method2() {        return s; // return type should not widen due to contextual type    },    async * method3() {        yield s; // yield type should not widen due to contextual type    },    * method4() {        yield s; // yield type should not widen due to contextual type    },    method5(p = s) { // parameter should not widen due to contextual type        return p;    }} : { method1(): unique symbol; method2(): Promise<unique symbol>; method3(): AsyncGenerator<unique symbol, void, undefined>; method4(): Generator<unique symbol, void, undefined>; method5(p?: unique symbol): unique symbol; }
 
     method1() {
 >method1 : () => unique symbol
@@ -829,7 +829,7 @@ const o4: Context = {
 
     },
     async * method3() {
->method3 : () => AsyncGenerator<unique symbol, void, unknown>
+>method3 : () => AsyncGenerator<unique symbol, void, undefined>
 
         yield s; // yield type should not widen due to contextual type
 >yield s : undefined
@@ -837,7 +837,7 @@ const o4: Context = {
 
     },
     * method4() {
->method4 : () => Generator<unique symbol, void, unknown>
+>method4 : () => Generator<unique symbol, void, undefined>
 
         yield s; // yield type should not widen due to contextual type
 >yield s : undefined


### PR DESCRIPTION
When unable to infer the *next iteration type* in `getReturnTypeFromBody`, use the *next iteration type* from the contextual return type, if available. This aligns with the behavior in `checkYieldExpression`.

Fixes #32696
