### PR TITLE
Improve the Omit helper type

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1443,10 +1443,17 @@ type Exclude<T, U> = T extends U ? never : T;
  */
 type Extract<T, U> = T extends U ? T : never;
 
+type KnownKeys<T> = {
+    [K in keyof T]: string extends K ? never : number extends K ? never : K
+} extends { [_ in keyof T]: infer U } ? ({} extends U ? never : U) : never;
+type OmitFromKnownKeys<T, K extends keyof T> = KnownKeys<T> extends infer U ?
+    [U] extends [keyof T] ? Pick<T, Exclude<U, K>> : never : never;
 /**
  * Construct a type with the properties of T except for those in type K.
  */
-type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type Omit<T, K extends keyof T> = OmitFromKnownKeys<T, K>
+    & (string extends K ? {} : (string extends keyof T ? { [n: string]: T[Exclude<keyof T, number>]} : {}))
+    & (number extends K ? {} : (number extends keyof T ? { [n: number]: T[Exclude<keyof T, string>]} : {}));
 
 /**
  * Exclude null and undefined from T


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #31153
Since `Omit` is the offical helper type now, I think it should be a perfect version. The common version not work with type like `{ a: string, b: number, [key: string]: any, }`, this version works. The detail see #31153