### PR TITLE
Fix the error when use spread arguments twice

### DIFF
--- a/tests/baselines/reference/callWithSpread3.errors.txt
+++ b/tests/baselines/reference/callWithSpread3.errors.txt
@@ -1,16 +1,20 @@
-tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(5,14): error TS2554: Expected 2 arguments, but got 3.
-tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(6,19): error TS2554: Expected 2 arguments, but got 5.
-tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(7,19): error TS2556: Expected 2 arguments, but got 4 or more.
-tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(8,19): error TS2556: Expected 2 arguments, but got 5 or more.
-tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(9,16): error TS2556: Expected 2 arguments, but got 1 or more.
-tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(10,9): error TS2554: Expected 2 arguments, but got 3.
+tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(9,14): error TS2554: Expected 2 arguments, but got 3.
+tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(10,19): error TS2554: Expected 2 arguments, but got 5.
+tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(11,19): error TS2556: Expected 2 arguments, but got 4 or more.
+tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(12,19): error TS2556: Expected 2 arguments, but got 5 or more.
+tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(13,16): error TS2556: Expected 2 arguments, but got 1 or more.
+tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(14,9): error TS2554: Expected 2 arguments, but got 3.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts (6 errors) ====
     declare function takeTwo(a: string, b: string): void;
     declare const t2: [string, string];
     declare const t3: [string, string, string];
+    declare function takeTwoOrMore (a: string, b: string, ...c: string[]): void
+    declare const t4: [string, string, ...string[]]
+    declare const t5: string[]
     
+    // error
     takeTwo('a', ...t2); // error on ...t2
                  ~~~~~
 !!! error TS2554: Expected 2 arguments, but got 3.
@@ -30,3 +34,10 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts(10,9): erro
     takeTwo(...t3); // error on ...t3
             ~~~~~
 !!! error TS2554: Expected 2 arguments, but got 3.
+    
+    // ok
+    takeTwoOrMore(...t4);
+    takeTwoOrMore(...t4, ...t5);
+    takeTwoOrMore(...t4, ...t4);
+    takeTwoOrMore(...t5, ...t4);
+    

--- a/tests/baselines/reference/callWithSpread3.js
+++ b/tests/baselines/reference/callWithSpread3.js
@@ -2,13 +2,24 @@
 declare function takeTwo(a: string, b: string): void;
 declare const t2: [string, string];
 declare const t3: [string, string, string];
+declare function takeTwoOrMore (a: string, b: string, ...c: string[]): void
+declare const t4: [string, string, ...string[]]
+declare const t5: string[]
 
+// error
 takeTwo('a', ...t2); // error on ...t2
 takeTwo('a', 'b', 'c', ...t2); // error on 'c' and ...t2
 takeTwo('a', 'b', ...t2, 'c'); // error on ...t2 and 'c'
 takeTwo('a', 'b', 'c', ...t2, 'd'); // error on 'c', ...t2 and 'd'
 takeTwo(...t2, 'a'); // error on 'a'
 takeTwo(...t3); // error on ...t3
