### PR TITLE
refactor(spelling): correct misspelled response

### DIFF
--- a/src/harness/client.ts
+++ b/src/harness/client.ts
@@ -290,7 +290,7 @@ namespace ts.server {
             const args: protocol.FileLocationRequestArgs = this.createFileLocationRequestArgs(fileName, position);
 
             const request = this.processRequest<protocol.DefinitionRequest>(CommandNames.DefinitionAndBoundSpan, args);
-            const response = this.processResponse<protocol.DefinitionInfoAndBoundSpanReponse>(request);
+            const response = this.processResponse<protocol.DefinitionInfoAndBoundSpanResponse>(request);
             const body = Debug.assertDefined(response.body); // TODO: GH#18217
 
             return {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -918,9 +918,12 @@ namespace ts.server.protocol {
         body?: FileSpanWithContext[];
     }
 
-    export interface DefinitionInfoAndBoundSpanReponse extends Response {
+    export interface DefinitionInfoAndBoundSpanResponse extends Response {
         body?: DefinitionInfoAndBoundSpan;
     }
+
+    /** @deprecated Use `DefinitionInfoAndBoundSpanResponse` instead. */
+    export type DefinitionInfoAndBoundSpanReponse = DefinitionInfoAndBoundSpanResponse;
 
     /**
      * Definition response message.  Gives text range for definition.

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6626,9 +6626,11 @@ declare namespace ts.server.protocol {
     interface DefinitionResponse extends Response {
         body?: FileSpanWithContext[];
     }
-    interface DefinitionInfoAndBoundSpanReponse extends Response {
+    interface DefinitionInfoAndBoundSpanResponse extends Response {
         body?: DefinitionInfoAndBoundSpan;
     }
+    /** @deprecated Use `DefinitionInfoAndBoundSpanResponse` instead. */
+    type DefinitionInfoAndBoundSpanReponse = DefinitionInfoAndBoundSpanResponse;
     /**
      * Definition response message.  Gives text range for definition.
      */


### PR DESCRIPTION
This PR fixes a spelling mistake introduced with https://github.com/microsoft/TypeScript/commit/8004fec2ceebc69c2dad06c61990bb47c8cd8daf. 