### PR TITLE
Check all intersection constituents against index signatures in target

### DIFF
--- a/tests/baselines/reference/intersectionsAndIndexSignatures.errors.txt
+++ b/tests/baselines/reference/intersectionsAndIndexSignatures.errors.txt
@@ -1,0 +1,74 @@
+tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts(13,1): error TS2322: Type '{ a: string; } & { b: number; }' is not assignable to type '{ [key: string]: string; }'.
+  Property 'b' is incompatible with index signature.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts(15,1): error TS2322: Type '{} & { b: number; }' is not assignable to type '{ [key: string]: string; }'.
+  Property 'b' is incompatible with index signature.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts(17,1): error TS2322: Type '{ [key: number]: string; } & { b: number; }' is not assignable to type '{ [key: string]: string; }'.
+  Property 'b' is incompatible with index signature.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts(19,1): error TS2322: Type '{ [key: string]: string; } & { b: number; }' is not assignable to type '{ [key: string]: string; }'.
+  Property 'b' is incompatible with index signature.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts(29,10): error TS2339: Property 'b' does not exist on type '{ a: string; }'.
+tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts(31,7): error TS2322: Type 'constr<{}, { [key: string]: { a: string; }; }>' is not assignable to type '{ [key: string]: { a: string; b: string; }; }'.
+  Index signatures are incompatible.
+    Property 'b' is missing in type '{ a: string; }' but required in type '{ a: string; b: string; }'.
+
+
+==== tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts (6 errors) ====
+    declare let s1: { a: string } & { b: string };
+    declare let s2: { a: string } & { b: number };
+    declare let s3: { [K in never]: never } & { b: string };
+    declare let s4: { [K in never]: never } & { b: number };
+    declare let s5: { [key: number]: string } & { b: string };
+    declare let s6: { [key: number]: string } & { b: number };
+    declare let s7: { [key: string]: string } & { b: string };
+    declare let s8: { [key: string]: string } & { b: number };
+    
+    declare let t1: { [key: string]: string };
+    
+    t1 = s1;
+    t1 = s2;  // Error
+    ~~
+!!! error TS2322: Type '{ a: string; } & { b: number; }' is not assignable to type '{ [key: string]: string; }'.
+!!! error TS2322:   Property 'b' is incompatible with index signature.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+    t1 = s3;
+    t1 = s4;  // Error
+    ~~
+!!! error TS2322: Type '{} & { b: number; }' is not assignable to type '{ [key: string]: string; }'.
+!!! error TS2322:   Property 'b' is incompatible with index signature.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+    t1 = s5;
+    t1 = s6;  // Error
+    ~~
+!!! error TS2322: Type '{ [key: number]: string; } & { b: number; }' is not assignable to type '{ [key: string]: string; }'.
+!!! error TS2322:   Property 'b' is incompatible with index signature.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+    t1 = s7;
+    t1 = s8;  // Error
+    ~~
+!!! error TS2322: Type '{ [key: string]: string; } & { b: number; }' is not assignable to type '{ [key: string]: string; }'.
+!!! error TS2322:   Property 'b' is incompatible with index signature.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+    
+    // Repro from #32484
+    
+    type constr<Source, Tgt> = { [K in keyof Source]: string } & Pick<Tgt, Exclude<keyof Tgt, keyof Source>>;
+    
+    type s = constr<{}, { [key: string]: { a: string } }>;
+    
+    declare const q: s;
+    q["asd"].a.substr(1);
+    q["asd"].b;  // Error
+             ~
+!!! error TS2339: Property 'b' does not exist on type '{ a: string; }'.
+    
+    const d: { [key: string]: {a: string, b: string} } = q;  // Error
+          ~
+!!! error TS2322: Type 'constr<{}, { [key: string]: { a: string; }; }>' is not assignable to type '{ [key: string]: { a: string; b: string; }; }'.
+!!! error TS2322:   Index signatures are incompatible.
+!!! error TS2322:     Property 'b' is missing in type '{ a: string; }' but required in type '{ a: string; b: string; }'.
+!!! related TS2728 tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts:31:39: 'b' is declared here.
+    

