### PR TITLE
Fix prototype property type lookup

### DIFF
--- a/tests/baselines/reference/jsdocConstructorFunctionTypeReference.symbols
+++ b/tests/baselines/reference/jsdocConstructorFunctionTypeReference.symbols
@@ -1,0 +1,31 @@
+=== tests/cases/conformance/salsa/jsdocConstructorFunctionTypeReference.js ===
+var Validator = function VFunc() {
+>Validator : Symbol(Validator, Decl(jsdocConstructorFunctionTypeReference.js, 0, 3))
+>VFunc : Symbol(VFunc, Decl(jsdocConstructorFunctionTypeReference.js, 0, 15))
+
+    this.flags = "gim"
+>flags : Symbol(VFunc.flags, Decl(jsdocConstructorFunctionTypeReference.js, 0, 34))
+
+};
+
+Validator.prototype.num = 12
+>Validator.prototype : Symbol(Validator.num, Decl(jsdocConstructorFunctionTypeReference.js, 2, 2))
+>Validator : Symbol(Validator, Decl(jsdocConstructorFunctionTypeReference.js, 0, 3))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>num : Symbol(Validator.num, Decl(jsdocConstructorFunctionTypeReference.js, 2, 2))
+
+/**
+ * @param {Validator} state
+ */
+var validateRegExpFlags = function(state) {
+>validateRegExpFlags : Symbol(validateRegExpFlags, Decl(jsdocConstructorFunctionTypeReference.js, 9, 3))
+>state : Symbol(state, Decl(jsdocConstructorFunctionTypeReference.js, 9, 35))
+
+    return state.flags
+>state.flags : Symbol(VFunc.flags, Decl(jsdocConstructorFunctionTypeReference.js, 0, 34))
+>state : Symbol(state, Decl(jsdocConstructorFunctionTypeReference.js, 9, 35))
+>flags : Symbol(VFunc.flags, Decl(jsdocConstructorFunctionTypeReference.js, 0, 34))
+
+};
+
+

--- a/tests/baselines/reference/jsdocConstructorFunctionTypeReference.types
+++ b/tests/baselines/reference/jsdocConstructorFunctionTypeReference.types
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/salsa/jsdocConstructorFunctionTypeReference.js ===
+var Validator = function VFunc() {
+>Validator : typeof VFunc
+>function VFunc() {    this.flags = "gim"} : typeof VFunc
+>VFunc : typeof VFunc
+
+    this.flags = "gim"
+>this.flags = "gim" : "gim"
+>this.flags : any
+>this : any
+>flags : any
+>"gim" : "gim"
+
+};
+
+Validator.prototype.num = 12
+>Validator.prototype.num = 12 : 12
+>Validator.prototype.num : any
+>Validator.prototype : any
+>Validator : typeof VFunc
+>prototype : any
+>num : any
+>12 : 12
+
+/**
+ * @param {Validator} state
+ */
+var validateRegExpFlags = function(state) {
+>validateRegExpFlags : (state: VFunc) => string
+>function(state) {    return state.flags} : (state: VFunc) => string
+>state : VFunc
+
+    return state.flags
+>state.flags : string
+>state : VFunc
+>flags : string
+
+};
+
+

--- a/tests/cases/conformance/salsa/jsdocConstructorFunctionTypeReference.ts
+++ b/tests/cases/conformance/salsa/jsdocConstructorFunctionTypeReference.ts
@@ -1,0 +1,19 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @noImplicitAny: true
+// @Filename: jsdocConstructorFunctionTypeReference.js
+
+var Validator = function VFunc() {
+    this.flags = "gim"
+};
+
+Validator.prototype.num = 12
+
+/**
+ * @param {Validator} state
+ */
+var validateRegExpFlags = function(state) {
+    return state.flags
+};
+


### PR DESCRIPTION
This removes over half of the weird code for supporting JS in getTypeReferenceType. Lookup of commonjs aliases is still there and still weird, but I improved the documentation a little.

Fixes #33013 