### PR TITLE
Fix compiler error when running with the new LKG

### DIFF
--- a/src/testRunner/parallel/worker.ts
+++ b/src/testRunner/parallel/worker.ts
@@ -305,7 +305,7 @@ namespace Harness.Parallel.Worker {
         // (Unit) Tests directly within the root suite
         let unitTestTestMap: ts.Map<Mocha.Test>;
 
-        if (runUnitTests) {
+        if (runUnitTests!) {
             unitTestSuite = new Suite("", new Mocha.Context());
             unitTestSuite.timeout(globalTimeout || 40_000);
             shimTestInterface(unitTestSuite, global);


### PR DESCRIPTION
We can't run `pack this` until the LKG passes as green,  this is one half of that. 

The other which I can't change is to update the baselines for the tsserverlibrary.d.ts:

```diff
@ tests/baselines/reference/api/tsserverlibrary.d.ts:8525 @ declare namespace ts.server {
        static resolveModule(moduleName: string, initialDir: string, host: ServerHost, log: (message: string) => void, logErrors?: (message: string) => void): {} | undefined;
        isKnownTypesPackageName(name: string): boolean;
        installPackage(options: InstallPackageOptions): Promise<ApplyCodeActionCommandResult>;
-        private readonly typingsCache;
+        private get typingsCache();
        getCompilationSettings(): CompilerOptions;
        getCompilerOptions(): CompilerOptions;
```

Which can't pass on both the current LKG, and a potential update to the LKG. 