### PR TITLE
report error on extraneous JSX prop instead of element name

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13040,15 +13040,10 @@ namespace ts {
                                     // JsxAttributes has an object-literal flag and undergo same type-assignablity check as normal object-literal.
                                     // However, using an object-literal error message will be very confusing to the users so we give different a message.
                                     // TODO: Spelling suggestions for excess jsx attributes (needs new diagnostic messages)
-
-                                    if (errorNode && isJsxOpeningLikeElement(errorNode.parent)) {
-                                        const attributes = errorNode.parent.attributes;
-                                        for (const jsxProperty of attributes.properties) {
-                                            if (jsxProperty.kind === SyntaxKind.JsxAttribute && jsxProperty.name.escapedText === prop.escapedName) {
-                                                // Move the error node to the actual JSX property, instead of pointing to the identifier in the JSX element.
-                                                errorNode = jsxProperty;
-                                            }
-                                        }
+                                    if (prop.valueDeclaration && isNamedDeclaration(prop.valueDeclaration) && prop.valueDeclaration.name && prop.valueDeclaration.name.pos !== -1) {
+                                        // If the "children" attribute is extraneous `<NoChild>extra</NoChild>` then the declaration's name has no location.
+                                        // In that case, do not update the error location, since there's no name to point to.
+                                        errorNode = prop.valueDeclaration.name;
                                     }
                                     reportError(Diagnostics.Property_0_does_not_exist_on_type_1, symbolToString(prop), typeToString(errorTarget));
                                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13040,9 +13040,9 @@ namespace ts {
                                     // JsxAttributes has an object-literal flag and undergo same type-assignablity check as normal object-literal.
                                     // However, using an object-literal error message will be very confusing to the users so we give different a message.
                                     // TODO: Spelling suggestions for excess jsx attributes (needs new diagnostic messages)
-                                    if (prop.valueDeclaration && isNamedDeclaration(prop.valueDeclaration) && prop.valueDeclaration.name && prop.valueDeclaration.name.pos !== -1) {
-                                        // If the "children" attribute is extraneous `<NoChild>extra</NoChild>` then the declaration's name has no location.
-                                        // In that case, do not update the error location, since there's no name to point to.
+                                    if (prop.valueDeclaration && isJsxAttribute(prop.valueDeclaration)) {
+                                        // Note that extraneous children (as in `<NoChild>extra</NoChild>`) don't pass this check,
+                                        // since `children` is a SyntaxKind.PropertySignature instead of a SyntaxKind.JsxAttribute.
                                         errorNode = prop.valueDeclaration.name;
                                     }
                                     reportError(Diagnostics.Property_0_does_not_exist_on_type_1, symbolToString(prop), typeToString(errorTarget));

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13040,6 +13040,16 @@ namespace ts {
                                     // JsxAttributes has an object-literal flag and undergo same type-assignablity check as normal object-literal.
                                     // However, using an object-literal error message will be very confusing to the users so we give different a message.
                                     // TODO: Spelling suggestions for excess jsx attributes (needs new diagnostic messages)
+
+                                    if (errorNode && isJsxOpeningLikeElement(errorNode.parent)) {
+                                        const attributes = errorNode.parent.attributes;
+                                        for (const jsxProperty of attributes.properties) {
+                                            if (jsxProperty.kind === SyntaxKind.JsxAttribute && jsxProperty.name.escapedText === prop.escapedName) {
+                                                // Move the error node to the actual JSX property, instead of pointing to the identifier in the JSX element.
+                                                errorNode = jsxProperty;
+                                            }
+                                        }
+                                    }
                                     reportError(Diagnostics.Property_0_does_not_exist_on_type_1, symbolToString(prop), typeToString(errorTarget));
                                 }
                                 else {

--- a/tests/baselines/reference/checkJsxChildrenProperty15.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty15.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(10,13): error TS2322: Type '{ children: Element; }' is not assignable to type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(10,17): error TS2322: Type '{ children: Element; }' is not assignable to type 'IntrinsicAttributes'.
   Property 'children' does not exist on type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(11,13): error TS2322: Type '{ children: Element; key: string; }' is not assignable to type 'IntrinsicAttributes'.
   Property 'children' does not exist on type 'IntrinsicAttributes'.
@@ -17,7 +17,7 @@ tests/cases/conformance/jsx/file.tsx(12,13): error TS2322: Type '{ children: Ele
     
     // Not OK (excess children)
     const k3 = <Tag children={<div></div>} />;
-                ~~~
+                    ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ children: Element; }' is not assignable to type 'IntrinsicAttributes'.
 !!! error TS2322:   Property 'children' does not exist on type 'IntrinsicAttributes'.
     const k4 = <Tag key="1"><div></div></Tag>;

--- a/tests/baselines/reference/checkJsxChildrenProperty15.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty15.errors.txt
@@ -17,7 +17,7 @@ tests/cases/conformance/jsx/file.tsx(12,13): error TS2322: Type '{ children: Ele
     
     // Not OK (excess children)
     const k3 = <Tag children={<div></div>} />;
-                    ~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~~~~~~
 !!! error TS2322: Type '{ children: Element; }' is not assignable to type 'IntrinsicAttributes'.
 !!! error TS2322:   Property 'children' does not exist on type 'IntrinsicAttributes'.
     const k4 = <Tag key="1"><div></div></Tag>;

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
@@ -1,34 +1,34 @@
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,13): error TS2769: No overload matches this call.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,64): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,13): error TS2769: No overload matches this call.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,12): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
       Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,13): error TS2769: No overload matches this call.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,43): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ extra: true; goTo: string; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
     Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(30,13): error TS2769: No overload matches this call.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(30,12): error TS2769: No overload matches this call.
   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ goTo: string; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'goTo' does not exist on type 'IntrinsicAttributes & ButtonProps'.
   Overload 2 of 2, '(linkProps: LinkProps): Element', gave the following error.
     Type '{ goTo: "home"; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(33,13): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(33,65): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
   Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): error TS2322: Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,44): error TS2322: Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
   Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 
 
