### PR TITLE
generate import statements and replace import types when implementing interface #28165

### DIFF
--- a/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
+++ b/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
@@ -60,7 +60,13 @@ namespace ts.codefix {
             createMissingIndexSignatureDeclaration(implementedType, IndexKind.String);
         }
 
-        createMissingMemberNodes(classDeclaration, nonPrivateAndNotExistedInHeritageClauseMembers, context, preferences, member => changeTracker.insertNodeAtClassStart(sourceFile, classDeclaration, member));
+        // Delete existing import statements, since they get overwritten by the fix.
+        const existingImportDeclarations = sourceFile.statements.filter(isImportDeclaration);
+        if (existingImportDeclarations.length > 0) {
+            changeTracker.deleteNodeRange(sourceFile, first(existingImportDeclarations), last(existingImportDeclarations));
+        }
+
+        createMissingMemberNodes(classDeclaration, nonPrivateAndNotExistedInHeritageClauseMembers, context, preferences, member => changeTracker.insertNodeAtClassStart(sourceFile, classDeclaration, member), importStatement => insertImport(changeTracker, sourceFile, importStatement));
 
         function createMissingIndexSignatureDeclaration(type: InterfaceType, kind: IndexKind): void {
             const indexInfoOfKind = checker.getIndexInfoOfType(type, kind);

--- a/tests/cases/fourslash/codeFixClassImplementInterface_typeInOtherFile.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterface_typeInOtherFile.ts
@@ -15,10 +15,10 @@ goTo.file("/C.ts");
 verify.codeFix({
     description: "Implement interface 'I'",
     newFileContent:
-`import { I } from "./I";
+`import { I, J } from "./I";
 export class C implements I {
-    x: import("./I").J;
-    m(): import("./I").J {
+    x: J;
+    m(): J {
         throw new Error("Method not implemented.");
     }
 }`,

--- a/tests/cases/fourslash/quickfixImplementInterfaceUnreachableTypeUsesRelativeImport.ts
+++ b/tests/cases/fourslash/quickfixImplementInterfaceUnreachableTypeUsesRelativeImport.ts
@@ -18,9 +18,10 @@ verify.codeFix({
     description: "Implement interface 'Foo'",
     newFileContent: {
         "/tests/cases/fourslash/index.ts": `import { Foo } from './interface';
+import { Class } from './class';
 
 class X implements Foo {
-    x: import("./class").Class;
+    x: Class;
 }`
     }
 });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #28165 
Fixes an issue where adding implemented members yields locally-imported types.

![giphy](https://user-images.githubusercontent.com/25084248/64013757-8a21aa00-caee-11e9-870a-d9d69705879b.gif)
