### PR TITLE
Better outlining spans for prototype methods

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -300,22 +300,25 @@ namespace ts.NavigationBar {
                     case AssignmentDeclarationKind.Prototype: {
                         const binaryExpression = (node as BinaryExpression);
                         const assignmentTarget = binaryExpression.left as PropertyAccessExpression;
-                        const prototypeAccess = assignmentTarget.expression as PropertyAccessExpression;
-                        // If we see a prototype assignment, start tracking the target as a class
-                        if (isIdentifier(prototypeAccess.expression)) {
-                            addTrackedEs5Class(prototypeAccess.expression.text);
+                        if (isPropertyAccessExpression(assignmentTarget.expression)) {
+                            const prototypeAccess = assignmentTarget.expression;
+                            // If we see a prototype assignment, start tracking the target as a class
+                            if (isIdentifier(prototypeAccess.expression)) {
+                                addTrackedEs5Class(prototypeAccess.expression.text);
+                            }
+                            if (isFunctionExpression(binaryExpression.right) || isArrowFunction(binaryExpression.right)) {
+                                addNodeWithRecursiveChild(node,
+                                    binaryExpression.right,
+                                    prototypeAccess.expression as Identifier);
+                            }
+                            else {
+                                startNode(binaryExpression, prototypeAccess.expression as Identifier);
+                                    addNodeWithRecursiveChild(node, binaryExpression.right, assignmentTarget.name);
+                                endNode();
+                            }
+                            return;
                         }
-                        if (isFunctionExpression(binaryExpression.right) || isArrowFunction(binaryExpression.right)) {
-                            addNodeWithRecursiveChild(node,
-                                binaryExpression.right,
-                                prototypeAccess.expression as Identifier);
-                        }
-                        else {
-                            startNode(binaryExpression, prototypeAccess.expression as Identifier);
-                                addNodeWithRecursiveChild(node, binaryExpression.right, assignmentTarget.name);
-                            endNode();
-                        }
-                        return;
+                        break;
                     }
                     case AssignmentDeclarationKind.ObjectDefinePropertyValue:
                     case AssignmentDeclarationKind.ObjectDefinePrototypeProperty: {

--- a/tests/cases/fourslash/navigationBarFunctionPrototype.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype.ts
@@ -10,7 +10,7 @@
 ////    get: function(){
 ////    } 
 ////});
-////Object.defineProperty(f, 'name', { 
+////Object.defineProperty(f.prototype, 'name', { 
 ////    set: function() {}, 
 ////    get: function(){
 ////    } 
@@ -29,21 +29,15 @@ verify.navigationTree({
                     "kind": "constructor"
                 },
                 {
-                    "text": "method",
-                    "kind": "function"
+                    "text": "x",
+                    "kind": "property"
                 },
                 {
-                    "text": "name",
-                    "childItems": [
-                        {
-                            "text": "get",
-                            "kind": "function"
-                        },
-                        {
-                            "text": "set",
-                            "kind": "function"
-                        }
-                    ]
+                    "text": "y"
+                },
+                {
+                    "text": "method",
+                    "kind": "function"
                 },
                 {
                     "text": "staticProp",
@@ -59,11 +53,17 @@ verify.navigationTree({
                     ]
                 },
                 {
-                    "text": "x",
-                    "kind": "property"
-                },
-                {
-                    "text": "y"
+                    "text": "name",
+                    "childItems": [
+                        {
+                            "text": "get",
+                            "kind": "function"
+                        },
+                        {
+                            "text": "set",
+                            "kind": "function"
+                        }
+                    ]
                 }
             ]
         }
@@ -90,21 +90,21 @@ verify.navigationBar([
                 "kind": "constructor"
             },
             {
-                "text": "method",
-                "kind": "function"
-            },
-            {
-                "text": "name"
-            },
-            {
-                "text": "staticProp"
-            },
-            {
                 "text": "x",
                 "kind": "property"
             },
             {
                 "text": "y"
+            },
+            {
+                "text": "method",
+                "kind": "function"
+            },
+            {
+                "text": "staticProp"
+            },
+            {
+                "text": "name"
             }
         ],
         "indent": 1

--- a/tests/cases/fourslash/navigationBarFunctionPrototype.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype.ts
@@ -3,6 +3,17 @@
 // @Filename: foo.js
 ////function f() {}
 ////f.prototype.x = 0;
+////f.prototype.method = function () {};
+////Object.defineProperty(f, 'staticProp', { 
+////    set: function() {}, 
+////    get: function(){
+////    } 
+////});
+////Object.defineProperty(f, 'name', { 
+////    set: function() {}, 
+////    get: function(){
+////    } 
+////}); 
 
 verify.navigationTree({
     "text": "<global>",
@@ -10,11 +21,47 @@ verify.navigationTree({
     "childItems": [
         {
             "text": "f",
-            "kind": "function"
-        },
-        {
-            "text": "x",
-            "kind": "property"
+            "kind": "class",
+            "childItems": [
+                {
+                    "text": "constructor",
+                    "kind": "constructor"
+                },
+                {
+                    "text": "method",
+                    "kind": "function"
+                },
+                {
+                    "text": "name",
+                    "childItems": [
+                        {
+                            "text": "get",
+                            "kind": "function"
+                        },
+                        {
+                            "text": "set",
+                            "kind": "function"
+                        }
+                    ]
+                },
+                {
+                    "text": "staticProp",
+                    "childItems": [
+                        {
+                            "text": "get",
+                            "kind": "function"
+                        },
+                        {
+                            "text": "set",
+                            "kind": "function"
+                        }
+                    ]
+                },
+                {
+                    "text": "x",
+                    "kind": "property"
+                }
+            ]
         }
     ]
 });
@@ -26,17 +73,33 @@ verify.navigationBar([
         "childItems": [
             {
                 "text": "f",
-                "kind": "function"
-            },
-            {
-                "text": "x",
-                "kind": "property"
+                "kind": "class"
             }
         ]
     },
     {
         "text": "f",
-        "kind": "function",
+        "kind": "class",
+        "childItems": [
+            {
+                "text": "constructor",
+                "kind": "constructor"
+            },
+            {
+                "text": "method",
+                "kind": "function"
+            },
+            {
+                "text": "name"
+            },
+            {
+                "text": "staticProp"
+            },
+            {
+                "text": "x",
+                "kind": "property"
+            }
+        ],
         "indent": 1
     }
 ]);

--- a/tests/cases/fourslash/navigationBarFunctionPrototype.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype.ts
@@ -3,6 +3,7 @@
 // @Filename: foo.js
 ////function f() {}
 ////f.prototype.x = 0;
+////f.y = 0;
 ////f.prototype.method = function () {};
 ////Object.defineProperty(f, 'staticProp', { 
 ////    set: function() {}, 
@@ -60,6 +61,9 @@ verify.navigationTree({
                 {
                     "text": "x",
                     "kind": "property"
+                },
+                {
+                    "text": "y"
                 }
             ]
         }
@@ -98,6 +102,9 @@ verify.navigationBar([
             {
                 "text": "x",
                 "kind": "property"
+            },
+            {
+                "text": "y"
             }
         ],
         "indent": 1

--- a/tests/cases/fourslash/navigationBarFunctionPrototype2.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype2.ts
@@ -1,0 +1,64 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: foo.js
+
+////A.prototype.a = function() { };
+////A.prototype.b = function() { };
+////function A() {}
+
+verify.navigationTree({
+  "text": "<global>",
+  "kind": "script",
+  "childItems": [
+    {
+      "text": "A",
+      "kind": "class",
+      "childItems": [
+        {
+          "text": "a",
+          "kind": "function"
+        },
+        {
+          "text": "b",
+          "kind": "function"
+        },
+        {
+          "text": "constructor",
+          "kind": "constructor"
+        }
+      ]
+    }
+  ]
+});
+
+verify.navigationBar([
+  {
+    "text": "<global>",
+    "kind": "script",
+    "childItems": [
+      {
+        "text": "A",
+        "kind": "class"
+      }
+    ]
+  },
+  {
+    "text": "A",
+    "kind": "class",
+    "childItems": [
+      {
+        "text": "a",
+        "kind": "function"
+      },
+      {
+        "text": "b",
+        "kind": "function"
+      },
+      {
+        "text": "constructor",
+        "kind": "constructor"
+      }
+    ],
+    "indent": 1
+  }
+]);

--- a/tests/cases/fourslash/navigationBarFunctionPrototype3.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype3.ts
@@ -1,0 +1,64 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: foo.js
+
+////var A; 
+////A.prototype.a = function() { };
+////A.b = function() { };
+
+verify.navigationTree({
+  "text": "<global>",
+  "kind": "script",
+  "childItems": [
+    {
+      "text": "A",
+      "kind": "class",
+      "childItems": [
+        {
+          "text": "constructor",
+          "kind": "constructor"
+        },
+        {
+          "text": "a",
+          "kind": "function"
+        },
+        {
+          "text": "b",
+          "kind": "function"
+        }
+      ]
+    }
+  ]
+});
+
+verify.navigationBar([
+  {
+    "text": "<global>",
+    "kind": "script",
+    "childItems": [
+      {
+        "text": "A",
+        "kind": "class"
+      }
+    ]
+  },
+  {
+    "text": "A",
+    "kind": "class",
+    "childItems": [
+      {
+        "text": "constructor",
+        "kind": "constructor"
+      },
+      {
+        "text": "a",
+        "kind": "function"
+      },
+      {
+        "text": "b",
+        "kind": "function"
+      }
+    ],
+    "indent": 1
+  }
+]);

--- a/tests/cases/fourslash/navigationBarFunctionPrototype4.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype4.ts
@@ -1,0 +1,64 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: foo.js
+
+////var A; 
+////A.prototype.a = function() { };
+////A.b = function() { };
+
+verify.navigationTree({
+  "text": "<global>",
+  "kind": "script",
+  "childItems": [
+    {
+      "text": "A",
+      "kind": "class",
+      "childItems": [
+        {
+          "text": "constructor",
+          "kind": "constructor"
+        },
+        {
+          "text": "a",
+          "kind": "function"
+        },
+        {
+          "text": "b",
+          "kind": "function"
+        }
+      ]
+    }
+  ]
+});
+
+verify.navigationBar([
+  {
+    "text": "<global>",
+    "kind": "script",
+    "childItems": [
+      {
+        "text": "A",
+        "kind": "class"
+      }
+    ]
+  },
+  {
+    "text": "A",
+    "kind": "class",
+    "childItems": [
+      {
+        "text": "constructor",
+        "kind": "constructor"
+      },
+      {
+        "text": "a",
+        "kind": "function"
+      },
+      {
+        "text": "b",
+        "kind": "function"
+      }
+    ],
+    "indent": 1
+  }
+]);

--- a/tests/cases/fourslash/navigationBarFunctionPrototype4.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype4.ts
@@ -4,6 +4,7 @@
 
 ////var A; 
 ////A.prototype = { };
+////A.prototype = { m() {} };
 ////A.prototype.a = function() { };
 ////A.b = function() { };
 
@@ -18,6 +19,10 @@ verify.navigationTree({
         {
           "text": "constructor",
           "kind": "constructor"
+        },
+        {
+          "text": "m",
+          "kind": "method"
         },
         {
           "text": "a",
@@ -50,6 +55,10 @@ verify.navigationBar([
       {
         "text": "constructor",
         "kind": "constructor"
+      },
+      {
+        "text": "m",
+        "kind": "method"
       },
       {
         "text": "a",

--- a/tests/cases/fourslash/navigationBarFunctionPrototype4.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype4.ts
@@ -3,6 +3,7 @@
 // @Filename: foo.js
 
 ////var A; 
+////A.prototype = { };
 ////A.prototype.a = function() { };
 ////A.b = function() { };
 

--- a/tests/cases/fourslash/navigationBarFunctionPrototypeBroken.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototypeBroken.ts
@@ -1,0 +1,156 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: foo.js
+
+////function A() {}
+////A. // Started typing something here
+////A.prototype.a = function() { };
+////G. // Started typing something here
+////A.prototype.a = function() { };
+
+verify.navigationTree({
+  "text": "<global>",
+  "kind": "script",
+  "spans": [
+    {
+      "start": 0,
+      "length": 151
+    }
+  ],
+  "childItems": [
+    {
+      "text": "G",
+      "kind": "method",
+      "spans": [
+        {
+          "start": 84,
+          "length": 66
+        }
+      ],
+      "nameSpan": {
+        "start": 84,
+        "length": 1
+      },
+      "childItems": [
+        {
+          "text": "A",
+          "kind": "method",
+          "spans": [
+            {
+              "start": 84,
+              "length": 66
+            }
+          ],
+          "nameSpan": {
+            "start": 120,
+            "length": 1
+          },
+          "childItems": [
+            {
+              "text": "a",
+              "kind": "function",
+              "spans": [
+                {
+                  "start": 136,
+                  "length": 14
+                }
+              ],
+              "nameSpan": {
+                "start": 132,
+                "length": 1
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "text": "A",
+      "kind": "class",
+      "spans": [
+        {
+          "start": 0,
+          "length": 82
+        }
+      ],
+      "nameSpan": {
+        "start": 9,
+        "length": 1
+      },
+      "childItems": [
+        {
+          "text": "constructor",
+          "kind": "constructor",
+          "spans": [
+            {
+              "start": 0,
+              "length": 15
+            }
+          ]
+        },
+        {
+          "text": "A",
+          "kind": "method",
+          "spans": [
+            {
+              "start": 16,
+              "length": 66
+            }
+          ],
+          "nameSpan": {
+            "start": 52,
+            "length": 1
+          },
+          "childItems": [
+            {
+              "text": "a",
+              "kind": "function",
+              "spans": [
+                {
+                  "start": 68,
+                  "length": 14
+                }
+              ],
+              "nameSpan": {
+                "start": 64,
+                "length": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}, { checkSpans: true });
+
+verify.navigationBar([
+  {
+    "text": "<global>",
+    "kind": "script",
+    "childItems": [
+      {
+        "text": "G",
+        "kind": "method"
+      },
+      {
+        "text": "A",
+        "kind": "class"
+      }
+    ]
+  },
+  {
+    "text": "A",
+    "kind": "class",
+    "childItems": [
+      {
+        "text": "constructor",
+        "kind": "constructor"
+      },
+      {
+        "text": "A",
+        "kind": "method"
+      }
+    ],
+    "indent": 1
+  }
+]);

--- a/tests/cases/fourslash/navigationBarFunctionPrototypeInterlaced.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototypeInterlaced.ts
@@ -1,0 +1,188 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: foo.js
+
+////var b = 1;
+////function A() {}; 
+////A.prototype.a = function() { };
+////A.b = function() { };
+////b = 2
+/////* Comment */
+////A.prototype.c = function() { }
+////var b = 2
+////A.prototype.d = function() { }
+
+verify.navigationTree({
+  "text": "<global>",
+  "kind": "script",
+  "spans": [
+    {
+      "start": 0,
+      "length": 174
+    }
+  ],
+  "childItems": [
+    {
+      "text": "A",
+      "kind": "class",
+      "spans": [
+        {
+          "start": 11,
+          "length": 122
+        },
+        {
+          "start": 144,
+          "length": 30
+        }
+      ],
+      "nameSpan": {
+        "start": 20,
+        "length": 1
+      },
+      "childItems": [
+        {
+          "text": "constructor",
+          "kind": "constructor",
+          "spans": [
+            {
+              "start": 11,
+              "length": 15
+            }
+          ]
+        },
+        {
+          "text": "a",
+          "kind": "function",
+          "spans": [
+            {
+              "start": 45,
+              "length": 14
+            }
+          ],
+          "nameSpan": {
+            "start": 41,
+            "length": 1
+          }
+        },
+        {
+          "text": "b",
+          "kind": "function",
+          "spans": [
+            {
+              "start": 67,
+              "length": 14
+            }
+          ],
+          "nameSpan": {
+            "start": 63,
+            "length": 1
+          }
+        },
+        {
+          "text": "c",
+          "kind": "function",
+          "spans": [
+            {
+              "start": 119,
+              "length": 14
+            }
+          ],
+          "nameSpan": {
+            "start": 115,
+            "length": 1
+          }
+        },
+        {
+          "text": "d",
+          "kind": "function",
+          "spans": [
+            {
+              "start": 160,
+              "length": 14
+            }
+          ],
+          "nameSpan": {
+            "start": 156,
+            "length": 1
+          }
+        }
+      ]
+    },
+    {
+      "text": "b",
+      "kind": "var",
+      "spans": [
+        {
+          "start": 4,
+          "length": 5
+        }
+      ],
+      "nameSpan": {
+        "start": 4,
+        "length": 1
+      }
+    },
+    {
+      "text": "b",
+      "kind": "var",
+      "spans": [
+        {
+          "start": 138,
+          "length": 5
+        }
+      ],
+      "nameSpan": {
+        "start": 138,
+        "length": 1
+      }
+    }
+  ]
+}, { checkSpans: true });
+
+verify.navigationBar([
+  {
+    "text": "<global>",
+    "kind": "script",
+    "childItems": [
+      {
+        "text": "A",
+        "kind": "class"
+      },
+      {
+        "text": "b",
+        "kind": "var"
+      },
+      {
+        "text": "b",
+        "kind": "var"
+      }
+    ]
+  },
+  {
+    "text": "A",
+    "kind": "class",
+    "childItems":  [
+      {
+        "text": "constructor",
+        "kind": "constructor"
+      },
+      {
+        "text": "a",
+        "kind": "function"
+      },
+      {
+        "text": "b",
+        "kind": "function"
+      },
+      {
+        "text": "c",
+        "kind": "function"
+      },
+      {
+        "text": "d",
+        "kind": "function"
+      }
+    ],
+    "indent": 1
+  }
+]);

--- a/tests/cases/fourslash/navigationBarFunctionPrototypeNested.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototypeNested.ts
@@ -1,0 +1,226 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: foo.js
+
+////function A() {}
+////A.B = function () {  } 
+////A.B.prototype.d = function () {  }  
+////Object.defineProperty(A.B.prototype, "x", {
+////    get() {}
+////})
+////A.prototype.D = function () {  } 
+////A.prototype.D.prototype.d = function () {  } 
+
+
+verify.navigationTree({
+  "text": "<global>",
+  "kind": "script",
+  "spans": [
+    {
+      "start": 0,
+      "length": 216
+    }
+  ],
+  "childItems": [
+    {
+      "text": "A",
+      "kind": "class",
+      "spans": [
+        {
+          "start": 0,
+          "length": 215
+        }
+      ],
+      "nameSpan": {
+        "start": 9,
+        "length": 1
+      },
+      "childItems": [
+        {
+          "text": "constructor",
+          "kind": "constructor",
+          "spans": [
+            {
+              "start": 0,
+              "length": 15
+            }
+          ]
+        },
+        {
+          "text": "B",
+          "kind": "class",
+          "spans": [
+            {
+              "start": 22,
+              "length": 114
+            }
+          ],
+          "nameSpan": {
+            "start": 18,
+            "length": 1
+          },
+          "childItems": [
+            {
+              "text": "constructor",
+              "kind": "constructor",
+              "spans": [
+                {
+                  "start": 22,
+                  "length": 16
+                }
+              ]
+            },
+            {
+              "text": "d",
+              "kind": "function",
+              "spans": [
+                {
+                  "start": 58,
+                  "length": 16
+                }
+              ],
+              "nameSpan": {
+                "start": 54,
+                "length": 1
+              }
+            },
+            {
+              "text": "x",
+              "spans": [
+                {
+                  "start": 77,
+                  "length": 59
+                }
+              ],
+              "nameSpan": {
+                "start": 114,
+                "length": 3
+              },
+              "childItems": [
+                {
+                  "text": "get",
+                  "kind": "method",
+                  "spans": [
+                    {
+                      "start": 125,
+                      "length": 8
+                    }
+                  ],
+                  "nameSpan": {
+                    "start": 125,
+                    "length": 3
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "text": "D",
+          "kind": "class",
+          "spans": [
+            {
+              "start": 153,
+              "length": 62
+            }
+          ],
+          "nameSpan": {
+            "start": 149,
+            "length": 1
+          },
+          "childItems": [
+            {
+              "text": "constructor",
+              "kind": "constructor",
+              "spans": [
+                {
+                  "start": 153,
+                  "length": 16
+                }
+              ]
+            },
+            {
+              "text": "d",
+              "kind": "function",
+              "spans": [
+                {
+                  "start": 199,
+                  "length": 16
+                }
+              ],
+              "nameSpan": {
+                "start": 195,
+                "length": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}, { checkSpans: true });
+
+verify.navigationBar([
+  {
+    "text": "<global>",
+    "kind": "script",
+    "childItems": [
+      {
+        "text": "A",
+        "kind": "class"
+      }
+    ]
+  },
+  {
+    "text": "A",
+    "kind": "class",
+    "childItems": [
+      {
+        "text": "constructor",
+        "kind": "constructor"
+      },
+      {
+        "text": "B",
+        "kind": "class"
+      },
+      {
+        "text": "D",
+        "kind": "class"
+      }
+    ],
+    "indent": 1
+  },
+  {
+    "text": "B",
+    "kind": "class",
+    "childItems": [
+      {
+        "text": "constructor",
+        "kind": "constructor"
+      },
+      {
+        "text": "d",
+        "kind": "function"
+      },
+      {
+        "text": "x"
+      }
+    ],
+    "indent": 2
+  },
+  {
+    "text": "D",
+    "kind": "class",
+    "childItems": [
+      {
+        "text": "constructor",
+        "kind": "constructor"
+      },
+      {
+        "text": "d",
+        "kind": "function"
+      }
+    ],
+    "indent": 2
+  }
+]);


### PR DESCRIPTION
Fixes #31516

Hi @DanielRosenwasser, @amcasey

I know it's been a while since i said I would have a look at this, but I finally got around to finishing the implementation for this.
First the good news, this is what an ES5 class looks like now:

![image](https://user-images.githubusercontent.com/8193316/62794764-97dea380-badd-11e9-87b3-40778a0f4b5c.png)

Now for the problems:
1. The implementation in VS code for outline view takes into account the node ranges returned when deciding how to display children. This means that the generated class node needs to encompass all the class members, otherwise the child nodes will not be displayed. This is fine if the members are contiguous, however it generates problems if there are other definitions between the members. The only ill effect I can see is that errors on these other definitions are displayed on the enclosing class.

![image](https://user-images.githubusercontent.com/8193316/62794811-bb095300-badd-11e9-8e45-303be17e0405.png)

I see some options: 
a. Do nothing, the outline looks nice, although the bug report about this kind of writes itself
b. Create multiple additional spans for the class if the members are not contiguous. This is probably the best option but it can end up splitting up the class outline node:
![image](https://user-images.githubusercontent.com/8193316/62795121-aa0d1180-bade-11e9-9768-9b48f1219b26.png)

c. Include any extra node in the class outline, maybe marking them in some distinctive way (although I am not sure what that would look like, and it would be kind of confusing)
d. Change the way errors are matched with outline nodes in VS-Code (probably a bigger change than we want to make for this feature)

2. Class static members. I tried to add to the outline view assignments that occur directly on the constructor (ie. static members) but ran into a problem. 

Given assignments of the form 
```ts
A.v = 1;
A.a = function() { };
```
It is impossible to tell without using the type checker, if the assignments will need to become static members on a class named `A` or they are just regular assignments. One option would be to keep all such assignments and remove them from the outline during the merging of outline nodes. This could end up creating a lot of extra nodes. My solution to limit the number of generated nodes was to track any found classes in the current scope, and only add nodes for the assignments above if a class like definition `A` was found in the current scope. `A` is considered a class like definition if a function `A` is declared, or if a something was already assigned to the prototype of `A` :

```ts
function A() { }
A.v = 1;
A.a = function() { };
```
![image](https://user-images.githubusercontent.com/8193316/62794587-21da3c80-badd-11e9-8dce-3adb594986db.png)

I do not search the scope before-hand, but rather mark the class when I find it, this does mean that if static members are assigned before I mark the class they do not appear in the outline as part of the class:
![image](https://user-images.githubusercontent.com/8193316/62796739-98c60400-bae2-11e9-9919-11afa4cd0ca6.png)

The alternative might be to not add these members at all.

3. If two or more nodes can be merged a class will be generated, however if there is just one node there is a change in what is displayed but I think it's for the better:
![image](https://user-images.githubusercontent.com/8193316/62795189-d9bc1980-bade-11e9-8398-1087dae8db1d.png)
