### PR TITLE
checkJs: require JSDoc type argument for Array, Object, and Promise in noImplicitAny

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9333,10 +9333,10 @@ namespace ts {
                         return globalFunctionType;
                     case "Array":
                     case "array":
-                        return !typeArgs || !typeArgs.length ? anyArrayType : undefined;
+                        return (!typeArgs || !typeArgs.length) && !noImplicitAny ? anyArrayType : undefined;
                     case "Promise":
                     case "promise":
-                        return !typeArgs || !typeArgs.length ? createPromiseType(anyType) : undefined;
+                        return (!typeArgs || !typeArgs.length) && !noImplicitAny ? createPromiseType(anyType) : undefined;
                     case "Object":
                         if (typeArgs && typeArgs.length === 2) {
                             if (isJSDocIndexSignature(node)) {
@@ -9348,7 +9348,7 @@ namespace ts {
                             return anyType;
                         }
                         checkNoTypeArguments(node);
-                        return anyType;
+                        return !noImplicitAny ? anyType : undefined;
                 }
             }
         }

--- a/tests/baselines/reference/jsdocArrayObjectPromiseImplicitAny.symbols
+++ b/tests/baselines/reference/jsdocArrayObjectPromiseImplicitAny.symbols
@@ -1,0 +1,69 @@
+=== tests/cases/compiler/jsdocArrayObjectPromiseImplicitAny.js ===
+/** @type {Array} */
+var anyArray = [5];
+>anyArray : Symbol(anyArray, Decl(jsdocArrayObjectPromiseImplicitAny.js, 1, 3))
+
+/** @type {Array<number>} */
+var numberArray = [5];
+>numberArray : Symbol(numberArray, Decl(jsdocArrayObjectPromiseImplicitAny.js, 4, 3))
+
+/**
+ * @param {Array} arr
+ * @return {Array}
+ */
+function returnAnyArray(arr) {
+>returnAnyArray : Symbol(returnAnyArray, Decl(jsdocArrayObjectPromiseImplicitAny.js, 4, 22))
+>arr : Symbol(arr, Decl(jsdocArrayObjectPromiseImplicitAny.js, 10, 24))
+
+  return arr;
+>arr : Symbol(arr, Decl(jsdocArrayObjectPromiseImplicitAny.js, 10, 24))
+}
+
+/** @type {Promise} */
+var anyPromise = Promise.resolve(5);
+>anyPromise : Symbol(anyPromise, Decl(jsdocArrayObjectPromiseImplicitAny.js, 15, 3))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+/** @type {Promise<number>} */
+var numberPromise = Promise.resolve(5);
+>numberPromise : Symbol(numberPromise, Decl(jsdocArrayObjectPromiseImplicitAny.js, 18, 3))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+/**
+ * @param {Promise} pr
+ * @return {Promise}
+ */
+function returnAnyPromise(pr) {
+>returnAnyPromise : Symbol(returnAnyPromise, Decl(jsdocArrayObjectPromiseImplicitAny.js, 18, 39))
+>pr : Symbol(pr, Decl(jsdocArrayObjectPromiseImplicitAny.js, 24, 26))
+
+  return pr;
+>pr : Symbol(pr, Decl(jsdocArrayObjectPromiseImplicitAny.js, 24, 26))
+}
+
+/** @type {Object} */
+var anyObject = {valueOf: 1}; // not an error since assigning to any.
+>anyObject : Symbol(anyObject, Decl(jsdocArrayObjectPromiseImplicitAny.js, 29, 3))
+>valueOf : Symbol(valueOf, Decl(jsdocArrayObjectPromiseImplicitAny.js, 29, 17))
+
+/** @type {Object<string, number>} */
+var paramedObject = {valueOf: 1};
+>paramedObject : Symbol(paramedObject, Decl(jsdocArrayObjectPromiseImplicitAny.js, 32, 3))
+>valueOf : Symbol(valueOf, Decl(jsdocArrayObjectPromiseImplicitAny.js, 32, 21))
+
+/**
+ * @param {Object} obj
+ * @return {Object}
+ */
+function returnAnyObject(obj) {
+>returnAnyObject : Symbol(returnAnyObject, Decl(jsdocArrayObjectPromiseImplicitAny.js, 32, 33))
+>obj : Symbol(obj, Decl(jsdocArrayObjectPromiseImplicitAny.js, 38, 25))
+
+  return obj;
+>obj : Symbol(obj, Decl(jsdocArrayObjectPromiseImplicitAny.js, 38, 25))
+}
+

