### PR TITLE
Mark deep indexed access comparisons as expanding

### DIFF
--- a/tests/baselines/reference/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.js
+++ b/tests/baselines/reference/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.js
@@ -1,0 +1,17 @@
+//// [comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts]
+type PartialDeep<T> = {[K in keyof T]?: PartialDeep<T[K]>};
+type Many<T> = T | readonly T[];
+
+interface Collection<T> {
+    sortBy(...iteratees: Many<PartialDeep<T>>[]): Collection<T>;
+}
+
+const x: Collection<{x: number}> = (null as any as Collection<{x: number, y: number}>);
+
+export {};
+
+
+//// [comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.js]
+"use strict";
+exports.__esModule = true;
+var x = null;

--- a/tests/baselines/reference/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.symbols
+++ b/tests/baselines/reference/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.symbols
@@ -1,0 +1,40 @@
+=== tests/cases/compiler/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts ===
+type PartialDeep<T> = {[K in keyof T]?: PartialDeep<T[K]>};
+>PartialDeep : Symbol(PartialDeep, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 0))
+>T : Symbol(T, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 17))
+>K : Symbol(K, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 24))
+>T : Symbol(T, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 17))
+>PartialDeep : Symbol(PartialDeep, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 0))
+>T : Symbol(T, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 17))
+>K : Symbol(K, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 24))
+
+type Many<T> = T | readonly T[];
+>Many : Symbol(Many, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 59))
+>T : Symbol(T, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 1, 10))
+>T : Symbol(T, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 1, 10))
+>T : Symbol(T, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 1, 10))
+
+interface Collection<T> {
+>Collection : Symbol(Collection, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 1, 32))
+>T : Symbol(T, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 3, 21))
+
+    sortBy(...iteratees: Many<PartialDeep<T>>[]): Collection<T>;
+>sortBy : Symbol(Collection.sortBy, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 3, 25))
+>iteratees : Symbol(iteratees, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 4, 11))
+>Many : Symbol(Many, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 59))
+>PartialDeep : Symbol(PartialDeep, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 0, 0))
+>T : Symbol(T, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 3, 21))
+>Collection : Symbol(Collection, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 1, 32))
+>T : Symbol(T, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 3, 21))
+}
+
+const x: Collection<{x: number}> = (null as any as Collection<{x: number, y: number}>);
+>x : Symbol(x, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 7, 5))
+>Collection : Symbol(Collection, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 1, 32))
+>x : Symbol(x, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 7, 21))
+>Collection : Symbol(Collection, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 1, 32))
+>x : Symbol(x, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 7, 63))
+>y : Symbol(y, Decl(comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts, 7, 73))
+
+export {};
+

--- a/tests/baselines/reference/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.types
+++ b/tests/baselines/reference/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.types
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts ===
+type PartialDeep<T> = {[K in keyof T]?: PartialDeep<T[K]>};
+>PartialDeep : PartialDeep<T>
+
+type Many<T> = T | readonly T[];
+>Many : Many<T>
+
+interface Collection<T> {
+    sortBy(...iteratees: Many<PartialDeep<T>>[]): Collection<T>;
+>sortBy : (...iteratees: Many<PartialDeep<T>>[]) => Collection<T>
+>iteratees : Many<PartialDeep<T>>[]
+}
+
+const x: Collection<{x: number}> = (null as any as Collection<{x: number, y: number}>);
+>x : Collection<{ x: number; }>
+>x : number
+>(null as any as Collection<{x: number, y: number}>) : Collection<{ x: number; y: number; }>
+>null as any as Collection<{x: number, y: number}> : Collection<{ x: number; y: number; }>
+>null as any : any
+>null : null
+>x : number
+>y : number
+
+export {};
+

--- a/tests/cases/compiler/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts
+++ b/tests/cases/compiler/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts
@@ -1,0 +1,11 @@
+// @strict: true
+type PartialDeep<T> = {[K in keyof T]?: PartialDeep<T[K]>};
+type Many<T> = T | readonly T[];
+
+interface Collection<T> {
+    sortBy(...iteratees: Many<PartialDeep<T>>[]): Collection<T>;
+}
+
+const x: Collection<{x: number}> = (null as any as Collection<{x: number, y: number}>);
+
+export {};


### PR DESCRIPTION
Fixes #33132

Just as `isDeeplyNestedType` marks objects which re-nest >5 times as maybe infinitely expanding, it now also marks indexed accesses which nest >5 times in the same way. Since a deeply nested indexed access is essentially the dual of a deeply nested object type (or at least you'd need a deeply nested object to satisfy the indexing operations!), this makes sense to me.