### PR TITLE
Remove redundant and misplaced perfLogger startup statement

### DIFF
--- a/src/compiler/perfLogger.ts
+++ b/src/compiler/perfLogger.ts
@@ -38,6 +38,4 @@ namespace ts {
 
     /** Performance logger that will generate ETW events if possible - check for `logEvent` member, as `etwModule` will be `{}` when browserified */
     export const perfLogger: PerfLogger = etwModule && etwModule.logEvent ? etwModule : nullLogger;
-    const args = typeof process === "undefined" ? [] : process.argv;
-    perfLogger.logInfoEvent(`Starting TypeScript v${versionMajorMinor} with command line: ${JSON.stringify(args)}`);
 }


### PR DESCRIPTION
Fixes #33246 

See my comments in that issue to understand why this is redundant.