### PR TITLE
fix(docs): sort's compareFn is a function

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -1255,7 +1255,7 @@ interface Array<T> {
     slice(start?: number, end?: number): T[];
     /**
       * Sorts an array.
-      * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
+      * @param compareFn A function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
       */
     sort(compareFn?: (a: T, b: T) => number): this;
     /**


### PR DESCRIPTION
The compareFn parameter of Array.prototype.sort is actually a function definition and not "_the name of a function_", as the documentation described.

This is only a internal documentation clarification and, for that reason, I've not opened an issue.
