### PR TITLE
Ensure functions that have prototype properties assigned by Object.defineProperty get marked as classes

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2925,10 +2925,10 @@ namespace ts {
             declareSymbol(symbolTable, namespaceSymbol, declaration, includes | SymbolFlags.Assignment, excludes & ~SymbolFlags.Assignment);
         }
 
-        function isTopLevelNamespaceAssignment(propertyAccessOrDefinePropertyCall: BindableAccessExpression | BindableObjectDefinePropertyCall) {
-            return isBinaryExpression(propertyAccessOrDefinePropertyCall.parent)
-                ? getParentOfBinaryExpression(propertyAccessOrDefinePropertyCall.parent).parent.kind === SyntaxKind.SourceFile
-                : propertyAccessOrDefinePropertyCall.parent.parent.kind === SyntaxKind.SourceFile;
+        function isTopLevelNamespaceAssignment(propertyAccess: BindableAccessExpression) {
+            return isBinaryExpression(propertyAccess.parent)
+                ? getParentOfBinaryExpression(propertyAccess.parent).parent.kind === SyntaxKind.SourceFile
+                : propertyAccess.parent.parent.kind === SyntaxKind.SourceFile;
         }
 
         function bindPropertyAssignment(name: BindableStaticNameExpression, propertyAccess: BindableStaticAccessExpression, isPrototypeProperty: boolean, containerIsClass: boolean) {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2789,6 +2789,10 @@ namespace ts {
 
         function bindObjectDefinePrototypeProperty(node: BindableObjectDefinePropertyCall) {
             const namespaceSymbol = lookupSymbolForPropertyAccess((node.arguments[0] as PropertyAccessExpression).expression as EntityNameExpression);
+            if (namespaceSymbol) {
+                // Ensure the namespace symbol becomes class-like
+                addDeclarationToSymbol(namespaceSymbol, namespaceSymbol.valueDeclaration, SymbolFlags.Class);
+            }
             bindPotentiallyNewExpandoMemberToNamespace(node, namespaceSymbol, /*isPrototypeProperty*/ true);
         }
 
@@ -2921,10 +2925,10 @@ namespace ts {
             declareSymbol(symbolTable, namespaceSymbol, declaration, includes | SymbolFlags.Assignment, excludes & ~SymbolFlags.Assignment);
         }
 
-        function isTopLevelNamespaceAssignment(propertyAccess: BindableAccessExpression) {
-            return isBinaryExpression(propertyAccess.parent)
-                ? getParentOfBinaryExpression(propertyAccess.parent).parent.kind === SyntaxKind.SourceFile
-                : propertyAccess.parent.parent.kind === SyntaxKind.SourceFile;
+        function isTopLevelNamespaceAssignment(propertyAccessOrDefinePropertyCall: BindableAccessExpression | BindableObjectDefinePropertyCall) {
+            return isBinaryExpression(propertyAccessOrDefinePropertyCall.parent)
+                ? getParentOfBinaryExpression(propertyAccessOrDefinePropertyCall.parent).parent.kind === SyntaxKind.SourceFile
+                : propertyAccessOrDefinePropertyCall.parent.parent.kind === SyntaxKind.SourceFile;
         }
 
         function bindPropertyAssignment(name: BindableStaticNameExpression, propertyAccess: BindableStaticAccessExpression, isPrototypeProperty: boolean, containerIsClass: boolean) {

--- a/tests/baselines/reference/javascriptDefinePropertyPrototypeNonConstructor.symbols
+++ b/tests/baselines/reference/javascriptDefinePropertyPrototypeNonConstructor.symbols
@@ -1,0 +1,23 @@
+=== /a.js ===
+function Graphic() {
+>Graphic : Symbol(Graphic, Decl(a.js, 0, 0))
+}
+
+Object.defineProperty(Graphic.prototype, "instance", {
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Graphic.prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>Graphic : Symbol(Graphic, Decl(a.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>"instance" : Symbol(Graphic.instance, Decl(a.js, 1, 1))
+
+  get: function() {
+>get : Symbol(get, Decl(a.js, 3, 54))
+
+    return this;
+>this : Symbol(Graphic, Decl(a.js, 0, 0))
+  }
+});
+
+

--- a/tests/baselines/reference/javascriptDefinePropertyPrototypeNonConstructor.types
+++ b/tests/baselines/reference/javascriptDefinePropertyPrototypeNonConstructor.types
@@ -1,0 +1,26 @@
+=== /a.js ===
+function Graphic() {
+>Graphic : typeof Graphic
+}
+
+Object.defineProperty(Graphic.prototype, "instance", {
+>Object.defineProperty(Graphic.prototype, "instance", {  get: function() {    return this;  }}) : any
+>Object.defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
+>Object : ObjectConstructor
+>defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
+>Graphic.prototype : any
+>Graphic : typeof Graphic
+>prototype : any
+>"instance" : "instance"
+>{  get: function() {    return this;  }} : { get: () => this; }
+
+  get: function() {
+>get : () => this
+>function() {    return this;  } : () => this
+
+    return this;
+>this : this
+  }
+});
+
+

--- a/tests/cases/compiler/javascriptDefinePropertyPrototypeNonConstructor.ts
+++ b/tests/cases/compiler/javascriptDefinePropertyPrototypeNonConstructor.ts
@@ -1,0 +1,14 @@
+// @allowJs: true
+// @checkJs: false
+// @noEmit: true
+// @Filename: /a.js
+
+function Graphic() {
+}
+
+Object.defineProperty(Graphic.prototype, "instance", {
+  get: function() {
+    return this;
+  }
+});
+


### PR DESCRIPTION


<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #34481 

Various JS constructs indicate to the binder that a function is actually a constructor:

- Assigning to `this` inside the body
- The `/** @constructor */` JSDoc tag
- Assigning to its prototype or prototype properties

A missing one was defining a prototype property via `Object.defineProperty`. So if you have the code

```js
function Graphic() {
}

Object.defineProperty(Graphic.prototype, "instance", {
  get: function() {
    return this;
  }
});
```

The `Object.defineProperty` to the prototype is the _sole_ indicator that `Graphic` is a constructor, but it was being missed, so the symbol `Graphic` was _not_ marked as a class. However, when the checker tries to get the type of `this`, it rightly assumes that `Graphic` _must_ be a class, and hence the crash.

---

It’s also notable that the provided repro had something like this:

```js
function Graphic() {
  Object.defineProperty(this, "_inlineContent", { value: 3 });
}
```

which we don’t recognize as a bindable declaration onto Graphic at all—if we did, this bug would have remained undiscovered. Similarly, if the original code had any assignment to `this`, or any property assignment to `Graphic.prototype`, or used the JSDoc `/** @constructor */` tag, the crash wouldn‘t have occurred because a different declaration would have marked `Graphic` as class-like.