### PR TITLE
Respect //@ts-nocheck in TS files

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1691,9 +1691,10 @@ namespace ts {
                 Debug.assert(!!sourceFile.bindDiagnostics);
 
                 const isCheckJs = isCheckJsEnabledForFile(sourceFile, options);
+                const isTsNoCheck = !!sourceFile.checkJsDirective && sourceFile.checkJsDirective.enabled === false;
                 // By default, only type-check .ts, .tsx, 'Deferred' and 'External' files (external files are added by plugins)
-                const includeBindAndCheckDiagnostics = sourceFile.scriptKind === ScriptKind.TS || sourceFile.scriptKind === ScriptKind.TSX ||
-                    sourceFile.scriptKind === ScriptKind.External || isCheckJs || sourceFile.scriptKind === ScriptKind.Deferred;
+                const includeBindAndCheckDiagnostics = !isTsNoCheck && (sourceFile.scriptKind === ScriptKind.TS || sourceFile.scriptKind === ScriptKind.TSX ||
+                    sourceFile.scriptKind === ScriptKind.External || isCheckJs || sourceFile.scriptKind === ScriptKind.Deferred);
                 const bindDiagnostics: readonly Diagnostic[] = includeBindAndCheckDiagnostics ? sourceFile.bindDiagnostics : emptyArray;
                 const checkDiagnostics = includeBindAndCheckDiagnostics ? typeChecker.getDiagnostics(sourceFile, cancellationToken) : emptyArray;
                 const fileProcessingDiagnosticsInFile = fileProcessingDiagnostics.getDiagnostics(sourceFile.fileName);

--- a/tests/baselines/reference/tsNoCheckForTypescript.js
+++ b/tests/baselines/reference/tsNoCheckForTypescript.js
@@ -1,0 +1,57 @@
+//// [file.ts]
+// @ts-nocheck
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+
+export interface Aleph {
+    q: number;
+}
+
+export class Bet implements Aleph {
+    q: string = "lol" // And so will this implements error
+}
+
+
+//// [file.js]
+"use strict";
+// @ts-nocheck
+exports.__esModule = true;
+exports.a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+var Bet = /** @class */ (function () {
+    function Bet() {
+        this.q = "lol"; // And so will this implements error
+    }
+    return Bet;
+}());
+exports.Bet = Bet;
+
+
+//// [file.d.ts]
+export declare const a: any;
+export interface Aleph {
+    q: number;
+}
+export declare class Bet implements Aleph {
+    q: string;
+}
+
+
+//// [DtsFileErrors]
+
+
+tests/cases/conformance/jsdoc/file.d.ts(6,5): error TS2416: Property 'q' in type 'Bet' is not assignable to the same property in base type 'Aleph'.
+  Type 'string' is not assignable to type 'number'.
+
+
+==== tests/cases/conformance/jsdoc/file.d.ts (1 errors) ====
+    export declare const a: any;
+    export interface Aleph {
+        q: number;
+    }
+    export declare class Bet implements Aleph {
+        q: string;
+        ~
+!!! error TS2416: Property 'q' in type 'Bet' is not assignable to the same property in base type 'Aleph'.
+!!! error TS2416:   Type 'string' is not assignable to type 'number'.
+    }
+    

--- a/tests/baselines/reference/tsNoCheckForTypescript.symbols
+++ b/tests/baselines/reference/tsNoCheckForTypescript.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/jsdoc/file.ts ===
+// @ts-nocheck
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+>a : Symbol(a, Decl(file.ts, 2, 12))
+
+export interface Aleph {
+>Aleph : Symbol(Aleph, Decl(file.ts, 2, 24))
+
+    q: number;
+>q : Symbol(Aleph.q, Decl(file.ts, 4, 24))
+}
+
+export class Bet implements Aleph {
+>Bet : Symbol(Bet, Decl(file.ts, 6, 1))
+>Aleph : Symbol(Aleph, Decl(file.ts, 2, 24))
+
+    q: string = "lol" // And so will this implements error
+>q : Symbol(Bet.q, Decl(file.ts, 8, 35))
+}
+

--- a/tests/baselines/reference/tsNoCheckForTypescript.types
+++ b/tests/baselines/reference/tsNoCheckForTypescript.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/jsdoc/file.ts ===
+// @ts-nocheck
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+>a : any
+>1 + {} : any
+>1 : 1
+>{} : {}
+
+export interface Aleph {
+    q: number;
+>q : number
+}
+
+export class Bet implements Aleph {
+>Bet : Bet
+
+    q: string = "lol" // And so will this implements error
+>q : string
+>"lol" : "lol"
+}
+

--- a/tests/cases/conformance/jsdoc/tsNoCheckForTypescript.ts
+++ b/tests/cases/conformance/jsdoc/tsNoCheckForTypescript.ts
@@ -1,0 +1,14 @@
+// @declaration: true
+// @filename: file.ts
+
+// @ts-nocheck
+
+export const a = 1 + {}; // This is an error, ofc, `Operator '+' cannot be applied to types '1' and '{}'`, which will be suppressed by the `nocheck` comment
+
+export interface Aleph {
+    q: number;
+}
+
+export class Bet implements Aleph {
+    q: string = "lol" // And so will this implements error
+}


### PR DESCRIPTION
Fixes parts of #19573 kinda.

Seeing as we already support `//@ts-ignore`, `//@ts-nocheck` is really just a file-scoped ignore, so there's nothing new here, really. It's also not really a big change.