### PR TITLE
Better ReturnType<>; Fixes Microsoft/TypeScript#33457

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1466,7 +1466,7 @@ type ConstructorParameters<T extends new (...args: any) => any> = T extends new 
 /**
  * Obtain the return type of a function type
  */
-type ReturnType<T extends (...args: any) => any> = T extends (...args: any) => infer R ? R : any;
+type ReturnType<T extends (...args: any) => any> = T extends (...args: never) => infer R ? R : any;
 
 /**
  * Obtain the return type of a constructor function type

--- a/tests/baselines/reference/inferTypes1.errors.txt
+++ b/tests/baselines/reference/inferTypes1.errors.txt
@@ -238,3 +238,11 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(145,40): error TS2322: 
     
     type Foo2<A extends any[]> = ReturnType<(...args: A) => string>;
     
+    // Repros from #33457
+    
+    type T82 = ReturnType<(arg: never) => string>;  // string
+    type T83 = ReturnType<(arg: never) => void>;  // void
+    type T84 = ReturnType<(arg0: never, arg1: any, arg2: never, arg3: string) => void>;  // void
+    type T85 = ReturnType<(...args : never) => number>;  // number
+    type T86 = ReturnType<(...args : never[]) => number>;  // number
+    

--- a/tests/baselines/reference/inferTypes1.js
+++ b/tests/baselines/reference/inferTypes1.js
@@ -178,6 +178,14 @@ const result = invoker('test', true)({ test: (a: boolean) => 123 })
 
 type Foo2<A extends any[]> = ReturnType<(...args: A) => string>;
 
+// Repros from #33457
+
+type T82 = ReturnType<(arg: never) => string>;  // string
+type T83 = ReturnType<(arg: never) => void>;  // void
+type T84 = ReturnType<(arg0: never, arg1: any, arg2: never, arg3: string) => void>;  // void
+type T85 = ReturnType<(...args : never) => number>;  // number
+type T86 = ReturnType<(...args : never[]) => number>;  // number
+
 
 //// [inferTypes1.js]
 "use strict";

--- a/tests/baselines/reference/inferTypes1.symbols
+++ b/tests/baselines/reference/inferTypes1.symbols
@@ -740,3 +740,33 @@ type Foo2<A extends any[]> = ReturnType<(...args: A) => string>;
 >args : Symbol(args, Decl(inferTypes1.ts, 177, 41))
 >A : Symbol(A, Decl(inferTypes1.ts, 177, 10))
 
+// Repros from #33457
+
+type T82 = ReturnType<(arg: never) => string>;  // string
+>T82 : Symbol(T82, Decl(inferTypes1.ts, 177, 64))
+>ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
+>arg : Symbol(arg, Decl(inferTypes1.ts, 181, 23))
+
+type T83 = ReturnType<(arg: never) => void>;  // void
+>T83 : Symbol(T83, Decl(inferTypes1.ts, 181, 46))
+>ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
+>arg : Symbol(arg, Decl(inferTypes1.ts, 182, 23))
+
+type T84 = ReturnType<(arg0: never, arg1: any, arg2: never, arg3: string) => void>;  // void
+>T84 : Symbol(T84, Decl(inferTypes1.ts, 182, 44))
+>ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
+>arg0 : Symbol(arg0, Decl(inferTypes1.ts, 183, 23))
+>arg1 : Symbol(arg1, Decl(inferTypes1.ts, 183, 35))
+>arg2 : Symbol(arg2, Decl(inferTypes1.ts, 183, 46))
+>arg3 : Symbol(arg3, Decl(inferTypes1.ts, 183, 59))
+
+type T85 = ReturnType<(...args : never) => number>;  // number
+>T85 : Symbol(T85, Decl(inferTypes1.ts, 183, 83))
+>ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(inferTypes1.ts, 184, 23))
+
+type T86 = ReturnType<(...args : never[]) => number>;  // number
+>T86 : Symbol(T86, Decl(inferTypes1.ts, 184, 51))
+>ReturnType : Symbol(ReturnType, Decl(lib.es5.d.ts, --, --))
+>args : Symbol(args, Decl(inferTypes1.ts, 185, 23))
+

--- a/tests/baselines/reference/inferTypes1.types
+++ b/tests/baselines/reference/inferTypes1.types
@@ -84,7 +84,7 @@ type T18 = ReturnType<Function>;  // Error
 >T18 : any
 
 type T19<T extends any[]> = ReturnType<(x: string, ...args: T) => T[]>;  // T[]
->T19 : T[]
+>T19 : ReturnType<(x: string, ...args: T) => T[]>
 >x : string
 >args : T
 
@@ -466,4 +466,29 @@ const result = invoker('test', true)({ test: (a: boolean) => 123 })
 type Foo2<A extends any[]> = ReturnType<(...args: A) => string>;
 >Foo2 : string
 >args : A
+
+// Repros from #33457
+
+type T82 = ReturnType<(arg: never) => string>;  // string
+>T82 : string
+>arg : never
+
+type T83 = ReturnType<(arg: never) => void>;  // void
+>T83 : void
+>arg : never
+
+type T84 = ReturnType<(arg0: never, arg1: any, arg2: never, arg3: string) => void>;  // void
+>T84 : void
+>arg0 : never
+>arg1 : any
+>arg2 : never
+>arg3 : string
+
+type T85 = ReturnType<(...args : never) => number>;  // number
+>T85 : number
+>args : never
+
+type T86 = ReturnType<(...args : never[]) => number>;  // number
+>T86 : number
+>args : never[]
 

--- a/tests/cases/conformance/types/conditional/inferTypes1.ts
+++ b/tests/cases/conformance/types/conditional/inferTypes1.ts
@@ -179,3 +179,11 @@ function invoker <K extends string | number | symbol, A extends any[]> (key: K, 
 const result = invoker('test', true)({ test: (a: boolean) => 123 })
 
 type Foo2<A extends any[]> = ReturnType<(...args: A) => string>;
+
+// Repros from #33457
+
+type T82 = ReturnType<(arg: never) => string>;  // string
+type T83 = ReturnType<(arg: never) => void>;  // void
+type T84 = ReturnType<(arg0: never, arg1: any, arg2: never, arg3: string) => void>;  // void
+type T85 = ReturnType<(...args : never) => number>;  // number
+type T86 = ReturnType<(...args : never[]) => number>;  // number


### PR DESCRIPTION

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Fixes #33457

There's no issue in the `Backlog` but I figured I'd try anyway =x
It fixes my issue and only affects one other test.

But that one other test seems to only have its type emit affected?
```ts
type T19<T extends any[]> = ReturnType<(x: string, ...args: T) => T[]>;
```

is emitted as,
```ts
ReturnType<(x: string, ...args: T) => T[]>;
```

But when a concrete `T` is substituted in, it resolves to `T[]`