### PR TITLE
Add completion test for partial generic object

### DIFF
--- a/tests/cases/fourslash/completionsWithOptionalPropertiesGenericValidBoolean.ts
+++ b/tests/cases/fourslash/completionsWithOptionalPropertiesGenericValidBoolean.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+// @strict: true
+
+//// interface MyOptions {
+////     hello?: boolean;
+////     world?: boolean;
+//// }
+//// declare function bar<T extends MyOptions>(options?: Partial<T>): void;
+//// bar({ hello: true, /*1*/ });
+
+verify.completions({
+  marker: '1',
+  includes: [
+    {
+      sortText: completion.SortText.OptionalMember,
+      name: 'world'
+    },
+  ]
+})


### PR DESCRIPTION
I noticed, that in https://github.com/microsoft/TypeScript/blob/master/tests/cases/fourslash/completionsWithOptionalPropertiesGeneric.ts the `hello` is invalid, as it needs a `: true` or `: false` next to it and points to a non-existing variable.
In addition, the other completion tests introduced by https://github.com/microsoft/TypeScript/pull/33937
all start with an empty object.

This is a small test to make sure, that we're also testing the "happy path" when there already is a valid property existing for the object that we're trying to auto-complete.