### PR TITLE
Add build-eslint-rules to npm prepare script

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -409,7 +409,7 @@ task("other-outputs").description = "Builds miscelaneous scripts and documents d
 
 const buildFoldStart = async () => { if (fold.isTravis()) console.log(fold.start("build")); };
 const buildFoldEnd = async () => { if (fold.isTravis()) console.log(fold.end("build")); };
-task("local", series(buildFoldStart, preBuild, parallel(buildEslintRules, localize, buildTsc, buildServer, buildServices, buildLssl, buildOtherOutputs), buildFoldEnd));
+task("local", series(buildFoldStart, preBuild, parallel(localize, buildTsc, buildServer, buildServices, buildLssl, buildOtherOutputs), buildFoldEnd));
 task("local").description = "Builds the full compiler and services";
 task("local").flags = {
     "   --built": "Compile using the built version of the compiler."

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -409,7 +409,7 @@ task("other-outputs").description = "Builds miscelaneous scripts and documents d
 
 const buildFoldStart = async () => { if (fold.isTravis()) console.log(fold.start("build")); };
 const buildFoldEnd = async () => { if (fold.isTravis()) console.log(fold.end("build")); };
-task("local", series(buildFoldStart, preBuild, parallel(localize, buildTsc, buildServer, buildServices, buildLssl, buildOtherOutputs), buildFoldEnd));
+task("local", series(buildFoldStart, preBuild, parallel(buildEslintRules, localize, buildTsc, buildServer, buildServices, buildLssl, buildOtherOutputs), buildFoldEnd));
 task("local").description = "Builds the full compiler and services";
 task("local").flags = {
     "   --built": "Compile using the built version of the compiler."

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
         "xml2js": "^0.4.19"
     },
     "scripts": {
+        "prepare": "gulp build-eslint-rules",
         "pretest": "gulp tests",
         "test": "gulp runtests-parallel --light=false",
         "test:eslint-rules": "gulp run-eslint-rules-tests",


### PR DESCRIPTION
My expectation is that my editor should be able to function properly in the TypeScript codebase after `npm install && npm run build`. This ensures custom eslint rules are built as part of the ~latter~ former command to avoid getting this:

![MicrosoftTeams-image](https://user-images.githubusercontent.com/3277153/64881510-ca654a00-d60f-11e9-86b5-2afc8b59750d.png)