@@ -60,7 +60,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): err
     }
     
     const b0 = <MainButton {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type "left" | "right"
-                ~~~~~~~~~~
+                                                                   ~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
@@ -69,7 +69,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): err
 !!! error TS2769:     Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b2 = <MainButton onClick={(k)=>{console.log(k)}} extra />;  // k has type "left" | "right"
-                ~~~~~~~~~~
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
@@ -78,7 +78,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): err
 !!! error TS2769:     Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2769:       Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b3 = <MainButton {...{goTo:"home"}} extra />;  // goTo has type"home" | "contact"
-                ~~~~~~~~~~
+                                              ~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ extra: true; goTo: string; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
@@ -87,7 +87,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): err
 !!! error TS2769:     Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2769:       Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b4 = <MainButton goTo="home" extra />;  // goTo has type "home" | "contact"
-                ~~~~~~~~~~
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ goTo: string; extra: true; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
@@ -98,13 +98,13 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,13): err
     
     export function NoOverload(buttonProps: ButtonProps): JSX.Element { return undefined }
     const c1 = <NoOverload  {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type any
-                ~~~~~~~~~~
+                                                                    ~~~~~
 !!! error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
 !!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
     
     export function NoOverload1(linkProps: LinkProps): JSX.Element { return undefined }
     const d1 = <NoOverload1 {...{goTo:"home"}} extra  />;  // goTo has type "home" | "contact"
-                ~~~~~~~~~~~
+                                               ~~~~~
 !!! error TS2322: Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     

--- a/tests/baselines/reference/tsxAttributeResolution1.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution1.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/conformance/jsx/file.tsx(23,8): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(24,2): error TS2322: Type '{ y: number; }' is not assignable to type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(24,8): error TS2322: Type '{ y: number; }' is not assignable to type 'Attribs1'.
   Property 'y' does not exist on type 'Attribs1'.
-tests/cases/conformance/jsx/file.tsx(25,2): error TS2322: Type '{ y: string; }' is not assignable to type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(25,8): error TS2322: Type '{ y: string; }' is not assignable to type 'Attribs1'.
   Property 'y' does not exist on type 'Attribs1'.
 tests/cases/conformance/jsx/file.tsx(26,8): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(27,2): error TS2322: Type '{ var: string; }' is not assignable to type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(27,8): error TS2322: Type '{ var: string; }' is not assignable to type 'Attribs1'.
   Property 'var' does not exist on type 'Attribs1'.
 tests/cases/conformance/jsx/file.tsx(29,2): error TS2741: Property 'reqd' is missing in type '{}' but required in type '{ reqd: string; }'.
 tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type 'number' is not assignable to type 'string'.
@@ -38,11 +38,11 @@ tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type 'number' is not a
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:10:2: The expected type comes from property 'x' which is declared here on type 'Attribs1'
     <test1 y={0} />; // Error, no property "y"
-     ~~~~~
+           ~~~~~
 !!! error TS2322: Type '{ y: number; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Property 'y' does not exist on type 'Attribs1'.
     <test1 y="foo" />; // Error, no property "y"
-     ~~~~~
+           ~~~~~~~
 !!! error TS2322: Type '{ y: string; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Property 'y' does not exist on type 'Attribs1'.
     <test1 x="32" />; // Error, "32" is not number
@@ -50,7 +50,7 @@ tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type 'number' is not a
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:10:2: The expected type comes from property 'x' which is declared here on type 'Attribs1'
     <test1 var="10" />; // Error, no 'var' property
-     ~~~~~
+           ~~~~~~~~
 !!! error TS2322: Type '{ var: string; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Property 'var' does not exist on type 'Attribs1'.
     

--- a/tests/baselines/reference/tsxAttributeResolution1.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution1.errors.txt
@@ -38,11 +38,11 @@ tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type 'number' is not a
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:10:2: The expected type comes from property 'x' which is declared here on type 'Attribs1'
     <test1 y={0} />; // Error, no property "y"
-           ~~~~~
+           ~
 !!! error TS2322: Type '{ y: number; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Property 'y' does not exist on type 'Attribs1'.
     <test1 y="foo" />; // Error, no property "y"
-           ~~~~~~~
+           ~
 !!! error TS2322: Type '{ y: string; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Property 'y' does not exist on type 'Attribs1'.
     <test1 x="32" />; // Error, "32" is not number
@@ -50,7 +50,7 @@ tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type 'number' is not a
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:10:2: The expected type comes from property 'x' which is declared here on type 'Attribs1'
     <test1 var="10" />; // Error, no 'var' property
-           ~~~~~~~~
+           ~~~
 !!! error TS2322: Type '{ var: string; }' is not assignable to type 'Attribs1'.
 !!! error TS2322:   Property 'var' does not exist on type 'Attribs1'.
     

--- a/tests/baselines/reference/tsxAttributeResolution11.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution11.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ bar: string; }' is not assignable to type 'IntrinsicAttributes & { ref?: string; }'.
+tests/cases/conformance/jsx/file.tsx(11,22): error TS2322: Type '{ bar: string; }' is not assignable to type 'IntrinsicAttributes & { ref?: string; }'.
   Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
 
 
