### PR TITLE
Flag non-nullable functions in `if` statements as errors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -27874,7 +27874,25 @@ namespace ts {
             // Grammar checking
             checkGrammarStatementInAmbientContext(node);
 
-            checkTruthinessExpression(node.expression);
+            const type = checkTruthinessExpression(node.expression);
+
+            if (strictNullChecks &&
+                (node.expression.kind === SyntaxKind.Identifier ||
+                node.expression.kind === SyntaxKind.PropertyAccessExpression ||
+                node.expression.kind === SyntaxKind.ElementAccessExpression)) {
+                const possiblyFalsy = !!getFalsyFlags(type);
+                if (!possiblyFalsy) {
+                    // While it technically should be invalid for any known-truthy value
+                    // to be tested, we de-scope to functions as a heuristic to identify
+                    // the most common bugs. There are too many false positives for values
+                    // sourced from type definitions without strictNullChecks otherwise.
+                    const callSignatures = getSignaturesOfType(type, SignatureKind.Call);
+                    if (callSignatures.length > 0) {
+                        error(node.expression, Diagnostics.This_condition_will_always_return_true_since_the_function_is_always_defined_Did_you_mean_to_call_it_instead);
+                    }
+                }
+            }
+
             checkSourceElement(node.thenStatement);
 
             if (node.thenStatement.kind === SyntaxKind.EmptyStatement) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2689,7 +2689,10 @@
         "category": "Error",
         "code": 2773
     },
-
+    "This condition will always return true since the function is always defined. Did you mean to call it instead?": {
+        "category": "Error",
+        "code": 2774
+    },
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",
         "code": 4000

