### PR TITLE
Ensure export= symbol from JavaScript always has a valueDeclaration

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2691,7 +2691,8 @@ namespace ts {
             const flags = exportAssignmentIsAlias(node)
                 ? SymbolFlags.Alias // An export= with an EntityNameExpression or a ClassExpression exports all meanings of that identifier or class
                 : SymbolFlags.Property | SymbolFlags.ExportValue | SymbolFlags.ValueModule;
-            declareSymbol(file.symbol.exports!, file.symbol, node, flags | SymbolFlags.Assignment, SymbolFlags.None);
+            const symbol = declareSymbol(file.symbol.exports!, file.symbol, node, flags | SymbolFlags.Assignment, SymbolFlags.None);
+            setValueDeclaration(symbol, node);
         }
 
         function bindThisPropertyAssignment(node: BindablePropertyAssignmentExpression | PropertyAccessExpression | LiteralLikeElementAccessExpression) {

--- a/tests/baselines/reference/javascriptImportDefaultBadExport.errors.txt
+++ b/tests/baselines/reference/javascriptImportDefaultBadExport.errors.txt
@@ -1,0 +1,16 @@
+/b.js(1,8): error TS1259: Module '"/a"' can only be default-imported using the 'esModuleInterop' flag
+
+
+==== /a.js (0 errors) ====
+    // https://github.com/microsoft/TypeScript/issues/34481
+    
+    
+    const alias = {};
+    module.exports = alias;
+    
+==== /b.js (1 errors) ====
+    import a from "./a";
+           ~
+!!! error TS1259: Module '"/a"' can only be default-imported using the 'esModuleInterop' flag
+!!! related TS2594 /a.js:5:1: This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
+    

--- a/tests/baselines/reference/javascriptImportDefaultBadExport.symbols
+++ b/tests/baselines/reference/javascriptImportDefaultBadExport.symbols
@@ -1,0 +1,17 @@
+=== /a.js ===
+// https://github.com/microsoft/TypeScript/issues/34481
+
+
+const alias = {};
+>alias : Symbol(alias, Decl(a.js, 3, 5))
+
+module.exports = alias;
+>module.exports : Symbol("/a", Decl(a.js, 0, 0))
+>module : Symbol(export=, Decl(a.js, 3, 17))
+>exports : Symbol(export=, Decl(a.js, 3, 17))
+>alias : Symbol(alias, Decl(a.js, 3, 5))
+
+=== /b.js ===
+import a from "./a";
+>a : Symbol(a, Decl(b.js, 0, 6))
+

--- a/tests/baselines/reference/javascriptImportDefaultBadExport.types
+++ b/tests/baselines/reference/javascriptImportDefaultBadExport.types
@@ -1,0 +1,19 @@
+=== /a.js ===
+// https://github.com/microsoft/TypeScript/issues/34481
+
+
+const alias = {};
+>alias : {}
+>{} : {}
+
+module.exports = alias;
+>module.exports = alias : {}
+>module.exports : {}
+>module : { "/a": {}; }
+>exports : {}
+>alias : {}
+
+=== /b.js ===
+import a from "./a";
+>a : any
+

--- a/tests/cases/compiler/javascriptImportDefaultBadExport.ts
+++ b/tests/cases/compiler/javascriptImportDefaultBadExport.ts
@@ -1,0 +1,12 @@
+// https://github.com/microsoft/TypeScript/issues/34481
+
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /a.js
+const alias = {};
+module.exports = alias;
+
+// @Filename: /b.js
+import a from "./a";


### PR DESCRIPTION
I encountered this bug while chasing #34481, but I think it’s ultimately unrelated (though might be @Jack-Works’ bug in that thread?)

There’s a preexisting assumption that the `export=` symbol always has a valueDeclaration (see #26973), but exports of aliases in JS weren’t setting valueDeclarations. I’m not sure if doing this without the `SymbolFlags.Value` flag is correct—I’m not 100% clear on what the criteria for setting valueDeclaration is supposed to be.