### PR TITLE
Fix completion disappear after a property declaration with a private modifier

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1566,7 +1566,7 @@ namespace ts.Completions {
             // If you're in an interface you don't want to repeat things from super-interface. So just stop here.
             if (!isClassLike(decl)) return GlobalsSearch.Success;
 
-            const classElement = contextToken.parent;
+            const classElement = contextToken.kind === SyntaxKind.SemicolonToken ? contextToken.parent.parent : contextToken.parent;
             let classElementModifierFlags = isClassElement(classElement) ? getModifierFlags(classElement) : ModifierFlags.None;
             // If this is context token is not something we are editing now, consider if this would lead to be modifier
             if (contextToken.kind === SyntaxKind.Identifier && !isCurrentlyEditingNode(contextToken)) {

--- a/tests/cases/fourslash/completionsClassPropertiesAfterPrivateProperty.ts
+++ b/tests/cases/fourslash/completionsClassPropertiesAfterPrivateProperty.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+//// interface X {
+////     bla: string;
+//// }
+//// class Y implements X {
+////     private blub = "";
+////     /**/
+//// }
+
+
+verify.completions({ marker: "", includes: "bla", isNewIdentifierLocation: true });


### PR DESCRIPTION
Fix class member completion disappear after a property declaration with a private modifier.

<!--
Thank you for submitting a pull request!

Please verify that:
* [Y] There is an associated issue in the `Backlog` milestone (**required**)
* [Y] Code is up-to-date with the `master` branch
* [Y] You've successfully run `gulp runtests` locally
* [Y] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #30290
