### PR TITLE
Fix default behavior for transpileModule when fileName not provided

### DIFF
--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -66,7 +66,7 @@ namespace ts {
         options.noResolve = true;
 
         // if jsx is specified then treat file as .tsx
-        const inputFileName = transpileOptions.fileName || (options.jsx ? "module.tsx" : "module.ts");
+        const inputFileName = transpileOptions.fileName || (transpileOptions.compilerOptions && transpileOptions.compilerOptions.jsx ? "module.tsx" : "module.ts");
         const sourceFile = createSourceFile(inputFileName, input, options.target!); // TODO: GH#18217
         if (transpileOptions.moduleName) {
             sourceFile.moduleName = transpileOptions.moduleName;

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -3,6 +3,7 @@ namespace ts {
 
         interface TranspileTestSettings {
             options?: TranspileOptions;
+            noSetFileName?: boolean;
         }
 
         function transpilesCorrectly(name: string, input: string, testSettings: TranspileTestSettings) {
@@ -30,15 +31,19 @@ namespace ts {
 
                 transpileOptions.compilerOptions.sourceMap = true;
 
-                if (!transpileOptions.fileName) {
-                    transpileOptions.fileName = transpileOptions.compilerOptions.jsx ? "file.tsx" : "file.ts";
+                let unitName = transpileOptions.fileName;
+                if (!unitName) {
+                    unitName = transpileOptions.compilerOptions.jsx ? "file.tsx" : "file.ts";
+                    if (!testSettings.noSetFileName) {
+                        transpileOptions.fileName = unitName;
+                    }
                 }
 
                 transpileOptions.reportDiagnostics = true;
 
                 justName = "transpile/" + name.replace(/[^a-z0-9\-. ]/ig, "") + (transpileOptions.compilerOptions.jsx ? Extension.Tsx : Extension.Ts);
                 toBeCompiled = [{
-                    unitName: transpileOptions.fileName,
+                    unitName,
                     content: input
                 }];
 
@@ -455,6 +460,10 @@ var x = 0;`, {
 
         transpilesCorrectly("Supports 'as const' arrays", `([] as const).forEach(k => console.log(k));`, {
             options: { compilerOptions: { module: ModuleKind.CommonJS } }
+        });
+
+        transpilesCorrectly("Infer correct file extension", `const fn = <T>(a: T) => a`, {
+            noSetFileName: true
         });
     });
 }

--- a/tests/baselines/reference/transpile/Infer correct file extension.js
+++ b/tests/baselines/reference/transpile/Infer correct file extension.js
@@ -1,0 +1,2 @@
+var fn = function (a) { return a; };
+//# sourceMappingURL=module.js.map

--- a/tests/baselines/reference/transpile/Infer correct file extension.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Infer correct file extension.oldTranspile.js
@@ -1,0 +1,2 @@
+var fn = function (a) { return a; };
+//# sourceMappingURL=module.js.map


### PR DESCRIPTION
Fixes an issue where we incorrectly assume a source is `TSX` when calling `transpile` or `transpileModule` without a filename or compiler options.

Fixes #32962
