### PR TITLE
Properly attach alias symbol to `readonly T[]` types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12438,7 +12438,7 @@ namespace ts {
 
         function getAliasSymbolForTypeNode(node: TypeNode) {
             let host = node.parent;
-            while (isParenthesizedTypeNode(host)) {
+            while (isParenthesizedTypeNode(host) || isTypeOperatorNode(host) && host.operator === SyntaxKind.ReadonlyKeyword) {
                 host = host.parent;
             }
             return isTypeAlias(host) ? getSymbolOfNode(host) : undefined;

--- a/tests/baselines/reference/readonlyArraysAndTuples.types
+++ b/tests/baselines/reference/readonlyArraysAndTuples.types
@@ -6,7 +6,7 @@ type T11 = Array<string>;
 >T11 : T11
 
 type T12 = readonly string[];
->T12 : readonly string[]
+>T12 : T12
 
 type T13 = ReadonlyArray<string>;
 >T13 : T13
@@ -15,7 +15,7 @@ type T20 = [number, number];
 >T20 : T20
 
 type T21 = readonly [number, number];
->T21 : readonly [number, number]
+>T21 : T21
 
 type T30 = readonly string;  // Error
 >T30 : string
@@ -24,10 +24,10 @@ type T31<T> = readonly T;  // Error
 >T31 : T
 
 type T32 = readonly readonly string[];  // Error
->T32 : readonly string[]
+>T32 : T32
 
 type T33 = readonly Array<string>;  // Error
->T33 : string[]
+>T33 : T33
 
 function f1(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) {
 >f1 : (ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) => void

--- a/tests/baselines/reference/readonlyArraysAndTuples2.types
+++ b/tests/baselines/reference/readonlyArraysAndTuples2.types
@@ -6,7 +6,7 @@ type T11 = Array<string>;
 >T11 : T11
 
 type T12 = readonly string[];
->T12 : readonly string[]
+>T12 : T12
 
 type T13 = ReadonlyArray<string>;
 >T13 : T13
@@ -15,7 +15,7 @@ type T20 = [number, number];
 >T20 : T20
 
 type T21 = readonly [number, number];
->T21 : readonly [number, number]
+>T21 : T21
 
 declare function f1(ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]): readonly [string, string];
 >f1 : (ma: string[], ra: readonly string[], mt: [string, string], rt: readonly [string, string]) => readonly [string, string]

--- a/tests/baselines/reference/recursiveTypeReferences1.types
+++ b/tests/baselines/reference/recursiveTypeReferences1.types
@@ -347,7 +347,7 @@ type T10 = T10[];
 >T10 : T10
 
 type T11 = readonly T11[];
->T11 : readonly (readonly (readonly (readonly (readonly (readonly (readonly (readonly (readonly (readonly (readonly any[])[])[])[])[])[])[])[])[])[])[]
+>T11 : T11
 
 type T12 = (T12)[];
 >T12 : T12


### PR DESCRIPTION
Fixes #34272.