### PR TITLE
Fixed goto when global declarations are on multiple files

### DIFF
--- a/tests/cases/fourslash/goToDefinitionAcrossMultipleProjects.ts
+++ b/tests/cases/fourslash/goToDefinitionAcrossMultipleProjects.ts
@@ -7,8 +7,16 @@
 ////var /*def2*/x: number;
 
 //@Filename: c.ts
+////var /*def3*/x: number;
+
+//@Filename: d.ts
+////var /*def4*/x: number;
+
+//@Filename: e.ts
 /////// <reference path="a.ts" />
 /////// <reference path="b.ts" />
+/////// <reference path="c.ts" />
+/////// <reference path="d.ts" />
 ////[|/*use*/x|]++;
 
-verify.goToDefinition("use", ["def1", "def2"]);
+verify.goToDefinition("use", ["def1", "def2", "def3", "def4"]);


### PR DESCRIPTION
Fixed an issue on goto when global declarations appears on multiple files.

Previously it was only returning only two declarations. After fix, it will return all of the declarations available.