### PR TITLE
Allow accessors in ambient class declarations

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -243,10 +243,6 @@
         "category": "Error",
         "code": 1085
     },
-    "An accessor cannot be declared in an ambient context.": {
-        "category": "Error",
-        "code": 1086
-    },
     "'{0}' modifier cannot appear on a constructor declaration.": {
         "category": "Error",
         "code": 1089

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -393,7 +393,7 @@ namespace ts {
             }
         }
 
-        function ensureParameter(p: ParameterDeclaration, modifierMask?: ModifierFlags): ParameterDeclaration {
+        function ensureParameter(p: ParameterDeclaration, modifierMask?: ModifierFlags, type?: TypeNode): ParameterDeclaration {
             let oldDiag: typeof getSymbolAccessibilityDiagnostic | undefined;
             if (!suppressNewDiagnosticContexts) {
                 oldDiag = getSymbolAccessibilityDiagnostic;
@@ -406,7 +406,7 @@ namespace ts {
                 p.dotDotDotToken,
                 filterBindingPatternInitializers(p.name),
                 resolver.isOptionalParameter(p) ? (p.questionToken || createToken(SyntaxKind.QuestionToken)) : undefined,
-                ensureType(p, p.type, /*ignorePrivate*/ true), // Ignore private param props, since this type is going straight back into a param
+                type || ensureType(p, p.type, /*ignorePrivate*/ true), // Ignore private param props, since this type is going straight back into a param
                 ensureNoInitializer(p)
             );
             if (!suppressNewDiagnosticContexts) {
@@ -533,6 +533,36 @@ namespace ts {
                 return undefined!; // TODO: GH#18217
             }
             return createNodeArray(newParams, params.hasTrailingComma);
+        }
+
+        function updateAccessorParamsList(input: AccessorDeclaration, isPrivate: boolean) {
+            let newParams: ParameterDeclaration[] | undefined;
+            if (!isPrivate) {
+                const thisParameter = getThisParameter(input);
+                if (thisParameter) {
+                    newParams = [ensureParameter(thisParameter)];
+                }
+            }
+            if (isSetAccessorDeclaration(input)) {
+                let newValueParameter: ParameterDeclaration | undefined;
+                if (!isPrivate) {
+                    const valueParameter = getSetAccessorValueParameter(input);
+                    if (valueParameter) {
+                        const accessorType = getTypeAnnotationFromAllAccessorDeclarations(input, resolver.getAllAccessorDeclarations(input));
+                        newValueParameter = ensureParameter(valueParameter, /*modifierMask*/ undefined, accessorType);
+                    }
+                }
+                if (!newValueParameter) {
+                    newValueParameter = createParameter(
+                        /*decorators*/ undefined,
+                        /*modifiers*/ undefined,
+                        /*dotDotDotToken*/ undefined,
+                        "value"
+                    );
+                }
+                newParams = append(newParams, newValueParameter);
+            }
+            return createNodeArray(newParams || emptyArray) as NodeArray<ParameterDeclaration>;
         }
 
         function ensureTypeParams(node: Node, params: NodeArray<TypeParameterDeclaration> | undefined) {
@@ -811,10 +841,33 @@ namespace ts {
                         return cleanup(sig);
                     }
                     case SyntaxKind.GetAccessor: {
+                        // For now, only emit class accessors as accessors if they were already declared in an ambient context.
+                        if (input.flags & NodeFlags.Ambient) {
+                            const isPrivate = hasModifier(input, ModifierFlags.Private);
+                            const accessorType = getTypeAnnotationFromAllAccessorDeclarations(input, resolver.getAllAccessorDeclarations(input));
+                            return cleanup(updateGetAccessor(
+                                input,
+                                /*decorators*/ undefined,
+                                ensureModifiers(input),
+                                input.name,
+                                updateAccessorParamsList(input, isPrivate),
+                                !isPrivate ? ensureType(input, accessorType) : undefined,
+                                /*body*/ undefined));
+                        }
                         const newNode = ensureAccessor(input);
                         return cleanup(newNode);
                     }
                     case SyntaxKind.SetAccessor: {
+                        // For now, only emit class accessors as accessors if they were already declared in an ambient context.
+                        if (input.flags & NodeFlags.Ambient) {
+                            return cleanup(updateSetAccessor(
+                                input,
+                                /*decorators*/ undefined,
+                                ensureModifiers(input),
+                                input.name,
+                                updateAccessorParamsList(input, hasModifier(input, ModifierFlags.Private)),
+                                /*body*/ undefined));
+                        }
                         const newNode = ensureAccessor(input);
                         return cleanup(newNode);
                     }
@@ -1374,17 +1427,27 @@ namespace ts {
             return maskModifierFlags(node, mask, additions);
         }
 
+        function getTypeAnnotationFromAllAccessorDeclarations(node: AccessorDeclaration, accessors: AllAccessorDeclarations) {
+            let accessorType = getTypeAnnotationFromAccessor(node);
+            if (!accessorType && node !== accessors.firstAccessor) {
+                accessorType = getTypeAnnotationFromAccessor(accessors.firstAccessor);
+                // If we end up pulling the type from the second accessor, we also need to change the diagnostic context to get the expected error message
+                getSymbolAccessibilityDiagnostic = createGetSymbolAccessibilityDiagnosticForNode(accessors.firstAccessor);
+            }
+            if (!accessorType && accessors.secondAccessor && node !== accessors.secondAccessor) {
+                accessorType = getTypeAnnotationFromAccessor(accessors.secondAccessor);
+                // If we end up pulling the type from the second accessor, we also need to change the diagnostic context to get the expected error message
+                getSymbolAccessibilityDiagnostic = createGetSymbolAccessibilityDiagnosticForNode(accessors.secondAccessor);
+            }
+            return accessorType;
+        }
+
         function ensureAccessor(node: AccessorDeclaration): PropertyDeclaration | undefined {
             const accessors = resolver.getAllAccessorDeclarations(node);
             if (node.kind !== accessors.firstAccessor.kind) {
                 return;
             }
-            let accessorType = getTypeAnnotationFromAccessor(node);
-            if (!accessorType && accessors.secondAccessor) {
-                accessorType = getTypeAnnotationFromAccessor(accessors.secondAccessor);
-                // If we end up pulling the type from the second accessor, we also need to change the diagnostic context to get the expected error message
-                getSymbolAccessibilityDiagnostic = createGetSymbolAccessibilityDiagnosticForNode(accessors.secondAccessor);
-            }
+            const accessorType = getTypeAnnotationFromAllAccessorDeclarations(node, accessors);
             const prop = createProperty(/*decorators*/ undefined, maskModifiers(node, /*mask*/ undefined, (!accessors.setAccessor) ? ModifierFlags.Readonly : ModifierFlags.None), node.name, node.questionToken, ensureType(node, accessorType), /*initializer*/ undefined);
             const leadingsSyntheticCommentRanges = accessors.secondAccessor && getLeadingCommentRangesOfNode(accessors.secondAccessor, currentSourceFile);
             if (leadingsSyntheticCommentRanges) {

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -406,7 +406,7 @@ namespace ts {
                 p.dotDotDotToken,
                 filterBindingPatternInitializers(p.name),
                 resolver.isOptionalParameter(p) ? (p.questionToken || createToken(SyntaxKind.QuestionToken)) : undefined,
-                type || ensureType(p, p.type, /*ignorePrivate*/ true), // Ignore private param props, since this type is going straight back into a param
+                ensureType(p, type || p.type, /*ignorePrivate*/ true), // Ignore private param props, since this type is going straight back into a param
                 ensureNoInitializer(p)
             );
             if (!suppressNewDiagnosticContexts) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3518,7 +3518,7 @@ namespace ts {
         return find(node.members, (member): member is ConstructorDeclaration & { body: FunctionBody } => isConstructorDeclaration(member) && nodeIsPresent(member.body));
     }
 
-    function getSetAccessorValueParameter(accessor: SetAccessorDeclaration): ParameterDeclaration | undefined {
+    export function getSetAccessorValueParameter(accessor: SetAccessorDeclaration): ParameterDeclaration | undefined {
         if (accessor && accessor.parameters.length > 0) {
             const hasThis = accessor.parameters.length === 2 && parameterIsThisKeyword(accessor.parameters[0]);
             return accessor.parameters[hasThis ? 1 : 0];
@@ -3553,7 +3553,7 @@ namespace ts {
         return id.originalKeywordKind === SyntaxKind.ThisKeyword;
     }
 
-    export function getAllAccessorDeclarations(declarations: NodeArray<Declaration>, accessor: AccessorDeclaration): AllAccessorDeclarations {
+    export function getAllAccessorDeclarations(declarations: readonly Declaration[], accessor: AccessorDeclaration): AllAccessorDeclarations {
         // TODO: GH#18217
         let firstAccessor!: AccessorDeclaration;
         let secondAccessor!: AccessorDeclaration;

--- a/tests/baselines/reference/accessorsInAmbientContext.errors.txt
+++ b/tests/baselines/reference/accessorsInAmbientContext.errors.txt
@@ -1,44 +1,44 @@
-tests/cases/compiler/accessorsInAmbientContext.ts(3,13): error TS1086: An accessor cannot be declared in an ambient context.
-tests/cases/compiler/accessorsInAmbientContext.ts(4,13): error TS1086: An accessor cannot be declared in an ambient context.
-tests/cases/compiler/accessorsInAmbientContext.ts(6,20): error TS1086: An accessor cannot be declared in an ambient context.
-tests/cases/compiler/accessorsInAmbientContext.ts(7,20): error TS1086: An accessor cannot be declared in an ambient context.
-tests/cases/compiler/accessorsInAmbientContext.ts(12,9): error TS1086: An accessor cannot be declared in an ambient context.
-tests/cases/compiler/accessorsInAmbientContext.ts(13,9): error TS1086: An accessor cannot be declared in an ambient context.
-tests/cases/compiler/accessorsInAmbientContext.ts(15,16): error TS1086: An accessor cannot be declared in an ambient context.
-tests/cases/compiler/accessorsInAmbientContext.ts(16,16): error TS1086: An accessor cannot be declared in an ambient context.
+tests/cases/compiler/accessorsInAmbientContext.ts(3,17): error TS1183: An implementation cannot be declared in ambient contexts.
+tests/cases/compiler/accessorsInAmbientContext.ts(4,18): error TS1183: An implementation cannot be declared in ambient contexts.
+tests/cases/compiler/accessorsInAmbientContext.ts(6,24): error TS1183: An implementation cannot be declared in ambient contexts.
+tests/cases/compiler/accessorsInAmbientContext.ts(7,25): error TS1183: An implementation cannot be declared in ambient contexts.
+tests/cases/compiler/accessorsInAmbientContext.ts(12,13): error TS1183: An implementation cannot be declared in ambient contexts.
+tests/cases/compiler/accessorsInAmbientContext.ts(13,14): error TS1183: An implementation cannot be declared in ambient contexts.
+tests/cases/compiler/accessorsInAmbientContext.ts(15,20): error TS1183: An implementation cannot be declared in ambient contexts.
+tests/cases/compiler/accessorsInAmbientContext.ts(16,21): error TS1183: An implementation cannot be declared in ambient contexts.
 
 
 ==== tests/cases/compiler/accessorsInAmbientContext.ts (8 errors) ====
     declare module M {
         class C {
             get X() { return 1; }
-                ~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                    ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
             set X(v) { }
-                ~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                     ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
     
             static get Y() { return 1; }
-                       ~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                           ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
             static set Y(v) { }
-                       ~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                            ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
         }
     }
     
     declare class C {
         get X() { return 1; }
-            ~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
         set X(v) { }
-            ~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                 ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
     
         static get Y() { return 1; }
-                   ~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                       ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
         static set Y(v) { }
-                   ~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                        ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
     }

--- a/tests/baselines/reference/ambientAccessors(target=es3).js
+++ b/tests/baselines/reference/ambientAccessors(target=es3).js
@@ -1,0 +1,30 @@
+//// [ambientAccessors.ts]
+// ok to use accessors in ambient class in ES3
+declare class C {
+    static get a(): string;
+    static set a(value: string);
+
+    private static get b(): string;
+    private static set b(foo: string);
+
+    get x(): string;
+    set x(value: string);
+
+    private get y(): string;
+    private set y(foo: string);
+}
+
+//// [ambientAccessors.js]
+
+
+//// [ambientAccessors.d.ts]
+declare class C {
+    static get a(): string;
+    static set a(value: string);
+    private static get b();
+    private static set b(value);
+    get x(): string;
+    set x(value: string);
+    private get y();
+    private set y(value);
+}

--- a/tests/baselines/reference/ambientAccessors(target=es3).symbols
+++ b/tests/baselines/reference/ambientAccessors(target=es3).symbols
@@ -1,0 +1,33 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts ===
+// ok to use accessors in ambient class in ES3
+declare class C {
+>C : Symbol(C, Decl(ambientAccessors.ts, 0, 0))
+
+    static get a(): string;
+>a : Symbol(C.a, Decl(ambientAccessors.ts, 1, 17), Decl(ambientAccessors.ts, 2, 27))
+
+    static set a(value: string);
+>a : Symbol(C.a, Decl(ambientAccessors.ts, 1, 17), Decl(ambientAccessors.ts, 2, 27))
+>value : Symbol(value, Decl(ambientAccessors.ts, 3, 17))
+
+    private static get b(): string;
+>b : Symbol(C.b, Decl(ambientAccessors.ts, 3, 32), Decl(ambientAccessors.ts, 5, 35))
+
+    private static set b(foo: string);
+>b : Symbol(C.b, Decl(ambientAccessors.ts, 3, 32), Decl(ambientAccessors.ts, 5, 35))
+>foo : Symbol(foo, Decl(ambientAccessors.ts, 6, 25))
+
+    get x(): string;
+>x : Symbol(C.x, Decl(ambientAccessors.ts, 6, 38), Decl(ambientAccessors.ts, 8, 20))
+
+    set x(value: string);
+>x : Symbol(C.x, Decl(ambientAccessors.ts, 6, 38), Decl(ambientAccessors.ts, 8, 20))
+>value : Symbol(value, Decl(ambientAccessors.ts, 9, 10))
+
+    private get y(): string;
+>y : Symbol(C.y, Decl(ambientAccessors.ts, 9, 25), Decl(ambientAccessors.ts, 11, 28))
+
+    private set y(foo: string);
+>y : Symbol(C.y, Decl(ambientAccessors.ts, 9, 25), Decl(ambientAccessors.ts, 11, 28))
+>foo : Symbol(foo, Decl(ambientAccessors.ts, 12, 18))
+}

--- a/tests/baselines/reference/ambientAccessors(target=es3).types
+++ b/tests/baselines/reference/ambientAccessors(target=es3).types
@@ -1,0 +1,33 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts ===
+// ok to use accessors in ambient class in ES3
+declare class C {
+>C : C
+
+    static get a(): string;
+>a : string
+
+    static set a(value: string);
+>a : string
+>value : string
+
+    private static get b(): string;
+>b : string
+
+    private static set b(foo: string);
+>b : string
+>foo : string
+
+    get x(): string;
+>x : string
+
+    set x(value: string);
+>x : string
+>value : string
+
+    private get y(): string;
+>y : string
+
+    private set y(foo: string);
+>y : string
+>foo : string
+}

--- a/tests/baselines/reference/ambientAccessors(target=es5).js
+++ b/tests/baselines/reference/ambientAccessors(target=es5).js
@@ -1,0 +1,30 @@
+//// [ambientAccessors.ts]
+// ok to use accessors in ambient class in ES3
+declare class C {
+    static get a(): string;
+    static set a(value: string);
+
+    private static get b(): string;
+    private static set b(foo: string);
+
+    get x(): string;
+    set x(value: string);
+
+    private get y(): string;
+    private set y(foo: string);
+}
+
+//// [ambientAccessors.js]
+
+
+//// [ambientAccessors.d.ts]
+declare class C {
+    static get a(): string;
+    static set a(value: string);
+    private static get b();
+    private static set b(value);
+    get x(): string;
+    set x(value: string);
+    private get y();
+    private set y(value);
+}

--- a/tests/baselines/reference/ambientAccessors(target=es5).symbols
+++ b/tests/baselines/reference/ambientAccessors(target=es5).symbols
@@ -1,0 +1,33 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts ===
+// ok to use accessors in ambient class in ES3
+declare class C {
+>C : Symbol(C, Decl(ambientAccessors.ts, 0, 0))
+
+    static get a(): string;
+>a : Symbol(C.a, Decl(ambientAccessors.ts, 1, 17), Decl(ambientAccessors.ts, 2, 27))
+
+    static set a(value: string);
+>a : Symbol(C.a, Decl(ambientAccessors.ts, 1, 17), Decl(ambientAccessors.ts, 2, 27))
+>value : Symbol(value, Decl(ambientAccessors.ts, 3, 17))
+
+    private static get b(): string;
+>b : Symbol(C.b, Decl(ambientAccessors.ts, 3, 32), Decl(ambientAccessors.ts, 5, 35))
+
+    private static set b(foo: string);
+>b : Symbol(C.b, Decl(ambientAccessors.ts, 3, 32), Decl(ambientAccessors.ts, 5, 35))
+>foo : Symbol(foo, Decl(ambientAccessors.ts, 6, 25))
+
+    get x(): string;
+>x : Symbol(C.x, Decl(ambientAccessors.ts, 6, 38), Decl(ambientAccessors.ts, 8, 20))
+
+    set x(value: string);
+>x : Symbol(C.x, Decl(ambientAccessors.ts, 6, 38), Decl(ambientAccessors.ts, 8, 20))
+>value : Symbol(value, Decl(ambientAccessors.ts, 9, 10))
+
+    private get y(): string;
+>y : Symbol(C.y, Decl(ambientAccessors.ts, 9, 25), Decl(ambientAccessors.ts, 11, 28))
+
+    private set y(foo: string);
+>y : Symbol(C.y, Decl(ambientAccessors.ts, 9, 25), Decl(ambientAccessors.ts, 11, 28))
+>foo : Symbol(foo, Decl(ambientAccessors.ts, 12, 18))
+}

--- a/tests/baselines/reference/ambientAccessors(target=es5).types
+++ b/tests/baselines/reference/ambientAccessors(target=es5).types
@@ -1,0 +1,33 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts ===
+// ok to use accessors in ambient class in ES3
+declare class C {
+>C : C
+
+    static get a(): string;
+>a : string
+
+    static set a(value: string);
+>a : string
+>value : string
+
+    private static get b(): string;
+>b : string
+
+    private static set b(foo: string);
+>b : string
+>foo : string
+
+    get x(): string;
+>x : string
+
+    set x(value: string);
+>x : string
+>value : string
+
+    private get y(): string;
+>y : string
+
+    private set y(foo: string);
+>y : string
+>foo : string
+}

--- a/tests/baselines/reference/ambientGetters.errors.txt
+++ b/tests/baselines/reference/ambientGetters.errors.txt
@@ -1,16 +1,13 @@
-tests/cases/compiler/ambientGetters.ts(2,9): error TS1086: An accessor cannot be declared in an ambient context.
-tests/cases/compiler/ambientGetters.ts(6,9): error TS1086: An accessor cannot be declared in an ambient context.
+tests/cases/compiler/ambientGetters.ts(6,18): error TS1183: An implementation cannot be declared in ambient contexts.
 
 
-==== tests/cases/compiler/ambientGetters.ts (2 errors) ====
+==== tests/cases/compiler/ambientGetters.ts (1 errors) ====
     declare class A {
         get length() : number;
-            ~~~~~~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
     }
     
     declare class B {
         get length() { return 0; }
-            ~~~~~~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                     ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
     }

--- a/tests/baselines/reference/giant.errors.txt
+++ b/tests/baselines/reference/giant.errors.txt
@@ -75,28 +75,22 @@ tests/cases/compiler/giant.ts(242,21): error TS1183: An implementation cannot be
 tests/cases/compiler/giant.ts(243,22): error TS1183: An implementation cannot be declared in ambient contexts.
 tests/cases/compiler/giant.ts(244,16): error TS2300: Duplicate identifier 'pgF'.
 tests/cases/compiler/giant.ts(244,22): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(245,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(245,20): error TS2300: Duplicate identifier 'pgF'.
 tests/cases/compiler/giant.ts(246,16): error TS2300: Duplicate identifier 'psF'.
 tests/cases/compiler/giant.ts(246,31): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(247,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(247,20): error TS2300: Duplicate identifier 'psF'.
 tests/cases/compiler/giant.ts(248,17): error TS2300: Duplicate identifier 'rgF'.
 tests/cases/compiler/giant.ts(248,23): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(249,21): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(249,21): error TS2300: Duplicate identifier 'rgF'.
 tests/cases/compiler/giant.ts(250,17): error TS2300: Duplicate identifier 'rsF'.
 tests/cases/compiler/giant.ts(250,32): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(251,21): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(251,21): error TS2300: Duplicate identifier 'rsF'.
 tests/cases/compiler/giant.ts(253,21): error TS1183: An implementation cannot be declared in ambient contexts.
 tests/cases/compiler/giant.ts(254,16): error TS2300: Duplicate identifier 'tsF'.
 tests/cases/compiler/giant.ts(254,31): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(255,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(255,20): error TS2300: Duplicate identifier 'tsF'.
 tests/cases/compiler/giant.ts(256,16): error TS2300: Duplicate identifier 'tgF'.
 tests/cases/compiler/giant.ts(256,22): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(257,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(257,20): error TS2300: Duplicate identifier 'tgF'.
 tests/cases/compiler/giant.ts(261,22): error TS1183: An implementation cannot be declared in ambient contexts.
 tests/cases/compiler/giant.ts(261,25): error TS1036: Statements are not allowed in ambient contexts.
@@ -178,28 +172,22 @@ tests/cases/compiler/giant.ts(500,21): error TS1183: An implementation cannot be
 tests/cases/compiler/giant.ts(501,22): error TS1183: An implementation cannot be declared in ambient contexts.
 tests/cases/compiler/giant.ts(502,16): error TS2300: Duplicate identifier 'pgF'.
 tests/cases/compiler/giant.ts(502,22): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(503,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(503,20): error TS2300: Duplicate identifier 'pgF'.
 tests/cases/compiler/giant.ts(504,16): error TS2300: Duplicate identifier 'psF'.
 tests/cases/compiler/giant.ts(504,31): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(505,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(505,20): error TS2300: Duplicate identifier 'psF'.
 tests/cases/compiler/giant.ts(506,17): error TS2300: Duplicate identifier 'rgF'.
 tests/cases/compiler/giant.ts(506,23): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(507,21): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(507,21): error TS2300: Duplicate identifier 'rgF'.
 tests/cases/compiler/giant.ts(508,17): error TS2300: Duplicate identifier 'rsF'.
 tests/cases/compiler/giant.ts(508,32): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(509,21): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(509,21): error TS2300: Duplicate identifier 'rsF'.
 tests/cases/compiler/giant.ts(511,21): error TS1183: An implementation cannot be declared in ambient contexts.
 tests/cases/compiler/giant.ts(512,16): error TS2300: Duplicate identifier 'tsF'.
 tests/cases/compiler/giant.ts(512,31): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(513,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(513,20): error TS2300: Duplicate identifier 'tsF'.
 tests/cases/compiler/giant.ts(514,16): error TS2300: Duplicate identifier 'tgF'.
 tests/cases/compiler/giant.ts(514,22): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(515,20): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(515,20): error TS2300: Duplicate identifier 'tgF'.
 tests/cases/compiler/giant.ts(519,22): error TS1183: An implementation cannot be declared in ambient contexts.
 tests/cases/compiler/giant.ts(519,25): error TS1036: Statements are not allowed in ambient contexts.
@@ -210,28 +198,22 @@ tests/cases/compiler/giant.ts(536,17): error TS1183: An implementation cannot be
 tests/cases/compiler/giant.ts(537,18): error TS1183: An implementation cannot be declared in ambient contexts.
 tests/cases/compiler/giant.ts(538,12): error TS2300: Duplicate identifier 'pgF'.
 tests/cases/compiler/giant.ts(538,18): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(539,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(539,16): error TS2300: Duplicate identifier 'pgF'.
 tests/cases/compiler/giant.ts(540,12): error TS2300: Duplicate identifier 'psF'.
 tests/cases/compiler/giant.ts(540,27): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(541,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(541,16): error TS2300: Duplicate identifier 'psF'.
 tests/cases/compiler/giant.ts(542,13): error TS2300: Duplicate identifier 'rgF'.
 tests/cases/compiler/giant.ts(542,19): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(543,17): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(543,17): error TS2300: Duplicate identifier 'rgF'.
 tests/cases/compiler/giant.ts(544,13): error TS2300: Duplicate identifier 'rsF'.
 tests/cases/compiler/giant.ts(544,28): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(545,17): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(545,17): error TS2300: Duplicate identifier 'rsF'.
 tests/cases/compiler/giant.ts(547,17): error TS1183: An implementation cannot be declared in ambient contexts.
 tests/cases/compiler/giant.ts(548,12): error TS2300: Duplicate identifier 'tsF'.
 tests/cases/compiler/giant.ts(548,27): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(549,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(549,16): error TS2300: Duplicate identifier 'tsF'.
 tests/cases/compiler/giant.ts(550,12): error TS2300: Duplicate identifier 'tgF'.
 tests/cases/compiler/giant.ts(550,18): error TS1183: An implementation cannot be declared in ambient contexts.
-tests/cases/compiler/giant.ts(551,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/giant.ts(551,16): error TS2300: Duplicate identifier 'tgF'.
 tests/cases/compiler/giant.ts(555,18): error TS1183: An implementation cannot be declared in ambient contexts.
 tests/cases/compiler/giant.ts(555,21): error TS1036: Statements are not allowed in ambient contexts.
@@ -265,7 +247,7 @@ tests/cases/compiler/giant.ts(671,25): error TS1036: Statements are not allowed 
 tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be declared in ambient contexts.
 
 
-==== tests/cases/compiler/giant.ts (265 errors) ====
+==== tests/cases/compiler/giant.ts (247 errors) ====
     /*
         Prefixes
         p -> public
@@ -666,8 +648,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             public get pgF()
                        ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-                       ~~~
 !!! error TS2300: Duplicate identifier 'pgF'.
             public psF(param:any) { }
                    ~~~
@@ -675,8 +655,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
                                   ~
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             public set psF(param:any)
-                       ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
                        ~~~
 !!! error TS2300: Duplicate identifier 'psF'.
             private rgF() { }
@@ -686,8 +664,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             private get rgF()
                         ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-                        ~~~
 !!! error TS2300: Duplicate identifier 'rgF'.
             private rsF(param:any) { }
                     ~~~
@@ -695,8 +671,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
                                    ~
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             private set rsF(param:any)
-                        ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
                         ~~~
 !!! error TS2300: Duplicate identifier 'rsF'.
             static tV;
@@ -710,8 +684,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             static set tsF(param:any)
                        ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-                       ~~~
 !!! error TS2300: Duplicate identifier 'tsF'.
             static tgF() { }
                    ~~~
@@ -719,8 +691,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
                          ~
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             static get tgF()
-                       ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
                        ~~~
 !!! error TS2300: Duplicate identifier 'tgF'.
         }
@@ -1130,8 +1100,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             public get pgF()
                        ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-                       ~~~
 !!! error TS2300: Duplicate identifier 'pgF'.
             public psF(param:any) { }
                    ~~~
@@ -1139,8 +1107,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
                                   ~
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             public set psF(param:any)
-                       ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
                        ~~~
 !!! error TS2300: Duplicate identifier 'psF'.
             private rgF() { }
@@ -1150,8 +1116,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             private get rgF()
                         ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-                        ~~~
 !!! error TS2300: Duplicate identifier 'rgF'.
             private rsF(param:any) { }
                     ~~~
@@ -1159,8 +1123,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
                                    ~
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             private set rsF(param:any)
-                        ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
                         ~~~
 !!! error TS2300: Duplicate identifier 'rsF'.
             static tV;
@@ -1174,8 +1136,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             static set tsF(param:any)
                        ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-                       ~~~
 !!! error TS2300: Duplicate identifier 'tsF'.
             static tgF() { }
                    ~~~
@@ -1183,8 +1143,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
                          ~
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
             static get tgF()
-                       ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
                        ~~~
 !!! error TS2300: Duplicate identifier 'tgF'.
         }
@@ -1230,8 +1188,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
         public get pgF()
                    ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-                   ~~~
 !!! error TS2300: Duplicate identifier 'pgF'.
         public psF(param:any) { }
                ~~~
@@ -1239,8 +1195,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
                               ~
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
         public set psF(param:any)
-                   ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
                    ~~~
 !!! error TS2300: Duplicate identifier 'psF'.
         private rgF() { }
@@ -1250,8 +1204,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
         private get rgF()
                     ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-                    ~~~
 !!! error TS2300: Duplicate identifier 'rgF'.
         private rsF(param:any) { }
                 ~~~
@@ -1259,8 +1211,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
                                ~
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
         private set rsF(param:any)
-                    ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
                     ~~~
 !!! error TS2300: Duplicate identifier 'rsF'.
         static tV;
@@ -1274,8 +1224,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
         static set tsF(param:any)
                    ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-                   ~~~
 !!! error TS2300: Duplicate identifier 'tsF'.
         static tgF() { }
                ~~~
@@ -1283,8 +1231,6 @@ tests/cases/compiler/giant.ts(675,30): error TS1183: An implementation cannot be
                      ~
 !!! error TS1183: An implementation cannot be declared in ambient contexts.
         static get tgF()
-                   ~~~
-!!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
                    ~~~
 !!! error TS2300: Duplicate identifier 'tgF'.
     }

--- a/tests/baselines/reference/giant.js
+++ b/tests/baselines/reference/giant.js
@@ -1237,19 +1237,19 @@ export declare module eM {
         pF(): void;
         private rF;
         pgF(): void;
-        readonly pgF: any;
+        get pgF(): any;
         psF(param: any): void;
-        psF: any;
+        set psF(param: any);
         private rgF;
-        private readonly rgF;
+        private get rgF();
         private rsF;
-        private rsF;
+        private set rsF(value);
         static tV: any;
         static tF(): void;
         static tsF(param: any): void;
-        static tsF: any;
+        static set tsF(param: any);
         static tgF(): void;
-        static readonly tgF: any;
+        static get tgF(): any;
     }
     module eaM {
         var V: any;
@@ -1277,19 +1277,19 @@ export declare class eaC {
     pF(): void;
     private rF;
     pgF(): void;
-    readonly pgF: any;
+    get pgF(): any;
     psF(param: any): void;
-    psF: any;
+    set psF(param: any);
     private rgF;
-    private readonly rgF;
+    private get rgF();
     private rsF;
-    private rsF;
+    private set rsF(value);
     static tV: any;
     static tF(): void;
     static tsF(param: any): void;
-    static tsF: any;
+    static set tsF(param: any);
     static tgF(): void;
-    static readonly tgF: any;
+    static get tgF(): any;
 }
 export declare module eaM {
     var V: any;

--- a/tests/baselines/reference/parserAccessors5.errors.txt
+++ b/tests/baselines/reference/parserAccessors5.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors5.ts(2,7): error TS1086: An accessor cannot be declared in an ambient context.
+tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors5.ts(2,13): error TS1183: An implementation cannot be declared in ambient contexts.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors5.ts (1 errors) ====
     declare class C {
       get foo() { return 0; }
-          ~~~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
     }

--- a/tests/baselines/reference/parserAccessors6.errors.txt
+++ b/tests/baselines/reference/parserAccessors6.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors6.ts(2,7): error TS1086: An accessor cannot be declared in an ambient context.
+tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors6.ts(2,14): error TS1183: An implementation cannot be declared in ambient contexts.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors6.ts (1 errors) ====
     declare class C {
       set foo(v) { }
-          ~~~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
+                 ~
+!!! error TS1183: An implementation cannot be declared in ambient contexts.
     }

--- a/tests/baselines/reference/parserComputedPropertyName23.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName23.errors.txt
@@ -1,12 +1,9 @@
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName23.ts(2,9): error TS1086: An accessor cannot be declared in an ambient context.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName23.ts(2,10): error TS2304: Cannot find name 'e'.
 
 
-==== tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName23.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName23.ts (1 errors) ====
     declare class C {
         get [e](): number 
-            ~~~
-!!! error TS1086: An accessor cannot be declared in an ambient context.
              ~
 !!! error TS2304: Cannot find name 'e'.
     }

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts
@@ -1,0 +1,16 @@
+// @target: es3, es5
+// @declaration: true
+// ok to use accessors in ambient class in ES3
+declare class C {
+    static get a(): string;
+    static set a(value: string);
+
+    private static get b(): string;
+    private static set b(foo: string);
+
+    get x(): string;
+    set x(value: string);
+
+    private get y(): string;
+    private set y(foo: string);
+}

--- a/tests/cases/fourslash/codeFixAmbientClassExtendAbstractMethod.ts
+++ b/tests/cases/fourslash/codeFixAmbientClassExtendAbstractMethod.ts
@@ -1,0 +1,31 @@
+/// <reference path='fourslash.ts' />
+
+////abstract class A {
+////    abstract f(a: number, b: string): boolean;
+////    abstract f(a: number, b: string): this;
+////    abstract f(a: string, b: number): Function;
+////    abstract f(a: string): Function;
+////    abstract foo(): number;
+////}
+////
+////declare class C extends A {}
+
+verify.codeFix({
+    description: "Implement inherited abstract class",
+    newFileContent:
+`abstract class A {
+    abstract f(a: number, b: string): boolean;
+    abstract f(a: number, b: string): this;
+    abstract f(a: string, b: number): Function;
+    abstract f(a: string): Function;
+    abstract foo(): number;
+}
+
+declare class C extends A {
+    f(a: number, b: string): boolean;
+    f(a: number, b: string): this;
+    f(a: string, b: number): Function;
+    f(a: string): Function;
+    foo(): number;
+}`
+});

--- a/tests/cases/fourslash/codeFixAmbientClassExtendAbstractMethod_all.ts
+++ b/tests/cases/fourslash/codeFixAmbientClassExtendAbstractMethod_all.ts
@@ -1,0 +1,26 @@
+/// <reference path='fourslash.ts' />
+
+////abstract class A {
+////    abstract m(): void;
+////    abstract n(): void;
+////}
+////declare class B extends A {}
+////declare class C extends A {}
+
+verify.codeFixAll({
+    fixId: "fixClassDoesntImplementInheritedAbstractMember",
+    fixAllDescription: "Implement all inherited abstract classes",
+    newFileContent:
+`abstract class A {
+    abstract m(): void;
+    abstract n(): void;
+}
+declare class B extends A {
+    m(): void;
+    n(): void;
+}
+declare class C extends A {
+    m(): void;
+    n(): void;
+}`,
+});

--- a/tests/cases/fourslash/codeFixAmbientClassImplementClassAbstractGettersAndSetters.ts
+++ b/tests/cases/fourslash/codeFixAmbientClassImplementClassAbstractGettersAndSetters.ts
@@ -9,7 +9,7 @@
 ////    abstract set c(arg: number | string);
 ////}
 ////
-////class C implements A {}
+////declare class C implements A {}
 
 verify.codeFix({
     description: "Implement interface 'A'",
@@ -23,18 +23,10 @@ verify.codeFix({
     abstract set c(arg: number | string);
 }
 
-class C implements A {
-    get a(): string {
-        throw new Error("Method not implemented.");
-    }
-    set a(newName: string) {
-        throw new Error("Method not implemented.");
-    }
-    get b(): number {
-        throw new Error("Method not implemented.");
-    }
-    set c(arg: string | number) {
-        throw new Error("Method not implemented.");
-    }
+declare class C implements A {
+    get a(): string;
+    set a(newName: string);
+    get b(): number;
+    set c(arg: string | number);
 }`,
 });

--- a/tests/cases/fourslash/codeFixAmbientClassImplementClassMethodViaHeritage.ts
+++ b/tests/cases/fourslash/codeFixAmbientClassImplementClassMethodViaHeritage.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+//// class C1 {
+////     f1() {}
+//// }
+////
+//// class C2 extends C1 {
+////
+//// }
+////
+//// declare class C3 implements C2 {[|
+////     |]f2();
+//// }
+
+verify.rangeAfterCodeFix(`f1(): void;
+`);

--- a/tests/cases/fourslash/codeFixClassExtendAbstractGetterSetter.ts
+++ b/tests/cases/fourslash/codeFixClassExtendAbstractGetterSetter.ts
@@ -38,12 +38,29 @@ verify.codeFix({
 abstract class B extends A {}
 
 class C extends A {
-    a: string | number;
-    b: this;
-    c: A;
-    d: string | number;
-    e: this;
-    f: A;
-    g: string;
+    get a(): string | number {
+        throw new Error("Method not implemented.");
+    }
+    get b(): this {
+        throw new Error("Method not implemented.");
+    }
+    get c(): A {
+        throw new Error("Method not implemented.");
+    }
+    set d(arg: string | number) {
+        throw new Error("Method not implemented.");
+    }
+    set e(arg: this) {
+        throw new Error("Method not implemented.");
+    }
+    set f(arg: A) {
+        throw new Error("Method not implemented.");
+    }
+    get g(): string {
+        throw new Error("Method not implemented.");
+    }
+    set g(newName: string) {
+        throw new Error("Method not implemented.");
+    }
 }`
 });


### PR DESCRIPTION
As part of the effort to support ECMAScript class fields, we will need to roll out features to the TypeScript compiler in phases. One of the key areas we need to address is the ability to properly distinguish between a "field" (a.k.a. a "Property Declaration" in TypeScript parlance), and an "accessor" (a getter or setter declaration). The reason we need to have these definitions cleanly separated is so that we can eventually issue error messages when you define a field on a superclass and an accessor on a subclass with the same name (or vice versa).

However, this is problematic today for several reasons:
- Subclasses currently can override a property declaration from a superclass with an accessor on a subclass:
    ```ts
    var Map: MapConstructor;
    interface Map<K, V> {
       readonly size: number;
       ...
    }
 
    class MyMap extends Map {
      get size() {
        return super.size + 1;
      }
      …
    }
    ```
- Declaration emit for class declarations converts get/set accessor pairs into property declarations and get-only accessors into `readonly` property declarations:
    ```ts
    // input: main.ts
    class MyClass {
      get x(): number { return 1; }
      set x(value: number) { … }
    }

    // output: main.d.ts
    declare class MyClass {
      x: number;
    }
    ```
- Interfaces can specify property declarations, but *can't* specify accessors.

This PR seeks to address some of these issues:

- Ambient Class declarations may now specify getters/setters.
- Code fixes for *implementing* a Class as if it were an interface, or *extending* an abstract class will now add implementations for getters/setters instead of fields when the implemented member is a getter or setter.
- Getters and Setters defined on an *ambient* class are *preserved* when emitting an output declaration file.

This PR does *not* change the following behavior:

- Getters and Setters are still not permitted on interfaces.
- Getters and Setters on a *non-ambient* class declaration will continue to be emitted as a property declaration.
- It is still not an error to have a subclass and superclass have a mismatch in a definition of a property that is either an accessor or a property declaration.

We are not changing the declaration emit for getters/setters immediately so that declaration files built against *existing* TypeScript code prior to this feature can still be used with earlier versions of the TypeScript compiler.  We do plan to change the declaration emit in a future release, which will give users a transitional period where they can become accustomed to the new syntax.

Examples:
```ts
declare class C {
  get x(): number;
}
```

Supersedes #32772
Related #27644
Fixes #19703