### PR TITLE
jsdoc template tags might be unmatched

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2343,7 +2343,7 @@ namespace ts {
     export function getTypeParameterFromJsDoc(node: TypeParameterDeclaration & { parent: JSDocTemplateTag }): TypeParameterDeclaration | undefined {
         const name = node.name.escapedText;
         const { typeParameters } = (node.parent.parent.parent as SignatureDeclaration | InterfaceDeclaration | ClassDeclaration);
-        return find(typeParameters!, p => p.name.escapedText === name);
+        return typeParameters && find(typeParameters, p => p.name.escapedText === name);
     }
 
     export function hasRestParameter(s: SignatureDeclaration | JSDocSignature): boolean {

--- a/tests/cases/fourslash/jsDocFunctionSignatures13.ts
+++ b/tests/cases/fourslash/jsDocFunctionSignatures13.ts
@@ -7,4 +7,4 @@
 
 
 goTo.marker('');
-verify.quickInfoIs("K", "a golden opportunity");
+verify.quickInfoIs("any");

--- a/tests/cases/fourslash/jsDocFunctionSignatures13.ts
+++ b/tests/cases/fourslash/jsDocFunctionSignatures13.ts
@@ -1,0 +1,10 @@
+///<reference path="fourslash.ts" />
+//// /**
+////  * @template {string} K/**/ a golden opportunity
+////  */
+//// function Multimap(iv) {
+//// };
+
+
+goTo.marker('');
+verify.quickInfoIs("K", "a golden opportunity");


### PR DESCRIPTION
Quick info tries to find the symbol for a type parameter when you ask for quick info in a `@template` tag. This applies to TS, where the `@template` tag isn't actually bound.

But the function might not actually have a matching type parameter. If it doesn't, services currently crashes because it assumes there is *always* a matching type parameter.

This bug is at least 2.5 years old, based on the git log.

Fixes #32935