### PR TITLE
Less aggressive contextual signature instantiation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -177,6 +177,7 @@ namespace ts {
     const enum ContextFlags {
         None = 0,
         Signature = 1 << 0,  // Obtaining contextual signature
+        NoConstraints = 1 << 1,  // Don't obtain type variable constraints
     }
 
     const enum AccessFlags {
@@ -19193,7 +19194,7 @@ namespace ts {
                 getContextualTypeForObjectLiteralMethod(node, contextFlags) :
                 getContextualType(node, contextFlags);
             const instantiatedType = instantiateContextualType(contextualType, node, contextFlags);
-            if (instantiatedType) {
+            if (instantiatedType && !(contextFlags && contextFlags & ContextFlags.NoConstraints && instantiatedType.flags & TypeFlags.TypeVariable)) {
                 const apparentType = mapType(instantiatedType, getApparentType, /*noReductions*/ true);
                 if (apparentType.flags & TypeFlags.Union) {
                     if (isObjectLiteralExpression(node)) {
@@ -25098,8 +25099,8 @@ namespace ts {
                 const constructSignature = getSingleSignature(type, SignatureKind.Construct, /*allowMembers*/ true);
                 const signature = callSignature || constructSignature;
                 if (signature && signature.typeParameters) {
-                    const contextualType = getApparentTypeOfContextualType(<Expression>node);
-                    if (contextualType && !isMixinConstructorType(contextualType)) {
+                    const contextualType = getApparentTypeOfContextualType(<Expression>node, ContextFlags.NoConstraints);
+                    if (contextualType) {
                         const contextualSignature = getSingleSignature(getNonNullableType(contextualType), callSignature ? SignatureKind.Call : SignatureKind.Construct, /*allowMembers*/ false);
                         if (contextualSignature && !contextualSignature.typeParameters) {
                             if (checkMode & CheckMode.SkipGenericFunctions) {

--- a/tests/baselines/reference/contextualSignatureInstantiation4.js
+++ b/tests/baselines/reference/contextualSignatureInstantiation4.js
@@ -1,0 +1,29 @@
+//// [contextualSignatureInstantiation4.ts]
+// Repros from #32976
+
+declare class Banana<T extends string> { constructor(a: string, property: T) }
+
+declare function fruitFactory1<TFruit>(Fruit: new (...args: any[]) => TFruit): TFruit
+const banana1 = fruitFactory1(Banana) // Banana<any>
+
+declare function fruitFactory2<TFruit>(Fruit: new (a: string, ...args: any[]) => TFruit): TFruit
+const banana2 = fruitFactory2(Banana) // Banana<any>
+
+declare function fruitFactory3<TFruit>(Fruit: new (a: string, s: "foo", ...args: any[]) => TFruit): TFruit
+const banana3 = fruitFactory3(Banana) // Banana<"foo">
+
+declare function fruitFactory4<TFruit>(Fruit: new (a: string, ...args: "foo"[]) => TFruit): TFruit
+const banana4 = fruitFactory4(Banana) // Banana<"foo">
+
+declare function fruitFactory5<TFruit>(Fruit: new (...args: "foo"[]) => TFruit): TFruit
+const banana5 = fruitFactory5(Banana) // Banana<"foo">
+
+
+//// [contextualSignatureInstantiation4.js]
+"use strict";
+// Repros from #32976
+var banana1 = fruitFactory1(Banana); // Banana<any>
+var banana2 = fruitFactory2(Banana); // Banana<any>
+var banana3 = fruitFactory3(Banana); // Banana<"foo">
+var banana4 = fruitFactory4(Banana); // Banana<"foo">
+var banana5 = fruitFactory5(Banana); // Banana<"foo">

--- a/tests/baselines/reference/contextualSignatureInstantiation4.symbols
+++ b/tests/baselines/reference/contextualSignatureInstantiation4.symbols
@@ -1,0 +1,79 @@
+=== tests/cases/compiler/contextualSignatureInstantiation4.ts ===
+// Repros from #32976
+
+declare class Banana<T extends string> { constructor(a: string, property: T) }
+>Banana : Symbol(Banana, Decl(contextualSignatureInstantiation4.ts, 0, 0))
+>T : Symbol(T, Decl(contextualSignatureInstantiation4.ts, 2, 21))
+>a : Symbol(a, Decl(contextualSignatureInstantiation4.ts, 2, 53))
+>property : Symbol(property, Decl(contextualSignatureInstantiation4.ts, 2, 63))
+>T : Symbol(T, Decl(contextualSignatureInstantiation4.ts, 2, 21))
+
+declare function fruitFactory1<TFruit>(Fruit: new (...args: any[]) => TFruit): TFruit
+>fruitFactory1 : Symbol(fruitFactory1, Decl(contextualSignatureInstantiation4.ts, 2, 78))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 4, 31))
+>Fruit : Symbol(Fruit, Decl(contextualSignatureInstantiation4.ts, 4, 39))
+>args : Symbol(args, Decl(contextualSignatureInstantiation4.ts, 4, 51))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 4, 31))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 4, 31))
+
+const banana1 = fruitFactory1(Banana) // Banana<any>
+>banana1 : Symbol(banana1, Decl(contextualSignatureInstantiation4.ts, 5, 5))
+>fruitFactory1 : Symbol(fruitFactory1, Decl(contextualSignatureInstantiation4.ts, 2, 78))
+>Banana : Symbol(Banana, Decl(contextualSignatureInstantiation4.ts, 0, 0))
+
+declare function fruitFactory2<TFruit>(Fruit: new (a: string, ...args: any[]) => TFruit): TFruit
+>fruitFactory2 : Symbol(fruitFactory2, Decl(contextualSignatureInstantiation4.ts, 5, 37))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 7, 31))
+>Fruit : Symbol(Fruit, Decl(contextualSignatureInstantiation4.ts, 7, 39))
+>a : Symbol(a, Decl(contextualSignatureInstantiation4.ts, 7, 51))
+>args : Symbol(args, Decl(contextualSignatureInstantiation4.ts, 7, 61))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 7, 31))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 7, 31))
+
+const banana2 = fruitFactory2(Banana) // Banana<any>
+>banana2 : Symbol(banana2, Decl(contextualSignatureInstantiation4.ts, 8, 5))
+>fruitFactory2 : Symbol(fruitFactory2, Decl(contextualSignatureInstantiation4.ts, 5, 37))
+>Banana : Symbol(Banana, Decl(contextualSignatureInstantiation4.ts, 0, 0))
+
+declare function fruitFactory3<TFruit>(Fruit: new (a: string, s: "foo", ...args: any[]) => TFruit): TFruit
+>fruitFactory3 : Symbol(fruitFactory3, Decl(contextualSignatureInstantiation4.ts, 8, 37))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 10, 31))
+>Fruit : Symbol(Fruit, Decl(contextualSignatureInstantiation4.ts, 10, 39))
+>a : Symbol(a, Decl(contextualSignatureInstantiation4.ts, 10, 51))
+>s : Symbol(s, Decl(contextualSignatureInstantiation4.ts, 10, 61))
+>args : Symbol(args, Decl(contextualSignatureInstantiation4.ts, 10, 71))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 10, 31))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 10, 31))
+
+const banana3 = fruitFactory3(Banana) // Banana<"foo">
+>banana3 : Symbol(banana3, Decl(contextualSignatureInstantiation4.ts, 11, 5))
+>fruitFactory3 : Symbol(fruitFactory3, Decl(contextualSignatureInstantiation4.ts, 8, 37))
+>Banana : Symbol(Banana, Decl(contextualSignatureInstantiation4.ts, 0, 0))
+
+declare function fruitFactory4<TFruit>(Fruit: new (a: string, ...args: "foo"[]) => TFruit): TFruit
+>fruitFactory4 : Symbol(fruitFactory4, Decl(contextualSignatureInstantiation4.ts, 11, 37))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 13, 31))
+>Fruit : Symbol(Fruit, Decl(contextualSignatureInstantiation4.ts, 13, 39))
+>a : Symbol(a, Decl(contextualSignatureInstantiation4.ts, 13, 51))
+>args : Symbol(args, Decl(contextualSignatureInstantiation4.ts, 13, 61))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 13, 31))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 13, 31))
+
+const banana4 = fruitFactory4(Banana) // Banana<"foo">
+>banana4 : Symbol(banana4, Decl(contextualSignatureInstantiation4.ts, 14, 5))
+>fruitFactory4 : Symbol(fruitFactory4, Decl(contextualSignatureInstantiation4.ts, 11, 37))
+>Banana : Symbol(Banana, Decl(contextualSignatureInstantiation4.ts, 0, 0))
+
+declare function fruitFactory5<TFruit>(Fruit: new (...args: "foo"[]) => TFruit): TFruit
+>fruitFactory5 : Symbol(fruitFactory5, Decl(contextualSignatureInstantiation4.ts, 14, 37))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 16, 31))
+>Fruit : Symbol(Fruit, Decl(contextualSignatureInstantiation4.ts, 16, 39))
+>args : Symbol(args, Decl(contextualSignatureInstantiation4.ts, 16, 51))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 16, 31))
+>TFruit : Symbol(TFruit, Decl(contextualSignatureInstantiation4.ts, 16, 31))
+
+const banana5 = fruitFactory5(Banana) // Banana<"foo">
+>banana5 : Symbol(banana5, Decl(contextualSignatureInstantiation4.ts, 17, 5))
+>fruitFactory5 : Symbol(fruitFactory5, Decl(contextualSignatureInstantiation4.ts, 14, 37))
+>Banana : Symbol(Banana, Decl(contextualSignatureInstantiation4.ts, 0, 0))
+

