### PR TITLE
Fix removeEventListener types

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -32,7 +32,6 @@ interface Account {
 
 interface AddEventListenerOptions extends EventListenerOptions {
     once?: boolean;
-    passive?: boolean;
 }
 
 interface AesCbcParams extends Algorithm {
@@ -480,6 +479,7 @@ interface EventInit {
 
 interface EventListenerOptions {
     capture?: boolean;
+    passive?: boolean;
 }
 
 interface EventModifierInit extends UIEventInit {


### PR DESCRIPTION
#32912

Fixes typing for `removeEventListener`. Event listener added with `passive: true` option can't be removed. `removeEventListener` should be provided with all options passed to `addEventListener`