--- a/tests/baselines/reference/jsdocArrayObjectPromiseImplicitAny.types
+++ b/tests/baselines/reference/jsdocArrayObjectPromiseImplicitAny.types
@@ -1,0 +1,81 @@
+=== tests/cases/compiler/jsdocArrayObjectPromiseImplicitAny.js ===
+/** @type {Array} */
+var anyArray = [5];
+>anyArray : any[]
+>[5] : number[]
+>5 : 5
+
+/** @type {Array<number>} */
+var numberArray = [5];
+>numberArray : number[]
+>[5] : number[]
+>5 : 5
+
+/**
+ * @param {Array} arr
+ * @return {Array}
+ */
+function returnAnyArray(arr) {
+>returnAnyArray : (arr: any[]) => any[]
+>arr : any[]
+
+  return arr;
+>arr : any[]
+}
+
+/** @type {Promise} */
+var anyPromise = Promise.resolve(5);
+>anyPromise : Promise<any>
+>Promise.resolve(5) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>5 : 5
+
+/** @type {Promise<number>} */
+var numberPromise = Promise.resolve(5);
+>numberPromise : Promise<number>
+>Promise.resolve(5) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>5 : 5
+
+/**
+ * @param {Promise} pr
+ * @return {Promise}
+ */
+function returnAnyPromise(pr) {
+>returnAnyPromise : (pr: Promise<any>) => Promise<any>
+>pr : Promise<any>
+
+  return pr;
+>pr : Promise<any>
+}
+
+/** @type {Object} */
+var anyObject = {valueOf: 1}; // not an error since assigning to any.
+>anyObject : any
+>{valueOf: 1} : { valueOf: number; }
+>valueOf : number
+>1 : 1
+
+/** @type {Object<string, number>} */
+var paramedObject = {valueOf: 1};
+>paramedObject : { [x: string]: number; }
+>{valueOf: 1} : { valueOf: number; }
+>valueOf : number
+>1 : 1
+
+/**
+ * @param {Object} obj
+ * @return {Object}
+ */
+function returnAnyObject(obj) {
+>returnAnyObject : (obj: any) => any
+>obj : any
+
+  return obj;
+>obj : any
+}
+

--- a/tests/baselines/reference/jsdocArrayObjectPromiseNoImplicitAny.errors.txt
+++ b/tests/baselines/reference/jsdocArrayObjectPromiseNoImplicitAny.errors.txt
@@ -1,0 +1,66 @@
+tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js(1,12): error TS2314: Generic type 'Array<T>' requires 1 type argument(s).
+tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js(8,12): error TS2314: Generic type 'Array<T>' requires 1 type argument(s).
+tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js(9,13): error TS2314: Generic type 'Array<T>' requires 1 type argument(s).
+tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js(15,12): error TS2314: Generic type 'Promise<T>' requires 1 type argument(s).
+tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js(22,12): error TS2314: Generic type 'Promise<T>' requires 1 type argument(s).
+tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js(23,13): error TS2314: Generic type 'Promise<T>' requires 1 type argument(s).
+tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js(30,21): error TS2322: Type 'number' is not assignable to type '() => Object'.
+
+
+==== tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js (7 errors) ====
+    /** @type {Array} */
+               ~~~~~
+!!! error TS2314: Generic type 'Array<T>' requires 1 type argument(s).
+    var notAnyArray = [5];
+    
+    /** @type {Array<number>} */
+    var numberArray = [5];
+    
+    /**
+     * @param {Array} arr
+               ~~~~~
+!!! error TS2314: Generic type 'Array<T>' requires 1 type argument(s).
+     * @return {Array}
+                ~~~~~
+!!! error TS2314: Generic type 'Array<T>' requires 1 type argument(s).
+     */
+    function returnNotAnyArray(arr) {
+      return arr;
+    }
+    
+    /** @type {Promise} */
+               ~~~~~~~
+!!! error TS2314: Generic type 'Promise<T>' requires 1 type argument(s).
+    var notAnyPromise = Promise.resolve(5);
+    
+    /** @type {Promise<number>} */
+    var numberPromise = Promise.resolve(5);
+    
+    /**
+     * @param {Promise} pr
+               ~~~~~~~
+!!! error TS2314: Generic type 'Promise<T>' requires 1 type argument(s).
+     * @return {Promise}
+                ~~~~~~~
+!!! error TS2314: Generic type 'Promise<T>' requires 1 type argument(s).
+     */
+    function returnNotAnyPromise(pr) {
+      return pr;
+    }
+    
+    /** @type {Object} */
+    var notAnyObject = {valueOf: 1}; // error since assigning to Object, not any.
+                        ~~~~~~~
+!!! error TS2322: Type 'number' is not assignable to type '() => Object'.
+    
+    /** @type {Object<string, number>} */
+    var paramedObject = {valueOf: 1};
+    
+    /**
+     * @param {Object} obj
+     * @return {Object}
+     */
+    function returnNotAnyObject(obj) {
+      return obj;
+    }
+    

