### PR TITLE
Bind typedef/enum on all assignment declaration kinds

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1827,7 +1827,23 @@ namespace ts {
                         bindPotentiallyMissingNamespaces(file.symbol, declName.parent, isTopLevel,
                             !!findAncestor(declName, d => isPropertyAccessExpression(d) && d.name.escapedText === "prototype"), /*containerIsClass*/ false);
                         const oldContainer = container;
-                        container = isPropertyAccessExpression(declName.parent.expression) ? declName.parent.expression.name : declName.parent.expression;
+                        switch (getAssignmentDeclarationPropertyAccessKind(declName.parent)) {
+                            case AssignmentDeclarationKind.ExportsProperty:
+                            case AssignmentDeclarationKind.ModuleExports:
+                                container = file;
+                                break;
+                            case AssignmentDeclarationKind.ThisProperty:
+                                container = declName.parent.expression;
+                                break;
+                            case AssignmentDeclarationKind.PrototypeProperty:
+                                container = (declName.parent.expression as PropertyAccessExpression).name;
+                                break;
+                            case AssignmentDeclarationKind.Property:
+                                container = isPropertyAccessExpression(declName.parent.expression) ? declName.parent.expression.name : declName.parent.expression;
+                                break;
+                            case AssignmentDeclarationKind.None:
+                                return Debug.fail("Shouldn't have detected typedef or enum on non-assignment declaration");
+                        }
                         declareModuleMember(typeAlias, SymbolFlags.TypeAlias, SymbolFlags.TypeAliasExcludes);
                         container = oldContainer;
                     }

--- a/tests/baselines/reference/enumTagOnExports.symbols
+++ b/tests/baselines/reference/enumTagOnExports.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/jsdoc/enumTagOnExports.js ===
+/** @enum {number} */
+exports.a = {};
+>exports.a : Symbol(a, Decl(enumTagOnExports.js, 0, 0), Decl(enumTagOnExports.js, 1, 8), Decl(enumTagOnExports.js, 0, 4))
+>exports : Symbol(a, Decl(enumTagOnExports.js, 0, 0), Decl(enumTagOnExports.js, 1, 8), Decl(enumTagOnExports.js, 0, 4))
+>a : Symbol(a, Decl(enumTagOnExports.js, 0, 0), Decl(enumTagOnExports.js, 1, 8), Decl(enumTagOnExports.js, 0, 4))
+
+/** @enum {string} */
+module.exports.b = {};
+>module.exports.b : Symbol(b, Decl(enumTagOnExports.js, 1, 15), Decl(enumTagOnExports.js, 4, 15), Decl(enumTagOnExports.js, 3, 4))
+>module.exports : Symbol(b, Decl(enumTagOnExports.js, 1, 15), Decl(enumTagOnExports.js, 4, 15), Decl(enumTagOnExports.js, 3, 4))
+>module : Symbol(module, Decl(enumTagOnExports.js, 1, 15))
+>exports : Symbol("tests/cases/conformance/jsdoc/enumTagOnExports", Decl(enumTagOnExports.js, 0, 0))
+>b : Symbol(b, Decl(enumTagOnExports.js, 1, 15), Decl(enumTagOnExports.js, 4, 15), Decl(enumTagOnExports.js, 3, 4))
+

--- a/tests/baselines/reference/enumTagOnExports.types
+++ b/tests/baselines/reference/enumTagOnExports.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/enumTagOnExports.js ===
+/** @enum {number} */
+exports.a = {};
+>exports.a = {} : {}
+>exports.a : typeof a
+>exports : typeof import("tests/cases/conformance/jsdoc/enumTagOnExports")
+>a : typeof a
+>{} : {}
+
+/** @enum {string} */
+module.exports.b = {};
+>module.exports.b = {} : {}
+>module.exports.b : typeof b
+>module.exports : typeof import("tests/cases/conformance/jsdoc/enumTagOnExports")
+>module : { "tests/cases/conformance/jsdoc/enumTagOnExports": typeof import("tests/cases/conformance/jsdoc/enumTagOnExports"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/enumTagOnExports")
+>b : typeof b
+>{} : {}
+

--- a/tests/baselines/reference/enumTagOnExports2.symbols
+++ b/tests/baselines/reference/enumTagOnExports2.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/jsdoc/enumTagOnExports.js ===
+/** @enum {string} */
+module.exports = {};
+>module.exports : Symbol("tests/cases/conformance/jsdoc/enumTagOnExports", Decl(enumTagOnExports.js, 0, 0))
+>module : Symbol(module, Decl(enumTagOnExports.js, 0, 0))
+>exports : Symbol("tests/cases/conformance/jsdoc/enumTagOnExports", Decl(enumTagOnExports.js, 0, 0))
+

--- a/tests/baselines/reference/enumTagOnExports2.types
+++ b/tests/baselines/reference/enumTagOnExports2.types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsdoc/enumTagOnExports.js ===
+/** @enum {string} */
+module.exports = {};
+>module.exports = {} : typeof import("tests/cases/conformance/jsdoc/enumTagOnExports")
+>module.exports : typeof import("tests/cases/conformance/jsdoc/enumTagOnExports")
+>module : { "tests/cases/conformance/jsdoc/enumTagOnExports": typeof import("tests/cases/conformance/jsdoc/enumTagOnExports"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/enumTagOnExports")
+>{} : {}
+

--- a/tests/cases/conformance/jsdoc/enumTagOnExports.ts
+++ b/tests/cases/conformance/jsdoc/enumTagOnExports.ts
@@ -1,0 +1,10 @@
+// @filename: enumTagOnExports.js
+// @allowjs: true
+// @checkjs: true
+// @noemit: true
+
+/** @enum {number} */
+exports.a = {};
+
+/** @enum {string} */
+module.exports.b = {};

--- a/tests/cases/conformance/jsdoc/enumTagOnExports2.ts
+++ b/tests/cases/conformance/jsdoc/enumTagOnExports2.ts
@@ -1,0 +1,7 @@
+// @filename: enumTagOnExports.js
+// @allowjs: true
+// @checkjs: true
+// @noemit: true
+
+/** @enum {string} */
+module.exports = {};


### PR DESCRIPTION
This fixes a crash on exports, but the code now handles all kinds returned from getAssignmentDeclarationPropertyAccessKind.

Fixes #33230