--- a/tests/baselines/reference/contextualSignatureInstantiation4.types
+++ b/tests/baselines/reference/contextualSignatureInstantiation4.types
@@ -1,0 +1,67 @@
+=== tests/cases/compiler/contextualSignatureInstantiation4.ts ===
+// Repros from #32976
+
+declare class Banana<T extends string> { constructor(a: string, property: T) }
+>Banana : Banana<T>
+>a : string
+>property : T
+
+declare function fruitFactory1<TFruit>(Fruit: new (...args: any[]) => TFruit): TFruit
+>fruitFactory1 : <TFruit>(Fruit: new (...args: any[]) => TFruit) => TFruit
+>Fruit : new (...args: any[]) => TFruit
+>args : any[]
+
+const banana1 = fruitFactory1(Banana) // Banana<any>
+>banana1 : Banana<any>
+>fruitFactory1(Banana) : Banana<any>
+>fruitFactory1 : <TFruit>(Fruit: new (...args: any[]) => TFruit) => TFruit
+>Banana : typeof Banana
+
+declare function fruitFactory2<TFruit>(Fruit: new (a: string, ...args: any[]) => TFruit): TFruit
+>fruitFactory2 : <TFruit>(Fruit: new (a: string, ...args: any[]) => TFruit) => TFruit
+>Fruit : new (a: string, ...args: any[]) => TFruit
+>a : string
+>args : any[]
+
+const banana2 = fruitFactory2(Banana) // Banana<any>
+>banana2 : Banana<any>
+>fruitFactory2(Banana) : Banana<any>
+>fruitFactory2 : <TFruit>(Fruit: new (a: string, ...args: any[]) => TFruit) => TFruit
+>Banana : typeof Banana
+
+declare function fruitFactory3<TFruit>(Fruit: new (a: string, s: "foo", ...args: any[]) => TFruit): TFruit
+>fruitFactory3 : <TFruit>(Fruit: new (a: string, s: "foo", ...args: any[]) => TFruit) => TFruit
+>Fruit : new (a: string, s: "foo", ...args: any[]) => TFruit
+>a : string
+>s : "foo"
+>args : any[]
+
+const banana3 = fruitFactory3(Banana) // Banana<"foo">
+>banana3 : Banana<"foo">
+>fruitFactory3(Banana) : Banana<"foo">
+>fruitFactory3 : <TFruit>(Fruit: new (a: string, s: "foo", ...args: any[]) => TFruit) => TFruit
+>Banana : typeof Banana
+
+declare function fruitFactory4<TFruit>(Fruit: new (a: string, ...args: "foo"[]) => TFruit): TFruit
+>fruitFactory4 : <TFruit>(Fruit: new (a: string, ...args: "foo"[]) => TFruit) => TFruit
+>Fruit : new (a: string, ...args: "foo"[]) => TFruit
+>a : string
+>args : "foo"[]
+
+const banana4 = fruitFactory4(Banana) // Banana<"foo">
+>banana4 : Banana<"foo">
+>fruitFactory4(Banana) : Banana<"foo">
+>fruitFactory4 : <TFruit>(Fruit: new (a: string, ...args: "foo"[]) => TFruit) => TFruit
+>Banana : typeof Banana
+
+declare function fruitFactory5<TFruit>(Fruit: new (...args: "foo"[]) => TFruit): TFruit
+>fruitFactory5 : <TFruit>(Fruit: new (...args: "foo"[]) => TFruit) => TFruit
+>Fruit : new (...args: "foo"[]) => TFruit
+>args : "foo"[]
+
+const banana5 = fruitFactory5(Banana) // Banana<"foo">
+>banana5 : Banana<"foo">
+>fruitFactory5(Banana) : Banana<"foo">
+>fruitFactory5 : <TFruit>(Fruit: new (...args: "foo"[]) => TFruit) => TFruit
+>Banana : typeof Banana
+

