### PR TITLE
Does not add a duplicate completion when offering an export which was re-declared as a global

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1000,6 +1000,7 @@ namespace ts.Completions {
         let completionKind = CompletionKind.None;
         let isNewIdentifierLocation = false;
         let keywordFilters = KeywordCompletionFilters.None;
+        // This also gets mutated in nested-functions after the return
         let symbols: Symbol[] = [];
         const symbolToOriginInfoMap: SymbolOriginInfoMap = [];
         const symbolToSortTextMap: SymbolSortTextMap = [];
@@ -1342,9 +1343,12 @@ namespace ts.Completions {
                     }
 
                     const symbolId = getSymbolId(symbol);
-                    symbols.push(symbol);
-                    symbolToOriginInfoMap[symbolId] = origin;
-                    symbolToSortTextMap[symbolId] = SortText.AutoImportSuggestions;
+                    const existingSymbol = findLast(symbols, symbol => symbol.id === symbolId);
+                    if (!existingSymbol) {
+                        symbols.push(symbol);
+                        symbolToOriginInfoMap[symbolId] = origin;
+                        symbolToSortTextMap[symbolId] = SortText.AutoImportSuggestions;
+                    }
                 });
             }
             filterGlobalCompletion(symbols);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1343,12 +1343,9 @@ namespace ts.Completions {
                     }
 
                     const symbolId = getSymbolId(symbol);
-                    const existingSymbol = findLast(symbols, symbol => symbol.id === symbolId);
-                    if (!existingSymbol) {
-                        symbols.push(symbol);
-                        symbolToOriginInfoMap[symbolId] = origin;
-                        symbolToSortTextMap[symbolId] = SortText.AutoImportSuggestions;
-                    }
+                    symbols.push(symbol);
+                    symbolToOriginInfoMap[symbolId] = origin;
+                    symbolToSortTextMap[symbolId] = SortText.AutoImportSuggestions;
                 });
             }
             filterGlobalCompletion(symbols);
@@ -1468,7 +1465,7 @@ namespace ts.Completions {
         }
 
         /**
-         * Gathers symbols that can be imported from other files, deduplicating along the way. Symbols can be “duplicates”
+         * Gathers symbols that can be imported from other files, de-duplicating along the way. Symbols can be "duplicates"
          * if re-exported from another module, e.g. `export { foo } from "./a"`. That syntax creates a fresh symbol, but
          * it’s just an alias to the first, and both have the same name, so we generally want to filter those aliases out,
          * if and only if the the first can be imported (it may be excluded due to package.json filtering in
@@ -1552,7 +1549,7 @@ namespace ts.Completions {
                 // Don't add another completion for `export =` of a symbol that's already global.
                 // So in `declare namespace foo {} declare module "foo" { export = foo; }`, there will just be the global completion for `foo`.
                 if (resolvedModuleSymbol !== moduleSymbol &&
-                    every(resolvedModuleSymbol.declarations, d => !!d.getSourceFile().externalModuleIndicator)) {
+                    every(resolvedModuleSymbol.declarations, d => !!d.getSourceFile().externalModuleIndicator && !findAncestor(d, isGlobalScopeAugmentation))) {
                     pushSymbol(resolvedModuleSymbol, moduleSymbol, /*skipFilter*/ true);
                 }
 

--- a/tests/cases/fourslash/completionsRedeclareModuleAsGlobal.ts
+++ b/tests/cases/fourslash/completionsRedeclareModuleAsGlobal.ts
@@ -1,5 +1,7 @@
 /// <reference path="fourslash.ts" />
 
+// 32675 - if this fails there are two copies of assert in completions
+
 // @esModuleInterop: true,
 // @target: esnext
 

--- a/tests/cases/fourslash/completionsRedeclareModuleAsGlobal.ts
+++ b/tests/cases/fourslash/completionsRedeclareModuleAsGlobal.ts
@@ -1,0 +1,33 @@
+/// <reference path="fourslash.ts" />
+
+// @esModuleInterop: true,
+// @target: esnext
+
+// @Filename: /myAssert.d.ts
+////declare function assert(value:any, message?:string):void;
+////export = assert;
+////export as namespace assert;
+
+// @Filename: /ambient.d.ts
+////import assert from './myAssert';
+////
+////type Assert = typeof assert;
+////
+////declare global {
+////  const assert: Assert;
+////}
+
+// @Filename: /index.ts
+/////// <reference path="./ambient.d.ts" />
+////asser/**/;
+
+verify.completions({
+  marker: "",
+  includes: [
+    {
+      name: "assert",
+      sortText: completion.SortText.GlobalsOrKeywords
+    }
+  ],
+  preferences: { includeCompletionsForModuleExports: true, includeInsertTextCompletions: true }
+});


### PR DESCRIPTION
Fixes #32675

There are no duplication checks for exported completions, which is typically not a problem, but turns out to be an issue when you are taking a umd global and re-exporting it as a global internally. 

Prior to my patch in completions.ts, this test would raise an error because of duplicate completions in the test. So the test verifies it doesn't crash and includes the assert.