--- a/tests/baselines/reference/jsdocArrayObjectPromiseNoImplicitAny.symbols
+++ b/tests/baselines/reference/jsdocArrayObjectPromiseNoImplicitAny.symbols
@@ -1,0 +1,69 @@
+=== tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js ===
+/** @type {Array} */
+var notAnyArray = [5];
+>notAnyArray : Symbol(notAnyArray, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 1, 3))
+
+/** @type {Array<number>} */
+var numberArray = [5];
+>numberArray : Symbol(numberArray, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 4, 3))
+
+/**
+ * @param {Array} arr
+ * @return {Array}
+ */
+function returnNotAnyArray(arr) {
+>returnNotAnyArray : Symbol(returnNotAnyArray, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 4, 22))
+>arr : Symbol(arr, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 10, 27))
+
+  return arr;
+>arr : Symbol(arr, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 10, 27))
+}
+
+/** @type {Promise} */
+var notAnyPromise = Promise.resolve(5);
+>notAnyPromise : Symbol(notAnyPromise, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 15, 3))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+/** @type {Promise<number>} */
+var numberPromise = Promise.resolve(5);
+>numberPromise : Symbol(numberPromise, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 18, 3))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+/**
+ * @param {Promise} pr
+ * @return {Promise}
+ */
+function returnNotAnyPromise(pr) {
+>returnNotAnyPromise : Symbol(returnNotAnyPromise, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 18, 39))
+>pr : Symbol(pr, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 24, 29))
+
+  return pr;
+>pr : Symbol(pr, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 24, 29))
+}
+
+/** @type {Object} */
+var notAnyObject = {valueOf: 1}; // error since assigning to Object, not any.
+>notAnyObject : Symbol(notAnyObject, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 29, 3))
+>valueOf : Symbol(valueOf, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 29, 20))
+
+/** @type {Object<string, number>} */
+var paramedObject = {valueOf: 1};
+>paramedObject : Symbol(paramedObject, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 32, 3))
+>valueOf : Symbol(valueOf, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 32, 21))
+
+/**
+ * @param {Object} obj
+ * @return {Object}
+ */
+function returnNotAnyObject(obj) {
+>returnNotAnyObject : Symbol(returnNotAnyObject, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 32, 33))
+>obj : Symbol(obj, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 38, 28))
+
+  return obj;
+>obj : Symbol(obj, Decl(jsdocArrayObjectPromiseNoImplicitAny.js, 38, 28))
+}
+

