### PR TITLE
Fix #32809

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18027,7 +18027,7 @@ namespace ts {
             // the entire control flow graph from the variable's declaration (i.e. when the flow container and
             // declaration container are the same).
             const assumeInitialized = isParameter || isAlias || isOuterVariable || isSpreadDestructuringAssignmentTarget || isModuleExports || isBindingElement(declaration) ||
-                type !== autoType && type !== autoArrayType && (!strictNullChecks || (type.flags & TypeFlags.AnyOrUnknown) !== 0 ||
+                type !== autoType && type !== autoArrayType && (!strictNullChecks || (type.flags & (TypeFlags.AnyOrUnknown | TypeFlags.Void)) !== 0 ||
                 isInTypeQuery(node) || node.parent.kind === SyntaxKind.ExportSpecifier) ||
                 node.parent.kind === SyntaxKind.NonNullExpression ||
                 declaration.kind === SyntaxKind.VariableDeclaration && (<VariableDeclaration>declaration).exclamationToken ||

--- a/tests/baselines/reference/logicalAndOperatorStrictMode.types
+++ b/tests/baselines/reference/logicalAndOperatorStrictMode.types
@@ -256,7 +256,7 @@ const v5 = v && v;
 >v5 : void
 >v && v : void
 >v : void
->v : never
+>v : void
 
 const v6 = v && u;
 >v6 : void

--- a/tests/baselines/reference/voidIsInitialized.js
+++ b/tests/baselines/reference/voidIsInitialized.js
@@ -1,0 +1,23 @@
+//// [voidIsInitialized.ts]
+const x: void = undefined;
+const y: void = undefined;
+
+if(typeof x === "undefined") {
+    x // no error: assume x2 is initialised
+}
+
+if(typeof y !== "undefined") {
+    y // no error: do not narrow void
+}
+
+
+//// [voidIsInitialized.js]
+"use strict";
+var x = undefined;
+var y = undefined;
+if (typeof x === "undefined") {
+    x; // no error: assume x2 is initialised
+}
+if (typeof y !== "undefined") {
+    y; // no error: do not narrow void
+}

--- a/tests/baselines/reference/voidIsInitialized.symbols
+++ b/tests/baselines/reference/voidIsInitialized.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/voidIsInitialized.ts ===
+const x: void = undefined;
+>x : Symbol(x, Decl(voidIsInitialized.ts, 0, 5))
+>undefined : Symbol(undefined)
+
+const y: void = undefined;
+>y : Symbol(y, Decl(voidIsInitialized.ts, 1, 5))
+>undefined : Symbol(undefined)
+
+if(typeof x === "undefined") {
+>x : Symbol(x, Decl(voidIsInitialized.ts, 0, 5))
+
+    x // no error: assume x2 is initialised
+>x : Symbol(x, Decl(voidIsInitialized.ts, 0, 5))
+}
+
+if(typeof y !== "undefined") {
+>y : Symbol(y, Decl(voidIsInitialized.ts, 1, 5))
+
+    y // no error: do not narrow void
+>y : Symbol(y, Decl(voidIsInitialized.ts, 1, 5))
+}
+

--- a/tests/baselines/reference/voidIsInitialized.types
+++ b/tests/baselines/reference/voidIsInitialized.types
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/voidIsInitialized.ts ===
+const x: void = undefined;
+>x : void
+>undefined : undefined
+
+const y: void = undefined;
+>y : void
+>undefined : undefined
+
+if(typeof x === "undefined") {
+>typeof x === "undefined" : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : void
+>"undefined" : "undefined"
+
+    x // no error: assume x2 is initialised
+>x : void
+}
+
+if(typeof y !== "undefined") {
+>typeof y !== "undefined" : boolean
+>typeof y : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>y : void
+>"undefined" : "undefined"
+
+    y // no error: do not narrow void
+>y : void
+}
+

--- a/tests/cases/compiler/voidIsInitialized.ts
+++ b/tests/cases/compiler/voidIsInitialized.ts
@@ -1,0 +1,12 @@
+// @strict: true
+
+const x: void = undefined;
+const y: void = undefined;
+
+if(typeof x === "undefined") {
+    x // no error: assume x2 is initialised
+}
+
+if(typeof y !== "undefined") {
+    y // no error: do not narrow void
+}


### PR DESCRIPTION
Fixes #32809

With this PR `void` variables are now assumed to be initialised, removing the possibility of _used for assigned errors_.

To assume a `void` variable is always assigned is nonsensical, but it's even more nonsensical to report errors based on whether it has, or has not, been assigned to.

This has the consequence that `void` is no longer narrowed under inequality.