### PR TITLE
Change default for TNext in Iterator/AsyncIterator

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23585,7 +23585,7 @@ namespace ts {
                 const globalType = resolver.getGlobalIterableIteratorType(/*reportErrors*/ false);
                 const iterationTypes = globalType !== emptyGenericType ? getIterationTypesOfGlobalIterableType(globalType, resolver) : undefined;
                 const iterableIteratorReturnType = iterationTypes ? iterationTypes.returnType : anyType;
-                const iterableIteratorNextType = iterationTypes ? iterationTypes.nextType : undefinedType;
+                const iterableIteratorNextType = iterationTypes ? iterationTypes.nextType : unknownType;
                 if (isTypeAssignableTo(returnType, iterableIteratorReturnType) &&
                     isTypeAssignableTo(iterableIteratorNextType, nextType)) {
                     if (globalType !== emptyGenericType) {

--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -20,7 +20,7 @@ interface IteratorReturnResult<TReturn> {
 
 type IteratorResult<T, TReturn = any> = IteratorYieldResult<T> | IteratorReturnResult<TReturn>;
 
-interface Iterator<T, TReturn = any, TNext = undefined> {
+interface Iterator<T, TReturn = any, TNext = unknown> {
     // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
     next(...args: [] | [TNext]): IteratorResult<T, TReturn>;
     return?(value?: TReturn): IteratorResult<T, TReturn>;

--- a/src/lib/es2018.asynciterable.d.ts
+++ b/src/lib/es2018.asynciterable.d.ts
@@ -9,7 +9,7 @@ interface SymbolConstructor {
     readonly asyncIterator: symbol;
 }
 
-interface AsyncIterator<T, TReturn = any, TNext = undefined> {
+interface AsyncIterator<T, TReturn = any, TNext = unknown> {
     // NOTE: 'next' is defined using a tuple to ensure we report the correct assignability errors in all places.
     next(...args: [] | [TNext]): Promise<IteratorResult<T, TReturn>>;
     return?(value?: TReturn | PromiseLike<TReturn>): Promise<IteratorResult<T, TReturn>>;

--- a/tests/baselines/reference/YieldStarExpression4_es6.types
+++ b/tests/baselines/reference/YieldStarExpression4_es6.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/yieldExpressions/YieldStarExpression4_es6.ts ===
 function *g() {
->g : () => Generator<any, void, undefined>
+>g : () => Generator<any, void, unknown>
 
     yield * [];
 >yield * [] : any

--- a/tests/baselines/reference/bigintWithLib.errors.txt
+++ b/tests/baselines/reference/bigintWithLib.errors.txt
@@ -5,10 +5,10 @@ tests/cases/compiler/bigintWithLib.ts(16,33): error TS2769: No overload matches 
   Overload 2 of 3, '(array: Iterable<bigint>): BigInt64Array', gave the following error.
     Argument of type 'number[]' is not assignable to parameter of type 'Iterable<bigint>'.
       Types of property '[Symbol.iterator]' are incompatible.
-        Type '() => IterableIterator<number>' is not assignable to type '() => Iterator<bigint, any, undefined>'.
-          Type 'IterableIterator<number>' is not assignable to type 'Iterator<bigint, any, undefined>'.
+        Type '() => IterableIterator<number>' is not assignable to type '() => Iterator<bigint, any, unknown>'.
+          Type 'IterableIterator<number>' is not assignable to type 'Iterator<bigint, any, unknown>'.
             Types of property 'next' are incompatible.
-              Type '(...args: [] | [undefined]) => IteratorResult<number, any>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<bigint, any>'.
+              Type '(...args: [] | [unknown]) => IteratorResult<number, any>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<bigint, any>'.
                 Type 'IteratorResult<number, any>' is not assignable to type 'IteratorResult<bigint, any>'.
                   Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<bigint, any>'.
                     Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<bigint>'.
@@ -56,10 +56,10 @@ tests/cases/compiler/bigintWithLib.ts(43,26): error TS2345: Argument of type '12
 !!! error TS2769:   Overload 2 of 3, '(array: Iterable<bigint>): BigInt64Array', gave the following error.
 !!! error TS2769:     Argument of type 'number[]' is not assignable to parameter of type 'Iterable<bigint>'.
 !!! error TS2769:       Types of property '[Symbol.iterator]' are incompatible.
-!!! error TS2769:         Type '() => IterableIterator<number>' is not assignable to type '() => Iterator<bigint, any, undefined>'.
-!!! error TS2769:           Type 'IterableIterator<number>' is not assignable to type 'Iterator<bigint, any, undefined>'.
+!!! error TS2769:         Type '() => IterableIterator<number>' is not assignable to type '() => Iterator<bigint, any, unknown>'.
+!!! error TS2769:           Type 'IterableIterator<number>' is not assignable to type 'Iterator<bigint, any, unknown>'.
 !!! error TS2769:             Types of property 'next' are incompatible.
-!!! error TS2769:               Type '(...args: [] | [undefined]) => IteratorResult<number, any>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<bigint, any>'.
+!!! error TS2769:               Type '(...args: [] | [unknown]) => IteratorResult<number, any>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<bigint, any>'.
 !!! error TS2769:                 Type 'IteratorResult<number, any>' is not assignable to type 'IteratorResult<bigint, any>'.
 !!! error TS2769:                   Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<bigint, any>'.
 !!! error TS2769:                     Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<bigint>'.

--- a/tests/baselines/reference/castOfYield.errors.txt
+++ b/tests/baselines/reference/castOfYield.errors.txt
@@ -1,8 +1,8 @@
-error TS2318: Cannot find global type 'IterableIterator'.
+error TS2318: Cannot find global type 'Generator'.
 tests/cases/compiler/castOfYield.ts(4,14): error TS1109: Expression expected.
 
 
-!!! error TS2318: Cannot find global type 'IterableIterator'.
+!!! error TS2318: Cannot find global type 'Generator'.
 ==== tests/cases/compiler/castOfYield.ts (1 errors) ====
     function* f() {
         <number> (yield 0);

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.types
@@ -36,7 +36,7 @@ class C4 {
 >C4 : C4
 
     async * f() {
->f : () => AsyncGenerator<number, void, undefined>
+>f : () => AsyncGenerator<number, void, unknown>
 
         const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2018.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2018.types
@@ -36,7 +36,7 @@ class C4 {
 >C4 : C4
 
     async * f() {
->f : () => AsyncGenerator<number, void, undefined>
+>f : () => AsyncGenerator<number, void, unknown>
 
         const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.types
@@ -36,7 +36,7 @@ class C4 {
 >C4 : C4
 
     async * f() {
->f : () => AsyncGenerator<number, void, undefined>
+>f : () => AsyncGenerator<number, void, unknown>
 
         const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.types
@@ -21,7 +21,7 @@ async function * f3() {
 }
 === tests/cases/conformance/emitter/es2015/asyncGenerators/F4.ts ===
 async function * f4() {
->f4 : () => AsyncGenerator<number, void, undefined>
+>f4 : () => AsyncGenerator<number, void, unknown>
 
     const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2018.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2018.types
@@ -21,7 +21,7 @@ async function * f3() {
 }
 === tests/cases/conformance/emitter/es2018/asyncGenerators/F4.ts ===
 async function * f4() {
->f4 : () => AsyncGenerator<number, void, undefined>
+>f4 : () => AsyncGenerator<number, void, unknown>
 
     const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.types
@@ -21,7 +21,7 @@ async function * f3() {
 }
 === tests/cases/conformance/emitter/es5/asyncGenerators/F4.ts ===
 async function * f4() {
->f4 : () => AsyncGenerator<number, void, undefined>
+>f4 : () => AsyncGenerator<number, void, unknown>
 
     const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.types
@@ -24,8 +24,8 @@ const f3 = async function * () {
 }
 === tests/cases/conformance/emitter/es2015/asyncGenerators/F4.ts ===
 const f4 = async function * () {
->f4 : () => AsyncGenerator<number, void, undefined>
->async function * () {    const x = yield* [1];} : () => AsyncGenerator<number, void, undefined>
+>f4 : () => AsyncGenerator<number, void, unknown>
+>async function * () {    const x = yield* [1];} : () => AsyncGenerator<number, void, unknown>
 
     const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2018.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2018.types
@@ -24,8 +24,8 @@ const f3 = async function * () {
 }
 === tests/cases/conformance/emitter/es2018/asyncGenerators/F4.ts ===
 const f4 = async function * () {
->f4 : () => AsyncGenerator<number, void, undefined>
->async function * () {    const x = yield* [1];} : () => AsyncGenerator<number, void, undefined>
+>f4 : () => AsyncGenerator<number, void, unknown>
+>async function * () {    const x = yield* [1];} : () => AsyncGenerator<number, void, unknown>
 
     const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.types
@@ -24,8 +24,8 @@ const f3 = async function * () {
 }
 === tests/cases/conformance/emitter/es5/asyncGenerators/F4.ts ===
 const f4 = async function * () {
->f4 : () => AsyncGenerator<number, void, undefined>
->async function * () {    const x = yield* [1];} : () => AsyncGenerator<number, void, undefined>
+>f4 : () => AsyncGenerator<number, void, unknown>
+>async function * () {    const x = yield* [1];} : () => AsyncGenerator<number, void, unknown>
 
     const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.types
@@ -36,11 +36,11 @@ const o3 = {
 }
 === tests/cases/conformance/emitter/es2015/asyncGenerators/O4.ts ===
 const o4 = {
->o4 : { f(): AsyncGenerator<number, void, undefined>; }
->{    async * f() {        const x = yield* [1];    }} : { f(): AsyncGenerator<number, void, undefined>; }
+>o4 : { f(): AsyncGenerator<number, void, unknown>; }
+>{    async * f() {        const x = yield* [1];    }} : { f(): AsyncGenerator<number, void, unknown>; }
 
     async * f() {
->f : () => AsyncGenerator<number, void, undefined>
+>f : () => AsyncGenerator<number, void, unknown>
 
         const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2018.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2018.types
@@ -36,11 +36,11 @@ const o3 = {
 }
 === tests/cases/conformance/emitter/es2018/asyncGenerators/O4.ts ===
 const o4 = {
->o4 : { f(): AsyncGenerator<number, void, undefined>; }
->{    async * f() {        const x = yield* [1];    }} : { f(): AsyncGenerator<number, void, undefined>; }
+>o4 : { f(): AsyncGenerator<number, void, unknown>; }
+>{    async * f() {        const x = yield* [1];    }} : { f(): AsyncGenerator<number, void, unknown>; }
 
     async * f() {
->f : () => AsyncGenerator<number, void, undefined>
+>f : () => AsyncGenerator<number, void, unknown>
 
         const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.types
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.types
@@ -36,11 +36,11 @@ const o3 = {
 }
 === tests/cases/conformance/emitter/es5/asyncGenerators/O4.ts ===
 const o4 = {
->o4 : { f(): AsyncGenerator<number, void, undefined>; }
->{    async * f() {        const x = yield* [1];    }} : { f(): AsyncGenerator<number, void, undefined>; }
+>o4 : { f(): AsyncGenerator<number, void, unknown>; }
+>{    async * f() {        const x = yield* [1];    }} : { f(): AsyncGenerator<number, void, unknown>; }
 
     async * f() {
->f : () => AsyncGenerator<number, void, undefined>
+>f : () => AsyncGenerator<number, void, unknown>
 
         const x = yield* [1];
 >x : any

--- a/tests/baselines/reference/for-of29.errors.txt
+++ b/tests/baselines/reference/for-of29.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/for-ofStatements/for-of29.ts(5,15): error TS2488: Type '{ [Symbol.iterator]?(): Iterator<string, any, undefined>; }' must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/es6/for-ofStatements/for-of29.ts(5,15): error TS2488: Type '{ [Symbol.iterator]?(): Iterator<string, any, unknown>; }' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/es6/for-ofStatements/for-of29.ts (1 errors) ====
@@ -8,5 +8,5 @@ tests/cases/conformance/es6/for-ofStatements/for-of29.ts(5,15): error TS2488: Ty
     
     for (var v of iterableWithOptionalIterator) { }
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2488: Type '{ [Symbol.iterator]?(): Iterator<string, any, undefined>; }' must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type '{ [Symbol.iterator]?(): Iterator<string, any, unknown>; }' must have a '[Symbol.iterator]()' method that returns an iterator.
     

--- a/tests/baselines/reference/for-of29.types
+++ b/tests/baselines/reference/for-of29.types
@@ -1,9 +1,9 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of29.ts ===
 var iterableWithOptionalIterator: {
->iterableWithOptionalIterator : { [Symbol.iterator]?(): Iterator<string, any, undefined>; }
+>iterableWithOptionalIterator : { [Symbol.iterator]?(): Iterator<string, any, unknown>; }
 
     [Symbol.iterator]?(): Iterator<string>
->[Symbol.iterator] : () => Iterator<string, any, undefined>
+>[Symbol.iterator] : () => Iterator<string, any, unknown>
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
 >iterator : symbol
@@ -12,5 +12,5 @@ var iterableWithOptionalIterator: {
 
 for (var v of iterableWithOptionalIterator) { }
 >v : any
->iterableWithOptionalIterator : { [Symbol.iterator]?(): Iterator<string, any, undefined>; }
+>iterableWithOptionalIterator : { [Symbol.iterator]?(): Iterator<string, any, unknown>; }
 

--- a/tests/baselines/reference/for-of39.errors.txt
+++ b/tests/baselines/reference/for-of39.errors.txt
@@ -2,10 +2,10 @@ tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,11): error TS2769: No
   Overload 1 of 3, '(iterable: Iterable<readonly [string, boolean]>): Map<string, boolean>', gave the following error.
     Argument of type '([string, number] | [string, true])[]' is not assignable to parameter of type 'Iterable<readonly [string, boolean]>'.
       Types of property '[Symbol.iterator]' are incompatible.
-        Type '() => IterableIterator<[string, number] | [string, true]>' is not assignable to type '() => Iterator<readonly [string, boolean], any, undefined>'.
-          Type 'IterableIterator<[string, number] | [string, true]>' is not assignable to type 'Iterator<readonly [string, boolean], any, undefined>'.
+        Type '() => IterableIterator<[string, number] | [string, true]>' is not assignable to type '() => Iterator<readonly [string, boolean], any, unknown>'.
+          Type 'IterableIterator<[string, number] | [string, true]>' is not assignable to type 'Iterator<readonly [string, boolean], any, unknown>'.
             Types of property 'next' are incompatible.
-              Type '(...args: [] | [undefined]) => IteratorResult<[string, number] | [string, true], any>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<readonly [string, boolean], any>'.
+              Type '(...args: [] | [unknown]) => IteratorResult<[string, number] | [string, true], any>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<readonly [string, boolean], any>'.
                 Type 'IteratorResult<[string, number] | [string, true], any>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
                   Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
                     Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorYieldResult<readonly [string, boolean]>'.
@@ -24,10 +24,10 @@ tests/cases/conformance/es6/for-ofStatements/for-of39.ts(1,11): error TS2769: No
 !!! error TS2769:   Overload 1 of 3, '(iterable: Iterable<readonly [string, boolean]>): Map<string, boolean>', gave the following error.
 !!! error TS2769:     Argument of type '([string, number] | [string, true])[]' is not assignable to parameter of type 'Iterable<readonly [string, boolean]>'.
 !!! error TS2769:       Types of property '[Symbol.iterator]' are incompatible.
-!!! error TS2769:         Type '() => IterableIterator<[string, number] | [string, true]>' is not assignable to type '() => Iterator<readonly [string, boolean], any, undefined>'.
-!!! error TS2769:           Type 'IterableIterator<[string, number] | [string, true]>' is not assignable to type 'Iterator<readonly [string, boolean], any, undefined>'.
+!!! error TS2769:         Type '() => IterableIterator<[string, number] | [string, true]>' is not assignable to type '() => Iterator<readonly [string, boolean], any, unknown>'.
+!!! error TS2769:           Type 'IterableIterator<[string, number] | [string, true]>' is not assignable to type 'Iterator<readonly [string, boolean], any, unknown>'.
 !!! error TS2769:             Types of property 'next' are incompatible.
-!!! error TS2769:               Type '(...args: [] | [undefined]) => IteratorResult<[string, number] | [string, true], any>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<readonly [string, boolean], any>'.
+!!! error TS2769:               Type '(...args: [] | [unknown]) => IteratorResult<[string, number] | [string, true], any>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<readonly [string, boolean], any>'.
 !!! error TS2769:                 Type 'IteratorResult<[string, number] | [string, true], any>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
 !!! error TS2769:                   Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorResult<readonly [string, boolean], any>'.
 !!! error TS2769:                     Type 'IteratorYieldResult<[string, number] | [string, true]>' is not assignable to type 'IteratorYieldResult<readonly [string, boolean]>'.

--- a/tests/baselines/reference/generatorReturnExpressionIsChecked.types
+++ b/tests/baselines/reference/generatorReturnExpressionIsChecked.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/generatorReturnExpressionIsChecked.ts ===
 function* f(): Iterator<number> {
->f : () => Iterator<number, any, undefined>
+>f : () => Iterator<number, any, unknown>
 
     return invalid;
 >invalid : any

--- a/tests/baselines/reference/generatorReturnTypeFallback.3.errors.txt
+++ b/tests/baselines/reference/generatorReturnTypeFallback.3.errors.txt
@@ -4,7 +4,6 @@ error TS2318: Cannot find global type 'Generator'.
 !!! error TS2318: Cannot find global type 'Generator'.
 ==== tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts (0 errors) ====
     // Do not allow generators to fallback to IterableIterator while in strictNullChecks mode if they need a type for the sent value.
-    // NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
     function* f() {
         const x: string = yield 1;
     }

--- a/tests/baselines/reference/generatorReturnTypeFallback.3.symbols
+++ b/tests/baselines/reference/generatorReturnTypeFallback.3.symbols
@@ -1,9 +1,8 @@
 === tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts ===
 // Do not allow generators to fallback to IterableIterator while in strictNullChecks mode if they need a type for the sent value.
-// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
 function* f() {
 >f : Symbol(f, Decl(generatorReturnTypeFallback.3.ts, 0, 0))
 
     const x: string = yield 1;
->x : Symbol(x, Decl(generatorReturnTypeFallback.3.ts, 3, 9))
+>x : Symbol(x, Decl(generatorReturnTypeFallback.3.ts, 2, 9))
 }

--- a/tests/baselines/reference/generatorReturnTypeFallback.3.types
+++ b/tests/baselines/reference/generatorReturnTypeFallback.3.types
@@ -1,6 +1,5 @@
 === tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts ===
 // Do not allow generators to fallback to IterableIterator while in strictNullChecks mode if they need a type for the sent value.
-// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
 function* f() {
 >f : () => {}
 

--- a/tests/baselines/reference/generatorReturnTypeFallback.4.errors.txt
+++ b/tests/baselines/reference/generatorReturnTypeFallback.4.errors.txt
@@ -1,0 +1,9 @@
+error TS2318: Cannot find global type 'Generator'.
+
+
+!!! error TS2318: Cannot find global type 'Generator'.
+==== tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts (0 errors) ====
+    // Do not allow generators to fallback to IterableIterator if they need a type for the sent value while not in strictNullChecks mode.
+    function* f() {
+        const x: string = yield 1;
+    }

--- a/tests/baselines/reference/generatorReturnTypeFallback.4.symbols
+++ b/tests/baselines/reference/generatorReturnTypeFallback.4.symbols
@@ -1,9 +1,8 @@
 === tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts ===
-// Allow generators to fallback to IterableIterator if they are not in strictNullChecks mode
-// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+// Do not allow generators to fallback to IterableIterator if they need a type for the sent value while not in strictNullChecks mode.
 function* f() {
 >f : Symbol(f, Decl(generatorReturnTypeFallback.4.ts, 0, 0))
 
     const x: string = yield 1;
->x : Symbol(x, Decl(generatorReturnTypeFallback.4.ts, 3, 9))
+>x : Symbol(x, Decl(generatorReturnTypeFallback.4.ts, 2, 9))
 }

--- a/tests/baselines/reference/generatorReturnTypeFallback.4.types
+++ b/tests/baselines/reference/generatorReturnTypeFallback.4.types
@@ -1,8 +1,7 @@
 === tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts ===
-// Allow generators to fallback to IterableIterator if they are not in strictNullChecks mode
-// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+// Do not allow generators to fallback to IterableIterator if they need a type for the sent value while not in strictNullChecks mode.
 function* f() {
->f : () => IterableIterator<number>
+>f : () => {}
 
     const x: string = yield 1;
 >x : string

--- a/tests/baselines/reference/generatorReturnTypeFallback.5.types
+++ b/tests/baselines/reference/generatorReturnTypeFallback.5.types
@@ -4,6 +4,6 @@ function* f(): IterableIterator<number> {
 >f : () => IterableIterator<number>
 
     yield 1;
->yield 1 : undefined
+>yield 1 : unknown
 >1 : 1
 }

--- a/tests/baselines/reference/generatorReturnTypeInference.types
+++ b/tests/baselines/reference/generatorReturnTypeInference.types
@@ -29,7 +29,7 @@ function* g002() { // Generator<number, void, unknown>
 }
 
 function* g003() { // Generator<never, void, undefined>
->g003 : () => Generator<never, void, undefined>
+>g003 : () => Generator<never, void, unknown>
 
     yield* [];
 >yield* [] : any
@@ -37,7 +37,7 @@ function* g003() { // Generator<never, void, undefined>
 }
 
 function* g004() { // Generator<number, void, undefined>
->g004 : () => Generator<number, void, undefined>
+>g004 : () => Generator<number, void, unknown>
 
     yield* iterableIterator;
 >yield* iterableIterator : any

--- a/tests/baselines/reference/generatorReturnTypeInferenceNonStrict.types
+++ b/tests/baselines/reference/generatorReturnTypeInferenceNonStrict.types
@@ -29,7 +29,7 @@ function* g002() { // Generator<number, void, unknown>
 }
 
 function* g003() { // Generator<any (implicit), void, unknown>
->g003 : () => Generator<any, void, undefined>
+>g003 : () => Generator<any, void, unknown>
 
     // NOTE: In strict mode, `[]` produces the type `never[]`.
     //       In non-strict mode, `[]` produces the type `undefined[]` which is implicitly any.
@@ -39,7 +39,7 @@ function* g003() { // Generator<any (implicit), void, unknown>
 }
 
 function* g004() { // Generator<number, void, undefined>
->g004 : () => Generator<number, void, undefined>
+>g004 : () => Generator<number, void, unknown>
 
     yield* iterableIterator;
 >yield* iterableIterator : any

--- a/tests/baselines/reference/generatorTypeCheck1.types
+++ b/tests/baselines/reference/generatorTypeCheck1.types
@@ -1,4 +1,4 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck1.ts ===
 function* g1(): Iterator<string> { }
->g1 : () => Iterator<string, any, undefined>
+>g1 : () => Iterator<string, any, unknown>
 

--- a/tests/baselines/reference/generatorTypeCheck13.types
+++ b/tests/baselines/reference/generatorTypeCheck13.types
@@ -3,7 +3,7 @@ function* g(): IterableIterator<number> {
 >g : () => IterableIterator<number>
 
     yield 0;
->yield 0 : undefined
+>yield 0 : unknown
 >0 : 0
 
     return "";

--- a/tests/baselines/reference/generatorTypeCheck17.types
+++ b/tests/baselines/reference/generatorTypeCheck17.types
@@ -12,10 +12,10 @@ function* g(): IterableIterator<Foo> {
 >g : () => IterableIterator<Foo>
 
     yield;
->yield : undefined
+>yield : unknown
 
     yield new Bar;
->yield new Bar : undefined
+>yield new Bar : unknown
 >new Bar : Bar
 >Bar : typeof Bar
 }

--- a/tests/baselines/reference/generatorTypeCheck18.types
+++ b/tests/baselines/reference/generatorTypeCheck18.types
@@ -11,10 +11,10 @@ function* g(): IterableIterator<Foo> {
 >g : () => IterableIterator<Foo>
 
     yield;
->yield : undefined
+>yield : unknown
 
     yield new Baz;
->yield new Baz : undefined
+>yield new Baz : unknown
 >new Baz : Baz
 >Baz : typeof Baz
 }

--- a/tests/baselines/reference/generatorTypeCheck19.types
+++ b/tests/baselines/reference/generatorTypeCheck19.types
@@ -12,7 +12,7 @@ function* g(): IterableIterator<Foo> {
 >g : () => IterableIterator<Foo>
 
     yield;
->yield : undefined
+>yield : unknown
 
     yield * [new Bar];
 >yield * [new Bar] : any

--- a/tests/baselines/reference/generatorTypeCheck20.types
+++ b/tests/baselines/reference/generatorTypeCheck20.types
@@ -11,7 +11,7 @@ function* g(): IterableIterator<Foo> {
 >g : () => IterableIterator<Foo>
 
     yield;
->yield : undefined
+>yield : unknown
 
     yield * [new Baz];
 >yield * [new Baz] : any

--- a/tests/baselines/reference/generatorTypeCheck21.types
+++ b/tests/baselines/reference/generatorTypeCheck21.types
@@ -12,7 +12,7 @@ function* g(): IterableIterator<Foo> {
 >g : () => IterableIterator<Foo>
 
     yield;
->yield : undefined
+>yield : unknown
 
     yield * new Bar;
 >yield * new Bar : any

--- a/tests/baselines/reference/generatorTypeCheck22.types
+++ b/tests/baselines/reference/generatorTypeCheck22.types
@@ -13,7 +13,7 @@ class Baz { z: number }
 >z : number
 
 function* g3() {
->g3 : () => Generator<Bar | Baz, void, undefined>
+>g3 : () => Generator<Bar | Baz, void, unknown>
 
     yield;
 >yield : any

--- a/tests/baselines/reference/generatorTypeCheck23.types
+++ b/tests/baselines/reference/generatorTypeCheck23.types
@@ -13,7 +13,7 @@ class Baz { z: number }
 >z : number
 
 function* g3() {
->g3 : () => Generator<Foo | Baz, void, undefined>
+>g3 : () => Generator<Foo | Baz, void, unknown>
 
     yield;
 >yield : any

--- a/tests/baselines/reference/generatorTypeCheck24.types
+++ b/tests/baselines/reference/generatorTypeCheck24.types
@@ -13,7 +13,7 @@ class Baz { z: number }
 >z : number
 
 function* g3() {
->g3 : () => Generator<Foo | Baz, void, undefined>
+>g3 : () => Generator<Foo | Baz, void, unknown>
 
     yield;
 >yield : any

--- a/tests/baselines/reference/generatorTypeCheck25.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck25.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck25.ts(4,5): error TS2322: Type '() => Generator<Bar | Baz, void, undefined>' is not assignable to type '() => Iterable<Foo>'.
-  Type 'Generator<Bar | Baz, void, undefined>' is not assignable to type 'Iterable<Foo>'.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck25.ts(4,5): error TS2322: Type '() => Generator<Bar | Baz, void, unknown>' is not assignable to type '() => Iterable<Foo>'.
+  Type 'Generator<Bar | Baz, void, unknown>' is not assignable to type 'Iterable<Foo>'.
     Types of property '[Symbol.iterator]' are incompatible.
-      Type '() => Generator<Bar | Baz, void, undefined>' is not assignable to type '() => Iterator<Foo, any, undefined>'.
-        Type 'Generator<Bar | Baz, void, undefined>' is not assignable to type 'Iterator<Foo, any, undefined>'.
+      Type '() => Generator<Bar | Baz, void, unknown>' is not assignable to type '() => Iterator<Foo, any, unknown>'.
+        Type 'Generator<Bar | Baz, void, unknown>' is not assignable to type 'Iterator<Foo, any, unknown>'.
           Types of property 'next' are incompatible.
-            Type '(...args: [] | [undefined]) => IteratorResult<Bar | Baz, void>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<Foo, any>'.
+            Type '(...args: [] | [unknown]) => IteratorResult<Bar | Baz, void>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<Foo, any>'.
               Type 'IteratorResult<Bar | Baz, void>' is not assignable to type 'IteratorResult<Foo, any>'.
                 Type 'IteratorYieldResult<Bar | Baz>' is not assignable to type 'IteratorResult<Foo, any>'.
                   Type 'IteratorYieldResult<Bar | Baz>' is not assignable to type 'IteratorYieldResult<Foo>'.
@@ -18,13 +18,13 @@ tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck25.ts(4,5): error
     class Baz { z: number }
     var g3: () => Iterable<Foo> = function* () {
         ~~
-!!! error TS2322: Type '() => Generator<Bar | Baz, void, undefined>' is not assignable to type '() => Iterable<Foo>'.
-!!! error TS2322:   Type 'Generator<Bar | Baz, void, undefined>' is not assignable to type 'Iterable<Foo>'.
+!!! error TS2322: Type '() => Generator<Bar | Baz, void, unknown>' is not assignable to type '() => Iterable<Foo>'.
+!!! error TS2322:   Type 'Generator<Bar | Baz, void, unknown>' is not assignable to type 'Iterable<Foo>'.
 !!! error TS2322:     Types of property '[Symbol.iterator]' are incompatible.
-!!! error TS2322:       Type '() => Generator<Bar | Baz, void, undefined>' is not assignable to type '() => Iterator<Foo, any, undefined>'.
-!!! error TS2322:         Type 'Generator<Bar | Baz, void, undefined>' is not assignable to type 'Iterator<Foo, any, undefined>'.
+!!! error TS2322:       Type '() => Generator<Bar | Baz, void, unknown>' is not assignable to type '() => Iterator<Foo, any, unknown>'.
+!!! error TS2322:         Type 'Generator<Bar | Baz, void, unknown>' is not assignable to type 'Iterator<Foo, any, unknown>'.
 !!! error TS2322:           Types of property 'next' are incompatible.
-!!! error TS2322:             Type '(...args: [] | [undefined]) => IteratorResult<Bar | Baz, void>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<Foo, any>'.
+!!! error TS2322:             Type '(...args: [] | [unknown]) => IteratorResult<Bar | Baz, void>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<Foo, any>'.
 !!! error TS2322:               Type 'IteratorResult<Bar | Baz, void>' is not assignable to type 'IteratorResult<Foo, any>'.
 !!! error TS2322:                 Type 'IteratorYieldResult<Bar | Baz>' is not assignable to type 'IteratorResult<Foo, any>'.
 !!! error TS2322:                   Type 'IteratorYieldResult<Bar | Baz>' is not assignable to type 'IteratorYieldResult<Foo>'.

--- a/tests/baselines/reference/generatorTypeCheck25.types
+++ b/tests/baselines/reference/generatorTypeCheck25.types
@@ -14,18 +14,18 @@ class Baz { z: number }
 
 var g3: () => Iterable<Foo> = function* () {
 >g3 : () => Iterable<Foo>
->function* () {    yield;    yield new Bar;    yield new Baz;    yield *[new Bar];    yield *[new Baz];} : () => Generator<Bar | Baz, void, undefined>
+>function* () {    yield;    yield new Bar;    yield new Baz;    yield *[new Bar];    yield *[new Baz];} : () => Generator<Bar | Baz, void, unknown>
 
     yield;
->yield : undefined
+>yield : unknown
 
     yield new Bar;
->yield new Bar : undefined
+>yield new Bar : unknown
 >new Bar : Bar
 >Bar : typeof Bar
 
     yield new Baz;
->yield new Baz : undefined
+>yield new Baz : unknown
 >new Baz : Baz
 >Baz : typeof Baz
 

--- a/tests/baselines/reference/generatorTypeCheck26.types
+++ b/tests/baselines/reference/generatorTypeCheck26.types
@@ -4,7 +4,7 @@ function* g(): IterableIterator<(x: string) => number> {
 >x : string
 
     yield x => x.length;
->yield x => x.length : undefined
+>yield x => x.length : unknown
 >x => x.length : (x: string) => number
 >x : string
 >x.length : number

--- a/tests/baselines/reference/generatorTypeCheck28.types
+++ b/tests/baselines/reference/generatorTypeCheck28.types
@@ -5,16 +5,16 @@ function* g(): IterableIterator<(x: string) => number> {
 
     yield * {
 >yield * {        *[Symbol.iterator]() {            yield x => x.length;        }    } : void
->{        *[Symbol.iterator]() {            yield x => x.length;        }    } : { [Symbol.iterator](): Generator<(x: string) => number, void, undefined>; }
+>{        *[Symbol.iterator]() {            yield x => x.length;        }    } : { [Symbol.iterator](): Generator<(x: string) => number, void, unknown>; }
 
         *[Symbol.iterator]() {
->[Symbol.iterator] : () => Generator<(x: string) => number, void, undefined>
+>[Symbol.iterator] : () => Generator<(x: string) => number, void, unknown>
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
 >iterator : symbol
 
             yield x => x.length;
->yield x => x.length : undefined
+>yield x => x.length : unknown
 >x => x.length : (x: string) => number
 >x : string
 >x.length : number

--- a/tests/baselines/reference/generatorTypeCheck29.types
+++ b/tests/baselines/reference/generatorTypeCheck29.types
@@ -1,10 +1,10 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck29.ts ===
 function* g2(): Iterator<Iterable<(x: string) => number>> {
->g2 : () => Iterator<Iterable<(x: string) => number>, any, undefined>
+>g2 : () => Iterator<Iterable<(x: string) => number>, any, unknown>
 >x : string
 
     yield function* () {
->yield function* () {        yield x => x.length;    } () : undefined
+>yield function* () {        yield x => x.length;    } () : unknown
 >function* () {        yield x => x.length;    } () : Generator<(x: any) => any, void, unknown>
 >function* () {        yield x => x.length;    } : () => Generator<(x: any) => any, void, unknown>
 

--- a/tests/baselines/reference/generatorTypeCheck30.types
+++ b/tests/baselines/reference/generatorTypeCheck30.types
@@ -1,10 +1,10 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck30.ts ===
 function* g2(): Iterator<Iterable<(x: string) => number>> {
->g2 : () => Iterator<Iterable<(x: string) => number>, any, undefined>
+>g2 : () => Iterator<Iterable<(x: string) => number>, any, unknown>
 >x : string
 
     yield function* () {
->yield function* () {        yield x => x.length;    } () : undefined
+>yield function* () {        yield x => x.length;    } () : unknown
 >function* () {        yield x => x.length;    } () : Generator<(x: any) => any, void, unknown>
 >function* () {        yield x => x.length;    } : () => Generator<(x: any) => any, void, unknown>
 

--- a/tests/baselines/reference/generatorTypeCheck31.types
+++ b/tests/baselines/reference/generatorTypeCheck31.types
@@ -1,10 +1,10 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts ===
 function* g2(): Iterator<() => Iterable<(x: string) => number>> {
->g2 : () => Iterator<() => Iterable<(x: string) => number>, any, undefined>
+>g2 : () => Iterator<() => Iterable<(x: string) => number>, any, unknown>
 >x : string
 
     yield function* () {
->yield function* () {        yield x => x.length;    } () : undefined
+>yield function* () {        yield x => x.length;    } () : unknown
 >function* () {        yield x => x.length;    } () : Generator<(x: any) => any, void, unknown>
 >function* () {        yield x => x.length;    } : () => Generator<(x: any) => any, void, unknown>
 

--- a/tests/baselines/reference/generatorTypeCheck45.types
+++ b/tests/baselines/reference/generatorTypeCheck45.types
@@ -1,18 +1,18 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck45.ts ===
 declare function foo<T, U>(x: T, fun: () => Iterator<(x: T) => U>, fun2: (y: U) => T): T;
->foo : <T, U>(x: T, fun: () => Iterator<(x: T) => U, any, undefined>, fun2: (y: U) => T) => T
+>foo : <T, U>(x: T, fun: () => Iterator<(x: T) => U, any, unknown>, fun2: (y: U) => T) => T
 >x : T
->fun : () => Iterator<(x: T) => U, any, undefined>
+>fun : () => Iterator<(x: T) => U, any, unknown>
 >x : T
 >fun2 : (y: U) => T
 >y : U
 
 foo("", function* () { yield x => x.length }, p => undefined); // T is fixed, should be string
 >foo("", function* () { yield x => x.length }, p => undefined) : string
->foo : <T, U>(x: T, fun: () => Iterator<(x: T) => U, any, undefined>, fun2: (y: U) => T) => T
+>foo : <T, U>(x: T, fun: () => Iterator<(x: T) => U, any, unknown>, fun2: (y: U) => T) => T
 >"" : ""
->function* () { yield x => x.length } : () => Generator<(x: string) => number, void, undefined>
->yield x => x.length : undefined
+>function* () { yield x => x.length } : () => Generator<(x: string) => number, void, unknown>
+>yield x => x.length : unknown
 >x => x.length : (x: string) => number
 >x : string
 >x.length : number

--- a/tests/baselines/reference/generatorTypeCheck46.types
+++ b/tests/baselines/reference/generatorTypeCheck46.types
@@ -11,20 +11,20 @@ foo("", function* () {
 >foo("", function* () {    yield* {        *[Symbol.iterator]() {            yield x => x.length        }    }}, p => undefined) : string
 >foo : <T, U>(x: T, fun: () => Iterable<(x: T) => U>, fun2: (y: U) => T) => T
 >"" : ""
->function* () {    yield* {        *[Symbol.iterator]() {            yield x => x.length        }    }} : () => Generator<(x: string) => number, void, undefined>
+>function* () {    yield* {        *[Symbol.iterator]() {            yield x => x.length        }    }} : () => Generator<(x: string) => number, void, unknown>
 
     yield* {
 >yield* {        *[Symbol.iterator]() {            yield x => x.length        }    } : void
->{        *[Symbol.iterator]() {            yield x => x.length        }    } : { [Symbol.iterator](): Generator<(x: string) => number, void, undefined>; }
+>{        *[Symbol.iterator]() {            yield x => x.length        }    } : { [Symbol.iterator](): Generator<(x: string) => number, void, unknown>; }
 
         *[Symbol.iterator]() {
->[Symbol.iterator] : () => Generator<(x: string) => number, void, undefined>
+>[Symbol.iterator] : () => Generator<(x: string) => number, void, unknown>
 >Symbol.iterator : symbol
 >Symbol : SymbolConstructor
 >iterator : symbol
 
             yield x => x.length
->yield x => x.length : undefined
+>yield x => x.length : unknown
 >x => x.length : (x: string) => number
 >x : string
 >x.length : number

--- a/tests/baselines/reference/generatorTypeCheck53.types
+++ b/tests/baselines/reference/generatorTypeCheck53.types
@@ -8,7 +8,7 @@ class Baz { z: number }
 >z : number
 
 function* g() {
->g : () => Generator<Foo | Baz, void, undefined>
+>g : () => Generator<Foo | Baz, void, unknown>
 
     yield new Foo;
 >yield new Foo : any

--- a/tests/baselines/reference/generatorTypeCheck54.types
+++ b/tests/baselines/reference/generatorTypeCheck54.types
@@ -8,7 +8,7 @@ class Baz { z: number }
 >z : number
 
 function* g() {
->g : () => Generator<Foo | Baz, void, undefined>
+>g : () => Generator<Foo | Baz, void, unknown>
 
     yield* [new Foo];
 >yield* [new Foo] : any

--- a/tests/baselines/reference/generatorTypeCheck62.types
+++ b/tests/baselines/reference/generatorTypeCheck62.types
@@ -12,7 +12,7 @@ export function strategy<T extends StrategicState>(stratName: string, gen: (a: T
 >a : T
 
     return function*(state) {
->function*(state) {        for (const next of gen(state)) {            if (next) {                next.lastStrategyApplied = stratName;            }            yield next;        }    } : (state: T) => Generator<T, void, undefined>
+>function*(state) {        for (const next of gen(state)) {            if (next) {                next.lastStrategyApplied = stratName;            }            yield next;        }    } : (state: T) => Generator<T, void, unknown>
 >state : T
 
         for (const next of gen(state)) {
@@ -32,7 +32,7 @@ export function strategy<T extends StrategicState>(stratName: string, gen: (a: T
 >stratName : string
             }
             yield next;
->yield next : undefined
+>yield next : unknown
 >next : T
         }
     }
@@ -53,7 +53,7 @@ export const Nothing1: Strategy<State> = strategy("Nothing", function*(state: St
 >strategy("Nothing", function*(state: State) {    return state;}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function*(state: State) {    return state;} : (state: State) => Generator<never, State, undefined>
+>function*(state: State) {    return state;} : (state: State) => Generator<never, State, unknown>
 >state : State
 
     return state;
@@ -66,11 +66,11 @@ export const Nothing2: Strategy<State> = strategy("Nothing", function*(state: St
 >strategy("Nothing", function*(state: State) {    yield state;}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function*(state: State) {    yield state;} : (state: State) => Generator<State, void, undefined>
+>function*(state: State) {    yield state;} : (state: State) => Generator<State, void, unknown>
 >state : State
 
     yield state;
->yield state : undefined
+>yield state : unknown
 >state : State
 
 });
@@ -80,11 +80,11 @@ export const Nothing3: Strategy<State> = strategy("Nothing", function* (state: S
 >strategy("Nothing", function* (state: State) {    yield ;    return state;}) : (a: any) => IterableIterator<any>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {    yield ;    return state;} : (state: State) => Generator<any, State, undefined>
+>function* (state: State) {    yield ;    return state;} : (state: State) => Generator<any, State, unknown>
 >state : State
 
     yield ;
->yield : undefined
+>yield : unknown
 
     return state;
 >state : State

--- a/tests/baselines/reference/generatorTypeCheck63.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck63.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(24,61): error TS2345: Argument of type '(state: State) => Generator<number, State, undefined>' is not assignable to parameter of type '(a: State) => IterableIterator<State>'.
-  Type 'Generator<number, State, undefined>' is not assignable to type 'IterableIterator<State>'.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(24,61): error TS2345: Argument of type '(state: State) => Generator<number, State, unknown>' is not assignable to parameter of type '(a: State) => IterableIterator<State>'.
+  Type 'Generator<number, State, unknown>' is not assignable to type 'IterableIterator<State>'.
     Types of property 'next' are incompatible.
-      Type '(...args: [] | [undefined]) => IteratorResult<number, State>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<State, any>'.
+      Type '(...args: [] | [unknown]) => IteratorResult<number, State>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<State, any>'.
         Type 'IteratorResult<number, State>' is not assignable to type 'IteratorResult<State, any>'.
           Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<State, any>'.
             Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<State>'.
@@ -34,10 +34,10 @@ tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts(24,61): err
     
     export const Nothing: Strategy<State> = strategy("Nothing", function* (state: State) {
                                                                 ~~~~~~~~
-!!! error TS2345: Argument of type '(state: State) => Generator<number, State, undefined>' is not assignable to parameter of type '(a: State) => IterableIterator<State>'.
-!!! error TS2345:   Type 'Generator<number, State, undefined>' is not assignable to type 'IterableIterator<State>'.
+!!! error TS2345: Argument of type '(state: State) => Generator<number, State, unknown>' is not assignable to parameter of type '(a: State) => IterableIterator<State>'.
+!!! error TS2345:   Type 'Generator<number, State, unknown>' is not assignable to type 'IterableIterator<State>'.
 !!! error TS2345:     Types of property 'next' are incompatible.
-!!! error TS2345:       Type '(...args: [] | [undefined]) => IteratorResult<number, State>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<State, any>'.
+!!! error TS2345:       Type '(...args: [] | [unknown]) => IteratorResult<number, State>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<State, any>'.
 !!! error TS2345:         Type 'IteratorResult<number, State>' is not assignable to type 'IteratorResult<State, any>'.
 !!! error TS2345:           Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorResult<State, any>'.
 !!! error TS2345:             Type 'IteratorYieldResult<number>' is not assignable to type 'IteratorYieldResult<State>'.

--- a/tests/baselines/reference/generatorTypeCheck63.types
+++ b/tests/baselines/reference/generatorTypeCheck63.types
@@ -12,7 +12,7 @@ export function strategy<T extends StrategicState>(stratName: string, gen: (a: T
 >a : T
 
     return function*(state) {
->function*(state) {        for (const next of gen(state)) {            if (next) {                next.lastStrategyApplied = stratName;            }            yield next;        }    } : (state: T) => Generator<T, void, undefined>
+>function*(state) {        for (const next of gen(state)) {            if (next) {                next.lastStrategyApplied = stratName;            }            yield next;        }    } : (state: T) => Generator<T, void, unknown>
 >state : T
 
         for (const next of gen(state)) {
@@ -32,7 +32,7 @@ export function strategy<T extends StrategicState>(stratName: string, gen: (a: T
 >stratName : string
             }
             yield next;
->yield next : undefined
+>yield next : unknown
 >next : T
         }
     }
@@ -53,7 +53,7 @@ export const Nothing: Strategy<State> = strategy("Nothing", function* (state: St
 >strategy("Nothing", function* (state: State) {    yield 1;    return state;}) : any
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {    yield 1;    return state;} : (state: State) => Generator<number, State, undefined>
+>function* (state: State) {    yield 1;    return state;} : (state: State) => Generator<number, State, unknown>
 >state : State
 
     yield 1;
@@ -70,7 +70,7 @@ export const Nothing1: Strategy<State> = strategy("Nothing", function* (state: S
 >strategy("Nothing", function* (state: State) {}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {} : (state: State) => Generator<never, void, undefined>
+>function* (state: State) {} : (state: State) => Generator<never, void, unknown>
 >state : State
 
 });
@@ -80,7 +80,7 @@ export const Nothing2: Strategy<State> = strategy("Nothing", function* (state: S
 >strategy("Nothing", function* (state: State) {    return 1;}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {    return 1;} : (state: State) => Generator<never, number, undefined>
+>function* (state: State) {    return 1;} : (state: State) => Generator<never, number, unknown>
 >state : State
 
     return 1;
@@ -93,11 +93,11 @@ export const Nothing3: Strategy<State> = strategy("Nothing", function* (state: S
 >strategy("Nothing", function* (state: State) {    yield state;    return 1;}) : (a: State) => IterableIterator<State>
 >strategy : <T extends StrategicState>(stratName: string, gen: (a: T) => IterableIterator<T>) => (a: T) => IterableIterator<T>
 >"Nothing" : "Nothing"
->function* (state: State) {    yield state;    return 1;} : (state: State) => Generator<State, number, undefined>
+>function* (state: State) {    yield state;    return 1;} : (state: State) => Generator<State, number, unknown>
 >state : State
 
     yield state;
->yield state : undefined
+>yield state : unknown
 >state : State
 
     return 1;

--- a/tests/baselines/reference/generatorTypeCheck7.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck7.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts(4,17): error TS2741: Property 'hello' is missing in type 'Generator<number, any, undefined>' but required in type 'WeirdIter'.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts(4,17): error TS2741: Property 'hello' is missing in type 'Generator<number, any, unknown>' but required in type 'WeirdIter'.
 
 
 ==== tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts (1 errors) ====
@@ -7,5 +7,5 @@ tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts(4,17): error
     }
     function* g1(): WeirdIter { }
                     ~~~~~~~~~
-!!! error TS2741: Property 'hello' is missing in type 'Generator<number, any, undefined>' but required in type 'WeirdIter'.
+!!! error TS2741: Property 'hello' is missing in type 'Generator<number, any, unknown>' but required in type 'WeirdIter'.
 !!! related TS2728 tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts:2:5: 'hello' is declared here.

--- a/tests/baselines/reference/generatorTypeCheck8.errors.txt
+++ b/tests/baselines/reference/generatorTypeCheck8.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck8.ts(2,17): error TS2322: Type 'Generator<string, any, undefined>' is not assignable to type 'BadGenerator'.
+tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck8.ts(2,17): error TS2322: Type 'Generator<string, any, unknown>' is not assignable to type 'BadGenerator'.
   Types of property 'next' are incompatible.
-    Type '(...args: [] | [undefined]) => IteratorResult<string, any>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<number, any>'.
+    Type '(...args: [] | [unknown]) => IteratorResult<string, any>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<number, any>'.
       Type 'IteratorResult<string, any>' is not assignable to type 'IteratorResult<number, any>'.
         Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorResult<number, any>'.
           Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorYieldResult<number>'.
@@ -11,9 +11,9 @@ tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck8.ts(2,17): error
     interface BadGenerator extends Iterator<number>, Iterable<string> { }
     function* g3(): BadGenerator { }
                     ~~~~~~~~~~~~
-!!! error TS2322: Type 'Generator<string, any, undefined>' is not assignable to type 'BadGenerator'.
+!!! error TS2322: Type 'Generator<string, any, unknown>' is not assignable to type 'BadGenerator'.
 !!! error TS2322:   Types of property 'next' are incompatible.
-!!! error TS2322:     Type '(...args: [] | [undefined]) => IteratorResult<string, any>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<number, any>'.
+!!! error TS2322:     Type '(...args: [] | [unknown]) => IteratorResult<string, any>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<number, any>'.
 !!! error TS2322:       Type 'IteratorResult<string, any>' is not assignable to type 'IteratorResult<number, any>'.
 !!! error TS2322:         Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorResult<number, any>'.
 !!! error TS2322:           Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorYieldResult<number>'.

--- a/tests/baselines/reference/importHelpersNoHelpersForAsyncGenerators.types
+++ b/tests/baselines/reference/importHelpersNoHelpersForAsyncGenerators.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/main.ts ===
 export async function * f() {
->f : () => AsyncGenerator<number, void, undefined>
+>f : () => AsyncGenerator<number, void, unknown>
 
     await 1;
 >await 1 : 1

--- a/tests/baselines/reference/iterableArrayPattern28.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern28.errors.txt
@@ -2,10 +2,10 @@ tests/cases/conformance/es6/destructuring/iterableArrayPattern28.ts(2,24): error
   Overload 1 of 3, '(iterable: Iterable<readonly [string, number]>): Map<string, number>', gave the following error.
     Argument of type '([string, number] | [string, boolean])[]' is not assignable to parameter of type 'Iterable<readonly [string, number]>'.
       Types of property '[Symbol.iterator]' are incompatible.
-        Type '() => IterableIterator<[string, number] | [string, boolean]>' is not assignable to type '() => Iterator<readonly [string, number], any, undefined>'.
-          Type 'IterableIterator<[string, number] | [string, boolean]>' is not assignable to type 'Iterator<readonly [string, number], any, undefined>'.
+        Type '() => IterableIterator<[string, number] | [string, boolean]>' is not assignable to type '() => Iterator<readonly [string, number], any, unknown>'.
+          Type 'IterableIterator<[string, number] | [string, boolean]>' is not assignable to type 'Iterator<readonly [string, number], any, unknown>'.
             Types of property 'next' are incompatible.
-              Type '(...args: [] | [undefined]) => IteratorResult<[string, number] | [string, boolean], any>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<readonly [string, number], any>'.
+              Type '(...args: [] | [unknown]) => IteratorResult<[string, number] | [string, boolean], any>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<readonly [string, number], any>'.
                 Type 'IteratorResult<[string, number] | [string, boolean], any>' is not assignable to type 'IteratorResult<readonly [string, number], any>'.
                   Type 'IteratorYieldResult<[string, number] | [string, boolean]>' is not assignable to type 'IteratorResult<readonly [string, number], any>'.
                     Type 'IteratorYieldResult<[string, number] | [string, boolean]>' is not assignable to type 'IteratorYieldResult<readonly [string, number]>'.
@@ -25,10 +25,10 @@ tests/cases/conformance/es6/destructuring/iterableArrayPattern28.ts(2,24): error
 !!! error TS2769:   Overload 1 of 3, '(iterable: Iterable<readonly [string, number]>): Map<string, number>', gave the following error.
 !!! error TS2769:     Argument of type '([string, number] | [string, boolean])[]' is not assignable to parameter of type 'Iterable<readonly [string, number]>'.
 !!! error TS2769:       Types of property '[Symbol.iterator]' are incompatible.
-!!! error TS2769:         Type '() => IterableIterator<[string, number] | [string, boolean]>' is not assignable to type '() => Iterator<readonly [string, number], any, undefined>'.
-!!! error TS2769:           Type 'IterableIterator<[string, number] | [string, boolean]>' is not assignable to type 'Iterator<readonly [string, number], any, undefined>'.
+!!! error TS2769:         Type '() => IterableIterator<[string, number] | [string, boolean]>' is not assignable to type '() => Iterator<readonly [string, number], any, unknown>'.
+!!! error TS2769:           Type 'IterableIterator<[string, number] | [string, boolean]>' is not assignable to type 'Iterator<readonly [string, number], any, unknown>'.
 !!! error TS2769:             Types of property 'next' are incompatible.
-!!! error TS2769:               Type '(...args: [] | [undefined]) => IteratorResult<[string, number] | [string, boolean], any>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<readonly [string, number], any>'.
+!!! error TS2769:               Type '(...args: [] | [unknown]) => IteratorResult<[string, number] | [string, boolean], any>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<readonly [string, number], any>'.
 !!! error TS2769:                 Type 'IteratorResult<[string, number] | [string, boolean], any>' is not assignable to type 'IteratorResult<readonly [string, number], any>'.
 !!! error TS2769:                   Type 'IteratorYieldResult<[string, number] | [string, boolean]>' is not assignable to type 'IteratorResult<readonly [string, number], any>'.
 !!! error TS2769:                     Type 'IteratorYieldResult<[string, number] | [string, boolean]>' is not assignable to type 'IteratorYieldResult<readonly [string, number]>'.

--- a/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.classMethods.es2018.types
@@ -175,7 +175,7 @@ class C16 {
 >C16 : C16
 
     async * f() {
->f : () => AsyncGenerator<any, void, undefined>
+>f : () => AsyncGenerator<any, void, unknown>
 
         yield * [];
 >yield * [] : any

--- a/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.functionDeclarations.es2018.types
@@ -111,7 +111,7 @@ async function * f15() {
 }
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarWithValueIsOk.ts ===
 async function * f16() {
->f16 : () => AsyncGenerator<any, void, undefined>
+>f16 : () => AsyncGenerator<any, void, unknown>
 
     yield * [];
 >yield * [] : any

--- a/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.functionExpressions.es2018.types
@@ -142,8 +142,8 @@ const f15 = async function * () {
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarWithValueIsOk.ts ===
 const f16 = async function * () {
->f16 : () => AsyncGenerator<any, void, undefined>
->async function * () {    yield * [];} : () => AsyncGenerator<any, void, undefined>
+>f16 : () => AsyncGenerator<any, void, unknown>
+>async function * () {    yield * [];} : () => AsyncGenerator<any, void, unknown>
 
     yield * [];
 >yield * [] : any

--- a/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.types
+++ b/tests/baselines/reference/parser.asyncGenerators.objectLiteralMethods.es2018.types
@@ -187,11 +187,11 @@ const o15 = {
 };
 === tests/cases/conformance/parser/ecmascript2018/asyncGenerators/yieldStarWithValueIsOk.ts ===
 const o16 = {
->o16 : { f(): AsyncGenerator<any, void, undefined>; }
->{    async * f() {        yield * [];    }} : { f(): AsyncGenerator<any, void, undefined>; }
+>o16 : { f(): AsyncGenerator<any, void, unknown>; }
+>{    async * f() {        yield * [];    }} : { f(): AsyncGenerator<any, void, unknown>; }
 
     async * f() {
->f : () => AsyncGenerator<any, void, undefined>
+>f : () => AsyncGenerator<any, void, unknown>
 
         yield * [];
 >yield * [] : any

--- a/tests/baselines/reference/types.asyncGenerators.es2018.1.types
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.1.types
@@ -42,7 +42,7 @@ async function * inferReturnType5() {
 >2 : 2
 }
 async function * inferReturnType6() {
->inferReturnType6 : () => AsyncGenerator<number, void, undefined>
+>inferReturnType6 : () => AsyncGenerator<number, void, unknown>
 
     yield* [1, 2];
 >yield* [1, 2] : any
@@ -51,7 +51,7 @@ async function * inferReturnType6() {
 >2 : 2
 }
 async function * inferReturnType7() {
->inferReturnType7 : () => AsyncGenerator<number, void, undefined>
+>inferReturnType7 : () => AsyncGenerator<number, void, unknown>
 
     yield* [Promise.resolve(1)];
 >yield* [Promise.resolve(1)] : any
@@ -75,19 +75,19 @@ async function * inferReturnType8() {
 }
 const assignability1: () => AsyncIterableIterator<number> = async function * () {
 >assignability1 : () => AsyncIterableIterator<number>
->async function * () {    yield 1;} : () => AsyncGenerator<number, void, undefined>
+>async function * () {    yield 1;} : () => AsyncGenerator<number, void, unknown>
 
     yield 1;
->yield 1 : undefined
+>yield 1 : unknown
 >1 : 1
 
 };
 const assignability2: () => AsyncIterableIterator<number> = async function * () {
 >assignability2 : () => AsyncIterableIterator<number>
->async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, undefined>
+>async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, unknown>
 
     yield Promise.resolve(1);
->yield Promise.resolve(1) : undefined
+>yield Promise.resolve(1) : unknown
 >Promise.resolve(1) : Promise<number>
 >Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
 >Promise : PromiseConstructor
@@ -97,7 +97,7 @@ const assignability2: () => AsyncIterableIterator<number> = async function * () 
 };
 const assignability3: () => AsyncIterableIterator<number> = async function * () {
 >assignability3 : () => AsyncIterableIterator<number>
->async function * () {    yield* [1, 2];} : () => AsyncGenerator<number, void, undefined>
+>async function * () {    yield* [1, 2];} : () => AsyncGenerator<number, void, unknown>
 
     yield* [1, 2];
 >yield* [1, 2] : any
@@ -108,7 +108,7 @@ const assignability3: () => AsyncIterableIterator<number> = async function * () 
 };
 const assignability4: () => AsyncIterableIterator<number> = async function * () {
 >assignability4 : () => AsyncIterableIterator<number>
->async function * () {    yield* [Promise.resolve(1)];} : () => AsyncGenerator<number, void, undefined>
+>async function * () {    yield* [Promise.resolve(1)];} : () => AsyncGenerator<number, void, unknown>
 
     yield* [Promise.resolve(1)];
 >yield* [Promise.resolve(1)] : any
@@ -135,19 +135,19 @@ const assignability5: () => AsyncIterableIterator<number> = async function * () 
 };
 const assignability6: () => AsyncIterable<number> = async function * () {
 >assignability6 : () => AsyncIterable<number>
->async function * () {    yield 1;} : () => AsyncGenerator<number, void, undefined>
+>async function * () {    yield 1;} : () => AsyncGenerator<number, void, unknown>
 
     yield 1;
->yield 1 : undefined
+>yield 1 : unknown
 >1 : 1
 
 };
 const assignability7: () => AsyncIterable<number> = async function * () {
 >assignability7 : () => AsyncIterable<number>
->async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, undefined>
+>async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, unknown>
 
     yield Promise.resolve(1);
->yield Promise.resolve(1) : undefined
+>yield Promise.resolve(1) : unknown
 >Promise.resolve(1) : Promise<number>
 >Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
 >Promise : PromiseConstructor
@@ -157,7 +157,7 @@ const assignability7: () => AsyncIterable<number> = async function * () {
 };
 const assignability8: () => AsyncIterable<number> = async function * () {
 >assignability8 : () => AsyncIterable<number>
->async function * () {    yield* [1, 2];} : () => AsyncGenerator<number, void, undefined>
+>async function * () {    yield* [1, 2];} : () => AsyncGenerator<number, void, unknown>
 
     yield* [1, 2];
 >yield* [1, 2] : any
@@ -168,7 +168,7 @@ const assignability8: () => AsyncIterable<number> = async function * () {
 };
 const assignability9: () => AsyncIterable<number> = async function * () {
 >assignability9 : () => AsyncIterable<number>
->async function * () {    yield* [Promise.resolve(1)];} : () => AsyncGenerator<number, void, undefined>
+>async function * () {    yield* [Promise.resolve(1)];} : () => AsyncGenerator<number, void, unknown>
 
     yield* [Promise.resolve(1)];
 >yield* [Promise.resolve(1)] : any
@@ -194,20 +194,20 @@ const assignability10: () => AsyncIterable<number> = async function * () {
 
 };
 const assignability11: () => AsyncIterator<number> = async function * () {
->assignability11 : () => AsyncIterator<number, any, undefined>
->async function * () {    yield 1;} : () => AsyncGenerator<number, void, undefined>
+>assignability11 : () => AsyncIterator<number, any, unknown>
+>async function * () {    yield 1;} : () => AsyncGenerator<number, void, unknown>
 
     yield 1;
->yield 1 : undefined
+>yield 1 : unknown
 >1 : 1
 
 };
 const assignability12: () => AsyncIterator<number> = async function * () {
->assignability12 : () => AsyncIterator<number, any, undefined>
->async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, undefined>
+>assignability12 : () => AsyncIterator<number, any, unknown>
+>async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, unknown>
 
     yield Promise.resolve(1);
->yield Promise.resolve(1) : undefined
+>yield Promise.resolve(1) : unknown
 >Promise.resolve(1) : Promise<number>
 >Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
 >Promise : PromiseConstructor
@@ -216,8 +216,8 @@ const assignability12: () => AsyncIterator<number> = async function * () {
 
 };
 const assignability13: () => AsyncIterator<number> = async function * () {
->assignability13 : () => AsyncIterator<number, any, undefined>
->async function * () {    yield* [1, 2];} : () => AsyncGenerator<number, void, undefined>
+>assignability13 : () => AsyncIterator<number, any, unknown>
+>async function * () {    yield* [1, 2];} : () => AsyncGenerator<number, void, unknown>
 
     yield* [1, 2];
 >yield* [1, 2] : any
@@ -227,8 +227,8 @@ const assignability13: () => AsyncIterator<number> = async function * () {
 
 };
 const assignability14: () => AsyncIterator<number> = async function * () {
->assignability14 : () => AsyncIterator<number, any, undefined>
->async function * () {    yield* [Promise.resolve(1)];} : () => AsyncGenerator<number, void, undefined>
+>assignability14 : () => AsyncIterator<number, any, unknown>
+>async function * () {    yield* [Promise.resolve(1)];} : () => AsyncGenerator<number, void, unknown>
 
     yield* [Promise.resolve(1)];
 >yield* [Promise.resolve(1)] : any
@@ -241,7 +241,7 @@ const assignability14: () => AsyncIterator<number> = async function * () {
 
 };
 const assignability15: () => AsyncIterator<number> = async function * () {
->assignability15 : () => AsyncIterator<number, any, undefined>
+>assignability15 : () => AsyncIterator<number, any, unknown>
 >async function * () {    yield* (async function * () { yield 1; })();} : () => AsyncGenerator<number, void, unknown>
 
     yield* (async function * () { yield 1; })();
@@ -257,14 +257,14 @@ async function * explicitReturnType1(): AsyncIterableIterator<number> {
 >explicitReturnType1 : () => AsyncIterableIterator<number>
 
     yield 1;
->yield 1 : undefined
+>yield 1 : unknown
 >1 : 1
 }
 async function * explicitReturnType2(): AsyncIterableIterator<number> {
 >explicitReturnType2 : () => AsyncIterableIterator<number>
 
     yield Promise.resolve(1);
->yield Promise.resolve(1) : undefined
+>yield Promise.resolve(1) : unknown
 >Promise.resolve(1) : Promise<number>
 >Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
 >Promise : PromiseConstructor
@@ -307,14 +307,14 @@ async function * explicitReturnType6(): AsyncIterable<number> {
 >explicitReturnType6 : () => AsyncIterable<number>
 
     yield 1;
->yield 1 : undefined
+>yield 1 : unknown
 >1 : 1
 }
 async function * explicitReturnType7(): AsyncIterable<number> {
 >explicitReturnType7 : () => AsyncIterable<number>
 
     yield Promise.resolve(1);
->yield Promise.resolve(1) : undefined
+>yield Promise.resolve(1) : unknown
 >Promise.resolve(1) : Promise<number>
 >Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
 >Promise : PromiseConstructor
@@ -354,17 +354,17 @@ async function * explicitReturnType10(): AsyncIterable<number> {
 >1 : 1
 }
 async function * explicitReturnType11(): AsyncIterator<number> {
->explicitReturnType11 : () => AsyncIterator<number, any, undefined>
+>explicitReturnType11 : () => AsyncIterator<number, any, unknown>
 
     yield 1;
->yield 1 : undefined
+>yield 1 : unknown
 >1 : 1
 }
 async function * explicitReturnType12(): AsyncIterator<number> {
->explicitReturnType12 : () => AsyncIterator<number, any, undefined>
+>explicitReturnType12 : () => AsyncIterator<number, any, unknown>
 
     yield Promise.resolve(1);
->yield Promise.resolve(1) : undefined
+>yield Promise.resolve(1) : unknown
 >Promise.resolve(1) : Promise<number>
 >Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
 >Promise : PromiseConstructor
@@ -372,7 +372,7 @@ async function * explicitReturnType12(): AsyncIterator<number> {
 >1 : 1
 }
 async function * explicitReturnType13(): AsyncIterator<number> {
->explicitReturnType13 : () => AsyncIterator<number, any, undefined>
+>explicitReturnType13 : () => AsyncIterator<number, any, unknown>
 
     yield* [1, 2];
 >yield* [1, 2] : any
@@ -381,7 +381,7 @@ async function * explicitReturnType13(): AsyncIterator<number> {
 >2 : 2
 }
 async function * explicitReturnType14(): AsyncIterator<number> {
->explicitReturnType14 : () => AsyncIterator<number, any, undefined>
+>explicitReturnType14 : () => AsyncIterator<number, any, unknown>
 
     yield* [Promise.resolve(1)];
 >yield* [Promise.resolve(1)] : any
@@ -393,7 +393,7 @@ async function * explicitReturnType14(): AsyncIterator<number> {
 >1 : 1
 }
 async function * explicitReturnType15(): AsyncIterator<number> {
->explicitReturnType15 : () => AsyncIterator<number, any, undefined>
+>explicitReturnType15 : () => AsyncIterator<number, any, unknown>
 
     yield* (async function * () { yield 1; })();
 >yield* (async function * () { yield 1; })() : void

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
@@ -1,45 +1,36 @@
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(2,12): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(8,12): error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(10,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
-  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(10,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
+  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
     Types of property 'next' are incompatible.
-      Type '(...args: [] | [undefined]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>'.
+      Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [unknown]) => Promise<IteratorResult<number, any>>'.
         Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
           Type 'IteratorResult<string, void>' is not assignable to type 'IteratorResult<number, any>'.
             Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorResult<number, any>'.
               Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorYieldResult<number>'.
                 Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(13,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
-  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(13,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
+  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(16,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
-    Types of property 'next' are incompatible.
-      Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>'.
-        Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(19,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
-  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
-    Types of property '[Symbol.asyncIterator]' are incompatible.
-      Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-        Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
-          Types of property 'next' are incompatible.
-            Type '(...args: [] | [undefined]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>'.
-              Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(22,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
-  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(25,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(19,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
     Types of property '[Symbol.asyncIterator]' are incompatible.
-      Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-        Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+      Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, unknown>'.
+        Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, unknown>'.
           Types of property 'next' are incompatible.
-            Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>'.
+            Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [unknown]) => Promise<IteratorResult<number, any>>'.
               Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(28,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(31,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(34,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(22,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
+  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(25,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
+  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(28,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, unknown>'.
+  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, unknown>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(31,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, unknown>'.
+  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, unknown>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(34,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, unknown>'.
+  Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, unknown>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(38,11): error TS2322: Type '"a"' is not assignable to type 'number'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(41,12): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(44,12): error TS2322: Type 'string' is not assignable to type 'number'.
@@ -49,11 +40,11 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(56,11): error TS2322: Type '"a"' is not assignable to type 'number'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(59,12): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(62,12): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(64,42): error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<number, any, undefined>' but required in type 'IterableIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(64,42): error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<number, any, unknown>' but required in type 'IterableIterator<number>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(67,42): error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<any, any, any>' but required in type 'Iterable<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(70,42): error TS2322: Type 'AsyncGenerator<number, any, undefined>' is not assignable to type 'Iterator<number, any, undefined>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(70,42): error TS2322: Type 'AsyncGenerator<number, any, unknown>' is not assignable to type 'Iterator<number, any, unknown>'.
   Types of property 'next' are incompatible.
-    Type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<number, any>'.
+    Type '(...args: [] | [unknown]) => Promise<IteratorResult<number, any>>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<number, any>'.
       Type 'Promise<IteratorResult<number, any>>' is not assignable to type 'IteratorResult<number, any>'.
         Property 'value' is missing in type 'Promise<IteratorResult<number, any>>' but required in type 'IteratorYieldResult<number>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(74,12): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
@@ -76,10 +67,10 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     }
     const assignability1: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
 !!! error TS2322:     Types of property 'next' are incompatible.
-!!! error TS2322:       Type '(...args: [] | [undefined]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>'.
+!!! error TS2322:       Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [unknown]) => Promise<IteratorResult<number, any>>'.
 !!! error TS2322:         Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
 !!! error TS2322:           Type 'IteratorResult<string, void>' is not assignable to type 'IteratorResult<number, any>'.
 !!! error TS2322:             Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorResult<number, any>'.
@@ -89,65 +80,56 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     };
     const assignability2: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
         yield* ["a", "b"];
     };
     const assignability3: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
 !!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
 !!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterableIterator<number>'.
-!!! error TS2322:     Types of property 'next' are incompatible.
-!!! error TS2322:       Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>'.
-!!! error TS2322:         Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         yield* (async function * () { yield "a"; })();
     };
     const assignability4: () => AsyncIterable<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
 !!! error TS2322:     Types of property '[Symbol.asyncIterator]' are incompatible.
-!!! error TS2322:       Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-!!! error TS2322:         Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+!!! error TS2322:       Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, unknown>'.
+!!! error TS2322:         Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, unknown>'.
 !!! error TS2322:           Types of property 'next' are incompatible.
-!!! error TS2322:             Type '(...args: [] | [undefined]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>'.
+!!! error TS2322:             Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [unknown]) => Promise<IteratorResult<number, any>>'.
 !!! error TS2322:               Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         yield "a";
     };
     const assignability5: () => AsyncIterable<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
         yield* ["a", "b"];
     };
     const assignability6: () => AsyncIterable<number> = async function * () {
           ~~~~~~~~~~~~~~
 !!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
 !!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterable<number>'.
-!!! error TS2322:     Types of property '[Symbol.asyncIterator]' are incompatible.
-!!! error TS2322:       Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-!!! error TS2322:         Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
-!!! error TS2322:           Types of property 'next' are incompatible.
-!!! error TS2322:             Type '(...args: [] | [unknown]) => Promise<IteratorResult<string, void>>' is not assignable to type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>'.
-!!! error TS2322:               Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         yield* (async function * () { yield "a"; })();
     };
     const assignability7: () => AsyncIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, unknown>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, unknown>'.
         yield "a";
     };
     const assignability8: () => AsyncIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, unknown>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, unknown>'.
         yield* ["a", "b"];
     };
     const assignability9: () => AsyncIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, undefined>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterator<number, any, unknown>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, unknown>' is not assignable to type 'AsyncIterator<number, any, unknown>'.
         yield* (async function * () { yield "a"; })();
     };
     async function * explicitReturnType1(): AsyncIterableIterator<number> {
@@ -197,7 +179,7 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     }
     async function * explicitReturnType10(): IterableIterator<number> {
                                              ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<number, any, undefined>' but required in type 'IterableIterator<number>'.
+!!! error TS2741: Property '[Symbol.iterator]' is missing in type 'AsyncGenerator<number, any, unknown>' but required in type 'IterableIterator<number>'.
 !!! related TS2728 /.ts/lib.es2015.iterable.d.ts:55:5: '[Symbol.iterator]' is declared here.
         yield 1;
     }
@@ -209,9 +191,9 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     }
     async function * explicitReturnType12(): Iterator<number> {
                                              ~~~~~~~~~~~~~~~~
-!!! error TS2322: Type 'AsyncGenerator<number, any, undefined>' is not assignable to type 'Iterator<number, any, undefined>'.
+!!! error TS2322: Type 'AsyncGenerator<number, any, unknown>' is not assignable to type 'Iterator<number, any, unknown>'.
 !!! error TS2322:   Types of property 'next' are incompatible.
-!!! error TS2322:     Type '(...args: [] | [undefined]) => Promise<IteratorResult<number, any>>' is not assignable to type '(...args: [] | [undefined]) => IteratorResult<number, any>'.
+!!! error TS2322:     Type '(...args: [] | [unknown]) => Promise<IteratorResult<number, any>>' is not assignable to type '(...args: [] | [unknown]) => IteratorResult<number, any>'.
 !!! error TS2322:       Type 'Promise<IteratorResult<number, any>>' is not assignable to type 'IteratorResult<number, any>'.
 !!! error TS2322:         Property 'value' is missing in type 'Promise<IteratorResult<number, any>>' but required in type 'IteratorYieldResult<number>'.
 !!! related TS2728 /.ts/lib.es2015.iterable.d.ts:33:5: 'value' is declared here.

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.types
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.types
@@ -29,16 +29,16 @@ async function * inferReturnType3() {
 }
 const assignability1: () => AsyncIterableIterator<number> = async function * () {
 >assignability1 : () => AsyncIterableIterator<number>
->async function * () {    yield "a";} : () => AsyncGenerator<string, void, undefined>
+>async function * () {    yield "a";} : () => AsyncGenerator<string, void, unknown>
 
     yield "a";
->yield "a" : undefined
+>yield "a" : unknown
 >"a" : "a"
 
 };
 const assignability2: () => AsyncIterableIterator<number> = async function * () {
 >assignability2 : () => AsyncIterableIterator<number>
->async function * () {    yield* ["a", "b"];} : () => AsyncGenerator<string, void, undefined>
+>async function * () {    yield* ["a", "b"];} : () => AsyncGenerator<string, void, unknown>
 
     yield* ["a", "b"];
 >yield* ["a", "b"] : any
@@ -62,16 +62,16 @@ const assignability3: () => AsyncIterableIterator<number> = async function * () 
 };
 const assignability4: () => AsyncIterable<number> = async function * () {
 >assignability4 : () => AsyncIterable<number>
->async function * () {    yield "a";} : () => AsyncGenerator<string, void, undefined>
+>async function * () {    yield "a";} : () => AsyncGenerator<string, void, unknown>
 
     yield "a";
->yield "a" : undefined
+>yield "a" : unknown
 >"a" : "a"
 
 };
 const assignability5: () => AsyncIterable<number> = async function * () {
 >assignability5 : () => AsyncIterable<number>
->async function * () {    yield* ["a", "b"];} : () => AsyncGenerator<string, void, undefined>
+>async function * () {    yield* ["a", "b"];} : () => AsyncGenerator<string, void, unknown>
 
     yield* ["a", "b"];
 >yield* ["a", "b"] : any
@@ -94,17 +94,17 @@ const assignability6: () => AsyncIterable<number> = async function * () {
 
 };
 const assignability7: () => AsyncIterator<number> = async function * () {
->assignability7 : () => AsyncIterator<number, any, undefined>
->async function * () {    yield "a";} : () => AsyncGenerator<string, void, undefined>
+>assignability7 : () => AsyncIterator<number, any, unknown>
+>async function * () {    yield "a";} : () => AsyncGenerator<string, void, unknown>
 
     yield "a";
->yield "a" : undefined
+>yield "a" : unknown
 >"a" : "a"
 
 };
 const assignability8: () => AsyncIterator<number> = async function * () {
->assignability8 : () => AsyncIterator<number, any, undefined>
->async function * () {    yield* ["a", "b"];} : () => AsyncGenerator<string, void, undefined>
+>assignability8 : () => AsyncIterator<number, any, unknown>
+>async function * () {    yield* ["a", "b"];} : () => AsyncGenerator<string, void, unknown>
 
     yield* ["a", "b"];
 >yield* ["a", "b"] : any
@@ -114,7 +114,7 @@ const assignability8: () => AsyncIterator<number> = async function * () {
 
 };
 const assignability9: () => AsyncIterator<number> = async function * () {
->assignability9 : () => AsyncIterator<number, any, undefined>
+>assignability9 : () => AsyncIterator<number, any, unknown>
 >async function * () {    yield* (async function * () { yield "a"; })();} : () => AsyncGenerator<string, void, unknown>
 
     yield* (async function * () { yield "a"; })();
@@ -130,7 +130,7 @@ async function * explicitReturnType1(): AsyncIterableIterator<number> {
 >explicitReturnType1 : () => AsyncIterableIterator<number>
 
     yield "a";
->yield "a" : undefined
+>yield "a" : unknown
 >"a" : "a"
 }
 async function * explicitReturnType2(): AsyncIterableIterator<number> {
@@ -157,7 +157,7 @@ async function * explicitReturnType4(): AsyncIterable<number> {
 >explicitReturnType4 : () => AsyncIterable<number>
 
     yield "a";
->yield "a" : undefined
+>yield "a" : unknown
 >"a" : "a"
 }
 async function * explicitReturnType5(): AsyncIterable<number> {
@@ -181,14 +181,14 @@ async function * explicitReturnType6(): AsyncIterable<number> {
 >"a" : "a"
 }
 async function * explicitReturnType7(): AsyncIterator<number> {
->explicitReturnType7 : () => AsyncIterator<number, any, undefined>
+>explicitReturnType7 : () => AsyncIterator<number, any, unknown>
 
     yield "a";
->yield "a" : undefined
+>yield "a" : unknown
 >"a" : "a"
 }
 async function * explicitReturnType8(): AsyncIterator<number> {
->explicitReturnType8 : () => AsyncIterator<number, any, undefined>
+>explicitReturnType8 : () => AsyncIterator<number, any, unknown>
 
     yield* ["a", "b"];
 >yield* ["a", "b"] : any
@@ -197,7 +197,7 @@ async function * explicitReturnType8(): AsyncIterator<number> {
 >"b" : "b"
 }
 async function * explicitReturnType9(): AsyncIterator<number> {
->explicitReturnType9 : () => AsyncIterator<number, any, undefined>
+>explicitReturnType9 : () => AsyncIterator<number, any, unknown>
 
     yield* (async function * () { yield "a"; })();
 >yield* (async function * () { yield "a"; })() : void
@@ -211,7 +211,7 @@ async function * explicitReturnType10(): IterableIterator<number> {
 >explicitReturnType10 : () => IterableIterator<number>
 
     yield 1;
->yield 1 : undefined
+>yield 1 : unknown
 >1 : 1
 }
 async function * explicitReturnType11(): Iterable<number> {
@@ -222,10 +222,10 @@ async function * explicitReturnType11(): Iterable<number> {
 >1 : 1
 }
 async function * explicitReturnType12(): Iterator<number> {
->explicitReturnType12 : () => Iterator<number, any, undefined>
+>explicitReturnType12 : () => Iterator<number, any, unknown>
 
     yield 1;
->yield 1 : undefined
+>yield 1 : unknown
 >1 : 1
 }
 async function * yieldStar() {

--- a/tests/baselines/reference/uniqueSymbols.types
+++ b/tests/baselines/reference/uniqueSymbols.types
@@ -131,7 +131,7 @@ function* genFuncYieldVarCall() { yield varCall; }
 function* genFuncYieldConstCallWithTypeQuery(): IterableIterator<typeof constCall> { yield constCall; }
 >genFuncYieldConstCallWithTypeQuery : () => IterableIterator<unique symbol>
 >constCall : unique symbol
->yield constCall : undefined
+>yield constCall : unknown
 >constCall : unique symbol
 
 // async function return inference
@@ -819,7 +819,7 @@ interface Context {
 
 const o3: Context = {
 >o3 : Context
->{    method1() {        return s; // return type should not widen due to contextual type    },    async method2() {        return s; // return type should not widen due to contextual type    },    async * method3() {        yield s; // yield type should not widen due to contextual type    },    * method4() {        yield s; // yield type should not widen due to contextual type    },    method5(p = s) { // parameter should not widen due to contextual type        return p;    },} : { method1(): unique symbol; method2(): Promise<unique symbol>; method3(): AsyncGenerator<unique symbol, void, undefined>; method4(): Generator<unique symbol, void, undefined>; method5(p?: unique symbol): unique symbol; }
+>{    method1() {        return s; // return type should not widen due to contextual type    },    async method2() {        return s; // return type should not widen due to contextual type    },    async * method3() {        yield s; // yield type should not widen due to contextual type    },    * method4() {        yield s; // yield type should not widen due to contextual type    },    method5(p = s) { // parameter should not widen due to contextual type        return p;    },} : { method1(): unique symbol; method2(): Promise<unique symbol>; method3(): AsyncGenerator<unique symbol, void, unknown>; method4(): Generator<unique symbol, void, unknown>; method5(p?: unique symbol): unique symbol; }
 
     method1() {
 >method1 : () => unique symbol
@@ -836,18 +836,18 @@ const o3: Context = {
 
     },
     async * method3() {
->method3 : () => AsyncGenerator<unique symbol, void, undefined>
+>method3 : () => AsyncGenerator<unique symbol, void, unknown>
 
         yield s; // yield type should not widen due to contextual type
->yield s : undefined
+>yield s : unknown
 >s : unique symbol
 
     },
     * method4() {
->method4 : () => Generator<unique symbol, void, undefined>
+>method4 : () => Generator<unique symbol, void, unknown>
 
         yield s; // yield type should not widen due to contextual type
->yield s : undefined
+>yield s : unknown
 >s : unique symbol
 
     },

--- a/tests/baselines/reference/yieldExpression1.types
+++ b/tests/baselines/reference/yieldExpression1.types
@@ -14,10 +14,10 @@ function* b(): IterableIterator<number> {
 >b : () => IterableIterator<number>
 
     yield;
->yield : undefined
+>yield : unknown
 
     yield 0;
->yield 0 : undefined
+>yield 0 : unknown
 >0 : 0
 }
 

--- a/tests/baselines/reference/yieldExpressionInnerCommentEmit.types
+++ b/tests/baselines/reference/yieldExpressionInnerCommentEmit.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/yieldExpressionInnerCommentEmit.ts ===
 function * foo2() {
->foo2 : () => Generator<number, void, undefined>
+>foo2 : () => Generator<number, void, unknown>
 
     /*comment1*/ yield 1;
 >yield 1 : any

--- a/tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts
+++ b/tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts
@@ -4,7 +4,6 @@
 // @strict: true
 
 // Do not allow generators to fallback to IterableIterator while in strictNullChecks mode if they need a type for the sent value.
-// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
 function* f() {
     const x: string = yield 1;
 }

--- a/tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts
+++ b/tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts
@@ -3,8 +3,7 @@
 // @noemit: true
 // @strict: false
 
-// Allow generators to fallback to IterableIterator if they are not in strictNullChecks mode
-// NOTE: In non-strictNullChecks mode, `undefined` (the default sent value) is assignable to everything.
+// Do not allow generators to fallback to IterableIterator if they need a type for the sent value while not in strictNullChecks mode.
 function* f() {
     const x: string = yield 1;
 }


### PR DESCRIPTION
Changes the default for `TNext` in `Iterator` and `AsyncIterator` to better support `yield*` delegation to iterables in a generator/async generator.

Fixes #33458