--- a/tests/baselines/reference/intersectionsAndIndexSignatures.js
+++ b/tests/baselines/reference/intersectionsAndIndexSignatures.js
@@ -1,0 +1,47 @@
+//// [intersectionsAndIndexSignatures.ts]
+declare let s1: { a: string } & { b: string };
+declare let s2: { a: string } & { b: number };
+declare let s3: { [K in never]: never } & { b: string };
+declare let s4: { [K in never]: never } & { b: number };
+declare let s5: { [key: number]: string } & { b: string };
+declare let s6: { [key: number]: string } & { b: number };
+declare let s7: { [key: string]: string } & { b: string };
+declare let s8: { [key: string]: string } & { b: number };
+
+declare let t1: { [key: string]: string };
+
+t1 = s1;
+t1 = s2;  // Error
+t1 = s3;
+t1 = s4;  // Error
+t1 = s5;
+t1 = s6;  // Error
+t1 = s7;
+t1 = s8;  // Error
+
+// Repro from #32484
+
+type constr<Source, Tgt> = { [K in keyof Source]: string } & Pick<Tgt, Exclude<keyof Tgt, keyof Source>>;
+
+type s = constr<{}, { [key: string]: { a: string } }>;
+
+declare const q: s;
+q["asd"].a.substr(1);
+q["asd"].b;  // Error
+
+const d: { [key: string]: {a: string, b: string} } = q;  // Error
+
+
+//// [intersectionsAndIndexSignatures.js]
+"use strict";
+t1 = s1;
+t1 = s2; // Error
+t1 = s3;
+t1 = s4; // Error
+t1 = s5;
+t1 = s6; // Error
+t1 = s7;
+t1 = s8; // Error
+q["asd"].a.substr(1);
+q["asd"].b; // Error
+var d = q; // Error