--- a/tests/baselines/reference/functionConstraintSatisfaction2.types
+++ b/tests/baselines/reference/functionConstraintSatisfaction2.types
@@ -79,8 +79,8 @@ var r7 = foo2(b);
 >b : new (x: string) => string
 
 var r8 = foo2(<U>(x: U) => x); // no error expected
->r8 : (x: string) => string
->foo2(<U>(x: U) => x) : (x: string) => string
+>r8 : <U>(x: U) => U
+>foo2(<U>(x: U) => x) : <U>(x: U) => U
 >foo2 : <T extends (x: string) => string>(x: T) => T
 ><U>(x: U) => x : <U>(x: U) => U
 >x : U

--- a/tests/baselines/reference/functionConstraintSatisfaction3.types
+++ b/tests/baselines/reference/functionConstraintSatisfaction3.types
@@ -103,16 +103,16 @@ var c2: { <T>(x: T): T; <T>(x: T, y: T): T };
 >y : T
 
 var r9 = foo(function <U>(x: U) { return x; });
->r9 : (x: string) => string
->foo(function <U>(x: U) { return x; }) : (x: string) => string
+>r9 : <U>(x: U) => U
+>foo(function <U>(x: U) { return x; }) : <U>(x: U) => U
 >foo : <T extends (x: string) => string>(x: T) => T
 >function <U>(x: U) { return x; } : <U>(x: U) => U
 >x : U
 >x : U
 
 var r10 = foo(<U extends string>(x: U) => x);
