### PR TITLE
fix duplicate async modifier codefix

### DIFF
--- a/src/services/codefixes/fixAwaitInSyncFunction.ts
+++ b/src/services/codefixes/fixAwaitInSyncFunction.ts
@@ -15,11 +15,14 @@ namespace ts.codefix {
             return [createCodeFixAction(fixId, changes, Diagnostics.Add_async_modifier_to_containing_function, fixId, Diagnostics.Add_all_missing_async_modifiers)];
         },
         fixIds: [fixId],
-        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => {
-            const nodes = getNodes(diag.file, diag.start);
-            if (!nodes) return;
-            doChange(changes, context.sourceFile, nodes);
-        }),
+        getAllCodeActions: context => {
+            const seen = createMap<true>();
+            return codeFixAll(context, errorCodes, (changes, diag) => {
+                const nodes = getNodes(diag.file, diag.start);
+                if (!nodes || !addToSeen(seen, getNodeId(nodes.insertBefore))) return;
+                doChange(changes, context.sourceFile, nodes);
+            });
+        },
     });
 
     function getReturnType(expr: FunctionDeclaration | MethodDeclaration | FunctionExpression | ArrowFunction) {

--- a/tests/cases/fourslash/codeFixAwaitInSyncFunction_all.ts
+++ b/tests/cases/fourslash/codeFixAwaitInSyncFunction_all.ts
@@ -2,9 +2,11 @@
 
 ////function f() {
 ////    await Promise.resolve();
+////    await Promise.resolve();
 ////}
 ////
 ////const g = () => {
+////    await f();
 ////    await f();
 ////}
 
@@ -14,9 +16,11 @@ verify.codeFixAll({
     newFileContent:
 `async function f() {
     await Promise.resolve();
+    await Promise.resolve();
 }
 
 const g = async () => {
+    await f();
     await f();
 }`,
 });


### PR DESCRIPTION
This pr avoid the duplicate `async` modifier after codefix `Add_all_missing_async_modifiers`

Fixes #33419