### PR TITLE
Fix discovery and execution of root-level tests in the parallel runner

### DIFF
--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -626,6 +626,7 @@ namespace Harness.Parallel.Host {
 
             const perfData = readSavedPerfData(configOption);
             context.describe = addSuite as Mocha.SuiteFunction;
+            context.it = addSuite as Mocha.TestFunction;
 
             function addSuite(title: string) {
                 // Note, sub-suites are not indexed (we assume such granularity is not required)

--- a/tests/baselines/reference/tsbuild/moduleSpecifiers/initial-build/resolves-correctly.js
+++ b/tests/baselines/reference/tsbuild/moduleSpecifiers/initial-build/resolves-correctly.js
@@ -14,8 +14,8 @@ exports.__esModule = true;
   "program": {
     "fileInfos": {
       "../../../.ts/lib.es5.d.ts": {
-        "version": "146944634190",
-        "signature": "146944634190"
+        "version": "406734842058",
+        "signature": "406734842058"
       },
       "../../../.ts/lib.es2015.d.ts": {
         "version": "57263133672",
@@ -114,8 +114,8 @@ exports.__esModule = true;
   "program": {
     "fileInfos": {
       "../../../.ts/lib.es5.d.ts": {
-        "version": "146944634190",
-        "signature": "146944634190"
+        "version": "406734842058",
+        "signature": "406734842058"
       },
       "../../../.ts/lib.es2015.d.ts": {
         "version": "57263133672",
@@ -237,8 +237,8 @@ exports.getVar = getVar;
   "program": {
     "fileInfos": {
       "../../../.ts/lib.es5.d.ts": {
-        "version": "146944634190",
-        "signature": "146944634190"
+        "version": "406734842058",
+        "signature": "406734842058"
       },
       "../../../.ts/lib.es2015.d.ts": {
         "version": "57263133672",


### PR DESCRIPTION
Root level unit tests were getting `noop`'d in the parallel harness, rather than discovered, causing them not to be executed except when tests are run not-in-parallel (ie, when the `user` suite is run in CI).