### PR TITLE
Added more helpful syntax error for enum member commas

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1035,7 +1035,7 @@
         "category": "Error",
         "code": 1356
     },
-    "An enum member name must be followed by a ',' or '='.": {
+    "An enum member name must be followed by a ',', '=', or '}'.": {
         "category": "Error",
         "code": 1357
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1035,6 +1035,10 @@
         "category": "Error",
         "code": 1356
     },
+    "An enum member name must be followed by a ',' or '='.": {
+        "category": "Error",
+        "code": 1357
+    },
 
     "Duplicate identifier '{0}'.": {
         "category": "Error",

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2125,7 +2125,7 @@ namespace ts {
 
                     // We didn't get a comma, and the list wasn't terminated, explicitly parse
                     // out a comma so we give a good error message.
-                    parseExpected(SyntaxKind.CommaToken);
+                    parseExpected(SyntaxKind.CommaToken, getExpectedCommaDiagnostic(kind));
 
                     // If the token was a semicolon, and the caller allows that, then skip it and
                     // continue.  This ensures we get back on track and don't result in tons of
@@ -2166,6 +2166,10 @@ namespace ts {
                 result.hasTrailingComma = true;
             }
             return result;
+        }
+
+        function getExpectedCommaDiagnostic(kind: ParsingContext) {
+            return kind === ParsingContext.EnumMembers ? Diagnostics.An_enum_member_name_must_be_followed_by_a_or : undefined;
         }
 
         interface MissingList<T extends Node> extends NodeArray<T> {

--- a/tests/baselines/reference/constEnum2.errors.txt
+++ b/tests/baselines/reference/constEnum2.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/constEnums/constEnum2.ts(10,9): error TS2474: const enum member initializers can only contain literal values and other computed enum values.
 tests/cases/conformance/constEnums/constEnum2.ts(11,9): error TS2474: const enum member initializers can only contain literal values and other computed enum values.
-tests/cases/conformance/constEnums/constEnum2.ts(12,5): error TS1005: ',' expected.
+tests/cases/conformance/constEnums/constEnum2.ts(12,5): error TS1357: An enum member name must be followed by a ',' or '='.
 tests/cases/conformance/constEnums/constEnum2.ts(12,9): error TS2474: const enum member initializers can only contain literal values and other computed enum values.
 
 
@@ -22,7 +22,7 @@ tests/cases/conformance/constEnums/constEnum2.ts(12,9): error TS2474: const enum
 !!! error TS2474: const enum member initializers can only contain literal values and other computed enum values.
         g = CONST,
         ~
-!!! error TS1005: ',' expected.
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
             ~~~~~
 !!! error TS2474: const enum member initializers can only contain literal values and other computed enum values.
     }

--- a/tests/baselines/reference/constEnum2.errors.txt
+++ b/tests/baselines/reference/constEnum2.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/constEnums/constEnum2.ts(10,9): error TS2474: const enum member initializers can only contain literal values and other computed enum values.
 tests/cases/conformance/constEnums/constEnum2.ts(11,9): error TS2474: const enum member initializers can only contain literal values and other computed enum values.
-tests/cases/conformance/constEnums/constEnum2.ts(12,5): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/constEnums/constEnum2.ts(12,5): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
 tests/cases/conformance/constEnums/constEnum2.ts(12,9): error TS2474: const enum member initializers can only contain literal values and other computed enum values.
 
 
@@ -22,7 +22,7 @@ tests/cases/conformance/constEnums/constEnum2.ts(12,9): error TS2474: const enum
 !!! error TS2474: const enum member initializers can only contain literal values and other computed enum values.
         g = CONST,
         ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
             ~~~~~
 !!! error TS2474: const enum member initializers can only contain literal values and other computed enum values.
     }

--- a/tests/baselines/reference/enumErrors.errors.txt
+++ b/tests/baselines/reference/enumErrors.errors.txt
@@ -11,9 +11,19 @@ tests/cases/conformance/enums/enumErrors.ts(35,9): error TS2553: Computed values
 tests/cases/conformance/enums/enumErrors.ts(36,9): error TS2553: Computed values are not permitted in an enum with string valued members.
 tests/cases/conformance/enums/enumErrors.ts(37,9): error TS2553: Computed values are not permitted in an enum with string valued members.
 tests/cases/conformance/enums/enumErrors.ts(38,9): error TS2553: Computed values are not permitted in an enum with string valued members.
+tests/cases/conformance/enums/enumErrors.ts(46,18): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(47,24): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(47,26): error TS2452: An enum member cannot have a numeric name.
+tests/cases/conformance/enums/enumErrors.ts(48,28): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(48,30): error TS2452: An enum member cannot have a numeric name.
+tests/cases/conformance/enums/enumErrors.ts(48,31): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(51,16): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(51,22): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(51,30): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(51,33): error TS2452: An enum member cannot have a numeric name.
 
 
-==== tests/cases/conformance/enums/enumErrors.ts (13 errors) ====
+==== tests/cases/conformance/enums/enumErrors.ts (23 errors) ====
     // Enum named with PredefinedTypes
     enum any { }
          ~~~
@@ -79,4 +89,36 @@ tests/cases/conformance/enums/enumErrors.ts(38,9): error TS2553: Computed values
             ~~~~~
 !!! error TS2553: Computed values are not permitted in an enum with string valued members.
     }
