### PR TITLE
Don't shadow `runUnitTests`

### DIFF
--- a/src/testRunner/parallel/worker.ts
+++ b/src/testRunner/parallel/worker.ts
@@ -137,14 +137,14 @@ namespace Harness.Parallel.Worker {
          */
         function runTests(task: Task, fn: (payload: TaskResult) => void) {
             if (task.runner === "unittest") {
-                return runUnitTests(task, fn);
+                return executeUnitTests(task, fn);
             }
             else {
                 return runFileTests(task, fn);
             }
         }
 
-        function runUnitTests(task: UnitTestTask, fn: (payload: TaskResult) => void) {
+        function executeUnitTests(task: UnitTestTask, fn: (payload: TaskResult) => void) {
             if (!unitTestSuiteMap && unitTestSuite.suites.length) {
                 unitTestSuiteMap = ts.createMap<Mocha.Suite>();
                 for (const suite of unitTestSuite.suites) {


### PR DESCRIPTION
Elsewhere in the same scope as this declaration we were saying
```ts
if (runUnitTests) {
```
while trying to refer to the *outer global* `runUnitTests`, not the always-truthy local declaration. This caused the unit tests to be unconditionally run on each worker thread 😭.

Caught by #33178 cc @jwbay !