--- a/tests/baselines/reference/jsdocArrayObjectPromiseNoImplicitAny.types
+++ b/tests/baselines/reference/jsdocArrayObjectPromiseNoImplicitAny.types
@@ -1,0 +1,81 @@
+=== tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.js ===
+/** @type {Array} */
+var notAnyArray = [5];
+>notAnyArray : any[]
+>[5] : number[]
+>5 : 5
+
+/** @type {Array<number>} */
+var numberArray = [5];
+>numberArray : number[]
+>[5] : number[]
+>5 : 5
+
+/**
+ * @param {Array} arr
+ * @return {Array}
+ */
+function returnNotAnyArray(arr) {
+>returnNotAnyArray : (arr: any[]) => any[]
+>arr : any[]
+
+  return arr;
+>arr : any[]
+}
+
+/** @type {Promise} */
+var notAnyPromise = Promise.resolve(5);
+>notAnyPromise : Promise<any>
+>Promise.resolve(5) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>5 : 5
+
+/** @type {Promise<number>} */
+var numberPromise = Promise.resolve(5);
+>numberPromise : Promise<number>
+>Promise.resolve(5) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>5 : 5
+
+/**
+ * @param {Promise} pr
+ * @return {Promise}
+ */
+function returnNotAnyPromise(pr) {
+>returnNotAnyPromise : (pr: Promise<any>) => Promise<any>
+>pr : Promise<any>
+
+  return pr;
+>pr : Promise<any>
+}
+
+/** @type {Object} */
+var notAnyObject = {valueOf: 1}; // error since assigning to Object, not any.
+>notAnyObject : Object
+>{valueOf: 1} : { valueOf: number; }
+>valueOf : number
+>1 : 1
+
+/** @type {Object<string, number>} */
+var paramedObject = {valueOf: 1};
+>paramedObject : { [x: string]: number; }
+>{valueOf: 1} : { valueOf: number; }
+>valueOf : number
+>1 : 1
+
+/**
+ * @param {Object} obj
+ * @return {Object}
+ */
+function returnNotAnyObject(obj) {
+>returnNotAnyObject : (obj: Object) => Object
+>obj : Object
+
+  return obj;
+>obj : Object
+}
+

--- a/tests/baselines/reference/jsdocParamTagTypeLiteral.errors.txt
+++ b/tests/baselines/reference/jsdocParamTagTypeLiteral.errors.txt
@@ -9,7 +9,7 @@ tests/cases/conformance/jsdoc/0.js(3,20): error TS8024: JSDoc '@param' tag has n
 !!! error TS8024: JSDoc '@param' tag has name 'unrelated', but there is no parameter with that name.
      */
     function normal(notSpecial) {
-        notSpecial; // should just be 'any'
+        notSpecial; // should just be 'Object'
     }
     normal(12);
     

--- a/tests/baselines/reference/jsdocParamTagTypeLiteral.symbols
+++ b/tests/baselines/reference/jsdocParamTagTypeLiteral.symbols
@@ -7,7 +7,7 @@ function normal(notSpecial) {
 >normal : Symbol(normal, Decl(0.js, 0, 0))
 >notSpecial : Symbol(notSpecial, Decl(0.js, 4, 16))
 
-    notSpecial; // should just be 'any'
+    notSpecial; // should just be 'Object'
 >notSpecial : Symbol(notSpecial, Decl(0.js, 4, 16))
 }
 normal(12);

--- a/tests/baselines/reference/jsdocParamTagTypeLiteral.types
+++ b/tests/baselines/reference/jsdocParamTagTypeLiteral.types
@@ -4,15 +4,15 @@
  * @param {string} unrelated - not actually related because it's not notSpecial.unrelated
  */
 function normal(notSpecial) {
->normal : (notSpecial: any) => void
->notSpecial : any
+>normal : (notSpecial: Object) => void
+>notSpecial : Object
 
-    notSpecial; // should just be 'any'
->notSpecial : any
+    notSpecial; // should just be 'Object'
+>notSpecial : Object
 }
 normal(12);
 >normal(12) : void
