### PR TITLE
Fix stack overflow in circular assignment declaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7269,7 +7269,6 @@ namespace ts {
 
             // Handle variable, parameter or property
             if (!pushTypeResolution(symbol, TypeSystemPropertyName.Type)) {
-                // Symbol is property of some kind that is merged with something - should use `getTypeOfFuncClassEnumModule` and not `getTypeOfVariableOrParameterOrProperty`
                 return reportCircularityError(symbol);
             }
             let type: Type | undefined;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7269,6 +7269,10 @@ namespace ts {
 
             // Handle variable, parameter or property
             if (!pushTypeResolution(symbol, TypeSystemPropertyName.Type)) {
+                // Symbol is property of some kind that is merged with something - should use `getTypeOfFuncClassEnumModule` and not `getTypeOfVariableOrParameterOrProperty`
+                if (symbol.flags & SymbolFlags.ValueModule && !(symbol.flags & SymbolFlags.Assignment)) {
+                    return getTypeOfFuncClassEnumModule(symbol);
+                }
                 return reportCircularityError(symbol);
             }
             let type: Type | undefined;
@@ -7335,6 +7339,10 @@ namespace ts {
             }
 
             if (!popTypeResolution()) {
+                // Symbol is property of some kind that is merged with something - should use `getTypeOfFuncClassEnumModule` and not `getTypeOfVariableOrParameterOrProperty`
+                if (symbol.flags & SymbolFlags.ValueModule && !(symbol.flags & SymbolFlags.Assignment)) {
+                    return getTypeOfFuncClassEnumModule(symbol);
+                }
                 return reportCircularityError(symbol);
             }
             return type;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7335,10 +7335,6 @@ namespace ts {
             }
 
             if (!popTypeResolution()) {
-                // Symbol is property of some kind that is merged with something - should use `getTypeOfFuncClassEnumModule` and not `getTypeOfVariableOrParameterOrProperty`
-                if (symbol.flags & SymbolFlags.ValueModule) {
-                    return getTypeOfFuncClassEnumModule(symbol);
-                }
                 return reportCircularityError(symbol);
             }
             return type;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7270,9 +7270,6 @@ namespace ts {
             // Handle variable, parameter or property
             if (!pushTypeResolution(symbol, TypeSystemPropertyName.Type)) {
                 // Symbol is property of some kind that is merged with something - should use `getTypeOfFuncClassEnumModule` and not `getTypeOfVariableOrParameterOrProperty`
-                if (symbol.flags & SymbolFlags.ValueModule) {
-                    return getTypeOfFuncClassEnumModule(symbol);
-                }
                 return reportCircularityError(symbol);
             }
             let type: Type | undefined;

--- a/tests/baselines/reference/circularMultipleAssignmentDeclaration.symbols
+++ b/tests/baselines/reference/circularMultipleAssignmentDeclaration.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/salsa/circularMultipleAssignmentDeclaration.js ===
+ns.next = ns.next || { shared: {} };
+>ns.next : Symbol(ns.next, Decl(circularMultipleAssignmentDeclaration.js, 0, 0), Decl(circularMultipleAssignmentDeclaration.js, 1, 3))
+>ns : Symbol(ns, Decl(circularMultipleAssignmentDeclaration.js, 0, 0), Decl(circularMultipleAssignmentDeclaration.js, 0, 36))
+>next : Symbol(ns.next, Decl(circularMultipleAssignmentDeclaration.js, 0, 0), Decl(circularMultipleAssignmentDeclaration.js, 1, 3))
+>ns.next : Symbol(ns.next, Decl(circularMultipleAssignmentDeclaration.js, 0, 0), Decl(circularMultipleAssignmentDeclaration.js, 1, 3))
+>ns : Symbol(ns, Decl(circularMultipleAssignmentDeclaration.js, 0, 0), Decl(circularMultipleAssignmentDeclaration.js, 0, 36))
+>next : Symbol(ns.next, Decl(circularMultipleAssignmentDeclaration.js, 0, 0), Decl(circularMultipleAssignmentDeclaration.js, 1, 3))
+>shared : Symbol(shared, Decl(circularMultipleAssignmentDeclaration.js, 0, 22))
+
+ns.next.shared.mymethod = {};
+>ns.next : Symbol(ns.next, Decl(circularMultipleAssignmentDeclaration.js, 0, 0), Decl(circularMultipleAssignmentDeclaration.js, 1, 3))
+>ns : Symbol(ns, Decl(circularMultipleAssignmentDeclaration.js, 0, 0), Decl(circularMultipleAssignmentDeclaration.js, 0, 36))
+>next : Symbol(ns.next, Decl(circularMultipleAssignmentDeclaration.js, 0, 0), Decl(circularMultipleAssignmentDeclaration.js, 1, 3))
+

--- a/tests/baselines/reference/circularMultipleAssignmentDeclaration.types
+++ b/tests/baselines/reference/circularMultipleAssignmentDeclaration.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/salsa/circularMultipleAssignmentDeclaration.js ===
+ns.next = ns.next || { shared: {} };
+>ns.next = ns.next || { shared: {} } : any
+>ns.next : any
+>ns : typeof ns
+>next : any
+>ns.next || { shared: {} } : any
+>ns.next : any
+>ns : typeof ns
+>next : any
+>{ shared: {} } : { shared: {}; }
+>shared : {}
+>{} : {}
+
+ns.next.shared.mymethod = {};
+>ns.next.shared.mymethod = {} : {}
+>ns.next.shared.mymethod : any
+>ns.next.shared : any
+>ns.next : any
+>ns : typeof ns
+>next : any
+>shared : any
+>mymethod : any
+>{} : {}
+

--- a/tests/cases/conformance/salsa/circularMultipleAssignmentDeclaration.ts
+++ b/tests/cases/conformance/salsa/circularMultipleAssignmentDeclaration.ts
@@ -1,0 +1,6 @@
+// @filename:circularMultipleAssignmentDeclaration.js
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+ns.next = ns.next || { shared: {} };
+ns.next.shared.mymethod = {};


### PR DESCRIPTION
The declaration also needs to have multiple assignments so that it has a ValueModule flag.

The fix is to remove the possibly-circular call to getTypeofFuncClassEnumModule in the circularity-detection code path.

Fixes #33006