### PR TITLE
Show more items in the navbar

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -111,8 +111,8 @@ namespace ts.NavigationBar {
         return root;
     }
 
-    function addLeafNode(node: Node): void {
-        pushChild(parent, emptyNavigationBarNode(node));
+    function addLeafNode(node: Node, name?: DeclarationName): void {
+        pushChild(parent, emptyNavigationBarNode(node, name));
     }
 
     function emptyNavigationBarNode(node: Node, name?: DeclarationName): NavigationBarNode {
@@ -243,6 +243,14 @@ namespace ts.NavigationBar {
                 }
                 break;
 
+            case SyntaxKind.ShorthandPropertyAssignment:
+                addNodeWithRecursiveChild(node, (<ShorthandPropertyAssignment>node).name);
+                break;
+            case SyntaxKind.SpreadAssignment:
+                const { expression } = <SpreadAssignment>node;
+                // Use the expression as the name of the SpreadAssignment, otherwise show as <unknown>.
+                isIdentifier(expression) ? addLeafNode(node, expression) : addLeafNode(node);
+                break;
             case SyntaxKind.BindingElement:
             case SyntaxKind.PropertyAssignment:
             case SyntaxKind.VariableDeclaration:

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -251,16 +251,10 @@ namespace ts.NavigationBar {
                     addChildrenRecursively(name);
                 }
                 else if (initializer && isFunctionOrClassExpression(initializer)) {
-                    if (initializer.name) {
-                        // Don't add a node for the VariableDeclaration, just for the initializer.
-                        addChildrenRecursively(initializer);
-                    }
-                    else {
-                        // Add a node for the VariableDeclaration, but not for the initializer.
-                        startNode(node);
-                        forEachChild(initializer, addChildrenRecursively);
-                        endNode();
-                    }
+                    // Add a node for the VariableDeclaration, but not for the initializer.
+                    startNode(node);
+                    forEachChild(initializer, addChildrenRecursively);
+                    endNode();
                 }
                 else {
                     addNodeWithRecursiveChild(node, initializer);
@@ -717,6 +711,9 @@ namespace ts.NavigationBar {
         return topLevel;
 
         function isTopLevel(item: NavigationBarNode): boolean {
+            if (item.children) {
+                return true;
+            }
             switch (navigationBarNodeKind(item)) {
                 case SyntaxKind.ClassDeclaration:
                 case SyntaxKind.ClassExpression:
@@ -735,7 +732,7 @@ namespace ts.NavigationBar {
                     return isTopLevelFunctionDeclaration(item);
 
                 default:
-                    return hasSomeImportantChild(item);
+                    return false;
             }
             function isTopLevelFunctionDeclaration(item: NavigationBarNode): boolean {
                 if (!(<FunctionDeclaration>item.node).body) {
@@ -749,11 +746,8 @@ namespace ts.NavigationBar {
                     case SyntaxKind.Constructor:
                         return true;
                     default:
-                        return hasSomeImportantChild(item);
+                        return false;
                 }
-            }
-            function hasSomeImportantChild(item: NavigationBarNode): boolean {
-                return item.children ? true : false;
             }
         }
     }

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -244,8 +244,9 @@ namespace ts.NavigationBar {
                 break;
 
             case SyntaxKind.BindingElement:
+            case SyntaxKind.PropertyAssignment:
             case SyntaxKind.VariableDeclaration:
-                const { name, initializer } = <VariableDeclaration | BindingElement>node;
+                const { name, initializer } = <VariableDeclaration | PropertyAssignment | BindingElement>node;
                 if (isBindingPattern(name)) {
                     addChildrenRecursively(name);
                 }
@@ -728,20 +729,13 @@ namespace ts.NavigationBar {
                 case SyntaxKind.JSDocCallbackTag:
                     return true;
 
-                case SyntaxKind.Constructor:
-                case SyntaxKind.MethodDeclaration:
-                case SyntaxKind.GetAccessor:
-                case SyntaxKind.SetAccessor:
-                case SyntaxKind.VariableDeclaration:
-                    return hasSomeImportantChild(item);
-
                 case SyntaxKind.ArrowFunction:
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.FunctionExpression:
                     return isTopLevelFunctionDeclaration(item);
 
                 default:
-                    return false;
+                    return hasSomeImportantChild(item);
             }
             function isTopLevelFunctionDeclaration(item: NavigationBarNode): boolean {
                 if (!(<FunctionDeclaration>item.node).body) {
@@ -759,10 +753,7 @@ namespace ts.NavigationBar {
                 }
             }
             function hasSomeImportantChild(item: NavigationBarNode): boolean {
-                return some(item.children, child => {
-                    const childKind = navigationBarNodeKind(child);
-                    return childKind !== SyntaxKind.VariableDeclaration && childKind !== SyntaxKind.BindingElement;
-                });
+                return item.children ? true : false;
             }
         }
     }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -354,6 +354,8 @@ namespace ts {
             case SyntaxKind.MethodSignature:
                 return ScriptElementKind.memberFunctionElement;
             case SyntaxKind.PropertyAssignment:
+                const {initializer} = node as PropertyAssignment;
+                return isFunctionLike(initializer) ? ScriptElementKind.memberFunctionElement : ScriptElementKind.memberVariableElement;
             case SyntaxKind.PropertyDeclaration:
             case SyntaxKind.PropertySignature:
                 return ScriptElementKind.memberVariableElement;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -353,6 +353,7 @@ namespace ts {
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.MethodSignature:
                 return ScriptElementKind.memberFunctionElement;
+            case SyntaxKind.PropertyAssignment:
             case SyntaxKind.PropertyDeclaration:
             case SyntaxKind.PropertySignature:
                 return ScriptElementKind.memberVariableElement;

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -358,6 +358,8 @@ namespace ts {
                 return isFunctionLike(initializer) ? ScriptElementKind.memberFunctionElement : ScriptElementKind.memberVariableElement;
             case SyntaxKind.PropertyDeclaration:
             case SyntaxKind.PropertySignature:
+            case SyntaxKind.ShorthandPropertyAssignment:
+            case SyntaxKind.SpreadAssignment:
                 return ScriptElementKind.memberVariableElement;
             case SyntaxKind.IndexSignature: return ScriptElementKind.indexSignatureElement;
             case SyntaxKind.ConstructSignature: return ScriptElementKind.constructSignatureElement;

--- a/tests/cases/fourslash/navbarNestedCommonJsExports.ts
+++ b/tests/cases/fourslash/navbarNestedCommonJsExports.ts
@@ -29,7 +29,23 @@ verify.navigationBar([
         kind: "script",
         childItems: [
             { text: "a", kind: "const" },
-        ],
+        ]
     },
+    {
+        text: "a",
+        kind: "const",
+        childItems: [
+            { text: "b", kind: "const"},
+        ],
+        indent: 1,
+    },
+    {
+        text: "b",
+        kind: "const",
+        childItems: [
+            { text: "c", kind: "const" },
+        ],
+        indent: 2,
+    }
 ]);
 

--- a/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
+++ b/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
@@ -62,7 +62,7 @@ verify.navigationTree({
                     "childItems": [
                         {
                             "text": "foo",
-                            "kind": "function"
+                            "kind": "property"
                         }
                     ]
                 }
@@ -185,7 +185,7 @@ verify.navigationBar([
         "childItems": [
             {
                 "text": "foo",
-                "kind": "function"
+                "kind": "property"
             }
         ],
         "indent": 2

--- a/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
+++ b/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
@@ -62,7 +62,7 @@ verify.navigationTree({
                     "childItems": [
                         {
                             "text": "foo",
-                            "kind": "property"
+                            "kind": "method"
                         }
                     ]
                 }
@@ -185,7 +185,7 @@ verify.navigationBar([
         "childItems": [
             {
                 "text": "foo",
-                "kind": "property"
+                "kind": "method"
             }
         ],
         "indent": 2

--- a/tests/cases/fourslash/navigationBarAssignmentTypes.ts
+++ b/tests/cases/fourslash/navigationBarAssignmentTypes.ts
@@ -1,0 +1,64 @@
+/// <reference path='fourslash.ts'/> 
+////'use strict'
+////const a = {
+////    ...b,
+////    c,
+////    d: 0
+////};
+
+verify.navigationTree({
+    text: "<global>",
+    kind: "script",
+    childItems: [
+        {
+            text: "a",
+            kind: "const",
+            childItems: [
+                {
+                    text: "b",
+                    kind: "property",
+                },
+                {
+                    text: "c",
+                    kind: "property"
+                },
+                {
+                    text: "d",
+                    kind: "property"
+                }
+            ]
+        }
+    ]
+});
+
+verify.navigationBar([
+    {
+        text: "<global>",
+        kind: "script",
+        childItems: [
+            {
+                text: "a",
+                kind: "const"
+            }
+        ]
+    },
+    {
+        text: "a",
+        kind: "const",
+        childItems: [
+            {
+                text: "b",
+                kind: "property",
+            },
+            {
+                text: "c",
+                kind: "property"
+            },
+            {
+                text: "d",
+                kind: "property"
+            }
+        ],
+        indent: 1
+    }
+]);

--- a/tests/cases/fourslash/navigationBarFunctionIndirectlyInVariableDeclaration.ts
+++ b/tests/cases/fourslash/navigationBarFunctionIndirectlyInVariableDeclaration.ts
@@ -1,11 +1,16 @@
 /// <reference path="fourslash.ts"/>
 
 ////var a = {
-////    propA: function() {}
+////    propA: function() {
+////        var c;
+////    }
 ////};
 ////var b;
 ////b = {
-////    propB: function() {}
+////    propB: function() {
+////    // function must not have an empty body to appear top level
+////        var d;
+////    }
 ////};
 
 verify.navigationTree({
@@ -18,7 +23,13 @@ verify.navigationTree({
             "childItems": [
                 {
                     "text": "propA",
-                    "kind": "function"
+                    "kind": "property",
+                    "childItems": [
+                        {
+                            "text": "c",
+                            "kind": "var"
+                        }
+                    ]
                 }
             ]
         },
@@ -28,7 +39,13 @@ verify.navigationTree({
         },
         {
             "text": "propB",
-            "kind": "function"
+            "kind": "property",
+            "childItems": [
+                {
+                    "text": "d",
+                    "kind": "var"
+                }
+            ]
         }
     ]
 });
@@ -48,7 +65,7 @@ verify.navigationBar([
           },
           {
               "text": "propB",
-              "kind": "function"
+              "kind": "property"
           }
       ]
     },
@@ -58,14 +75,31 @@ verify.navigationBar([
         "childItems": [
             {
                 "text": "propA",
-                "kind": "function"
+                "kind": "property"
             }
         ],
         "indent": 1
     },
     {
+        "text": "propA",
+        "kind": "property",
+        "childItems": [
+            {
+                "text": "c",
+                "kind": "var"
+            }
+        ],
+        "indent": 2
+    },
+    {
         "text": "propB",
-        "kind": "function",
+        "kind": "property",
+        "childItems": [
+            {
+                "text": "d",
+                "kind": "var"
+            }
+        ],
         "indent": 1
     }
 ]);

--- a/tests/cases/fourslash/navigationBarFunctionIndirectlyInVariableDeclaration.ts
+++ b/tests/cases/fourslash/navigationBarFunctionIndirectlyInVariableDeclaration.ts
@@ -23,7 +23,7 @@ verify.navigationTree({
             "childItems": [
                 {
                     "text": "propA",
-                    "kind": "property",
+                    "kind": "method",
                     "childItems": [
                         {
                             "text": "c",
@@ -39,7 +39,7 @@ verify.navigationTree({
         },
         {
             "text": "propB",
-            "kind": "property",
+            "kind": "method",
             "childItems": [
                 {
                     "text": "d",
@@ -65,7 +65,7 @@ verify.navigationBar([
           },
           {
               "text": "propB",
-              "kind": "property"
+              "kind": "method"
           }
       ]
     },
@@ -75,14 +75,14 @@ verify.navigationBar([
         "childItems": [
             {
                 "text": "propA",
-                "kind": "property"
+                "kind": "method"
             }
         ],
         "indent": 1
     },
     {
         "text": "propA",
-        "kind": "property",
+        "kind": "method",
         "childItems": [
             {
                 "text": "c",
@@ -93,7 +93,7 @@ verify.navigationBar([
     },
     {
         "text": "propB",
-        "kind": "property",
+        "kind": "method",
         "childItems": [
             {
                 "text": "d",

--- a/tests/cases/fourslash/navigationBarFunctionLikePropertyAssignments.ts
+++ b/tests/cases/fourslash/navigationBarFunctionLikePropertyAssignments.ts
@@ -1,0 +1,91 @@
+/// <reference path="fourslash.ts"/>
+
+////var functions = {
+////    a: 0,
+////    b: function () { },
+////    c: function x() { },
+////    d: () => { },
+////    e: y(),
+////    f() { }
+////};
+
+verify.navigationTree({
+    text: "<global>",
+    kind: "script",
+    childItems: [
+        {
+            text: "functions",
+            kind: "var",
+            childItems: [
+                {
+                    text: "a",
+                    kind: "property"
+                },
+                {
+                    text: "b",
+                    kind: "method"
+                },
+                {
+                    text: "c",
+                    kind: "method"
+                },
+                {
+                    text: "d",
+                    kind: "method"
+                },
+                {
+                    text: "e",
+                    kind: "property"
+                },
+                {
+                    text: "f",
+                    kind: "method"
+                }
+            ]
+        }
+    ]
+});
+
+verify.navigationBar([
+    {
+        "text": "<global>",
+        "kind": "script",
+        "childItems": [
+            {
+                "text": "functions",
+                "kind": "var"
+            }
+        ]
+    },
+    {
+        "text": "functions",
+        "kind": "var",
+        "childItems": [
+            {
+                "text": "a",
+                "kind": "property"
+            },
+            {
+                "text": "b",
+                "kind": "method"
+            },
+            {
+                "text": "c",
+                "kind": "method"
+            },
+            {
+                "text": "d",
+                "kind": "method"
+            },
+            {
+                "text": "e",
+                "kind": "property"
+            },
+            {
+                "text": "f",
+                "kind": "method"
+            }
+        ],
+        "indent": 1
+    }
+]);

--- a/tests/cases/fourslash/navigationBarFunctionPrototype.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype.ts
@@ -44,11 +44,11 @@ verify.navigationTree({
                     "childItems": [
                         {
                             "text": "get",
-                            "kind": "property"
+                            "kind": "method"
                         },
                         {
                             "text": "set",
-                            "kind": "property"
+                            "kind": "method"
                         }
                     ]
                 },
@@ -57,11 +57,11 @@ verify.navigationTree({
                     "childItems": [
                         {
                             "text": "get",
-                            "kind": "property"
+                            "kind": "method"
                         },
                         {
                             "text": "set",
-                            "kind": "property"
+                            "kind": "method"
                         }
                     ]
                 }
@@ -114,11 +114,11 @@ verify.navigationBar([
         "childItems": [
           {
             "text": "get",
-            "kind": "property"
+            "kind": "method"
           },
           {
             "text": "set",
-            "kind": "property"
+            "kind": "method"
           }
         ],
         "indent": 2
@@ -128,11 +128,11 @@ verify.navigationBar([
         "childItems": [
           {
             "text": "get",
-            "kind": "property"
+            "kind": "method"
           },
           {
             "text": "set",
-            "kind": "property"
+            "kind": "method"
           }
         ],
         "indent": 2

--- a/tests/cases/fourslash/navigationBarFunctionPrototype.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototype.ts
@@ -44,11 +44,11 @@ verify.navigationTree({
                     "childItems": [
                         {
                             "text": "get",
-                            "kind": "function"
+                            "kind": "property"
                         },
                         {
                             "text": "set",
-                            "kind": "function"
+                            "kind": "property"
                         }
                     ]
                 },
@@ -57,11 +57,11 @@ verify.navigationTree({
                     "childItems": [
                         {
                             "text": "get",
-                            "kind": "function"
+                            "kind": "property"
                         },
                         {
                             "text": "set",
-                            "kind": "function"
+                            "kind": "property"
                         }
                     ]
                 }
@@ -108,5 +108,33 @@ verify.navigationBar([
             }
         ],
         "indent": 1
-    }
+    },
+    {
+        "text": "staticProp",
+        "childItems": [
+          {
+            "text": "get",
+            "kind": "property"
+          },
+          {
+            "text": "set",
+            "kind": "property"
+          }
+        ],
+        "indent": 2
+      },
+      {
+        "text": "name",
+        "childItems": [
+          {
+            "text": "get",
+            "kind": "property"
+          },
+          {
+            "text": "set",
+            "kind": "property"
+          }
+        ],
+        "indent": 2
+      }
 ]);

--- a/tests/cases/fourslash/navigationBarFunctionPrototypeBroken.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototypeBroken.ts
@@ -139,6 +139,28 @@ verify.navigationBar([
     ]
   },
   {
+    "text": "G",
+    "kind": "method",
+    "childItems": [
+      {
+        "text": "A",
+        "kind": "method"
+      }
+    ],
+    "indent": 1
+  },
+  {
+    "text": "A",
+    "kind": "method",
+    "childItems": [
+      {
+        "text": "a",
+        "kind": "function"
+      }
+    ],
+    "indent": 2
+  },
+  {
     "text": "A",
     "kind": "class",
     "childItems": [
@@ -152,5 +174,16 @@ verify.navigationBar([
       }
     ],
     "indent": 1
-  }
+  },
+  {
+    "text": "A",
+    "kind": "method",
+    "childItems": [
+      {
+        "text": "a",
+        "kind": "function"
+      }
+    ],
+    "indent": 2
+  },
 ]);

--- a/tests/cases/fourslash/navigationBarFunctionPrototypeNested.ts
+++ b/tests/cases/fourslash/navigationBarFunctionPrototypeNested.ts
@@ -209,6 +209,16 @@ verify.navigationBar([
     "indent": 2
   },
   {
+    "text": "x",
+    "childItems": [
+      {
+        "text": "get",
+        "kind": "method"
+      }
+    ],
+    "indent": 3
+  },
+  {
     "text": "D",
     "kind": "class",
     "childItems": [

--- a/tests/cases/fourslash/navigationBarInitializerSpans.ts
+++ b/tests/cases/fourslash/navigationBarInitializerSpans.ts
@@ -1,10 +1,25 @@
 /// <reference path="fourslash.ts" />
 
-////const [|[|x|] = () => 0|];
-////const f = [|function [|f|]() {}|];
+////// get the name for the navbar from the variable name rather than the function name
+////const [|[|x|] = () => { var [|a|]; }|];
+////const [|[|f|] = function f() { var [|b|]; }|];
+////const [|[|y|] = { [|[|z|]: function z() { var [|c|]; }|] }|];
 
-const [s0, s0Name, s1, s1Name] = test.spans();
-const sGlobal = { start: 0, length: 45 };
+const [
+    s0,
+    s0Name,
+    s0Child,
+    s1, 
+    s1Name, 
+    s1Child, 
+    s2, 
+    s2Name, 
+    s2Child, 
+    s2ChildName, 
+    s2GrandChildName
+] = test.spans();
+
+const sGlobal = { start: 0, length: 188 };
 
 verify.navigationTree({
     text: "<global>",
@@ -13,16 +28,54 @@ verify.navigationTree({
     childItems: [
         {
             text: "f",
-            kind: "function",
+            kind: "const",
             spans: [s1],
             nameSpan: s1Name,
+            childItems: [
+                {
+                    text: "b",
+                    kind: "var",
+                    spans: [s1Child],
+                    nameSpan: s1Child,
+                },
+            ],
         },
         {
             text: "x",
             kind: "const",
             spans: [s0],
             nameSpan: s0Name,
+            childItems: [
+                {
+                    text: "a",
+                    kind: "var",
+                    spans: [s0Child],
+                    nameSpan: s0Child,
+                },
+            ],
         },
+        {
+            text: "y",
+            kind: "const",
+            spans: [s2],
+            nameSpan: s2Name,
+            childItems:[
+                {
+                    text: "z",
+                    kind: "property",
+                    spans: [s2Child],
+                    nameSpan: s2ChildName,
+                    childItems: [
+                        {
+                            text: "c",
+                            kind: "var",
+                            spans: [s2GrandChildName],
+                            nameSpan: s2GrandChildName,
+                        },
+                    ],
+                },
+            ],
+        }
     ]
 }, { checkSpans: true });
 
@@ -34,7 +87,7 @@ verify.navigationBar([
         childItems: [
             {
                 text: "f",
-                kind: "function",
+                kind: "const",
                 spans: [s1],
             },
             {
@@ -42,12 +95,63 @@ verify.navigationBar([
                 kind: "const",
                 spans: [s0],
             },
+            {
+                text: "y",
+                kind: "const",
+                spans: [s2],
+            }
         ],
     },
     {
         text: "f",
-        kind: "function",
+        kind: "const",
         spans: [s1],
+        childItems: [
+            {
+                text: "b",
+                kind: "var",
+                spans: [s1Child],
+            },
+        ],
         indent: 1,
+    },
+    {
+        text: "x",
+        kind: "const",
+        spans: [s0],
+        childItems: [
+            {
+                text: "a",
+                kind: "var",
+                spans: [s0Child],
+            },
+        ],
+        indent: 1,
+    },
+    {
+        text: "y",
+        kind: "const",
+        spans: [s2],
+        childItems: [
+            {
+                text: "z",
+                kind: "property",
+                spans: [s2Child],
+            },
+        ],
+        indent: 1,
+    },
+    {
+        text: "z",
+        kind: "property",
+        spans: [s2Child],
+        childItems: [
+            {
+                text: "c",
+                kind: "var",
+                spans: [s2GrandChildName],
+            },
+        ],
+        indent: 2,
     },
 ], { checkSpans: true });

--- a/tests/cases/fourslash/navigationBarInitializerSpans.ts
+++ b/tests/cases/fourslash/navigationBarInitializerSpans.ts
@@ -62,7 +62,7 @@ verify.navigationTree({
             childItems:[
                 {
                     text: "z",
-                    kind: "property",
+                    kind: "method",
                     spans: [s2Child],
                     nameSpan: s2ChildName,
                     childItems: [
@@ -135,7 +135,7 @@ verify.navigationBar([
         childItems: [
             {
                 text: "z",
-                kind: "property",
+                kind: "method",
                 spans: [s2Child],
             },
         ],
@@ -143,7 +143,7 @@ verify.navigationBar([
     },
     {
         text: "z",
-        kind: "property",
+        kind: "method",
         spans: [s2Child],
         childItems: [
             {

--- a/tests/cases/fourslash/navigationBarItemsBindingPatterns.ts
+++ b/tests/cases/fourslash/navigationBarItemsBindingPatterns.ts
@@ -5,6 +5,7 @@
 ////let foo1, {a, b}
 ////const bar1, [c, d]
 ////var {e, x: [f, g]} = {a:1, x:[]};
+////var { h: i = function j() {} } = obj;
 
 verify.navigationTree({
     "text": "<global>",
@@ -52,6 +53,10 @@ verify.navigationTree({
         },
         {
             "text": "g",
+            "kind": "var"
+        },
+        {
+            "text": "i",
             "kind": "var"
         }
     ]
@@ -104,6 +109,10 @@ verify.navigationBar([
             },
             {
                 "text": "g",
+                "kind": "var"
+            },
+            {
+                "text": "i",
                 "kind": "var"
             }
         ]

--- a/tests/cases/fourslash/navigationBarItemsFunctions.ts
+++ b/tests/cases/fourslash/navigationBarItemsFunctions.ts
@@ -7,6 +7,9 @@
 ////        function biz() {
 ////            var z = 10;
 ////        }
+////        function qux() {
+////            // A function with an empty body should not be top level
+////        }
 ////    }
 ////}
 ////
@@ -45,6 +48,10 @@ verify.navigationTree({
                                     "kind": "var"
                                 }
                             ]
+                        },
+                        {
+                            "text": "qux",
+                            "kind": "function"
                         },
                         {
                             "text": "y",
@@ -111,10 +118,26 @@ verify.navigationBar([
                 "kind": "function"
             },
             {
+                "text": "qux",
+                "kind": "function"
+            },
+            {
                 "text": "y",
                 "kind": "var"
             }
         ],
         "indent": 2
-    }
+    },
+    {
+        "text": "biz",
+        "kind": "function",
+        "childItems": [
+            {
+                "text": "z",
+                "kind": "var"
+            }
+        ],
+        "indent": 3
+    },
+
 ]);

--- a/tests/cases/fourslash/navigationBarItemsPropertiesDefinedInConstructors.ts
+++ b/tests/cases/fourslash/navigationBarItemsPropertiesDefinedInConstructors.ts
@@ -78,5 +78,17 @@ verify.navigationBar([
             }
         ],
         "indent": 1
+    },
+    {
+      "text": "constructor",
+      "kind": "constructor",
+      "childItems": [
+        {
+          "text": "local",
+          "kind": "var"
+        }
+      ],
+      "indent": 2
     }
+    
 ]);

--- a/tests/cases/fourslash/navigationBarMerging_grandchildren.ts
+++ b/tests/cases/fourslash/navigationBarMerging_grandchildren.ts
@@ -1,5 +1,6 @@
 /// <reference path="fourslash.ts"/>
 
+////// Should not merge grandchildren with property assignments
 ////const o = {
 ////    a: {
 ////        m() {},
@@ -17,8 +18,20 @@ verify.navigationTree({
             text: "o",
             kind: "const",
             childItems: [
-                { text: "m", kind: "method" },
-                { text: "m", kind: "method" },
+                { 
+                    text: "a",
+                    kind: "property",
+                    childItems: [
+                        { text: "m", kind: "method" }
+                    ]
+                },
+                { 
+                    text: "b",
+                    kind: "property",
+                    childItems: [
+                        { text: "m", kind: "method" }
+                    ]
+                },
             ],
         },
     ]
@@ -36,9 +49,26 @@ verify.navigationBar([
         text: "o",
         kind: "const",
         childItems: [
-            { text: "m", kind: "method" },
-            { text: "m", kind: "method" },
+            { text: "a", kind: "property" },
+            { text: "b", kind: "property" },
         ],
         indent: 1,
     },
+    {
+        text: "a",
+        kind: "property",
+        childItems: [
+            { text: "m", kind: "method" },
+        ],
+        indent: 2,
+    },
+    {
+        text: "b",
+        kind: "property",
+        childItems: [
+            { text: "m", kind: "method" },
+        ],
+        indent: 2,
+    },
+
 ]);

--- a/tests/cases/fourslash/navigationBarNestedObjectLiterals.ts
+++ b/tests/cases/fourslash/navigationBarNestedObjectLiterals.ts
@@ -1,0 +1,139 @@
+/// <reference path="fourslash.ts"/>
+
+////var a = {
+////    b: 0,
+////    c: {},
+////    d: {
+////        e: 1,
+////    },
+////    f: {
+////        g: 2,
+////        h: {
+////            i: 3,
+////        },
+////    },
+////}
+
+verify.navigationTree({
+    "text": "<global>",
+    "kind": "script",
+    "childItems": [
+      {
+        "text": "a",
+        "kind": "var",
+        "childItems": [
+          {
+            "text": "b",
+            "kind": "property"
+          },
+          {
+            "text": "c",
+            "kind": "property"
+          },
+          {
+            "text": "d",
+            "kind": "property",
+            "childItems": [
+              {
+                "text": "e",
+                "kind": "property"
+              }
+            ]
+          },
+          {
+            "text": "f",
+            "kind": "property",
+            "childItems": [
+              {
+                "text": "g",
+                "kind": "property"
+              },
+              {
+                "text": "h",
+                "kind": "property",
+                "childItems": [
+                  {
+                    "text": "i",
+                    "kind": "property"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  });
+
+verify.navigationBar([
+    {
+      "text": "<global>",
+      "kind": "script",
+      "childItems": [
+        {
+          "text": "a",
+          "kind": "var"
+        }
+      ]
+    },
+    {
+      "text": "a",
+      "kind": "var",
+      "childItems": [
+        {
+          "text": "b",
+          "kind": "property"
+        },
+        {
+          "text": "c",
+          "kind": "property"
+        },
+        {
+          "text": "d",
+          "kind": "property"
+        },
+        {
+          "text": "f",
+          "kind": "property"
+        }
+      ],
+      "indent": 1
+    },
+    {
+      "text": "d",
+      "kind": "property",
+      "childItems": [
+        {
+          "text": "e",
+          "kind": "property"
+        }
+      ],
+      "indent": 2
+    },
+    {
+      "text": "f",
+      "kind": "property",
+      "childItems": [
+        {
+            "text": "g",
+            "kind": "property"
+        },
+        {
+            "text": "h",
+            "kind": "property"
+        }
+      ],
+      "indent": 2
+    },
+    {
+        "text": "h",
+        "kind": "property",
+        "childItems": [
+          {
+              "text": "i",
+              "kind": "property"
+          }
+        ],
+        "indent": 3
+      }
+  ]);


### PR DESCRIPTION
Currently the navigation bar in Visual Studio is not very useful for JavaScript files. We make the choice to show an item in the navbar based on the node type of its child items, and in some cases, its parent node.

By relaxing most the rules around what makes a navigation item "top level," we will get a more informative code hierarchy in the middle "object" dropdown, similar to how the navtree is presented in VSCode.

The right "member" dropdown always shows the child nodes of whichever node is selected in the middle dropdown, so we can keep navigation leaf nodes out of the middle dropdown to reduce clutter. 

Property assignments and class `this` properties will also be added to the navigation tree with this change.

Take the following sample:

```ts
const foo = {
    bar: {
        baz: {}
    },
    biz: function qux() {
        var quim;
    }
};

var someFunctions = function () {
    var a = () => { };
    var b = function () { };
    var c = function d() { var C; };
    var e = function () {
        var f = function () { var F; };
    };
};
```

**Before**

Property assignments do not show up, so we don't see any structure of nested objects (see `foo`) unless they have an 'important' node such as a function (`qux`). In those cases, the name of the function shows up in the child items list rather than the more intuitive member name.

![RoughBeforeFoo](https://user-images.githubusercontent.com/42591254/63951052-ef639580-ca31-11e9-9356-bbd1207ba3e6.png)

![RoughBeforeQux](https://user-images.githubusercontent.com/42591254/63951790-3aca7380-ca33-11e9-9665-a6576c319e57.png)

All of the child functions of `someFunctions` are deemed unimportant and only show in the member dropdown. Indeed even function `e` is woefully unimportant until its child `f` gets its own important child.

![BeforeSomeFunction](https://user-images.githubusercontent.com/42591254/63952276-1e7b0680-ca34-11e9-8d2e-a2d6577de0c4.png)

**After**

Property assignments now show up in navigation, and the name of the property shows instead of the function name.

We keep the decision to not show functions with empty bodies in the middle dropdown (though they do show as a child item in the right dropdown). `e` and `f` both show, as having _any_ child item is now considered a good enough reason to show up in navigation.

![RoughFooAfter](https://user-images.githubusercontent.com/42591254/63951807-428a1800-ca33-11e9-861d-1e7e5859e315.png)



