### PR TITLE
Ignore unknown files to search from in document highlights

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1565,7 +1565,7 @@ namespace ts {
             const normalizedFileName = normalizePath(fileName);
             Debug.assert(filesToSearch.some(f => normalizePath(f) === normalizedFileName));
             synchronizeHostData();
-            const sourceFilesToSearch = filesToSearch.map(getValidSourceFile);
+            const sourceFilesToSearch = mapDefined(filesToSearch, fileName => program.getSourceFile(fileName));
             const sourceFile = getValidSourceFile(fileName);
             return DocumentHighlights.getDocumentHighlights(program, cancellationToken, sourceFile, position, sourceFilesToSearch);
         }

--- a/tests/cases/fourslash/documentHighlights_moduleImport_filesToSearchWithInvalidFile.ts
+++ b/tests/cases/fourslash/documentHighlights_moduleImport_filesToSearchWithInvalidFile.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /node_modules/@types/foo/index.d.ts
+////export const x: number;
+
+// @Filename: /a.ts
+////import * as foo from "foo";
+////foo.[|x|];
+
+// @Filename: /b.ts
+////import { [|x|] } from "foo";
+
+// @Filename: /c.ts
+////import { x } from "foo";
+
+const [r0, r1] = test.ranges();
+verify.rangesAreDocumentHighlights(test.ranges(), { filesToSearch: ["/a.ts", "/b.ts", "/unknown.ts"] });


### PR DESCRIPTION
@amcasey this fixes the issue you brought up when two files don't belong to same project during your scenario we were getting exception earlier.