### PR TITLE
Fix writing multi-line text without semicolons

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3506,7 +3506,7 @@ namespace ts {
                 const sig = nodeBuilder.signatureToSignatureDeclaration(signature, sigOutput, enclosingDeclaration, toNodeBuilderFlags(flags) | NodeBuilderFlags.IgnoreErrors | NodeBuilderFlags.WriteTypeParametersInQualifiedName);
                 const printer = createPrinter({ removeComments: true, omitTrailingSemicolon: true });
                 const sourceFile = enclosingDeclaration && getSourceFileOfNode(enclosingDeclaration);
-                printer.writeNode(EmitHint.Unspecified, sig!, /*sourceFile*/ sourceFile, getTrailingSemicolonOmittingWriter(writer)); // TODO: GH#18217
+                printer.writeNode(EmitHint.Unspecified, sig!, /*sourceFile*/ sourceFile, getTrailingSemicolonDeferringWriter(writer)); // TODO: GH#18217
                 return writer;
             }
         }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2514,7 +2514,7 @@ namespace ts {
             }
 
             emitWhileClause(node, node.statement.end);
-            writePunctuation(";");
+            writeTrailingSemicolon();
         }
 
         function emitWhileStatement(node: WhileStatement) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1056,7 +1056,7 @@ namespace ts {
 
         function setWriter(_writer: EmitTextWriter | undefined, _sourceMapGenerator: SourceMapGenerator | undefined) {
             if (_writer && printerOptions.omitTrailingSemicolon) {
-                _writer = getTrailingSemicolonOmittingWriter(_writer);
+                _writer = getTrailingSemicolonDeferringWriter(_writer);
             }
 
             writer = _writer!; // TODO: GH#18217

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3369,7 +3369,11 @@ namespace ts {
         };
     }
 
-    export function getTrailingSemicolonOmittingWriter(writer: EmitTextWriter): EmitTextWriter {
+    export interface TrailingSemicolonDeferringWriter extends EmitTextWriter {
+        resetPendingTrailingSemicolon(): void;
+    }
+
+    export function getTrailingSemicolonDeferringWriter(writer: EmitTextWriter): TrailingSemicolonDeferringWriter {
         let pendingTrailingSemicolon = false;
 
         function commitPendingTrailingSemicolon() {
@@ -3435,7 +3439,21 @@ namespace ts {
             decreaseIndent() {
                 commitPendingTrailingSemicolon();
                 writer.decreaseIndent();
+            },
+            resetPendingTrailingSemicolon() {
+                pendingTrailingSemicolon = false;
             }
+        };
+    }
+
+    export function getTrailingSemicolonOmittingWriter(writer: EmitTextWriter): EmitTextWriter {
+        const deferringWriter = getTrailingSemicolonDeferringWriter(writer);
+        return {
+            ...deferringWriter,
+            writeLine() {
+                deferringWriter.resetPendingTrailingSemicolon();
+                writer.writeLine();
+            },
         };
     }
 

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -854,7 +854,7 @@ namespace ts.textChanges {
             const omitTrailingSemicolon = !!sourceFile && !probablyUsesSemicolons(sourceFile);
             const writer = createWriter(newLineCharacter, omitTrailingSemicolon);
             const newLine = newLineCharacter === "\n" ? NewLineKind.LineFeed : NewLineKind.CarriageReturnLineFeed;
-            createPrinter({ newLine, neverAsciiEscape: true, omitTrailingSemicolon }, writer).writeNode(EmitHint.Unspecified, node, sourceFile, writer);
+            createPrinter({ newLine, neverAsciiEscape: true }, writer).writeNode(EmitHint.Unspecified, node, sourceFile, writer);
             return { text: writer.getText(), node: assignPositionsToNode(node) };
         }
     }

--- a/tests/cases/fourslash/convertFunctionToEs6Class_objectLiteralInArrowFunction.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class_objectLiteralInArrowFunction.ts
@@ -15,7 +15,7 @@ verify.codeFix({
     constructor() {
     }
     foo() {
-        ({ bar: () => { } });
+        ({ bar: () => { } })
     }
 }
 `,

--- a/tests/cases/fourslash/extract-method25.ts
+++ b/tests/cases/fourslash/extract-method25.ts
@@ -18,7 +18,7 @@ edit.applyRefactor({
     q[0]++
 
     function newFunction() {
-        return [0];
+        return [0]
     }
 }`
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #18780 

I have just learned that my fix in #31801, in the cases that it _does_ work, works entirely by accident. The writer returned by `getTrailingSemicolonOmittingWriter` was never intended to be a writer that actually drops semicolons; it simply doesn’t write them until you start writing something _else_. The places where it was used to omit a semicolon were simply single-statement (or even less than a single statement) writes, like printing a signature for quick info. If the writer had continued on to print another statement, the semicolon would then be added.

The reason #31801 worked at all is that the emitter ultimately ended up with a semicolon-omitting writer wrapped inside a semicolon-omitting writer, and as a result would _never_ write a trailing semicolon, even where it’s necessary by the rules of ASI. Technically the current state is pretty wrong, but I _think_ that the bad effects of being so wrong will never actually manifest, because I _think_ the emitter always emits list elements on separate lines.

This fix renames `getTrailingSemicolonOmittingWriter` to `getTrailingSemicolonDeferringWriter`, and adds a proper `getTrailingSemicolonOmittingWriter` which will commit trailing semicolons only if they are _not_ followed by a newline.

It should be noted that, because the writer is generally not syntax-aware and can’t perform lookahead, it fails to omit semicolons where it technically _could_ in two scenarios:

1. Closing parens of do/while statements:

```ts
do {} while (false) console.log()
//                 ^ don’t need one here but we print it anyway
```

2. Where the offending token is `}`:

```ts
if (true) {
  1
  2
  3 }
// ^ don’t need one here but we print it anyway
```

I think these are ok.

Additional note: I didn’t change the behavior of `PrinterOptions['omitTrailingSemicolons']` because it’s public API. Everything I changed is internal and applies only to changes made with `TextChanges`, but would be open to discussing other options.