@@ -27,7 +27,7 @@ tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ bar: string; 
     
     // Should be an OK
     var x = <MyComponent bar='world' />;
-             ~~~~~~~~~~~
+                         ~~~~~~~~~~~
 !!! error TS2322: Type '{ bar: string; }' is not assignable to type 'IntrinsicAttributes & { ref?: string; }'.
 !!! error TS2322:   Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
     

--- a/tests/baselines/reference/tsxAttributeResolution11.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution11.errors.txt
@@ -27,7 +27,7 @@ tests/cases/conformance/jsx/file.tsx(11,22): error TS2322: Type '{ bar: string; 
     
     // Should be an OK
     var x = <MyComponent bar='world' />;
-                         ~~~~~~~~~~~
+                         ~~~
 !!! error TS2322: Type '{ bar: string; }' is not assignable to type 'IntrinsicAttributes & { ref?: string; }'.
 !!! error TS2322:   Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
     

--- a/tests/baselines/reference/tsxAttributeResolution15.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution15.errors.txt
@@ -15,7 +15,7 @@ tests/cases/conformance/jsx/file.tsx(14,44): error TS7017: Element implicitly ha
     
     // Error
     let a = <BigGreeter prop1="hello" />
-                        ~~~~~~~~~~~~~
+                        ~~~~~
 !!! error TS2322: Type '{ prop1: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
 !!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
     

--- a/tests/baselines/reference/tsxAttributeResolution15.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution15.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ prop1: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(11,21): error TS2322: Type '{ prop1: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
   Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
 tests/cases/conformance/jsx/file.tsx(14,44): error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.
 
@@ -15,7 +15,7 @@ tests/cases/conformance/jsx/file.tsx(14,44): error TS7017: Element implicitly ha
     
     // Error
     let a = <BigGreeter prop1="hello" />
-             ~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS2322: Type '{ prop1: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
 !!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
     

--- a/tests/baselines/reference/tsxElementResolution11.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution11.errors.txt
@@ -20,7 +20,7 @@ tests/cases/conformance/jsx/file.tsx(17,7): error TS2322: Type '{ x: number; }' 
     }
     var Obj2: Obj2type;
     <Obj2 x={10} />; // Error
-          ~~~~~~
+          ~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type '{ q?: number; }'.
 !!! error TS2322:   Property 'x' does not exist on type '{ q?: number; }'.
     

--- a/tests/baselines/reference/tsxElementResolution11.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution11.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(17,2): error TS2322: Type '{ x: number; }' is not assignable to type '{ q?: number; }'.
+tests/cases/conformance/jsx/file.tsx(17,7): error TS2322: Type '{ x: number; }' is not assignable to type '{ q?: number; }'.
   Property 'x' does not exist on type '{ q?: number; }'.
 
 
@@ -20,7 +20,7 @@ tests/cases/conformance/jsx/file.tsx(17,2): error TS2322: Type '{ x: number; }' 
     }
     var Obj2: Obj2type;
     <Obj2 x={10} />; // Error
-     ~~~~
+          ~~~~~~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type '{ q?: number; }'.
 !!! error TS2322:   Property 'x' does not exist on type '{ q?: number; }'.
     

--- a/tests/baselines/reference/tsxElementResolution3.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution3.errors.txt
@@ -15,6 +15,6 @@ tests/cases/conformance/jsx/file.tsx(12,7): error TS2322: Type '{ w: string; }' 
     
     // Error
     <span w='err' />;
-          ~~~~~~~
+          ~
 !!! error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
 !!! error TS2322:   Property 'w' does not exist on type '{ n: string; }'.

--- a/tests/baselines/reference/tsxElementResolution3.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution3.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(12,2): error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
+tests/cases/conformance/jsx/file.tsx(12,7): error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
   Property 'w' does not exist on type '{ n: string; }'.
 
 
@@ -15,6 +15,6 @@ tests/cases/conformance/jsx/file.tsx(12,2): error TS2322: Type '{ w: string; }' 
     
     // Error
     <span w='err' />;
