### PR TITLE
add the loading attribute for iframe

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -6887,6 +6887,12 @@ interface HTMLFrameElement extends HTMLElement {
     /** @deprecated */
     frameBorder: string;
     /**
+     * Tell the browser if the iframe is a good ("lazy"), bad ("eager") or undetermined ("auto")
+     * candidate for lazy loading. If the iframe is lazy laoded, the browser will wait untill
+     * it actually appears in the user screen to load its content.
+     */
+    loading: "lazy" | "eager" | "auto";
+    /**
      * Sets or retrieves a URI to a long description of the object.
      */
     /** @deprecated */
@@ -7166,6 +7172,12 @@ interface HTMLImageElement extends HTMLElement {
      * Sets or retrieves whether the image is a server-side image map.
      */
     isMap: boolean;
+    /**
+     * Tell the browser if the image is a good ("lazy"), bad ("eager") or undetermined ("auto")
+     * candidate for lazy loading. If the image is lazy laoded, the browser will wait untill
+     * it actually appears in the user screen to load it.
+     */
+    loading: "lazy" | "eager" | "auto";
     /**
      * Sets or retrieves a Uniform Resource Identifier (URI) to a long description of the object.
      */


### PR DESCRIPTION
We have a new "loading" attribute for the img and iframe tag. Let's use it without 

See https://web.dev/native-lazy-loading
See https://github.com/whatwg/html/pull/3752/files#diff-36cd38f49b9afa08222c0dc9ebfe35eb

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