--- a/tests/baselines/reference/truthinessCallExpressionCoercion.errors.txt
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion.errors.txt
@@ -1,0 +1,69 @@
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(3,5): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(7,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(24,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(27,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(44,13): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+
+
+==== tests/cases/compiler/truthinessCallExpressionCoercion.ts (5 errors) ====
+    function func() { return Math.random() > 0.5; }
+    
+    if (func) { // error
+        ~~~~
+!!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+    }
+    
+    function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
+        if (required) { // error
+            ~~~~~~~~
+!!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+        }
+    
+        if (required()) { // ok
+        }
+    
+        if (optional) { // ok
+        }
+    }
+    
+    function checksPropertyAndElementAccess() {
+        const x = {
+            foo: {
+                bar() { }
+            }
+        }
+    
+        if (x.foo.bar) { // error
+            ~~~~~~~~~
+!!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+        }
+        
+        if (x.foo['bar']) { // error
+            ~~~~~~~~~~~~
+!!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+        }
+    }
+    
+    function maybeBoolean(param: boolean | (() => boolean)) {
+        if (param) { // ok
+        }
+    }
+    
+    class Foo {
+        maybeIsUser?: () => boolean;
+    
+        isUser() {
+            return true;
+        }
+    
+        test() {
+            if (this.isUser) { // error
+                ~~~~~~~~~~~
+!!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+            }
+    
+            if (this.maybeIsUser) { // ok
+            }
+        }
+    }
+    

--- a/tests/baselines/reference/truthinessCallExpressionCoercion.errors.txt
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion.errors.txt
@@ -1,11 +1,14 @@
 tests/cases/compiler/truthinessCallExpressionCoercion.ts(3,5): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
 tests/cases/compiler/truthinessCallExpressionCoercion.ts(7,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-tests/cases/compiler/truthinessCallExpressionCoercion.ts(24,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-tests/cases/compiler/truthinessCallExpressionCoercion.ts(27,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
-tests/cases/compiler/truthinessCallExpressionCoercion.ts(44,13): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(29,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(32,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(35,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(58,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(61,9): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+tests/cases/compiler/truthinessCallExpressionCoercion.ts(78,13): error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
 
 
-==== tests/cases/compiler/truthinessCallExpressionCoercion.ts (5 errors) ====
+==== tests/cases/compiler/truthinessCallExpressionCoercion.ts (8 errors) ====
     function func() { return Math.random() > 0.5; }
     
     if (func) { // error
@@ -13,23 +16,63 @@ tests/cases/compiler/truthinessCallExpressionCoercion.ts(44,13): error TS2774: T
 !!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
     }
     
-    function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
+    function onlyErrorsWhenTestingNonNullableFunctionType(required: () => boolean, optional?: () => boolean) {
         if (required) { // error
             ~~~~~~~~
 !!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
         }
     
-        if (required()) { // ok
+        if (optional) { // ok
         }
     
-        if (optional) { // ok
+        if (!!required) { // ok
+        }
+    
+        if (required()) { // ok
+        }
+    }
+    
+    function onlyErrorsWhenReturnsBoolean(
+        bool: () => boolean,
+        nullableBool: () => boolean | undefined,
+        nullableTrue: () => true | undefined,
+        nullable: () => undefined | null,
+        notABool: () => string,
+        unionWithBool: () => boolean | string,
+        nullableString: () => string | undefined
+    ) {
+        if (bool) { // error
+            ~~~~
+!!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+        }
+    
+        if (nullableBool) { // error
+            ~~~~~~~~~~~~
+!!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+        }
+    
+        if (nullableTrue) { // error
+            ~~~~~~~~~~~~
+!!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
+        }
+    
+        if (nullable) { // ok
+        }
+    
+        if (notABool) { // ok
+        }
+    
+        if (unionWithBool) { // ok
+        }
+    
+        if (nullableString) { // ok
         }
     }
     
     function checksPropertyAndElementAccess() {
         const x = {
             foo: {
-                bar() { }
+                bar() { return true; }
             }
         }
     
@@ -37,7 +80,7 @@ tests/cases/compiler/truthinessCallExpressionCoercion.ts(44,13): error TS2774: T
             ~~~~~~~~~
 !!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?
         }
-        
+    
         if (x.foo['bar']) { // error
             ~~~~~~~~~~~~
 !!! error TS2774: This condition will always return true since the function is always defined. Did you mean to call it instead?

--- a/tests/baselines/reference/truthinessCallExpressionCoercion.js
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion.js
@@ -4,27 +4,61 @@ function func() { return Math.random() > 0.5; }
 if (func) { // error
 }
 
-function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
+function onlyErrorsWhenTestingNonNullableFunctionType(required: () => boolean, optional?: () => boolean) {
     if (required) { // error
+    }
+
+    if (optional) { // ok
+    }
+
+    if (!!required) { // ok
     }
 
     if (required()) { // ok
     }
+}
 
-    if (optional) { // ok
+function onlyErrorsWhenReturnsBoolean(
+    bool: () => boolean,
+    nullableBool: () => boolean | undefined,
+    nullableTrue: () => true | undefined,
+    nullable: () => undefined | null,
+    notABool: () => string,
+    unionWithBool: () => boolean | string,
+    nullableString: () => string | undefined
+) {
+    if (bool) { // error
+    }
+
+    if (nullableBool) { // error
+    }
+
+    if (nullableTrue) { // error
+    }
+
+    if (nullable) { // ok
+    }
+
+    if (notABool) { // ok
+    }
+
+    if (unionWithBool) { // ok
+    }
+
+    if (nullableString) { // ok
     }
 }
 
 function checksPropertyAndElementAccess() {
     const x = {
         foo: {
-            bar() { }
+            bar() { return true; }
         }
     }
 
     if (x.foo.bar) { // error
     }
-    
+
     if (x.foo['bar']) { // error
     }
 }
@@ -55,18 +89,36 @@ class Foo {
 function func() { return Math.random() > 0.5; }
 if (func) { // error
 }
-function onlyErrorsWhenNonNullable(required, optional) {
+function onlyErrorsWhenTestingNonNullableFunctionType(required, optional) {
     if (required) { // error
+    }
+    if (optional) { // ok
+    }
+    if (!!required) { // ok
     }
     if (required()) { // ok
     }
-    if (optional) { // ok
+}
+function onlyErrorsWhenReturnsBoolean(bool, nullableBool, nullableTrue, nullable, notABool, unionWithBool, nullableString) {
+    if (bool) { // error
+    }
+    if (nullableBool) { // error
+    }
+    if (nullableTrue) { // error
+    }
+    if (nullable) { // ok
+    }
+    if (notABool) { // ok
+    }
+    if (unionWithBool) { // ok
+    }
+    if (nullableString) { // ok
     }
 }
 function checksPropertyAndElementAccess() {
     var x = {
         foo: {
-            bar: function () { }
+            bar: function () { return true; }
         }
     };
     if (x.foo.bar) { // error

--- a/tests/baselines/reference/truthinessCallExpressionCoercion.js
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion.js
@@ -1,0 +1,94 @@
+//// [truthinessCallExpressionCoercion.ts]
+function func() { return Math.random() > 0.5; }
+
+if (func) { // error
+}
+
+function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
+    if (required) { // error
+    }
+
+    if (required()) { // ok
+    }
+
+    if (optional) { // ok
+    }
+}
+
+function checksPropertyAndElementAccess() {
+    const x = {
+        foo: {
+            bar() { }
+        }
+    }
+
+    if (x.foo.bar) { // error
+    }
+    
+    if (x.foo['bar']) { // error
+    }
+}
+
+function maybeBoolean(param: boolean | (() => boolean)) {
+    if (param) { // ok
+    }
+}
+
+class Foo {
+    maybeIsUser?: () => boolean;
+
+    isUser() {
+        return true;
+    }
+
+    test() {
+        if (this.isUser) { // error
+        }
+
+        if (this.maybeIsUser) { // ok
+        }
+    }
+}
+
+
+//// [truthinessCallExpressionCoercion.js]
+function func() { return Math.random() > 0.5; }
+if (func) { // error
+}
+function onlyErrorsWhenNonNullable(required, optional) {
+    if (required) { // error
+    }
+    if (required()) { // ok
+    }
+    if (optional) { // ok
+    }
+}
+function checksPropertyAndElementAccess() {
+    var x = {
+        foo: {
+            bar: function () { }
+        }
+    };
+    if (x.foo.bar) { // error
+    }
+    if (x.foo['bar']) { // error
+    }
+}
+function maybeBoolean(param) {
+    if (param) { // ok
+    }
+}
+var Foo = /** @class */ (function () {
+    function Foo() {
+    }
+    Foo.prototype.isUser = function () {
+        return true;
+    };
+    Foo.prototype.test = function () {
+        if (this.isUser) { // error
+        }
+        if (this.maybeIsUser) { // ok
+        }
+    };
+    return Foo;
+}());

--- a/tests/baselines/reference/truthinessCallExpressionCoercion.symbols
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion.symbols
@@ -1,0 +1,97 @@
+=== tests/cases/compiler/truthinessCallExpressionCoercion.ts ===
+function func() { return Math.random() > 0.5; }
+>func : Symbol(func, Decl(truthinessCallExpressionCoercion.ts, 0, 0))
+>Math.random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.es5.d.ts, --, --))
+
+if (func) { // error
+>func : Symbol(func, Decl(truthinessCallExpressionCoercion.ts, 0, 0))
+}
+
+function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
+>onlyErrorsWhenNonNullable : Symbol(onlyErrorsWhenNonNullable, Decl(truthinessCallExpressionCoercion.ts, 3, 1))
+>required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 35))
+>optional : Symbol(optional, Decl(truthinessCallExpressionCoercion.ts, 5, 59))
+
+    if (required) { // error
+>required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 35))
+    }
+
+    if (required()) { // ok
+>required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 35))
+    }
+
+    if (optional) { // ok
+>optional : Symbol(optional, Decl(truthinessCallExpressionCoercion.ts, 5, 59))
+    }
+}
+
+function checksPropertyAndElementAccess() {
+>checksPropertyAndElementAccess : Symbol(checksPropertyAndElementAccess, Decl(truthinessCallExpressionCoercion.ts, 14, 1))
+
+    const x = {
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion.ts, 17, 9))
+
+        foo: {
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
+
+            bar() { }
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 18, 14))
+        }
+    }
+
+    if (x.foo.bar) { // error
+>x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 18, 14))
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion.ts, 17, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 18, 14))
+    }
+    
+    if (x.foo['bar']) { // error
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion.ts, 17, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
+>'bar' : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 18, 14))
+    }
+}
+
+function maybeBoolean(param: boolean | (() => boolean)) {
+>maybeBoolean : Symbol(maybeBoolean, Decl(truthinessCallExpressionCoercion.ts, 28, 1))
+>param : Symbol(param, Decl(truthinessCallExpressionCoercion.ts, 30, 22))
+
+    if (param) { // ok
+>param : Symbol(param, Decl(truthinessCallExpressionCoercion.ts, 30, 22))
+    }
+}
+
+class Foo {
+>Foo : Symbol(Foo, Decl(truthinessCallExpressionCoercion.ts, 33, 1))
+
+    maybeIsUser?: () => boolean;
+>maybeIsUser : Symbol(Foo.maybeIsUser, Decl(truthinessCallExpressionCoercion.ts, 35, 11))
+
+    isUser() {
+>isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion.ts, 36, 32))
+
+        return true;
+    }
+
+    test() {
+>test : Symbol(Foo.test, Decl(truthinessCallExpressionCoercion.ts, 40, 5))
+
+        if (this.isUser) { // error
+>this.isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion.ts, 36, 32))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion.ts, 33, 1))
+>isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion.ts, 36, 32))
+        }
+
+        if (this.maybeIsUser) { // ok
+>this.maybeIsUser : Symbol(Foo.maybeIsUser, Decl(truthinessCallExpressionCoercion.ts, 35, 11))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion.ts, 33, 1))
+>maybeIsUser : Symbol(Foo.maybeIsUser, Decl(truthinessCallExpressionCoercion.ts, 35, 11))
+        }
+    }
+}
+