--- a/tests/baselines/reference/intersectionsAndIndexSignatures.symbols
+++ b/tests/baselines/reference/intersectionsAndIndexSignatures.symbols
@@ -1,0 +1,118 @@
+=== tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts ===
+declare let s1: { a: string } & { b: string };
+>s1 : Symbol(s1, Decl(intersectionsAndIndexSignatures.ts, 0, 11))
+>a : Symbol(a, Decl(intersectionsAndIndexSignatures.ts, 0, 17))
+>b : Symbol(b, Decl(intersectionsAndIndexSignatures.ts, 0, 33))
+
+declare let s2: { a: string } & { b: number };
+>s2 : Symbol(s2, Decl(intersectionsAndIndexSignatures.ts, 1, 11))
+>a : Symbol(a, Decl(intersectionsAndIndexSignatures.ts, 1, 17))
+>b : Symbol(b, Decl(intersectionsAndIndexSignatures.ts, 1, 33))
+
+declare let s3: { [K in never]: never } & { b: string };
+>s3 : Symbol(s3, Decl(intersectionsAndIndexSignatures.ts, 2, 11))
+>K : Symbol(K, Decl(intersectionsAndIndexSignatures.ts, 2, 19))
+>b : Symbol(b, Decl(intersectionsAndIndexSignatures.ts, 2, 43))
+
+declare let s4: { [K in never]: never } & { b: number };
+>s4 : Symbol(s4, Decl(intersectionsAndIndexSignatures.ts, 3, 11))
+>K : Symbol(K, Decl(intersectionsAndIndexSignatures.ts, 3, 19))
+>b : Symbol(b, Decl(intersectionsAndIndexSignatures.ts, 3, 43))
+
+declare let s5: { [key: number]: string } & { b: string };
+>s5 : Symbol(s5, Decl(intersectionsAndIndexSignatures.ts, 4, 11))
+>key : Symbol(key, Decl(intersectionsAndIndexSignatures.ts, 4, 19))
+>b : Symbol(b, Decl(intersectionsAndIndexSignatures.ts, 4, 45))
+
+declare let s6: { [key: number]: string } & { b: number };
+>s6 : Symbol(s6, Decl(intersectionsAndIndexSignatures.ts, 5, 11))
+>key : Symbol(key, Decl(intersectionsAndIndexSignatures.ts, 5, 19))
+>b : Symbol(b, Decl(intersectionsAndIndexSignatures.ts, 5, 45))
+
+declare let s7: { [key: string]: string } & { b: string };
+>s7 : Symbol(s7, Decl(intersectionsAndIndexSignatures.ts, 6, 11))
+>key : Symbol(key, Decl(intersectionsAndIndexSignatures.ts, 6, 19))
+>b : Symbol(b, Decl(intersectionsAndIndexSignatures.ts, 6, 45))
+
+declare let s8: { [key: string]: string } & { b: number };
+>s8 : Symbol(s8, Decl(intersectionsAndIndexSignatures.ts, 7, 11))
+>key : Symbol(key, Decl(intersectionsAndIndexSignatures.ts, 7, 19))
+>b : Symbol(b, Decl(intersectionsAndIndexSignatures.ts, 7, 45))
+
+declare let t1: { [key: string]: string };
+>t1 : Symbol(t1, Decl(intersectionsAndIndexSignatures.ts, 9, 11))
+>key : Symbol(key, Decl(intersectionsAndIndexSignatures.ts, 9, 19))
+
+t1 = s1;
+>t1 : Symbol(t1, Decl(intersectionsAndIndexSignatures.ts, 9, 11))
+>s1 : Symbol(s1, Decl(intersectionsAndIndexSignatures.ts, 0, 11))
+
+t1 = s2;  // Error
+>t1 : Symbol(t1, Decl(intersectionsAndIndexSignatures.ts, 9, 11))
+>s2 : Symbol(s2, Decl(intersectionsAndIndexSignatures.ts, 1, 11))
+
+t1 = s3;
+>t1 : Symbol(t1, Decl(intersectionsAndIndexSignatures.ts, 9, 11))
+>s3 : Symbol(s3, Decl(intersectionsAndIndexSignatures.ts, 2, 11))
+
+t1 = s4;  // Error
+>t1 : Symbol(t1, Decl(intersectionsAndIndexSignatures.ts, 9, 11))
+>s4 : Symbol(s4, Decl(intersectionsAndIndexSignatures.ts, 3, 11))
+
+t1 = s5;
+>t1 : Symbol(t1, Decl(intersectionsAndIndexSignatures.ts, 9, 11))
+>s5 : Symbol(s5, Decl(intersectionsAndIndexSignatures.ts, 4, 11))
+
+t1 = s6;  // Error
+>t1 : Symbol(t1, Decl(intersectionsAndIndexSignatures.ts, 9, 11))
+>s6 : Symbol(s6, Decl(intersectionsAndIndexSignatures.ts, 5, 11))
+
+t1 = s7;
+>t1 : Symbol(t1, Decl(intersectionsAndIndexSignatures.ts, 9, 11))
+>s7 : Symbol(s7, Decl(intersectionsAndIndexSignatures.ts, 6, 11))
+
+t1 = s8;  // Error
+>t1 : Symbol(t1, Decl(intersectionsAndIndexSignatures.ts, 9, 11))
+>s8 : Symbol(s8, Decl(intersectionsAndIndexSignatures.ts, 7, 11))
+
+// Repro from #32484
+
+type constr<Source, Tgt> = { [K in keyof Source]: string } & Pick<Tgt, Exclude<keyof Tgt, keyof Source>>;
+>constr : Symbol(constr, Decl(intersectionsAndIndexSignatures.ts, 18, 8))
+>Source : Symbol(Source, Decl(intersectionsAndIndexSignatures.ts, 22, 12))
+>Tgt : Symbol(Tgt, Decl(intersectionsAndIndexSignatures.ts, 22, 19))
+>K : Symbol(K, Decl(intersectionsAndIndexSignatures.ts, 22, 30))
+>Source : Symbol(Source, Decl(intersectionsAndIndexSignatures.ts, 22, 12))
+>Pick : Symbol(Pick, Decl(lib.es5.d.ts, --, --))
+>Tgt : Symbol(Tgt, Decl(intersectionsAndIndexSignatures.ts, 22, 19))
+>Exclude : Symbol(Exclude, Decl(lib.es5.d.ts, --, --))
+>Tgt : Symbol(Tgt, Decl(intersectionsAndIndexSignatures.ts, 22, 19))
+>Source : Symbol(Source, Decl(intersectionsAndIndexSignatures.ts, 22, 12))
+
+type s = constr<{}, { [key: string]: { a: string } }>;
+>s : Symbol(s, Decl(intersectionsAndIndexSignatures.ts, 22, 105))
+>constr : Symbol(constr, Decl(intersectionsAndIndexSignatures.ts, 18, 8))
+>key : Symbol(key, Decl(intersectionsAndIndexSignatures.ts, 24, 23))
+>a : Symbol(a, Decl(intersectionsAndIndexSignatures.ts, 24, 38))
+
+declare const q: s;
+>q : Symbol(q, Decl(intersectionsAndIndexSignatures.ts, 26, 13))
+>s : Symbol(s, Decl(intersectionsAndIndexSignatures.ts, 22, 105))
+
+q["asd"].a.substr(1);
+>q["asd"].a.substr : Symbol(String.substr, Decl(lib.es5.d.ts, --, --))
+>q["asd"].a : Symbol(a, Decl(intersectionsAndIndexSignatures.ts, 24, 38))
+>q : Symbol(q, Decl(intersectionsAndIndexSignatures.ts, 26, 13))
+>a : Symbol(a, Decl(intersectionsAndIndexSignatures.ts, 24, 38))
+>substr : Symbol(String.substr, Decl(lib.es5.d.ts, --, --))
+
+q["asd"].b;  // Error
+>q : Symbol(q, Decl(intersectionsAndIndexSignatures.ts, 26, 13))
+
+const d: { [key: string]: {a: string, b: string} } = q;  // Error
+>d : Symbol(d, Decl(intersectionsAndIndexSignatures.ts, 30, 5))
+>key : Symbol(key, Decl(intersectionsAndIndexSignatures.ts, 30, 12))
+>a : Symbol(a, Decl(intersectionsAndIndexSignatures.ts, 30, 27))
+>b : Symbol(b, Decl(intersectionsAndIndexSignatures.ts, 30, 37))
+>q : Symbol(q, Decl(intersectionsAndIndexSignatures.ts, 26, 13))
+

