### PR TITLE
cleanup: remove unused variable assignment

### DIFF
--- a/scripts/buildProtocol.ts
+++ b/scripts/buildProtocol.ts
@@ -21,9 +21,8 @@ class DeclarationsWalker {
 
     static getExtraDeclarations(typeChecker: ts.TypeChecker, protocolFile: ts.SourceFile): string {
         const walker = new DeclarationsWalker(typeChecker, protocolFile);
-        let text = "declare namespace ts.server.protocol {\n";
         walker.visitTypeNodes(protocolFile);
-        text = walker.text
+        let text = walker.text
             ? `declare namespace ts.server.protocol {\n${walker.text}}`
             : "";
         if (walker.removedTypes) {


### PR DESCRIPTION
The initial value in `text` was being immediately overwritten by the next statement

There's no existing issue for this...but I figured it couldn't hurt as a one line fix.