### PR TITLE
Fix references to path-mapped ambient modules in declaration files

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -752,6 +752,7 @@ namespace ts {
             useCaseSensitiveFileNames: () => host.useCaseSensitiveFileNames(),
             getProgramBuildInfo: returnUndefined,
             getSourceFileFromReference: returnUndefined,
+            redirectTargetsMap: createMultiMap()
         };
         emitFiles(
             notImplementedResolver,

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1446,6 +1446,7 @@ namespace ts {
                 useCaseSensitiveFileNames: () => host.useCaseSensitiveFileNames(),
                 getProgramBuildInfo: () => program.getProgramBuildInfo && program.getProgramBuildInfo(),
                 getSourceFileFromReference: (file, ref) => program.getSourceFileFromReference(file, ref),
+                redirectTargetsMap,
             };
         }
 

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -327,6 +327,26 @@ namespace ts {
                     }
 
                     if (declFileName) {
+                        const specifier = moduleSpecifiers.getModuleSpecifier(
+                            // We pathify the baseUrl since we pathify the other paths here, so we can still easily check if the other paths are within the baseUrl
+                            // TODO: Should we _always_ be pathifying the baseUrl as we read it in?
+                            {...options, baseUrl: options.baseUrl && toPath(options.baseUrl, host.getCurrentDirectory(), host.getCanonicalFileName)},
+                            currentSourceFile,
+                            toPath(outputFilePath, host.getCurrentDirectory(), host.getCanonicalFileName),
+                            toPath(declFileName, host.getCurrentDirectory(), host.getCanonicalFileName),
+                            host,
+                            host.getSourceFiles(),
+                            /*preferences*/ undefined,
+                            host.redirectTargetsMap
+                        );
+                        if (!pathIsRelative(specifier)) {
+                            // If some compiler option/symlink/whatever allows access to the file containing the ambient module declaration
+                            // via a non-relative name, emit a type reference directive to that non-relative name, rather than
+                            // a relative path to the declaration file
+                            recordTypeReferenceDirectivesIfNecessary([specifier]);
+                            return;
+                        }
+
                         let fileName = getRelativePathToDirectoryOrUrl(
                             outputFilePath,
                             declFileName,

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -330,7 +330,7 @@ namespace ts {
                         const specifier = moduleSpecifiers.getModuleSpecifier(
                             // We pathify the baseUrl since we pathify the other paths here, so we can still easily check if the other paths are within the baseUrl
                             // TODO: Should we _always_ be pathifying the baseUrl as we read it in?
-                            {...options, baseUrl: options.baseUrl && toPath(options.baseUrl, host.getCurrentDirectory(), host.getCanonicalFileName)},
+                            { ...options, baseUrl: options.baseUrl && toPath(options.baseUrl, host.getCurrentDirectory(), host.getCanonicalFileName) },
                             currentSourceFile,
                             toPath(outputFilePath, host.getCurrentDirectory(), host.getCanonicalFileName),
                             toPath(declFileName, host.getCurrentDirectory(), host.getCanonicalFileName),

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5440,6 +5440,7 @@ namespace ts {
         writeFile: WriteFileCallback;
         getProgramBuildInfo(): ProgramBuildInfo | undefined;
         getSourceFileFromReference: Program["getSourceFileFromReference"];
+        readonly redirectTargetsMap: RedirectTargetsMap;
     }
 
     export interface TransformationContext {

--- a/tests/baselines/reference/declarationEmitPathMappingMonorepo.js
+++ b/tests/baselines/reference/declarationEmitPathMappingMonorepo.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/declarationEmitPathMappingMonorepo.ts] ////
+
+//// [index.d.ts]
+declare module "@ts-bug/a" {
+    export type AText = {
+      value: string;
+    };
+    export function a(text: string): AText;
+  }
+  
+//// [index.ts]
+import { a } from "@ts-bug/a";
+
+export function b(text: string) {
+  return a(text);
+}
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var a_1 = require("@ts-bug/a");
+function b(text) {
+    return a_1.a(text);
+}
+exports.b = b;
+
+
+//// [index.d.ts]
+/// <reference types="@ts-bug/a" />
+export declare function b(text: string): import("@ts-bug/a").AText;

--- a/tests/baselines/reference/declarationEmitPathMappingMonorepo.symbols
+++ b/tests/baselines/reference/declarationEmitPathMappingMonorepo.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/packages/a/index.d.ts ===
+declare module "@ts-bug/a" {
+>"@ts-bug/a" : Symbol("@ts-bug/a", Decl(index.d.ts, 0, 0))
+
+    export type AText = {
+>AText : Symbol(AText, Decl(index.d.ts, 0, 28))
+
+      value: string;
+>value : Symbol(value, Decl(index.d.ts, 1, 25))
+
+    };
+    export function a(text: string): AText;
+>a : Symbol(a, Decl(index.d.ts, 3, 6))
+>text : Symbol(text, Decl(index.d.ts, 4, 22))
+>AText : Symbol(AText, Decl(index.d.ts, 0, 28))
+  }
+  
+=== tests/cases/compiler/packages/b/src/index.ts ===
+import { a } from "@ts-bug/a";
+>a : Symbol(a, Decl(index.ts, 0, 8))
+
+export function b(text: string) {
+>b : Symbol(b, Decl(index.ts, 0, 30))
+>text : Symbol(text, Decl(index.ts, 2, 18))
+
+  return a(text);
+>a : Symbol(a, Decl(index.ts, 0, 8))
+>text : Symbol(text, Decl(index.ts, 2, 18))
+}

--- a/tests/baselines/reference/declarationEmitPathMappingMonorepo.types
+++ b/tests/baselines/reference/declarationEmitPathMappingMonorepo.types
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/packages/a/index.d.ts ===
+declare module "@ts-bug/a" {
+>"@ts-bug/a" : typeof import("@ts-bug/a")
+
+    export type AText = {
+>AText : AText
+
+      value: string;
+>value : string
+
+    };
+    export function a(text: string): AText;
+>a : (text: string) => AText
+>text : string
+  }
+  
+=== tests/cases/compiler/packages/b/src/index.ts ===
+import { a } from "@ts-bug/a";
+>a : (text: string) => import("@ts-bug/a").AText
+
+export function b(text: string) {
+>b : (text: string) => import("@ts-bug/a").AText
+>text : string
+
+  return a(text);
+>a(text) : import("@ts-bug/a").AText
+>a : (text: string) => import("@ts-bug/a").AText
+>text : string
+}

--- a/tests/cases/compiler/declarationEmitPathMappingMonorepo.ts
+++ b/tests/cases/compiler/declarationEmitPathMappingMonorepo.ts
@@ -1,0 +1,28 @@
+// @filename: packages/a/index.d.ts
+declare module "@ts-bug/a" {
+    export type AText = {
+      value: string;
+    };
+    export function a(text: string): AText;
+  }
+  
+// @filename: packages/b/src/index.ts
+import { a } from "@ts-bug/a";
+
+export function b(text: string) {
+  return a(text);
+}
+// @filename: packages/b/tsconfig.json
+{
+    "compilerOptions": {
+        "outDir": "dist",
+        "declaration": true,
+        "baseUrl": ".",
+        "paths": {
+            "@ts-bug/a": ["../a"]
+        }
+    }
+}
+
+// @link: tests/cases/compiler/packages/a -> tests/cases/compiler/node_modules/@ts-bug/a
+// @link: tests/cases/compiler/packages/b -> tests/cases/compiler/node_modules/@ts-bug/b


### PR DESCRIPTION
Fixes #26863

With this change, we now attempt to use a non-relative reference to a declaration file, if possible, before emitting a relative reference.