-     ~~~~
+          ~~~~~~~
 !!! error TS2322: Type '{ w: string; }' is not assignable to type '{ n: string; }'.
 !!! error TS2322:   Property 'w' does not exist on type '{ n: string; }'.

--- a/tests/baselines/reference/tsxElementResolution4.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution4.errors.txt
@@ -19,7 +19,7 @@ tests/cases/conformance/jsx/file.tsx(16,7): error TS2322: Type '{ q: string; }' 
     
     // Error
     <span q='' />;
-          ~~~~
+          ~
 !!! error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
 !!! error TS2322:   Property 'q' does not exist on type '{ m: string; }'.
     

--- a/tests/baselines/reference/tsxElementResolution4.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution4.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(16,2): error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
+tests/cases/conformance/jsx/file.tsx(16,7): error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
   Property 'q' does not exist on type '{ m: string; }'.
 
 
@@ -19,7 +19,7 @@ tests/cases/conformance/jsx/file.tsx(16,2): error TS2322: Type '{ q: string; }' 
     
     // Error
     <span q='' />;
-     ~~~~
+          ~~~~
 !!! error TS2322: Type '{ q: string; }' is not assignable to type '{ m: string; }'.
 !!! error TS2322:   Property 'q' does not exist on type '{ m: string; }'.
     

--- a/tests/baselines/reference/tsxLibraryManagedAttributes.errors.txt
+++ b/tests/baselines/reference/tsxLibraryManagedAttributes.errors.txt
@@ -82,7 +82,7 @@ tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(123,49): error TS232
 !!! error TS2322:   Type '{ foo: number; }' is missing the following properties from type '{ bar: string | number | ReactComponent<{}, {}> | null | undefined; baz: string; }': bar, baz
     const c = <Component bar="yes" baz="yeah" />;
     const d = <Component bar="yes" baz="yo" bat="ohno" />; // Error, baz not a valid prop
-                                            ~~~~~~~~~~
+                                            ~~~
 !!! error TS2322: Type '{ bar: string; baz: string; bat: string; }' is not assignable to type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
 !!! error TS2322:   Property 'bat' does not exist on type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
     const e = <Component foo={12} bar={null} baz="cool" />; // bar is nullable/undefinable since it's not marked `isRequired`
@@ -116,7 +116,7 @@ tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(123,49): error TS232
     
     const k = <JustDefaultProps foo={12} />;
     const l = <JustDefaultProps foo={12} bar="ok" />; // error, no prop named bar
-                                         ~~~~~~~~
+                                         ~~~
 !!! error TS2322: Type '{ foo: number; bar: string; }' is not assignable to type 'Defaultize<{}, { foo: number; }>'.
 !!! error TS2322:   Property 'bar' does not exist on type 'Defaultize<{}, { foo: number; }>'.
     const m = <JustDefaultProps foo="no" />; // error, wrong type
@@ -145,7 +145,7 @@ tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(123,49): error TS232
 !!! error TS2322:   Type '{ foo: string; }' is missing the following properties from type '{ bar: string | number | ReactComponent<{}, {}> | null | undefined; baz: number; }': bar, baz
     const p = <BothWithSpecifiedGeneric bar="yes" baz={12} />;
     const q = <BothWithSpecifiedGeneric bar="yes" baz={12} bat="ohno" />; // Error, baz not a valid prop
-                                                           ~~~~~~~~~~
+                                                           ~~~
 !!! error TS2322: Type '{ bar: string; baz: number; bat: string; }' is not assignable to type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
 !!! error TS2322:   Property 'bat' does not exist on type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
     const r = <BothWithSpecifiedGeneric foo="no" bar={null} baz={0} />; // bar is nullable/undefinable since it's not marked `isRequired`
@@ -181,7 +181,7 @@ tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(123,49): error TS232
     
     const x = <JustDefaultPropsWithSpecifiedGeneric foo="eh" />;
     const y = <JustDefaultPropsWithSpecifiedGeneric foo="no" bar="ok" />; // error, no prop named bar
-                                                             ~~~~~~~~
+                                                             ~~~
 !!! error TS2322: Type '{ foo: string; bar: string; }' is not assignable to type 'Defaultize<FooProps, { foo: string; }>'.
 !!! error TS2322:   Property 'bar' does not exist on type 'Defaultize<FooProps, { foo: string; }>'.
     const z = <JustDefaultPropsWithSpecifiedGeneric foo={12} />; // error, wrong type

--- a/tests/baselines/reference/tsxLibraryManagedAttributes.errors.txt
+++ b/tests/baselines/reference/tsxLibraryManagedAttributes.errors.txt
@@ -1,22 +1,22 @@
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(55,12): error TS2322: Type '{ foo: number; }' is not assignable to type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
   Type '{ foo: number; }' is missing the following properties from type '{ bar: string | number | ReactComponent<{}, {}> | null | undefined; baz: string; }': bar, baz
-tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(57,12): error TS2322: Type '{ bar: string; baz: string; bat: string; }' is not assignable to type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
+tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(57,41): error TS2322: Type '{ bar: string; baz: string; bat: string; }' is not assignable to type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
   Property 'bat' does not exist on type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(59,42): error TS2322: Type 'null' is not assignable to type 'string'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(69,26): error TS2322: Type 'string' is not assignable to type 'number | null | undefined'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(71,35): error TS2322: Type 'null' is not assignable to type 'ReactNode'.
-tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(80,12): error TS2322: Type '{ foo: number; bar: string; }' is not assignable to type 'Defaultize<{}, { foo: number; }>'.
+tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(80,38): error TS2322: Type '{ foo: number; bar: string; }' is not assignable to type 'Defaultize<{}, { foo: number; }>'.
   Property 'bar' does not exist on type 'Defaultize<{}, { foo: number; }>'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(81,29): error TS2322: Type 'string' is not assignable to type 'number | undefined'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(98,12): error TS2322: Type '{ foo: string; }' is not assignable to type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
   Type '{ foo: string; }' is missing the following properties from type '{ bar: string | number | ReactComponent<{}, {}> | null | undefined; baz: number; }': bar, baz
-tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(100,12): error TS2322: Type '{ bar: string; baz: number; bat: string; }' is not assignable to type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
+tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(100,56): error TS2322: Type '{ bar: string; baz: number; bat: string; }' is not assignable to type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
   Property 'bat' does not exist on type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(102,57): error TS2322: Type 'null' is not assignable to type 'number'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(111,46): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(112,46): error TS2322: Type 'null' is not assignable to type 'string'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(113,57): error TS2322: Type 'null' is not assignable to type 'ReactNode'.
-tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(122,12): error TS2322: Type '{ foo: string; bar: string; }' is not assignable to type 'Defaultize<FooProps, { foo: string; }>'.
+tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(122,58): error TS2322: Type '{ foo: string; bar: string; }' is not assignable to type 'Defaultize<FooProps, { foo: string; }>'.
   Property 'bar' does not exist on type 'Defaultize<FooProps, { foo: string; }>'.
 tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(123,49): error TS2322: Type 'number' is not assignable to type 'string | undefined'.
 
@@ -82,7 +82,7 @@ tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(123,49): error TS232
 !!! error TS2322:   Type '{ foo: number; }' is missing the following properties from type '{ bar: string | number | ReactComponent<{}, {}> | null | undefined; baz: string; }': bar, baz
     const c = <Component bar="yes" baz="yeah" />;
     const d = <Component bar="yes" baz="yo" bat="ohno" />; // Error, baz not a valid prop
-               ~~~~~~~~~
+                                            ~~~~~~~~~~
 !!! error TS2322: Type '{ bar: string; baz: string; bat: string; }' is not assignable to type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
 !!! error TS2322:   Property 'bat' does not exist on type 'Defaultize<InferredPropTypes<{ foo: PropTypeChecker<number, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<string, true>; }>, { foo: number; }>'.
     const e = <Component foo={12} bar={null} baz="cool" />; // bar is nullable/undefinable since it's not marked `isRequired`
@@ -116,7 +116,7 @@ tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(123,49): error TS232
     
     const k = <JustDefaultProps foo={12} />;
     const l = <JustDefaultProps foo={12} bar="ok" />; // error, no prop named bar
-               ~~~~~~~~~~~~~~~~
+                                         ~~~~~~~~
 !!! error TS2322: Type '{ foo: number; bar: string; }' is not assignable to type 'Defaultize<{}, { foo: number; }>'.
 !!! error TS2322:   Property 'bar' does not exist on type 'Defaultize<{}, { foo: number; }>'.
     const m = <JustDefaultProps foo="no" />; // error, wrong type
@@ -145,7 +145,7 @@ tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(123,49): error TS232
 !!! error TS2322:   Type '{ foo: string; }' is missing the following properties from type '{ bar: string | number | ReactComponent<{}, {}> | null | undefined; baz: number; }': bar, baz
     const p = <BothWithSpecifiedGeneric bar="yes" baz={12} />;
     const q = <BothWithSpecifiedGeneric bar="yes" baz={12} bat="ohno" />; // Error, baz not a valid prop
-               ~~~~~~~~~~~~~~~~~~~~~~~~
+                                                           ~~~~~~~~~~
 !!! error TS2322: Type '{ bar: string; baz: number; bat: string; }' is not assignable to type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
 !!! error TS2322:   Property 'bat' does not exist on type 'Defaultize<FooProps & InferredPropTypes<{ foo: PropTypeChecker<string, false>; bar: PropTypeChecker<ReactNode, false>; baz: PropTypeChecker<number, true>; }>, { foo: string; }>'.
     const r = <BothWithSpecifiedGeneric foo="no" bar={null} baz={0} />; // bar is nullable/undefinable since it's not marked `isRequired`
@@ -181,7 +181,7 @@ tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx(123,49): error TS232
     
     const x = <JustDefaultPropsWithSpecifiedGeneric foo="eh" />;
     const y = <JustDefaultPropsWithSpecifiedGeneric foo="no" bar="ok" />; // error, no prop named bar
