### PR TITLE
Don't assume that all symbols have declarations

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -584,7 +584,7 @@ namespace ts.FindAllReferences.Core {
     }
 
     function getReferencedSymbolsForModuleIfDeclaredBySourceFile(symbol: Symbol, program: Program, sourceFiles: readonly SourceFile[], cancellationToken: CancellationToken, options: Options, sourceFilesSet: ReadonlyMap<true>) {
-        const moduleSourceFile = symbol.flags & SymbolFlags.Module ? find(symbol.declarations, isSourceFile) : undefined;
+        const moduleSourceFile = (symbol.flags & SymbolFlags.Module) && symbol.declarations && find(symbol.declarations, isSourceFile);
         if (!moduleSourceFile) return undefined;
         const exportEquals = symbol.exports!.get(InternalSymbolName.ExportEquals);
         // If !!exportEquals, we're about to add references to `import("mod")` anyway, so don't double-count them.

--- a/tests/cases/fourslash/findAllRefsGlobalThisKeywordInModule.ts
+++ b/tests/cases/fourslash/findAllRefsGlobalThisKeywordInModule.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+// @noLib: true
+
+////[|this|];
+////export const c = 1;
+
+const [glob] = test.ranges();
+verify.referenceGroups(glob, undefined);


### PR DESCRIPTION
...in Find All References.  For example, global `this` doesn't in
modules.

Part of #34404