### PR TITLE
Prefer the non-module name of a symbol when writing the name of a symbol

### DIFF
--- a/tests/baselines/reference/augmentExportEquals3.symbols
+++ b/tests/baselines/reference/augmentExportEquals3.symbols
@@ -1,9 +1,9 @@
 === tests/cases/compiler/file1.ts ===
 function foo() {}
->foo : Symbol("tests/cases/compiler/file1.ts", Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 17), Decl(file2.ts, 1, 8))
+>foo : Symbol(foo, Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 17), Decl(file2.ts, 1, 8))
 
 namespace foo {
->foo : Symbol("tests/cases/compiler/file1.ts", Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 17), Decl(file2.ts, 1, 8))
+>foo : Symbol(foo, Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 17), Decl(file2.ts, 1, 8))
 
     export var v = 1;
 >v : Symbol(v, Decl(file1.ts, 2, 14))

--- a/tests/baselines/reference/augmentExportEquals3_1.symbols
+++ b/tests/baselines/reference/augmentExportEquals3_1.symbols
@@ -3,10 +3,10 @@ declare module "file1" {
 >"file1" : Symbol("file1", Decl(file1.d.ts, 0, 0))
 
     function foo(): void;
->foo : Symbol("tests/cases/compiler/file1.d.ts", Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 25), Decl(file2.ts, 2, 8))
+>foo : Symbol(foo, Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 25), Decl(file2.ts, 2, 8))
 
     namespace foo {
->foo : Symbol("tests/cases/compiler/file1.d.ts", Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 25), Decl(file2.ts, 2, 8))
+>foo : Symbol(foo, Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 25), Decl(file2.ts, 2, 8))
 
         export var v: number;
 >v : Symbol(v, Decl(file1.d.ts, 3, 18))

--- a/tests/baselines/reference/augmentExportEquals4.symbols
+++ b/tests/baselines/reference/augmentExportEquals4.symbols
@@ -1,9 +1,9 @@
 === tests/cases/compiler/file1.ts ===
 class foo {}
->foo : Symbol("tests/cases/compiler/file1.ts", Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 12), Decl(file2.ts, 1, 8))
+>foo : Symbol(foo, Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 12), Decl(file2.ts, 1, 8))
 
 namespace foo {
->foo : Symbol("tests/cases/compiler/file1.ts", Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 12), Decl(file2.ts, 1, 8))
+>foo : Symbol(foo, Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 12), Decl(file2.ts, 1, 8))
 
     export var v = 1;
 >v : Symbol(v, Decl(file1.ts, 2, 14))

--- a/tests/baselines/reference/augmentExportEquals4_1.symbols
+++ b/tests/baselines/reference/augmentExportEquals4_1.symbols
@@ -3,10 +3,10 @@ declare module "file1" {
 >"file1" : Symbol("file1", Decl(file1.d.ts, 0, 0))
 
     class foo {}
->foo : Symbol("tests/cases/compiler/file1.d.ts", Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 16), Decl(file2.ts, 2, 8))
+>foo : Symbol(foo, Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 16), Decl(file2.ts, 2, 8))
 
     namespace foo {
->foo : Symbol("tests/cases/compiler/file1.d.ts", Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 16), Decl(file2.ts, 2, 8))
+>foo : Symbol(foo, Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 16), Decl(file2.ts, 2, 8))
 
         export var v: number;
 >v : Symbol(v, Decl(file1.d.ts, 3, 18))

