### PR TITLE
Treat any mix of element/prop access as declaration in JS

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2061,26 +2061,30 @@ namespace ts {
             isBindableStaticNameExpression(expr.arguments[0], /*excludeThisKeyword*/ true);
     }
 
-    export function isBindableStaticElementAccessExpression(node: Node, excludeThisKeyword?: boolean): node is BindableStaticElementAccessExpression {
-        return isLiteralLikeElementAccess(node)
-            && ((!excludeThisKeyword && node.expression.kind === SyntaxKind.ThisKeyword) ||
-                isEntityNameExpression(node.expression) ||
-                isBindableStaticElementAccessExpression(node.expression, /*excludeThisKeyword*/ true));
-    }
-
+    /** x.y OR x[0] */
     export function isLiteralLikeAccess(node: Node): node is LiteralLikeElementAccessExpression | PropertyAccessExpression {
         return isPropertyAccessExpression(node) || isLiteralLikeElementAccess(node);
     }
 
+    /** x[0] OR x['a'] OR x[Symbol.y] */
     export function isLiteralLikeElementAccess(node: Node): node is LiteralLikeElementAccessExpression {
         return isElementAccessExpression(node) && (
             isStringOrNumericLiteralLike(node.argumentExpression) ||
             isWellKnownSymbolSyntactically(node.argumentExpression));
     }
 
+    /** Any series of property and element accesses. */
     export function isBindableStaticAccessExpression(node: Node, excludeThisKeyword?: boolean): node is BindableStaticAccessExpression {
         return isPropertyAccessExpression(node) && (!excludeThisKeyword && node.expression.kind === SyntaxKind.ThisKeyword || isBindableStaticNameExpression(node.expression, /*excludeThisKeyword*/ true))
-        || isBindableStaticElementAccessExpression(node, excludeThisKeyword);
+            || isBindableStaticElementAccessExpression(node, excludeThisKeyword);
+    }
+
+    /** Any series of property and element accesses, ending in a literal element access */
+    export function isBindableStaticElementAccessExpression(node: Node, excludeThisKeyword?: boolean): node is BindableStaticElementAccessExpression {
+        return isLiteralLikeElementAccess(node)
+            && ((!excludeThisKeyword && node.expression.kind === SyntaxKind.ThisKeyword) ||
+                isEntityNameExpression(node.expression) ||
+                isBindableStaticAccessExpression(node.expression, /*excludeThisKeyword*/ true));
     }
 
     export function isBindableStaticNameExpression(node: Node, excludeThisKeyword?: boolean): node is BindableStaticNameExpression {

--- a/tests/baselines/reference/mixedPropertyElementAccessAssignmentDeclaration.js
+++ b/tests/baselines/reference/mixedPropertyElementAccessAssignmentDeclaration.js
@@ -1,0 +1,10 @@
+//// [mixedPropertyElementAccessAssignmentDeclaration.ts]
+// Should not crash: #34642
+var arr = [];
+arr[0].prop[2] = {};
+
+
+//// [mixedPropertyElementAccessAssignmentDeclaration.js]
+// Should not crash: #34642
+var arr = [];
+arr[0].prop[2] = {};

--- a/tests/baselines/reference/mixedPropertyElementAccessAssignmentDeclaration.symbols
+++ b/tests/baselines/reference/mixedPropertyElementAccessAssignmentDeclaration.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/conformance/salsa/mixedPropertyElementAccessAssignmentDeclaration.ts ===
+// Should not crash: #34642
+var arr = [];
+>arr : Symbol(arr, Decl(mixedPropertyElementAccessAssignmentDeclaration.ts, 1, 3))
+
+arr[0].prop[2] = {};
+>arr : Symbol(arr, Decl(mixedPropertyElementAccessAssignmentDeclaration.ts, 1, 3))
+

--- a/tests/baselines/reference/mixedPropertyElementAccessAssignmentDeclaration.types
+++ b/tests/baselines/reference/mixedPropertyElementAccessAssignmentDeclaration.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/salsa/mixedPropertyElementAccessAssignmentDeclaration.ts ===
+// Should not crash: #34642
+var arr = [];
+>arr : any[]
+>[] : undefined[]
+
+arr[0].prop[2] = {};
+>arr[0].prop[2] = {} : {}
+>arr[0].prop[2] : any
+>arr[0].prop : any
+>arr[0] : any
+>arr : any[]
+>0 : 0
+>prop : any
+>2 : 2
+>{} : {}
+

--- a/tests/cases/conformance/salsa/mixedPropertyElementAccessAssignmentDeclaration.ts
+++ b/tests/cases/conformance/salsa/mixedPropertyElementAccessAssignmentDeclaration.ts
@@ -1,0 +1,3 @@
+// Should not crash: #34642
+var arr = [];
+arr[0].prop[2] = {};


### PR DESCRIPTION
Fixes #34642 but, notably, doesn't actually make the assignment into a working declaration. It just fixes the crash.