### PR TITLE
Avoid a crash with `@typedef` in a script file.

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -564,7 +564,7 @@ namespace ts {
                 //       and this case is specially handled. Module augmentations should only be merged with original module definition
                 //       and should never be merged directly with other augmentation, and the latter case would be possible if automatic merge is allowed.
                 if (isJSDocTypeAlias(node)) Debug.assert(isInJSFile(node)); // We shouldn't add symbols for JSDoc nodes if not in a JS file.
-                if ((!isAmbientModule(node) && (hasExportModifier || container.flags & NodeFlags.ExportContext)) || isJSDocTypeAlias(node)) {
+                if ((!isAmbientModule(node) && (hasExportModifier || container.flags & NodeFlags.ExportContext)) || (isJSDocTypeAlias(node) && container.symbol)) {
                     if (!container.locals || (hasModifier(node, ModifierFlags.Default) && !getDeclarationName(node))) {
                         return declareSymbol(container.symbol.exports!, container.symbol, node, symbolFlags, symbolExcludes); // No local symbol for an unnamed default!
                     }

--- a/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.errors.txt
+++ b/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/conformance/jsdoc/0.js(10,20): error TS2694: Namespace 'exports' has no exported member 'SomeName'.
+
+
+==== tests/cases/conformance/jsdoc/0.js (1 errors) ====
+    // @ts-check
+    
+    var exports = {};
+    
+    /**
+     * @typedef {string}
+     */
+    exports.SomeName;
+    
+    /** @type {exports.SomeName} */
+                       ~~~~~~~~
+!!! error TS2694: Namespace 'exports' has no exported member 'SomeName'.
+    const myString = 'str';
+    

--- a/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.js
+++ b/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.js
@@ -1,0 +1,18 @@
+//// [0.js]
+// @ts-check
+
+var exports = {};
+
+/**
+ * @typedef {string}
+ */
+exports.SomeName;
+
+
+//// [0.js]
+// @ts-check
+var exports = {};
+/**
+ * @typedef {string}
+ */
+exports.SomeName;

--- a/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.js
+++ b/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.js
@@ -8,6 +8,9 @@ var exports = {};
  */
 exports.SomeName;
 
+/** @type {exports.SomeName} */
+const myString = 'str';
+
 
 //// [0.js]
 // @ts-check
@@ -16,3 +19,5 @@ var exports = {};
  * @typedef {string}
  */
 exports.SomeName;
+/** @type {exports.SomeName} */
+var myString = 'str';

--- a/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.symbols
+++ b/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/jsdoc/0.js ===
+// @ts-check
+
+var exports = {};
+>exports : Symbol(exports, Decl(0.js, 2, 3))
+
+/**
+ * @typedef {string}
+ */
+exports.SomeName;
+>exports : Symbol(exports, Decl(0.js, 2, 3))
+

--- a/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.symbols
+++ b/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.symbols
@@ -10,3 +10,7 @@ var exports = {};
 exports.SomeName;
 >exports : Symbol(exports, Decl(0.js, 2, 3))
 
+/** @type {exports.SomeName} */
+const myString = 'str';
+>myString : Symbol(myString, Decl(0.js, 10, 5))
+

--- a/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.types
+++ b/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.types
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/jsdoc/0.js ===
+// @ts-check
+
+var exports = {};
+>exports : {}
+>{} : {}
+
+/**
+ * @typedef {string}
+ */
+exports.SomeName;
+>exports.SomeName : any
+>exports : {}
+>SomeName : any
+

--- a/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.types
+++ b/tests/baselines/reference/checkJsdocTypedefOnlySourceFile.types
@@ -13,3 +13,8 @@ exports.SomeName;
 >exports : {}
 >SomeName : any
 
+/** @type {exports.SomeName} */
+const myString = 'str';
+>myString : any
+>'str' : "str"
+

--- a/tests/cases/conformance/jsdoc/checkJsdocTypedefOnlySourceFile.ts
+++ b/tests/cases/conformance/jsdoc/checkJsdocTypedefOnlySourceFile.ts
@@ -1,0 +1,12 @@
+// @allowJS: true
+// @suppressOutputPathCheck: true
+
+// @filename: 0.js
+// @ts-check
+
+var exports = {};
+
+/**
+ * @typedef {string}
+ */
+exports.SomeName;

--- a/tests/cases/conformance/jsdoc/checkJsdocTypedefOnlySourceFile.ts
+++ b/tests/cases/conformance/jsdoc/checkJsdocTypedefOnlySourceFile.ts
@@ -10,3 +10,6 @@ var exports = {};
  * @typedef {string}
  */
 exports.SomeName;
+
+/** @type {exports.SomeName} */
+const myString = 'str';


### PR DESCRIPTION
Scripts (as opposed to modules) do not have a symbol object. If a script
contains a `@typdef` defined on a namespace called `exports`, TypeScript
crashes because it attempts to create an exported symbol on the
(non-existent) symbol of the SourceFile.

This change avoids the crash by explicitly checking if the source file
has a symbol object, i.e. whether it is a module.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