--- a/tests/baselines/reference/truthinessCallExpressionCoercion.symbols
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion.symbols
@@ -9,88 +9,146 @@ if (func) { // error
 >func : Symbol(func, Decl(truthinessCallExpressionCoercion.ts, 0, 0))
 }
 
-function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
->onlyErrorsWhenNonNullable : Symbol(onlyErrorsWhenNonNullable, Decl(truthinessCallExpressionCoercion.ts, 3, 1))
->required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 35))
->optional : Symbol(optional, Decl(truthinessCallExpressionCoercion.ts, 5, 59))
+function onlyErrorsWhenTestingNonNullableFunctionType(required: () => boolean, optional?: () => boolean) {
+>onlyErrorsWhenTestingNonNullableFunctionType : Symbol(onlyErrorsWhenTestingNonNullableFunctionType, Decl(truthinessCallExpressionCoercion.ts, 3, 1))
+>required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 54))
+>optional : Symbol(optional, Decl(truthinessCallExpressionCoercion.ts, 5, 78))
 
     if (required) { // error
->required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 35))
-    }
-
-    if (required()) { // ok
->required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 35))
+>required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 54))
     }
 
     if (optional) { // ok
->optional : Symbol(optional, Decl(truthinessCallExpressionCoercion.ts, 5, 59))
+>optional : Symbol(optional, Decl(truthinessCallExpressionCoercion.ts, 5, 78))
+    }
+
+    if (!!required) { // ok
+>required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 54))
+    }
+
+    if (required()) { // ok
+>required : Symbol(required, Decl(truthinessCallExpressionCoercion.ts, 5, 54))
+    }
+}
+
+function onlyErrorsWhenReturnsBoolean(
+>onlyErrorsWhenReturnsBoolean : Symbol(onlyErrorsWhenReturnsBoolean, Decl(truthinessCallExpressionCoercion.ts, 17, 1))
+
+    bool: () => boolean,
+>bool : Symbol(bool, Decl(truthinessCallExpressionCoercion.ts, 19, 38))
+
+    nullableBool: () => boolean | undefined,
+>nullableBool : Symbol(nullableBool, Decl(truthinessCallExpressionCoercion.ts, 20, 24))
+
+    nullableTrue: () => true | undefined,
+>nullableTrue : Symbol(nullableTrue, Decl(truthinessCallExpressionCoercion.ts, 21, 44))
+
+    nullable: () => undefined | null,
+>nullable : Symbol(nullable, Decl(truthinessCallExpressionCoercion.ts, 22, 41))
+
+    notABool: () => string,
+>notABool : Symbol(notABool, Decl(truthinessCallExpressionCoercion.ts, 23, 37))
+
+    unionWithBool: () => boolean | string,
+>unionWithBool : Symbol(unionWithBool, Decl(truthinessCallExpressionCoercion.ts, 24, 27))
+
+    nullableString: () => string | undefined
+>nullableString : Symbol(nullableString, Decl(truthinessCallExpressionCoercion.ts, 25, 42))
+
+) {
+    if (bool) { // error
+>bool : Symbol(bool, Decl(truthinessCallExpressionCoercion.ts, 19, 38))
+    }
+
+    if (nullableBool) { // error
+>nullableBool : Symbol(nullableBool, Decl(truthinessCallExpressionCoercion.ts, 20, 24))
+    }
+
+    if (nullableTrue) { // error
+>nullableTrue : Symbol(nullableTrue, Decl(truthinessCallExpressionCoercion.ts, 21, 44))
+    }
+
+    if (nullable) { // ok
+>nullable : Symbol(nullable, Decl(truthinessCallExpressionCoercion.ts, 22, 41))
+    }
+
+    if (notABool) { // ok
+>notABool : Symbol(notABool, Decl(truthinessCallExpressionCoercion.ts, 23, 37))
+    }
+
+    if (unionWithBool) { // ok
+>unionWithBool : Symbol(unionWithBool, Decl(truthinessCallExpressionCoercion.ts, 24, 27))
+    }
+
+    if (nullableString) { // ok
+>nullableString : Symbol(nullableString, Decl(truthinessCallExpressionCoercion.ts, 25, 42))
     }
 }
 
 function checksPropertyAndElementAccess() {
->checksPropertyAndElementAccess : Symbol(checksPropertyAndElementAccess, Decl(truthinessCallExpressionCoercion.ts, 14, 1))
+>checksPropertyAndElementAccess : Symbol(checksPropertyAndElementAccess, Decl(truthinessCallExpressionCoercion.ts, 48, 1))
 
     const x = {
->x : Symbol(x, Decl(truthinessCallExpressionCoercion.ts, 17, 9))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion.ts, 51, 9))
 
         foo: {
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 51, 15))
 
