### PR TITLE
Fix export=global auto-import exclusion

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1289,7 +1289,7 @@ namespace ts.Completions {
                 if (resolvedModuleSymbol !== moduleSymbol &&
                     // Don't add another completion for `export =` of a symbol that's already global.
                     // So in `declare namespace foo {} declare module "foo" { export = foo; }`, there will just be the global completion for `foo`.
-                    some(resolvedModuleSymbol.declarations, d => !!d.getSourceFile().externalModuleIndicator)) {
+                    every(resolvedModuleSymbol.declarations, d => !!d.getSourceFile().externalModuleIndicator)) {
                     symbols.push(resolvedModuleSymbol);
                     symbolToSortTextMap[getSymbolId(resolvedModuleSymbol)] = SortText.AutoImportSuggestions;
                     symbolToOriginInfoMap[getSymbolId(resolvedModuleSymbol)] = { kind: SymbolOriginInfoKind.Export, moduleSymbol, isDefaultExport: false };

--- a/tests/cases/fourslash/completionsImport_exportEquals_global.ts
+++ b/tests/cases/fourslash/completionsImport_exportEquals_global.ts
@@ -1,0 +1,31 @@
+/// <reference path="fourslash.ts" />
+
+// @module: es6
+
+// @Filename: /console.d.ts
+////interface Console {}
+////declare var console: Console;
+////declare module "console" {
+////  export = console;
+////}
+
+// @Filename: /react-native.d.ts
+//// import 'console';
+////declare global {
+////  interface Console {}
+////  var console: Console;
+////}
+
+// @Filename: /a.ts
+////conso/**/
+
+verify.completions({
+  exact: completion.globalsPlus([{
+    hasAction: undefined, // asserts that it does *not* have an action
+    name: "console"
+  }]),
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true
+  }
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #30471 

If _any_ declaration of a symbol is global, then a global is available. Conversely, _every_ declaration of what `export=` resolves to has to be in an ES6 module in order for us to give you an auto-import.