### PR TITLE
Remove error on invalid jsdoc tokens

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1842,7 +1842,8 @@ namespace ts {
                 node.originalKeywordKind! >= SyntaxKind.FirstFutureReservedWord &&
                 node.originalKeywordKind! <= SyntaxKind.LastFutureReservedWord &&
                 !isIdentifierName(node) &&
-                !(node.flags & NodeFlags.Ambient)) {
+                !(node.flags & NodeFlags.Ambient) &&
+                !(node.flags & NodeFlags.JSDoc)) {
 
                 // Report error only if there are no parse errors in file
                 if (!file.parseDiagnostics.length) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6434,7 +6434,7 @@ namespace ts {
             export function parseIsolatedJSDocComment(content: string, start: number | undefined, length: number | undefined): { jsDoc: JSDoc, diagnostics: Diagnostic[] } | undefined {
                 initializeState(content, ScriptTarget.Latest, /*_syntaxCursor:*/ undefined, ScriptKind.JS);
                 sourceFile = <SourceFile>{ languageVariant: LanguageVariant.Standard, text: content }; // tslint:disable-line no-object-literal-type-assertion
-                const jsDoc = parseJSDocCommentWorker(start, length);
+                const jsDoc = doInsideOfContext(NodeFlags.JSDoc, () => parseJSDocCommentWorker(start, length));
                 const diagnostics = parseDiagnostics;
                 clearState();
 
@@ -6446,7 +6446,7 @@ namespace ts {
                 const saveParseDiagnosticsLength = parseDiagnostics.length;
                 const saveParseErrorBeforeNextFinishedNode = parseErrorBeforeNextFinishedNode;
 
-                const comment = parseJSDocCommentWorker(start, length);
+                const comment = doInsideOfContext(NodeFlags.JSDoc, () => parseJSDocCommentWorker(start, length));
                 if (comment) {
                     comment.parent = parent;
                 }
@@ -6477,7 +6477,7 @@ namespace ts {
                 CallbackParameter = 1 << 2,
             }
 
-            export function parseJSDocCommentWorker(start = 0, length: number | undefined): JSDoc | undefined {
+            function parseJSDocCommentWorker(start = 0, length: number | undefined): JSDoc | undefined {
                 const content = sourceText;
                 const end = length === undefined ? content.length : start + length;
                 length = end - start;

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -2159,7 +2159,6 @@ namespace ts {
                         tokenValue = String.fromCharCode(cookedChar) + scanIdentifierParts();
                         return token = getIdentifierToken();
                     }
-                    error(Diagnostics.Invalid_character);
                     pos++;
                     return token = SyntaxKind.Unknown;
             }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@link tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.@link tags.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 127,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.Nested @param tags.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 66,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argSynonymForParamTag.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 44,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.argumentSynonymForParamTag.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 49,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.asteriskAfterPreamble.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.asteriskAfterPreamble.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 23,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "comment": "* @type {number}"

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.authorTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.authorTag.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 112,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.emptyComment.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.emptyComment.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 5,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0
 }

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.leadingAsterisk.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.leadingAsterisk.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 27,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.less-than and greater-than characters.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 61,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noLeadingAsterisk.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noLeadingAsterisk.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 27,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noReturnType.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.noReturnType.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 20,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.oneParamTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.oneParamTag.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 34,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTag1.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 59,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName1.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 61,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagBracketedName2.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 66,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType1.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 34,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramTagNameThenType2.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 46,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramWithoutType.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.paramWithoutType.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 23,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag1.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 29,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnTag2.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 54,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnsTag1.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.returnsTag1.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 30,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 24,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag2.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 26,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag3.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag3.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 27,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag4.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag4.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 27,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag5.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag5.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 28,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.templateTag6.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 60,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.threeAsterisks.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.threeAsterisks.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 7,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "comment": "*"

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTag2.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTag2.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 60,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTagOnSameLine.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.twoParamTagOnSameLine.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 56,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typeTag.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typeTag.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 27,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
@@ -2,6 +2,7 @@
     "kind": "JSDocComment",
     "pos": 0,
     "end": 102,
+    "flags": "JSDoc",
     "modifierFlagsCache": 0,
     "transformFlags": 0,
     "tags": {

--- a/tests/baselines/reference/jsdocInvalidTokens.symbols
+++ b/tests/baselines/reference/jsdocInvalidTokens.symbols
@@ -1,10 +1,11 @@
 === tests/cases/conformance/scanner/jsdocInvalidTokens.js ===
 /**
  *
- * quoted-pair = "\" should not have error for invalid quote sequence
+ * unicode-escape = \u{abcdefghi} -- should not have error for invalid unicode escape
+ * quoted-pair = "\" -- should not have error for invalid quote sequence
  * or for the tag below:
  * @private
  */
 var hi = 1
->hi : Symbol(hi, Decl(jsdocInvalidTokens.js, 6, 3))
+>hi : Symbol(hi, Decl(jsdocInvalidTokens.js, 7, 3))
 

--- a/tests/baselines/reference/jsdocInvalidTokens.symbols
+++ b/tests/baselines/reference/jsdocInvalidTokens.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/scanner/jsdocInvalidTokens.js ===
+/**
+ *
+ * quoted-pair = "\" should not have error for invalid quote sequence
+ * or for the tag below:
+ * @private
+ */
+var hi = 1
+>hi : Symbol(hi, Decl(jsdocInvalidTokens.js, 6, 3))
+

--- a/tests/baselines/reference/jsdocInvalidTokens.symbols
+++ b/tests/baselines/reference/jsdocInvalidTokens.symbols
@@ -2,10 +2,11 @@
 /**
  *
  * unicode-escape = "\u{abcdefghi}" -- should not have error for invalid unicode escape
+ * unicode-escape2 = "qq\u{abcdefghi}" -- no error here either
  * quoted-pair = "\" -- should not have error for invalid quote sequence
  * or for the tag below:
  * @private
  */
 var hi = 1
->hi : Symbol(hi, Decl(jsdocInvalidTokens.js, 7, 3))
+>hi : Symbol(hi, Decl(jsdocInvalidTokens.js, 8, 3))
 

--- a/tests/baselines/reference/jsdocInvalidTokens.symbols
+++ b/tests/baselines/reference/jsdocInvalidTokens.symbols
@@ -1,7 +1,7 @@
 === tests/cases/conformance/scanner/jsdocInvalidTokens.js ===
 /**
  *
- * unicode-escape = \u{abcdefghi} -- should not have error for invalid unicode escape
+ * unicode-escape = "\u{abcdefghi}" -- should not have error for invalid unicode escape
  * quoted-pair = "\" -- should not have error for invalid quote sequence
  * or for the tag below:
  * @private

--- a/tests/baselines/reference/jsdocInvalidTokens.types
+++ b/tests/baselines/reference/jsdocInvalidTokens.types
@@ -1,7 +1,8 @@
 === tests/cases/conformance/scanner/jsdocInvalidTokens.js ===
 /**
  *
- * quoted-pair = "\" should not have error for invalid quote sequence
+ * unicode-escape = \u{abcdefghi} -- should not have error for invalid unicode escape
+ * quoted-pair = "\" -- should not have error for invalid quote sequence
  * or for the tag below:
  * @private
  */

--- a/tests/baselines/reference/jsdocInvalidTokens.types
+++ b/tests/baselines/reference/jsdocInvalidTokens.types
@@ -2,6 +2,7 @@
 /**
  *
  * unicode-escape = "\u{abcdefghi}" -- should not have error for invalid unicode escape
+ * unicode-escape2 = "qq\u{abcdefghi}" -- no error here either
  * quoted-pair = "\" -- should not have error for invalid quote sequence
  * or for the tag below:
  * @private

--- a/tests/baselines/reference/jsdocInvalidTokens.types
+++ b/tests/baselines/reference/jsdocInvalidTokens.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/scanner/jsdocInvalidTokens.js ===
+/**
+ *
+ * quoted-pair = "\" should not have error for invalid quote sequence
+ * or for the tag below:
+ * @private
+ */
+var hi = 1
+>hi : number
+>1 : 1
+

--- a/tests/baselines/reference/jsdocInvalidTokens.types
+++ b/tests/baselines/reference/jsdocInvalidTokens.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/scanner/jsdocInvalidTokens.js ===
 /**
  *
- * unicode-escape = \u{abcdefghi} -- should not have error for invalid unicode escape
+ * unicode-escape = "\u{abcdefghi}" -- should not have error for invalid unicode escape
  * quoted-pair = "\" -- should not have error for invalid quote sequence
  * or for the tag below:
  * @private

--- a/tests/cases/conformance/scanner/jsdocInvalidTokens.ts
+++ b/tests/cases/conformance/scanner/jsdocInvalidTokens.ts
@@ -1,0 +1,13 @@
+// @Filename: jsdocInvalidTokens.js
+// @strict: true
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+/**
+ *
+ * quoted-pair = "\" should not have error for invalid quote sequence
+ * or for the tag below:
+ * @private
+ */
+var hi = 1

--- a/tests/cases/conformance/scanner/jsdocInvalidTokens.ts
+++ b/tests/cases/conformance/scanner/jsdocInvalidTokens.ts
@@ -6,7 +6,7 @@
 
 /**
  *
- * unicode-escape = \u{abcdefghi} -- should not have error for invalid unicode escape
+ * unicode-escape = "\u{abcdefghi}" -- should not have error for invalid unicode escape
  * quoted-pair = "\" -- should not have error for invalid quote sequence
  * or for the tag below:
  * @private

--- a/tests/cases/conformance/scanner/jsdocInvalidTokens.ts
+++ b/tests/cases/conformance/scanner/jsdocInvalidTokens.ts
@@ -6,7 +6,8 @@
 
 /**
  *
- * quoted-pair = "\" should not have error for invalid quote sequence
+ * unicode-escape = \u{abcdefghi} -- should not have error for invalid unicode escape
+ * quoted-pair = "\" -- should not have error for invalid quote sequence
  * or for the tag below:
  * @private
  */

--- a/tests/cases/conformance/scanner/jsdocInvalidTokens.ts
+++ b/tests/cases/conformance/scanner/jsdocInvalidTokens.ts
@@ -7,6 +7,7 @@
 /**
  *
  * unicode-escape = "\u{abcdefghi}" -- should not have error for invalid unicode escape
+ * unicode-escape2 = "qq\u{abcdefghi}" -- no error here either
  * quoted-pair = "\" -- should not have error for invalid quote sequence
  * or for the tag below:
  * @private


### PR DESCRIPTION
In JSDoc:

1. In the scanner, don't issue an error, even for invalid identifiers.
2. In the binder, don't issue an error for reserved (but otherwise valid)
identifiers.

```js
/**
 * Example of 1: "\"
 * Example of 2: @private
 */
```

I'm not sure of the fix in the binder. It might be better to avoid setting originalKeywordKind in the parser for bad identifiers in jsdoc, but that seems wrong because the jsdoc code path really should behave just like the normal one so that it's easy to remove later.

Fixes #32756