-            bar() { }
->bar : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 18, 14))
+            bar() { return true; }
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 52, 14))
         }
     }
 
     if (x.foo.bar) { // error
->x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 18, 14))
->x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
->x : Symbol(x, Decl(truthinessCallExpressionCoercion.ts, 17, 9))
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
->bar : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 18, 14))
+>x.foo.bar : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 52, 14))
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 51, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion.ts, 51, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 51, 15))
+>bar : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 52, 14))
     }
-    
+
     if (x.foo['bar']) { // error
->x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
->x : Symbol(x, Decl(truthinessCallExpressionCoercion.ts, 17, 9))
->foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 17, 15))
->'bar' : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 18, 14))
+>x.foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 51, 15))
+>x : Symbol(x, Decl(truthinessCallExpressionCoercion.ts, 51, 9))
+>foo : Symbol(foo, Decl(truthinessCallExpressionCoercion.ts, 51, 15))
+>'bar' : Symbol(bar, Decl(truthinessCallExpressionCoercion.ts, 52, 14))
     }
 }
 
 function maybeBoolean(param: boolean | (() => boolean)) {
->maybeBoolean : Symbol(maybeBoolean, Decl(truthinessCallExpressionCoercion.ts, 28, 1))
->param : Symbol(param, Decl(truthinessCallExpressionCoercion.ts, 30, 22))
+>maybeBoolean : Symbol(maybeBoolean, Decl(truthinessCallExpressionCoercion.ts, 62, 1))
+>param : Symbol(param, Decl(truthinessCallExpressionCoercion.ts, 64, 22))
 
     if (param) { // ok
->param : Symbol(param, Decl(truthinessCallExpressionCoercion.ts, 30, 22))
+>param : Symbol(param, Decl(truthinessCallExpressionCoercion.ts, 64, 22))
     }
 }
 
 class Foo {
->Foo : Symbol(Foo, Decl(truthinessCallExpressionCoercion.ts, 33, 1))
+>Foo : Symbol(Foo, Decl(truthinessCallExpressionCoercion.ts, 67, 1))
 
     maybeIsUser?: () => boolean;
->maybeIsUser : Symbol(Foo.maybeIsUser, Decl(truthinessCallExpressionCoercion.ts, 35, 11))
+>maybeIsUser : Symbol(Foo.maybeIsUser, Decl(truthinessCallExpressionCoercion.ts, 69, 11))
 
     isUser() {
->isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion.ts, 36, 32))
+>isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion.ts, 70, 32))
 
         return true;
     }
 
     test() {
->test : Symbol(Foo.test, Decl(truthinessCallExpressionCoercion.ts, 40, 5))
+>test : Symbol(Foo.test, Decl(truthinessCallExpressionCoercion.ts, 74, 5))
 
         if (this.isUser) { // error
->this.isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion.ts, 36, 32))
->this : Symbol(Foo, Decl(truthinessCallExpressionCoercion.ts, 33, 1))
->isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion.ts, 36, 32))
+>this.isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion.ts, 70, 32))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion.ts, 67, 1))
+>isUser : Symbol(Foo.isUser, Decl(truthinessCallExpressionCoercion.ts, 70, 32))
         }
 
         if (this.maybeIsUser) { // ok
->this.maybeIsUser : Symbol(Foo.maybeIsUser, Decl(truthinessCallExpressionCoercion.ts, 35, 11))
->this : Symbol(Foo, Decl(truthinessCallExpressionCoercion.ts, 33, 1))
->maybeIsUser : Symbol(Foo.maybeIsUser, Decl(truthinessCallExpressionCoercion.ts, 35, 11))
+>this.maybeIsUser : Symbol(Foo.maybeIsUser, Decl(truthinessCallExpressionCoercion.ts, 69, 11))
+>this : Symbol(Foo, Decl(truthinessCallExpressionCoercion.ts, 67, 1))
+>maybeIsUser : Symbol(Foo.maybeIsUser, Decl(truthinessCallExpressionCoercion.ts, 69, 11))
         }
     }
 }

