### PR TITLE
Fix warning on implicit imports when importing from Javascript files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2665,12 +2665,13 @@ namespace ts {
                 return ambientModule;
             }
             const currentSourceFile = getSourceFileOfNode(location);
+            const currentSourceFileExtension = currentSourceFile ? extensionFromPath(currentSourceFile.fileName) : Extension.Ts;
             const resolvedModule = getResolvedModule(currentSourceFile, moduleReference)!; // TODO: GH#18217
             const resolutionDiagnostic = resolvedModule && getResolutionDiagnostic(compilerOptions, resolvedModule);
             const sourceFile = resolvedModule && !resolutionDiagnostic && host.getSourceFile(resolvedModule.resolvedFileName);
             if (sourceFile) {
                 if (sourceFile.symbol) {
-                    if (resolvedModule.isExternalLibraryImport && !resolutionExtensionIsTSOrJson(resolvedModule.extension)) {
+                    if (resolvedModule.isExternalLibraryImport && !resolutionExtensionIsTSOrJson(resolvedModule.extension) && !extensionIsJS(currentSourceFileExtension)) {
                         errorOnImplicitAnyModule(/*isError*/ false, errorNode, resolvedModule, moduleReference);
                     }
                     // merged symbol is module declaration symbol combined with all augmentations
@@ -2704,7 +2705,7 @@ namespace ts {
                     const diag = Diagnostics.Invalid_module_name_in_augmentation_Module_0_resolves_to_an_untyped_module_at_1_which_cannot_be_augmented;
                     error(errorNode, diag, moduleReference, resolvedModule.resolvedFileName);
                 }
-                else {
+                else if(!extensionIsJS(currentSourceFileExtension)){
                     errorOnImplicitAnyModule(/*isError*/ noImplicitAny && !!moduleNotFoundError, errorNode, resolvedModule, moduleReference);
                 }
                 // Failed imports and untyped modules are both treated in an untyped manner; only difference is whether we give a diagnostic first.

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -8159,6 +8159,10 @@ namespace ts {
         return extensionIsTS(ext) || ext === Extension.Json;
     }
 
+    export function extensionIsJS(ext: Extension): boolean {
+      return ext === Extension.Js || ext === Extension.Jsx;
+    }
+
     /**
      * Gets the extension from a path.
      * Path must have a valid extension.

--- a/tests/cases/fourslash/codeFixCannotFindModule_suggestion_js.ts
+++ b/tests/cases/fourslash/codeFixCannotFindModule_suggestion_js.ts
@@ -14,20 +14,6 @@ test.setTypesRegistry({ "abs": undefined });
 
 verify.noErrors();
 goTo.file("/a.js");
-verify.getSuggestionDiagnostics([{
-    message: "Could not find a declaration file for module 'abs'. '/node_modules/abs/index.js' implicitly has an 'any' type.",
-    code: 7016,
-}]);
 
-verify.codeFixAvailable([
-    {
-        description: "Install '@types/abs'",
-        commands: [{
-            type: "install package",
-            file: "/a.js",
-            packageName: "@types/abs",
-        }],
-    },
-    { description: "Ignore this error message" },
-    { description: "Disable checking for this file" },
-]);
+verify.getSuggestionDiagnostics([]);
+verify.codeFixAvailable([]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ x ] Code is up-to-date with the `master` branch
* [ x ] You've successfully run `gulp runtests` locally
* [ x ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #34271
