### PR TITLE
Improve error message when reserved word is used as identifier

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1043,6 +1043,10 @@
         "category": "Error",
         "code": 1358
     },
+    "Identifier expected. '{0}' is a reserved word that cannot be used here.": {
+        "category": "Error",
+        "code": 1359
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1401,7 +1401,14 @@ namespace ts {
             // Only for end of file because the error gets reported incorrectly on embedded script tags.
             const reportAtCurrentPosition = token() === SyntaxKind.EndOfFileToken;
 
-            return createMissingNode<Identifier>(SyntaxKind.Identifier, reportAtCurrentPosition, diagnosticMessage || Diagnostics.Identifier_expected);
+            const isReservedWord = scanner.isReservedWord();
+            const msgArg = scanner.getTokenText();
+
+            const defaultMessage = isReservedWord ?
+                Diagnostics.Identifier_expected_0_is_a_reserved_word_that_cannot_be_used_here :
+                Diagnostics.Identifier_expected;
+
+            return createMissingNode<Identifier>(SyntaxKind.Identifier, reportAtCurrentPosition, diagnosticMessage || defaultMessage, msgArg);
         }
 
         function parseIdentifier(diagnosticMessage?: DiagnosticMessage): Identifier {

--- a/tests/baselines/reference/aliasErrors.errors.txt
+++ b/tests/baselines/reference/aliasErrors.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/aliasErrors.ts(11,12): error TS2503: Cannot find namespace 
 tests/cases/compiler/aliasErrors.ts(12,13): error TS2503: Cannot find namespace 'no'.
 tests/cases/compiler/aliasErrors.ts(13,12): error TS1003: Identifier expected.
 tests/cases/compiler/aliasErrors.ts(14,12): error TS1003: Identifier expected.
-tests/cases/compiler/aliasErrors.ts(15,12): error TS1003: Identifier expected.
+tests/cases/compiler/aliasErrors.ts(15,12): error TS1359: Identifier expected. 'null' is a reserved word that cannot be used here.
 tests/cases/compiler/aliasErrors.ts(16,12): error TS2503: Cannot find namespace 'undefined'.
 tests/cases/compiler/aliasErrors.ts(26,15): error TS2694: Namespace 'foo.bar.baz' has no exported member 'bar'.
 
@@ -32,7 +32,7 @@ tests/cases/compiler/aliasErrors.ts(26,15): error TS2694: Namespace 'foo.bar.baz
 !!! error TS1003: Identifier expected.
     import q = null;
                ~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'null' is a reserved word that cannot be used here.
     import r = undefined;
                ~~~~~~~~~
 !!! error TS2503: Cannot find namespace 'undefined'.

--- a/tests/baselines/reference/decoratorOnClassMethodThisParameter.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethodThisParameter.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(4,17): error TS1003: Identifier expected.
+tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(4,17): error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
 tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodThisParameter.ts(4,17): error TS2680: A 'this' parameter must be the first parameter.
 
 
@@ -8,7 +8,7 @@ tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethod
     class C {
         method(@dec this: C) {}
                     ~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
                     ~~~~~~~
 !!! error TS2680: A 'this' parameter must be the first parameter.
     }

--- a/tests/baselines/reference/destructuringParameterDeclaration6.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration6.errors.txt
@@ -8,7 +8,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration6.ts(
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration6.ts(9,26): error TS2304: Cannot find name 'public'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration6.ts(9,32): error TS1005: ';' expected.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration6.ts(9,33): error TS1128: Declaration or statement expected.
-tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration6.ts(10,16): error TS1003: Identifier expected.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration6.ts(10,16): error TS1359: Identifier expected. 'while' is a reserved word that cannot be used here.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration6.ts(10,21): error TS1005: '(' expected.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration6.ts(12,13): error TS2370: A rest parameter must be of an array type.
 
@@ -45,7 +45,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration6.ts(
 !!! error TS1128: Declaration or statement expected.
     function a5(...while) { }
                    ~~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'while' is a reserved word that cannot be used here.
                         ~
 !!! error TS1005: '(' expected.
     function a6(...public) { }

--- a/tests/baselines/reference/objectBindingPatternKeywordIdentifiers02.errors.txt
+++ b/tests/baselines/reference/objectBindingPatternKeywordIdentifiers02.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers02.ts(1,14): error TS1003: Identifier expected.
+tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers02.ts(1,14): error TS1359: Identifier expected. 'while' is a reserved word that cannot be used here.
 tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers02.ts(1,20): error TS1005: ':' expected.
 
 
 ==== tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers02.ts (2 errors) ====
     var { while: while } = { while: 1 }
                  ~~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'while' is a reserved word that cannot be used here.
                        ~
 !!! error TS1005: ':' expected.

--- a/tests/baselines/reference/objectBindingPatternKeywordIdentifiers04.errors.txt
+++ b/tests/baselines/reference/objectBindingPatternKeywordIdentifiers04.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers04.ts(1,16): error TS1003: Identifier expected.
+tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers04.ts(1,16): error TS1359: Identifier expected. 'while' is a reserved word that cannot be used here.
 tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers04.ts(1,22): error TS1005: ':' expected.
 
 
 ==== tests/cases/conformance/es6/destructuring/objectBindingPatternKeywordIdentifiers04.ts (2 errors) ====
     var { "while": while } = { while: 1 }
                    ~~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'while' is a reserved word that cannot be used here.
                          ~
 !!! error TS1005: ':' expected.

--- a/tests/baselines/reference/parserEnumDeclaration4.errors.txt
+++ b/tests/baselines/reference/parserEnumDeclaration4.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration4.ts(1,6): error TS1003: Identifier expected.
+tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration4.ts(1,6): error TS1359: Identifier expected. 'void' is a reserved word that cannot be used here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration4.ts (1 errors) ====
     enum void {
          ~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'void' is a reserved word that cannot be used here.
     }

--- a/tests/baselines/reference/reservedWords2.errors.txt
+++ b/tests/baselines/reference/reservedWords2.errors.txt
@@ -4,7 +4,7 @@ tests/cases/compiler/reservedWords2.ts(1,16): error TS2580: Cannot find name 're
 tests/cases/compiler/reservedWords2.ts(1,31): error TS1005: ')' expected.
 tests/cases/compiler/reservedWords2.ts(2,12): error TS2300: Duplicate identifier '(Missing)'.
 tests/cases/compiler/reservedWords2.ts(2,12): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
-tests/cases/compiler/reservedWords2.ts(2,14): error TS1003: Identifier expected.
+tests/cases/compiler/reservedWords2.ts(2,14): error TS1359: Identifier expected. 'while' is a reserved word that cannot be used here.
 tests/cases/compiler/reservedWords2.ts(2,20): error TS1005: '(' expected.
 tests/cases/compiler/reservedWords2.ts(2,20): error TS2304: Cannot find name 'from'.
 tests/cases/compiler/reservedWords2.ts(2,25): error TS1005: ')' expected.
@@ -12,7 +12,7 @@ tests/cases/compiler/reservedWords2.ts(4,5): error TS1134: Variable declaration 
 tests/cases/compiler/reservedWords2.ts(4,12): error TS1109: Expression expected.
 tests/cases/compiler/reservedWords2.ts(5,9): error TS2300: Duplicate identifier '(Missing)'.
 tests/cases/compiler/reservedWords2.ts(5,9): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
-tests/cases/compiler/reservedWords2.ts(5,10): error TS1003: Identifier expected.
+tests/cases/compiler/reservedWords2.ts(5,10): error TS1359: Identifier expected. 'throw' is a reserved word that cannot be used here.
 tests/cases/compiler/reservedWords2.ts(5,18): error TS1005: '=>' expected.
 tests/cases/compiler/reservedWords2.ts(6,1): error TS2580: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i @types/node`.
 tests/cases/compiler/reservedWords2.ts(6,8): error TS1005: ';' expected.
@@ -29,10 +29,13 @@ tests/cases/compiler/reservedWords2.ts(9,14): error TS1005: ';' expected.
 tests/cases/compiler/reservedWords2.ts(9,18): error TS1005: '(' expected.
 tests/cases/compiler/reservedWords2.ts(9,20): error TS1128: Declaration or statement expected.
 tests/cases/compiler/reservedWords2.ts(10,5): error TS2567: Enum declarations can only merge with namespace or other enum declarations.
-tests/cases/compiler/reservedWords2.ts(10,6): error TS1003: Identifier expected.
+tests/cases/compiler/reservedWords2.ts(10,6): error TS1359: Identifier expected. 'void' is a reserved word that cannot be used here.
+tests/cases/compiler/reservedWords2.ts(11,12): error TS1359: Identifier expected. 'default' is a reserved word that cannot be used here.
+tests/cases/compiler/reservedWords2.ts(12,13): error TS1359: Identifier expected. 'null' is a reserved word that cannot be used here.
+tests/cases/compiler/reservedWords2.ts(12,17): error TS1138: Parameter declaration expected.
 
 
-==== tests/cases/compiler/reservedWords2.ts (32 errors) ====
+==== tests/cases/compiler/reservedWords2.ts (35 errors) ====
     import while = require("dfdf");
            ~~~~~
 !!! error TS1109: Expression expected.
@@ -48,7 +51,7 @@ tests/cases/compiler/reservedWords2.ts(10,6): error TS1003: Identifier expected.
                
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
                  ~~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'while' is a reserved word that cannot be used here.
                        ~~~~
 !!! error TS1005: '(' expected.
                        ~~~~
@@ -67,7 +70,7 @@ tests/cases/compiler/reservedWords2.ts(10,6): error TS1003: Identifier expected.
             
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
              ~~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'throw' is a reserved word that cannot be used here.
                      ~
 !!! error TS1005: '=>' expected.
     module void {}
@@ -106,7 +109,14 @@ tests/cases/compiler/reservedWords2.ts(10,6): error TS1003: Identifier expected.
         
 !!! error TS2567: Enum declarations can only merge with namespace or other enum declarations.
          ~~~~
-!!! error TS1003: Identifier expected.
-    
+!!! error TS1359: Identifier expected. 'void' is a reserved word that cannot be used here.
+    function f(default: number) {}
+               ~~~~~~~
+!!! error TS1359: Identifier expected. 'default' is a reserved word that cannot be used here.
+    class C { m(null: string) {} }
+                ~~~~
+!!! error TS1359: Identifier expected. 'null' is a reserved word that cannot be used here.
+                    ~
+!!! error TS1138: Parameter declaration expected.
     
     

--- a/tests/baselines/reference/reservedWords2.js
+++ b/tests/baselines/reference/reservedWords2.js
@@ -9,7 +9,8 @@ var {while, return} = { while: 1, return: 2 };
 var {this, switch: { continue} } = { this: 1, switch: { continue: 2 }};
 var [debugger, if] = [1, 2];
 enum void {}
-
+function f(default: number) {}
+class C { m(null: string) {} }
 
 
 
@@ -38,3 +39,10 @@ if ()
 (function () {
 })( || ( = {}));
 void {};
+function f() { }
+var C = /** @class */ (function () {
+    function C() {
+    }
+    C.prototype.m = function (, string) { };
+    return C;
+}());

--- a/tests/baselines/reference/reservedWords2.symbols
+++ b/tests/baselines/reference/reservedWords2.symbols
@@ -30,5 +30,14 @@ var [debugger, if] = [1, 2];
 enum void {}
 > : Symbol((Missing), Decl(reservedWords2.ts, 8, 28))
 
+function f(default: number) {}
+>f : Symbol(f, Decl(reservedWords2.ts, 9, 12))
+> : Symbol((Missing), Decl(reservedWords2.ts, 10, 11))
+
+class C { m(null: string) {} }
+>C : Symbol(C, Decl(reservedWords2.ts, 10, 30))
+>m : Symbol(C.m, Decl(reservedWords2.ts, 11, 9))
+> : Symbol((Missing), Decl(reservedWords2.ts, 11, 12))
+>string : Symbol(string, Decl(reservedWords2.ts, 11, 17))
 
 

--- a/tests/baselines/reference/reservedWords2.types
+++ b/tests/baselines/reference/reservedWords2.types
@@ -64,5 +64,14 @@ enum void {}
 >void {} : undefined
 >{} : {}
 
+function f(default: number) {}
+>f : (: number) => void
+> : number
+
+class C { m(null: string) {} }
+>C : C
+>m : (: any, string: any) => void
+> : any
+>string : any
 
 

--- a/tests/baselines/reference/thisTypeInFunctionsNegative.errors.txt
+++ b/tests/baselines/reference/thisTypeInFunctionsNegative.errors.txt
@@ -74,15 +74,15 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(158,17): e
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(162,9): error TS2681: A constructor cannot have a 'this' parameter.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(164,31): error TS2681: A constructor cannot have a 'this' parameter.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(165,30): error TS2680: A 'this' parameter must be the first parameter.
-tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(168,26): error TS1003: Identifier expected.
+tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(168,26): error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(168,26): error TS2680: A 'this' parameter must be the first parameter.
-tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(169,23): error TS1003: Identifier expected.
+tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(169,23): error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(169,23): error TS2680: A 'this' parameter must be the first parameter.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(170,23): error TS1005: ',' expected.
-tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(171,28): error TS1003: Identifier expected.
+tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(171,28): error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(171,28): error TS2680: A 'this' parameter must be the first parameter.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,30): error TS1005: ',' expected.
-tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,32): error TS1003: Identifier expected.
+tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,32): error TS1359: Identifier expected. 'new' is a reserved word that cannot be used here.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,37): error TS1005: ',' expected.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,38): error TS1109: Expression expected.
 tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(172,39): error TS1005: ';' expected.
@@ -395,12 +395,12 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(178,22): e
     ///// parse errors /////
     function modifiers(async this: C): number { return this.n; }
                              ~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
                              ~~~~~~~
 !!! error TS2680: A 'this' parameter must be the first parameter.
     function restParam(...this: C): number { return this.n; }
                           ~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
                           ~~~~~~~
 !!! error TS2680: A 'this' parameter must be the first parameter.
     function optional(this?: C): number { return this.n; }
@@ -408,14 +408,14 @@ tests/cases/conformance/types/thisType/thisTypeInFunctionsNegative.ts(178,22): e
 !!! error TS1005: ',' expected.
     function decorated(@deco() this: C): number { return this.n; }
                                ~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'this' is a reserved word that cannot be used here.
                                ~~~~~~~
 !!! error TS2680: A 'this' parameter must be the first parameter.
     function initializer(this: C = new C()): number { return this.n; }
                                  ~
 !!! error TS1005: ',' expected.
                                    ~~~
-!!! error TS1003: Identifier expected.
+!!! error TS1359: Identifier expected. 'new' is a reserved word that cannot be used here.
                                         ~
 !!! error TS1005: ',' expected.
                                          ~

--- a/tests/cases/compiler/reservedWords2.ts
+++ b/tests/cases/compiler/reservedWords2.ts
@@ -8,5 +8,6 @@ var {while, return} = { while: 1, return: 2 };
 var {this, switch: { continue} } = { this: 1, switch: { continue: 2 }};
 var [debugger, if] = [1, 2];
 enum void {}
-
+function f(default: number) {}
+class C { m(null: string) {} }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
*Issue number of the reported bug or feature request: #16934*

**Describe your changes**
Changed the messages shown when a reserved keyword is used as an identifier from "Identifier expected" to "Identifier expected. '<keyword>' is a reserved word that cannot be used here."

**Testing performed**
New automated test cases, manual testing.

**Additional context**
Original error message:
![image](https://user-images.githubusercontent.com/3222948/65707790-25be2000-e085-11e9-8626-c0b7e8b41b20.png)

New error message:
![image](https://user-images.githubusercontent.com/3222948/65707622-d4159580-e084-11e9-81c6-e8738e3ba018.png)

Work done by Sergey Tychinin (@dettier).