### PR TITLE
Narrowed the return type of Object.keys()

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -258,7 +258,7 @@ interface ObjectConstructor {
      * Returns the names of the enumerable string properties and methods of an object.
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    keys(o: object): string[];
+    keys<T extends object = object>(o: T): Array<keyof typeof T>;
 }
 
 /**


### PR DESCRIPTION
This allows further operations to be limited to those specific keys more easily.

e.g.
```typescript
            (Object.keys(entities) as Array<keyof typeof entities>).map(
              entity =>entities[entity],
            )
```
becomes
``typescript
            Object.keys(entities).map(
              entity =>entities[entity],
            )
````

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
