### PR TITLE
Stop pre-emptively creating directories

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -124,7 +124,7 @@ namespace ts {
                 try {
                     writeFileWorker(fileName, data, writeByteOrderMark);
                 }
-                catch (_) {
+                catch {
                     ensureDirectoriesExist(getDirectoryPath(normalizePath(fileName)));
                     writeFileWorker(fileName, data, writeByteOrderMark);
                 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -114,9 +114,9 @@ namespace ts {
                     fileName,
                     data,
                     writeByteOrderMark,
-                    writeFileWorker,
-                    compilerHost.createDirectory || system.createDirectory,
-                    directoryExists);
+                    (f, d, w) => writeFileWorker(f, d, w),
+                    p => (compilerHost.createDirectory || system.createDirectory)(p),
+                    p => directoryExists(p));
 
                 performance.mark("afterIOWrite");
                 performance.measure("I/O Write", "beforeIOWrite", "afterIOWrite");

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -114,9 +114,9 @@ namespace ts {
                     fileName,
                     data,
                     writeByteOrderMark,
-                    (f, d, w) => writeFileWorker(f, d, w),
-                    p => (compilerHost.createDirectory || system.createDirectory)(p),
-                    p => directoryExists(p));
+                    (path, data, writeByteOrderMark) => writeFileWorker(path, data, writeByteOrderMark),
+                    path => (compilerHost.createDirectory || system.createDirectory)(path),
+                    path => directoryExists(path));
 
                 performance.mark("afterIOWrite");
                 performance.measure("I/O Write", "beforeIOWrite", "afterIOWrite");

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -522,17 +522,6 @@ namespace ts {
         }
     }
 
-    function recursiveCreateDirectory(directoryPath: string, sys: System) {
-        const basePath = getDirectoryPath(directoryPath);
-        const shouldCreateParent = basePath !== "" && directoryPath !== basePath && !sys.directoryExists(basePath);
-        if (shouldCreateParent) {
-            recursiveCreateDirectory(basePath, sys);
-        }
-        if (shouldCreateParent || !sys.directoryExists(directoryPath)) {
-            sys.createDirectory(directoryPath);
-        }
-    }
-
     /**
      * patch writefile to create folder before writing the file
      */
