### PR TITLE
Print program only if there are files are added or removed from the program.

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1009,8 +1009,11 @@ namespace ts.server {
             );
             const elapsed = timestamp() - start;
             this.writeLog(`Finishing updateGraphWorker: Project: ${this.getProjectName()} Version: ${this.getProjectVersion()} structureChanged: ${hasNewProgram} Elapsed: ${elapsed}ms`);
-            if (this.program !== oldProgram) {
+            if (this.hasAddedorRemovedFiles) {
                 this.print();
+            }
+            else if (this.program !== oldProgram) {
+                this.writeLog(`Different program with same set of files:: oldProgram.structureIsReused:: ${oldProgram && oldProgram.structureIsReused}`);
             }
             return hasNewProgram;
         }


### PR DESCRIPTION
This avoids littering tsserver log with program files which becomes too hard to diagnose
