### PR TITLE
Change doc-string for Unreliable variance flag.

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4214,7 +4214,7 @@ namespace ts {
         Independent   = 1 << 2,  // Unwitnessed type parameter
         VarianceMask  = Invariant | Covariant | Contravariant | Independent, // Mask containing all measured variances without the unmeasurable flag
         Unmeasurable  = 1 << 3,  // Variance result is unusable - relationship relies on structural comparisons which are not reflected in generic relationships
-        Unreliable    = 1 << 4,  // Variance result is unreliable - relationship relies on structural comparisons which are not reflected in generic relationships
+        Unreliable    = 1 << 4,  // Variance result is unreliable - checking may produce false negatives, but not false positives
         AllowsStructuralFallback = Unmeasurable | Unreliable,
     }
 


### PR DESCRIPTION
Minor documentation change that may be helpful to distinguish unreliable/unmeasurable.