--- a/tests/baselines/reference/intersectionsAndIndexSignatures.types
+++ b/tests/baselines/reference/intersectionsAndIndexSignatures.types
@@ -1,0 +1,121 @@
+=== tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts ===
+declare let s1: { a: string } & { b: string };
+>s1 : { a: string; } & { b: string; }
+>a : string
+>b : string
+
+declare let s2: { a: string } & { b: number };
+>s2 : { a: string; } & { b: number; }
+>a : string
+>b : number
+
+declare let s3: { [K in never]: never } & { b: string };
+>s3 : {} & { b: string; }
+>b : string
+
+declare let s4: { [K in never]: never } & { b: number };
+>s4 : {} & { b: number; }
+>b : number
+
+declare let s5: { [key: number]: string } & { b: string };
+>s5 : { [key: number]: string; } & { b: string; }
+>key : number
+>b : string
+
+declare let s6: { [key: number]: string } & { b: number };
+>s6 : { [key: number]: string; } & { b: number; }
+>key : number
+>b : number
+
+declare let s7: { [key: string]: string } & { b: string };
+>s7 : { [key: string]: string; } & { b: string; }
+>key : string
+>b : string
+
+declare let s8: { [key: string]: string } & { b: number };
+>s8 : { [key: string]: string; } & { b: number; }
+>key : string
+>b : number
+
+declare let t1: { [key: string]: string };
+>t1 : { [key: string]: string; }
+>key : string
+
+t1 = s1;
+>t1 = s1 : { a: string; } & { b: string; }
+>t1 : { [key: string]: string; }
+>s1 : { a: string; } & { b: string; }
+
+t1 = s2;  // Error
+>t1 = s2 : { a: string; } & { b: number; }
+>t1 : { [key: string]: string; }
+>s2 : { a: string; } & { b: number; }
+
+t1 = s3;
+>t1 = s3 : {} & { b: string; }
+>t1 : { [key: string]: string; }
+>s3 : {} & { b: string; }
+
+t1 = s4;  // Error
+>t1 = s4 : {} & { b: number; }
+>t1 : { [key: string]: string; }
+>s4 : {} & { b: number; }
+
+t1 = s5;
+>t1 = s5 : { [key: number]: string; } & { b: string; }
+>t1 : { [key: string]: string; }
+>s5 : { [key: number]: string; } & { b: string; }
+
+t1 = s6;  // Error
+>t1 = s6 : { [key: number]: string; } & { b: number; }
+>t1 : { [key: string]: string; }
+>s6 : { [key: number]: string; } & { b: number; }
+
+t1 = s7;
+>t1 = s7 : { [key: string]: string; } & { b: string; }
+>t1 : { [key: string]: string; }
+>s7 : { [key: string]: string; } & { b: string; }
+
+t1 = s8;  // Error
+>t1 = s8 : { [key: string]: string; } & { b: number; }
+>t1 : { [key: string]: string; }
+>s8 : { [key: string]: string; } & { b: number; }
+
+// Repro from #32484
+
+type constr<Source, Tgt> = { [K in keyof Source]: string } & Pick<Tgt, Exclude<keyof Tgt, keyof Source>>;
+>constr : constr<Source, Tgt>
+
+type s = constr<{}, { [key: string]: { a: string } }>;
+>s : constr<{}, { [key: string]: { a: string; }; }>
+>key : string
+>a : string
+
+declare const q: s;
+>q : constr<{}, { [key: string]: { a: string; }; }>
+
+q["asd"].a.substr(1);
+>q["asd"].a.substr(1) : string
+>q["asd"].a.substr : (from: number, length?: number | undefined) => string
+>q["asd"].a : string
+>q["asd"] : { a: string; }
+>q : constr<{}, { [key: string]: { a: string; }; }>
+>"asd" : "asd"
+>a : string
+>substr : (from: number, length?: number | undefined) => string
+>1 : 1
+
+q["asd"].b;  // Error
+>q["asd"].b : any
+>q["asd"] : { a: string; }
+>q : constr<{}, { [key: string]: { a: string; }; }>
+>"asd" : "asd"
+>b : any
+
+const d: { [key: string]: {a: string, b: string} } = q;  // Error
+>d : { [key: string]: { a: string; b: string; }; }
+>key : string
+>a : string
+>b : string
+>q : constr<{}, { [key: string]: { a: string; }; }>
+

