### PR TITLE
Fix the third crash in the chrome user suite test by remembering to pass excludeThisKeyword

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2060,7 +2060,7 @@ namespace ts {
             idText(expr.expression.expression) === "Object" &&
             idText(expr.expression.name) === "defineProperty" &&
             isStringOrNumericLiteralLike(expr.arguments[1]) &&
-            isBindableStaticNameExpression(expr.arguments[0]);
+            isBindableStaticNameExpression(expr.arguments[0], /*excludeThisKeyword*/ true);
     }
 
     export function isBindableStaticElementAccessExpression(node: Node, excludeThisKeyword?: boolean): node is BindableStaticElementAccessExpression {

--- a/tests/baselines/reference/jsCheckObjectDefineThisNoCrash.errors.txt
+++ b/tests/baselines/reference/jsCheckObjectDefineThisNoCrash.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/jsCheckObjectDefineThisNoCrash.js(5,36): error TS2339: Property '_prop' does not exist on type 'C'.
+
+
+==== tests/cases/compiler/jsCheckObjectDefineThisNoCrash.js (1 errors) ====
+    class C {
+        constructor() {
+            // Neither of the following should be recognized as declarations yet
+            Object.defineProperty(this, "_prop", { value: {} });
+            Object.defineProperty(this._prop, "num", { value: 12 });
+                                       ~~~~~
+!!! error TS2339: Property '_prop' does not exist on type 'C'.
+        }
+    }

--- a/tests/baselines/reference/jsCheckObjectDefineThisNoCrash.symbols
+++ b/tests/baselines/reference/jsCheckObjectDefineThisNoCrash.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/jsCheckObjectDefineThisNoCrash.js ===
+class C {
+>C : Symbol(C, Decl(jsCheckObjectDefineThisNoCrash.js, 0, 0))
+
+    constructor() {
+        // Neither of the following should be recognized as declarations yet
+        Object.defineProperty(this, "_prop", { value: {} });
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>this : Symbol(C, Decl(jsCheckObjectDefineThisNoCrash.js, 0, 0))
+>value : Symbol(value, Decl(jsCheckObjectDefineThisNoCrash.js, 3, 46))
+
+        Object.defineProperty(this._prop, "num", { value: 12 });
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>this : Symbol(C, Decl(jsCheckObjectDefineThisNoCrash.js, 0, 0))
+>value : Symbol(value, Decl(jsCheckObjectDefineThisNoCrash.js, 4, 50))
+    }
+}

--- a/tests/baselines/reference/jsCheckObjectDefineThisNoCrash.types
+++ b/tests/baselines/reference/jsCheckObjectDefineThisNoCrash.types
@@ -1,0 +1,31 @@
+=== tests/cases/compiler/jsCheckObjectDefineThisNoCrash.js ===
+class C {
+>C : C
+
+    constructor() {
+        // Neither of the following should be recognized as declarations yet
+        Object.defineProperty(this, "_prop", { value: {} });
+>Object.defineProperty(this, "_prop", { value: {} }) : any
+>Object.defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
+>Object : ObjectConstructor
+>defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
+>this : this
+>"_prop" : "_prop"
+>{ value: {} } : { value: {}; }
+>value : {}
+>{} : {}
+
+        Object.defineProperty(this._prop, "num", { value: 12 });
+>Object.defineProperty(this._prop, "num", { value: 12 }) : any
+>Object.defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
+>Object : ObjectConstructor
+>defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
+>this._prop : any
+>this : this
+>_prop : any
+>"num" : "num"
+>{ value: 12 } : { value: number; }
+>value : number
+>12 : 12
+    }
+}

--- a/tests/cases/compiler/jsCheckObjectDefineThisNoCrash.ts
+++ b/tests/cases/compiler/jsCheckObjectDefineThisNoCrash.ts
@@ -1,0 +1,11 @@
+// @checkJs: true
+// @allowJs: true
+// @noEmit: true
+// @filename: jsCheckObjectDefineThisNoCrash.js
+class C {
+    constructor() {
+        // Neither of the following should be recognized as declarations yet
+        Object.defineProperty(this, "_prop", { value: {} });
+        Object.defineProperty(this._prop, "num", { value: 12 });
+    }
+}


### PR DESCRIPTION
#33687 only fixed one of two issues, as it happens.

In #33537, `isBindableObjectDefinePropertyCall`  was changed to use a new helper to handle element accesses, but `Object.defineProperty` codepaths don't have handling for binding `this` members (and didn't handle them before), so `Object.definteProperty(this._whatever, "field", { value: 12 })` would cause a crash. 🙁

It looks we we just forgot to pass in the `excludeThisKeyword` parameter at this callsite.

This time I've validated the that the whole `chrome-devtools-frontend` test no longer crashes (and, in fact, has _way fewer_ errors)~
