### PR TITLE
Detect unbindable exports before setting CommonJS module indicator

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2174,9 +2174,11 @@ namespace ts {
                 nextToLast = nextToLast.expression as Exclude<BindableStaticNameExpression, Identifier>;
             }
             const id = nextToLast.expression;
-            if (id.escapedText === "exports" ||
-                id.escapedText === "module" && getElementOrPropertyAccessName(nextToLast) === "exports") {
-                // exports.name = expr OR module.exports.name = expr
+            if ((id.escapedText === "exports" ||
+                id.escapedText === "module" && getElementOrPropertyAccessName(nextToLast) === "exports") &&
+                // ExportsProperty does not support late binding; it must have a static name
+                isBindableStaticAccessExpression(lhs)) {
+                // exports.name = expr OR module.exports.name = expr OR exports["name"] = expr ...
                 return AssignmentDeclarationKind.ExportsProperty;
             }
             // F.G...x = expr

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2176,7 +2176,7 @@ namespace ts {
             const id = nextToLast.expression;
             if ((id.escapedText === "exports" ||
                 id.escapedText === "module" && getElementOrPropertyAccessName(nextToLast) === "exports") &&
-                // ExportsProperty does not support late binding; it must have a static name
+                // ExportsProperty does not support binding with computed names
                 isBindableStaticAccessExpression(lhs)) {
                 // exports.name = expr OR module.exports.name = expr OR exports["name"] = expr ...
                 return AssignmentDeclarationKind.ExportsProperty;

--- a/src/testRunner/parallel/host.ts
+++ b/src/testRunner/parallel/host.ts
@@ -147,7 +147,7 @@ namespace Harness.Parallel.Host {
                 }
 
                 cursor.hide();
-                readline.moveCursor(process.stdout, -process.stdout.columns!, -this._lineCount);
+                readline.moveCursor(process.stdout, -process.stdout.columns, -this._lineCount);
                 let lineCount = 0;
                 const numProgressBars = this._progressBars.length;
                 for (let i = 0; i < numProgressBars; i++) {
@@ -156,7 +156,7 @@ namespace Harness.Parallel.Host {
                         process.stdout.write(this._progressBars[i].text + os.EOL);
                     }
                     else {
-                        readline.moveCursor(process.stdout, -process.stdout.columns!, +1);
+                        readline.moveCursor(process.stdout, -process.stdout.columns, +1);
                     }
 
                     lineCount++;

--- a/tests/baselines/reference/lateBoundAssignmentDeclarationSupport2.symbols
+++ b/tests/baselines/reference/lateBoundAssignmentDeclarationSupport2.symbols
@@ -26,20 +26,20 @@ const _str = "my-fake-sym";
 
 module.exports[_sym] = "ok";
 >module.exports : Symbol("tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport2", Decl(lateBoundAssignmentDeclarationSupport2.js, 0, 0))
->module : Symbol(module, Decl(lateBoundAssignmentDeclarationSupport2.js, 2, 27))
+>module : Symbol(module, Decl(lateBoundAssignmentDeclarationSupport2.js, 5, 28))
 >exports : Symbol("tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport2", Decl(lateBoundAssignmentDeclarationSupport2.js, 0, 0))
 >_sym : Symbol(_sym, Decl(lateBoundAssignmentDeclarationSupport2.js, 1, 5))
 
 module.exports[_str] = "ok";
 >module.exports : Symbol("tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport2", Decl(lateBoundAssignmentDeclarationSupport2.js, 0, 0))
->module : Symbol(module, Decl(lateBoundAssignmentDeclarationSupport2.js, 2, 27))
+>module : Symbol(module, Decl(lateBoundAssignmentDeclarationSupport2.js, 5, 28))
 >exports : Symbol("tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport2", Decl(lateBoundAssignmentDeclarationSupport2.js, 0, 0))
 >_str : Symbol(_str, Decl(lateBoundAssignmentDeclarationSupport2.js, 2, 5))
 
 module.exports.S = _sym;
 >module.exports.S : Symbol(S, Decl(lateBoundAssignmentDeclarationSupport2.js, 5, 28))
 >module.exports : Symbol(S, Decl(lateBoundAssignmentDeclarationSupport2.js, 5, 28))
->module : Symbol(module, Decl(lateBoundAssignmentDeclarationSupport2.js, 2, 27))
+>module : Symbol(module, Decl(lateBoundAssignmentDeclarationSupport2.js, 5, 28))
 >exports : Symbol("tests/cases/conformance/salsa/lateBoundAssignmentDeclarationSupport2", Decl(lateBoundAssignmentDeclarationSupport2.js, 0, 0))
 >S : Symbol(S, Decl(lateBoundAssignmentDeclarationSupport2.js, 5, 28))
 >_sym : Symbol(_sym, Decl(lateBoundAssignmentDeclarationSupport2.js, 1, 5))

--- a/tests/baselines/reference/moduleExportsElementAccessAssignment2.symbols
+++ b/tests/baselines/reference/moduleExportsElementAccessAssignment2.symbols
@@ -1,0 +1,33 @@
+=== tests/cases/conformance/jsdoc/file1.js ===
+// this file _should_ be a global file
+var GlobalThing = { x: 12 };
+>GlobalThing : Symbol(GlobalThing, Decl(file1.js, 1, 3))
+>x : Symbol(x, Decl(file1.js, 1, 19))
+
+/**
+ * @param {*} type 
+ * @param {*} ctor
+ * @param {*} exports
+ */
+function f(type, ctor, exports) {
+>f : Symbol(f, Decl(file1.js, 1, 28))
+>type : Symbol(type, Decl(file1.js, 8, 11))
+>ctor : Symbol(ctor, Decl(file1.js, 8, 16))
+>exports : Symbol(exports, Decl(file1.js, 8, 22))
+
+    if (typeof exports !== "undefined") {
+>exports : Symbol(exports, Decl(file1.js, 8, 22))
+
+        exports["AST_" + type] = ctor;
+>exports : Symbol(exports, Decl(file1.js, 8, 22))
+>type : Symbol(type, Decl(file1.js, 8, 11))
+>ctor : Symbol(ctor, Decl(file1.js, 8, 16))
+    }
+}
+
+=== tests/cases/conformance/jsdoc/ref.js ===
+GlobalThing.x
+>GlobalThing.x : Symbol(x, Decl(file1.js, 1, 19))
+>GlobalThing : Symbol(GlobalThing, Decl(file1.js, 1, 3))
+>x : Symbol(x, Decl(file1.js, 1, 19))
+

--- a/tests/baselines/reference/moduleExportsElementAccessAssignment2.types
+++ b/tests/baselines/reference/moduleExportsElementAccessAssignment2.types
@@ -1,0 +1,42 @@
+=== tests/cases/conformance/jsdoc/file1.js ===
+// this file _should_ be a global file
+var GlobalThing = { x: 12 };
+>GlobalThing : { x: number; }
+>{ x: 12 } : { x: number; }
+>x : number
+>12 : 12
+
+/**
+ * @param {*} type 
+ * @param {*} ctor
+ * @param {*} exports
+ */
+function f(type, ctor, exports) {
+>f : (type: any, ctor: any, exports: any) => void
+>type : any
+>ctor : any
+>exports : any
+
+    if (typeof exports !== "undefined") {
+>typeof exports !== "undefined" : boolean
+>typeof exports : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>exports : any
+>"undefined" : "undefined"
+
+        exports["AST_" + type] = ctor;
+>exports["AST_" + type] = ctor : any
+>exports["AST_" + type] : any
+>exports : any
+>"AST_" + type : string
+>"AST_" : "AST_"
+>type : any
+>ctor : any
+    }
+}
+
+=== tests/cases/conformance/jsdoc/ref.js ===
+GlobalThing.x
+>GlobalThing.x : number
+>GlobalThing : { x: number; }
+>x : number
+

--- a/tests/cases/conformance/jsdoc/moduleExportsElementAccessAssignment2.ts
+++ b/tests/cases/conformance/jsdoc/moduleExportsElementAccessAssignment2.ts
@@ -1,0 +1,22 @@
+// @noEmit: true
+// @checkJs: true
+// @allowJs: true
+// @strict: true
+// @Filename: file1.js
+
+// this file _should_ be a global file
+var GlobalThing = { x: 12 };
+
+/**
+ * @param {*} type 
+ * @param {*} ctor
+ * @param {*} exports
+ */
+function f(type, ctor, exports) {
+    if (typeof exports !== "undefined") {
+        exports["AST_" + type] = ctor;
+    }
+}
+
+// @Filename: ref.js
+GlobalThing.x


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes the part of #33765 that breaks the UglifyJS user test
