### PR TITLE
Enable caching for control flow paths that precede loops

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17099,7 +17099,7 @@ namespace ts {
                 }
             }
 
-            function getInitialOrAssignedType(flow: FlowAssignment, reference: Node) {
+            function getInitialOrAssignedType(flow: FlowAssignment) {
                 const node = flow.node;
                 if (flow.flags & FlowFlags.Cached) {
                     const cached = flowAssignmentTypes[getNodeId(node)];
@@ -17133,11 +17133,11 @@ namespace ts {
                         if (isEmptyArrayAssignment(node)) {
                             return getEvolvingArrayType(neverType);
                         }
-                        const assignedType = getBaseTypeOfLiteralType(getInitialOrAssignedType(flow, reference));
+                        const assignedType = getBaseTypeOfLiteralType(getInitialOrAssignedType(flow));
                         return isTypeAssignableTo(assignedType, declaredType) ? assignedType : anyArrayType;
                     }
                     if (declaredType.flags & TypeFlags.Union) {
-                        return getAssignmentReducedType(<UnionType>declaredType, getInitialOrAssignedType(flow, reference));
+                        return getAssignmentReducedType(<UnionType>declaredType, getInitialOrAssignedType(flow));
                     }
                     return declaredType;
                 }


### PR DESCRIPTION
This PR tweaks our control flow analysis logic for loops to ensure that caching of assignment nodes occurs in control flow paths that precede loops.