### PR TITLE
test(ts-toolbelt): recursive iteration types

### DIFF
--- a/tests/cases/user/ts-toolbelt/index.ts
+++ b/tests/cases/user/ts-toolbelt/index.ts
@@ -1,3 +1,5 @@
+// ! this library is mostly used with ramda
+
 import {I, T, Test} from "ts-toolbelt";
 
 const {check, checks} = Test;

--- a/tests/cases/user/ts-toolbelt/index.ts
+++ b/tests/cases/user/ts-toolbelt/index.ts
@@ -3,27 +3,40 @@ import {I, T, Test} from "ts-toolbelt";
 const {check, checks} = Test;
 
 // iterates over `T` and returns the `Iteration` position when finished
-type RecursiveIteration<T extends any[], I extends I.Iteration = I.IterationOf<'0'>> = {
-    0: RecursiveIteration<T, I.Next<I>>;
+type StdRecursiveIteration<T extends any[], I extends I.Iteration = I.IterationOf<'0'>> = {
+    0: StdRecursiveIteration<T, I.Next<I>>;
     1: I.Pos<I>;
 }[
-    T.Length<T> extends I.Pos<I>
-    ? 1
-    : 0
-];
+    I.Pos<I> extends T.Length<T> // this form of recursion is preferred
+    ? 1                          // because it will let the user know if                   
+    : 0                          // the instantiation depth has been hit
+];                               // (but error is swallowed by type atm)
 
 checks([
-    check<RecursiveIteration<[
+    check<StdRecursiveIteration<[
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
     ]>, 40, Test.Pass>(), // max length is 40
-    check<RecursiveIteration<[
+]);
+
+// iterates over `T` and returns the `Iteration` position when finished
+type SafeRecursiveIteration<T extends any[], I extends I.Iteration = I.IterationOf<'0'>> = {
+    0: SafeRecursiveIteration<T, I.Next<I>>;
+    1: I.Pos<I>;
+}[
+    I.Key<I> extends T.Length<T, 's'> // this form of recursion is the safest
+    ? 1                               // because `T.Length<T, 's'>` will force
+    : 0                               // the length to comply with the limits
+];                                    // => won't compute if excessive length                           
+
+checks([
+    check<SafeRecursiveIteration<[
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    ]>, number, Test.Pass>() // it overflowed
+    ]>, 0, Test.Pass>() // did not compute
 ]);

--- a/tests/cases/user/ts-toolbelt/index.ts
+++ b/tests/cases/user/ts-toolbelt/index.ts
@@ -10,7 +10,7 @@ type StdRecursiveIteration<T extends any[], I extends I.Iteration = I.IterationO
     I.Pos<I> extends T.Length<T> // this form of recursion is preferred
     ? 1                          // because it will let the user know if                   
     : 0                          // the instantiation depth has been hit
-];                               // (but error is swallowed by type atm)
+];                               // (but error is sometimes swallowed (?))
 
 checks([
     check<StdRecursiveIteration<[

--- a/tests/cases/user/ts-toolbelt/index.ts
+++ b/tests/cases/user/ts-toolbelt/index.ts
@@ -1,0 +1,29 @@
+import {I, T, Test} from "ts-toolbelt";
+
+const {check, checks} = Test;
+
+// iterates over `T` and returns the `Iteration` position when finished
+type RecursiveIteration<T extends any[], I extends I.Iteration = I.IterationOf<'0'>> = {
+    0: RecursiveIteration<T, I.Next<I>>;
+    1: I.Pos<I>;
+}[
+    T.Length<T> extends I.Pos<I>
+    ? 1
+    : 0
+];
+
+checks([
+    check<RecursiveIteration<[
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]>, 40, Test.Pass>(), // max length is 40
+    check<RecursiveIteration<[
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ]>, number, Test.Pass>() // it overflowed
+]);

--- a/tests/cases/user/ts-toolbelt/package.json
+++ b/tests/cases/user/ts-toolbelt/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "ts-toolbelt-test",
+  "version": "1.0.0",
+  "description": "",
+  "author": "",
+  "license": "Apache-2.0",
+  "repository":  {
+    "type": "git",
+    "url": "https://github.com/pirix-gh/ts-toolbelt"
+  },
+  "dependencies": {
+    "ts-toolbelt": "latest"
+  }
+}

--- a/tests/cases/user/ts-toolbelt/tsconfig.json
+++ b/tests/cases/user/ts-toolbelt/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "strict": true
+    }
+}


### PR DESCRIPTION
Added a test for **recursive iteration types** to preserve ts-toolbelt's recursion capabilities in the future (as discussed with @sandersn)

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
