### PR TITLE
Fix `Identifiers: NaN` diagnostic when having JSON SourceFiles

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -770,7 +770,11 @@ namespace ts {
                 fixupParentReferences(sourceFile);
             }
 
+            sourceFile.nodeCount = nodeCount;
+            sourceFile.identifierCount = identifierCount;
+            sourceFile.identifiers = identifiers;
             sourceFile.parseDiagnostics = parseDiagnostics;
+
             const result = sourceFile as JsonSourceFile;
             clearState();
             return result;

--- a/src/testRunner/unittests/programApi.ts
+++ b/src/testRunner/unittests/programApi.ts
@@ -160,4 +160,22 @@ namespace ts {
             }
         }
     });
+
+    describe("unittests:: Program.getNodeCount / Program.getIdentifierCount", () => {
+        it("works on projects that have .json files", () => {
+            const main = new documents.TextDocument("/main.ts", 'export { version } from "./package.json";');
+            const pkg = new documents.TextDocument("/package.json", '{"version": "1.0.0"}');
+
+            const fs = vfs.createFromFileSystem(Harness.IO, /*ignoreCase*/ false, { documents: [main, pkg], cwd: "/" });
+            const program = createProgram(["/main.ts"], { resolveJsonModule: true }, new fakes.CompilerHost(fs, { newLine: NewLineKind.LineFeed }));
+
+            const json = program.getSourceFile("/package.json")!;
+            assert.equal(json.scriptKind, ScriptKind.JSON);
+            assert.isNumber(json.nodeCount);
+            assert.isNumber(json.identifierCount);
+
+            assert.isNotNaN(program.getNodeCount());
+            assert.isNotNaN(program.getIdentifierCount());
+        });
+    });
 }


### PR DESCRIPTION
This makes sure that the `identifierCount` and `nodeCount` properties
are always initialized for `SourceFile` objects.

I would appreciate some help on how to best write a test for this :-)

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #33389
