### PR TITLE
Do not emit this for helpers at the top level of a strict-mode source file

### DIFF
--- a/src/compiler/transformers/es2017.ts
+++ b/src/compiler/transformers/es2017.ts
@@ -41,6 +41,8 @@ namespace ts {
         /** A set of node IDs for generated super accessors (variable statements). */
         const substitutedSuperAccessors: boolean[] = [];
 
+        let topLevel: boolean;
+
         // Save the previous transformation hooks.
         const previousOnEmitNode = context.onEmitNode;
         const previousOnSubstituteNode = context.onSubstituteNode;
@@ -56,9 +58,24 @@ namespace ts {
                 return node;
             }
 
+            topLevel = isEffectiveStrictModeSourceFile(node, compilerOptions);
             const visited = visitEachChild(node, visitor, context);
             addEmitHelpers(visited, context.readEmitHelpers());
             return visited;
+        }
+
+        function doOutsideOfTopLevel<T, U>(cb: (value: T) => U, value: T) {
+            if (topLevel) {
+                topLevel = false;
+                const result = cb(value);
+                topLevel = true;
+                return result;
+            }
+            return cb(value);
+        }
+
+        function visitDefault(node: Node): VisitResult<Node> {
+            return visitEachChild(node, visitor, context);
         }
 
         function visitor(node: Node): VisitResult<Node> {
@@ -74,13 +91,13 @@ namespace ts {
                     return visitAwaitExpression(<AwaitExpression>node);
 
                 case SyntaxKind.MethodDeclaration:
-                    return visitMethodDeclaration(<MethodDeclaration>node);
+                    return doOutsideOfTopLevel(visitMethodDeclaration, <MethodDeclaration>node);
 
                 case SyntaxKind.FunctionDeclaration:
-                    return visitFunctionDeclaration(<FunctionDeclaration>node);
+                    return doOutsideOfTopLevel(visitFunctionDeclaration, <FunctionDeclaration>node);
 
                 case SyntaxKind.FunctionExpression:
-                    return visitFunctionExpression(<FunctionExpression>node);
+                    return doOutsideOfTopLevel(visitFunctionExpression, <FunctionExpression>node);
 
                 case SyntaxKind.ArrowFunction:
                     return visitArrowFunction(<ArrowFunction>node);
@@ -96,6 +113,13 @@ namespace ts {
                         hasSuperElementAccess = true;
                     }
                     return visitEachChild(node, visitor, context);
+
+                case SyntaxKind.GetAccessor:
+                case SyntaxKind.SetAccessor:
+                case SyntaxKind.Constructor:
+                case SyntaxKind.ClassDeclaration:
+                case SyntaxKind.ClassExpression:
+                    return doOutsideOfTopLevel(visitDefault, node);
 
                 default:
                     return visitEachChild(node, visitor, context);
@@ -433,6 +457,7 @@ namespace ts {
                     createReturn(
                         createAwaiterHelper(
                             context,
+                            !topLevel,
                             hasLexicalArguments,
                             promiseConstructor,
                             transformAsyncFunctionBodyWorker(<Block>node.body, statementOffset)
@@ -473,6 +498,7 @@ namespace ts {
             else {
                 const expression = createAwaiterHelper(
                     context,
+                    !topLevel,
                     hasLexicalArguments,
                     promiseConstructor,
                     transformAsyncFunctionBodyWorker(node.body!)
@@ -786,7 +812,7 @@ namespace ts {
             };`
     };
 
-    function createAwaiterHelper(context: TransformationContext, hasLexicalArguments: boolean, promiseConstructor: EntityName | Expression | undefined, body: Block) {
+    function createAwaiterHelper(context: TransformationContext, hasLexicalThis: boolean, hasLexicalArguments: boolean, promiseConstructor: EntityName | Expression | undefined, body: Block) {
         context.requestEmitHelper(awaiterHelper);
 
         const generatorFunc = createFunctionExpression(
@@ -806,7 +832,7 @@ namespace ts {
             getUnscopedHelperName("__awaiter"),
             /*typeArguments*/ undefined,
             [
-                createThis(),
+                hasLexicalThis ? createThis() : createVoidZero(),
                 hasLexicalArguments ? createIdentifier("arguments") : createVoidZero(),
                 promiseConstructor ? createExpressionFromEntityName(promiseConstructor) : createVoidZero(),
                 generatorFunc

--- a/src/compiler/transformers/es2018.ts
+++ b/src/compiler/transformers/es2018.ts
@@ -26,6 +26,7 @@ namespace ts {
         let enabledSubstitutions: ESNextSubstitutionFlags;
         let enclosingFunctionFlags: FunctionFlags;
         let enclosingSuperContainerFlags: NodeCheckFlags = 0;
+        let topLevel: boolean;
 
         /** Keeps track of property names accessed on super (`super.x`) within async functions. */
         let capturedSuperProperties: UnderscoreEscapedMap<true>;
@@ -42,6 +43,7 @@ namespace ts {
             }
 
             exportedVariableStatement = false;
+            topLevel = isEffectiveStrictModeSourceFile(node, compilerOptions);
             const visited = visitEachChild(node, visitor, context);
             addEmitHelpers(visited, context.readEmitHelpers());
             return visited;
@@ -60,6 +62,20 @@ namespace ts {
                 return undefined;
             }
             return node;
+        }
+
+        function doOutsideOfTopLevel<T, U>(cb: (value: T) => U, value: T) {
+            if (topLevel) {
+                topLevel = false;
+                const result = cb(value);
+                topLevel = true;
+                return result;
+            }
+            return cb(value);
+        }
+
+        function visitDefault(node: Node): VisitResult<Node> {
+            return visitEachChild(node, visitor, context);
         }
 
         function visitorWorker(node: Node, noDestructuringValue: boolean): VisitResult<Node> {
@@ -92,17 +108,17 @@ namespace ts {
                 case SyntaxKind.VoidExpression:
                     return visitVoidExpression(node as VoidExpression);
                 case SyntaxKind.Constructor:
-                    return visitConstructorDeclaration(node as ConstructorDeclaration);
+                    return doOutsideOfTopLevel(visitConstructorDeclaration, node as ConstructorDeclaration);
                 case SyntaxKind.MethodDeclaration:
-                    return visitMethodDeclaration(node as MethodDeclaration);
+                    return doOutsideOfTopLevel(visitMethodDeclaration, node as MethodDeclaration);
                 case SyntaxKind.GetAccessor:
-                    return visitGetAccessorDeclaration(node as GetAccessorDeclaration);
+                    return doOutsideOfTopLevel(visitGetAccessorDeclaration, node as GetAccessorDeclaration);
                 case SyntaxKind.SetAccessor:
-                    return visitSetAccessorDeclaration(node as SetAccessorDeclaration);
+                    return doOutsideOfTopLevel(visitSetAccessorDeclaration, node as SetAccessorDeclaration);
                 case SyntaxKind.FunctionDeclaration:
-                    return visitFunctionDeclaration(node as FunctionDeclaration);
+                    return doOutsideOfTopLevel(visitFunctionDeclaration, node as FunctionDeclaration);
                 case SyntaxKind.FunctionExpression:
-                    return visitFunctionExpression(node as FunctionExpression);
+                    return doOutsideOfTopLevel(visitFunctionExpression, node as FunctionExpression);
                 case SyntaxKind.ArrowFunction:
                     return visitArrowFunction(node as ArrowFunction);
                 case SyntaxKind.Parameter:
@@ -121,6 +137,9 @@ namespace ts {
                         hasSuperElementAccess = true;
                     }
                     return visitEachChild(node, visitor, context);
+                case SyntaxKind.ClassDeclaration:
+                case SyntaxKind.ClassExpression:
+                    return doOutsideOfTopLevel(visitDefault, node);
                 default:
                     return visitEachChild(node, visitor, context);
             }
@@ -754,7 +773,8 @@ namespace ts {
                             node.body!,
                             visitLexicalEnvironment(node.body!.statements, visitor, context, statementOffset)
                         )
-                    )
+                    ),
+                    !topLevel
                 )
             );
 
@@ -1057,7 +1077,7 @@ namespace ts {
             };`
     };
 
-    function createAsyncGeneratorHelper(context: TransformationContext, generatorFunc: FunctionExpression) {
+    function createAsyncGeneratorHelper(context: TransformationContext, generatorFunc: FunctionExpression, hasLexicalThis: boolean) {
         context.requestEmitHelper(awaitHelper);
         context.requestEmitHelper(asyncGeneratorHelper);
 
@@ -1068,7 +1088,7 @@ namespace ts {
             getUnscopedHelperName("__asyncGenerator"),
             /*typeArguments*/ undefined,
             [
-                createThis(),
+                hasLexicalThis ? createThis() : createVoidZero(),
                 createIdentifier("arguments"),
                 generatorFunc
             ]

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -700,6 +700,43 @@ namespace ts {
         return isExternalModule(node) || compilerOptions.isolatedModules || ((getEmitModuleKind(compilerOptions) === ModuleKind.CommonJS) && !!node.commonJsModuleIndicator);
     }
 
+    /**
+     * Returns whether the source file will be treated as if it were in strict mode at runtime.
+     */
+    export function isEffectiveStrictModeSourceFile(node: SourceFile, compilerOptions: CompilerOptions) {
+        // We can only verify strict mode for JS/TS files
+        switch (node.scriptKind) {
+            case ScriptKind.JS:
+            case ScriptKind.TS:
+            case ScriptKind.JSX:
+            case ScriptKind.TSX:
+                break;
+            default:
+                return false;
+        }
+        // Strict mode does not matter for declaration files.
+        if (node.isDeclarationFile) {
+            return false;
+        }
+        // If `alwaysStrict` is set, then treat the file as strict.
+        if (getStrictOptionValue(compilerOptions, "alwaysStrict")) {
+            return true;
+        }
+        // Starting with a "use strict" directive indicates the file is strict.
+        if (startsWithUseStrict(node.statements)) {
+            return true;
+        }
+        if (isExternalModule(node) || compilerOptions.isolatedModules) {
+            // ECMAScript Modules are always strict.
+            if (getEmitModuleKind(compilerOptions) >= ModuleKind.ES2015) {
+                return true;
+            }
+            // Other modules are strict unless otherwise specified.
+            return !compilerOptions.noImplicitUseStrict;
+        }
+        return false;
+    }
+
     export function isBlockScope(node: Node, parentNode: Node): boolean {
         switch (node.kind) {
             case SyntaxKind.SourceFile:

--- a/tests/baselines/reference/asyncAwaitIsolatedModules_es5.js
+++ b/tests/baselines/reference/asyncAwaitIsolatedModules_es5.js
@@ -77,7 +77,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var _this = this;
 Object.defineProperty(exports, "__esModule", { value: true });
 var missing_1 = require("missing");
 function f0() {
@@ -110,25 +109,25 @@ var f6 = function () {
         return [2 /*return*/];
     }); });
 };
-var f7 = function () { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+var f7 = function () { return __awaiter(void 0, void 0, void 0, function () { return __generator(this, function (_a) {
     return [2 /*return*/];
 }); }); };
-var f8 = function () { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+var f8 = function () { return __awaiter(void 0, void 0, void 0, function () { return __generator(this, function (_a) {
     return [2 /*return*/];
 }); }); };
-var f9 = function () { return __awaiter(_this, void 0, missing_1.MyPromise, function () { return __generator(this, function (_a) {
+var f9 = function () { return __awaiter(void 0, void 0, missing_1.MyPromise, function () { return __generator(this, function (_a) {
     return [2 /*return*/];
 }); }); };
-var f10 = function () { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+var f10 = function () { return __awaiter(void 0, void 0, void 0, function () { return __generator(this, function (_a) {
     return [2 /*return*/, p];
 }); }); };
-var f11 = function () { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+var f11 = function () { return __awaiter(void 0, void 0, void 0, function () { return __generator(this, function (_a) {
     return [2 /*return*/, mp];
 }); }); };
-var f12 = function () { return __awaiter(_this, void 0, void 0, function () { return __generator(this, function (_a) {
+var f12 = function () { return __awaiter(void 0, void 0, void 0, function () { return __generator(this, function (_a) {
     return [2 /*return*/, mp];
 }); }); };
-var f13 = function () { return __awaiter(_this, void 0, missing_1.MyPromise, function () { return __generator(this, function (_a) {
+var f13 = function () { return __awaiter(void 0, void 0, missing_1.MyPromise, function () { return __generator(this, function (_a) {
     return [2 /*return*/, p];
 }); }); };
 var o = {

--- a/tests/baselines/reference/asyncAwaitIsolatedModules_es6.js
+++ b/tests/baselines/reference/asyncAwaitIsolatedModules_es6.js
@@ -67,13 +67,13 @@ let f5 = function () {
 let f6 = function () {
     return __awaiter(this, void 0, void 0, function* () { });
 };
-let f7 = () => __awaiter(this, void 0, void 0, function* () { });
-let f8 = () => __awaiter(this, void 0, void 0, function* () { });
-let f9 = () => __awaiter(this, void 0, void 0, function* () { });
-let f10 = () => __awaiter(this, void 0, void 0, function* () { return p; });
-let f11 = () => __awaiter(this, void 0, void 0, function* () { return mp; });
-let f12 = () => __awaiter(this, void 0, void 0, function* () { return mp; });
-let f13 = () => __awaiter(this, void 0, void 0, function* () { return p; });
+let f7 = () => __awaiter(void 0, void 0, void 0, function* () { });
+let f8 = () => __awaiter(void 0, void 0, void 0, function* () { });
+let f9 = () => __awaiter(void 0, void 0, void 0, function* () { });
+let f10 = () => __awaiter(void 0, void 0, void 0, function* () { return p; });
+let f11 = () => __awaiter(void 0, void 0, void 0, function* () { return mp; });
+let f12 = () => __awaiter(void 0, void 0, void 0, function* () { return mp; });
+let f13 = () => __awaiter(void 0, void 0, void 0, function* () { return p; });
 let o = {
     m1() {
         return __awaiter(this, void 0, void 0, function* () { });

--- a/tests/baselines/reference/asyncFunctionsAcrossFiles.js
+++ b/tests/baselines/reference/asyncFunctionsAcrossFiles.js
@@ -27,7 +27,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import { a } from './a';
 export const b = {
-    f: () => __awaiter(this, void 0, void 0, function* () {
+    f: () => __awaiter(void 0, void 0, void 0, function* () {
         yield a.f();
     })
 };
@@ -43,7 +43,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import { b } from './b';
 export const a = {
-    f: () => __awaiter(this, void 0, void 0, function* () {
+    f: () => __awaiter(void 0, void 0, void 0, function* () {
         yield b.f();
     })
 };

--- a/tests/baselines/reference/exportDefaultAsyncFunction2.js
+++ b/tests/baselines/reference/exportDefaultAsyncFunction2.js
@@ -43,7 +43,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         step((generator = generator.apply(thisArg, _arguments || [])).next());
     });
 };
-export default () => __awaiter(this, void 0, void 0, function* () { return 0; });
+export default () => __awaiter(void 0, void 0, void 0, function* () { return 0; });
 //// [c.js]
 import { async } from 'asyncawait';
 export default async();

--- a/tests/baselines/reference/importCallExpressionAsyncES3AMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES3AMD.js
@@ -67,7 +67,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 define(["require", "exports"], function (require, exports) {
     "use strict";
-    var _this = this;
     exports.__esModule = true;
     function fn() {
         return __awaiter(this, void 0, void 0, function () {
@@ -105,7 +104,7 @@ define(["require", "exports"], function (require, exports) {
     }());
     exports.cl1 = cl1;
     exports.obj = {
-        m: function () { return __awaiter(_this, void 0, void 0, function () {
+        m: function () { return __awaiter(void 0, void 0, void 0, function () {
             var req;
             return __generator(this, function (_a) {
                 switch (_a.label) {
@@ -139,7 +138,7 @@ define(["require", "exports"], function (require, exports) {
         return cl2;
     }());
     exports.cl2 = cl2;
-    exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+    exports.l = function () { return __awaiter(void 0, void 0, void 0, function () {
         var req;
         return __generator(this, function (_a) {
             switch (_a.label) {

--- a/tests/baselines/reference/importCallExpressionAsyncES3CJS.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES3CJS.js
@@ -66,7 +66,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var _this = this;
 exports.__esModule = true;
 function fn() {
     return __awaiter(this, void 0, void 0, function () {
@@ -104,7 +103,7 @@ var cl1 = /** @class */ (function () {
 }());
 exports.cl1 = cl1;
 exports.obj = {
-    m: function () { return __awaiter(_this, void 0, void 0, function () {
+    m: function () { return __awaiter(void 0, void 0, void 0, function () {
         var req;
         return __generator(this, function (_a) {
             switch (_a.label) {
@@ -138,7 +137,7 @@ var cl2 = /** @class */ (function () {
     return cl2;
 }());
 exports.cl2 = cl2;
-exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+exports.l = function () { return __awaiter(void 0, void 0, void 0, function () {
     var req;
     return __generator(this, function (_a) {
         switch (_a.label) {

--- a/tests/baselines/reference/importCallExpressionAsyncES3System.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES3System.js
@@ -67,8 +67,7 @@ System.register([], function (exports_1, context_1) {
             if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
         }
     };
-    var _this, cl1, obj, cl2, l;
-    _this = this;
+    var cl1, obj, cl2, l;
     var __moduleName = context_1 && context_1.id;
     function fn() {
         return __awaiter(this, void 0, void 0, function () {
@@ -109,7 +108,7 @@ System.register([], function (exports_1, context_1) {
             }());
             exports_1("cl1", cl1);
             exports_1("obj", obj = {
-                m: function () { return __awaiter(_this, void 0, void 0, function () {
+                m: function () { return __awaiter(void 0, void 0, void 0, function () {
                     var req;
                     return __generator(this, function (_a) {
                         switch (_a.label) {
@@ -143,7 +142,7 @@ System.register([], function (exports_1, context_1) {
                 return cl2;
             }());
             exports_1("cl2", cl2);
-            exports_1("l", l = function () { return __awaiter(_this, void 0, void 0, function () {
+            exports_1("l", l = function () { return __awaiter(void 0, void 0, void 0, function () {
                 var req;
                 return __generator(this, function (_a) {
                     switch (_a.label) {

--- a/tests/baselines/reference/importCallExpressionAsyncES3UMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES3UMD.js
@@ -76,7 +76,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 })(function (require, exports) {
     "use strict";
     var __syncRequire = typeof module === "object" && typeof module.exports === "object";
-    var _this = this;
     exports.__esModule = true;
     function fn() {
         return __awaiter(this, void 0, void 0, function () {
@@ -114,7 +113,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }());
     exports.cl1 = cl1;
     exports.obj = {
-        m: function () { return __awaiter(_this, void 0, void 0, function () {
+        m: function () { return __awaiter(void 0, void 0, void 0, function () {
             var req;
             return __generator(this, function (_a) {
                 switch (_a.label) {
@@ -148,7 +147,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         return cl2;
     }());
     exports.cl2 = cl2;
-    exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+    exports.l = function () { return __awaiter(void 0, void 0, void 0, function () {
         var req;
         return __generator(this, function (_a) {
             switch (_a.label) {

--- a/tests/baselines/reference/importCallExpressionAsyncES5AMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES5AMD.js
@@ -67,7 +67,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 };
 define(["require", "exports"], function (require, exports) {
     "use strict";
-    var _this = this;
     Object.defineProperty(exports, "__esModule", { value: true });
     function fn() {
         return __awaiter(this, void 0, void 0, function () {
@@ -105,7 +104,7 @@ define(["require", "exports"], function (require, exports) {
     }());
     exports.cl1 = cl1;
     exports.obj = {
-        m: function () { return __awaiter(_this, void 0, void 0, function () {
+        m: function () { return __awaiter(void 0, void 0, void 0, function () {
             var req;
             return __generator(this, function (_a) {
                 switch (_a.label) {
@@ -139,7 +138,7 @@ define(["require", "exports"], function (require, exports) {
         return cl2;
     }());
     exports.cl2 = cl2;
-    exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+    exports.l = function () { return __awaiter(void 0, void 0, void 0, function () {
         var req;
         return __generator(this, function (_a) {
             switch (_a.label) {

--- a/tests/baselines/reference/importCallExpressionAsyncES5CJS.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES5CJS.js
@@ -66,7 +66,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var _this = this;
 Object.defineProperty(exports, "__esModule", { value: true });
 function fn() {
     return __awaiter(this, void 0, void 0, function () {
@@ -104,7 +103,7 @@ var cl1 = /** @class */ (function () {
 }());
 exports.cl1 = cl1;
 exports.obj = {
-    m: function () { return __awaiter(_this, void 0, void 0, function () {
+    m: function () { return __awaiter(void 0, void 0, void 0, function () {
         var req;
         return __generator(this, function (_a) {
             switch (_a.label) {
@@ -138,7 +137,7 @@ var cl2 = /** @class */ (function () {
     return cl2;
 }());
 exports.cl2 = cl2;
-exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+exports.l = function () { return __awaiter(void 0, void 0, void 0, function () {
     var req;
     return __generator(this, function (_a) {
         switch (_a.label) {

--- a/tests/baselines/reference/importCallExpressionAsyncES5System.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES5System.js
@@ -67,8 +67,7 @@ System.register([], function (exports_1, context_1) {
             if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
         }
     };
-    var _this, cl1, obj, cl2, l;
-    _this = this;
+    var cl1, obj, cl2, l;
     var __moduleName = context_1 && context_1.id;
     function fn() {
         return __awaiter(this, void 0, void 0, function () {
@@ -109,7 +108,7 @@ System.register([], function (exports_1, context_1) {
             }());
             exports_1("cl1", cl1);
             exports_1("obj", obj = {
-                m: function () { return __awaiter(_this, void 0, void 0, function () {
+                m: function () { return __awaiter(void 0, void 0, void 0, function () {
                     var req;
                     return __generator(this, function (_a) {
                         switch (_a.label) {
@@ -143,7 +142,7 @@ System.register([], function (exports_1, context_1) {
                 return cl2;
             }());
             exports_1("cl2", cl2);
-            exports_1("l", l = function () { return __awaiter(_this, void 0, void 0, function () {
+            exports_1("l", l = function () { return __awaiter(void 0, void 0, void 0, function () {
                 var req;
                 return __generator(this, function (_a) {
                     switch (_a.label) {

--- a/tests/baselines/reference/importCallExpressionAsyncES5UMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES5UMD.js
@@ -76,7 +76,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 })(function (require, exports) {
     "use strict";
     var __syncRequire = typeof module === "object" && typeof module.exports === "object";
-    var _this = this;
     Object.defineProperty(exports, "__esModule", { value: true });
     function fn() {
         return __awaiter(this, void 0, void 0, function () {
@@ -114,7 +113,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }());
     exports.cl1 = cl1;
     exports.obj = {
-        m: function () { return __awaiter(_this, void 0, void 0, function () {
+        m: function () { return __awaiter(void 0, void 0, void 0, function () {
             var req;
             return __generator(this, function (_a) {
                 switch (_a.label) {
@@ -148,7 +147,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         return cl2;
     }());
     exports.cl2 = cl2;
-    exports.l = function () { return __awaiter(_this, void 0, void 0, function () {
+    exports.l = function () { return __awaiter(void 0, void 0, void 0, function () {
         var req;
         return __generator(this, function (_a) {
             switch (_a.label) {

--- a/tests/baselines/reference/importCallExpressionAsyncES6AMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES6AMD.js
@@ -56,7 +56,7 @@ define(["require", "exports"], function (require, exports) {
     }
     exports.cl1 = cl1;
     exports.obj = {
-        m: () => __awaiter(this, void 0, void 0, function* () {
+        m: () => __awaiter(void 0, void 0, void 0, function* () {
             const req = yield new Promise((resolve_3, reject_3) => { require(['./test'], resolve_3, reject_3); }); // THREE
         })
     };
@@ -70,7 +70,7 @@ define(["require", "exports"], function (require, exports) {
         }
     }
     exports.cl2 = cl2;
-    exports.l = () => __awaiter(this, void 0, void 0, function* () {
+    exports.l = () => __awaiter(void 0, void 0, void 0, function* () {
         const req = yield new Promise((resolve_5, reject_5) => { require(['./test'], resolve_5, reject_5); }); // FIVE
     });
 });

--- a/tests/baselines/reference/importCallExpressionAsyncES6CJS.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES6CJS.js
@@ -55,7 +55,7 @@ class cl1 {
 }
 exports.cl1 = cl1;
 exports.obj = {
-    m: () => __awaiter(this, void 0, void 0, function* () {
+    m: () => __awaiter(void 0, void 0, void 0, function* () {
         const req = yield Promise.resolve().then(() => require('./test')); // THREE
     })
 };
@@ -69,6 +69,6 @@ class cl2 {
     }
 }
 exports.cl2 = cl2;
-exports.l = () => __awaiter(this, void 0, void 0, function* () {
+exports.l = () => __awaiter(void 0, void 0, void 0, function* () {
     const req = yield Promise.resolve().then(() => require('./test')); // FIVE
 });

--- a/tests/baselines/reference/importCallExpressionAsyncES6System.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES6System.js
@@ -60,7 +60,7 @@ System.register([], function (exports_1, context_1) {
             };
             exports_1("cl1", cl1);
             exports_1("obj", obj = {
-                m: () => __awaiter(this, void 0, void 0, function* () {
+                m: () => __awaiter(void 0, void 0, void 0, function* () {
                     const req = yield context_1.import('./test'); // THREE
                 })
             });
@@ -74,7 +74,7 @@ System.register([], function (exports_1, context_1) {
                 }
             };
             exports_1("cl2", cl2);
-            exports_1("l", l = () => __awaiter(this, void 0, void 0, function* () {
+            exports_1("l", l = () => __awaiter(void 0, void 0, void 0, function* () {
                 const req = yield context_1.import('./test'); // FIVE
             }));
         }

--- a/tests/baselines/reference/importCallExpressionAsyncES6UMD.js
+++ b/tests/baselines/reference/importCallExpressionAsyncES6UMD.js
@@ -65,7 +65,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
     }
     exports.cl1 = cl1;
     exports.obj = {
-        m: () => __awaiter(this, void 0, void 0, function* () {
+        m: () => __awaiter(void 0, void 0, void 0, function* () {
             const req = yield __syncRequire ? Promise.resolve().then(() => require('./test')) : new Promise((resolve_3, reject_3) => { require(['./test'], resolve_3, reject_3); }); // THREE
         })
     };
@@ -79,7 +79,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
         }
     }
     exports.cl2 = cl2;
-    exports.l = () => __awaiter(this, void 0, void 0, function* () {
+    exports.l = () => __awaiter(void 0, void 0, void 0, function* () {
         const req = yield __syncRequire ? Promise.resolve().then(() => require('./test')) : new Promise((resolve_5, reject_5) => { require(['./test'], resolve_5, reject_5); }); // FIVE
     });
 });

--- a/tests/baselines/reference/importMeta(module=commonjs,target=es5).js
+++ b/tests/baselines/reference/importMeta(module=commonjs,target=es5).js
@@ -76,10 +76,9 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var _this = this;
 Object.defineProperty(exports, "__esModule", { value: true });
 // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
-(function () { return __awaiter(_this, void 0, void 0, function () {
+(function () { return __awaiter(void 0, void 0, void 0, function () {
     var response, blob, size, image;
     return __generator(this, function (_a) {
         switch (_a.label) {

--- a/tests/baselines/reference/importMeta(module=esnext,target=es5).js
+++ b/tests/baselines/reference/importMeta(module=esnext,target=es5).js
@@ -75,9 +75,8 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var _this = this;
 // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
-(function () { return __awaiter(_this, void 0, void 0, function () {
+(function () { return __awaiter(void 0, void 0, void 0, function () {
     var response, blob, size, image;
     return __generator(this, function (_a) {
         switch (_a.label) {

--- a/tests/baselines/reference/importMeta(module=system,target=es5).js
+++ b/tests/baselines/reference/importMeta(module=system,target=es5).js
@@ -77,14 +77,12 @@ System.register([], function (exports_1, context_1) {
             if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
         }
     };
-    var _this;
-    _this = this;
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [],
         execute: function () {
             // Adapted from https://github.com/tc39/proposal-import-meta/tree/c3902a9ffe2e69a7ac42c19d7ea74cbdcea9b7fb#example
-            (function () { return __awaiter(_this, void 0, void 0, function () {
+            (function () { return __awaiter(void 0, void 0, void 0, function () {
                 var response, blob, size, image;
                 return __generator(this, function (_a) {
                     switch (_a.label) {

--- a/tests/baselines/reference/reactReduxLikeDeferredInferenceAllowsAssignment.js
+++ b/tests/baselines/reference/reactReduxLikeDeferredInferenceAllowsAssignment.js
@@ -198,7 +198,6 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
-var _this = this;
 exports.__esModule = true;
 var simpleAction = function (payload) { return ({
     type: "SIMPLE_ACTION",
@@ -206,7 +205,7 @@ var simpleAction = function (payload) { return ({
 }); };
 var thunkAction = function (param1, param2) { return function (dispatch, _a) {
     var foo = _a.foo;
-    return __awaiter(_this, void 0, void 0, function () {
+    return __awaiter(void 0, void 0, void 0, function () {
         return __generator(this, function (_b) {
             return [2 /*return*/, foo];
         });


### PR DESCRIPTION
This PR changes our emit to avoid adding a `this` keyword to some helpers when at the top level of a strict-mode source file.

Fixes #27935