@@ -540,22 +529,14 @@ namespace ts {
     export function patchWriteFileEnsuringDirectory(sys: System) {
         // patch writefile to create folder before writing the file
         const originalWriteFile = sys.writeFile;
-        sys.writeFile = (path, data, writeBom) => {
-            // PERF: Checking for directory existence is expensive.
-            // Instead, assume the directory exists and fall back
-            // to creating it if the file write fails.
-            try {
-                originalWriteFile.call(sys, path, data, writeBom);
-            }
-            catch {
-                const directoryPath = getDirectoryPath(normalizeSlashes(path));
-                if (directoryPath && !sys.directoryExists(directoryPath)) {
-                    recursiveCreateDirectory(directoryPath, sys);
-                }
-
-                originalWriteFile.call(sys, path, data, writeBom);
-            }
-        };
+        sys.writeFile = (path, data, writeBom) =>
+            writeFileEnsuringDirectories(
+                path,
+                data,
+                writeBom,
+                (p, d, w) => originalWriteFile.call(sys, p, d, w),
+                sys.createDirectory,
+                sys.directoryExists);
     }
 
     /*@internal*/

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -547,7 +547,7 @@ namespace ts {
             try {
                 originalWriteFile.call(sys, path, data, writeBom);
             }
-            catch (_) {
+            catch {
                 const directoryPath = getDirectoryPath(normalizeSlashes(path));
                 if (directoryPath && !sys.directoryExists(directoryPath)) {
                     recursiveCreateDirectory(directoryPath, sys);

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -533,10 +533,10 @@ namespace ts {
             writeFileEnsuringDirectories(
                 path,
                 data,
-                writeBom,
+                !!writeBom,
                 (p, d, w) => originalWriteFile.call(sys, p, d, w),
-                p => sys.createDirectory.call(sys, p),
-                p => sys.directoryExists.call(sys, p));
+                p => sys.createDirectory(p),
+                p => sys.directoryExists(p));
     }
 
     /*@internal*/

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -535,8 +535,8 @@ namespace ts {
                 data,
                 writeBom,
                 (p, d, w) => originalWriteFile.call(sys, p, d, w),
-                sys.createDirectory,
-                sys.directoryExists);
+                p => sys.createDirectory.call(sys, p),
+                p => sys.directoryExists.call(sys, p));
     }
 
     /*@internal*/

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -534,9 +534,9 @@ namespace ts {
                 path,
                 data,
                 !!writeBom,
-                (p, d, w) => originalWriteFile.call(sys, p, d, w),
-                p => sys.createDirectory(p),
-                p => sys.directoryExists(p));
+                (path, data, writeByteOrderMark) => originalWriteFile.call(sys, path, data, writeByteOrderMark),
+                path => sys.createDirectory(path),
+                path => sys.directoryExists(path));
     }
 
     /*@internal*/

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3714,8 +3714,8 @@ namespace ts {
     export function writeFileEnsuringDirectories(
         path: string,
         data: string,
-        writeByteOrderMark: boolean | undefined,
-        writeFile: (path: string, data: string, writeByteOrderMark?: boolean) => void,
+        writeByteOrderMark: boolean,
+        writeFile: (path: string, data: string, writeByteOrderMark: boolean) => void,
         createDirectory: (path: string) => void,
         directoryExists: (path: string) => boolean): void {
 

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -307,9 +307,20 @@ namespace ts {
         function writeFile(fileName: string, text: string, writeByteOrderMark: boolean, onError: (message: string) => void) {
             try {
                 performance.mark("beforeIOWrite");
-                ensureDirectoriesExist(getDirectoryPath(normalizePath(fileName)));
 
-                host.writeFile!(fileName, text, writeByteOrderMark);
+                // PERF: Checking for directory existence is expensive.
+                // Instead, assume the directory exists and fall back
+                // to creating it if the file write fails.
+                // NOTE: If patchWriteFileEnsuringDirectory has been called,
+                // the file write will do its own directory creation and
+                // the ensureDirectoriesExist call will always be redundant.
+                try {
+                    host.writeFile!(fileName, text, writeByteOrderMark);
+                }
+                catch {
+                    ensureDirectoriesExist(getDirectoryPath(normalizePath(fileName)));
+                    host.writeFile!(fileName, text, writeByteOrderMark);
+                }
 
                 performance.mark("afterIOWrite");
                 performance.measure("I/O Write", "beforeIOWrite", "afterIOWrite");

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -303,7 +303,13 @@ namespace ts {
                 // NOTE: If patchWriteFileEnsuringDirectory has been called,
                 // the host.writeFile will do its own directory creation and
                 // the ensureDirectoriesExist call will always be redundant.
-                writeFileEnsuringDirectories(fileName, text, writeByteOrderMark, host.writeFile!, host.createDirectory!, host.directoryExists!);
+                writeFileEnsuringDirectories(
+                    fileName,
+                    text,
+                    writeByteOrderMark,
+                    (f, w, d) => host.writeFile!(f, w, d),
+                    p => host.createDirectory!(p),
+                    p => host.directoryExists!(p));
 
                 performance.mark("afterIOWrite");
                 performance.measure("I/O Write", "beforeIOWrite", "afterIOWrite");

--- a/src/compiler/watch.ts
+++ b/src/compiler/watch.ts
@@ -307,9 +307,9 @@ namespace ts {
                     fileName,
                     text,
                     writeByteOrderMark,
-                    (f, w, d) => host.writeFile!(f, w, d),
-                    p => host.createDirectory!(p),
-                    p => host.directoryExists!(p));
+                    (path, data, writeByteOrderMark) => host.writeFile!(path, data, writeByteOrderMark),
+                    path => host.createDirectory!(path),
+                    path => host.directoryExists!(path));
 
                 performance.mark("afterIOWrite");
                 performance.measure("I/O Write", "beforeIOWrite", "afterIOWrite");


### PR DESCRIPTION
Checking for directory existence is expensive and frequently indicates success.  Instead of pre-emptively creating the directory containing a file to be written, attempt to create the file and only do the directory scaffolding if the write fails.
    
Appears to reduce file write time by 10-20% for a file-I/O heavy partner build.
    
Thanks to @rbuckton for the suggestion!