+
+// ok
+takeTwoOrMore(...t4);
+takeTwoOrMore(...t4, ...t5);
+takeTwoOrMore(...t4, ...t4);
+takeTwoOrMore(...t5, ...t4);
+
 
 //// [callWithSpread3.js]
 var __spreadArrays = (this && this.__spreadArrays) || function () {
@@ -18,9 +29,15 @@ var __spreadArrays = (this && this.__spreadArrays) || function () {
             r[k] = a[j];
     return r;
 };
+// error
 takeTwo.apply(void 0, __spreadArrays(['a'], t2)); // error on ...t2
 takeTwo.apply(void 0, __spreadArrays(['a', 'b', 'c'], t2)); // error on 'c' and ...t2
 takeTwo.apply(void 0, __spreadArrays(['a', 'b'], t2, ['c'])); // error on ...t2 and 'c'
 takeTwo.apply(void 0, __spreadArrays(['a', 'b', 'c'], t2, ['d'])); // error on 'c', ...t2 and 'd'
 takeTwo.apply(void 0, __spreadArrays(t2, ['a'])); // error on 'a'
 takeTwo.apply(void 0, t3); // error on ...t3
+// ok
+takeTwoOrMore.apply(void 0, t4);
+takeTwoOrMore.apply(void 0, __spreadArrays(t4, t5));
+takeTwoOrMore.apply(void 0, __spreadArrays(t4, t4));
+takeTwoOrMore.apply(void 0, __spreadArrays(t5, t4));

--- a/tests/baselines/reference/callWithSpread3.symbols
+++ b/tests/baselines/reference/callWithSpread3.symbols
@@ -10,6 +10,19 @@ declare const t2: [string, string];
 declare const t3: [string, string, string];
 >t3 : Symbol(t3, Decl(callWithSpread3.ts, 2, 13))
 
+declare function takeTwoOrMore (a: string, b: string, ...c: string[]): void
+>takeTwoOrMore : Symbol(takeTwoOrMore, Decl(callWithSpread3.ts, 2, 43))
+>a : Symbol(a, Decl(callWithSpread3.ts, 3, 32))
+>b : Symbol(b, Decl(callWithSpread3.ts, 3, 42))
+>c : Symbol(c, Decl(callWithSpread3.ts, 3, 53))
+
+declare const t4: [string, string, ...string[]]
+>t4 : Symbol(t4, Decl(callWithSpread3.ts, 4, 13))
+
+declare const t5: string[]
+>t5 : Symbol(t5, Decl(callWithSpread3.ts, 5, 13))
+
+// error
 takeTwo('a', ...t2); // error on ...t2
 >takeTwo : Symbol(takeTwo, Decl(callWithSpread3.ts, 0, 0))
 >t2 : Symbol(t2, Decl(callWithSpread3.ts, 1, 13))
@@ -33,4 +46,24 @@ takeTwo(...t2, 'a'); // error on 'a'
 takeTwo(...t3); // error on ...t3
 >takeTwo : Symbol(takeTwo, Decl(callWithSpread3.ts, 0, 0))
 >t3 : Symbol(t3, Decl(callWithSpread3.ts, 2, 13))
+
+// ok
+takeTwoOrMore(...t4);
+>takeTwoOrMore : Symbol(takeTwoOrMore, Decl(callWithSpread3.ts, 2, 43))
+>t4 : Symbol(t4, Decl(callWithSpread3.ts, 4, 13))
+
+takeTwoOrMore(...t4, ...t5);
+>takeTwoOrMore : Symbol(takeTwoOrMore, Decl(callWithSpread3.ts, 2, 43))
+>t4 : Symbol(t4, Decl(callWithSpread3.ts, 4, 13))
+>t5 : Symbol(t5, Decl(callWithSpread3.ts, 5, 13))
+
+takeTwoOrMore(...t4, ...t4);
+>takeTwoOrMore : Symbol(takeTwoOrMore, Decl(callWithSpread3.ts, 2, 43))
+>t4 : Symbol(t4, Decl(callWithSpread3.ts, 4, 13))
+>t4 : Symbol(t4, Decl(callWithSpread3.ts, 4, 13))
+
+takeTwoOrMore(...t5, ...t4);
+>takeTwoOrMore : Symbol(takeTwoOrMore, Decl(callWithSpread3.ts, 2, 43))
+>t5 : Symbol(t5, Decl(callWithSpread3.ts, 5, 13))
+>t4 : Symbol(t4, Decl(callWithSpread3.ts, 4, 13))
 

--- a/tests/baselines/reference/callWithSpread3.types
+++ b/tests/baselines/reference/callWithSpread3.types
@@ -10,6 +10,19 @@ declare const t2: [string, string];
 declare const t3: [string, string, string];
 >t3 : [string, string, string]
 
+declare function takeTwoOrMore (a: string, b: string, ...c: string[]): void
+>takeTwoOrMore : (a: string, b: string, ...c: string[]) => void
+>a : string
+>b : string
+>c : string[]
+
+declare const t4: [string, string, ...string[]]
+>t4 : [string, string, ...string[]]
+
+declare const t5: string[]
+>t5 : string[]
+
+// error
 takeTwo('a', ...t2); // error on ...t2
 >takeTwo('a', ...t2) : void
 >takeTwo : (a: string, b: string) => void
@@ -57,4 +70,35 @@ takeTwo(...t3); // error on ...t3
 >takeTwo : (a: string, b: string) => void
 >...t3 : string
 >t3 : [string, string, string]
+
+// ok
+takeTwoOrMore(...t4);
+>takeTwoOrMore(...t4) : void
+>takeTwoOrMore : (a: string, b: string, ...c: string[]) => void
+>...t4 : string
+>t4 : [string, string, ...string[]]
+
+takeTwoOrMore(...t4, ...t5);
+>takeTwoOrMore(...t4, ...t5) : void
+>takeTwoOrMore : (a: string, b: string, ...c: string[]) => void
+>...t4 : string
+>t4 : [string, string, ...string[]]
+>...t5 : string
+>t5 : string[]
+
+takeTwoOrMore(...t4, ...t4);
+>takeTwoOrMore(...t4, ...t4) : void
+>takeTwoOrMore : (a: string, b: string, ...c: string[]) => void
+>...t4 : string
+>t4 : [string, string, ...string[]]
+>...t4 : string
+>t4 : [string, string, ...string[]]
+
+takeTwoOrMore(...t5, ...t4);
+>takeTwoOrMore(...t5, ...t4) : void
+>takeTwoOrMore : (a: string, b: string, ...c: string[]) => void
+>...t5 : string
+>t5 : string[]
+>...t4 : string
+>t4 : [string, string, ...string[]]
 

--- a/tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts
+++ b/tests/cases/conformance/expressions/functionCalls/callWithSpread3.ts
@@ -1,10 +1,20 @@
 declare function takeTwo(a: string, b: string): void;
 declare const t2: [string, string];
 declare const t3: [string, string, string];
+declare function takeTwoOrMore (a: string, b: string, ...c: string[]): void
+declare const t4: [string, string, ...string[]]
+declare const t5: string[]
 
+// error
 takeTwo('a', ...t2); // error on ...t2
 takeTwo('a', 'b', 'c', ...t2); // error on 'c' and ...t2
 takeTwo('a', 'b', ...t2, 'c'); // error on ...t2 and 'c'
 takeTwo('a', 'b', 'c', ...t2, 'd'); // error on 'c', ...t2 and 'd'
 takeTwo(...t2, 'a'); // error on 'a'
 takeTwo(...t3); // error on ...t3
+
+// ok
+takeTwoOrMore(...t4);
+takeTwoOrMore(...t4, ...t5);
+takeTwoOrMore(...t4, ...t4);
+takeTwoOrMore(...t5, ...t4);


### PR DESCRIPTION
This is a partial fix for #32835, but a full fix should also handle the additional test posted there.