-               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                             ~~~~~~~~
 !!! error TS2322: Type '{ foo: string; bar: string; }' is not assignable to type 'Defaultize<FooProps, { foo: string; }>'.
 !!! error TS2322:   Property 'bar' does not exist on type 'Defaultize<FooProps, { foo: string; }>'.
     const z = <JustDefaultPropsWithSpecifiedGeneric foo={12} />; // error, wrong type

--- a/tests/baselines/reference/tsxSpreadAttributesResolution14.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution14.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ Property1: true; property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
+tests/cases/conformance/jsx/file.tsx(11,38): error TS2322: Type '{ Property1: true; property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
   Property 'Property1' does not exist on type 'IntrinsicAttributes & AnotherComponentProps'.
 
 
@@ -14,7 +14,7 @@ tests/cases/conformance/jsx/file.tsx(11,10): error TS2322: Type '{ Property1: tr
         return (
             // Error extra property
             <AnotherComponent {...props} Property1/>
-             ~~~~~~~~~~~~~~~~
+                                         ~~~~~~~~~
 !!! error TS2322: Type '{ Property1: true; property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
 !!! error TS2322:   Property 'Property1' does not exist on type 'IntrinsicAttributes & AnotherComponentProps'.
         );

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
@@ -48,6 +48,6 @@ tests/cases/conformance/jsx/file.tsx(24,40): error TS2322: Type '{ X: string; x:
 !!! error TS2322:   Types of property 'x' are incompatible.
 !!! error TS2322:     Type 'number' is not assignable to type 'string'.
     let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
-                                           ~~~~~~
+                                           ~
 !!! error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 !!! error TS2322:   Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
@@ -5,7 +5,7 @@ tests/cases/conformance/jsx/file.tsx(22,21): error TS2322: Type 'true' is not as
 tests/cases/conformance/jsx/file.tsx(23,10): error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
   Types of property 'x' are incompatible.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(24,11): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(24,40): error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
   Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 
 
@@ -48,6 +48,6 @@ tests/cases/conformance/jsx/file.tsx(24,11): error TS2322: Type '{ X: string; x:
 !!! error TS2322:   Types of property 'x' are incompatible.
 !!! error TS2322:     Type 'number' is not assignable to type 'string'.
     let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
-              ~~~~~~~~
+                                           ~~~~~~
 !!! error TS2322: Type '{ X: string; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 !!! error TS2322:   Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -1,23 +1,23 @@
-tests/cases/conformance/jsx/file.tsx(12,13): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(12,22): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes'.
       Property 'extraProp' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
       Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-tests/cases/conformance/jsx/file.tsx(13,13): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(13,12): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
     Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes'.
       Property 'yy' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
     Property 'yy1' is missing in type '{ yy: number; }' but required in type '{ yy: number; yy1: string; }'.
-tests/cases/conformance/jsx/file.tsx(14,12): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(14,31): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
     Type '{ yy1: true; yy: number; }' is not assignable to type 'IntrinsicAttributes'.
       Property 'yy1' does not exist on type 'IntrinsicAttributes'.
   Overload 2 of 2, '(l: { yy: number; yy1: string; }): Element', gave the following error.
     Type 'true' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(16,13): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(16,31): error TS2769: No overload matches this call.
   Overload 1 of 2, '(): Element', gave the following error.
     Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes'.
       Property 'y1' does not exist on type 'IntrinsicAttributes'.
@@ -89,7 +89,7 @@ tests/cases/conformance/jsx/file.tsx(36,12): error TS2769: No overload matches t
     
     // Error
     const c0 = <OneThing extraProp />;  // extra property;
-                ~~~~~~~~
+                         ~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
 !!! error TS2769:     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes'.
@@ -98,7 +98,7 @@ tests/cases/conformance/jsx/file.tsx(36,12): error TS2769: No overload matches t
 !!! error TS2769:     Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 !!! error TS2769:       Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
     const c1 = <OneThing yy={10}/>;  // missing property;
-                ~~~~~~~~
+               ~~~~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
 !!! error TS2769:     Type '{ yy: number; }' is not assignable to type 'IntrinsicAttributes'.
@@ -107,7 +107,7 @@ tests/cases/conformance/jsx/file.tsx(36,12): error TS2769: No overload matches t
 !!! error TS2769:     Property 'yy1' is missing in type '{ yy: number; }' but required in type '{ yy: number; yy1: string; }'.
 !!! related TS2728 tests/cases/conformance/jsx/file.tsx:3:43: 'yy1' is declared here.
     const c2 = <OneThing {...obj} yy1 />; // type incompatible;
-               ~~~~~~~~~~~~~~~~~~~~~~~~~
+                                  ~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
 !!! error TS2769:     Type '{ yy1: true; yy: number; }' is not assignable to type 'IntrinsicAttributes'.
@@ -117,7 +117,7 @@ tests/cases/conformance/jsx/file.tsx(36,12): error TS2769: No overload matches t
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:3:43: The expected type comes from property 'yy1' which is declared here on type 'IntrinsicAttributes & { yy: number; yy1: string; }'
     const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  //  This is OK becuase all attribute are spread
     const c4 = <OneThing {...obj} y1={10000} />;  // extra property;