--- a/tests/baselines/reference/truthinessCallExpressionCoercion.types
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion.types
@@ -12,8 +12,8 @@ if (func) { // error
 >func : () => boolean
 }
 
-function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
->onlyErrorsWhenNonNullable : (required: () => boolean, optional?: (() => boolean) | undefined) => void
+function onlyErrorsWhenTestingNonNullableFunctionType(required: () => boolean, optional?: () => boolean) {
+>onlyErrorsWhenTestingNonNullableFunctionType : (required: () => boolean, optional?: (() => boolean) | undefined) => void
 >required : () => boolean
 >optional : (() => boolean) | undefined
 
@@ -21,13 +21,75 @@ function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boo
 >required : () => boolean
     }
 
+    if (optional) { // ok
+>optional : (() => boolean) | undefined
+    }
+
+    if (!!required) { // ok
+>!!required : true
+>!required : false
+>required : () => boolean
+    }
+
     if (required()) { // ok
 >required() : boolean
 >required : () => boolean
     }
+}
 
-    if (optional) { // ok
->optional : (() => boolean) | undefined
+function onlyErrorsWhenReturnsBoolean(
+>onlyErrorsWhenReturnsBoolean : (bool: () => boolean, nullableBool: () => boolean | undefined, nullableTrue: () => true | undefined, nullable: () => null | undefined, notABool: () => string, unionWithBool: () => string | boolean, nullableString: () => string | undefined) => void
+
+    bool: () => boolean,
+>bool : () => boolean
+
+    nullableBool: () => boolean | undefined,
+>nullableBool : () => boolean | undefined
+
+    nullableTrue: () => true | undefined,
+>nullableTrue : () => true | undefined
+>true : true
+
+    nullable: () => undefined | null,
+>nullable : () => null | undefined
+>null : null
+
+    notABool: () => string,
+>notABool : () => string
+
+    unionWithBool: () => boolean | string,
+>unionWithBool : () => string | boolean
+
+    nullableString: () => string | undefined
+>nullableString : () => string | undefined
+
+) {
+    if (bool) { // error
+>bool : () => boolean
+    }
+
+    if (nullableBool) { // error
+>nullableBool : () => boolean | undefined
+    }
+
+    if (nullableTrue) { // error
+>nullableTrue : () => true | undefined
+    }
+
+    if (nullable) { // ok
+>nullable : () => null | undefined
+    }
+
+    if (notABool) { // ok
+>notABool : () => string
+    }
+
+    if (unionWithBool) { // ok
+>unionWithBool : () => string | boolean
+    }
+
+    if (nullableString) { // ok
+>nullableString : () => string | undefined
     }
 }
 
@@ -35,31 +97,32 @@ function checksPropertyAndElementAccess() {
 >checksPropertyAndElementAccess : () => void
 
     const x = {
->x : { foo: { bar(): void; }; }
->{        foo: {            bar() { }        }    } : { foo: { bar(): void; }; }
+>x : { foo: { bar(): boolean; }; }
+>{        foo: {            bar() { return true; }        }    } : { foo: { bar(): boolean; }; }
 
         foo: {
->foo : { bar(): void; }
->{            bar() { }        } : { bar(): void; }
+>foo : { bar(): boolean; }
+>{            bar() { return true; }        } : { bar(): boolean; }
 
-            bar() { }
->bar : () => void
+            bar() { return true; }
+>bar : () => boolean
+>true : true
         }
     }
 
     if (x.foo.bar) { // error
->x.foo.bar : () => void
->x.foo : { bar(): void; }
->x : { foo: { bar(): void; }; }
->foo : { bar(): void; }
->bar : () => void
+>x.foo.bar : () => boolean
+>x.foo : { bar(): boolean; }
+>x : { foo: { bar(): boolean; }; }
+>foo : { bar(): boolean; }
+>bar : () => boolean
     }
-    
+
     if (x.foo['bar']) { // error
->x.foo['bar'] : () => void
->x.foo : { bar(): void; }
->x : { foo: { bar(): void; }; }
->foo : { bar(): void; }
+>x.foo['bar'] : () => boolean
+>x.foo : { bar(): boolean; }
+>x : { foo: { bar(): boolean; }; }
+>foo : { bar(): boolean; }
 >'bar' : "bar"
     }
 }

--- a/tests/baselines/reference/truthinessCallExpressionCoercion.types
+++ b/tests/baselines/reference/truthinessCallExpressionCoercion.types
@@ -1,0 +1,105 @@
+=== tests/cases/compiler/truthinessCallExpressionCoercion.ts ===
+function func() { return Math.random() > 0.5; }
+>func : () => boolean
+>Math.random() > 0.5 : boolean
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+>0.5 : 0.5
+
+if (func) { // error
+>func : () => boolean
+}
+
+function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
+>onlyErrorsWhenNonNullable : (required: () => boolean, optional?: (() => boolean) | undefined) => void
+>required : () => boolean
+>optional : (() => boolean) | undefined
+
+    if (required) { // error
+>required : () => boolean
+    }
+
+    if (required()) { // ok
+>required() : boolean
+>required : () => boolean
+    }
+
+    if (optional) { // ok
+>optional : (() => boolean) | undefined
+    }
+}
+
+function checksPropertyAndElementAccess() {
+>checksPropertyAndElementAccess : () => void
+
+    const x = {
+>x : { foo: { bar(): void; }; }
+>{        foo: {            bar() { }        }    } : { foo: { bar(): void; }; }
+
+        foo: {
+>foo : { bar(): void; }
+>{            bar() { }        } : { bar(): void; }
+
+            bar() { }
+>bar : () => void
+        }
+    }
+
+    if (x.foo.bar) { // error
+>x.foo.bar : () => void
+>x.foo : { bar(): void; }
+>x : { foo: { bar(): void; }; }
+>foo : { bar(): void; }
+>bar : () => void
+    }
+    
+    if (x.foo['bar']) { // error
+>x.foo['bar'] : () => void
+>x.foo : { bar(): void; }
+>x : { foo: { bar(): void; }; }
+>foo : { bar(): void; }
+>'bar' : "bar"
+    }
+}
+
+function maybeBoolean(param: boolean | (() => boolean)) {
+>maybeBoolean : (param: boolean | (() => boolean)) => void
+>param : boolean | (() => boolean)
+
+    if (param) { // ok
+>param : boolean | (() => boolean)
+    }
+}
+
+class Foo {
+>Foo : Foo
+
+    maybeIsUser?: () => boolean;
+>maybeIsUser : (() => boolean) | undefined
+
+    isUser() {
+>isUser : () => boolean
+
+        return true;
+>true : true
+    }
+
+    test() {
+>test : () => void
+
+        if (this.isUser) { // error
+>this.isUser : () => boolean
+>this : this
+>isUser : () => boolean
+        }
+
+        if (this.maybeIsUser) { // ok
+>this.maybeIsUser : (() => boolean) | undefined
+>this : this
+>maybeIsUser : (() => boolean) | undefined
+        }
+    }
+}
+