--- a/tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts
+++ b/tests/cases/conformance/types/intersection/intersectionsAndIndexSignatures.ts
@@ -1,0 +1,33 @@
+// @strict: true
+
+declare let s1: { a: string } & { b: string };
+declare let s2: { a: string } & { b: number };
+declare let s3: { [K in never]: never } & { b: string };
+declare let s4: { [K in never]: never } & { b: number };
+declare let s5: { [key: number]: string } & { b: string };
+declare let s6: { [key: number]: string } & { b: number };
+declare let s7: { [key: string]: string } & { b: string };
+declare let s8: { [key: string]: string } & { b: number };
+
+declare let t1: { [key: string]: string };
+
+t1 = s1;
+t1 = s2;  // Error
+t1 = s3;
+t1 = s4;  // Error
+t1 = s5;
+t1 = s6;  // Error
+t1 = s7;
+t1 = s8;  // Error
+
+// Repro from #32484
+
+type constr<Source, Tgt> = { [K in keyof Source]: string } & Pick<Tgt, Exclude<keyof Tgt, keyof Source>>;
+
+type s = constr<{}, { [key: string]: { a: string } }>;
+
+declare const q: s;
+q["asd"].a.substr(1);
+q["asd"].b;  // Error
+
+const d: { [key: string]: {a: string, b: string} } = q;  // Error


### PR DESCRIPTION
With this PR we check that all constituents of an intersection source type relate to index signatures in the target type. For example:

```ts
declare let s: { a: string } & { b: number };
declare let t: { [key: string]: string };
t = s;  // Error
```

Previously, no error was reported above.

Fixes #32484.
