### PR TITLE
only add .js and .js.map files to "getAllProjectOutputs" if "emitDeclarationOnly" is false

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -186,9 +186,9 @@ namespace ts {
             for (const inputFileName of configFile.fileNames) {
                 if (fileExtensionIs(inputFileName, Extension.Dts)) continue;
                 const js = getOutputJSFileName(inputFileName, configFile, ignoreCase);
-                addOutput(js);
+                if (!configFile.options.emitDeclarationOnly) addOutput(js);
                 if (fileExtensionIs(inputFileName, Extension.Json)) continue;
-                if (js && configFile.options.sourceMap) {
+                if (js && configFile.options.sourceMap && !configFile.options.emitDeclarationOnly) {
                     addOutput(`${js}.map`);
                 }
                 if (getEmitDeclarations(configFile.options) && hasTSFileExtension(inputFileName)) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Currently if you try to use `createSolutionBuilder` with a `ts.config` that sets `emitDeclarationOnly` to true. It will never be able to invalidate a build.

When it calls `getAllProjectOutputs` the outputs include `.js` and `.js.d.ts` files. Since these files are never emitted the build can never invalidate.

This change only adds `.js` and `.js.d.ts` files to the `createSolutionBuilder` return value only if `emitDeclarationOnly` is false

* [ ] There are new or updated unit tests validating the change (I am unsure of where to add test so any pointers are appreciated!)