--- a/tests/cases/compiler/truthinessCallExpressionCoercion.ts
+++ b/tests/cases/compiler/truthinessCallExpressionCoercion.ts
@@ -1,0 +1,52 @@
+// @strictNullChecks:true
+
+function func() { return Math.random() > 0.5; }
+
+if (func) { // error
+}
+
+function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
+    if (required) { // error
+    }
+
+    if (required()) { // ok
+    }
+
+    if (optional) { // ok
+    }
+}
+
+function checksPropertyAndElementAccess() {
+    const x = {
+        foo: {
+            bar() { }
+        }
+    }
+
+    if (x.foo.bar) { // error
+    }
+    
+    if (x.foo['bar']) { // error
+    }
+}
+
+function maybeBoolean(param: boolean | (() => boolean)) {
+    if (param) { // ok
+    }
+}
+
+class Foo {
+    maybeIsUser?: () => boolean;
+
+    isUser() {
+        return true;
+    }
+
+    test() {
+        if (this.isUser) { // error
+        }
+
+        if (this.maybeIsUser) { // ok
+        }
+    }
+}

--- a/tests/cases/compiler/truthinessCallExpressionCoercion.ts
+++ b/tests/cases/compiler/truthinessCallExpressionCoercion.ts
@@ -5,27 +5,61 @@ function func() { return Math.random() > 0.5; }
 if (func) { // error
 }
 
