### PR TITLE
Change to missing file watcher on linux and darwin explicitly to avoid watching deleted inode

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1039,11 +1039,6 @@ namespace ts {
                     lastDirectoryPartWithDirectorySeparator = fileOrDirectory.substr(fileOrDirectory.lastIndexOf(directorySeparator));
                     lastDirectoryPart = lastDirectoryPartWithDirectorySeparator.slice(directorySeparator.length);
                 }   
-                    fileOrDirectory.substr(fileOrDirectory.lastIndexOf(directorySeparator)) :
-                    undefined;
-                const lastDirectoryPart = isLinuxOrMacOs ?
-                    lastDirectoryPartWithDirectorySeparator!.slice(directorySeparator.length) :
-                    undefined;
                 /** Watcher for the file system entry depending on whether it is missing or present */
                 let watcher = !fileSystemEntryExists(fileOrDirectory, entryKind) ?
                     watchMissingFileSystemEntry() :

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1033,7 +1033,12 @@ namespace ts {
 
             function fsWatch(fileOrDirectory: string, entryKind: FileSystemEntryKind.File | FileSystemEntryKind.Directory, callback: FsWatchCallback, recursive: boolean, fallbackPollingWatchFile: HostWatchFile, pollingInterval?: number): FileWatcher {
                 let options: any;
-                const lastDirectoryPartWithDirectorySeparator = isLinuxOrMacOs ?
+                let lastDirectoryPartWithDirectorySeparator: string | undefined;
+                let lastDirectoryPart: string | undefined;
+                if (isLinuxOrMacOs) {
+                    lastDirectoryPartWithDirectorySeparator = fileOrDirectory.substr(fileOrDirectory.lastIndexOf(directorySeparator));
+                    lastDirectoryPart = lastDirectoryPartWithDirectorySeparator.slice(directorySeparator.length);
+                }   
                     fileOrDirectory.substr(fileOrDirectory.lastIndexOf(directorySeparator)) :
                     undefined;
                 const lastDirectoryPart = isLinuxOrMacOs ?

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -380,6 +380,9 @@ namespace ts {
     export const ignoredPaths = ["/node_modules/.", "/.git", "/.#"];
 
     /*@internal*/
+    export let sysLog: (s: string) => void = noop;
+
+    /*@internal*/
     export interface RecursiveDirectoryWatcherHost {
         watchDirectory: HostWatchDirectory;
         useCaseSensitiveFileNames: boolean;
@@ -1053,6 +1056,7 @@ namespace ts {
                  * @param createWatcher
                  */
                 function invokeCallbackAndUpdateWatcher(createWatcher: () => FileWatcher) {
+                    sysLog(`sysLog:: ${fileOrDirectory}:: Changing watcher to ${createWatcher === watchPresentFileSystemEntry ? "Present" : "Missing"}FileSystemEntryWatcher`);
                     // Call the callback for current directory
                     callback("rename", "");
 
@@ -1115,6 +1119,7 @@ namespace ts {
                  * Eg. on linux the number of watches are limited and one could easily exhaust watches and the exception ENOSPC is thrown when creating watcher at that point
                  */
                 function watchPresentFileSystemEntryWithFsWatchFile(): FileWatcher {
+                    sysLog(`sysLog:: ${fileOrDirectory}:: Changing to fsWatchFile`);
                     return fallbackPollingWatchFile(fileOrDirectory, createFileWatcherCallback(callback), pollingInterval);
                 }
 

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1109,7 +1109,7 @@ namespace ts {
 
                 function callbackChangingToMissingFileSystemEntry(event: "rename" | "change", relativeName: string | undefined) {
                     // because relativeName is not guaranteed to be correct we need to check on each rename with few combinations
-                    // Eg on ubuntoo while watchin app/node_modules the relativeName is "node_modules" which is neither relative nor full path
+                    // Eg on ubuntu while watching app/node_modules the relativeName is "node_modules" which is neither relative nor full path
                     return event === "rename" &&
                         (!relativeName ||
                             relativeName === lastDirectoryPart ||

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1038,7 +1038,7 @@ namespace ts {
                 if (isLinuxOrMacOs) {
                     lastDirectoryPartWithDirectorySeparator = fileOrDirectory.substr(fileOrDirectory.lastIndexOf(directorySeparator));
                     lastDirectoryPart = lastDirectoryPartWithDirectorySeparator.slice(directorySeparator.length);
-                }   
+                }
                 /** Watcher for the file system entry depending on whether it is missing or present */
                 let watcher = !fileSystemEntryExists(fileOrDirectory, entryKind) ?
                     watchMissingFileSystemEntry() :

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -370,6 +370,9 @@ namespace ts {
         const createFileWatcher: CreateFileWatcher<WatchFileHost, PollingInterval, FileWatcherEventKind, never, X, Y> = getCreateFileWatcher(watchLogLevel, watchFile);
         const createFilePathWatcher: CreateFileWatcher<WatchFileHost, PollingInterval, FileWatcherEventKind, Path, X, Y> = watchLogLevel === WatchLogLevel.None ? watchFilePath : createFileWatcher;
         const createDirectoryWatcher: CreateFileWatcher<WatchDirectoryHost, WatchDirectoryFlags, undefined, never, X, Y> = getCreateFileWatcher(watchLogLevel, watchDirectory);
+        if (watchLogLevel === WatchLogLevel.Verbose && sysLog === noop) {
+            sysLog = s => log(s);
+        }
         return {
             watchFile: (host, file, callback, pollingInterval, detailInfo1, detailInfo2) =>
                 createFileWatcher(host, file, callback, pollingInterval, /*passThrough*/ undefined, detailInfo1, detailInfo2, watchFile, log, "FileWatcher", getDetailWatchInfo),


### PR DESCRIPTION
This partially fixes issue with #32033 wherein `npm i` was not recognized because we were still watching deleted `node_modules` inode for changes in directory.
This does not fix the interruptions to intellisense while `npm install` is going on. That has more to do with recursive watches and that would be handled separately.