--- a/tests/baselines/reference/augmentExportEquals5.symbols
+++ b/tests/baselines/reference/augmentExportEquals5.symbols
@@ -16,12 +16,12 @@ declare module "express" {
 >"express" : Symbol("express", Decl(express.d.ts, 4, 1))
 
     function e(): e.Express;
->e : Symbol("tests/cases/compiler/express.d.ts", Decl(express.d.ts, 6, 26), Decl(express.d.ts, 7, 28), Decl(augmentation.ts, 1, 29))
+>e : Symbol(e, Decl(express.d.ts, 6, 26), Decl(express.d.ts, 7, 28), Decl(augmentation.ts, 1, 29))
 >e : Symbol(e, Decl(express.d.ts, 6, 26), Decl(express.d.ts, 7, 28))
 >Express : Symbol(Express, Decl(express.d.ts, 52, 9))
 
     namespace e {
->e : Symbol("tests/cases/compiler/express.d.ts", Decl(express.d.ts, 6, 26), Decl(express.d.ts, 7, 28), Decl(augmentation.ts, 1, 29))
+>e : Symbol(e, Decl(express.d.ts, 6, 26), Decl(express.d.ts, 7, 28), Decl(augmentation.ts, 1, 29))
 
         interface IRoute {
 >IRoute : Symbol(IRoute, Decl(express.d.ts, 8, 17))

--- a/tests/baselines/reference/augmentExportEquals6.symbols
+++ b/tests/baselines/reference/augmentExportEquals6.symbols
@@ -1,9 +1,9 @@
 === tests/cases/compiler/file1.ts ===
 class foo {}
->foo : Symbol("tests/cases/compiler/file1.ts", Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 12), Decl(file2.ts, 1, 10))
+>foo : Symbol(foo, Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 12), Decl(file2.ts, 1, 10))
 
 namespace foo {
->foo : Symbol("tests/cases/compiler/file1.ts", Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 12), Decl(file2.ts, 1, 10))
+>foo : Symbol(foo, Decl(file1.ts, 0, 0), Decl(file1.ts, 0, 12), Decl(file2.ts, 1, 10))
 
     export class A {}
 >A : Symbol(A, Decl(file1.ts, 1, 15), Decl(file2.ts, 4, 26))

--- a/tests/baselines/reference/augmentExportEquals6_1.symbols
+++ b/tests/baselines/reference/augmentExportEquals6_1.symbols
@@ -3,10 +3,10 @@ declare module "file1" {
 >"file1" : Symbol("file1", Decl(file1.d.ts, 0, 0))
 
     class foo {}
->foo : Symbol("tests/cases/compiler/file1.d.ts", Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 16), Decl(file2.ts, 1, 28))
+>foo : Symbol(foo, Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 16), Decl(file2.ts, 1, 28))
 
     namespace foo {
->foo : Symbol("tests/cases/compiler/file1.d.ts", Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 16), Decl(file2.ts, 1, 28))
+>foo : Symbol(foo, Decl(file1.d.ts, 0, 24), Decl(file1.d.ts, 1, 16), Decl(file2.ts, 1, 28))
 
         class A {}
 >A : Symbol(A, Decl(file1.d.ts, 2, 19), Decl(file2.ts, 4, 24))

--- a/tests/baselines/reference/checkMergedGlobalUMDSymbol.symbols
+++ b/tests/baselines/reference/checkMergedGlobalUMDSymbol.symbols
@@ -17,12 +17,12 @@ declare global {
 >global : Symbol(global, Decl(global.d.ts, 2, 26))
 
   export const THREE: typeof _three;
->THREE : Symbol("tests/cases/compiler/global", Decl(global.d.ts, 0, 0), Decl(global.d.ts, 5, 14))
+>THREE : Symbol(THREE, Decl(global.d.ts, 0, 0), Decl(global.d.ts, 5, 14))
 >_three : Symbol(_three, Decl(global.d.ts, 0, 6))
 }
 
 === tests/cases/compiler/test.ts ===
 const m = THREE
 >m : Symbol(m, Decl(test.ts, 0, 5))
->THREE : Symbol("tests/cases/compiler/global", Decl(global.d.ts, 0, 0), Decl(global.d.ts, 5, 14))
+>THREE : Symbol(THREE, Decl(global.d.ts, 0, 0), Decl(global.d.ts, 5, 14))
 

