### PR TITLE
getConstraintDeclaration gets the first declaration with a constraint…

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8971,7 +8971,7 @@ namespace ts {
             return undefined;
         }
 
-        function getConstraintDeclaration(type: TypeParameter) {
+        function getConstraintDeclaration(type: TypeParameter): TypeNode | undefined {
             return mapDefined(filter(type.symbol && type.symbol.declarations, isTypeParameterDeclaration), getEffectiveConstraintOfTypeParameter)[0];
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8972,8 +8972,7 @@ namespace ts {
         }
 
         function getConstraintDeclaration(type: TypeParameter) {
-            const decl = type.symbol && getDeclarationOfKind<TypeParameterDeclaration>(type.symbol, SyntaxKind.TypeParameter);
-            return decl && getEffectiveConstraintOfTypeParameter(decl);
+            return mapDefined(filter(type.symbol && type.symbol.declarations, isTypeParameterDeclaration), getEffectiveConstraintOfTypeParameter)[0];
         }
 
         function getInferredTypeParameterConstraint(typeParameter: TypeParameter) {
@@ -29233,11 +29232,10 @@ namespace ts {
                     const constraint = getEffectiveConstraintOfTypeParameter(source);
                     const sourceConstraint = constraint && getTypeFromTypeNode(constraint);
                     const targetConstraint = getConstraintOfTypeParameter(target);
-                    if (sourceConstraint) {
-                        // relax check if later interface augmentation has no constraint
-                        if (!targetConstraint || !isTypeIdenticalTo(sourceConstraint, targetConstraint)) {
-                            return false;
-                        }
+                    // relax check if later interface augmentation has no constraint, it's more broad and is OK to merge with
+                    // a more constrained interface (this could be generalized to a full heirarchy check, but that's maybe overkill)
+                    if (sourceConstraint && targetConstraint && !isTypeIdenticalTo(sourceConstraint, targetConstraint)) {
+                        return false;
                     }
 
                     // If the type parameter node has a default and it is not identical to the default

--- a/tests/baselines/reference/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.js
+++ b/tests/baselines/reference/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.ts] ////
+
+//// [working.ts]
+// minmal samples from #33395
+export namespace ns {
+    interface Function<T extends (...args: any) => any> {
+        throttle(): Function<T>;
+    }
+    interface Function<T> {
+        unary(): Function<() => ReturnType<T>>;
+    }
+}
+//// [regression.ts]
+export namespace ns {
+    interface Function<T> {
+        unary(): Function<() => ReturnType<T>>;
+    }
+    interface Function<T extends (...args: any) => any> {
+        throttle(): Function<T>;
+    }
+}
+
+//// [working.js]
+"use strict";
+exports.__esModule = true;
+//// [regression.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.symbols
+++ b/tests/baselines/reference/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.symbols
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/working.ts ===
+// minmal samples from #33395
+export namespace ns {
+>ns : Symbol(ns, Decl(working.ts, 0, 0))
+
+    interface Function<T extends (...args: any) => any> {
+>Function : Symbol(Function, Decl(working.ts, 1, 21), Decl(working.ts, 4, 5))
+>T : Symbol(T, Decl(working.ts, 2, 23), Decl(working.ts, 5, 23))
+>args : Symbol(args, Decl(working.ts, 2, 34))
+
+        throttle(): Function<T>;
+>throttle : Symbol(Function.throttle, Decl(working.ts, 2, 57))
+>Function : Symbol(Function, Decl(working.ts, 1, 21), Decl(working.ts, 4, 5))
+>T : Symbol(T, Decl(working.ts, 2, 23), Decl(working.ts, 5, 23))
+    }
+    interface Function<T> {
+>Function : Symbol(Function, Decl(working.ts, 1, 21), Decl(working.ts, 4, 5))
+>T : Symbol(T, Decl(working.ts, 2, 23), Decl(working.ts, 5, 23))
+
+        unary(): Function<() => ReturnType<T>>;
+>unary : Symbol(Function.unary, Decl(working.ts, 5, 27))
+>Function : Symbol(Function, Decl(working.ts, 1, 21), Decl(working.ts, 4, 5))
+>ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(working.ts, 2, 23), Decl(working.ts, 5, 23))
+    }
+}
+=== tests/cases/compiler/regression.ts ===
+export namespace ns {
+>ns : Symbol(ns, Decl(regression.ts, 0, 0))
+
+    interface Function<T> {
+>Function : Symbol(Function, Decl(regression.ts, 0, 21), Decl(regression.ts, 3, 5))
+>T : Symbol(T, Decl(regression.ts, 1, 23), Decl(regression.ts, 4, 23))
+
+        unary(): Function<() => ReturnType<T>>;
+>unary : Symbol(Function.unary, Decl(regression.ts, 1, 27))
+>Function : Symbol(Function, Decl(regression.ts, 0, 21), Decl(regression.ts, 3, 5))
+>ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(regression.ts, 1, 23), Decl(regression.ts, 4, 23))
+    }
+    interface Function<T extends (...args: any) => any> {
+>Function : Symbol(Function, Decl(regression.ts, 0, 21), Decl(regression.ts, 3, 5))
+>T : Symbol(T, Decl(regression.ts, 1, 23), Decl(regression.ts, 4, 23))
+>args : Symbol(args, Decl(regression.ts, 4, 34))
+
+        throttle(): Function<T>;
+>throttle : Symbol(Function.throttle, Decl(regression.ts, 4, 57))
+>Function : Symbol(Function, Decl(regression.ts, 0, 21), Decl(regression.ts, 3, 5))
+>T : Symbol(T, Decl(regression.ts, 1, 23), Decl(regression.ts, 4, 23))
+    }
+}

--- a/tests/baselines/reference/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.types
+++ b/tests/baselines/reference/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/working.ts ===
+// minmal samples from #33395
+export namespace ns {
+    interface Function<T extends (...args: any) => any> {
+>args : any
+
+        throttle(): Function<T>;
+>throttle : () => Function<T>
+    }
+    interface Function<T> {
+        unary(): Function<() => ReturnType<T>>;
+>unary : () => Function<() => ReturnType<T>>
+    }
+}
+=== tests/cases/compiler/regression.ts ===
+export namespace ns {
+    interface Function<T> {
+        unary(): Function<() => ReturnType<T>>;
+>unary : () => Function<() => ReturnType<T>>
+    }
+    interface Function<T extends (...args: any) => any> {
+>args : any
+
+        throttle(): Function<T>;
+>throttle : () => Function<T>
+    }
+}

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
@@ -75,7 +75,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
       x: T;
     }
     
-    interface C<T extends number> { // error
+    interface C<T extends number> { // ok
       y: T;
     }
     

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
@@ -4,11 +4,9 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
 tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(14,15): error TS2428: All declarations of 'B' must have identical type parameters.
 tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(32,22): error TS2428: All declarations of 'A' must have identical type parameters.
 tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(38,22): error TS2428: All declarations of 'A' must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(53,11): error TS2428: All declarations of 'C' must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(57,11): error TS2428: All declarations of 'C' must have identical type parameters.
 
 
-==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts (8 errors) ====
+==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts (6 errors) ====
     interface A<T extends Date> {
               ~
 !!! error TS2428: All declarations of 'A' must have identical type parameters.
@@ -74,14 +72,10 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
     }
     
     interface C<T> {
-              ~
-!!! error TS2428: All declarations of 'C' must have identical type parameters.
       x: T;
     }
     
     interface C<T extends number> { // error
-              ~
-!!! error TS2428: All declarations of 'C' must have identical type parameters.
       y: T;
     }
     

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.js
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.js
@@ -55,7 +55,7 @@ interface C<T> {
   x: T;
 }
 
-interface C<T extends number> { // error
+interface C<T extends number> { // ok
   y: T;
 }
 

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.symbols
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.symbols
@@ -137,7 +137,7 @@ interface C<T> {
 >T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 52, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 56, 12))
 }
 
-interface C<T extends number> { // error
+interface C<T extends number> { // ok
 >C : Symbol(C, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 50, 1), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 54, 1))
 >T : Symbol(T, Decl(twoGenericInterfacesWithDifferentConstraints.ts, 52, 12), Decl(twoGenericInterfacesWithDifferentConstraints.ts, 56, 12))
 

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.types
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.types
@@ -70,7 +70,7 @@ interface C<T> {
 >x : T
 }
 
-interface C<T extends number> { // error
+interface C<T extends number> { // ok
   y: T;
 >y : T
 }

--- a/tests/cases/compiler/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.ts
+++ b/tests/cases/compiler/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.ts
@@ -1,0 +1,19 @@
+// @filename: working.ts
+// minmal samples from #33395
+export namespace ns {
+    interface Function<T extends (...args: any) => any> {
+        throttle(): Function<T>;
+    }
+    interface Function<T> {
+        unary(): Function<() => ReturnType<T>>;
+    }
+}
+// @filename: regression.ts
+export namespace ns {
+    interface Function<T> {
+        unary(): Function<() => ReturnType<T>>;
+    }
+    interface Function<T extends (...args: any) => any> {
+        throttle(): Function<T>;
+    }
+}

--- a/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts
+++ b/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts
@@ -54,7 +54,7 @@ interface C<T> {
   x: T;
 }
 
-interface C<T extends number> { // error
+interface C<T extends number> { // ok
   y: T;
 }
 


### PR DESCRIPTION
…, rather than just the first declaration

Fixes #33395

@HerringtonDarkholme if you're still watching, what was the original justification for this to be order dependent, anyway? You just commented that it was and it was just.... accepted. It leads to some odd and hard to understand behavior, as in #33395.