### PR TITLE
Add prefix/suffix only to binding element name

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -365,7 +365,7 @@ namespace ts.FindAllReferences {
             const { node, kind } = entry;
             const name = originalNode.text;
             const isShorthandAssignment = isShorthandPropertyAssignment(node.parent);
-            if (isShorthandAssignment || isObjectBindingElementWithoutPropertyName(node.parent)) {
+            if (isShorthandAssignment || isObjectBindingElementWithoutPropertyName(node.parent) && node.parent.name === node) {
                 const prefixColon: PrefixAndSuffix = { prefixText: name + ": " };
                 const suffixColon: PrefixAndSuffix = { suffixText: ": " + name };
                 return kind === EntryKind.SearchedLocalFoundProperty ? prefixColon

--- a/tests/cases/fourslash/renameBindingElementInitializerExternal.ts
+++ b/tests/cases/fourslash/renameBindingElementInitializerExternal.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts"/>
+
+////[|const [|{| "contextRangeIndex": 0 |}external|] = true;|]
+////
+////function f({
+////    lvl1 = [|external|],
+////    nested: { lvl2 = [|external|]},
+////    oldName: newName = [|external|]
+////}) {}
+////
+////const {
+////    lvl1 = [|external|],
+////    nested: { lvl2 = [|external|]},
+////    oldName: newName = [|external|]
+////} = obj;
+
+verify.rangesWithSameTextAreRenameLocations("external");

--- a/tests/cases/fourslash/renameBindingElementInitializerProperty.ts
+++ b/tests/cases/fourslash/renameBindingElementInitializerProperty.ts
@@ -1,0 +1,20 @@
+/// <reference path="fourslash.ts"/>
+
+////function f([|{[|{| "contextRangeIndex": 0 |}required|], optional = [|required|]}: {[|[|{| "contextRangeIndex": 3 |}required|]: number,|] optional?: number}|]) {
+////    console.log("required", [|required|]);
+////    console.log("optional", optional);
+////}
+////
+////f({[|[|{| "contextRangeIndex": 6 |}required|]: 10|]});
+
+const [r0Def, r0, r1, r2Def, r2, r3, r4Def, r4] = test.ranges();
+verify.renameLocations([r0, r1, r3], [
+    { range: r0, prefixText: "required: " },
+    { range: r1},
+    { range: r3}
+]);
+verify.renameLocations([r2, r4], [
+    { range: r0, suffixText: ": required" },
+    { range: r2},
+    { range: r4}
+]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #33518

This PR ensures that prefix or suffix will be added only to `name` of `BindingElement` and not to `initializer`.