### PR TITLE
Reuse unchanged ambient declarations in incremental parsing

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1827,12 +1827,10 @@ namespace ts {
             return node;
         }
 
-        function consumeNode<T extends TextRange | undefined>(node: T): T {
-            if (node) {
-                // Move the scanner so it is after the node we just consumed.
-                scanner.setTextPos(node.end);
-                nextToken();
-            }
+        function consumeNode(node: Node) {
+            // Move the scanner so it is after the node we just consumed.
+            scanner.setTextPos(node.end);
+            nextToken();
             return node;
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5484,11 +5484,7 @@ namespace ts {
         }
 
         function parseDeclaration(): Statement {
-            const [decorators, modifiers] = lookAhead(() => [
-                parseDecorators(),
-                parseModifiers(),
-            ]);
-
+            const modifiers = lookAhead(() => (parseDecorators(), parseModifiers()));
             // `parseListElement` attempted to get the reused node at this position,
             // but the ambient context flag was not yet set, so the node appeared
             // not reusable in that context.
@@ -5501,8 +5497,8 @@ namespace ts {
             }
 
             const node = <Statement>createNodeWithJSDoc(SyntaxKind.Unknown);
-            node.decorators = consumeNode(decorators);
-            node.modifiers = consumeNode(modifiers);
+            node.decorators = parseDecorators();
+            node.modifiers = parseModifiers();
             if (isAmbient) {
                 for (const m of node.modifiers!) {
                     m.flags |= NodeFlags.Ambient;

--- a/src/testRunner/unittests/incrementalParser.ts
+++ b/src/testRunner/unittests/incrementalParser.ts
@@ -671,7 +671,7 @@ module m3 { }\
             const oldText = ScriptSnapshot.fromString(source);
             const newTextAndChange = withInsert(oldText, 0, "{");
 
-            compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, 4);
+            compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, 9);
         });
 
         it("Removing block around function declarations", () => {
@@ -680,7 +680,7 @@ module m3 { }\
             const oldText = ScriptSnapshot.fromString(source);
             const newTextAndChange = withDelete(oldText, 0, "{".length);
 
-            compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, 4);
+            compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, 9);
         });
 
         it("Moving methods from class to object literal", () => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Turns out that ambient declarations were happily reused for several years, until two years ago we made `NodeFlags.Ambient` and put it in `NodeFlags.ContextFlags` in #17831. Henceforth, the context flags on ambient declarations did not match the parsing context where the parser was attempting to reuse the node (`parseListElement`), so we needlessly re-parsed.

I’m doing this because for #32517, it’s very handy to have a cheap check on whether ambient module declarations and module augmentations have changed.