### PR TITLE
Improve error messages for empty DOM interface property access (#33907)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22954,7 +22954,12 @@ namespace ts {
                         relatedInfo = suggestion.valueDeclaration && createDiagnosticForNode(suggestion.valueDeclaration, Diagnostics._0_is_declared_here, suggestedName);
                     }
                     else {
-                        errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1, declarationNameToString(propNode), typeToString(containingType));
+                        if (isEmptyDomInterface(containingType)) {
+                            errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1_Try_changing_the_lib_compiler_option_to_include_dom, declarationNameToString(propNode), typeToString(containingType));
+                        }
+                        else {
+                            errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Property_0_does_not_exist_on_type_1, declarationNameToString(propNode), typeToString(containingType));
+                        }
                     }
                 }
             }
@@ -22963,6 +22968,10 @@ namespace ts {
                 addRelatedInfo(resultDiagnostic, relatedInfo);
             }
             diagnostics.add(resultDiagnostic);
+        }
+
+        function isEmptyDomInterface(type: Type): boolean {
+            return isEmptyObjectType(type) && /\bHTML\w*Element\b(?![:"])/.test(typeToString(type));
         }
 
         function typeHasStaticProperty(propName: __String, containingType: Type): boolean {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2201,6 +2201,10 @@
         "category": "Error",
         "code": 2594
     },
+    "Property '{0}' does not exist on type '{1}'. Try changing the `lib` compiler option to include 'dom'.": {
+        "category": "Error",
+        "code": 2595
+    },
     "JSX element attributes type '{0}' may not be a union type.": {
         "category": "Error",
         "code": 2600
@@ -4044,7 +4048,7 @@
         "category": "Message",
         "code": 6201
     },
-        "Project references may not form a circular graph. Cycle detected: {0}": {
+    "Project references may not form a circular graph. Cycle detected: {0}": {
         "category": "Error",
         "code": 6202
     },

--- a/tests/baselines/reference/accessPropertyOfEmptyDomInterface.errors.txt
+++ b/tests/baselines/reference/accessPropertyOfEmptyDomInterface.errors.txt
@@ -1,0 +1,49 @@
+tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts(9,13): error TS2595: Property 'value' does not exist on type 'HTMLInputElement'. Try changing the `lib` compiler option to include 'dom'.
+tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts(11,18): error TS2595: Property 'value' does not exist on type 'HTMLInputElement & EventTarget'. Try changing the `lib` compiler option to include 'dom'.
+tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts(13,11): error TS2595: Property 'value' does not exist on type 'HTMLInputElement | EventTarget'. Try changing the `lib` compiler option to include 'dom'.
+  Property 'value' does not exist on type 'HTMLInputElement'.
+tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts(16,5): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts(18,19): error TS2339: Property 'value' does not exist on type '"HTMLInputElement"'.
+tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts(20,11): error TS2339: Property 'value' does not exist on type '{ HTMLInputElement: string; }'.
+tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts(22,21): error TS2339: Property 'value' does not exist on type 'HTMLInputElementFoo'.
+
+
+==== tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts (7 errors) ====
+    interface HTMLInputElement {}
+    interface EventTarget {}
+    interface HTMLInputElementFoo {}
+    
+    let _: any;
+    
+    // These errors should suggest adding 'dom' to `lib`.
+    const element = {} as HTMLInputElement;
+    _ = element.value;
+                ~~~~~
+!!! error TS2595: Property 'value' does not exist on type 'HTMLInputElement'. Try changing the `lib` compiler option to include 'dom'.
+    const intersection = {} as HTMLInputElement & EventTarget;
+    _ = intersection.value;
+                     ~~~~~
+!!! error TS2595: Property 'value' does not exist on type 'HTMLInputElement & EventTarget'. Try changing the `lib` compiler option to include 'dom'.
+    const union = {} as HTMLInputElement | EventTarget;
+    _ = union.value;
+              ~~~~~
+!!! error TS2595: Property 'value' does not exist on type 'HTMLInputElement | EventTarget'. Try changing the `lib` compiler option to include 'dom'.
+!!! error TS2595:   Property 'value' does not exist on type 'HTMLInputElement'.
+    
+    // These errors should not suggest adding 'dom' to `lib`.
+    _ = undefined.value;
+        ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    const stringLiteral = "HTMLInputElement";
+    _ = stringLiteral.value;
+                      ~~~~~
+!!! error TS2339: Property 'value' does not exist on type '"HTMLInputElement"'.
+    const asKey = { HTMLInputElement: "" };
+    _ = asKey.value;
+              ~~~~~
+!!! error TS2339: Property 'value' does not exist on type '{ HTMLInputElement: string; }'.
+    const extraCharacters = {} as HTMLInputElementFoo;
+    _ = extraCharacters.value;
+                        ~~~~~
+!!! error TS2339: Property 'value' does not exist on type 'HTMLInputElementFoo'.
+    

--- a/tests/baselines/reference/accessPropertyOfEmptyDomInterface.js
+++ b/tests/baselines/reference/accessPropertyOfEmptyDomInterface.js
@@ -1,0 +1,42 @@
+//// [accessPropertyOfEmptyDomInterface.ts]
+interface HTMLInputElement {}
+interface EventTarget {}
+interface HTMLInputElementFoo {}
+
+let _: any;
+
+// These errors should suggest adding 'dom' to `lib`.
+const element = {} as HTMLInputElement;
+_ = element.value;
+const intersection = {} as HTMLInputElement & EventTarget;
+_ = intersection.value;
+const union = {} as HTMLInputElement | EventTarget;
+_ = union.value;
+
+// These errors should not suggest adding 'dom' to `lib`.
+_ = undefined.value;
+const stringLiteral = "HTMLInputElement";
+_ = stringLiteral.value;
+const asKey = { HTMLInputElement: "" };
+_ = asKey.value;
+const extraCharacters = {} as HTMLInputElementFoo;
+_ = extraCharacters.value;
+
+
+//// [accessPropertyOfEmptyDomInterface.js]
+var _;
+// These errors should suggest adding 'dom' to `lib`.
+var element = {};
+_ = element.value;
+var intersection = {};
+_ = intersection.value;
+var union = {};
+_ = union.value;
+// These errors should not suggest adding 'dom' to `lib`.
+_ = undefined.value;
+var stringLiteral = "HTMLInputElement";
+_ = stringLiteral.value;
+var asKey = { HTMLInputElement: "" };
+_ = asKey.value;
+var extraCharacters = {};
+_ = extraCharacters.value;

--- a/tests/baselines/reference/accessPropertyOfEmptyDomInterface.symbols
+++ b/tests/baselines/reference/accessPropertyOfEmptyDomInterface.symbols
@@ -1,0 +1,68 @@
+=== tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts ===
+interface HTMLInputElement {}
+>HTMLInputElement : Symbol(HTMLInputElement, Decl(accessPropertyOfEmptyDomInterface.ts, 0, 0))
+
+interface EventTarget {}
+>EventTarget : Symbol(EventTarget, Decl(accessPropertyOfEmptyDomInterface.ts, 0, 29))
+
+interface HTMLInputElementFoo {}
+>HTMLInputElementFoo : Symbol(HTMLInputElementFoo, Decl(accessPropertyOfEmptyDomInterface.ts, 1, 24))
+
+let _: any;
+>_ : Symbol(_, Decl(accessPropertyOfEmptyDomInterface.ts, 4, 3))
+
+// These errors should suggest adding 'dom' to `lib`.
+const element = {} as HTMLInputElement;
+>element : Symbol(element, Decl(accessPropertyOfEmptyDomInterface.ts, 7, 5))
+>HTMLInputElement : Symbol(HTMLInputElement, Decl(accessPropertyOfEmptyDomInterface.ts, 0, 0))
+
+_ = element.value;
+>_ : Symbol(_, Decl(accessPropertyOfEmptyDomInterface.ts, 4, 3))
+>element : Symbol(element, Decl(accessPropertyOfEmptyDomInterface.ts, 7, 5))
+
+const intersection = {} as HTMLInputElement & EventTarget;
+>intersection : Symbol(intersection, Decl(accessPropertyOfEmptyDomInterface.ts, 9, 5))
+>HTMLInputElement : Symbol(HTMLInputElement, Decl(accessPropertyOfEmptyDomInterface.ts, 0, 0))
+>EventTarget : Symbol(EventTarget, Decl(accessPropertyOfEmptyDomInterface.ts, 0, 29))
+
+_ = intersection.value;
+>_ : Symbol(_, Decl(accessPropertyOfEmptyDomInterface.ts, 4, 3))
+>intersection : Symbol(intersection, Decl(accessPropertyOfEmptyDomInterface.ts, 9, 5))
+
+const union = {} as HTMLInputElement | EventTarget;
+>union : Symbol(union, Decl(accessPropertyOfEmptyDomInterface.ts, 11, 5))
+>HTMLInputElement : Symbol(HTMLInputElement, Decl(accessPropertyOfEmptyDomInterface.ts, 0, 0))
+>EventTarget : Symbol(EventTarget, Decl(accessPropertyOfEmptyDomInterface.ts, 0, 29))
+
+_ = union.value;
+>_ : Symbol(_, Decl(accessPropertyOfEmptyDomInterface.ts, 4, 3))
+>union : Symbol(union, Decl(accessPropertyOfEmptyDomInterface.ts, 11, 5))
+
+// These errors should not suggest adding 'dom' to `lib`.
+_ = undefined.value;
+>_ : Symbol(_, Decl(accessPropertyOfEmptyDomInterface.ts, 4, 3))
+>undefined : Symbol(undefined)
+
+const stringLiteral = "HTMLInputElement";
+>stringLiteral : Symbol(stringLiteral, Decl(accessPropertyOfEmptyDomInterface.ts, 16, 5))
+
+_ = stringLiteral.value;
+>_ : Symbol(_, Decl(accessPropertyOfEmptyDomInterface.ts, 4, 3))
+>stringLiteral : Symbol(stringLiteral, Decl(accessPropertyOfEmptyDomInterface.ts, 16, 5))
+
+const asKey = { HTMLInputElement: "" };
+>asKey : Symbol(asKey, Decl(accessPropertyOfEmptyDomInterface.ts, 18, 5))
+>HTMLInputElement : Symbol(HTMLInputElement, Decl(accessPropertyOfEmptyDomInterface.ts, 18, 15))
+
+_ = asKey.value;
+>_ : Symbol(_, Decl(accessPropertyOfEmptyDomInterface.ts, 4, 3))
+>asKey : Symbol(asKey, Decl(accessPropertyOfEmptyDomInterface.ts, 18, 5))
+
+const extraCharacters = {} as HTMLInputElementFoo;
+>extraCharacters : Symbol(extraCharacters, Decl(accessPropertyOfEmptyDomInterface.ts, 20, 5))
+>HTMLInputElementFoo : Symbol(HTMLInputElementFoo, Decl(accessPropertyOfEmptyDomInterface.ts, 1, 24))
+
+_ = extraCharacters.value;
+>_ : Symbol(_, Decl(accessPropertyOfEmptyDomInterface.ts, 4, 3))
+>extraCharacters : Symbol(extraCharacters, Decl(accessPropertyOfEmptyDomInterface.ts, 20, 5))
+

--- a/tests/baselines/reference/accessPropertyOfEmptyDomInterface.types
+++ b/tests/baselines/reference/accessPropertyOfEmptyDomInterface.types
@@ -1,0 +1,89 @@
+=== tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts ===
+interface HTMLInputElement {}
+interface EventTarget {}
+interface HTMLInputElementFoo {}
+
+let _: any;
+>_ : any
+
+// These errors should suggest adding 'dom' to `lib`.
+const element = {} as HTMLInputElement;
+>element : HTMLInputElement
+>{} as HTMLInputElement : HTMLInputElement
+>{} : {}
+
+_ = element.value;
+>_ = element.value : any
+>_ : any
+>element.value : any
+>element : HTMLInputElement
+>value : any
+
+const intersection = {} as HTMLInputElement & EventTarget;
+>intersection : HTMLInputElement & EventTarget
+>{} as HTMLInputElement & EventTarget : HTMLInputElement & EventTarget
+>{} : {}
+
+_ = intersection.value;
+>_ = intersection.value : any
+>_ : any
+>intersection.value : any
+>intersection : HTMLInputElement & EventTarget
+>value : any
+
+const union = {} as HTMLInputElement | EventTarget;
+>union : HTMLInputElement | EventTarget
+>{} as HTMLInputElement | EventTarget : HTMLInputElement | EventTarget
+>{} : {}
+
+_ = union.value;
+>_ = union.value : any
+>_ : any
+>union.value : any
+>union : HTMLInputElement | EventTarget
+>value : any
+
+// These errors should not suggest adding 'dom' to `lib`.
+_ = undefined.value;
+>_ = undefined.value : any
+>_ : any
+>undefined.value : any
+>undefined : undefined
+>value : any
+
+const stringLiteral = "HTMLInputElement";
+>stringLiteral : "HTMLInputElement"
+>"HTMLInputElement" : "HTMLInputElement"
+
+_ = stringLiteral.value;
+>_ = stringLiteral.value : any
+>_ : any
+>stringLiteral.value : any
+>stringLiteral : "HTMLInputElement"
+>value : any
+
+const asKey = { HTMLInputElement: "" };
+>asKey : { HTMLInputElement: string; }
+>{ HTMLInputElement: "" } : { HTMLInputElement: string; }
+>HTMLInputElement : string
+>"" : ""
+
+_ = asKey.value;
+>_ = asKey.value : any
+>_ : any
+>asKey.value : any
+>asKey : { HTMLInputElement: string; }
+>value : any
+
+const extraCharacters = {} as HTMLInputElementFoo;
+>extraCharacters : HTMLInputElementFoo
+>{} as HTMLInputElementFoo : HTMLInputElementFoo
+>{} : {}
+
+_ = extraCharacters.value;
+>_ = extraCharacters.value : any
+>_ : any
+>extraCharacters.value : any
+>extraCharacters : HTMLInputElementFoo
+>value : any
+

--- a/tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts
+++ b/tests/cases/compiler/accessPropertyOfEmptyDomInterface.ts
@@ -1,0 +1,24 @@
+// @lib: es2019
+
+interface HTMLInputElement {}
+interface EventTarget {}
+interface HTMLInputElementFoo {}
+
+let _: any;
+
+// These errors should suggest adding 'dom' to `lib`.
+const element = {} as HTMLInputElement;
+_ = element.value;
+const intersection = {} as HTMLInputElement & EventTarget;
+_ = intersection.value;
+const union = {} as HTMLInputElement | EventTarget;
+_ = union.value;
+
+// These errors should not suggest adding 'dom' to `lib`.
+_ = undefined.value;
+const stringLiteral = "HTMLInputElement";
+_ = stringLiteral.value;
+const asKey = { HTMLInputElement: "" };
+_ = asKey.value;
+const extraCharacters = {} as HTMLInputElementFoo;
+_ = extraCharacters.value;


### PR DESCRIPTION
Fixes #33907

## Summary

If the user attempts to access a property on an empty DOM interface,
the compiler will now suggest adding 'dom' to `lib`.

## Example of change

Given the following setup:
```typescript
// node_modules/@types/react/global.d.ts
interface HTMLInputElement {}

// App.tsx
class App extends React.Component<{}, { text: string; }> {
    constructor(props: {}) {
        super(props);
        this.state = { text: "" };
    }

    render() {
        return <input value={this.state.text} onChange={this.onChange} />;
    }

    onChange(event: React.ChangeEvent<HTMLInputElement>) {
        const text = event.target.value;
        // ERROR:          ^^^^^^^^^^^^
    }
}
```

**Behavior before this PR:**

Error message:

```text
error TS2339: Property 'value' does not exist on type 'EventTarget & HTMLInputElement'
```

**Behavior after this PR:**

Error message:

```text
error TS2595: Property 'value' does not exist on type 'HTMLInputElement'. Try changing the `lib` compiler option to include 'dom'.
```

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