-                ~~~~~~~~
+                                  ~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
 !!! error TS2769:     Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -117,7 +117,7 @@ tests/cases/conformance/jsx/file.tsx(36,12): error TS2769: No overload matches t
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:3:43: The expected type comes from property 'yy1' which is declared here on type 'IntrinsicAttributes & { yy: number; yy1: string; }'
     const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  //  This is OK becuase all attribute are spread
     const c4 = <OneThing {...obj} y1={10000} />;  // extra property;
-                                  ~~~~~~~~~~
+                                  ~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 2, '(): Element', gave the following error.
 !!! error TS2769:     Type '{ y1: number; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(48,13): error TS2769: No overload matches this call.
+tests/cases/conformance/jsx/file.tsx(48,12): error TS2769: No overload matches this call.
   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
     Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
       Property 'to' does not exist on type 'IntrinsicAttributes & ButtonProps'.
@@ -80,7 +80,7 @@ tests/cases/conformance/jsx/file.tsx(56,12): error TS2769: No overload matches t
     
     // Error
     const b0 = <MainButton to='/some/path' onClick={(e)=>{}}>GO</MainButton>;  // extra property;
-                ~~~~~~~~~~
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2769: No overload matches this call.
 !!! error TS2769:   Overload 1 of 3, '(buttonProps: ButtonProps): Element', gave the following error.
 !!! error TS2769:     Type '{ children: string; to: string; onClick: (e: MouseEvent<any>) => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
@@ -32,7 +32,7 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
     let a1 = <Greet name='world' extra-prop />;
     // Error
     let b = <Greet naaame='world' />;
-                   ~~~~~~~~~~~~~~
+                   ~~~~~~
 !!! error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
 !!! error TS2322:   Property 'naaame' does not exist on type 'IntrinsicAttributes & { name: string; }'.
     
@@ -47,7 +47,7 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
 !!! error TS2322: Type 'number' is not assignable to type 'string'.
     // Error
     let f = <Meet naaaaaaame='no' />;
-                  ~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~
 !!! error TS2322: Type '{ naaaaaaame: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
 !!! error TS2322:   Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
     
@@ -65,7 +65,7 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
 !!! error TS2322: Type '{ prop1: true; }' is not assignable to type 'IntrinsicAttributes'.
 !!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes'.
     let i1 = <EmptyPropSFC ref={x => x.greeting.substr(10)} />
-                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                           ~~~
 !!! error TS2322: Type '{ ref: (x: any) => any; }' is not assignable to type 'IntrinsicAttributes'.
 !!! error TS2322:   Property 'ref' does not exist on type 'IntrinsicAttributes'.
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
@@ -1,12 +1,12 @@
-tests/cases/conformance/jsx/file.tsx(19,10): error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
+tests/cases/conformance/jsx/file.tsx(19,16): error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
   Property 'naaame' does not exist on type 'IntrinsicAttributes & { name: string; }'.
 tests/cases/conformance/jsx/file.tsx(27,15): error TS2322: Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(29,10): error TS2322: Type '{ naaaaaaame: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
+tests/cases/conformance/jsx/file.tsx(29,15): error TS2322: Type '{ naaaaaaame: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
   Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
 tests/cases/conformance/jsx/file.tsx(34,10): error TS2741: Property '"prop-name"' is missing in type '{ extra-prop-name: string; }' but required in type '{ "prop-name": string; }'.
-tests/cases/conformance/jsx/file.tsx(37,10): error TS2322: Type '{ prop1: true; }' is not assignable to type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(37,23): error TS2322: Type '{ prop1: true; }' is not assignable to type 'IntrinsicAttributes'.
   Property 'prop1' does not exist on type 'IntrinsicAttributes'.
-tests/cases/conformance/jsx/file.tsx(38,11): error TS2322: Type '{ ref: (x: any) => any; }' is not assignable to type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(38,24): error TS2322: Type '{ ref: (x: any) => any; }' is not assignable to type 'IntrinsicAttributes'.
   Property 'ref' does not exist on type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(41,16): error TS1005: ',' expected.
 tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolean; }' has no properties in common with type 'IntrinsicAttributes'.
@@ -32,7 +32,7 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
     let a1 = <Greet name='world' extra-prop />;
     // Error
     let b = <Greet naaame='world' />;
-             ~~~~~
+                   ~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ naaame: string; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
 !!! error TS2322:   Property 'naaame' does not exist on type 'IntrinsicAttributes & { name: string; }'.
     
@@ -47,7 +47,7 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
 !!! error TS2322: Type 'number' is not assignable to type 'string'.
     // Error
     let f = <Meet naaaaaaame='no' />;
-             ~~~~
+                  ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ naaaaaaame: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
 !!! error TS2322:   Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
     
@@ -61,11 +61,11 @@ tests/cases/conformance/jsx/file.tsx(45,11): error TS2559: Type '{ prop1: boolea
     
     // Error
     let i = <EmptyPropSFC prop1 />
