### PR TITLE
Merge pull request #33056 from amcasey/TripleSlashRestrictions

### DIFF
--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -771,6 +771,14 @@ namespace ts {
                 return false;
             }
 
+            // Limiting classification to exactly the elements and attributes
+            // defined in `ts.commentPragmas` would be excessive, but we can avoid
+            // some obvious false positives (e.g. in XML-like doc comments) by
+            // checking the element name.
+            if (!match[3] || !(match[3] in commentPragmas)) {
+                return false;
+            }
+
             let pos = start;
 
             pushCommentRange(pos, match[1].length); // ///
@@ -778,10 +786,6 @@ namespace ts {
 
             pushClassification(pos, match[2].length, ClassificationType.punctuation); // <
             pos += match[2].length;
-
-            if (!match[3]) {
-                return true;
-            }
 
             pushClassification(pos, match[3].length, ClassificationType.jsxSelfClosingTagName); // element name
             pos += match[3].length;

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash17.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash17.ts
@@ -1,7 +1,7 @@
 /// <reference path="fourslash.ts"/>
 
-//// /// <
+//// /// <summary>Text</summary>
 
 var c = classification;
 verify.syntacticClassificationsAre(
-    c.comment("/// <")); // Don't classify until we recognize the element name
+    c.comment("/// <summary>Text</summary>"));

--- a/tests/cases/fourslash/syntacticClassificationsTripleSlash18.ts
+++ b/tests/cases/fourslash/syntacticClassificationsTripleSlash18.ts
@@ -1,7 +1,7 @@
 /// <reference path="fourslash.ts"/>
 
-//// /// <
+//// /// <reference>Text</reference>
 
 var c = classification;
 verify.syntacticClassificationsAre(
-    c.comment("/// <")); // Don't classify until we recognize the element name
+    c.comment("/// <reference>Text</reference>"));


### PR DESCRIPTION
Make triple-slash comment classification more restrictive

(cherry picked from commit 5b59cfb1c4663efb2699483ce61eb12b91a311ed)