### PR TITLE
Fix incorrect string match on node_modules

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -377,7 +377,7 @@ namespace ts {
     }
 
     /*@internal*/
-    export const ignoredPaths = ["/node_modules/.", "/.git", "/.#"];
+    export const ignoredPaths = ["/node_modules/", "/.git", "/.#"];
 
     /*@internal*/
     export let sysLog: (s: string) => void = noop;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

`ignoredPaths` is used in a string match, so the dot is unnecessary and causes it to never match.

Fixes #33338
Related to #22826
Related to #31248
Related to #33335
