### PR TITLE
Change link to tutorial in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ with any additional questions or comments.
 
 ## Documentation
 
-*  [Quick tutorial](https://www.typescriptlang.org/docs/tutorial.html)
+*  [TypeScript in 5 minutes](https://www.typescriptlang.org/docs/handbook/typescript-in-5-minutes.html)
 *  [Programming handbook](https://www.typescriptlang.org/docs/handbook/basic-types.html)
 *  [Language specification](https://github.com/microsoft/TypeScript/blob/master/doc/spec.md)
 *  [Homepage](https://www.typescriptlang.org/)


### PR DESCRIPTION
The tutorial that was previously linked to doesn't show up in the sidebar of typescriptlang.org/docs/ anymore.

The "TypeScript in 5 minutes" tutorial is essentially the same tutorial, but does show up in the sidebar and the docs overview.

By linking to this, the user that clicks through knows where they end up on the docs page, instead of being lost on the "Quick Tutorial" that they can't find again, except through this README.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