+    
+    // Enum with incorrect syntax
+    enum E13 {
+        postComma,
+        postValueComma = 1,
+    
+        postSemicolon;
+                     ~
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
+        postColonValueComma: 2,
+                           ~
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
+                             ~
+!!! error TS2452: An enum member cannot have a numeric name.
+        postColonValueSemicolon: 3;
+                               ~
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
+                                 ~
+!!! error TS2452: An enum member cannot have a numeric name.
+                                  ~
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
+    };
+    
+    enum E14 { a, b: any "hello" += 1, c, d}
+                   ~
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
+                         ~~~~~~~
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
+                                 ~~
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
+                                    ~
+!!! error TS2452: An enum member cannot have a numeric name.
     

--- a/tests/baselines/reference/enumErrors.errors.txt
+++ b/tests/baselines/reference/enumErrors.errors.txt
@@ -11,15 +11,15 @@ tests/cases/conformance/enums/enumErrors.ts(35,9): error TS2553: Computed values
 tests/cases/conformance/enums/enumErrors.ts(36,9): error TS2553: Computed values are not permitted in an enum with string valued members.
 tests/cases/conformance/enums/enumErrors.ts(37,9): error TS2553: Computed values are not permitted in an enum with string valued members.
 tests/cases/conformance/enums/enumErrors.ts(38,9): error TS2553: Computed values are not permitted in an enum with string valued members.
-tests/cases/conformance/enums/enumErrors.ts(46,18): error TS1357: An enum member name must be followed by a ',' or '='.
-tests/cases/conformance/enums/enumErrors.ts(47,24): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(46,18): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
+tests/cases/conformance/enums/enumErrors.ts(47,24): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
 tests/cases/conformance/enums/enumErrors.ts(47,26): error TS2452: An enum member cannot have a numeric name.
-tests/cases/conformance/enums/enumErrors.ts(48,28): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(48,28): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
 tests/cases/conformance/enums/enumErrors.ts(48,30): error TS2452: An enum member cannot have a numeric name.
-tests/cases/conformance/enums/enumErrors.ts(48,31): error TS1357: An enum member name must be followed by a ',' or '='.
-tests/cases/conformance/enums/enumErrors.ts(51,16): error TS1357: An enum member name must be followed by a ',' or '='.
-tests/cases/conformance/enums/enumErrors.ts(51,22): error TS1357: An enum member name must be followed by a ',' or '='.
-tests/cases/conformance/enums/enumErrors.ts(51,30): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/enums/enumErrors.ts(48,31): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
+tests/cases/conformance/enums/enumErrors.ts(51,16): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
+tests/cases/conformance/enums/enumErrors.ts(51,22): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
+tests/cases/conformance/enums/enumErrors.ts(51,30): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
 tests/cases/conformance/enums/enumErrors.ts(51,33): error TS2452: An enum member cannot have a numeric name.
 
 
@@ -97,28 +97,28 @@ tests/cases/conformance/enums/enumErrors.ts(51,33): error TS2452: An enum member
     
         postSemicolon;
                      ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
         postColonValueComma: 2,
                            ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
                              ~
 !!! error TS2452: An enum member cannot have a numeric name.
         postColonValueSemicolon: 3;
                                ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
                                  ~
 !!! error TS2452: An enum member cannot have a numeric name.
                                   ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
     };
     
     enum E14 { a, b: any "hello" += 1, c, d}
                    ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
                          ~~~~~~~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
                                  ~~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
                                     ~
 !!! error TS2452: An enum member cannot have a numeric name.
     

--- a/tests/baselines/reference/enumErrors.js
+++ b/tests/baselines/reference/enumErrors.js
@@ -39,6 +39,18 @@ enum E12 {
     E = 1 + 1,
 }
 
