### PR TITLE
CI Builds with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - release-*
+  pull_request:
+    branches:
+      - master
+      - release-*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        fetch-depth: 5
+    - name: Use node version ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Remove existing TypeScript
+      run: |
+        npm uninstall typescript --no-save
+        npm uninstall tslint --no-save
+    - name: npm install and test
+      run: |
+        npm install
+        npm update
+        npm test


### PR DESCRIPTION
I wanted to see if there was any interest in adding GitHub Actions to the party for validating pull request builds and merges into master.

This should be almost the same configuration as what you have for Azure Pipelines and Travis, except with a lack of caching. (Artifact caching is coming 🔜 to GitHub Actions, but I was curious how well it performed even without that.)

/cc @RyanCavanaugh 