### PR TITLE
Adds a debugging command to the scanner

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -877,7 +877,7 @@ namespace ts {
 
         setText(text, start, length);
 
-        return {
+        const scanner: Scanner = {
             getStartPos: () => startPos,
             getTextPos: () => pos,
             getToken: () => token,
@@ -911,6 +911,17 @@ namespace ts {
             lookAhead,
             scanRange,
         };
+
+        if (Debug.isDebugging) {
+            Object.defineProperty(scanner, "__debugShowCurrentPositionInText", {
+                get: () => {
+                    const text = scanner.getText();
+                    return text.slice(0, scanner.getStartPos()) + "║" + text.slice(scanner.getStartPos());
+                },
+            });
+        }
+
+        return scanner;
 
         function error(message: DiagnosticMessage): void;
         function error(message: DiagnosticMessage, errPos: number, length: number): void;


### PR DESCRIPTION
Let's you see where the scanner currently is in it's text:

```sh
> scanner. __debugShowCurrentPositionInText
"
const a = (
  <div
>║x
      
  </div>
)
"
```