### PR TITLE
Suggestions now use diagnosticCollection

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -585,7 +585,7 @@ namespace ts {
                     checkSourceFile(file);
                     Debug.assert(!!(getNodeLinks(file).flags & NodeCheckFlags.TypeChecked));
 
-                    diagnostics = addRange(diagnostics, suggestionDiagnostics.get(file.fileName));
+                    diagnostics = addRange(diagnostics, suggestionDiagnostics.getDiagnostics(file.fileName));
                     if (!file.isDeclarationFile && (!unusedIsError(UnusedKind.Local) || !unusedIsError(UnusedKind.Parameter))) {
                         addUnusedDiagnostics();
                     }
@@ -848,8 +848,7 @@ namespace ts {
         const awaitedTypeStack: number[] = [];
 
         const diagnostics = createDiagnosticCollection();
-        // Suggestion diagnostics must have a file. Keyed by source file name.
-        const suggestionDiagnostics = createMultiMap<DiagnosticWithLocation>();
+        const suggestionDiagnostics = createDiagnosticCollection();
 
         const typeofTypesByName: ReadonlyMap<Type> = createMapFromTemplate<Type>({
             string: stringType,
@@ -944,7 +943,7 @@ namespace ts {
                 diagnostics.add(diagnostic);
             }
             else {
-                suggestionDiagnostics.add(diagnostic.file.fileName, { ...diagnostic, category: DiagnosticCategory.Suggestion });
+                suggestionDiagnostics.add({ ...diagnostic, category: DiagnosticCategory.Suggestion });
             }
         }
         function errorOrSuggestion(isError: boolean, location: Node, message: DiagnosticMessage | DiagnosticMessageChain, arg0?: string | number, arg1?: string | number, arg2?: string | number, arg3?: string | number): void {

--- a/tests/cases/fourslash/suggestionNoDuplicates.ts
+++ b/tests/cases/fourslash/suggestionNoDuplicates.ts
@@ -1,0 +1,14 @@
+// @strict: false
+/// <reference path="fourslash.ts" />
+// @Filename: foo.ts
+//// import { f } from [|'m'|]
+//// f
+
+// @Filename: node_modules/m/index.js
+//// module.exports.f = function (x) { return x }
+
+verify.getSemanticDiagnostics([])
+verify.getSuggestionDiagnostics([{
+    code: 7016,
+    message: "Could not find a declaration file for module 'm'. '/tests/cases/fourslash/node_modules/m/index.js' implicitly has an 'any' type.",
+}])


### PR DESCRIPTION
Previously they used multimaps, unlike all the other diagnostics. This prevents duplicate suggestions, like other kinds of diagnostics.

Fixes #28710