-function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
+function onlyErrorsWhenTestingNonNullableFunctionType(required: () => boolean, optional?: () => boolean) {
     if (required) { // error
+    }
+
+    if (optional) { // ok
+    }
+
+    if (!!required) { // ok
     }
 
     if (required()) { // ok
     }
+}
 
-    if (optional) { // ok
+function onlyErrorsWhenReturnsBoolean(
+    bool: () => boolean,
+    nullableBool: () => boolean | undefined,
+    nullableTrue: () => true | undefined,
+    nullable: () => undefined | null,
+    notABool: () => string,
+    unionWithBool: () => boolean | string,
+    nullableString: () => string | undefined
+) {
+    if (bool) { // error
+    }
+
+    if (nullableBool) { // error
+    }
+
+    if (nullableTrue) { // error
+    }
+
+    if (nullable) { // ok
+    }
+
+    if (notABool) { // ok
+    }
+
+    if (unionWithBool) { // ok
+    }
+
+    if (nullableString) { // ok
     }
 }
 
 function checksPropertyAndElementAccess() {
     const x = {
         foo: {
-            bar() { }
+            bar() { return true; }
         }
     }
 
     if (x.foo.bar) { // error
     }
-    
+
     if (x.foo['bar']) { // error
     }
 }


### PR DESCRIPTION
Under `--strictNullChecks`, we now error on testing non-nullable function types in if statements if they're not called. This is a subset of #9041 as mentioned here: https://github.com/microsoft/TypeScript/issues/9041#issuecomment-299961331.

Example:

```ts
function onlyErrorsWhenNonNullable(required: () => boolean, optional?: () => boolean) {
    if (required) { // now an error...
    }

    if (required()) { // ...because you probably meant this, which is still ok
    }

    if (optional) { // still ok
    }
}
```

Note the concern about third-party values coming in without a strictNullChecks context is still valid :
```ts
import { ThirdPartyType, create } from 'some-package'

const x: ThirdPartyType = create();

// this may now flag an error because the type definitions for some-package
// don't mark someFunc as nullable when it should be
if (x.someFunc) {
}
```

Should we make a recommendation here in the error message like casting to a nullable type?