-             ~~~~~~~~~~~~
+                          ~~~~~
 !!! error TS2322: Type '{ prop1: true; }' is not assignable to type 'IntrinsicAttributes'.
 !!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes'.
     let i1 = <EmptyPropSFC ref={x => x.greeting.substr(10)} />
-              ~~~~~~~~~~~~
+                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ ref: (x: any) => any; }' is not assignable to type 'IntrinsicAttributes'.
 !!! error TS2322:   Property 'ref' does not exist on type 'IntrinsicAttributes'.
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
@@ -25,7 +25,7 @@ tests/cases/conformance/jsx/file.tsx(35,26): error TS2339: Property 'propertyNot
     let b = <Greet key="k" />;
     // Error - not allowed to specify 'ref' on SFCs
     let c = <Greet ref="myRef" />;
-                   ~~~~~~~~~~~
+                   ~~~
 !!! error TS2322: Type '{ ref: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
 !!! error TS2322:   Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(19,10): error TS2322: Type '{ ref: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
+tests/cases/conformance/jsx/file.tsx(19,16): error TS2322: Type '{ ref: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
   Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
 tests/cases/conformance/jsx/file.tsx(25,42): error TS2551: Property 'subtr' does not exist on type 'string'. Did you mean 'substr'?
 tests/cases/conformance/jsx/file.tsx(27,33): error TS2339: Property 'notARealProperty' does not exist on type 'BigGreeter'.
@@ -25,7 +25,7 @@ tests/cases/conformance/jsx/file.tsx(35,26): error TS2339: Property 'propertyNot
     let b = <Greet key="k" />;
     // Error - not allowed to specify 'ref' on SFCs
     let c = <Greet ref="myRef" />;
-             ~~~~~
+                   ~~~~~~~~~~~
 !!! error TS2322: Type '{ ref: string; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
 !!! error TS2322:   Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
     

--- a/tests/baselines/reference/tsxUnionElementType4.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType4.errors.txt
@@ -42,7 +42,7 @@ tests/cases/conformance/jsx/file.tsx(34,22): error TS2322: Type '{ prop: true; }
 !!! error TS2322: Type 'true' is not assignable to type 'never'.
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:3:36: The expected type comes from property 'x' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC1 | RC2> & { x: number; } & { children?: ReactNode; } & { x: string; } & { children?: ReactNode; }'
     let b = <PartRCComp x={10} />
-                        ~~~~~~
+                        ~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
 !!! error TS2322:   Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
     let c = <EmptyRCComp prop />;

--- a/tests/baselines/reference/tsxUnionElementType4.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType4.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/jsx/file.tsx(32,17): error TS2322: Type 'true' is not assignable to type 'never'.
-tests/cases/conformance/jsx/file.tsx(33,10): error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(33,21): error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
   Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
-tests/cases/conformance/jsx/file.tsx(34,10): error TS2322: Type '{ prop: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(34,22): error TS2322: Type '{ prop: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
   Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
 
 
@@ -42,11 +42,11 @@ tests/cases/conformance/jsx/file.tsx(34,10): error TS2322: Type '{ prop: true; }
 !!! error TS2322: Type 'true' is not assignable to type 'never'.
 !!! related TS6500 tests/cases/conformance/jsx/file.tsx:3:36: The expected type comes from property 'x' which is declared here on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC1 | RC2> & { x: number; } & { children?: ReactNode; } & { x: string; } & { children?: ReactNode; }'
     let b = <PartRCComp x={10} />
-             ~~~~~~~~~~
+                        ~~~~~~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
 !!! error TS2322:   Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
     let c = <EmptyRCComp prop />;
-             ~~~~~~~~~~~
+                         ~~~~
 !!! error TS2322: Type '{ prop: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
 !!! error TS2322:   Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
     

--- a/tests/baselines/reference/tsxUnionElementType6.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType6.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(18,10): error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(18,23): error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes'.
   Property 'x' does not exist on type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(19,27): error TS2322: Type 'string' is not assignable to type 'boolean'.
 tests/cases/conformance/jsx/file.tsx(20,10): error TS2741: Property 'x' is missing in type '{}' but required in type '{ x: boolean; }'.
@@ -24,7 +24,7 @@ tests/cases/conformance/jsx/file.tsx(21,10): error TS2741: Property 'x' is missi
     var SFC2AndEmptyComp = SFC2 || EmptySFC1;
     // Error
     let a = <EmptySFCComp x />;
-             ~~~~~~~~~~~~
+                          ~
 !!! error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes'.
 !!! error TS2322:   Property 'x' does not exist on type 'IntrinsicAttributes'.
     let b = <SFC2AndEmptyComp x="hi" />;


### PR DESCRIPTION
Fixes #33476

Before:
```typescript
import * as React from 'react';

function Example(props: {x: number, y: string}) {
    return <>Hello, world.</>;
}

<Example x={3} y="a" z={6} />
 ~~~~~~~
```

After:
```typescript
import * as React from 'react';

function Example(props: {x: number, y: string}) {
    return <>Hello, world.</>;
}

<Example x={3} y="a" z={6} />
                     ~
```
