### PR TITLE
Make extractSymbol explicitly drop JSDoc nodes

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -975,6 +975,8 @@ namespace ts {
             return getSpanOfTokenAtPosition(sourceFile, node.pos);
         }
 
+        Debug.assert(!isJSDoc(errorNode));
+
         const isMissing = nodeIsMissing(errorNode);
         const pos = isMissing || isJsxText(node)
             ? errorNode.pos

--- a/src/services/refactors/extractSymbol.ts
+++ b/src/services/refactors/extractSymbol.ts
@@ -116,6 +116,7 @@ namespace ts.refactor.extractSymbol {
         export const cannotExtractRange: DiagnosticMessage = createMessage("Cannot extract range.");
         export const cannotExtractImport: DiagnosticMessage = createMessage("Cannot extract import statement.");
         export const cannotExtractSuper: DiagnosticMessage = createMessage("Cannot extract super call.");
+        export const cannotExtractJSDoc: DiagnosticMessage = createMessage("Cannot extract JSDoc.");
         export const cannotExtractEmpty: DiagnosticMessage = createMessage("Cannot extract empty range.");
         export const expressionExpected: DiagnosticMessage = createMessage("expression expected.");
         export const uselessConstantType: DiagnosticMessage = createMessage("No reason to extract constant of type.");
@@ -244,6 +245,10 @@ namespace ts.refactor.extractSymbol {
             }
 
             return { targetRange: { range: statements, facts: rangeFacts, declarations } };
+        }
+
+        if (isJSDoc(start)) {
+            return { errors: [createFileDiagnostic(sourceFile, span.start, length, Messages.cannotExtractJSDoc)] };
         }
 
         if (isReturnStatement(start) && !start.expression) {

--- a/src/testRunner/unittests/services/extract/ranges.ts
+++ b/src/testRunner/unittests/services/extract/ranges.ts
@@ -380,6 +380,10 @@ switch (x) {
             `[#|{ 1;|] }`,
             [refactor.extractSymbol.Messages.cannotExtractRange.message]);
 
+        testExtractRangeFailed("extractRangeFailed19",
+            `[#|/** @type {number} */|] const foo = 1;`,
+            [refactor.extractSymbol.Messages.cannotExtractJSDoc.message]);
+
         testExtractRangeFailed("extract-method-not-for-token-expression-statement", `[#|a|]`, [refactor.extractSymbol.Messages.cannotExtractIdentifier.message]);
     });
 }


### PR DESCRIPTION
Since they're neither statements nor expressions, they cannot be extracted.  Ironically, we then fail to create an (unobservable) error describing why they cannot be extracted, skip past trivia (bonus: `isTrivia` returns false, but `skipTrivia` moves past them), and compute an invalid range.

Note that users encountering this error aren't necessarily trying to extract JSDoc comments - we compute this on their behalf whenever a range is selected.

Fixes #33332 
