### PR TITLE
fix: Intl.PluralRulesOptions to behave according to spec

### DIFF
--- a/src/lib/es2018.intl.d.ts
+++ b/src/lib/es2018.intl.d.ts
@@ -1,23 +1,33 @@
 declare namespace Intl {
+
+    // http://cldr.unicode.org/index/cldr-spec/plural-rules#TOC-Determining-Plural-Categories
+    type LDMLPluralRule = "zero" | "one" | "two" | "few" | "many" | "other";
+    type PluralRuleType = "cardinal" | "ordinal";
+
     interface PluralRulesOptions {
         localeMatcher?: "lookup" | "best fit";
-        type?: "cardinal" | "ordinal";
+        type?: PluralRuleType;
+        minimumIntegerDigits?: number;
+        minimumFractionDigits?: number;
+        maximumFractionDigits?: number;
+        minimumSignificantDigits?: number;
+        maximumSignificantDigits?: number;
     }
 
     interface ResolvedPluralRulesOptions {
         locale: string;
-        pluralCategories: string[];
-        type: "cardinal" | "ordinal";
+        pluralCategories: LDMLPluralRule[];
+        type: PluralRuleType;
         minimumIntegerDigits: number;
         minimumFractionDigits: number;
         maximumFractionDigits: number;
-        minimumSignificantDigits: number;
-        maximumSignificantDigits: number;
+        minimumSignificantDigits?: number;
+        maximumSignificantDigits?: number;
     }
 
     interface PluralRules {
         resolvedOptions(): ResolvedPluralRulesOptions;
-        select(n: number): string;
+        select(n: number): LDMLPluralRule;
     }
 
     const PluralRules: {


### PR DESCRIPTION
TL;DR: MDN doc is not accurate: https://github.com/tc39/ecma402/issues/365#issuecomment-530617744

According to spec, `PluralRulesOptions` do take in these extra params:
- point 2 in https://tc39.es/ecma402/#sec-intl-pluralrules-constructor) initializes the internal slot
- https://tc39.es/ecma402/#sec-initializepluralrules triggers `SetNumberFormatDigitsOptions`
- https://tc39.es/ecma402/#sec-setnfdigitoptions calls `GetNumberOption` looking for those attributes

Add `LDMLPluralRule` according to http://cldr.unicode.org/index/cldr-spec/plural-rules#TOC-Determining-Plural-Categories

ResolvedPluralRulesOptions also have these params as optional because according to spec
https://tc39.es/ecma402/#sec-initializepluralrules
https://tc39.es/ecma402/#sec-setnfdigitoptions
Current spec indicate `minimumFractionDigits` & `maximumFractionDigits` will always be there (default to 0 & 3 respectively). However in the new Unified NumberFormat spec, they can be `undefined`:
https://tc39.es/proposal-unified-intl-numberformat/section11/numberformat_diff_out.html

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #33413
