### PR TITLE
Added optional trailing slash to navigation bar regex

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -713,6 +713,6 @@ namespace ts.NavigationBar {
         // \r - Carriage Return
         // \u2028 - Line separator
         // \u2029 - Paragraph separator
-        return text.replace(/\\(\r?\n|\r|\u2028|\u2029)/g, "");
+        return text.replace(/\\?(\r?\n|\r|\u2028|\u2029)/g, "");
     }
 }

--- a/tests/cases/fourslash/navigationBarItemsMultilineStringIdentifiers2.ts
+++ b/tests/cases/fourslash/navigationBarItemsMultilineStringIdentifiers2.ts
@@ -8,6 +8,10 @@
 ////     const a = ' ''line1\
 ////         line2';
 //// }
+////
+//// f(() => { }, `unterminated backtick 1
+//// unterminated backtick 2
+//// unterminated backtick 3
 
 verify.navigationTree({
     "text": "<global>",
@@ -34,6 +38,10 @@ verify.navigationTree({
         {
             "text": "f(`line1line2line3`) callback",
             "kind": "function"
+        },
+        {
+            "text": "f(`unterminated backtick 1unterminated backtick 2unterminated backtick 3) callback",
+            "kind": "function"
         }
     ]
 });
@@ -53,6 +61,10 @@ verify.navigationBar([
             },
             {
                 "text": "f(`line1line2line3`) callback",
+                "kind": "function"
+            },
+            {
+                "text": "f(`unterminated backtick 1unterminated backtick 2unterminated backtick 3) callback",
                 "kind": "function"
             }
         ]
@@ -79,6 +91,11 @@ verify.navigationBar([
     },
     {
         "text": "f(`line1line2line3`) callback",
+        "kind": "function",
+        "indent": 1
+    },
+    {
+        "text": "f(`unterminated backtick 1unterminated backtick 2unterminated backtick 3) callback",
         "kind": "function",
         "indent": 1
     }


### PR DESCRIPTION
Fixed an issue with the navigation bar when the using the following code:
```ts
f(() => { }, `unterminated backtick 1
unterminated backtick 2
unterminated backtick 3
```