### PR TITLE
Add assertion when classification has unexpected length

### DIFF
--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -499,8 +499,10 @@ namespace ts {
         return { spans, endOfLineState: EndOfLineState.None };
 
         function pushClassification(start: number, end: number, type: ClassificationType): void {
+            const length = end - start;
+            Debug.assert(length >= 0, `Classification had non-positive length of ${length}`);
             spans.push(start);
-            spans.push(end - start);
+            spans.push(length);
             spans.push(type);
         }
     }

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -500,7 +500,7 @@ namespace ts {
 
         function pushClassification(start: number, end: number, type: ClassificationType): void {
             const length = end - start;
-            Debug.assert(length >= 0, `Classification had non-positive length of ${length}`);
+            Debug.assert(length > 0, `Classification had non-positive length of ${length}`);
             spans.push(start);
             spans.push(length);
             spans.push(type);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

While investigating https://github.com/microsoft/TypeScript/issues/33935, one reported repro was found because it caused a classification to have negative length.
Here, we add an assertion so that the language service fails, rather than the client having to handle such a case.
