### PR TITLE
getTypeFromJSDocValueReference: handle import types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10754,7 +10754,7 @@ namespace ts {
         /**
          * A JSdoc TypeReference may be to a value, but resolve it as a type anyway.
          * Note: If the value is imported from commonjs, it should really be an alias,
-         * but this function fakes special-case code fakes alias resolution as well.
+         * but this function's special-case code fakes alias resolution as well.
          */
         function getTypeFromJSDocValueReference(node: NodeWithTypeArguments, symbol: Symbol): Type | undefined {
             const valueType = getTypeOfSymbol(symbol);
@@ -10766,7 +10766,7 @@ namespace ts {
                     && isCallExpression(decl.initializer)
                     && isRequireCall(decl.initializer, /*requireStringLiteralLikeArgument*/ true)
                     && valueType.symbol;
-                if (isRequireAlias) {
+                if (isRequireAlias || node.kind === SyntaxKind.ImportType) {
                     typeType = getTypeReferenceType(node, valueType.symbol);
                 }
             }

--- a/tests/baselines/reference/jsdocImportTypeReferenceToClassAlias.symbols
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToClassAlias.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/jsdoc/mod1.js ===
+class C {
+>C : Symbol(C, Decl(mod1.js, 0, 0))
+
+    s() { }
+>s : Symbol(C.s, Decl(mod1.js, 0, 9))
+}
+module.exports.C = C
+>module.exports.C : Symbol(C, Decl(mod1.js, 2, 1))
+>module.exports : Symbol(C, Decl(mod1.js, 2, 1))
+>module : Symbol(module, Decl(mod1.js, 2, 1))
+>exports : Symbol("tests/cases/conformance/jsdoc/mod1", Decl(mod1.js, 0, 0))
+>C : Symbol(C, Decl(mod1.js, 2, 1))
+>C : Symbol(C, Decl(mod1.js, 0, 0))
+
+=== tests/cases/conformance/jsdoc/test.js ===
+/** @typedef {import('./mod1').C} X */
+/** @param {X} c */
+function demo(c) {
+>demo : Symbol(demo, Decl(test.js, 0, 0))
+>c : Symbol(c, Decl(test.js, 2, 14))
+
+    c.s
+>c.s : Symbol(C.s, Decl(mod1.js, 0, 9))
+>c : Symbol(c, Decl(test.js, 2, 14))
+>s : Symbol(C.s, Decl(mod1.js, 0, 9))
+}
+

--- a/tests/baselines/reference/jsdocImportTypeReferenceToClassAlias.types
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToClassAlias.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/jsdoc/mod1.js ===
+class C {
+>C : C
+
+    s() { }
+>s : () => void
+}
+module.exports.C = C
+>module.exports.C = C : typeof C
+>module.exports.C : typeof C
+>module.exports : typeof import("tests/cases/conformance/jsdoc/mod1")
+>module : { "tests/cases/conformance/jsdoc/mod1": typeof import("tests/cases/conformance/jsdoc/mod1"); }
+>exports : typeof import("tests/cases/conformance/jsdoc/mod1")
+>C : typeof C
+>C : typeof C
+
+=== tests/cases/conformance/jsdoc/test.js ===
+/** @typedef {import('./mod1').C} X */
+/** @param {X} c */
+function demo(c) {
+>demo : (c: C) => void
+>c : C
+
+    c.s
+>c.s : () => void
+>c : C
+>s : () => void
+}
+

--- a/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToClassAlias.ts
+++ b/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToClassAlias.ts
@@ -1,0 +1,15 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: mod1.js
+class C {
+    s() { }
+}
+module.exports.C = C
+
+// @Filename: test.js
+/** @typedef {import('./mod1').C} X */
+/** @param {X} c */
+function demo(c) {
+    c.s
+}


### PR DESCRIPTION
Previously it only handled types whose declaration was from `require`, but now it handles types whose reference is an import type as well.

Fixes #34671

This doesn't explain the differences in chrome-devtools-frontend, so I'm going to investigate those now.