### PR TITLE
Fix issue when types installed after watch/editor is opened for auto type reference that is for global types not being detected

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -545,6 +545,9 @@ namespace ts {
         return resolutions;
     }
 
+    /* @internal */
+    export const inferredTypesContainingFile = "__inferred type names__.ts";
+
     interface DiagnosticCache<T extends Diagnostic> {
         perFile?: Map<T[]>;
         allDiagnostics?: Diagnostic[];
@@ -875,7 +878,7 @@ namespace ts {
             if (typeReferences.length) {
                 // This containingFilename needs to match with the one used in managed-side
                 const containingDirectory = options.configFilePath ? getDirectoryPath(options.configFilePath) : host.getCurrentDirectory();
-                const containingFilename = combinePaths(containingDirectory, "__inferred type names__.ts");
+                const containingFilename = combinePaths(containingDirectory, inferredTypesContainingFile);
                 const resolutions = resolveTypeReferenceDirectiveNamesWorker(typeReferences, containingFilename);
                 for (let i = 0; i < typeReferences.length; i++) {
                     processTypeReferenceDirective(typeReferences[i], resolutions[i]);

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -669,6 +669,11 @@ namespace ts {
                         // Mark the file as needing re-evaluation of module resolution instead of using it blindly.
                         resolution.isInvalidated = true;
                         (filesWithInvalidatedResolutions || (filesWithInvalidatedResolutions = createMap<true>())).set(containingFilePath, true);
+
+                        // When its a file with inferred types resolution, invalidate type reference directive resolution
+                        if (containingFilePath.endsWith(inferredTypesContainingFile)) {
+                            resolutionHost.onChangedAutomaticTypeDirectiveNames();
+                        }
                     }
                 });
             });


### PR DESCRIPTION
When the code doesn't have any other resolution, if auto type references are not invalidated program will think its upto date since file versions have not change (there is no module resolution from files included by program that failed or changed). So setting the changed auto type reference included being change when the file is not a program file but a inferredTypes file, will handle the situation.
Fixes #32285
