### PR TITLE
With --isolatedModules, --declaration emit is now allowed and builder handles it for incremental compilation

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -173,8 +173,7 @@ namespace ts {
         const compilerOptions = newProgram.getCompilerOptions();
         state.compilerOptions = compilerOptions;
         // With --out or --outFile, any change affects all semantic diagnostics so no need to cache them
-        // With --isolatedModules, emitting changed file doesnt emit dependent files so we cant know of dependent files to retrieve errors so dont cache the errors
-        if (!compilerOptions.outFile && !compilerOptions.out && !compilerOptions.isolatedModules) {
+        if (!compilerOptions.outFile && !compilerOptions.out) {
             state.semanticDiagnosticsPerFile = createMap<readonly Diagnostic[]>();
         }
         state.changedFilesSet = createMap<true>();
@@ -483,14 +482,41 @@ namespace ts {
         return !state.semanticDiagnosticsFromOldState.size;
     }
 
+    function isChangedSignagure(state: BuilderProgramState, path: Path) {
+        const newSignature = Debug.assertDefined(state.currentAffectedFilesSignatures).get(path);
+        const oldSignagure = Debug.assertDefined(state.fileInfos.get(path)).signature;
+        return newSignature !== oldSignagure;
+    }
+
     /**
      * Iterate on referencing modules that export entities from affected file
      */
     function forEachReferencingModulesOfExportOfAffectedFile(state: BuilderProgramState, affectedFile: SourceFile, fn: (state: BuilderProgramState, filePath: Path) => boolean) {
         // If there was change in signature (dts output) for the changed file,
         // then only we need to handle pending file emit
-        if (!state.exportedModulesMap || state.affectedFiles!.length === 1 || !state.changedFilesSet.has(affectedFile.path)) {
+        if (!state.exportedModulesMap || !state.changedFilesSet.has(affectedFile.path)) {
             return;
+        }
+
+        if (!isChangedSignagure(state, affectedFile.path)) return;
+
+        // Since isolated modules dont change js files, files affected by change in signature is itself
+        // But we need to cleanup semantic diagnostics and queue dts emit for affected files
+        if (state.compilerOptions.isolatedModules) {
+            const seenFileNamesMap = createMap<true>();
+            seenFileNamesMap.set(affectedFile.path, true);
+            const queue = BuilderState.getReferencedByPaths(state, affectedFile.resolvedPath);
+            while (queue.length > 0) {
+                const currentPath = queue.pop()!;
+                if (!seenFileNamesMap.has(currentPath)) {
+                    seenFileNamesMap.set(currentPath, true);
+                    const result = fn(state, currentPath);
+                    if (result && isChangedSignagure(state, currentPath)) {
+                        const currentSourceFile = Debug.assertDefined(state.program).getSourceFileByPath(currentPath)!;
+                        queue.push(...BuilderState.getReferencedByPaths(state, currentSourceFile.resolvedPath));
+                    }
+                }
+            }
         }
 
         Debug.assert(!!state.currentAffectedFilesExportedModulesMap);

--- a/src/compiler/builderState.ts
+++ b/src/compiler/builderState.ts
@@ -466,7 +466,7 @@ namespace ts.BuilderState {
     /**
      * Gets the files referenced by the the file path
      */
-    function getReferencedByPaths(state: Readonly<BuilderState>, referencedFilePath: Path) {
+    export function getReferencedByPaths(state: Readonly<BuilderState>, referencedFilePath: Path) {
         return arrayFrom(mapDefinedIterator(state.referencedMap!.entries(), ([filePath, referencesInFile]) =>
             referencesInFile.has(referencedFilePath) ? filePath as Path : undefined
         ));

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2808,10 +2808,6 @@ namespace ts {
             }
 
             if (options.isolatedModules) {
-                if (getEmitDeclarations(options)) {
-                    createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, getEmitDeclarationOptionName(options), "isolatedModules");
-                }
-
                 if (options.out) {
                     createDiagnosticForOptionName(Diagnostics.Option_0_cannot_be_specified_with_option_1, "out", "isolatedModules");
                 }

--- a/src/testRunner/unittests/tsbuild/helpers.ts
+++ b/src/testRunner/unittests/tsbuild/helpers.ts
@@ -230,7 +230,7 @@ interface Symbol {
         }
     }
 
-    interface BuildInput {
+    export interface BuildInput {
         fs: vfs.FileSystem;
         tick: () => void;
         rootNames: readonly string[];
@@ -239,7 +239,7 @@ interface Symbol {
         baselineBuildInfo?: true;
     }
 
-    function build({ fs, tick, rootNames, modifyFs, baselineSourceMap, baselineBuildInfo }: BuildInput) {
+    export function tscBuild({ fs, tick, rootNames, modifyFs, baselineSourceMap, baselineBuildInfo }: BuildInput) {
         const actualReadFileMap = createMap<number>();
         modifyFs(fs);
         tick();
@@ -344,7 +344,7 @@ Mismatch Actual(path, actual, expected): ${JSON.stringify(arrayFrom(mapDefinedIt
             let host: fakes.SolutionBuilderHost;
             let initialWrittenFiles: Map<true>;
             before(() => {
-                const result = build({
+                const result = tscBuild({
                     fs: projFs().shadow(),
                     tick,
                     rootNames,
@@ -390,7 +390,7 @@ Mismatch Actual(path, actual, expected): ${JSON.stringify(arrayFrom(mapDefinedIt
                         tick();
                         newFs = fs.shadow();
                         tick();
-                        ({ actualReadFileMap, host } = build({
+                        ({ actualReadFileMap, host } = tscBuild({
                             fs: newFs,
                             tick,
                             rootNames,
@@ -429,7 +429,7 @@ Mismatch Actual(path, actual, expected): ${JSON.stringify(arrayFrom(mapDefinedIt
                         });
                     }
                     it(`Verify emit output file text is same when built clean`, () => {
-                        const { fs, writtenFiles } = build({
+                        const { fs, writtenFiles } = tscBuild({
                             fs: newFs.shadow(),
                             tick,
                             rootNames,

--- a/src/testRunner/unittests/tsbuild/inferredTypeFromTransitiveModule.ts
+++ b/src/testRunner/unittests/tsbuild/inferredTypeFromTransitiveModule.ts
@@ -25,7 +25,7 @@ namespace ts {
                 ]
             },
             incrementalDtsChangedBuild: {
-                modifyFs: fs => replaceText(fs, "/src/bar.ts", "param: string", ""),
+                modifyFs: changeBarParam,
                 expectedDiagnostics: [
                     getExpectedDiagnosticForProjectsInBuild("src/tsconfig.json"),
                     [Diagnostics.Project_0_is_out_of_date_because_oldest_output_1_is_older_than_newest_input_2, "src/tsconfig.json", "src/obj/bar.js", "src/bar.ts"],
@@ -36,5 +36,55 @@ namespace ts {
             baselineOnly: true,
             verifyDiagnostics: true
         });
+
+        verifyTsbuildOutput({
+            scenario: "inferred type from transitive module with isolatedModules",
+            projFs: () => projFs,
+            time,
+            tick,
+            proj: "inferredTypeFromTransitiveModule",
+            rootNames: ["/src"],
+            initialBuild: { modifyFs: changeToIsolatedModules },
+            incrementalDtsChangedBuild: { modifyFs: changeBarParam },
+            baselineOnly: true,
+        });
+
+        it("reports errors in files affected by change in signature", () => {
+            const { fs, host } = tscBuild({
+                fs: projFs.shadow(),
+                tick,
+                rootNames: ["/src"],
+                modifyFs: fs => {
+                    changeToIsolatedModules(fs);
+                    appendText(fs, "/src/lazyIndex.ts", `
+import { default as bar } from './bar';
+bar("hello");`);
+                }
+            });
+            host.assertErrors(/*empty*/);
+
+            tick();
+            const { fs: newFs, host: newHost, writtenFiles } = tscBuild({
+                fs: fs.shadow(),
+                tick,
+                rootNames: ["/src"],
+                modifyFs: changeBarParam
+            });
+            // Has errors
+            newHost.assertErrors({
+                message: [Diagnostics.Expected_0_arguments_but_got_1, 0, 1],
+                location: expectedLocationIndexOf(newFs, "/src/lazyIndex.ts", `"hello"`)
+            });
+            // No written files
+            assert.equal(writtenFiles.size, 0);
+        });
     });
+
+    function changeToIsolatedModules(fs: vfs.FileSystem) {
+        replaceText(fs, "/src/tsconfig.json", `"incremental": true`, `"incremental": true, "isolatedModules": true`);
+    }
+
+    function changeBarParam(fs: vfs.FileSystem) {
+        replaceText(fs, "/src/bar.ts", "param: string", "");
+    }
 }

--- a/tests/baselines/reference/isolatedModulesDeclaration.errors.txt
+++ b/tests/baselines/reference/isolatedModulesDeclaration.errors.txt
@@ -1,6 +1,0 @@
-error TS5053: Option 'declaration' cannot be specified with option 'isolatedModules'.
-
-
-!!! error TS5053: Option 'declaration' cannot be specified with option 'isolatedModules'.
-==== tests/cases/compiler/file1.ts (0 errors) ====
-    export var x;

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/incremental-declaration-changes/inferred-type-from-transitive-module-with-isolatedModules.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/incremental-declaration-changes/inferred-type-from-transitive-module-with-isolatedModules.js
@@ -1,0 +1,82 @@
+//// [/src/bar.ts]
+interface RawAction {
+    (...args: any[]): Promise<any> | void;
+}
+interface ActionFactory {
+    <T extends RawAction>(target: T): T;
+}
+declare function foo<U extends any[] = any[]>(): ActionFactory;
+export default foo()(function foobar(): void {
+});
+
+//// [/src/obj/bar.d.ts]
+declare const _default: () => void;
+export default _default;
+
+
+//// [/src/obj/bar.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = foo()(function foobar() {
+});
+
+
+//// [/src/obj/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+      },
+      "../bar.ts": {
+        "version": "747071916-interface RawAction {\r\n    (...args: any[]): Promise<any> | void;\r\n}\r\ninterface ActionFactory {\r\n    <T extends RawAction>(target: T): T;\r\n}\r\ndeclare function foo<U extends any[] = any[]>(): ActionFactory;\r\nexport default foo()(function foobar(): void {\r\n});",
+        "signature": "-9232740537-declare const _default: () => void;\r\nexport default _default;\r\n"
+      },
+      "../bundling.ts": {
+        "version": "-21659820217-export class LazyModule<TModule> {\r\n    constructor(private importCallback: () => Promise<TModule>) {}\r\n}\r\n\r\nexport class LazyAction<\r\n    TAction extends (...args: any[]) => any,\r\n    TModule\r\n>  {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction) {\r\n    }\r\n}\r\n",
+        "signature": "-40032907372-export declare class LazyModule<TModule> {\r\n    private importCallback;\r\n    constructor(importCallback: () => Promise<TModule>);\r\n}\r\nexport declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);\r\n}\r\n"
+      },
+      "../global.d.ts": {
+        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}"
+      },
+      "../lazyindex.ts": {
+        "version": "-6956449754-export { default as bar } from './bar';\n",
+        "signature": "-6224542381-export { default as bar } from './bar';\r\n"
+      },
+      "../index.ts": {
+        "version": "-11602502901-import { LazyAction, LazyModule } from './bundling';\r\nconst lazyModule = new LazyModule(() =>\r\n    import('./lazyIndex')\r\n);\r\nexport const lazyBar = new LazyAction(lazyModule, m => m.bar);",
+        "signature": "18468008756-import { LazyAction } from './bundling';\r\nexport declare const lazyBar: LazyAction<(param: string) => void, typeof import(\"./lazyIndex\")>;\r\n"
+      }
+    },
+    "options": {
+      "target": 1,
+      "declaration": true,
+      "outDir": "./",
+      "incremental": true,
+      "isolatedModules": true,
+      "configFilePath": "../tsconfig.json"
+    },
+    "referencedMap": {
+      "../index.ts": [
+        "../bundling.ts",
+        "../lazyindex.ts"
+      ],
+      "../lazyindex.ts": [
+        "../bar.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "../index.ts": [
+        "../bundling.ts",
+        "../lazyindex.ts"
+      ],
+      "../lazyindex.ts": [
+        "../bar.ts"
+      ]
+    }
+  },
+  "version": "FakeTSVersion"
+}
+

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/incremental-declaration-changes/inferred-type-from-transitive-module-with-isolatedModules.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/incremental-declaration-changes/inferred-type-from-transitive-module-with-isolatedModules.js
@@ -21,6 +21,12 @@ exports.default = foo()(function foobar() {
 });
 
 
+//// [/src/obj/index.d.ts]
+import { LazyAction } from './bundling';
+export declare const lazyBar: LazyAction<() => void, typeof import("./lazyIndex")>;
+
+
+//// [/src/obj/lazyIndex.d.ts] file written with same contents
 //// [/src/obj/tsconfig.tsbuildinfo]
 {
   "program": {
@@ -47,7 +53,7 @@ exports.default = foo()(function foobar() {
       },
       "../index.ts": {
         "version": "-11602502901-import { LazyAction, LazyModule } from './bundling';\r\nconst lazyModule = new LazyModule(() =>\r\n    import('./lazyIndex')\r\n);\r\nexport const lazyBar = new LazyAction(lazyModule, m => m.bar);",
-        "signature": "18468008756-import { LazyAction } from './bundling';\r\nexport declare const lazyBar: LazyAction<(param: string) => void, typeof import(\"./lazyIndex\")>;\r\n"
+        "signature": "6256067474-import { LazyAction } from './bundling';\r\nexport declare const lazyBar: LazyAction<() => void, typeof import(\"./lazyIndex\")>;\r\n"
       }
     },
     "options": {
@@ -75,7 +81,15 @@ exports.default = foo()(function foobar() {
       "../lazyindex.ts": [
         "../bar.ts"
       ]
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../bar.ts",
+      "../bundling.ts",
+      "../global.d.ts",
+      "../index.ts",
+      "../lazyindex.ts"
+    ]
   },
   "version": "FakeTSVersion"
 }

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-Build/inferred-type-from-transitive-module-with-isolatedModules.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-Build/inferred-type-from-transitive-module-with-isolatedModules.js
@@ -1,0 +1,135 @@
+//// [/src/obj/bar.d.ts]
+declare const _default: (param: string) => void;
+export default _default;
+
+
+//// [/src/obj/bar.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = foo()(function foobar(param) {
+});
+
+
+//// [/src/obj/bundling.d.ts]
+export declare class LazyModule<TModule> {
+    private importCallback;
+    constructor(importCallback: () => Promise<TModule>);
+}
+export declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {
+    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);
+}
+
+
+//// [/src/obj/bundling.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var LazyModule = /** @class */ (function () {
+    function LazyModule(importCallback) {
+        this.importCallback = importCallback;
+    }
+    return LazyModule;
+}());
+exports.LazyModule = LazyModule;
+var LazyAction = /** @class */ (function () {
+    function LazyAction(_lazyModule, _getter) {
+    }
+    return LazyAction;
+}());
+exports.LazyAction = LazyAction;
+
+
+//// [/src/obj/index.d.ts]
+import { LazyAction } from './bundling';
+export declare const lazyBar: LazyAction<(param: string) => void, typeof import("./lazyIndex")>;
+
+
+//// [/src/obj/index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var bundling_1 = require("./bundling");
+var lazyModule = new bundling_1.LazyModule(function () {
+    return Promise.resolve().then(function () { return require('./lazyIndex'); });
+});
+exports.lazyBar = new bundling_1.LazyAction(lazyModule, function (m) { return m.bar; });
+
+
+//// [/src/obj/lazyIndex.d.ts]
+export { default as bar } from './bar';
+
+
+//// [/src/obj/lazyIndex.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var bar_1 = require("./bar");
+exports.bar = bar_1.default;
+
+
+//// [/src/obj/tsconfig.tsbuildinfo]
+{
+  "program": {
+    "fileInfos": {
+      "../../lib/lib.d.ts": {
+        "version": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };",
+        "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
+      },
+      "../bar.ts": {
+        "version": "5936740878-interface RawAction {\r\n    (...args: any[]): Promise<any> | void;\r\n}\r\ninterface ActionFactory {\r\n    <T extends RawAction>(target: T): T;\r\n}\r\ndeclare function foo<U extends any[] = any[]>(): ActionFactory;\r\nexport default foo()(function foobar(param: string): void {\r\n});",
+        "signature": "11191036521-declare const _default: (param: string) => void;\r\nexport default _default;\r\n"
+      },
+      "../bundling.ts": {
+        "version": "-21659820217-export class LazyModule<TModule> {\r\n    constructor(private importCallback: () => Promise<TModule>) {}\r\n}\r\n\r\nexport class LazyAction<\r\n    TAction extends (...args: any[]) => any,\r\n    TModule\r\n>  {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction) {\r\n    }\r\n}\r\n",
+        "signature": "-40032907372-export declare class LazyModule<TModule> {\r\n    private importCallback;\r\n    constructor(importCallback: () => Promise<TModule>);\r\n}\r\nexport declare class LazyAction<TAction extends (...args: any[]) => any, TModule> {\r\n    constructor(_lazyModule: LazyModule<TModule>, _getter: (module: TModule) => TAction);\r\n}\r\n"
+      },
+      "../global.d.ts": {
+        "version": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}",
+        "signature": "-9780226215-interface PromiseConstructor {\r\n    new <T>(): Promise<T>;\r\n}\r\ndeclare var Promise: PromiseConstructor;\r\ninterface Promise<T> {\r\n}"
+      },
+      "../lazyindex.ts": {
+        "version": "-6956449754-export { default as bar } from './bar';\n",
+        "signature": "-6224542381-export { default as bar } from './bar';\r\n"
+      },
+      "../index.ts": {
+        "version": "-11602502901-import { LazyAction, LazyModule } from './bundling';\r\nconst lazyModule = new LazyModule(() =>\r\n    import('./lazyIndex')\r\n);\r\nexport const lazyBar = new LazyAction(lazyModule, m => m.bar);",
+        "signature": "18468008756-import { LazyAction } from './bundling';\r\nexport declare const lazyBar: LazyAction<(param: string) => void, typeof import(\"./lazyIndex\")>;\r\n"
+      }
+    },
+    "options": {
+      "target": 1,
+      "declaration": true,
+      "outDir": "./",
+      "incremental": true,
+      "isolatedModules": true,
+      "configFilePath": "../tsconfig.json"
+    },
+    "referencedMap": {
+      "../index.ts": [
+        "../bundling.ts",
+        "../lazyindex.ts"
+      ],
+      "../lazyindex.ts": [
+        "../bar.ts"
+      ]
+    },
+    "exportedModulesMap": {
+      "../index.ts": [
+        "../bundling.ts",
+        "../lazyindex.ts"
+      ],
+      "../lazyindex.ts": [
+        "../bar.ts"
+      ]
+    }
+  },
+  "version": "FakeTSVersion"
+}
+
+//// [/src/tsconfig.json]
+{
+  "compilerOptions": {
+    "target": "es5",
+    "declaration": true,
+    "outDir": "obj",
+    "incremental": true, "isolatedModules": true
+  }
+}
+

--- a/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-Build/inferred-type-from-transitive-module-with-isolatedModules.js
+++ b/tests/baselines/reference/tsbuild/inferredTypeFromTransitiveModule/initial-Build/inferred-type-from-transitive-module-with-isolatedModules.js
@@ -118,7 +118,15 @@ exports.bar = bar_1.default;
       "../lazyindex.ts": [
         "../bar.ts"
       ]
-    }
+    },
+    "semanticDiagnosticsPerFile": [
+      "../../lib/lib.d.ts",
+      "../bar.ts",
+      "../bundling.ts",
+      "../global.d.ts",
+      "../index.ts",
+      "../lazyindex.ts"
+    ]
   },
   "version": "FakeTSVersion"
 }


### PR DESCRIPTION
Enables .d.ts emit with `--isolatedModules`
Builder handles the emit so that it can cache semantic diagnostics as well as do d.ts emit

Fixes #29490 and #32294