+// Enum with incorrect syntax
+enum E13 {
+    postComma,
+    postValueComma = 1,
+
+    postSemicolon;
+    postColonValueComma: 2,
+    postColonValueSemicolon: 3;
+};
+
+enum E14 { a, b: any "hello" += 1, c, d}
+
 
 //// [enumErrors.js]
 // Enum named with PredefinedTypes
@@ -88,3 +100,25 @@ var E12;
     E12[E12["D"] = 0] = "D";
     E12[E12["E"] = 0] = "E";
 })(E12 || (E12 = {}));
+// Enum with incorrect syntax
+var E13;
+(function (E13) {
+    E13[E13["postComma"] = 0] = "postComma";
+    E13[E13["postValueComma"] = 1] = "postValueComma";
+    E13[E13["postSemicolon"] = 2] = "postSemicolon";
+    E13[E13["postColonValueComma"] = 3] = "postColonValueComma";
+    E13[E13[2] = 4] = 2;
+    E13[E13["postColonValueSemicolon"] = 5] = "postColonValueSemicolon";
+    E13[E13[3] = 6] = 3;
+})(E13 || (E13 = {}));
+;
+var E14;
+(function (E14) {
+    E14[E14["a"] = 0] = "a";
+    E14[E14["b"] = 1] = "b";
+    E14[E14["any"] = 2] = "any";
+    E14[E14["hello"] = 3] = "hello";
+    E14[E14[1] = 4] = 1;
+    E14[E14["c"] = 5] = "c";
+    E14[E14["d"] = 6] = "d";
+})(E14 || (E14 = {}));

--- a/tests/baselines/reference/enumErrors.symbols
+++ b/tests/baselines/reference/enumErrors.symbols
@@ -91,3 +91,36 @@ enum E12 {
 >E : Symbol(E12.E, Decl(enumErrors.ts, 36, 11))
 }
 
+// Enum with incorrect syntax
+enum E13 {
+>E13 : Symbol(E13, Decl(enumErrors.ts, 38, 1))
+
+    postComma,
+>postComma : Symbol(E13.postComma, Decl(enumErrors.ts, 41, 10))
+
+    postValueComma = 1,
+>postValueComma : Symbol(E13.postValueComma, Decl(enumErrors.ts, 42, 14))
+
+    postSemicolon;
+>postSemicolon : Symbol(E13.postSemicolon, Decl(enumErrors.ts, 43, 23))
+
+    postColonValueComma: 2,
+>postColonValueComma : Symbol(E13.postColonValueComma, Decl(enumErrors.ts, 45, 18))
+>2 : Symbol(E13[2], Decl(enumErrors.ts, 46, 24))
+
+    postColonValueSemicolon: 3;
+>postColonValueSemicolon : Symbol(E13.postColonValueSemicolon, Decl(enumErrors.ts, 46, 27))
+>3 : Symbol(E13[3], Decl(enumErrors.ts, 47, 28))
+
+};
+
+enum E14 { a, b: any "hello" += 1, c, d}
+>E14 : Symbol(E14, Decl(enumErrors.ts, 48, 2))
+>a : Symbol(E14.a, Decl(enumErrors.ts, 50, 10))
+>b : Symbol(E14.b, Decl(enumErrors.ts, 50, 13))
+>any : Symbol(E14.any, Decl(enumErrors.ts, 50, 16))
+>"hello" : Symbol(E14["hello"], Decl(enumErrors.ts, 50, 20))
+>1 : Symbol(E14[1], Decl(enumErrors.ts, 50, 31))
+>c : Symbol(E14.c, Decl(enumErrors.ts, 50, 34))
+>d : Symbol(E14.d, Decl(enumErrors.ts, 50, 37))
+

--- a/tests/baselines/reference/enumErrors.types
+++ b/tests/baselines/reference/enumErrors.types
@@ -102,3 +102,37 @@ enum E12 {
 >1 : 1
 }
 
+// Enum with incorrect syntax
+enum E13 {
+>E13 : E13
+
+    postComma,
+>postComma : E13.postComma
+
+    postValueComma = 1,
+>postValueComma : E13.postValueComma
+>1 : 1
+
+    postSemicolon;
+>postSemicolon : E13.postSemicolon
+
+    postColonValueComma: 2,
+>postColonValueComma : E13.postColonValueComma
+>2 : E13.2
+
+    postColonValueSemicolon: 3;
+>postColonValueSemicolon : E13.postColonValueSemicolon
+>3 : E13.3
+
+};
+
+enum E14 { a, b: any "hello" += 1, c, d}
+>E14 : E14
+>a : E14.a
+>b : E14.b
+>any : E14.any
+>"hello" : E14.hello
+>1 : E14.1
+>c : E14.c
+>d : E14.d
+