->normal : (notSpecial: any) => void
+>normal : (notSpecial: Object) => void
 >12 : 12
 
 /**

--- a/tests/baselines/reference/typedefTagNested.types
+++ b/tests/baselines/reference/typedefTagNested.types
@@ -68,9 +68,9 @@ sala.name
 >name : string
 
 sala.not
->sala.not : any
+>sala.not : Object
 >sala : Upp
->not : any
+>not : Object
 
 sala.nested
 >sala.nested : string

--- a/tests/cases/compiler/jsdocArrayObjectPromiseImplicitAny.ts
+++ b/tests/cases/compiler/jsdocArrayObjectPromiseImplicitAny.ts
@@ -1,0 +1,49 @@
+// @lib: es2015
+// @strict: true
+// @noImplicitAny: false
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @fileName: jsdocArrayObjectPromiseImplicitAny.js
+/** @type {Array} */
+var anyArray = [5];
+
+/** @type {Array<number>} */
+var numberArray = [5];
+
+/**
+ * @param {Array} arr
+ * @return {Array}
+ */
+function returnAnyArray(arr) {
+  return arr;
+}
+
+/** @type {Promise} */
+var anyPromise = Promise.resolve(5);
+
+/** @type {Promise<number>} */
+var numberPromise = Promise.resolve(5);
+
+/**
+ * @param {Promise} pr
+ * @return {Promise}
+ */
+function returnAnyPromise(pr) {
+  return pr;
+}
+
+/** @type {Object} */
+var anyObject = {valueOf: 1}; // not an error since assigning to any.
+
+/** @type {Object<string, number>} */
+var paramedObject = {valueOf: 1};
+
+/**
+ * @param {Object} obj
+ * @return {Object}
+ */
+function returnAnyObject(obj) {
+  return obj;
+}

--- a/tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.ts
+++ b/tests/cases/compiler/jsdocArrayObjectPromiseNoImplicitAny.ts
@@ -1,0 +1,48 @@
+// @lib: es2015
+// @strict: true
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @fileName: jsdocArrayObjectPromiseNoImplicitAny.js
+/** @type {Array} */
+var notAnyArray = [5];
+
+/** @type {Array<number>} */
+var numberArray = [5];
+
+/**
+ * @param {Array} arr
+ * @return {Array}
+ */
+function returnNotAnyArray(arr) {
+  return arr;
+}
+
+/** @type {Promise} */
+var notAnyPromise = Promise.resolve(5);
+
+/** @type {Promise<number>} */
+var numberPromise = Promise.resolve(5);
+
+/**
+ * @param {Promise} pr
+ * @return {Promise}
+ */
+function returnNotAnyPromise(pr) {
+  return pr;
+}
+
+/** @type {Object} */
+var notAnyObject = {valueOf: 1}; // error since assigning to Object, not any.
+
+/** @type {Object<string, number>} */
+var paramedObject = {valueOf: 1};
+
+/**
+ * @param {Object} obj
+ * @return {Object}
+ */
+function returnNotAnyObject(obj) {
+  return obj;
+}

--- a/tests/cases/conformance/jsdoc/jsdocParamTagTypeLiteral.ts
+++ b/tests/cases/conformance/jsdoc/jsdocParamTagTypeLiteral.ts
@@ -10,7 +10,7 @@
  * @param {string} unrelated - not actually related because it's not notSpecial.unrelated
  */
 function normal(notSpecial) {
-    notSpecial; // should just be 'any'
+    notSpecial; // should just be 'Object'
 }
 normal(12);
 


### PR DESCRIPTION
Fixes #32766

As discussed in that issue, when `noImplicitAny` is set in `checkJs`, this change makes it an error to not specify a type argument in the jsdoc annotations for `/** @type {Array} */`, `/** @type {Object} */`, and `/** @type {Promise} */` the same way it is for all other jsdoc parameterized types.

If not `noImplicitAny`, nothing changes and the type argument(s) will continue to default to `any` for these three special cases.

Also as discussed in https://github.com/microsoft/TypeScript/issues/32766#issuecomment-520487842, dropping the `Object -> any` mapping will be a bigger change than the other two types, though
- it's arguably what the author wants if they've set `noImplicitAny` and
- it's unclear how many `strict` `checkJs` projects are out there that will break with this change