### PR TITLE
Common properties check:Fix intersection-parent check

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16066,7 +16066,7 @@ namespace ts {
         /**
          * A type is 'weak' if it is an object type with at least one optional property
          * and no required properties, call/construct signatures or index signatures
-         * Note: current change be further fixed by distinguishing "very weak" -- object or intersectoin w/some very weak -- from "weak" -- object or intersection w/all 
+         * Note: current change be further fixed by distinguishing "very weak" -- object or intersectoin w/some very weak -- from "weak" -- object or intersection w/all
          */
         function isWeakType(type: Type): boolean {
             if (type.flags & TypeFlags.Object) {

--- a/tests/baselines/reference/commonTypeIntersection.errors.txt
+++ b/tests/baselines/reference/commonTypeIntersection.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/conformance/types/intersection/commonTypeIntersection.ts(2,5): error TS2326: Types of property '__typename' are incompatible.
+  Type '"TypeTwo" | undefined' is not assignable to type '"TypeOne" | undefined'.
+    Type '"TypeTwo"' is not assignable to type '"TypeOne" | undefined'.
+tests/cases/conformance/types/intersection/commonTypeIntersection.ts(4,5): error TS2326: Types of property '__typename' are incompatible.
+  Type '"TypeTwo" | undefined' is not assignable to type '"TypeOne" | undefined'.
+    Type '"TypeTwo"' is not assignable to type '"TypeOne" | undefined'.
+
+
+==== tests/cases/conformance/types/intersection/commonTypeIntersection.ts (2 errors) ====
+    declare let x1: { __typename?: 'TypeTwo' } & { a: boolean };
+    let y1: { __typename?: 'TypeOne' } & { a: boolean} = x1;  // No error!
+        ~~
+!!! error TS2326: Types of property '__typename' are incompatible.
+!!! error TS2326:   Type '"TypeTwo" | undefined' is not assignable to type '"TypeOne" | undefined'.
+!!! error TS2326:     Type '"TypeTwo"' is not assignable to type '"TypeOne" | undefined'.
+    declare let x2: { __typename?: 'TypeTwo' } & string;
+    let y2: { __typename?: 'TypeOne' } & string = x2;  // No error!
+        ~~
+!!! error TS2326: Types of property '__typename' are incompatible.
+!!! error TS2326:   Type '"TypeTwo" | undefined' is not assignable to type '"TypeOne" | undefined'.
+!!! error TS2326:     Type '"TypeTwo"' is not assignable to type '"TypeOne" | undefined'.
+    

--- a/tests/baselines/reference/commonTypeIntersection.js
+++ b/tests/baselines/reference/commonTypeIntersection.js
@@ -1,0 +1,11 @@
+//// [commonTypeIntersection.ts]
+declare let x1: { __typename?: 'TypeTwo' } & { a: boolean };
+let y1: { __typename?: 'TypeOne' } & { a: boolean} = x1;  // No error!
+declare let x2: { __typename?: 'TypeTwo' } & string;
+let y2: { __typename?: 'TypeOne' } & string = x2;  // No error!
+
+
+//// [commonTypeIntersection.js]
+"use strict";
+var y1 = x1; // No error!
+var y2 = x2; // No error!

--- a/tests/baselines/reference/commonTypeIntersection.symbols
+++ b/tests/baselines/reference/commonTypeIntersection.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/types/intersection/commonTypeIntersection.ts ===
+declare let x1: { __typename?: 'TypeTwo' } & { a: boolean };
+>x1 : Symbol(x1, Decl(commonTypeIntersection.ts, 0, 11))
+>__typename : Symbol(__typename, Decl(commonTypeIntersection.ts, 0, 17))
+>a : Symbol(a, Decl(commonTypeIntersection.ts, 0, 46))
+
+let y1: { __typename?: 'TypeOne' } & { a: boolean} = x1;  // No error!
+>y1 : Symbol(y1, Decl(commonTypeIntersection.ts, 1, 3))
+>__typename : Symbol(__typename, Decl(commonTypeIntersection.ts, 1, 9))
+>a : Symbol(a, Decl(commonTypeIntersection.ts, 1, 38))
+>x1 : Symbol(x1, Decl(commonTypeIntersection.ts, 0, 11))
+
+declare let x2: { __typename?: 'TypeTwo' } & string;
+>x2 : Symbol(x2, Decl(commonTypeIntersection.ts, 2, 11))
+>__typename : Symbol(__typename, Decl(commonTypeIntersection.ts, 2, 17))
+
+let y2: { __typename?: 'TypeOne' } & string = x2;  // No error!
+>y2 : Symbol(y2, Decl(commonTypeIntersection.ts, 3, 3))
+>__typename : Symbol(__typename, Decl(commonTypeIntersection.ts, 3, 9))
+>x2 : Symbol(x2, Decl(commonTypeIntersection.ts, 2, 11))
+

--- a/tests/baselines/reference/commonTypeIntersection.types
+++ b/tests/baselines/reference/commonTypeIntersection.types
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/types/intersection/commonTypeIntersection.ts ===
+declare let x1: { __typename?: 'TypeTwo' } & { a: boolean };
+>x1 : { __typename?: "TypeTwo" | undefined; } & { a: boolean; }
+>__typename : "TypeTwo" | undefined
+>a : boolean
+
+let y1: { __typename?: 'TypeOne' } & { a: boolean} = x1;  // No error!
+>y1 : { __typename?: "TypeOne" | undefined; } & { a: boolean; }
+>__typename : "TypeOne" | undefined
+>a : boolean
+>x1 : { __typename?: "TypeTwo" | undefined; } & { a: boolean; }
+
+declare let x2: { __typename?: 'TypeTwo' } & string;
+>x2 : { __typename?: "TypeTwo" | undefined; } & string
+>__typename : "TypeTwo" | undefined
+
+let y2: { __typename?: 'TypeOne' } & string = x2;  // No error!
+>y2 : { __typename?: "TypeOne" | undefined; } & string
+>__typename : "TypeOne" | undefined
+>x2 : { __typename?: "TypeTwo" | undefined; } & string
+

--- a/tests/baselines/reference/reactReadonlyHOCAssignabilityReal.errors.txt
+++ b/tests/baselines/reference/reactReadonlyHOCAssignabilityReal.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx(7,21): error TS2326: Types of property 'name' are incompatible.
+  Type '"Matt"' is not assignable to type 'P["name"] & string'.
+    Type '"Matt"' is not assignable to type 'P["name"]'.
+
+
+==== tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx (1 errors) ====
+    /// <reference path="/.lib/react16.d.ts" />
+    import * as React from "react";
+    
+    function myHigherOrderComponent<P>(Inner: React.ComponentClass<P & {name: string}>): React.ComponentClass<P> {
+        return class OuterComponent extends React.Component<P> {
+            render() {
+                return <Inner {...this.props} name="Matt"/>;
+                        ~~~~~
+!!! error TS2326: Types of property 'name' are incompatible.
+!!! error TS2326:   Type '"Matt"' is not assignable to type 'P["name"] & string'.
+!!! error TS2326:     Type '"Matt"' is not assignable to type 'P["name"]'.
+            }
+        };
+    }

--- a/tests/baselines/reference/reactReadonlyHOCAssignabilityReal.types
+++ b/tests/baselines/reference/reactReadonlyHOCAssignabilityReal.types
@@ -26,7 +26,7 @@ function myHigherOrderComponent<P>(Inner: React.ComponentClass<P & {name: string
 >this.props : Readonly<{ children?: React.ReactNode; }> & Readonly<P>
 >this : this
 >props : Readonly<{ children?: React.ReactNode; }> & Readonly<P>
->name : "Matt"
+>name : string
         }
     };
 }

--- a/tests/cases/conformance/types/intersection/commonTypeIntersection.ts
+++ b/tests/cases/conformance/types/intersection/commonTypeIntersection.ts
@@ -1,0 +1,5 @@
+// @strict: true
+declare let x1: { __typename?: 'TypeTwo' } & { a: boolean };
+let y1: { __typename?: 'TypeOne' } & { a: boolean} = x1;  // No error!
+declare let x2: { __typename?: 'TypeTwo' } & string;
+let y2: { __typename?: 'TypeOne' } & string = x2;  // No error!


### PR DESCRIPTION
The check for common properties ("weak type check") when the target is an intersection is *supposed* to skip the common property check for constituents and instead check assignability of properties for the entire type. The current code correctly skips the check for constituents, but fails to check the whole intersection sometimes. That's because the whole-intersection check uses `isPerformingCommonPropertyChecks`, but that reports the state of the intersection itself, not its constituents.

This PR changes the boolean flag `isApparentIntersectionConstituent` to a box, `{ skipped: boolean }`, that lets children report whether they skipped the common property check or not.

The meat of the PR is in the first page or so; everything else is just changing the type of isApparentIntersection.

This PR is not done:

1. I'm not sure this approach is correct. It might be better to **always** run the whole-intersection property check, even when no constituent is weak.
2. I haven't cleaned up the parameter-passing code; in particular, I didn't introduce a type alias for the result box, and most calls create a box and then don't look at the result.
3. The new, weaker isPerformingExcessPropertyChecks and isPerformingCommonPropertyChecks need to be checked with !isApparentIntersection, but probably not everywhere.

And I don't attempt to fix known problems with the existing approach, like the caching problem or the fact that source intersections also have their children skip common property checks.

Fixes #33944
