### PR TITLE
Fix quick info for methods whose contextual type is a mapped type property

### DIFF
--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -237,7 +237,7 @@ namespace ts.SymbolDisplay {
                 // get the signature from the declaration and write it
                 const functionDeclaration = <FunctionLike>location.parent;
                 // Use function declaration to write the signatures only if the symbol corresponding to this declaration
-                const locationIsSymbolDeclaration = find(symbol.declarations, declaration =>
+                const locationIsSymbolDeclaration = symbol.declarations && find(symbol.declarations, declaration =>
                     declaration === (location.kind === SyntaxKind.ConstructorKeyword ? functionDeclaration.parent : functionDeclaration));
 
                 if (locationIsSymbolDeclaration) {

--- a/tests/cases/fourslash/quickInfoMappedTypeMethods.ts
+++ b/tests/cases/fourslash/quickInfoMappedTypeMethods.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+// https://github.com/microsoft/TypeScript/issues/32983
+
+////type M = { [K in 'one']: any };
+////const x: M = {
+////  /**/one() {}
+////}
+
+verify.quickInfoAt("", "(property) one: any");


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #32983
