### PR TITLE
Add implementation for fixExpectedComma

### DIFF
--- a/src/services/codefixes/fixExpectedComma.ts
+++ b/src/services/codefixes/fixExpectedComma.ts
@@ -1,0 +1,46 @@
+/* @internal */
+namespace ts.codefix {
+    const fixId = "fixExpectedComma";
+    const expectedErrorCode = Diagnostics._0_expected.code;
+    const errorCodes = [expectedErrorCode];
+
+    registerCodeFix({
+        errorCodes,
+        getCodeActions(context) {
+            const { sourceFile } = context;
+            const info = getInfo(sourceFile, context.span.start, context.errorCode);
+            if (!info) { return undefined; }
+
+            const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, info));
+
+            return [createCodeFixAction(
+                fixId,
+                changes,
+                [Diagnostics.Change_0_to_1, ";", ","],
+                fixId,
+                [Diagnostics.Change_0_to_1, ";", ","]
+            )];
+        },
+        fixIds: [fixId],
+        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => {
+            const info = getInfo(diag.file, diag.start, diag.code);
+            if (info) doChange(changes, context.sourceFile, info);
+        }),
+    });
+
+    interface Info { readonly node: Node; }
+
+    function getInfo(sourceFile: SourceFile, pos: number, _: number): Info | undefined {
+        const node = getTokenAtPosition(sourceFile, pos);
+
+        return (node.kind === SyntaxKind.SemicolonToken &&
+                node.parent &&
+                (isObjectLiteralExpression(node.parent) ||
+                 isArrayLiteralExpression(node.parent))) ? { node } : undefined;
+    }
+
+    function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, { node }: Info): void {
+        const newNode = createNode(SyntaxKind.CommaToken);
+        changes.replaceNode(sourceFile, node, newNode);
+    }
+}

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -84,6 +84,7 @@
         "codefixes/convertToMappedObjectType.ts",
         "codefixes/removeUnnecessaryAwait.ts",
         "codefixes/convertConstToLet.ts",
+        "codefixes/fixExpectedComma.ts",
         "refactors/convertExport.ts",
         "refactors/convertImport.ts",
         "refactors/extractSymbol.ts",

--- a/tests/cases/fourslash/codeFixExpectedComma01.ts
+++ b/tests/cases/fourslash/codeFixExpectedComma01.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+////class C {
+////    const example = [|{ a : "one"; c : "two"}|]
+////}
+
+verify.codeFixAvailable([
+    { description: `Change ';' to ','` }
+]);
+
+verify.codeFix({
+    description: "Change ';' to ','",
+    index: 0,
+    newRangeContent: `{ a : "one", c : "two"}`,
+});

--- a/tests/cases/fourslash/codeFixExpectedComma02.ts
+++ b/tests/cases/fourslash/codeFixExpectedComma02.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+////class C {
+////    const example = [|["one"; "two"]|]
+////}
+
+verify.codeFixAvailable([
+    { description: `Change ';' to ','` }
+]);
+
+verify.codeFix({
+    description: "Change ';' to ','",
+    index: 0,
+    newRangeContent: `["one", "two"]`,
+});

--- a/tests/cases/fourslash/codeFixExpectedComma03.ts
+++ b/tests/cases/fourslash/codeFixExpectedComma03.ts
@@ -1,0 +1,7 @@
+/// <reference path='fourslash.ts' />
+
+////class C {
+////    const example = [|{ one: 1 one }|]
+////}
+
+verify.not.codeFixAvailable("fixExpectedComma")


### PR DESCRIPTION
Code fix for changing `;` to a `,` within a list. Work done by @adeniszczyc.

Fixes #25201 

![quick_fix](https://user-images.githubusercontent.com/2099219/65708140-d0ced980-e085-11e9-98db-0fd15d4b1808.gif)

**Describe your changes**
Adds the quick fix for changing a `;` to `,` between list items in either an object or array context by using the `_0_expected` diagnostic.

**Testing performed**
Tested in VSCode to ensure that the error generates the expected quick fix for changing a `;` to a `,` within the above context.

**Additional context**
No additional context.

