### PR TITLE
Show all matching enum flags in debug flag formatter

### DIFF
--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -100,11 +100,14 @@ namespace ts {
             if (isFlags) {
                 let result = "";
                 let remainingFlags = value;
-                for (let i = members.length - 1; i >= 0 && remainingFlags !== 0; i--) {
+                for (let i = 0; i < members.length; i++) {
                     const [enumValue, enumName] = members[i];
-                    if (enumValue !== 0 && (remainingFlags & enumValue) === enumValue) {
+                    if (enumValue > value) {
+                        break;
+                    }
+                    if (enumValue !== 0 && enumValue & value) {
+                        result = `${result}${result ? "|" : ""}${enumName}`;
                         remainingFlags &= ~enumValue;
-                        result = `${enumName}${result ? "|" : ""}${result}`;
                     }
                 }
                 if (remainingFlags === 0) {

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -95,7 +95,7 @@ namespace ts {
         export function formatEnum(value = 0, enumObject: any, isFlags?: boolean) {
             const members = getEnumMembers(enumObject);
             if (value === 0) {
-                return members.length > 0 && members[0][0] === 0 ? members[0][1] : "0";
+                return members.length > 0 && members[0][0] === 0 ? members[0][1].join("|") : "0";
             }
             if (isFlags) {
                 let result = "";
@@ -104,7 +104,7 @@ namespace ts {
                     const [enumValue, enumName] = members[i];
                     if (enumValue !== 0 && (remainingFlags & enumValue) === enumValue) {
                         remainingFlags &= ~enumValue;
-                        result = `${enumName}${result ? "|" : ""}${result}`;
+                        result = `${enumName.join("|")}${result ? "|" : ""}${result}`;
                     }
                 }
                 if (remainingFlags === 0) {
@@ -114,7 +114,7 @@ namespace ts {
             else {
                 for (const [enumValue, enumName] of members) {
                     if (enumValue === value) {
-                        return enumName;
+                        return enumName[0];
                     }
                 }
             }
@@ -122,15 +122,17 @@ namespace ts {
         }
 
         function getEnumMembers(enumObject: any) {
-            const result: [number, string][] = [];
+            const result = createMultiMap<string>();
             for (const name in enumObject) {
                 const value = enumObject[name];
                 if (typeof value === "number") {
-                    result.push([value, name]);
+                    result.add("" + value, name);
                 }
             }
 
-            return stableSort<[number, string]>(result, (x, y) => compareValues(x[0], y[0]));
+            return stableSort(
+                map(arrayFrom(result.entries()), ([x, y]) => [+x, y] as const),
+                (x, y) => compareValues(x[0], y[0]));
         }
 
         export function formatSyntaxKind(kind: SyntaxKind | undefined): string {

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -95,7 +95,7 @@ namespace ts {
         export function formatEnum(value = 0, enumObject: any, isFlags?: boolean) {
             const members = getEnumMembers(enumObject);
             if (value === 0) {
-                return members.length > 0 && members[0][0] === 0 ? members[0][1].join("|") : "0";
+                return members.length > 0 && members[0][0] === 0 ? members[0][1] : "0";
             }
             if (isFlags) {
                 let result = "";
@@ -104,7 +104,7 @@ namespace ts {
                     const [enumValue, enumName] = members[i];
                     if (enumValue !== 0 && (remainingFlags & enumValue) === enumValue) {
                         remainingFlags &= ~enumValue;
-                        result = `${enumName.join("|")}${result ? "|" : ""}${result}`;
+                        result = `${enumName}${result ? "|" : ""}${result}`;
                     }
                 }
                 if (remainingFlags === 0) {
@@ -114,7 +114,7 @@ namespace ts {
             else {
                 for (const [enumValue, enumName] of members) {
                     if (enumValue === value) {
-                        return enumName[0];
+                        return enumName;
                     }
                 }
             }
@@ -122,17 +122,15 @@ namespace ts {
         }
 
         function getEnumMembers(enumObject: any) {
-            const result = createMultiMap<string>();
+            const result: [number, string][] = [];
             for (const name in enumObject) {
                 const value = enumObject[name];
                 if (typeof value === "number") {
-                    result.add("" + value, name);
+                    result.push([value, name]);
                 }
             }
 
-            return stableSort(
-                map(arrayFrom(result.entries()), ([x, y]) => [+x, y] as const),
-                (x, y) => compareValues(x[0], y[0]));
+            return stableSort<[number, string]>(result, (x, y) => compareValues(x[0], y[0]));
         }
 
         export function formatSyntaxKind(kind: SyntaxKind | undefined): string {

--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -100,8 +100,7 @@ namespace ts {
             if (isFlags) {
                 let result = "";
                 let remainingFlags = value;
-                for (let i = 0; i < members.length; i++) {
-                    const [enumValue, enumName] = members[i];
+                for (const [enumValue, enumName] of members) {
                     if (enumValue > value) {
                         break;
                     }


### PR DESCRIPTION
Before:

![Screen Shot 2019-10-23 at 4 06 34 PM](https://user-images.githubusercontent.com/3277153/67441320-46f52c00-f5b1-11e9-8741-394ce2ec1465.png)

After:

![Screen Shot 2019-10-23 at 4 12 08 PM](https://user-images.githubusercontent.com/3277153/67441327-4bb9e000-f5b1-11e9-9800-ee866787f2c5.png)

Thoughts?