--- a/tests/baselines/reference/parserComputedPropertyName30.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName30.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(3,5): error TS1164: Computed property names are not allowed in enums.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(3,11): error TS2304: Cannot find name 'id'.
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(4,5): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(4,5): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(4,5): error TS1164: Computed property names are not allowed in enums.
 
 
@@ -14,7 +14,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
 !!! error TS2304: Cannot find name 'id'.
         [e2] = 1
         ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
         ~~~~
 !!! error TS1164: Computed property names are not allowed in enums.
     }

--- a/tests/baselines/reference/parserComputedPropertyName30.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName30.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(3,5): error TS1164: Computed property names are not allowed in enums.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(3,11): error TS2304: Cannot find name 'id'.
-tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(4,5): error TS1005: ',' expected.
+tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(4,5): error TS1357: An enum member name must be followed by a ',' or '='.
 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName30.ts(4,5): error TS1164: Computed property names are not allowed in enums.
 
 
@@ -14,7 +14,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
 !!! error TS2304: Cannot find name 'id'.
         [e2] = 1
         ~
-!!! error TS1005: ',' expected.
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
         ~~~~
 !!! error TS1164: Computed property names are not allowed in enums.
     }

--- a/tests/baselines/reference/parserEnum5.errors.txt
+++ b/tests/baselines/reference/parserEnum5.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(2,12): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(2,12): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
 tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(2,14): error TS2452: An enum member cannot have a numeric name.
-tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,15): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,15): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
 tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,17): error TS2452: An enum member cannot have a numeric name.
-tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,24): error TS1357: An enum member name must be followed by a ',' or '='.
+tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,24): error TS1357: An enum member name must be followed by a ',', '=', or '}'.
 tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,26): error TS2452: An enum member cannot have a numeric name.
 
 
@@ -10,15 +10,15 @@ tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,26)
     enum E2 { a, }
     enum E3 { a: 1, }
                ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
                  ~
 !!! error TS2452: An enum member cannot have a numeric name.
     enum E1 { a, b: 1, c, d: 2 = 3 }
                   ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
                     ~
 !!! error TS2452: An enum member cannot have a numeric name.
                            ~
-!!! error TS1357: An enum member name must be followed by a ',' or '='.
+!!! error TS1357: An enum member name must be followed by a ',', '=', or '}'.
                              ~
 !!! error TS2452: An enum member cannot have a numeric name.

--- a/tests/baselines/reference/parserEnum5.errors.txt
+++ b/tests/baselines/reference/parserEnum5.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(2,12): error TS1005: ',' expected.
+tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(2,12): error TS1357: An enum member name must be followed by a ',' or '='.
 tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(2,14): error TS2452: An enum member cannot have a numeric name.
-tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,15): error TS1005: ',' expected.
+tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,15): error TS1357: An enum member name must be followed by a ',' or '='.
 tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,17): error TS2452: An enum member cannot have a numeric name.
-tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,24): error TS1005: ',' expected.
+tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,24): error TS1357: An enum member name must be followed by a ',' or '='.
 tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,26): error TS2452: An enum member cannot have a numeric name.
 
 
@@ -10,15 +10,15 @@ tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum5.ts(3,26)
     enum E2 { a, }
     enum E3 { a: 1, }
                ~
-!!! error TS1005: ',' expected.
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
                  ~
 !!! error TS2452: An enum member cannot have a numeric name.
     enum E1 { a, b: 1, c, d: 2 = 3 }
                   ~
-!!! error TS1005: ',' expected.
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
                     ~
 !!! error TS2452: An enum member cannot have a numeric name.
                            ~
-!!! error TS1005: ',' expected.
+!!! error TS1357: An enum member name must be followed by a ',' or '='.
                              ~
 !!! error TS2452: An enum member cannot have a numeric name.

--- a/tests/cases/conformance/enums/enumErrors.ts
+++ b/tests/cases/conformance/enums/enumErrors.ts
@@ -37,3 +37,15 @@ enum E12 {
     D = {},
     E = 1 + 1,
 }
+
+// Enum with incorrect syntax
+enum E13 {
+    postComma,
+    postValueComma = 1,
+
+    postSemicolon;
+    postColonValueComma: 2,
+    postColonValueSemicolon: 3;
+};
+
+enum E14 { a, b: any "hello" += 1, c, d}


### PR DESCRIPTION
Switches the error message emitted by the parser to the more specific _"An enum member name must be followed by a ',' or '='."_ when the expected comma doesn't follow the member.

Fixes #838.