### PR TITLE
fix: add this type for Reflect.defineProperty

### DIFF
--- a/lib/lib.es2015.reflect.d.ts
+++ b/lib/lib.es2015.reflect.d.ts
@@ -21,7 +21,7 @@ and limitations under the License.
 declare namespace Reflect {
     function apply(target: Function, thisArgument: any, argumentsList: ArrayLike<any>): any;
     function construct(target: Function, argumentsList: ArrayLike<any>, newTarget?: any): any;
-    function defineProperty(target: object, propertyKey: PropertyKey, attributes: PropertyDescriptor): boolean;
+    function defineProperty(target: object, propertyKey: PropertyKey, attributes: PropertyDescriptor & ThisType<any>): boolean;
     function deleteProperty(target: object, propertyKey: PropertyKey): boolean;
     function get(target: object, propertyKey: PropertyKey, receiver?: any): any;
     function getOwnPropertyDescriptor(target: object, propertyKey: PropertyKey): PropertyDescriptor | undefined;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

# Example

```ts
var A: {a?: number, b: number} = {b:2}
Reflect.defineProperty(A, 'a', {
  // set(this: any, value: any) { // to fix
  set(value: any) {
    console.log(this.b); // Property 'b' does not exist on type 'PropertyDescriptor'.
  },
  enumerable: true,
  configurable: true
});
A.a = 1;
```

Fixes 
https://github.com/microsoft/TypeScript/issues/33542