->r10 : (x: string) => string
->foo(<U extends string>(x: U) => x) : (x: string) => string
+>r10 : <U extends string>(x: U) => U
+>foo(<U extends string>(x: U) => x) : <U extends string>(x: U) => U
 >foo : <T extends (x: string) => string>(x: T) => T
 ><U extends string>(x: U) => x : <U extends string>(x: U) => U
 >x : U

--- a/tests/cases/compiler/contextualSignatureInstantiation4.ts
+++ b/tests/cases/compiler/contextualSignatureInstantiation4.ts
@@ -1,0 +1,20 @@
+// @strict: true
+
+// Repros from #32976
+
+declare class Banana<T extends string> { constructor(a: string, property: T) }
+
+declare function fruitFactory1<TFruit>(Fruit: new (...args: any[]) => TFruit): TFruit
+const banana1 = fruitFactory1(Banana) // Banana<any>
+
+declare function fruitFactory2<TFruit>(Fruit: new (a: string, ...args: any[]) => TFruit): TFruit
+const banana2 = fruitFactory2(Banana) // Banana<any>
+
+declare function fruitFactory3<TFruit>(Fruit: new (a: string, s: "foo", ...args: any[]) => TFruit): TFruit
+const banana3 = fruitFactory3(Banana) // Banana<"foo">
+
+declare function fruitFactory4<TFruit>(Fruit: new (a: string, ...args: "foo"[]) => TFruit): TFruit
+const banana4 = fruitFactory4(Banana) // Banana<"foo">
+
+declare function fruitFactory5<TFruit>(Fruit: new (...args: "foo"[]) => TFruit): TFruit
+const banana5 = fruitFactory5(Banana) // Banana<"foo">


### PR DESCRIPTION
With this PR we perform less aggressive contextual signature instantiation:

```ts
declare function foo<T extends (x: string) => string>(f: T): T;

const f = foo(<U>(x: U) => x);  // <U>(x: U) => U
```

Previously, we'd infer type `(x: string) => string` for `f` because we'd obtain the apparent type of `T` and then instantiate the argument type `<U>(x: U) => U` in the context of that type. While not incorrect, a better course of action is to leave the argument type alone and just infer it as-is when inferring directly to a type variable. That's the change in this PR.

This change also fixes #32976 because we no longer need to check for mixin constructor types (which wasn't really a correct check to begin with).

Fixes #32976.