### PR TITLE
Handle string literals in merge conflict regions

### DIFF
--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -985,8 +985,7 @@ namespace ts {
                 return ClassificationType.bigintLiteral;
             }
             else if (tokenKind === SyntaxKind.StringLiteral) {
-                // TODO: GH#18217
-                return token!.parent.kind === SyntaxKind.JsxAttribute ? ClassificationType.jsxAttributeStringLiteralValue : ClassificationType.stringLiteral;
+                return token && token.parent.kind === SyntaxKind.JsxAttribute ? ClassificationType.jsxAttributeStringLiteralValue : ClassificationType.stringLiteral;
             }
             else if (tokenKind === SyntaxKind.RegularExpressionLiteral) {
                 // TODO: we should get another classification type for these literals.

--- a/tests/cases/fourslash/syntacticClassificationsMergeConflictMarker1.ts
+++ b/tests/cases/fourslash/syntacticClassificationsMergeConflictMarker1.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts"/>
+
+//// <<<<<<< HEAD
+//// "AAAA"
+//// =======
+//// "BBBB"
+//// >>>>>>> Feature
+
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("<<<<<<< HEAD"),
+    c.stringLiteral("\"AAAA\""),
+    c.comment("======="),
+    c.stringLiteral("\"BBBB\""),
+    c.comment(">>>>>>> Feature"));


### PR DESCRIPTION
Check for undefined, like the other code paths in the same function.