### PR TITLE
useDefineForClassFields: Emit computed property temps even w/o initialiser

### DIFF
--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -132,7 +132,7 @@ namespace ts {
             // Create a temporary variable to store a computed property name (if necessary).
             // If it's not inlineable, then we emit an expression after the class which assigns
             // the property name to the temporary variable.
-            const expr = getPropertyNameExpressionIfNeeded(node.name, !!node.initializer);
+            const expr = getPropertyNameExpressionIfNeeded(node.name, !!node.initializer || !!context.getCompilerOptions().useDefineForClassFields);
             if (expr && !isSimpleInlineableExpression(expr)) {
                 (pendingExpressions || (pendingExpressions = [])).push(expr);
             }
@@ -145,7 +145,7 @@ namespace ts {
             }
 
             const savedPendingExpressions = pendingExpressions;
-            pendingExpressions = undefined!;
+            pendingExpressions = undefined;
 
             const extendsClauseElement = getEffectiveBaseTypeNode(node);
             const isDerivedClass = !!(extendsClauseElement && skipOuterExpressions(extendsClauseElement.expression).kind !== SyntaxKind.NullKeyword);

--- a/tests/baselines/reference/instanceMemberWithComputedPropertyName2.js
+++ b/tests/baselines/reference/instanceMemberWithComputedPropertyName2.js
@@ -1,0 +1,25 @@
+//// [instanceMemberWithComputedPropertyName2.ts]
+// https://github.com/microsoft/TypeScript/issues/33857
+"use strict";
+const x = 1;
+class C {
+    [x]: string;
+}
+
+
+//// [instanceMemberWithComputedPropertyName2.js]
+// https://github.com/microsoft/TypeScript/issues/33857
+"use strict";
+var _a;
+const x = 1;
+class C {
+    constructor() {
+        Object.defineProperty(this, _a, {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
+    }
+}
+_a = x;

--- a/tests/baselines/reference/instanceMemberWithComputedPropertyName2.symbols
+++ b/tests/baselines/reference/instanceMemberWithComputedPropertyName2.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName2.ts ===
+// https://github.com/microsoft/TypeScript/issues/33857
+"use strict";
+const x = 1;
+>x : Symbol(x, Decl(instanceMemberWithComputedPropertyName2.ts, 2, 5))
+
+class C {
+>C : Symbol(C, Decl(instanceMemberWithComputedPropertyName2.ts, 2, 12))
+
+    [x]: string;
+>[x] : Symbol(C[x], Decl(instanceMemberWithComputedPropertyName2.ts, 3, 9))
+>x : Symbol(x, Decl(instanceMemberWithComputedPropertyName2.ts, 2, 5))
+}
+

--- a/tests/baselines/reference/instanceMemberWithComputedPropertyName2.types
+++ b/tests/baselines/reference/instanceMemberWithComputedPropertyName2.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName2.ts ===
+// https://github.com/microsoft/TypeScript/issues/33857
+"use strict";
+>"use strict" : "use strict"
+
+const x = 1;
+>x : 1
+>1 : 1
+
+class C {
+>C : C
+
+    [x]: string;
+>[x] : string
+>x : 1
+}
+

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName2.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName2.ts
@@ -1,0 +1,8 @@
+// https://github.com/microsoft/TypeScript/issues/33857
+// @useDefineForClassFields: true
+// @target: es2015
+"use strict";
+const x = 1;
+class C {
+    [x]: string;
+}


### PR DESCRIPTION
Fixes #33857
