### PR TITLE
When a packed version of TypeScript is requested, request a build of Monaco

### DIFF
--- a/scripts/post-vsts-artifact-comment.js
+++ b/scripts/post-vsts-artifact-comment.js
@@ -28,6 +28,10 @@ async function main() {
         type: "token",
         token: process.argv[2]
     });
+
+    // Please keep the strings "an installable tgz" and "packed" in this message, as well as the devDependencies section,
+    // so that the playgrounds deployment process can find these comments.
+
     await gh.issues.createComment({
         number: +process.env.SOURCE_ISSUE,
         owner: "Microsoft",
@@ -43,6 +47,9 @@ async function main() {
 and then running \`npm install\`.
 `
     });
+
+    // Send a ping to https://github.com/orta/make-monaco-builds#pull-request-builds
+    await gh.request("POST /repos/orta/make-monaco-builds/dispatches", { event_type: +process.env.SOURCE_ISSUE })
 }
 
 main().catch(async e => {


### PR DESCRIPTION
This adds a hook to trigger the generation of a build of Monaco-typescript and Monaco-editor from the pack comment inside the TS repo. 

Here's an [example build](https://github.com/orta/make-monaco-builds/commit/b86c1ada200443a615e12d7df74cdbcf1bc39de9/checks) which I triggered pretending it was coming from https://github.com/microsoft/TypeScript/pull/33290 

All the deploy work is explained in https://github.com/orta/make-monaco-builds/