### PR TITLE
Do not consider element accesses which are neither statically bindable nor late bound as special assignments

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2115,7 +2115,7 @@ namespace ts {
         if (expr.operatorToken.kind !== SyntaxKind.EqualsToken || !isAccessExpression(expr.left)) {
             return AssignmentDeclarationKind.None;
         }
-        if (isBindableStaticNameExpression(expr.left.expression) && getElementOrPropertyAccessName(expr.left) === "prototype" && isObjectLiteralExpression(getInitializerOfBinaryExpression(expr))) {
+        if (isBindableStaticNameExpression(expr.left.expression, /*excludeThisKeyword*/ true) && getElementOrPropertyAccessName(expr.left) === "prototype" && isObjectLiteralExpression(getInitializerOfBinaryExpression(expr))) {
             // F.prototype = { ... }
             return AssignmentDeclarationKind.Prototype;
         }
@@ -2183,8 +2183,10 @@ namespace ts {
                 // exports.name = expr OR module.exports.name = expr OR exports["name"] = expr ...
                 return AssignmentDeclarationKind.ExportsProperty;
             }
-            // F.G...x = expr
-            return AssignmentDeclarationKind.Property;
+            if (isBindableStaticNameExpression(lhs, /*excludeThisKeyword*/ true) || (isElementAccessExpression(lhs) && isDynamicName(lhs) && lhs.expression.kind !== SyntaxKind.ThisKeyword)) {
+                // F.G...x = expr
+                return AssignmentDeclarationKind.Property;
+            }
         }
 
         return AssignmentDeclarationKind.None;

--- a/tests/baselines/reference/jsNegativeElementAccessNotBound.symbols
+++ b/tests/baselines/reference/jsNegativeElementAccessNotBound.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/jsNegativeELementAccessNotBound.js ===
+var indexMap = {};
+>indexMap : Symbol(indexMap, Decl(jsNegativeELementAccessNotBound.js, 0, 3))
+
+indexMap[-1] = 0;
+>indexMap : Symbol(indexMap, Decl(jsNegativeELementAccessNotBound.js, 0, 3))
+

--- a/tests/baselines/reference/jsNegativeElementAccessNotBound.types
+++ b/tests/baselines/reference/jsNegativeElementAccessNotBound.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/jsNegativeELementAccessNotBound.js ===
+var indexMap = {};
+>indexMap : {}
+>{} : {}
+
+indexMap[-1] = 0;
+>indexMap[-1] = 0 : 0
+>indexMap[-1] : any
+>indexMap : {}
+>-1 : -1
+>1 : 1
+>0 : 0
+

--- a/tests/cases/compiler/jsNegativeElementAccessNotBound.ts
+++ b/tests/cases/compiler/jsNegativeElementAccessNotBound.ts
@@ -1,0 +1,6 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @filename: jsNegativeELementAccessNotBound.js
+var indexMap = {};
+indexMap[-1] = 0;


### PR DESCRIPTION
Fixes #34672