--- a/tests/baselines/reference/exportAssignmentMembersVisibleInAugmentation.symbols
+++ b/tests/baselines/reference/exportAssignmentMembersVisibleInAugmentation.symbols
@@ -3,7 +3,7 @@ export = foo;
 >foo : Symbol(foo, Decl(index.d.ts, 0, 13))
 
 declare namespace foo {
->foo : Symbol("/node_modules/foo/index.d.ts", Decl(index.d.ts, 0, 13), Decl(a.ts, 0, 27), Decl(b.ts, 0, 27))
+>foo : Symbol(foo, Decl(index.d.ts, 0, 13), Decl(a.ts, 0, 27), Decl(b.ts, 0, 27))
 
     export type T = number;
 >T : Symbol(T, Decl(index.d.ts, 1, 23))

--- a/tests/baselines/reference/moduleAugmentationDuringSyntheticDefaultCheck.symbols
+++ b/tests/baselines/reference/moduleAugmentationDuringSyntheticDefaultCheck.symbols
@@ -6,12 +6,12 @@ import moment = require("moment-timezone");
 
 === tests/cases/compiler/node_modules/moment/index.d.ts ===
 declare function moment(): moment.Moment;
->moment : Symbol("tests/cases/compiler/node_modules/moment/index.d.ts", Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
+>moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
 >moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41))
 >Moment : Symbol(Moment, Decl(index.d.ts, 1, 26))
 
 declare namespace moment {
->moment : Symbol("tests/cases/compiler/node_modules/moment/index.d.ts", Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
+>moment : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
 
   interface Moment extends Object {
 >Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34), Decl(index.d.ts, 2, 25))
@@ -32,7 +32,7 @@ export = moment;
 >moment : Symbol(moment, Decl(index.d.ts, 0, 6))
 
 declare module "moment" {
->"moment" : Symbol("tests/cases/compiler/node_modules/moment/index.d.ts", Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
+>"moment" : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
 
     interface Moment {
 >Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34), Decl(index.d.ts, 2, 25))
@@ -46,7 +46,7 @@ import * as _moment from "moment";
 >_moment : Symbol(_moment, Decl(idx.ts, 0, 6))
 
 declare module "moment" {
->"moment" : Symbol("tests/cases/compiler/node_modules/moment/index.d.ts", Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
+>"moment" : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(index.d.ts, 1, 16))
 
     interface Moment {
 >Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34), Decl(index.d.ts, 2, 25))
@@ -57,7 +57,7 @@ declare module "moment" {
     }
 }
 declare module "moment-timezone" {
->"moment-timezone" : Symbol("tests/cases/compiler/node_modules/moment/index.d.ts", Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(idx.ts, 5, 1))
+>"moment-timezone" : Symbol(moment, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 41), Decl(idx.ts, 0, 34), Decl(idx.ts, 5, 1))
 
     interface Moment {
 >Moment : Symbol(Moment, Decl(index.d.ts, 1, 26), Decl(idx.ts, 1, 25), Decl(idx.ts, 6, 34), Decl(index.d.ts, 2, 25))

--- a/tests/baselines/reference/module_augmentUninstantiatedModule.symbols
+++ b/tests/baselines/reference/module_augmentUninstantiatedModule.symbols
@@ -3,10 +3,10 @@ declare module "foo" {
 >"foo" : Symbol("foo", Decl(module_augmentUninstantiatedModule.ts, 0, 0))
 
    namespace M {}
->M : Symbol("tests/cases/compiler/module_augmentUninstantiatedModule.ts", Decl(module_augmentUninstantiatedModule.ts, 0, 22), Decl(module_augmentUninstantiatedModule.ts, 2, 6), Decl(module_augmentUninstantiatedModule.ts, 6, 22))
+>M : Symbol(M, Decl(module_augmentUninstantiatedModule.ts, 0, 22), Decl(module_augmentUninstantiatedModule.ts, 2, 6), Decl(module_augmentUninstantiatedModule.ts, 6, 22))
 
    var M;
->M : Symbol("tests/cases/compiler/module_augmentUninstantiatedModule.ts", Decl(module_augmentUninstantiatedModule.ts, 0, 22), Decl(module_augmentUninstantiatedModule.ts, 2, 6), Decl(module_augmentUninstantiatedModule.ts, 6, 22))
+>M : Symbol(M, Decl(module_augmentUninstantiatedModule.ts, 0, 22), Decl(module_augmentUninstantiatedModule.ts, 2, 6), Decl(module_augmentUninstantiatedModule.ts, 6, 22))
 
    export = M;
 >M : Symbol(M, Decl(module_augmentUninstantiatedModule.ts, 0, 22), Decl(module_augmentUninstantiatedModule.ts, 2, 6))
@@ -16,5 +16,5 @@ declare module "bar" {
 >"bar" : Symbol("bar", Decl(module_augmentUninstantiatedModule.ts, 4, 1))
 
     module "foo" {}
->"foo" : Symbol("tests/cases/compiler/module_augmentUninstantiatedModule.ts", Decl(module_augmentUninstantiatedModule.ts, 0, 22), Decl(module_augmentUninstantiatedModule.ts, 2, 6), Decl(module_augmentUninstantiatedModule.ts, 6, 22))
+>"foo" : Symbol(M, Decl(module_augmentUninstantiatedModule.ts, 0, 22), Decl(module_augmentUninstantiatedModule.ts, 2, 6), Decl(module_augmentUninstantiatedModule.ts, 6, 22))
 }

--- a/tests/baselines/reference/noCrashUMDMergedWithGlobalValue.symbols
+++ b/tests/baselines/reference/noCrashUMDMergedWithGlobalValue.symbols
@@ -7,12 +7,12 @@ export type Action = "PUSH" | "POP" | "REPLACE";
 
 === /main.ts ===
 interface SomeInterface {
->SomeInterface : Symbol("/other", Decl(other.d.ts, 0, 0), Decl(main.ts, 0, 0))
+>SomeInterface : Symbol(SomeInterface, Decl(other.d.ts, 0, 0), Decl(main.ts, 0, 0))
 
   readonly length: number;
 >length : Symbol(length, Decl(main.ts, 0, 25))
 }
 declare const value: SomeInterface;
 >value : Symbol(value, Decl(main.ts, 3, 13))
->SomeInterface : Symbol("/other", Decl(other.d.ts, 0, 0), Decl(main.ts, 0, 0))
+>SomeInterface : Symbol(SomeInterface, Decl(other.d.ts, 0, 0), Decl(main.ts, 0, 0))
 

--- a/tests/baselines/reference/reactTransitiveImportHasValidDeclaration.symbols
+++ b/tests/baselines/reference/reactTransitiveImportHasValidDeclaration.symbols
@@ -1,6 +1,6 @@
 === tests/cases/compiler/node_modules/react/index.d.ts ===
 declare namespace React {
->React : Symbol("tests/cases/compiler/node_modules/react/index.d.ts", Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 0))
+>React : Symbol(React, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 0))
 
     export interface DetailedHTMLProps<T, U> {}
 >DetailedHTMLProps : Symbol(DetailedHTMLProps, Decl(index.d.ts, 0, 25))
@@ -20,7 +20,7 @@ export as namespace React;
 === tests/cases/compiler/node_modules/create-emotion-styled/types/react/index.d.ts ===
 /// <reference types="react" />
 declare module 'react' { // augment
->'react' : Symbol("tests/cases/compiler/node_modules/react/index.d.ts", Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 0))
+>'react' : Symbol(React, Decl(index.d.ts, 0, 0), Decl(index.d.ts, 0, 0))
 
     interface HTMLAttributes<T> {
 >HTMLAttributes : Symbol(HTMLAttributes, Decl(index.d.ts, 1, 47), Decl(index.d.ts, 1, 24))

--- a/tests/baselines/reference/umd-augmentation-3.symbols
+++ b/tests/baselines/reference/umd-augmentation-3.symbols
@@ -44,7 +44,7 @@ export = M2D;
 >M2D : Symbol(M2D, Decl(index.d.ts, 2, 13))
 
 declare namespace M2D {
->M2D : Symbol("tests/cases/conformance/externalModules/node_modules/math2d/index.d.ts", Decl(index.d.ts, 2, 13), Decl(math2d-augment.d.ts, 0, 33))
+>M2D : Symbol(M2D, Decl(index.d.ts, 2, 13), Decl(math2d-augment.d.ts, 0, 33))
 
 	interface Point {
 >Point : Symbol(Point, Decl(index.d.ts, 4, 23))

--- a/tests/baselines/reference/umd-augmentation-4.symbols
+++ b/tests/baselines/reference/umd-augmentation-4.symbols
@@ -42,7 +42,7 @@ export = M2D;
 >M2D : Symbol(M2D, Decl(index.d.ts, 2, 13))
 
 declare namespace M2D {
->M2D : Symbol("tests/cases/conformance/externalModules/node_modules/math2d/index.d.ts", Decl(index.d.ts, 2, 13), Decl(math2d-augment.d.ts, 0, 33))
+>M2D : Symbol(M2D, Decl(index.d.ts, 2, 13), Decl(math2d-augment.d.ts, 0, 33))
 
 	interface Point {
 >Point : Symbol(Point, Decl(index.d.ts, 4, 23))

--- a/tests/baselines/reference/umdGlobalAugmentationNoCrash.symbols
+++ b/tests/baselines/reference/umdGlobalAugmentationNoCrash.symbols
@@ -3,7 +3,7 @@ declare global {
 >global : Symbol(global, Decl(global.d.ts, 0, 0))
 
     const React: typeof import("./module");
->React : Symbol("tests/cases/compiler/module", Decl(module.d.ts, 0, 0), Decl(global.d.ts, 1, 9))
+>React : Symbol(React, Decl(module.d.ts, 0, 0), Decl(global.d.ts, 1, 9))
 }
 export {};
 
@@ -18,7 +18,7 @@ export function foo(): string;
 export {}
 React.foo;
 >React.foo : Symbol(foo, Decl(module.d.ts, 0, 26))
->React : Symbol("tests/cases/compiler/module", Decl(module.d.ts, 0, 0), Decl(global.d.ts, 1, 9))
+>React : Symbol(React, Decl(module.d.ts, 0, 0), Decl(global.d.ts, 1, 9))
 >foo : Symbol(foo, Decl(module.d.ts, 0, 26))
 
 === tests/cases/compiler/emits.ts ===
@@ -29,6 +29,6 @@ console.log("hello");
 
 React.foo;
 >React.foo : Symbol(foo, Decl(module.d.ts, 0, 26))
->React : Symbol("tests/cases/compiler/module", Decl(module.d.ts, 0, 0), Decl(global.d.ts, 1, 9))
+>React : Symbol(React, Decl(module.d.ts, 0, 0), Decl(global.d.ts, 1, 9))
 >foo : Symbol(foo, Decl(module.d.ts, 0, 26))
 

--- a/tests/cases/fourslash/findAllReferencesUmdModuleAsGlobalConst.ts
+++ b/tests/cases/fourslash/findAllReferencesUmdModuleAsGlobalConst.ts
@@ -39,7 +39,5 @@
 ////}
 
 const [r0Def, r0, r1Def, r1, r2Def, ...rest] = test.ranges();
-// GH#29533
-// TODO:: this should be var THREE: typeof import instead of module name as var but thats existing issue and repros with quickInfo too.
-verify.singleReferenceGroup(`module "/node_modules/@types/three/index"
-var "/node_modules/@types/three/index": typeof import("/node_modules/@types/three/index")`, [r0, r1, ...rest]);
+verify.singleReferenceGroup(`module THREE
+var THREE: typeof import("/node_modules/@types/three/index")`, [r0, r1, ...rest]);

--- a/tests/cases/fourslash/moduleReexportedIntoGlobalQuickInfo.ts
+++ b/tests/cases/fourslash/moduleReexportedIntoGlobalQuickInfo.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /node_modules/@types/three/index.d.ts
+////export class Vector3 {}
+////export as namespace THREE;
+// @Filename: /global.d.ts
+////import * as _THREE from 'three';
+////
+////declare global {
+////  const THREE: typeof _THREE;
+////}
+// @Filename: /index.ts
+////let v = new /*1*/THREE.Vector3();
+
+verify.quickInfoAt("1", `module THREE
+var THREE: typeof import("/node_modules/@types/three/index")`);


### PR DESCRIPTION
Fixes #29533
