### PR TITLE
Fixes for tsbuild scenarios

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4172,6 +4172,14 @@
         "category": "Message",
         "code": 6381
     },
+    "Skipping build of project '{0}' because its dependency '{1}' was not built": {
+        "category": "Message",
+        "code": 6382
+    },
+    "Project '{0}' can't be built because its dependency '{1}' was not built": {
+        "category": "Message",
+        "code": 6383
+    },
 
     "The expected type comes from property '{0}' which is declared here on type '{1}'": {
         "category": "Message",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -552,6 +552,12 @@ namespace ts {
         allDiagnostics?: Diagnostic[];
     }
 
+    interface RefFile extends TextRange {
+        kind: RefFileKind;
+        index: number;
+        file: SourceFile;
+    }
+
     /**
      * Determines if program structure is upto date or needs to be recreated
      */
@@ -717,6 +723,8 @@ namespace ts {
         let noDiagnosticsTypeChecker: TypeChecker;
         let classifiableNames: UnderscoreEscapedMap<true>;
         const ambientModuleNameToUnmodifiedFileName = createMap<string>();
+        // Todo:: Use this to report why file was included in --extendedDiagnostics
+        let refFileMap: MultiMap<ts.RefFile> | undefined;
 
         const cachedSemanticDiagnosticsForFile: DiagnosticCache<Diagnostic> = {};
         const cachedDeclarationDiagnosticsForFile: DiagnosticCache<DiagnosticWithLocation> = {};
@@ -913,6 +921,7 @@ namespace ts {
             getSourceFileByPath,
             getSourceFiles: () => files,
             getMissingFilePaths: () => missingFilePaths!, // TODO: GH#18217
+            getRefFileMap: () => refFileMap,
             getCompilerOptions: () => options,
             getSyntacticDiagnostics,
             getOptionsDiagnostics,
@@ -1391,6 +1400,7 @@ namespace ts {
             }
 
             missingFilePaths = oldProgram.getMissingFilePaths();
+            refFileMap = oldProgram.getRefFileMap();
 
             // update fileName -> file mapping
             for (const newSourceFile of newSourceFiles) {
@@ -2179,25 +2189,24 @@ namespace ts {
         }
 
         /** This has side effects through `findSourceFile`. */
-        function processSourceFile(fileName: string, isDefaultLib: boolean, ignoreNoDefaultLib: boolean, packageId: PackageId | undefined, refFile?: SourceFile, refPos?: number, refEnd?: number): void {
-            getSourceFileFromReferenceWorker(fileName,
-                fileName => findSourceFile(fileName, toPath(fileName), isDefaultLib, ignoreNoDefaultLib, refFile!, refPos!, refEnd!, packageId), // TODO: GH#18217
-                (diagnostic, ...args) => {
-                    fileProcessingDiagnostics.add(refFile !== undefined && refEnd !== undefined && refPos !== undefined
-                        ? createFileDiagnostic(refFile, refPos, refEnd - refPos, diagnostic, ...args)
-                        : createCompilerDiagnostic(diagnostic, ...args));
-                },
-                refFile);
+        function processSourceFile(fileName: string, isDefaultLib: boolean, ignoreNoDefaultLib: boolean, packageId: PackageId | undefined, refFile?: RefFile): void {
+            getSourceFileFromReferenceWorker(
+                fileName,
+                fileName => findSourceFile(fileName, toPath(fileName), isDefaultLib, ignoreNoDefaultLib, refFile, packageId), // TODO: GH#18217
+                (diagnostic, ...args) => fileProcessingDiagnostics.add(
+                    createRefFileDiagnostic(refFile, diagnostic, ...args)
+                ),
+                refFile && refFile.file
+            );
         }
 
-        function reportFileNamesDifferOnlyInCasingError(fileName: string, existingFileName: string, refFile: SourceFile, refPos: number, refEnd: number): void {
-            if (refFile !== undefined && refPos !== undefined && refEnd !== undefined) {
-                fileProcessingDiagnostics.add(createFileDiagnostic(refFile, refPos, refEnd - refPos,
-                    Diagnostics.File_name_0_differs_from_already_included_file_name_1_only_in_casing, fileName, existingFileName));
-            }
-            else {
-                fileProcessingDiagnostics.add(createCompilerDiagnostic(Diagnostics.File_name_0_differs_from_already_included_file_name_1_only_in_casing, fileName, existingFileName));
-            }
+        function reportFileNamesDifferOnlyInCasingError(fileName: string, existingFileName: string, refFile: RefFile | undefined): void {
+            fileProcessingDiagnostics.add(createRefFileDiagnostic(
+                refFile,
+                Diagnostics.File_name_0_differs_from_already_included_file_name_1_only_in_casing,
+                fileName,
+                existingFileName
+            ));
         }
 
         function createRedirectSourceFile(redirectTarget: SourceFile, unredirected: SourceFile, fileName: string, path: Path, resolvedPath: Path, originalFileName: string): SourceFile {
@@ -2222,7 +2231,7 @@ namespace ts {
         }
 
         // Get source file from normalized fileName
-        function findSourceFile(fileName: string, path: Path, isDefaultLib: boolean, ignoreNoDefaultLib: boolean, refFile: SourceFile, refPos: number, refEnd: number, packageId: PackageId | undefined): SourceFile | undefined {
+        function findSourceFile(fileName: string, path: Path, isDefaultLib: boolean, ignoreNoDefaultLib: boolean, refFile: RefFile | undefined, packageId: PackageId | undefined): SourceFile | undefined {
             const originalFileName = fileName;
             if (filesByName.has(path)) {
                 const file = filesByName.get(path);
@@ -2239,7 +2248,7 @@ namespace ts {
                     const checkedAbsolutePath = getNormalizedAbsolutePathWithoutRoot(checkedName, currentDirectory);
                     const inputAbsolutePath = getNormalizedAbsolutePathWithoutRoot(inputName, currentDirectory);
                     if (checkedAbsolutePath !== inputAbsolutePath) {
-                        reportFileNamesDifferOnlyInCasingError(inputName, checkedName, refFile, refPos, refEnd);
+                        reportFileNamesDifferOnlyInCasingError(inputName, checkedName, refFile);
                     }
                 }
 
@@ -2266,6 +2275,7 @@ namespace ts {
                     }
                 }
 
+                addFileToRefFileMap(file || undefined, refFile);
                 return file || undefined;
             }
 
@@ -2289,15 +2299,17 @@ namespace ts {
             }
 
             // We haven't looked for this file, do so now and cache result
-            const file = host.getSourceFile(fileName, options.target!, hostErrorMessage => { // TODO: GH#18217
-                if (refFile !== undefined && refPos !== undefined && refEnd !== undefined) {
-                    fileProcessingDiagnostics.add(createFileDiagnostic(refFile, refPos, refEnd - refPos,
-                        Diagnostics.Cannot_read_file_0_Colon_1, fileName, hostErrorMessage));
-                }
-                else {
-                    fileProcessingDiagnostics.add(createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, hostErrorMessage));
-                }
-            }, shouldCreateNewSourceFile);
+            const file = host.getSourceFile(
+                fileName,
+                options.target!,
+                hostErrorMessage => fileProcessingDiagnostics.add(createRefFileDiagnostic(
+                    refFile,
+                    Diagnostics.Cannot_read_file_0_Colon_1,
+                    fileName,
+                    hostErrorMessage
+                )),
+                shouldCreateNewSourceFile
+            );
 
             if (packageId) {
                 const packageIdKey = packageIdToString(packageId);
@@ -2331,7 +2343,7 @@ namespace ts {
                     // for case-sensitive file systems check if we've already seen some file with similar filename ignoring case
                     const existingFile = filesByNameIgnoreCase!.get(pathLowerCase);
                     if (existingFile) {
-                        reportFileNamesDifferOnlyInCasingError(fileName, existingFile.fileName, refFile, refPos, refEnd);
+                        reportFileNamesDifferOnlyInCasingError(fileName, existingFile.fileName, refFile);
                     }
                     else {
                         filesByNameIgnoreCase!.set(pathLowerCase, file);
@@ -2359,8 +2371,18 @@ namespace ts {
                     processingOtherFiles!.push(file);
                 }
             }
-
+            addFileToRefFileMap(file, refFile);
             return file;
+        }
+
+        function addFileToRefFileMap(file: SourceFile | undefined, refFile: RefFile | undefined) {
+            if (refFile && file) {
+                (refFileMap || (refFileMap = createMultiMap())).add(file.path, {
+                    kind: refFile.kind,
+                    index: refFile.index,
+                    file: refFile.file.path
+                });
+            }
         }
 
         function addFileToFilesByName(file: SourceFile | undefined, path: Path, redirectedPath: Path | undefined) {
@@ -2479,9 +2501,21 @@ namespace ts {
         }
 
         function processReferencedFiles(file: SourceFile, isDefaultLib: boolean) {
-            forEach(file.referencedFiles, ref => {
+            forEach(file.referencedFiles, (ref, index) => {
                 const referencedFileName = resolveTripleslashReference(ref.fileName, file.originalFileName);
-                processSourceFile(referencedFileName, isDefaultLib, /*ignoreNoDefaultLib*/ false, /*packageId*/ undefined, file, ref.pos, ref.end);
+                processSourceFile(
+                    referencedFileName,
+                    isDefaultLib,
+                    /*ignoreNoDefaultLib*/ false,
+                    /*packageId*/ undefined,
+                    {
+                        kind: RefFileKind.ReferenceFile,
+                        index,
+                        file,
+                        pos: ref.pos,
+                        end: ref.end
+                    }
+                );
             });
         }
 
@@ -2500,12 +2534,25 @@ namespace ts {
                 // store resolved type directive on the file
                 const fileName = ref.fileName.toLocaleLowerCase();
                 setResolvedTypeReferenceDirective(file, fileName, resolvedTypeReferenceDirective);
-                processTypeReferenceDirective(fileName, resolvedTypeReferenceDirective, file, ref.pos, ref.end);
+                processTypeReferenceDirective(
+                    fileName,
+                    resolvedTypeReferenceDirective,
+                    {
+                        kind: RefFileKind.TypeReferenceDirective,
+                        index: i,
+                        file,
+                        pos: ref.pos,
+                        end: ref.end
+                    }
+                );
             }
         }
 
-        function processTypeReferenceDirective(typeReferenceDirective: string, resolvedTypeReferenceDirective?: ResolvedTypeReferenceDirective,
-            refFile?: SourceFile, refPos?: number, refEnd?: number): void {
+        function processTypeReferenceDirective(
+            typeReferenceDirective: string,
+            resolvedTypeReferenceDirective?: ResolvedTypeReferenceDirective,
+            refFile?: RefFile
+        ): void {
 
             // If we already found this library as a primary reference - nothing to do
             const previousResolution = resolvedTypeReferenceDirectives.get(typeReferenceDirective);
@@ -2518,7 +2565,7 @@ namespace ts {
 
                 if (resolvedTypeReferenceDirective.primary) {
                     // resolved from the primary path
-                    processSourceFile(resolvedTypeReferenceDirective.resolvedFileName!, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false, resolvedTypeReferenceDirective.packageId, refFile, refPos, refEnd); // TODO: GH#18217
+                    processSourceFile(resolvedTypeReferenceDirective.resolvedFileName!, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false, resolvedTypeReferenceDirective.packageId, refFile); // TODO: GH#18217
                 }
                 else {
                     // If we already resolved to this file, it must have been a secondary reference. Check file contents
@@ -2528,12 +2575,15 @@ namespace ts {
                         if (resolvedTypeReferenceDirective.resolvedFileName !== previousResolution.resolvedFileName) {
                             const otherFileText = host.readFile(resolvedTypeReferenceDirective.resolvedFileName!);
                             if (otherFileText !== getSourceFile(previousResolution.resolvedFileName!)!.text) {
-                                fileProcessingDiagnostics.add(createDiagnostic(refFile!, refPos!, refEnd!, // TODO: GH#18217
-                                    Diagnostics.Conflicting_definitions_for_0_found_at_1_and_2_Consider_installing_a_specific_version_of_this_library_to_resolve_the_conflict,
-                                    typeReferenceDirective,
-                                    resolvedTypeReferenceDirective.resolvedFileName,
-                                    previousResolution.resolvedFileName
-                                ));
+                                fileProcessingDiagnostics.add(
+                                    createRefFileDiagnostic(
+                                        refFile,
+                                        Diagnostics.Conflicting_definitions_for_0_found_at_1_and_2_Consider_installing_a_specific_version_of_this_library_to_resolve_the_conflict,
+                                        typeReferenceDirective,
+                                        resolvedTypeReferenceDirective.resolvedFileName,
+                                        previousResolution.resolvedFileName
+                                    )
+                                );
                             }
                         }
                         // don't overwrite previous resolution result
@@ -2541,14 +2591,18 @@ namespace ts {
                     }
                     else {
                         // First resolution of this library
-                        processSourceFile(resolvedTypeReferenceDirective.resolvedFileName!, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false, resolvedTypeReferenceDirective.packageId, refFile, refPos, refEnd);
+                        processSourceFile(resolvedTypeReferenceDirective.resolvedFileName!, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false, resolvedTypeReferenceDirective.packageId, refFile);
                     }
                 }
 
                 if (resolvedTypeReferenceDirective.isExternalLibraryImport) currentNodeModulesDepth--;
             }
             else {
-                fileProcessingDiagnostics.add(createDiagnostic(refFile!, refPos!, refEnd!, Diagnostics.Cannot_find_type_definition_file_for_0, typeReferenceDirective)); // TODO: GH#18217
+                fileProcessingDiagnostics.add(createRefFileDiagnostic(
+                    refFile,
+                    Diagnostics.Cannot_find_type_definition_file_for_0,
+                    typeReferenceDirective
+                ));
             }
 
             if (saveResolution) {
@@ -2568,17 +2622,24 @@ namespace ts {
                     const unqualifiedLibName = removeSuffix(removePrefix(libName, "lib."), ".d.ts");
                     const suggestion = getSpellingSuggestion(unqualifiedLibName, libs, identity);
                     const message = suggestion ? Diagnostics.Cannot_find_lib_definition_for_0_Did_you_mean_1 : Diagnostics.Cannot_find_lib_definition_for_0;
-                    fileProcessingDiagnostics.add(createDiagnostic(file, libReference.pos, libReference.end, message, libName, suggestion));
+                    fileProcessingDiagnostics.add(createFileDiagnostic(
+                        file,
+                        libReference.pos,
+                        libReference.end - libReference.pos,
+                        message,
+                        libName,
+                        suggestion
+                    ));
                 }
             });
         }
 
-        function createDiagnostic(refFile: SourceFile, refPos: number, refEnd: number, message: DiagnosticMessage, ...args: any[]): Diagnostic {
-            if (refFile === undefined || refPos === undefined || refEnd === undefined) {
+        function createRefFileDiagnostic(refFile: RefFile | undefined, message: DiagnosticMessage, ...args: any[]): Diagnostic {
+            if (!refFile) {
                 return createCompilerDiagnostic(message, ...args);
             }
             else {
-                return createFileDiagnostic(refFile, refPos, refEnd - refPos, message, ...args);
+                return createFileDiagnostic(refFile.file, refFile.pos, refFile.end - refFile.pos, message, ...args);
             }
         }
 
@@ -2632,7 +2693,20 @@ namespace ts {
                     else if (shouldAddFile) {
                         const path = toPath(resolvedFileName);
                         const pos = skipTrivia(file.text, file.imports[i].pos);
-                        findSourceFile(resolvedFileName, path, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false, file, pos, file.imports[i].end, resolution.packageId);
+                        findSourceFile(
+                            resolvedFileName,
+                            path,
+                            /*isDefaultLib*/ false,
+                            /*ignoreNoDefaultLib*/ false,
+                            {
+                                kind: RefFileKind.Import,
+                                index: i,
+                                file,
+                                pos,
+                                end: file.imports[i].end
+                            },
+                            resolution.packageId
+                        );
                     }
 
                     if (isFromNodeModulesSearch) {
@@ -2654,12 +2728,20 @@ namespace ts {
         function checkSourceFilesBelongToPath(sourceFiles: ReadonlyArray<SourceFile>, rootDirectory: string): boolean {
             let allFilesBelongToPath = true;
             const absoluteRootDirectoryPath = host.getCanonicalFileName(getNormalizedAbsolutePath(rootDirectory, currentDirectory));
+            let rootPaths: Map<true> | undefined;
 
             for (const sourceFile of sourceFiles) {
                 if (!sourceFile.isDeclarationFile) {
                     const absoluteSourceFilePath = host.getCanonicalFileName(getNormalizedAbsolutePath(sourceFile.fileName, currentDirectory));
                     if (absoluteSourceFilePath.indexOf(absoluteRootDirectoryPath) !== 0) {
-                        programDiagnostics.add(createCompilerDiagnostic(Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, sourceFile.fileName, rootDirectory));
+                        if (!rootPaths) rootPaths = arrayToSet(rootNames, toPath);
+                        addProgramDiagnosticAtRefPath(
+                            sourceFile,
+                            rootPaths,
+                            Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files,
+                            sourceFile.fileName,
+                            rootDirectory
+                        );
                         allFilesBelongToPath = false;
                     }
                 }
@@ -2771,12 +2853,18 @@ namespace ts {
 
             // List of collected files is complete; validate exhautiveness if this is a project with a file list
             if (options.composite) {
-                const rootPaths = rootNames.map(toPath);
+                const rootPaths = arrayToSet(rootNames, toPath);
                 for (const file of files) {
                     // Ignore file that is not emitted
                     if (!sourceFileMayBeEmitted(file, options, isSourceFileFromExternalLibrary, getResolvedProjectReferenceToRedirect)) continue;
-                    if (rootPaths.indexOf(file.path) === -1) {
-                        programDiagnostics.add(createCompilerDiagnostic(Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, file.fileName, options.configFilePath || ""));
+                    if (!rootPaths.has(file.path)) {
+                        addProgramDiagnosticAtRefPath(
+                            file,
+                            rootPaths,
+                            Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern,
+                            file.fileName,
+                            options.configFilePath || ""
+                        );
                     }
                 }
             }
@@ -2981,6 +3069,35 @@ namespace ts {
                         emitFilesSeen.set(emitFileKey, true);
                     }
                 }
+            }
+        }
+
+        function addProgramDiagnosticAtRefPath(file: SourceFile, rootPaths: Map<true>, message: DiagnosticMessage, ...args: (string | number | undefined)[]) {
+            const refPaths = refFileMap && refFileMap.get(file.path);
+            const refPathToReportErrorOn = forEach(refPaths, refPath => rootPaths.has(refPath.file) ? refPath : undefined) ||
+                elementAt(refPaths, 0);
+            if (refPathToReportErrorOn) {
+                const refFile = Debug.assertDefined(getSourceFileByPath(refPathToReportErrorOn.file));
+                const { kind, index } = refPathToReportErrorOn;
+                let pos: number, end: number;
+                switch (kind) {
+                    case RefFileKind.Import:
+                        pos = skipTrivia(refFile.text, refFile.imports[index].pos);
+                        end = refFile.imports[index].end;
+                        break;
+                    case RefFileKind.ReferenceFile:
+                        ({ pos, end } = refFile.referencedFiles[index]);
+                        break;
+                    case RefFileKind.TypeReferenceDirective:
+                        ({ pos, end } = refFile.typeReferenceDirectives[index]);
+                        break;
+                    default:
+                        return Debug.assertNever(kind);
+                }
+                programDiagnostics.add(createFileDiagnostic(refFile, pos, end - pos, message, ...args));
+            }
+            else {
+                programDiagnostics.add(createCompilerDiagnostic(message, ...args));
             }
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2914,6 +2914,20 @@ namespace ts {
         throwIfCancellationRequested(): void;
     }
 
+    /*@internal*/
+    export enum RefFileKind {
+        Import,
+        ReferenceFile,
+        TypeReferenceDirective
+    }
+
+    /*@internal*/
+    export interface RefFile {
+        kind: RefFileKind;
+        index: number;
+        file: Path;
+    }
+
     // TODO: This should implement TypeCheckerHost but that's an internal type.
     export interface Program extends ScriptReferenceHost {
 
@@ -2933,6 +2947,8 @@ namespace ts {
          */
         /* @internal */
         getMissingFilePaths(): ReadonlyArray<Path>;
+        /* @internal */
+        getRefFileMap(): MultiMap<RefFile> | undefined;
 
         /**
          * Emits the JavaScript and declaration files.  If targetSourceFile is not specified, then

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3079,6 +3079,9 @@ namespace ts {
 
         // When build skipped because passed in project is invalid
         InvalidProject_OutputsSkipped = 3,
+
+        // When build is skipped because project references form cycle
+        ProjectReferenceCycle_OutputsSkupped = 4,
     }
 
     export interface EmitResult {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -192,7 +192,7 @@ namespace ts {
     export function arrayToSet<T>(array: ReadonlyArray<T>, makeKey: (value: T) => string | undefined): Map<true>;
     export function arrayToSet<T>(array: ReadonlyArray<T>, makeKey: (value: T) => __String | undefined): UnderscoreEscapedMap<true>;
     export function arrayToSet(array: ReadonlyArray<any>, makeKey?: (value: any) => string | __String | undefined): Map<true> | UnderscoreEscapedMap<true> {
-        return arrayToMap<any, true>(array, makeKey || (s => s), () => true);
+        return arrayToMap<any, true>(array, makeKey || (s => s), returnTrue);
     }
 
     export function cloneMap(map: SymbolTable): SymbolTable;

--- a/src/harness/fakes.ts
+++ b/src/harness/fakes.ts
@@ -375,11 +375,114 @@ namespace fakes {
         }
     }
 
-    export type ExpectedDiagnostic = [ts.DiagnosticMessage, ...(string | number)[]];
-    function expectedDiagnosticToText([message, ...args]: ExpectedDiagnostic) {
+    export type ExpectedDiagnosticMessage = [ts.DiagnosticMessage, ...(string | number)[]];
+    export interface ExpectedDiagnosticMessageChain {
+        message: ExpectedDiagnosticMessage;
+        next?: ExpectedDiagnosticMessageChain[];
+    }
+
+    export interface ExpectedDiagnosticLocation {
+        file: string;
+        start: number;
+        length: number;
+    }
+    export interface ExpectedDiagnosticRelatedInformation extends ExpectedDiagnosticMessageChain {
+        location?: ExpectedDiagnosticLocation;
+    }
+
+    export enum DiagnosticKind {
+        Error = "Error",
+        Status = "Status"
+    }
+    export interface ExpectedErrorDiagnostic extends ExpectedDiagnosticRelatedInformation {
+        relatedInformation?: ExpectedDiagnosticRelatedInformation[];
+    }
+
+    export type ExpectedDiagnostic = ExpectedDiagnosticMessage | ExpectedErrorDiagnostic;
+
+    interface SolutionBuilderDiagnostic {
+        kind: DiagnosticKind;
+        diagnostic: ts.Diagnostic;
+    }
+
+    function indentedText(indent: number, text: string) {
+        if (!indent) return text;
+        let indentText = "";
+        for (let i = 0; i < indent; i++) {
+            indentText += "  ";
+        }
+        return `
+${indentText}${text}`;
+    }
+
+    function expectedDiagnosticMessageToText([message, ...args]: ExpectedDiagnosticMessage) {
         let text = ts.getLocaleSpecificMessage(message);
         if (args.length) {
             text = ts.formatStringFromArgs(text, args);
+        }
+        return text;
+    }
+
+    function expectedDiagnosticMessageChainToText({ message, next }: ExpectedDiagnosticMessageChain, indent = 0) {
+        let text = indentedText(indent, expectedDiagnosticMessageToText(message));
+        if (next) {
+            indent++;
+            next.forEach(kid => text += expectedDiagnosticMessageChainToText(kid, indent));
+        }
+        return text;
+    }
+
+    function expectedDiagnosticRelatedInformationToText({ location, ...diagnosticMessage }: ExpectedDiagnosticRelatedInformation) {
+        const text = expectedDiagnosticMessageChainToText(diagnosticMessage);
+        if (location) {
+            const { file, start, length } = location;
+            return `${file}(${start}:${length}):: ${text}`;
+        }
+        return text;
+    }
+
+    function expectedErrorDiagnosticToText({ relatedInformation, ...diagnosticRelatedInformation }: ExpectedErrorDiagnostic) {
+        let text = `${DiagnosticKind.Error}!: ${expectedDiagnosticRelatedInformationToText(diagnosticRelatedInformation)}`;
+        if (relatedInformation) {
+            for (const kid of relatedInformation) {
+                text += `
+  related:: ${expectedDiagnosticRelatedInformationToText(kid)}`;
+            }
+        }
+        return text;
+    }
+
+    function expectedDiagnosticToText(errorOrStatus: ExpectedDiagnostic) {
+        return ts.isArray(errorOrStatus) ?
+            `${DiagnosticKind.Status}!: ${expectedDiagnosticMessageToText(errorOrStatus)}` :
+            expectedErrorDiagnosticToText(errorOrStatus);
+    }
+
+    function diagnosticMessageChainToText({ messageText, next}: ts.DiagnosticMessageChain, indent = 0) {
+        let text = indentedText(indent, messageText);
+        if (next) {
+            indent++;
+            next.forEach(kid => text += diagnosticMessageChainToText(kid, indent));
+        }
+        return text;
+    }
+
+    function diagnosticRelatedInformationToText({ file, start, length, messageText }: ts.DiagnosticRelatedInformation) {
+        const text = typeof messageText === "string" ?
+            messageText :
+            diagnosticMessageChainToText(messageText);
+        return file ?
+            `${file.fileName}(${start}:${length}):: ${text}` :
+            text;
+    }
+
+    function diagnosticToText({ kind, diagnostic: { relatedInformation, ...diagnosticRelatedInformation } }: SolutionBuilderDiagnostic) {
+        let text = `${kind}!: ${diagnosticRelatedInformationToText(diagnosticRelatedInformation)}`;
+        if (relatedInformation) {
+            for (const kid of relatedInformation) {
+                text += `
+  related:: ${diagnosticRelatedInformationToText(kid)}`;
+            }
         }
         return text;
     }
@@ -446,14 +549,14 @@ namespace fakes {
             return new Date(this.sys.vfs.time());
         }
 
-        diagnostics: ts.Diagnostic[] = [];
+        diagnostics: SolutionBuilderDiagnostic[] = [];
 
         reportDiagnostic(diagnostic: ts.Diagnostic) {
-            this.diagnostics.push(diagnostic);
+            this.diagnostics.push({ kind: DiagnosticKind.Error, diagnostic });
         }
 
         reportSolutionBuilderStatus(diagnostic: ts.Diagnostic) {
-            this.diagnostics.push(diagnostic);
+            this.diagnostics.push({ kind: DiagnosticKind.Status, diagnostic });
         }
 
         clearDiagnostics() {
@@ -461,7 +564,7 @@ namespace fakes {
         }
 
         assertDiagnosticMessages(...expectedDiagnostics: ExpectedDiagnostic[]) {
-            const actual = this.diagnostics.slice().map(d => d.messageText as string);
+            const actual = this.diagnostics.slice().map(diagnosticToText);
             const expected = expectedDiagnostics.map(expectedDiagnosticToText);
             assert.deepEqual(actual, expected, `Diagnostic arrays did not match:
 Actual: ${JSON.stringify(actual, /*replacer*/ undefined, " ")}
@@ -471,8 +574,8 @@ Expected: ${JSON.stringify(expected, /*replacer*/ undefined, " ")}`);
         printDiagnostics(header = "== Diagnostics ==") {
             const out = ts.createDiagnosticReporter(ts.sys);
             ts.sys.write(header + "\r\n");
-            for (const d of this.diagnostics) {
-                out(d);
+            for (const { diagnostic } of this.diagnostics) {
+                out(diagnostic);
             }
         }
     }

--- a/src/harness/virtualFileSystemWithWatch.ts
+++ b/src/harness/virtualFileSystemWithWatch.ts
@@ -11,7 +11,7 @@ interface Number { toExponential: any; }
 interface Object {}
 interface RegExp {}
 interface String { charAt: any; }
-interface Array<T> {}`
+interface Array<T> { length: number; [n: number]: T; }`
     };
 
     export const safeList = {

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -93,6 +93,7 @@
         "unittests/services/transpile.ts",
         "unittests/tsbuild/amdModulesWithOut.ts",
         "unittests/tsbuild/containerOnlyReferenced.ts",
+        "unittests/tsbuild/demo.ts",
         "unittests/tsbuild/emptyFiles.ts",
         "unittests/tsbuild/graphOrdering.ts",
         "unittests/tsbuild/inferredTypeFromTransitiveModule.ts",

--- a/src/testRunner/unittests/config/projectReferences.ts
+++ b/src/testRunner/unittests/config/projectReferences.ts
@@ -193,7 +193,7 @@ namespace ts {
             };
 
             testProjectReferences(spec, "/primary/tsconfig.json", program => {
-                const errs = program.getOptionsDiagnostics();
+                const errs = program.getSemanticDiagnostics(program.getSourceFile("/primary/a.ts"));
                 assertHasError("Reports an error about b.ts not being in the list", errs, Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern);
             });
         });
@@ -343,8 +343,9 @@ namespace ts {
                 }
             };
             testProjectReferences(spec, "/alpha/tsconfig.json", (program) => {
-                assertHasError("Issues an error about the rootDir", program.getOptionsDiagnostics(), Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files);
-                assertHasError("Issues an error about the fileList", program.getOptionsDiagnostics(), Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern);
+                const semanticDiagnostics = program.getSemanticDiagnostics(program.getSourceFile("/alpha/src/a.ts"));
+                assertHasError("Issues an error about the rootDir", semanticDiagnostics, Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files);
+                assertHasError("Issues an error about the fileList", semanticDiagnostics, Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern);
             });
         });
     });

--- a/src/testRunner/unittests/tsbuild/demo.ts
+++ b/src/testRunner/unittests/tsbuild/demo.ts
@@ -93,7 +93,7 @@ namespace ts {
                 expectedExitStatus: ExitStatus.ProjectReferenceCycle_OutputsSkupped,
                 expectedDiagnostics: [
                     getExpectedDiagnosticForProjectsInBuild("src/animals/tsconfig.json", "src/zoo/tsconfig.json", "src/core/tsconfig.json", "src/tsconfig.json"),
-                    [
+                    errorDiagnostic([
                         Diagnostics.Project_references_may_not_form_a_circular_graph_Cycle_detected_Colon_0,
                         [
                             "/src/tsconfig.json",
@@ -101,7 +101,7 @@ namespace ts {
                             "/src/zoo/tsconfig.json",
                             "/src/animals/tsconfig.json"
                         ].join("\r\n")
-                    ]
+                    ])
                 ],
                 expectedOutputs: emptyArray,
                 notExpectedOutputs: [...coreOutputs(), ...animalOutputs(), ...zooOutputs()]
@@ -121,12 +121,12 @@ namespace ts {
                     getExpectedDiagnosticForProjectsInBuild("src/core/tsconfig.json", "src/animals/tsconfig.json", "src/zoo/tsconfig.json", "src/tsconfig.json"),
                     [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/core/tsconfig.json", "src/lib/core/utilities.js"],
                     [Diagnostics.Building_project_0, "/src/core/tsconfig.json"],
-                    [Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, "/src/animals/animal.ts", "/src/core"],
-                    [Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, "/src/animals/dog.ts", "/src/core"],
-                    [Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, "/src/animals/index.ts", "/src/core"],
-                    [Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, "/src/animals/animal.ts", "/src/core/tsconfig.json"],
-                    [Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, "/src/animals/dog.ts", "/src/core/tsconfig.json"],
-                    [Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, "/src/animals/index.ts", "/src/core/tsconfig.json"],
+                    errorDiagnostic([Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, "/src/animals/animal.ts", "/src/core"]),
+                    errorDiagnostic([Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, "/src/animals/dog.ts", "/src/core"]),
+                    errorDiagnostic([Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, "/src/animals/index.ts", "/src/core"]),
+                    errorDiagnostic([Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, "/src/animals/animal.ts", "/src/core/tsconfig.json"]),
+                    errorDiagnostic([Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, "/src/animals/dog.ts", "/src/core/tsconfig.json"]),
+                    errorDiagnostic([Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, "/src/animals/index.ts", "/src/core/tsconfig.json"]),
                     [Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_has_errors, "src/animals/tsconfig.json", "src/core"],
                     [Diagnostics.Skipping_build_of_project_0_because_its_dependency_1_has_errors, "/src/animals/tsconfig.json", "/src/core"],
                     [Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_was_not_built, "src/zoo/tsconfig.json", "src/animals"],

--- a/src/testRunner/unittests/tsbuild/demo.ts
+++ b/src/testRunner/unittests/tsbuild/demo.ts
@@ -1,0 +1,80 @@
+namespace ts {
+    describe("unittests:: tsbuild:: on demo project", () => {
+        let projFs: vfs.FileSystem;
+        const { time } = getTime();
+
+        before(() => {
+            projFs = loadProjectFromDisk("tests/projects/demo", time);
+        });
+
+        after(() => {
+            projFs = undefined!; // Release the contents
+        });
+
+        function coreOutputs(): string[] {
+            return [
+                "/src/lib/core/utilities.js",
+                "/src/lib/core/utilities.d.ts",
+                "/src/lib/core/tsconfig.tsbuildinfo"
+            ];
+        }
+
+        function animalOutputs(): string[] {
+            return [
+                "/src/lib/animals/animal.js",
+                "/src/lib/animals/animal.d.ts",
+                "/src/lib/animals/index.js",
+                "/src/lib/animals/index.d.ts",
+                "/src/lib/animals/dog.js",
+                "/src/lib/animals/dog.d.ts",
+                "/src/lib/animals/tsconfig.tsbuildinfo"
+            ];
+        }
+
+        function zooOutputs(): string[] {
+            return [
+                "/src/lib/zoo/zoo.js",
+                "/src/lib/zoo/zoo.d.ts",
+                "/src/lib/zoo/tsconfig.tsbuildinfo"
+            ];
+        }
+
+        interface VerifyBuild {
+            modifyDiskLayout: (fs: vfs.FileSystem) => void;
+            expectedExitStatus: ExitStatus;
+            expectedDiagnostics: fakes.ExpectedDiagnostic[];
+            expectedOutputs: readonly string[];
+            notExpectedOutputs: readonly string[];
+        }
+
+        function verifyBuild({ modifyDiskLayout, expectedExitStatus, expectedDiagnostics, expectedOutputs, notExpectedOutputs }: VerifyBuild) {
+            const fs = projFs.shadow();
+            const host = new fakes.SolutionBuilderHost(fs);
+            modifyDiskLayout(fs);
+            const builder = createSolutionBuilder(host, ["/src/tsconfig.json"], { verbose: true });
+            const exitStatus = builder.build();
+            assert.equal(exitStatus, expectedExitStatus);
+            host.assertDiagnosticMessages(...expectedDiagnostics);
+            verifyOutputsPresent(fs, expectedOutputs);
+            verifyOutputsAbsent(fs, notExpectedOutputs);
+        }
+
+        it("in master branch with everything setup correctly, reports no error", () => {
+            verifyBuild({
+                modifyDiskLayout: noop,
+                expectedExitStatus: ExitStatus.Success,
+                expectedDiagnostics: [
+                    getExpectedDiagnosticForProjectsInBuild("src/core/tsconfig.json", "src/animals/tsconfig.json", "src/zoo/tsconfig.json", "src/tsconfig.json"),
+                    [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/core/tsconfig.json", "src/lib/core/utilities.js"],
+                    [Diagnostics.Building_project_0, "/src/core/tsconfig.json"],
+                    [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/animals/tsconfig.json", "src/lib/animals/animal.js"],
+                    [Diagnostics.Building_project_0, "/src/animals/tsconfig.json"],
+                    [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/zoo/tsconfig.json", "src/lib/zoo/zoo.js"],
+                    [Diagnostics.Building_project_0, "/src/zoo/tsconfig.json"]
+                ],
+                expectedOutputs: [...coreOutputs(), ...animalOutputs(), ...zooOutputs()],
+                notExpectedOutputs: emptyArray
+            });
+        });
+    });
+}

--- a/src/testRunner/unittests/tsbuild/demo.ts
+++ b/src/testRunner/unittests/tsbuild/demo.ts
@@ -107,5 +107,34 @@ namespace ts {
                 notExpectedOutputs: [...coreOutputs(), ...animalOutputs(), ...zooOutputs()]
             });
         });
+
+        it("in bad-ref branch reports the error about files not in rootDir at the import location", () => {
+            verifyBuild({
+                modifyDiskLayout: fs => prependText(
+                    fs,
+                    "/src/core/utilities.ts",
+                    `import * as A from '../animals';
+`
+                ),
+                expectedExitStatus: ExitStatus.DiagnosticsPresent_OutputsSkipped,
+                expectedDiagnostics: [
+                    getExpectedDiagnosticForProjectsInBuild("src/core/tsconfig.json", "src/animals/tsconfig.json", "src/zoo/tsconfig.json", "src/tsconfig.json"),
+                    [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/core/tsconfig.json", "src/lib/core/utilities.js"],
+                    [Diagnostics.Building_project_0, "/src/core/tsconfig.json"],
+                    [Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, "/src/animals/animal.ts", "/src/core"],
+                    [Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, "/src/animals/dog.ts", "/src/core"],
+                    [Diagnostics.File_0_is_not_under_rootDir_1_rootDir_is_expected_to_contain_all_source_files, "/src/animals/index.ts", "/src/core"],
+                    [Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, "/src/animals/animal.ts", "/src/core/tsconfig.json"],
+                    [Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, "/src/animals/dog.ts", "/src/core/tsconfig.json"],
+                    [Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern, "/src/animals/index.ts", "/src/core/tsconfig.json"],
+                    [Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_has_errors, "src/animals/tsconfig.json", "src/core"],
+                    [Diagnostics.Skipping_build_of_project_0_because_its_dependency_1_has_errors, "/src/animals/tsconfig.json", "/src/core"],
+                    [Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_was_not_built, "src/zoo/tsconfig.json", "src/animals"],
+                    [Diagnostics.Skipping_build_of_project_0_because_its_dependency_1_was_not_built, "/src/zoo/tsconfig.json", "/src/animals"],
+                ],
+                expectedOutputs: emptyArray,
+                notExpectedOutputs: [...coreOutputs(), ...animalOutputs(), ...zooOutputs()]
+            });
+        });
     });
 }

--- a/src/testRunner/unittests/tsbuild/emptyFiles.ts
+++ b/src/testRunner/unittests/tsbuild/emptyFiles.ts
@@ -17,11 +17,7 @@ namespace ts {
             builder.build();
             host.assertDiagnosticMessages({
                 message: [Diagnostics.The_files_list_in_config_file_0_is_empty, "/src/no-references/tsconfig.json"],
-                location: {
-                    file: "/src/no-references/tsconfig.json",
-                    start: lastIndexOf(fs, "/src/no-references/tsconfig.json", "[]"),
-                    length: 2
-                }
+                location: expectedLocationLastIndexOf(fs, "/src/no-references/tsconfig.json", "[]"),
             });
 
             // Check for outputs to not be written.

--- a/src/testRunner/unittests/tsbuild/emptyFiles.ts
+++ b/src/testRunner/unittests/tsbuild/emptyFiles.ts
@@ -15,7 +15,14 @@ namespace ts {
 
             host.clearDiagnostics();
             builder.build();
-            host.assertDiagnosticMessages([Diagnostics.The_files_list_in_config_file_0_is_empty, "/src/no-references/tsconfig.json"]);
+            host.assertDiagnosticMessages({
+                message: [Diagnostics.The_files_list_in_config_file_0_is_empty, "/src/no-references/tsconfig.json"],
+                location: {
+                    file: "/src/no-references/tsconfig.json",
+                    start: lastIndexOf(fs, "/src/no-references/tsconfig.json", "[]"),
+                    length: 2
+                }
+            });
 
             // Check for outputs to not be written.
             verifyOutputsAbsent(fs, allExpectedOutputs);

--- a/src/testRunner/unittests/tsbuild/graphOrdering.ts
+++ b/src/testRunner/unittests/tsbuild/graphOrdering.ts
@@ -8,13 +8,17 @@ namespace ts {
             ["B", "D"],
             ["C", "D"],
             ["C", "E"],
-            ["F", "E"]
+            ["F", "E"],
+            ["H", "I"],
+            ["I", "J"],
+            ["J", "H"],
+            ["J", "E"]
         ];
 
         before(() => {
             const fs = new vfs.FileSystem(false);
             host = new fakes.SolutionBuilderHost(fs);
-            writeProjects(fs, ["A", "B", "C", "D", "E", "F", "G"], deps);
+            writeProjects(fs, ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J"], deps);
         });
 
         after(() => {
@@ -37,17 +41,25 @@ namespace ts {
             checkGraphOrdering(["F", "C", "A"], ["E", "F", "D", "C", "B", "A"]);
         });
 
-        function checkGraphOrdering(rootNames: string[], expectedBuildSet: string[]) {
-            const builder = createSolutionBuilder(host!, rootNames.map(getProjectFileName), { dry: true, force: false, verbose: false });
-            const buildQueue = builder.getBuildOrder();
+        it("returns circular order", () => {
+            checkGraphOrdering(["H"], ["E", "J", "I", "H"], /*circular*/ true);
+            checkGraphOrdering(["A", "H"], ["D", "E", "C", "B", "A", "J", "I", "H"], /*circular*/ true);
+        });
 
+        function checkGraphOrdering(rootNames: string[], expectedBuildSet: string[], circular?: true) {
+            const builder = createSolutionBuilder(host!, rootNames.map(getProjectFileName), { dry: true, force: false, verbose: false });
+            const buildOrder = builder.getBuildOrder();
+            assert.equal(isCircularBuildOrder(buildOrder), !!circular);
+            const buildQueue = getBuildOrderFromAnyBuildOrder(buildOrder);
             assert.deepEqual(buildQueue, expectedBuildSet.map(getProjectFileName));
 
-            for (const dep of deps) {
-                const child = getProjectFileName(dep[0]);
-                if (buildQueue.indexOf(child) < 0) continue;
-                const parent = getProjectFileName(dep[1]);
-                assert.isAbove(buildQueue.indexOf(child), buildQueue.indexOf(parent), `Expecting child ${child} to be built after parent ${parent}`);
+            if (!circular) {
+                for (const dep of deps) {
+                    const child = getProjectFileName(dep[0]);
+                    if (buildQueue.indexOf(child) < 0) continue;
+                    const parent = getProjectFileName(dep[1]);
+                    assert.isAbove(buildQueue.indexOf(child), buildQueue.indexOf(parent), `Expecting child ${child} to be built after parent ${parent}`);
+                }
             }
         }
 

--- a/src/testRunner/unittests/tsbuild/helpers.ts
+++ b/src/testRunner/unittests/tsbuild/helpers.ts
@@ -62,6 +62,22 @@ namespace ts {
         return content.lastIndexOf(searchStr);
     }
 
+    export function expectedLocationIndexOf(fs: vfs.FileSystem, file: string, searchStr: string): fakes.ExpectedDiagnosticLocation {
+        return {
+            file,
+            start: indexOf(fs, file, searchStr),
+            length: searchStr.length
+        };
+    }
+
+    export function expectedLocationLastIndexOf(fs: vfs.FileSystem, file: string, searchStr: string): fakes.ExpectedDiagnosticLocation {
+        return {
+            file,
+            start: lastIndexOf(fs, file, searchStr),
+            length: searchStr.length
+        };
+    }
+
     export function getTime() {
         let currentTime = 100;
         return { tick, time, touch };

--- a/src/testRunner/unittests/tsbuild/helpers.ts
+++ b/src/testRunner/unittests/tsbuild/helpers.ts
@@ -1,4 +1,8 @@
 namespace ts {
+    export function errorDiagnostic(message: fakes.ExpectedDiagnosticMessage): fakes.ExpectedErrorDiagnostic {
+        return { message };
+    }
+
     export function getExpectedDiagnosticForProjectsInBuild(...projects: string[]): fakes.ExpectedDiagnostic {
         return [Diagnostics.Projects_in_this_build_Colon_0, projects.map(p => "\r\n    * " + p).join("")];
     }
@@ -40,6 +44,22 @@ namespace ts {
         }
         const old = fs.readFileSync(path, "utf-8");
         fs.writeFileSync(path, `${old}${additionalContent}`);
+    }
+
+    export function indexOf(fs: vfs.FileSystem, path: string, searchStr: string) {
+        if (!fs.statSync(path).isFile()) {
+            throw new Error(`File ${path} does not exist`);
+        }
+        const content = fs.readFileSync(path, "utf-8");
+        return content.indexOf(searchStr);
+    }
+
+    export function lastIndexOf(fs: vfs.FileSystem, path: string, searchStr: string) {
+        if (!fs.statSync(path).isFile()) {
+            throw new Error(`File ${path} does not exist`);
+        }
+        const content = fs.readFileSync(path, "utf-8");
+        return content.lastIndexOf(searchStr);
     }
 
     export function getTime() {

--- a/src/testRunner/unittests/tsbuild/missingExtendedFile.ts
+++ b/src/testRunner/unittests/tsbuild/missingExtendedFile.ts
@@ -7,10 +7,10 @@ namespace ts {
             const builder = createSolutionBuilder(host, ["/src/tsconfig.json"], {});
             builder.build();
             host.assertDiagnosticMessages(
-                [Diagnostics.The_specified_path_does_not_exist_Colon_0, "/src/foobar.json"],
-                [Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2, "/src/tsconfig.first.json", "[\"**/*\"]", "[]"],
-                [Diagnostics.The_specified_path_does_not_exist_Colon_0, "/src/foobar.json"],
-                [Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2, "/src/tsconfig.second.json", "[\"**/*\"]", "[]"]
+                errorDiagnostic([Diagnostics.The_specified_path_does_not_exist_Colon_0, "/src/foobar.json"]),
+                errorDiagnostic([Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2, "/src/tsconfig.first.json", "[\"**/*\"]", "[]"]),
+                errorDiagnostic([Diagnostics.The_specified_path_does_not_exist_Colon_0, "/src/foobar.json"]),
+                errorDiagnostic([Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2, "/src/tsconfig.second.json", "[\"**/*\"]", "[]"])
             );
         });
     });

--- a/src/testRunner/unittests/tsbuild/referencesWithRootDirInParent.ts
+++ b/src/testRunner/unittests/tsbuild/referencesWithRootDirInParent.ts
@@ -45,11 +45,7 @@ namespace ts {
                 [Diagnostics.Building_project_0, "/src/src/main/tsconfig.json"],
                 {
                     message: [Diagnostics.Cannot_write_file_0_because_it_will_overwrite_tsbuildinfo_file_generated_by_referenced_project_1, "/src/dist/tsconfig.tsbuildinfo", "/src/src/other"],
-                    location: {
-                        file: "/src/src/main/tsconfig.json",
-                        start: indexOf(fs, "/src/src/main/tsconfig.json", `{ "path": "../other" }`),
-                        length: `{ "path": "../other" }`.length
-                    }
+                    location: expectedLocationIndexOf(fs, "/src/src/main/tsconfig.json", `{ "path": "../other" }`),
                 }
             );
             verifyOutputsPresent(fs, allExpectedOutputs);
@@ -84,11 +80,7 @@ namespace ts {
                 [Diagnostics.Building_project_0, "/src/src/main/tsconfig.json"],
                 {
                     message: [Diagnostics.Cannot_write_file_0_because_it_will_overwrite_tsbuildinfo_file_generated_by_referenced_project_1, "/src/dist/tsconfig.tsbuildinfo", "/src/src/other"],
-                    location: {
-                        file: "/src/src/main/tsconfig.json",
-                        start: indexOf(fs, "/src/src/main/tsconfig.json", `{"path":"../other"}`),
-                        length: `{"path":"../other"}`.length
-                    }
+                    location: expectedLocationIndexOf(fs, "/src/src/main/tsconfig.json", `{"path":"../other"}`),
                 }
             );
             verifyOutputsPresent(fs, allExpectedOutputs);

--- a/src/testRunner/unittests/tsbuild/referencesWithRootDirInParent.ts
+++ b/src/testRunner/unittests/tsbuild/referencesWithRootDirInParent.ts
@@ -43,7 +43,14 @@ namespace ts {
                 [Diagnostics.Building_project_0, "/src/src/other/tsconfig.json"],
                 [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/src/main/tsconfig.json", "src/dist/a.js"],
                 [Diagnostics.Building_project_0, "/src/src/main/tsconfig.json"],
-                [Diagnostics.Cannot_write_file_0_because_it_will_overwrite_tsbuildinfo_file_generated_by_referenced_project_1, "/src/dist/tsconfig.tsbuildinfo", "/src/src/other"]
+                {
+                    message: [Diagnostics.Cannot_write_file_0_because_it_will_overwrite_tsbuildinfo_file_generated_by_referenced_project_1, "/src/dist/tsconfig.tsbuildinfo", "/src/src/other"],
+                    location: {
+                        file: "/src/src/main/tsconfig.json",
+                        start: indexOf(fs, "/src/src/main/tsconfig.json", `{ "path": "../other" }`),
+                        length: `{ "path": "../other" }`.length
+                    }
+                }
             );
             verifyOutputsPresent(fs, allExpectedOutputs);
             verifyOutputsAbsent(fs, missingOutputs);
@@ -75,7 +82,14 @@ namespace ts {
                 [Diagnostics.Building_project_0, "/src/src/other/tsconfig.json"],
                 [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/src/main/tsconfig.json", "src/dist/a.js"],
                 [Diagnostics.Building_project_0, "/src/src/main/tsconfig.json"],
-                [Diagnostics.Cannot_write_file_0_because_it_will_overwrite_tsbuildinfo_file_generated_by_referenced_project_1, "/src/dist/tsconfig.tsbuildinfo", "/src/src/other"]
+                {
+                    message: [Diagnostics.Cannot_write_file_0_because_it_will_overwrite_tsbuildinfo_file_generated_by_referenced_project_1, "/src/dist/tsconfig.tsbuildinfo", "/src/src/other"],
+                    location: {
+                        file: "/src/src/main/tsconfig.json",
+                        start: indexOf(fs, "/src/src/main/tsconfig.json", `{"path":"../other"}`),
+                        length: `{"path":"../other"}`.length
+                    }
+                }
             );
             verifyOutputsPresent(fs, allExpectedOutputs);
             verifyOutputsAbsent(fs, missingOutputs);

--- a/src/testRunner/unittests/tsbuild/resolveJsonModule.ts
+++ b/src/testRunner/unittests/tsbuild/resolveJsonModule.ts
@@ -30,11 +30,14 @@ namespace ts {
         it("with resolveJsonModule and include only", () => {
             verifyProjectWithResolveJsonModule(
                 "/src/tsconfig_withInclude.json",
-                errorDiagnostic([
-                    Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern,
-                    "/src/src/hello.json",
-                    "/src/tsconfig_withInclude.json"
-                ])
+                {
+                    message: [
+                        Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern,
+                        "/src/src/hello.json",
+                        "/src/tsconfig_withInclude.json"
+                    ],
+                    location: expectedLocationIndexOf(projFs, "/src/src/index.ts", `"./hello.json"`)
+                }
             );
         });
 

--- a/src/testRunner/unittests/tsbuild/resolveJsonModule.ts
+++ b/src/testRunner/unittests/tsbuild/resolveJsonModule.ts
@@ -28,11 +28,14 @@ namespace ts {
         }
 
         it("with resolveJsonModule and include only", () => {
-            verifyProjectWithResolveJsonModule("/src/tsconfig_withInclude.json", [
-                Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern,
-                "/src/src/hello.json",
-                "/src/tsconfig_withInclude.json"
-            ]);
+            verifyProjectWithResolveJsonModule(
+                "/src/tsconfig_withInclude.json",
+                errorDiagnostic([
+                    Diagnostics.File_0_is_not_listed_within_the_file_list_of_project_1_Projects_must_list_all_files_or_use_an_include_pattern,
+                    "/src/src/hello.json",
+                    "/src/tsconfig_withInclude.json"
+                ])
+            );
         });
 
         it("with resolveJsonModule and include of *.json along with other include", () => {

--- a/src/testRunner/unittests/tsbuild/sample.ts
+++ b/src/testRunner/unittests/tsbuild/sample.ts
@@ -452,11 +452,7 @@ namespace ts {
                     [Diagnostics.Building_project_0, "/src/logic/tsconfig.json"],
                     {
                         message: [Diagnostics.Property_0_does_not_exist_on_type_1, "muitply", `typeof import("/src/core/index")`],
-                        location: {
-                            file: "/src/logic/index.ts",
-                            start: indexOf(fs, "/src/logic/index.ts", "muitply"),
-                            length: "muitply".length
-                        }
+                        location: expectedLocationIndexOf(fs, "/src/logic/index.ts", "muitply"),
                     },
                     [Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_has_errors, "src/tests/tsconfig.json", "src/logic"],
                     [Diagnostics.Skipping_build_of_project_0_because_its_dependency_1_has_errors, "/src/tests/tsconfig.json", "/src/logic"]

--- a/src/testRunner/unittests/tsbuild/sample.ts
+++ b/src/testRunner/unittests/tsbuild/sample.ts
@@ -450,7 +450,14 @@ namespace ts {
                     [Diagnostics.Building_project_0, "/src/core/tsconfig.json"],
                     [Diagnostics.Project_0_is_out_of_date_because_output_file_1_does_not_exist, "src/logic/tsconfig.json", "src/logic/index.js"],
                     [Diagnostics.Building_project_0, "/src/logic/tsconfig.json"],
-                    [Diagnostics.Property_0_does_not_exist_on_type_1, "muitply", `typeof import("/src/core/index")`],
+                    {
+                        message: [Diagnostics.Property_0_does_not_exist_on_type_1, "muitply", `typeof import("/src/core/index")`],
+                        location: {
+                            file: "/src/logic/index.ts",
+                            start: indexOf(fs, "/src/logic/index.ts", "muitply"),
+                            length: "muitply".length
+                        }
+                    },
                     [Diagnostics.Project_0_can_t_be_built_because_its_dependency_1_has_errors, "src/tests/tsconfig.json", "src/logic"],
                     [Diagnostics.Skipping_build_of_project_0_because_its_dependency_1_has_errors, "/src/tests/tsconfig.json", "/src/logic"]
                 );

--- a/src/testRunner/unittests/tsbuild/transitiveReferences.ts
+++ b/src/testRunner/unittests/tsbuild/transitiveReferences.ts
@@ -69,7 +69,14 @@ export const b = new A();`);
             verifyBuild(fs => modifyFsBTsToNonRelativeImport(fs, "node"),
                 allExpectedOutputs,
                 expectedFileTraces,
-                [Diagnostics.Cannot_find_module_0, "a"],
+                {
+                    message: [Diagnostics.Cannot_find_module_0, "a"],
+                    location: {
+                        file: "/src/b.ts",
+                        start: `import {A} from 'a';`.indexOf(`'a'`),
+                        length: `'a'`.length
+                    }
+                },
             );
         });
     });

--- a/src/testRunner/unittests/tsbuild/watchMode.ts
+++ b/src/testRunner/unittests/tsbuild/watchMode.ts
@@ -16,7 +16,6 @@ namespace ts.tscWatch {
         return host;
     }
 
-
     export function createSolutionBuilder(system: WatchedSystem, rootNames: ReadonlyArray<string>, defaultOptions?: BuildOptions) {
         const host = createSolutionBuilderHost(system);
         host.now = system.now.bind(system);
@@ -1228,5 +1227,91 @@ export function someFn() { }`);
                 `Building project '/user/username/projects/sample1/tests/tsconfig.json'...\n\n`,
             ]);
         });
+    });
+
+    describe("unittests:: tsbuild:: watchMode:: with demo project", () => {
+        const projectLocation = `${projectsLocation}/demo`;
+        let coreFiles: File[];
+        let animalFiles: File[];
+        let zooFiles: File[];
+        let solutionFile: File;
+        let baseConfig: File;
+        let allFilesExceptBase: File[];
+        before(() => {
+            coreFiles = subProjectFiles("core", ["tsconfig.json", "utilities.ts"]);
+            animalFiles = subProjectFiles("animals", ["tsconfig.json", "animal.ts", "dog.ts", "index.ts"]);
+            zooFiles = subProjectFiles("zoo", ["tsconfig.json", "zoo.ts"]);
+            solutionFile = projectFile("tsconfig.json");
+            baseConfig = projectFile("tsconfig-base.json");
+            allFilesExceptBase = [...coreFiles, ...animalFiles, ...zooFiles, solutionFile];
+        });
+
+        after(() => {
+            coreFiles = undefined!;
+            animalFiles = undefined!;
+            zooFiles = undefined!;
+            solutionFile = undefined!;
+            baseConfig = undefined!;
+            allFilesExceptBase = undefined!;
+        });
+
+        it("updates with circular reference", () => {
+            const host = createTsBuildWatchSystem([
+                ...allFilesExceptBase,
+                baseConfig,
+                { path: libFile.path, content: libContent }
+            ], { currentDirectory: projectLocation });
+            host.writeFile(coreFiles[0].path, coreFiles[0].content.replace(
+                "}",
+                `},
+  "references": [
+    {
+      "path": "../zoo"
+    }
+  ]`
+            ));
+            createSolutionBuilderWithWatch(host, ["tsconfig.json"], { verbose: true, watch: true });
+            checkOutputErrorsInitial(host, [
+                `error TS6202: Project references may not form a circular graph. Cycle detected: /user/username/projects/demo/tsconfig.json\r\n/user/username/projects/demo/core/tsconfig.json\r\n/user/username/projects/demo/zoo/tsconfig.json\r\n/user/username/projects/demo/animals/tsconfig.json\n`
+            ], /*disableConsoleClears*/ undefined, [
+                `Projects in this build: \r\n    * animals/tsconfig.json\r\n    * zoo/tsconfig.json\r\n    * core/tsconfig.json\r\n    * tsconfig.json\n\n`
+            ]);
+            verifyWatches(host);
+
+            // Make changes
+            host.writeFile(coreFiles[0].path, coreFiles[0].content);
+            host.checkTimeoutQueueLengthAndRun(1); // build core
+            host.checkTimeoutQueueLengthAndRun(1); // build animals
+            host.checkTimeoutQueueLengthAndRun(1); // build zoo
+            host.checkTimeoutQueueLengthAndRun(1); // build solution
+            host.checkTimeoutQueueLength(0);
+            checkOutputErrorsIncremental(host, emptyArray, /*disableConsoleClears*/ undefined, /*logsBeforeWatchDiagnostics*/ undefined, [
+                `Project 'core/tsconfig.json' is out of date because output file 'lib/core/utilities.js' does not exist\n\n`,
+                `Building project '/user/username/projects/demo/core/tsconfig.json'...\n\n`,
+                `Project 'animals/tsconfig.json' is out of date because output file 'lib/animals/animal.js' does not exist\n\n`,
+                `Building project '/user/username/projects/demo/animals/tsconfig.json'...\n\n`,
+                `Project 'zoo/tsconfig.json' is out of date because output file 'lib/zoo/zoo.js' does not exist\n\n`,
+                `Building project '/user/username/projects/demo/zoo/tsconfig.json'...\n\n`,
+            ]);
+        });
+
+        function subProjectFiles(subProject: string, fileNames: readonly string[]): File[] {
+            return fileNames.map(file => projectFile(`${subProject}/${file}`));
+        }
+
+        function projectFile(fileName: string): File {
+            return getFileFromProject("demo", fileName);
+        }
+
+        function verifyWatches(host: TsBuildWatchSystem) {
+            checkWatchedFilesDetailed(host, allFilesExceptBase.map(f => f.path), 1);
+            checkWatchedDirectories(host, emptyArray, /*recursive*/ false);
+            checkWatchedDirectoriesDetailed(
+                host,
+                [`${projectLocation}/core`, `${projectLocation}/animals`, `${projectLocation}/zoo`],
+                1,
+                /*recursive*/ true
+            );
+        }
     });
 }

--- a/src/testRunner/unittests/tscWatch/helpers.ts
+++ b/src/testRunner/unittests/tscWatch/helpers.ts
@@ -54,30 +54,51 @@ namespace ts.tscWatch {
 
     const elapsedRegex = /^Elapsed:: [0-9]+ms/;
     const buildVerboseLogRegEx = /^.+ \- /;
-    function checkOutputErrors(
+    export enum HostOutputKind {
+        Log,
+        Diagnostic,
+        WatchDiagnostic
+    }
+
+    export interface HostOutputLog {
+        kind: HostOutputKind.Log;
+        expected: string;
+        caption?: string;
+    }
+
+    export interface HostOutputDiagnostic {
+        kind: HostOutputKind.Diagnostic;
+        diagnostic: Diagnostic | string;
+    }
+
+    export interface HostOutputWatchDiagnostic {
+        kind: HostOutputKind.WatchDiagnostic;
+        diagnostic: Diagnostic | string;
+    }
+
+    export type HostOutput = HostOutputLog | HostOutputDiagnostic | HostOutputWatchDiagnostic;
+
+    export function checkOutputErrors(
         host: WatchedSystem,
-        logsBeforeWatchDiagnostic: string[] | undefined,
-        preErrorsWatchDiagnostic: Diagnostic | undefined,
-        logsBeforeErrors: string[] | undefined,
-        errors: ReadonlyArray<Diagnostic> | ReadonlyArray<string>,
-        disableConsoleClears?: boolean | undefined,
-        ...postErrorsWatchDiagnostics: Diagnostic[] | string[]
+        expected: readonly HostOutput[],
+        disableConsoleClears?: boolean | undefined
     ) {
         let screenClears = 0;
         const outputs = host.getOutput();
-        const expectedOutputCount = (preErrorsWatchDiagnostic ? 1 : 0) +
-            errors.length +
-            postErrorsWatchDiagnostics.length +
-            (logsBeforeWatchDiagnostic ? logsBeforeWatchDiagnostic.length : 0) +
-            (logsBeforeErrors ? logsBeforeErrors.length : 0);
-        assert.equal(outputs.length, expectedOutputCount, JSON.stringify(outputs));
+        assert.equal(outputs.length, expected.length, JSON.stringify(outputs));
         let index = 0;
-        forEach(logsBeforeWatchDiagnostic, log => assertLog("logsBeforeWatchDiagnostic", log));
-        if (preErrorsWatchDiagnostic) assertWatchDiagnostic(preErrorsWatchDiagnostic);
-        forEach(logsBeforeErrors, log => assertLog("logBeforeError", log));
-        // Verify errors
-        forEach(errors, assertDiagnostic);
-        forEach(postErrorsWatchDiagnostics, assertWatchDiagnostic);
+        forEach(expected, expected => {
+            switch (expected.kind) {
+                case HostOutputKind.Log:
+                    return assertLog(expected);
+                case HostOutputKind.Diagnostic:
+                    return assertDiagnostic(expected);
+                case HostOutputKind.WatchDiagnostic:
+                    return assertWatchDiagnostic(expected);
+                default:
+                    return Debug.assertNever(expected);
+            }
+        });
         assert.equal(host.screenClears.length, screenClears, "Expected number of screen clears");
         host.clearOutput();
 
@@ -85,7 +106,7 @@ namespace ts.tscWatch {
             return !!(diagnostic as Diagnostic).messageText;
         }
 
-        function assertDiagnostic(diagnostic: Diagnostic | string) {
+        function assertDiagnostic({ diagnostic }: HostOutputDiagnostic) {
             const expected = isDiagnostic(diagnostic) ? formatDiagnostic(diagnostic, host) : diagnostic;
             assert.equal(outputs[index], expected, getOutputAtFailedMessage("Diagnostic", expected));
             index++;
@@ -95,13 +116,13 @@ namespace ts.tscWatch {
             return log.replace(elapsedRegex, "").replace(buildVerboseLogRegEx, "");
         }
 
-        function assertLog(caption: string, expected: string) {
+        function assertLog({ caption, expected }: HostOutputLog) {
             const actual = outputs[index];
-            assert.equal(getCleanLogString(actual), getCleanLogString(expected), getOutputAtFailedMessage(caption, expected));
+            assert.equal(getCleanLogString(actual), getCleanLogString(expected), getOutputAtFailedMessage(caption || "Log", expected));
             index++;
         }
 
-        function assertWatchDiagnostic(diagnostic: Diagnostic | string) {
+        function assertWatchDiagnostic({ diagnostic }: HostOutputWatchDiagnostic) {
             if (isString(diagnostic)) {
                 assert.equal(outputs[index], diagnostic, getOutputAtFailedMessage("Diagnostic", diagnostic));
             }
@@ -128,54 +149,82 @@ namespace ts.tscWatch {
         }
     }
 
-    function createErrorsFoundCompilerDiagnostic(errors: ReadonlyArray<Diagnostic> | ReadonlyArray<string>) {
-        return errors.length === 1
-            ? createCompilerDiagnostic(Diagnostics.Found_1_error_Watching_for_file_changes)
-            : createCompilerDiagnostic(Diagnostics.Found_0_errors_Watching_for_file_changes, errors.length);
+    export function hostOutputLog(expected: string, caption?: string): HostOutputLog {
+        return { kind: HostOutputKind.Log, expected, caption };
+    }
+    export function hostOutputDiagnostic(diagnostic: Diagnostic | string): HostOutputDiagnostic {
+        return { kind: HostOutputKind.Diagnostic, diagnostic };
+    }
+    export function hostOutputWatchDiagnostic(diagnostic: Diagnostic | string): HostOutputWatchDiagnostic {
+        return { kind: HostOutputKind.WatchDiagnostic, diagnostic };
+    }
+
+    export function startingCompilationInWatchMode() {
+        return hostOutputWatchDiagnostic(createCompilerDiagnostic(Diagnostics.Starting_compilation_in_watch_mode));
+    }
+    export function foundErrorsWatching(errors: readonly any[]) {
+        return hostOutputWatchDiagnostic(errors.length === 1 ?
+            createCompilerDiagnostic(Diagnostics.Found_1_error_Watching_for_file_changes) :
+            createCompilerDiagnostic(Diagnostics.Found_0_errors_Watching_for_file_changes, errors.length)
+        );
+    }
+    export function fileChangeDetected() {
+        return hostOutputWatchDiagnostic(createCompilerDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation));
     }
 
     export function checkOutputErrorsInitial(host: WatchedSystem, errors: ReadonlyArray<Diagnostic> | ReadonlyArray<string>, disableConsoleClears?: boolean, logsBeforeErrors?: string[]) {
         checkOutputErrors(
             host,
-            /*logsBeforeWatchDiagnostic*/ undefined,
-            createCompilerDiagnostic(Diagnostics.Starting_compilation_in_watch_mode),
-            logsBeforeErrors,
-            errors,
-            disableConsoleClears,
-            createErrorsFoundCompilerDiagnostic(errors));
+            [
+                startingCompilationInWatchMode(),
+                ...map(logsBeforeErrors || emptyArray, expected => hostOutputLog(expected, "logBeforeError")),
+                ...map(errors, hostOutputDiagnostic),
+                foundErrorsWatching(errors)
+            ],
+            disableConsoleClears
+        );
     }
 
     export function checkOutputErrorsIncremental(host: WatchedSystem, errors: ReadonlyArray<Diagnostic> | ReadonlyArray<string>, disableConsoleClears?: boolean, logsBeforeWatchDiagnostic?: string[], logsBeforeErrors?: string[]) {
         checkOutputErrors(
             host,
-            logsBeforeWatchDiagnostic,
-            createCompilerDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation),
-            logsBeforeErrors,
-            errors,
-            disableConsoleClears,
-            createErrorsFoundCompilerDiagnostic(errors));
+            [
+                ...map(logsBeforeWatchDiagnostic || emptyArray, expected => hostOutputLog(expected, "logsBeforeWatchDiagnostic")),
+                fileChangeDetected(),
+                ...map(logsBeforeErrors || emptyArray, expected => hostOutputLog(expected, "logBeforeError")),
+                ...map(errors, hostOutputDiagnostic),
+                foundErrorsWatching(errors)
+            ],
+            disableConsoleClears
+        );
     }
 
     export function checkOutputErrorsIncrementalWithExit(host: WatchedSystem, errors: ReadonlyArray<Diagnostic> | ReadonlyArray<string>, expectedExitCode: ExitStatus, disableConsoleClears?: boolean, logsBeforeWatchDiagnostic?: string[], logsBeforeErrors?: string[]) {
         checkOutputErrors(
             host,
-            logsBeforeWatchDiagnostic,
-            createCompilerDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation),
-            logsBeforeErrors,
-            errors,
-            disableConsoleClears);
+            [
+                ...map(logsBeforeWatchDiagnostic || emptyArray, expected => hostOutputLog(expected, "logsBeforeWatchDiagnostic")),
+                fileChangeDetected(),
+                ...map(logsBeforeErrors || emptyArray, expected => hostOutputLog(expected, "logBeforeError")),
+                ...map(errors, hostOutputDiagnostic),
+            ],
+            disableConsoleClears
+        );
         assert.equal(host.exitCode, expectedExitCode);
     }
 
     export function checkNormalBuildErrors(host: WatchedSystem, errors: ReadonlyArray<Diagnostic> | ReadonlyArray<string>, reportErrorSummary?: boolean) {
         checkOutputErrors(
             host,
-            /*logsBeforeWatchDiagnostic*/ undefined,
-            /*preErrorsWatchDiagnostic*/ undefined,
-            /*logsBeforeErrors*/ undefined,
-            errors,
-            /*disableConsoleClears*/ undefined,
-            ...(reportErrorSummary ? [getErrorSummaryText(errors.length, host.newLine)] : emptyArray)
+            [
+                ...map(errors, hostOutputDiagnostic),
+                ...map(
+                    reportErrorSummary ?
+                        [getErrorSummaryText(errors.length, host.newLine)] :
+                        emptyArray,
+                    hostOutputWatchDiagnostic
+                )
+            ]
         );
     }
 

--- a/src/testRunner/unittests/tscWatch/helpers.ts
+++ b/src/testRunner/unittests/tscWatch/helpers.ts
@@ -218,12 +218,9 @@ namespace ts.tscWatch {
             host,
             [
                 ...map(errors, hostOutputDiagnostic),
-                ...map(
-                    reportErrorSummary ?
-                        [getErrorSummaryText(errors.length, host.newLine)] :
-                        emptyArray,
-                    hostOutputWatchDiagnostic
-                )
+                ...reportErrorSummary ?
+                    [hostOutputWatchDiagnostic(getErrorSummaryText(errors.length, host.newLine))] :
+                    emptyArray
             ]
         );
     }

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1917,7 +1917,8 @@ declare namespace ts {
         Success = 0,
         DiagnosticsPresent_OutputsSkipped = 1,
         DiagnosticsPresent_OutputsGenerated = 2,
-        InvalidProject_OutputsSkipped = 3
+        InvalidProject_OutputsSkipped = 3,
+        ProjectReferenceCycle_OutputsSkupped = 4
     }
     export interface EmitResult {
         emitSkipped: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1917,7 +1917,8 @@ declare namespace ts {
         Success = 0,
         DiagnosticsPresent_OutputsSkipped = 1,
         DiagnosticsPresent_OutputsGenerated = 2,
-        InvalidProject_OutputsSkipped = 3
+        InvalidProject_OutputsSkipped = 3,
+        ProjectReferenceCycle_OutputsSkupped = 4
     }
     export interface EmitResult {
         emitSkipped: boolean;

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/incremental-declaration-changes/inferred-type-from-transitive-module.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/incremental-declaration-changes/inferred-type-from-transitive-module.js
@@ -31,8 +31,8 @@ export declare const lazyBar: LazyAction<() => void, typeof import("./lazyIndex"
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../bar.ts": {
         "version": "747071916",

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-Build/inferred-type-from-transitive-module.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-Build/inferred-type-from-transitive-module.js
@@ -69,8 +69,8 @@ exports.bar = bar_1.default;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../bar.ts": {
         "version": "5936740878",

--- a/tests/baselines/reference/tsbuild/lateBoundSymbol/incremental-declaration-doesnt-change/interface-is-merged-and-contains-late-bound-member.js
+++ b/tests/baselines/reference/tsbuild/lateBoundSymbol/incremental-declaration-doesnt-change/interface-is-merged-and-contains-late-bound-member.js
@@ -22,8 +22,8 @@ type A = HKT<number>[typeof sym];
   "program": {
     "fileInfos": {
       "../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./src/globals.d.ts": {
         "version": "-1994196675",

--- a/tests/baselines/reference/tsbuild/lateBoundSymbol/initial-Build/interface-is-merged-and-contains-late-bound-member.js
+++ b/tests/baselines/reference/tsbuild/lateBoundSymbol/initial-Build/interface-is-merged-and-contains-late-bound-member.js
@@ -15,8 +15,8 @@ var x = 10;
   "program": {
     "fileInfos": {
       "../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./src/globals.d.ts": {
         "version": "-1994196675",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/sample.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/sample.js
@@ -172,8 +172,8 @@ export class someClass { }
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",
@@ -212,8 +212,8 @@ export class someClass { }
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-2069755619",
@@ -262,8 +262,8 @@ export class someClass { }
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-2069755619",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-declaration-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-declaration-option-changes.js
@@ -21,8 +21,8 @@ export declare function multiply(a: number, b: number): number;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-esModuleInterop-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-esModuleInterop-option-changes.js
@@ -37,8 +37,8 @@ exports.m = mod;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-logic-config-changes-declaration-dir.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-logic-config-changes-declaration-dir.js
@@ -25,8 +25,8 @@ export declare const m: typeof mod;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",
@@ -76,8 +76,8 @@ export declare const m: typeof mod;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-module-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-module-option-changes.js
@@ -31,8 +31,8 @@ define(["require", "exports"], function (require, exports) {
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-target-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-changes/when-target-option-changes.js
@@ -33,8 +33,8 @@ exports.multiply = multiply;
         "signature": "8926001564"
       },
       "../../lib/lib.esnext.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",

--- a/tests/baselines/reference/tsbuild/sample1/incremental-declaration-doesnt-change/sample.js
+++ b/tests/baselines/reference/tsbuild/sample1/incremental-declaration-doesnt-change/sample.js
@@ -25,8 +25,8 @@ class someClass { }
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/sample.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/sample.js
@@ -185,8 +185,8 @@ exports.multiply = multiply;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",
@@ -370,8 +370,8 @@ sourceFile:index.ts
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",
@@ -436,8 +436,8 @@ exports.m = mod;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-declaration-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-declaration-option-changes.js
@@ -27,8 +27,8 @@ exports.multiply = multiply;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-esModuleInterop-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-esModuleInterop-option-changes.js
@@ -35,8 +35,8 @@ exports.multiply = multiply;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",
@@ -96,8 +96,8 @@ exports.m = mod;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",
@@ -178,8 +178,8 @@ exports.m = mod;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-logic-config-changes-declaration-dir.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-logic-config-changes-declaration-dir.js
@@ -185,8 +185,8 @@ exports.multiply = multiply;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",
@@ -370,8 +370,8 @@ sourceFile:index.ts
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",
@@ -436,8 +436,8 @@ exports.m = mod;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-logic-specifies-tsBuildInfoFile.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-logic-specifies-tsBuildInfoFile.js
@@ -185,8 +185,8 @@ exports.multiply = multiply;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",
@@ -370,8 +370,8 @@ sourceFile:index.ts
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",
@@ -453,8 +453,8 @@ exports.m = mod;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../core/index.ts": {
         "version": "-13851440507",

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-module-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-module-option-changes.js
@@ -27,8 +27,8 @@ exports.multiply = multiply;
   "program": {
     "fileInfos": {
       "../../lib/lib.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "./anothermodule.ts": {
         "version": "-2676574883",

--- a/tests/baselines/reference/tsbuild/sample1/initial-Build/when-target-option-changes.js
+++ b/tests/baselines/reference/tsbuild/sample1/initial-Build/when-target-option-changes.js
@@ -13,7 +13,7 @@ interface Number { toExponential: any; }
 interface Object {}
 interface RegExp {}
 interface String { charAt: any; }
-interface Array<T> {}
+interface Array<T> { length: number; [n: number]: T; }
 interface ReadonlyArray<T> {}
 declare const console: { log(msg: any): void; };
 
@@ -46,8 +46,8 @@ export function multiply(a, b) { return a * b; }
   "program": {
     "fileInfos": {
       "../../lib/lib.esnext.d.ts": {
-        "version": "-15964756381",
-        "signature": "-15964756381"
+        "version": "3858781397",
+        "signature": "3858781397"
       },
       "../../lib/lib.esnext.full.d.ts": {
         "version": "8926001564",

--- a/tests/projects/demo/animals/animal.ts
+++ b/tests/projects/demo/animals/animal.ts
@@ -1,0 +1,4 @@
+export type Size = "small" | "medium" | "large";
+export default interface Animal {
+    size: Size;
+}

--- a/tests/projects/demo/animals/dog.ts
+++ b/tests/projects/demo/animals/dog.ts
@@ -1,0 +1,18 @@
+import Animal from '.';
+import { makeRandomName } from '../core/utilities';
+
+export interface Dog extends Animal {
+    woof(): void;
+    name: string;
+}
+
+export function createDog(): Dog {
+    return ({
+        size: "medium",
+        woof: function(this: Dog) {
+            console.log(`${this.name} says "Woof"!`);
+        },
+        name: makeRandomName()
+    });
+}
+

--- a/tests/projects/demo/animals/index.ts
+++ b/tests/projects/demo/animals/index.ts
@@ -1,0 +1,5 @@
+import Animal from './animal';
+
+export default Animal;
+import { createDog, Dog } from './dog';
+export { createDog, Dog };

--- a/tests/projects/demo/animals/tsconfig.json
+++ b/tests/projects/demo/animals/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../tsconfig-base.json",
+  "compilerOptions": {
+    "outDir": "../lib/animals",
+    "rootDir": ".",
+  },
+  "references": [
+    { "path": "../core" }
+  ]
+}

--- a/tests/projects/demo/core/tsconfig.json
+++ b/tests/projects/demo/core/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig-base.json",
+  "compilerOptions": {
+    "outDir": "../lib/core",
+    "rootDir": "."
+  }
+}

--- a/tests/projects/demo/core/utilities.ts
+++ b/tests/projects/demo/core/utilities.ts
@@ -1,0 +1,10 @@
+
+export function makeRandomName() {
+    return "Bob!?! ";
+}
+
+export function lastElementOf<T>(arr: T[]): T | undefined {
+    if (arr.length === 0) return undefined;
+    return arr[arr.length - 1];
+}
+

--- a/tests/projects/demo/tsconfig-base.json
+++ b/tests/projects/demo/tsconfig-base.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+        "declaration": true,
+        "target": "es5",
+        "module": "commonjs",
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
+        "composite": true
+    }
+}

--- a/tests/projects/demo/tsconfig.json
+++ b/tests/projects/demo/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./core"
+    },
+    {
+      "path": "./animals"
+    },
+    {
+      "path": "./zoo"
+    }
+  ]
+}

--- a/tests/projects/demo/zoo/tsconfig.json
+++ b/tests/projects/demo/zoo/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig-base.json",
+  "compilerOptions": {
+    "outDir": "../lib/zoo",
+    "rootDir": "."
+  },
+  "references": [
+    {
+      "path": "../animals"
+    }
+  ]
+}

--- a/tests/projects/demo/zoo/zoo.ts
+++ b/tests/projects/demo/zoo/zoo.ts
@@ -1,0 +1,9 @@
+// import Animal from '../animals/index';
+import { Dog, createDog } from '../animals/index';
+
+export function createZoo(): Array<Dog> {
+    return [
+        createDog()
+    ];
+}
+

--- a/tests/projects/demo/zoo/zoo.ts
+++ b/tests/projects/demo/zoo/zoo.ts
@@ -1,4 +1,3 @@
-// import Animal from '../animals/index';
 import { Dog, createDog } from '../animals/index';
 
 export function createZoo(): Array<Dog> {


### PR DESCRIPTION
- When reporting circular reference diagnostic, instead of reporting that as a status (continuing build after that) report as error so build stops there.
- When a project is not built because it's referenced projects had error, we do not want to build the project containing reference to that project as well.
- Report error about file not in include list or file does not belong to rootDir at the file that references it. The import from root file is preferred if any otherwise first reference is used to report the error