### PR TITLE
Only check import = reference when target is Value

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2405,8 +2405,11 @@ namespace ts {
                 // This way a chain of imports can be elided if ultimately the final input is only used in a type
                 // position.
                 if (isInternalModuleImportEqualsDeclaration(node)) {
-                    // import foo = <symbol>
-                    checkExpressionCached(<Expression>node.moduleReference);
+                    const target = resolveSymbol(symbol);
+                    if (target === unknownSymbol || target.flags & SymbolFlags.Value) {
+                        // import foo = <symbol>
+                        checkExpressionCached(<Expression>node.moduleReference);
+                    }
                 }
             }
         }

--- a/tests/baselines/reference/importDeclarationNotCheckedAsValueWhenTargetNonValue.symbols
+++ b/tests/baselines/reference/importDeclarationNotCheckedAsValueWhenTargetNonValue.symbols
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/file.d.ts ===
+declare namespace dojox {
+>dojox : Symbol(dojox, Decl(file.d.ts, 0, 0))
+
+    namespace charting {
+>charting : Symbol(charting, Decl(file.d.ts, 0, 25))
+
+        namespace axis2d {
+>axis2d : Symbol(axis2d, Decl(file.d.ts, 1, 24))
+
+            export class Val { }
+>Val : Symbol(Val, Decl(file.d.ts, 2, 26))
+
+            interface common {
+>common : Symbol(common, Decl(file.d.ts, 3, 32), Decl(file.d.ts, 6, 13))
+
+                createText: object;
+>createText : Symbol(common.createText, Decl(file.d.ts, 4, 30))
+            }
+            namespace common {
+>common : Symbol(common, Decl(file.d.ts, 3, 32), Decl(file.d.ts, 6, 13))
+
+                interface createText {
+>createText : Symbol(createText, Decl(file.d.ts, 7, 30))
+
+                    gfx(): string
+>gfx : Symbol(createText.gfx, Decl(file.d.ts, 8, 38))
+                }
+            }
+        }
+    }
+}
+declare module "dojox/charting/axis2d/common.createText" {
+>"dojox/charting/axis2d/common.createText" : Symbol("dojox/charting/axis2d/common.createText", Decl(file.d.ts, 14, 1))
+
+    import exp = dojox.charting.axis2d.common
+>exp : Symbol(exp, Decl(file.d.ts, 15, 58))
+>dojox : Symbol(dojox, Decl(file.d.ts, 0, 0))
+>charting : Symbol(dojox.charting, Decl(file.d.ts, 0, 25))
+>axis2d : Symbol(dojox.charting.axis2d, Decl(file.d.ts, 1, 24))
+>common : Symbol(exp, Decl(file.d.ts, 3, 32), Decl(file.d.ts, 6, 13))
+
+    export = exp;
+>exp : Symbol(exp, Decl(file.d.ts, 15, 58))
+}

--- a/tests/baselines/reference/importDeclarationNotCheckedAsValueWhenTargetNonValue.types
+++ b/tests/baselines/reference/importDeclarationNotCheckedAsValueWhenTargetNonValue.types
@@ -1,0 +1,39 @@
+=== tests/cases/compiler/file.d.ts ===
+declare namespace dojox {
+>dojox : typeof dojox
+
+    namespace charting {
+>charting : typeof charting
+
+        namespace axis2d {
+>axis2d : typeof axis2d
+
+            export class Val { }
+>Val : Val
+
+            interface common {
+                createText: object;
+>createText : object
+            }
+            namespace common {
+                interface createText {
+                    gfx(): string
+>gfx : () => string
+                }
+            }
+        }
+    }
+}
+declare module "dojox/charting/axis2d/common.createText" {
+>"dojox/charting/axis2d/common.createText" : typeof import("dojox/charting/axis2d/common.createText")
+
+    import exp = dojox.charting.axis2d.common
+>exp : any
+>dojox : typeof dojox
+>charting : typeof dojox.charting
+>axis2d : typeof dojox.charting.axis2d
+>common : exp
+
+    export = exp;
+>exp : exp
+}

--- a/tests/cases/compiler/importDeclarationNotCheckedAsValueWhenTargetNonValue.ts
+++ b/tests/cases/compiler/importDeclarationNotCheckedAsValueWhenTargetNonValue.ts
@@ -1,0 +1,20 @@
+// @filename: file.d.ts
+declare namespace dojox {
+    namespace charting {
+        namespace axis2d {
+            export class Val { }
+            interface common {
+                createText: object;
+            }
+            namespace common {
+                interface createText {
+                    gfx(): string
+                }
+            }
+        }
+    }
+}
+declare module "dojox/charting/axis2d/common.createText" {
+    import exp = dojox.charting.axis2d.common
+    export = exp;
+}


### PR DESCRIPTION
Fixes #32746

This gives the `import=` alias expression the same guard against checking that `export=` and `export default` have.