### PR TITLE
Check cancellation token in function/arrow/class expresisons, Cleanup after open file only if new file is opened in the request

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -25271,7 +25271,18 @@ namespace ts {
         }
 
         function checkExpressionWorker(node: Expression | QualifiedName, checkMode: CheckMode | undefined, forceTuple?: boolean): Type {
-            switch (node.kind) {
+            const kind = node.kind;
+            if (cancellationToken) {
+                // Only bother checking on a few construct kinds.  We don't want to be excessively
+                // hitting the cancellation token on every node we check.
+                switch (kind) {
+                    case SyntaxKind.ClassExpression:
+                    case SyntaxKind.FunctionExpression:
+                    case SyntaxKind.ArrowFunction:
+                        cancellationToken.throwIfCancellationRequested();
+                }
+            }
+            switch (kind) {
                 case SyntaxKind.Identifier:
                     return checkIdentifier(<Identifier>node);
                 case SyntaxKind.ThisKeyword:

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2705,8 +2705,6 @@ namespace ts.server {
             // It was then postponed to cleanup these script infos so that they can be reused if
             // the file from that old project is reopened because of opening file from here.
             this.removeOrphanScriptInfos();
-
-            this.printProjects();
         }
 
         openClientFileWithNormalizedPath(fileName: NormalizedPath, fileContent?: string, scriptKind?: ScriptKind, hasMixedContent?: boolean, projectRootPath?: NormalizedPath): OpenConfiguredProjectResult {
@@ -2714,6 +2712,7 @@ namespace ts.server {
             const { defaultConfigProject, ...result } = this.assignProjectToOpenedScriptInfo(info);
             this.cleanupAfterOpeningFile(defaultConfigProject);
             this.telemetryOnOpenFile(info);
+            this.printProjects();
             return result;
         }
 
@@ -2914,12 +2913,16 @@ namespace ts.server {
                 this.assignOrphanScriptInfosToInferredProject();
             }
 
-            // Cleanup projects
-            this.cleanupAfterOpeningFile(defaultConfigProjects);
-
-            // Telemetry
-            forEach(openScriptInfos, info => this.telemetryOnOpenFile(info));
-            this.printProjects();
+            if (openScriptInfos) {
+                // Cleanup projects
+                this.cleanupAfterOpeningFile(defaultConfigProjects);
+                // Telemetry
+                openScriptInfos.forEach(info => this.telemetryOnOpenFile(info));
+                this.printProjects();
+            }
+            else if (length(closedFiles)) {
+                this.printProjects();
+            }
         }
 
         /* @internal */


### PR DESCRIPTION
This includes fixes to improve the performance with completions in large js files.
1. Cleanup after script info open needs to be done only if file is opened in `updateOpen` command
2. Check cancellation token in Class expression, function expression and arrow expression as their counter part declarations so that we can exit sooner if the request is cancelled. (Which happens to be case in #31452 where suggestion diagnostics takes 30s for `typescript.js` and takes about 6-7 sec to cancel without this fix resulting in delays with completions)

Fixes #31452, #28389
