### PR TITLE
Prevent excessive compilation of files within a cycle

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -997,7 +997,21 @@ namespace ts {
     }
 
     function addToAffectedFilesPendingEmit(state: BuilderProgramState, affectedFilesPendingEmit: readonly Path[]) {
-        state.affectedFilesPendingEmit = concatenate(state.affectedFilesPendingEmit, affectedFilesPendingEmit);
+        const actualAffectedFilesPendingEmit = affectedFilesPendingEmit.filter((f) => {
+            // No point in concatenating if its already in there
+            if (state.affectedFilesPendingEmit && state.affectedFilesPendingEmit.some((v) => v === f)) {
+                return false;
+            }
+
+            return true;
+        });
+
+        if (actualAffectedFilesPendingEmit.length === 0) {
+            // We filtered everything out, abort.
+            return;
+        }
+
+        state.affectedFilesPendingEmit = concatenate(state.affectedFilesPendingEmit, actualAffectedFilesPendingEmit);
         // affectedFilesPendingEmitIndex === undefined
         // - means the emit state.affectedFilesPendingEmit was undefined before adding current affected files
         //   so start from 0 as array would be affectedFilesPendingEmit


### PR DESCRIPTION
Cycles within a project previously would emit (to both memory and then later to disk) multiple times per file.

This would not have been possible without the large amount of time that @bjlaub put into debugging.

This was affecting us on versions 3.4 and 3.5 and master.

Fixes #31398

Nature: When using a tsbuildinfo file, a project with code that was circular in nature, would often OOM the compiler and would take far longer to rebuild for a tiny change vs just rebuilding from scratch.

Repro:
* Checkout https://github.com/ericanderson/test-case-ts-bug-a
* Add logging to `emitter.ts` in the file `printSourceFileOrBundle`, first line add `console.log(`=== printSourceFileOrBundle: jsFilePath=${jsFilePath} sourceMapFilePath=${sourceMapFilePath} `);`
* rebuild typescript
* build the project `node ../locationOfTypescriptCheckout/built/local/tsc.js --build packages/*`
* Notice that each file is basically printed once (there is another bug I believe that is not addressed here, in which the .d.ts files are printed an extra time)
* Change `a.ts` to add `foo: any` to the interface `A`.
* build the project `node ../locationOfTypescriptCheckout/built/local/tsc.js --build packages/*`
* Notice many prints.

Internally to our company, we have a project that was building in about 110s when there were no tsbuildinfo files. When starting with tsbuildinfo files in place and making a trivial change it would oom 4gb and if we set it to 6gb it would take over 20m to complete.

After this change we can get back to a 3gb heap and the rebuild from a tsbuildinfo file takes 108 seconds.

cc/ @ahejlsberg @weswigham @sheetalkamat @RyanCavanaugh @DanielRosenwasser 

Shoutout to @bjlaub for the countless hours of debugging to track this down.