### PR TITLE
Bind `@class` in the right place -- bindWorker not bindChildrenWorker

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -821,9 +821,6 @@ namespace ts {
                 case SyntaxKind.JSDocEnumTag:
                     bindJSDocTypeAlias(node as JSDocTypedefTag | JSDocCallbackTag | JSDocEnumTag);
                     break;
-                case SyntaxKind.JSDocClassTag:
-                    bindJSDocClassTag(node as JSDocClassTag);
-                    break;
                 // In source files and blocks, bind functions first to match hoisting that occurs at runtime
                 case SyntaxKind.SourceFile: {
                     bindEachFunctionsFirst((node as SourceFile).statements);
@@ -2454,6 +2451,8 @@ namespace ts {
                 case SyntaxKind.JSDocTypeLiteral:
                 case SyntaxKind.MappedType:
                     return bindAnonymousTypeWorker(node as TypeLiteralNode | MappedTypeNode | JSDocTypeLiteral);
+                case SyntaxKind.JSDocClassTag:
+                    return bindJSDocClassTag(node as JSDocClassTag);
                 case SyntaxKind.ObjectLiteralExpression:
                     return bindObjectLiteralExpression(<ObjectLiteralExpression>node);
                 case SyntaxKind.FunctionExpression:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7688,6 +7688,7 @@ namespace ts {
         // The outer type parameters are those defined by enclosing generic classes, methods, or functions.
         function getOuterTypeParametersOfClassOrInterface(symbol: Symbol): TypeParameter[] | undefined {
             const declaration = symbol.flags & SymbolFlags.Class ? symbol.valueDeclaration : getDeclarationOfKind(symbol, SyntaxKind.InterfaceDeclaration)!;
+            Debug.assert(!!declaration, "Class was missing valueDeclaration -OR- non-class had no interface declarations");
             return getOuterTypeParameters(declaration);
         }
 

--- a/tests/baselines/reference/callOfPropertylessConstructorFunction.errors.txt
+++ b/tests/baselines/reference/callOfPropertylessConstructorFunction.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/jsdoc/callOfPropertylessConstructorFunction.js(7,1): error TS2348: Value of type 'typeof Dependency' is not callable. Did you mean to include 'new'?
+
+
+==== tests/cases/conformance/jsdoc/callOfPropertylessConstructorFunction.js (1 errors) ====
+    /**
+     * @constructor
+     */
+    function Dependency(j) {
+      return j
+    }
+    Dependency({})
+    ~~~~~~~~~~~~~~
+!!! error TS2348: Value of type 'typeof Dependency' is not callable. Did you mean to include 'new'?
+    

--- a/tests/baselines/reference/callOfPropertylessConstructorFunction.symbols
+++ b/tests/baselines/reference/callOfPropertylessConstructorFunction.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/callOfPropertylessConstructorFunction.js ===
+/**
+ * @constructor
+ */
+function Dependency(j) {
+>Dependency : Symbol(Dependency, Decl(callOfPropertylessConstructorFunction.js, 0, 0))
+>j : Symbol(j, Decl(callOfPropertylessConstructorFunction.js, 3, 20))
+
+  return j
+>j : Symbol(j, Decl(callOfPropertylessConstructorFunction.js, 3, 20))
+}
+Dependency({})
+>Dependency : Symbol(Dependency, Decl(callOfPropertylessConstructorFunction.js, 0, 0))
+

--- a/tests/baselines/reference/callOfPropertylessConstructorFunction.types
+++ b/tests/baselines/reference/callOfPropertylessConstructorFunction.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/jsdoc/callOfPropertylessConstructorFunction.js ===
+/**
+ * @constructor
+ */
+function Dependency(j) {
+>Dependency : typeof Dependency
+>j : any
+
+  return j
+>j : any
+}
+Dependency({})
+>Dependency({}) : any
+>Dependency : typeof Dependency
+>{} : {}
+

--- a/tests/cases/conformance/jsdoc/callOfPropertylessConstructorFunction.ts
+++ b/tests/cases/conformance/jsdoc/callOfPropertylessConstructorFunction.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @Filename: callOfPropertylessConstructorFunction.js
+/**
+ * @constructor
+ */
+function Dependency(j) {
+  return j
+}
+Dependency({})


### PR DESCRIPTION
Also add an assert to make future mismatches fail in an obvious place instead of in a while loop.

I believe the reason that this never failed before was that all of the tests had either `this.prop` assignments or `F.prototype = { ...` assignments, both of which also set the `SymbolFlags.Class` flag.

Fixes #34346