### PR TITLE
Allow looking for properties inside the base of a mixin'd class

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20645,10 +20645,20 @@ namespace ts {
                 }
                 return apparentType;
             }
-            const prop = getPropertyOfType(apparentType, right.escapedText);
+            let prop = getPropertyOfType(apparentType, right.escapedText);
             if (isIdentifier(left) && parentSymbol && !(prop && isConstEnumOrConstEnumOnlyModule(prop))) {
                 markAliasReferenced(parentSymbol, node);
             }
+
+            // Check for properties added via mixer-style base types also
+            if (!prop && typeIsInterfaceType(apparentType)) {
+                for (const base of apparentType.resolvedBaseTypes) {
+                    if (!prop) {
+                        prop = getPropertyOfType(base, right.escapedText);
+                    }
+                }
+            }
+
             if (!prop) {
                 const indexInfo = assignmentKind === AssignmentKind.None || !isGenericObjectType(leftType) || isThisTypeParameter(leftType) ? getIndexInfoOfType(apparentType, IndexKind.String) : undefined;
                 if (!(indexInfo && indexInfo.type)) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5440,6 +5440,10 @@ namespace ts {
             ? node.parent.constraint
             : undefined;
     }
+
+    export function typeIsInterfaceType(type: Type): type is InterfaceType {
+        return !!type && hasProperty(type as InterfaceType, "typeParameters") && hasProperty(type as InterfaceType, "resolvedBaseTypes");
+    }
 }
 
 // Simple node tests of the form `node.kind === SyntaxKind.Foo`.

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -420,7 +420,6 @@ namespace ts {
         getDefault(): Type | undefined {
             return this.checker.getDefaultFromTypeParameter(this);
         }
-
         isUnion(): this is UnionType {
             return !!(this.flags & TypeFlags.Union);
         }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3381,6 +3381,7 @@ declare namespace ts {
      */
     function getEffectiveTypeParameterDeclarations(node: DeclarationWithTypeParameters): ReadonlyArray<TypeParameterDeclaration>;
     function getEffectiveConstraintOfTypeParameter(node: TypeParameterDeclaration): TypeNode | undefined;
+    function typeIsInterfaceType(type: Type): type is InterfaceType;
 }
 declare namespace ts {
     function isNumericLiteral(node: Node): node is NumericLiteral;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3381,6 +3381,7 @@ declare namespace ts {
      */
     function getEffectiveTypeParameterDeclarations(node: DeclarationWithTypeParameters): ReadonlyArray<TypeParameterDeclaration>;
     function getEffectiveConstraintOfTypeParameter(node: TypeParameterDeclaration): TypeNode | undefined;
+    function typeIsInterfaceType(type: Type): type is InterfaceType;
 }
 declare namespace ts {
     function isNumericLiteral(node: Node): node is NumericLiteral;

--- a/tests/baselines/reference/expressionPropertyLookupIncludesMixins.js
+++ b/tests/baselines/reference/expressionPropertyLookupIncludesMixins.js
@@ -1,0 +1,90 @@
+//// [expressionPropertyLookupIncludesMixins.ts]
+// https://github.com/microsoft/TypeScript/issues/31426
+
+export type AnyFunction<A = any>        = (...input : any[]) => A
+export type AnyConstructor<A = object>  = new (...input : any[]) => A
+export type Mixin<T extends AnyFunction> = InstanceType<ReturnType<T>>
+
+export const Box = <T extends AnyConstructor<object>>(base : T) =>
+class Box extends base {
+    value       : any
+}
+export interface Box extends Mixin<typeof Box> {}
+
+export const Observable = <T extends AnyConstructor<object>>(base : T) =>
+class Observable extends base {
+    observe () : IQuark {
+        return
+    }
+}
+export interface Observable extends Mixin<typeof Observable> {}
+
+export const CQuark = <T extends AnyConstructor<Box & Observable>>(base : T) =>
+class Quark extends base {
+
+    observe () : Quark {
+        // No error here!
+        this.value
+        
+        
+        return
+    }
+}
+export interface IQuark extends Mixin<typeof CQuark> {}
+
+const test = (a : IQuark) => a.value // <-- Should not error
+
+
+//// [expressionPropertyLookupIncludesMixins.js]
+"use strict";
+// https://github.com/microsoft/TypeScript/issues/31426
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+exports.Box = function (base) {
+    return /** @class */ (function (_super) {
+        __extends(Box, _super);
+        function Box() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        return Box;
+    }(base));
+};
+exports.Observable = function (base) {
+    return /** @class */ (function (_super) {
+        __extends(Observable, _super);
+        function Observable() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        Observable.prototype.observe = function () {
+            return;
+        };
+        return Observable;
+    }(base));
+};
+exports.CQuark = function (base) {
+    return /** @class */ (function (_super) {
+        __extends(Quark, _super);
+        function Quark() {
+            return _super !== null && _super.apply(this, arguments) || this;
+        }
+        Quark.prototype.observe = function () {
+            // No error here!
+            this.value;
+            return;
+        };
+        return Quark;
+    }(base));
+};
+var test = function (a) { return a.value; }; // <-- Should not error

--- a/tests/baselines/reference/expressionPropertyLookupIncludesMixins.symbols
+++ b/tests/baselines/reference/expressionPropertyLookupIncludesMixins.symbols
@@ -1,0 +1,105 @@
+=== tests/cases/compiler/expressionPropertyLookupIncludesMixins.ts ===
+// https://github.com/microsoft/TypeScript/issues/31426
+
+export type AnyFunction<A = any>        = (...input : any[]) => A
+>AnyFunction : Symbol(AnyFunction, Decl(expressionPropertyLookupIncludesMixins.ts, 0, 0))
+>A : Symbol(A, Decl(expressionPropertyLookupIncludesMixins.ts, 2, 24))
+>input : Symbol(input, Decl(expressionPropertyLookupIncludesMixins.ts, 2, 43))
+>A : Symbol(A, Decl(expressionPropertyLookupIncludesMixins.ts, 2, 24))
+
+export type AnyConstructor<A = object>  = new (...input : any[]) => A
+>AnyConstructor : Symbol(AnyConstructor, Decl(expressionPropertyLookupIncludesMixins.ts, 2, 65))
+>A : Symbol(A, Decl(expressionPropertyLookupIncludesMixins.ts, 3, 27))
+>input : Symbol(input, Decl(expressionPropertyLookupIncludesMixins.ts, 3, 47))
+>A : Symbol(A, Decl(expressionPropertyLookupIncludesMixins.ts, 3, 27))
+
+export type Mixin<T extends AnyFunction> = InstanceType<ReturnType<T>>
+>Mixin : Symbol(Mixin, Decl(expressionPropertyLookupIncludesMixins.ts, 3, 69))
+>T : Symbol(T, Decl(expressionPropertyLookupIncludesMixins.ts, 4, 18))
+>AnyFunction : Symbol(AnyFunction, Decl(expressionPropertyLookupIncludesMixins.ts, 0, 0))
+>InstanceType : Symbol(InstanceType, Decl(lib.es5.d.ts, --, --))
+>ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(expressionPropertyLookupIncludesMixins.ts, 4, 18))
+
+export const Box = <T extends AnyConstructor<object>>(base : T) =>
+>Box : Symbol(Box, Decl(expressionPropertyLookupIncludesMixins.ts, 6, 12), Decl(expressionPropertyLookupIncludesMixins.ts, 9, 1))
+>T : Symbol(T, Decl(expressionPropertyLookupIncludesMixins.ts, 6, 20))
+>AnyConstructor : Symbol(AnyConstructor, Decl(expressionPropertyLookupIncludesMixins.ts, 2, 65))
+>base : Symbol(base, Decl(expressionPropertyLookupIncludesMixins.ts, 6, 54))
+>T : Symbol(T, Decl(expressionPropertyLookupIncludesMixins.ts, 6, 20))
+
+class Box extends base {
+>Box : Symbol(Box, Decl(expressionPropertyLookupIncludesMixins.ts, 6, 66))
+>base : Symbol(base, Decl(expressionPropertyLookupIncludesMixins.ts, 6, 54))
+
+    value       : any
+>value : Symbol(Box.value, Decl(expressionPropertyLookupIncludesMixins.ts, 7, 24))
+}
+export interface Box extends Mixin<typeof Box> {}
+>Box : Symbol(Box, Decl(expressionPropertyLookupIncludesMixins.ts, 6, 12), Decl(expressionPropertyLookupIncludesMixins.ts, 9, 1))
+>Mixin : Symbol(Mixin, Decl(expressionPropertyLookupIncludesMixins.ts, 3, 69))
+>Box : Symbol(Box, Decl(expressionPropertyLookupIncludesMixins.ts, 6, 12), Decl(expressionPropertyLookupIncludesMixins.ts, 9, 1))
+
+export const Observable = <T extends AnyConstructor<object>>(base : T) =>
+>Observable : Symbol(Observable, Decl(expressionPropertyLookupIncludesMixins.ts, 12, 12), Decl(expressionPropertyLookupIncludesMixins.ts, 17, 1))
+>T : Symbol(T, Decl(expressionPropertyLookupIncludesMixins.ts, 12, 27))
+>AnyConstructor : Symbol(AnyConstructor, Decl(expressionPropertyLookupIncludesMixins.ts, 2, 65))
+>base : Symbol(base, Decl(expressionPropertyLookupIncludesMixins.ts, 12, 61))
+>T : Symbol(T, Decl(expressionPropertyLookupIncludesMixins.ts, 12, 27))
+
+class Observable extends base {
+>Observable : Symbol(Observable, Decl(expressionPropertyLookupIncludesMixins.ts, 12, 73))
+>base : Symbol(base, Decl(expressionPropertyLookupIncludesMixins.ts, 12, 61))
+
+    observe () : IQuark {
+>observe : Symbol(Observable.observe, Decl(expressionPropertyLookupIncludesMixins.ts, 13, 31))
+>IQuark : Symbol(IQuark, Decl(expressionPropertyLookupIncludesMixins.ts, 30, 1))
+
+        return
+    }
+}
+export interface Observable extends Mixin<typeof Observable> {}
+>Observable : Symbol(Observable, Decl(expressionPropertyLookupIncludesMixins.ts, 12, 12), Decl(expressionPropertyLookupIncludesMixins.ts, 17, 1))
+>Mixin : Symbol(Mixin, Decl(expressionPropertyLookupIncludesMixins.ts, 3, 69))
+>Observable : Symbol(Observable, Decl(expressionPropertyLookupIncludesMixins.ts, 12, 12), Decl(expressionPropertyLookupIncludesMixins.ts, 17, 1))
+
+export const CQuark = <T extends AnyConstructor<Box & Observable>>(base : T) =>
+>CQuark : Symbol(CQuark, Decl(expressionPropertyLookupIncludesMixins.ts, 20, 12))
+>T : Symbol(T, Decl(expressionPropertyLookupIncludesMixins.ts, 20, 23))
+>AnyConstructor : Symbol(AnyConstructor, Decl(expressionPropertyLookupIncludesMixins.ts, 2, 65))
+>Box : Symbol(Box, Decl(expressionPropertyLookupIncludesMixins.ts, 6, 12), Decl(expressionPropertyLookupIncludesMixins.ts, 9, 1))
+>Observable : Symbol(Observable, Decl(expressionPropertyLookupIncludesMixins.ts, 12, 12), Decl(expressionPropertyLookupIncludesMixins.ts, 17, 1))
+>base : Symbol(base, Decl(expressionPropertyLookupIncludesMixins.ts, 20, 67))
+>T : Symbol(T, Decl(expressionPropertyLookupIncludesMixins.ts, 20, 23))
+
+class Quark extends base {
+>Quark : Symbol(Quark, Decl(expressionPropertyLookupIncludesMixins.ts, 20, 79))
+>base : Symbol(base, Decl(expressionPropertyLookupIncludesMixins.ts, 20, 67))
+
+    observe () : Quark {
+>observe : Symbol(Quark.observe, Decl(expressionPropertyLookupIncludesMixins.ts, 21, 26))
+>Quark : Symbol(Quark, Decl(expressionPropertyLookupIncludesMixins.ts, 20, 79))
+
+        // No error here!
+        this.value
+>this.value : Symbol(Box.value, Decl(expressionPropertyLookupIncludesMixins.ts, 7, 24))
+>this : Symbol(Quark, Decl(expressionPropertyLookupIncludesMixins.ts, 20, 79))
+>value : Symbol(Box.value, Decl(expressionPropertyLookupIncludesMixins.ts, 7, 24))
+        
+        
+        return
+    }
+}
+export interface IQuark extends Mixin<typeof CQuark> {}
+>IQuark : Symbol(IQuark, Decl(expressionPropertyLookupIncludesMixins.ts, 30, 1))
+>Mixin : Symbol(Mixin, Decl(expressionPropertyLookupIncludesMixins.ts, 3, 69))
+>CQuark : Symbol(CQuark, Decl(expressionPropertyLookupIncludesMixins.ts, 20, 12))
+
+const test = (a : IQuark) => a.value // <-- Should not error
+>test : Symbol(test, Decl(expressionPropertyLookupIncludesMixins.ts, 33, 5))
+>a : Symbol(a, Decl(expressionPropertyLookupIncludesMixins.ts, 33, 14))
+>IQuark : Symbol(IQuark, Decl(expressionPropertyLookupIncludesMixins.ts, 30, 1))
+>a.value : Symbol(Box.value, Decl(expressionPropertyLookupIncludesMixins.ts, 7, 24))
+>a : Symbol(a, Decl(expressionPropertyLookupIncludesMixins.ts, 33, 14))
+>value : Symbol(Box.value, Decl(expressionPropertyLookupIncludesMixins.ts, 7, 24))
+

--- a/tests/baselines/reference/expressionPropertyLookupIncludesMixins.types
+++ b/tests/baselines/reference/expressionPropertyLookupIncludesMixins.types
@@ -1,0 +1,83 @@
+=== tests/cases/compiler/expressionPropertyLookupIncludesMixins.ts ===
+// https://github.com/microsoft/TypeScript/issues/31426
+
+export type AnyFunction<A = any>        = (...input : any[]) => A
+>AnyFunction : AnyFunction<A>
+>input : any[]
+
+export type AnyConstructor<A = object>  = new (...input : any[]) => A
+>AnyConstructor : AnyConstructor<A>
+>input : any[]
+
+export type Mixin<T extends AnyFunction> = InstanceType<ReturnType<T>>
+>Mixin : InstanceType<ReturnType<T>>
+
+export const Box = <T extends AnyConstructor<object>>(base : T) =>
+>Box : <T extends AnyConstructor<object>>(base: T) => { new (...input: any[]): Box; prototype: Box<any>.Box; } & T
+><T extends AnyConstructor<object>>(base : T) =>class Box extends base {    value       : any} : <T extends AnyConstructor<object>>(base: T) => { new (...input: any[]): Box; prototype: Box<any>.Box; } & T
+>base : T
+
+class Box extends base {
+>class Box extends base {    value       : any} : { new (...input: any[]): Box; prototype: Box<any>.Box; } & T
+>Box : { new (...input: any[]): Box; prototype: Box<any>.Box; } & T
+>base : object
+
+    value       : any
+>value : any
+}
+export interface Box extends Mixin<typeof Box> {}
+>Box : <T extends AnyConstructor<object>>(base: T) => { new (...input: any[]): Box; prototype: Box<any>.Box; } & T
+
+export const Observable = <T extends AnyConstructor<object>>(base : T) =>
+>Observable : <T extends AnyConstructor<object>>(base: T) => { new (...input: any[]): Observable; prototype: Observable<any>.Observable; } & T
+><T extends AnyConstructor<object>>(base : T) =>class Observable extends base {    observe () : IQuark {        return    }} : <T extends AnyConstructor<object>>(base: T) => { new (...input: any[]): Observable; prototype: Observable<any>.Observable; } & T
+>base : T
+
+class Observable extends base {
+>class Observable extends base {    observe () : IQuark {        return    }} : { new (...input: any[]): Observable; prototype: Observable<any>.Observable; } & T
+>Observable : { new (...input: any[]): Observable; prototype: Observable<any>.Observable; } & T
+>base : object
+
+    observe () : IQuark {
+>observe : () => IQuark
+
+        return
+    }
+}
+export interface Observable extends Mixin<typeof Observable> {}
+>Observable : <T extends AnyConstructor<object>>(base: T) => { new (...input: any[]): Observable; prototype: Observable<any>.Observable; } & T
+
+export const CQuark = <T extends AnyConstructor<Box & Observable>>(base : T) =>
+>CQuark : <T extends AnyConstructor<Box & Observable>>(base: T) => { new (...input: any[]): Quark; prototype: CQuark<any>.Quark; } & T
+><T extends AnyConstructor<Box & Observable>>(base : T) =>class Quark extends base {    observe () : Quark {        // No error here!        this.value                        return    }} : <T extends AnyConstructor<Box & Observable>>(base: T) => { new (...input: any[]): Quark; prototype: CQuark<any>.Quark; } & T
+>base : T
+
+class Quark extends base {
+>class Quark extends base {    observe () : Quark {        // No error here!        this.value                        return    }} : { new (...input: any[]): Quark; prototype: CQuark<any>.Quark; } & T
+>Quark : { new (...input: any[]): Quark; prototype: CQuark<any>.Quark; } & T
+>base : Box & Observable
+
+    observe () : Quark {
+>observe : () => Quark
+
+        // No error here!
+        this.value
+>this.value : any
+>this : this
+>value : any
+        
+        
+        return
+    }
+}
+export interface IQuark extends Mixin<typeof CQuark> {}
+>CQuark : <T extends AnyConstructor<Box & Observable>>(base: T) => { new (...input: any[]): Quark; prototype: CQuark<any>.Quark; } & T
+
+const test = (a : IQuark) => a.value // <-- Should not error
+>test : (a: IQuark) => any
+>(a : IQuark) => a.value : (a: IQuark) => any
+>a : IQuark
+>a.value : any
+>a : IQuark
+>value : any
+

--- a/tests/cases/compiler/expressionPropertyLookupIncludesMixins.ts
+++ b/tests/cases/compiler/expressionPropertyLookupIncludesMixins.ts
@@ -1,0 +1,34 @@
+// https://github.com/microsoft/TypeScript/issues/31426
+
+export type AnyFunction<A = any>        = (...input : any[]) => A
+export type AnyConstructor<A = object>  = new (...input : any[]) => A
+export type Mixin<T extends AnyFunction> = InstanceType<ReturnType<T>>
+
+export const Box = <T extends AnyConstructor<object>>(base : T) =>
+class Box extends base {
+    value       : any
+}
+export interface Box extends Mixin<typeof Box> {}
+
+export const Observable = <T extends AnyConstructor<object>>(base : T) =>
+class Observable extends base {
+    observe () : IQuark {
+        return
+    }
+}
+export interface Observable extends Mixin<typeof Observable> {}
+
+export const CQuark = <T extends AnyConstructor<Box & Observable>>(base : T) =>
+class Quark extends base {
+
+    observe () : Quark {
+        // No error here!
+        this.value
+        
+        
+        return
+    }
+}
+export interface IQuark extends Mixin<typeof CQuark> {}
+
+const test = (a : IQuark) => a.value // <-- Should not error


### PR DESCRIPTION
Fixes #31426

I could see via a repl that:

```ts
getPropertyOfType(apparentType.getBaseTypes()[0], right.escapedText);
```

would return the right property, but at this point it was returning nothing. I couldn't find a way to  convert my `Type` into an `InterfaceType` and so I  built a helper to get towards having access to `.getBaseTypes`. From there it adds the extra checks. 