### PR TITLE
Fix regression in mixin emit by removing unneeded line of code

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4087,8 +4087,6 @@ namespace ts {
                     else if (context.flags & NodeBuilderFlags.WriteClassExpressionAsTypeLiteral &&
                         type.symbol.valueDeclaration &&
                         isClassLike(type.symbol.valueDeclaration) &&
-                        // Use `import` types for refs to other scopes, only anonymize something defined in the same scope
-                        findAncestor(type.symbol.valueDeclaration, d => d === getSourceFileOfNode(context.enclosingDeclaration)) &&
                         !isValueSymbolAccessible(type.symbol, context.enclosingDeclaration)
                     ) {
                         return createAnonymousTypeNode(type);

--- a/tests/baselines/reference/anonClassDeclarationEmitIsAnon.js
+++ b/tests/baselines/reference/anonClassDeclarationEmitIsAnon.js
@@ -9,13 +9,46 @@ export function wrapClass(param: any) {
     }
 }
 
+export type Constructor<T = {}> = new (...args: any[]) => T;
+
+export function Timestamped<TBase extends Constructor>(Base: TBase) {
+    return class extends Base {
+        timestamp = Date.now();
+    };
+}
+
 //// [index.ts]
-import { wrapClass } from "./wrapClass";
+import { wrapClass, Timestamped } from "./wrapClass";
 
 export default wrapClass(0);
 
+// Simple class
+export class User {
+    name = '';
+}
+
+// User that is Timestamped
+export class TimestampedUser extends Timestamped(User) {
+    constructor() {
+        super();
+    }
+}
+
 //// [wrapClass.js]
 "use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
 exports.__esModule = true;
 function wrapClass(param) {
     return /** @class */ (function () {
@@ -28,11 +61,53 @@ function wrapClass(param) {
     }());
 }
 exports.wrapClass = wrapClass;
+function Timestamped(Base) {
+    return /** @class */ (function (_super) {
+        __extends(class_1, _super);
+        function class_1() {
+            var _this = _super !== null && _super.apply(this, arguments) || this;
+            _this.timestamp = Date.now();
+            return _this;
+        }
+        return class_1;
+    }(Base));
+}
+exports.Timestamped = Timestamped;
 //// [index.js]
 "use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = function (d, b) {
+        extendStatics = Object.setPrototypeOf ||
+            ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+            function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+        return extendStatics(d, b);
+    };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
 exports.__esModule = true;
 var wrapClass_1 = require("./wrapClass");
 exports["default"] = wrapClass_1.wrapClass(0);
+// Simple class
+var User = /** @class */ (function () {
+    function User() {
+        this.name = '';
+    }
+    return User;
+}());
+exports.User = User;
+// User that is Timestamped
+var TimestampedUser = /** @class */ (function (_super) {
+    __extends(TimestampedUser, _super);
+    function TimestampedUser() {
+        return _super.call(this) || this;
+    }
+    return TimestampedUser;
+}(wrapClass_1.Timestamped(User)));
+exports.TimestampedUser = TimestampedUser;
 
 
 //// [wrapClass.d.ts]
@@ -41,6 +116,12 @@ export declare function wrapClass(param: any): {
         foo(): any;
     };
 };
+export declare type Constructor<T = {}> = new (...args: any[]) => T;
+export declare function Timestamped<TBase extends Constructor>(Base: TBase): {
+    new (...args: any[]): {
+        timestamp: number;
+    };
+} & TBase;
 //// [index.d.ts]
 declare const _default: {
     new (): {
@@ -48,3 +129,14 @@ declare const _default: {
     };
 };
 export default _default;
+export declare class User {
+    name: string;
+}
+declare const TimestampedUser_base: {
+    new (...args: any[]): {
+        timestamp: number;
+    };
+} & typeof User;
+export declare class TimestampedUser extends TimestampedUser_base {
+    constructor();
+}

--- a/tests/baselines/reference/anonClassDeclarationEmitIsAnon.js
+++ b/tests/baselines/reference/anonClassDeclarationEmitIsAnon.js
@@ -1,0 +1,50 @@
+//// [tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts] ////
+
+//// [wrapClass.ts]
+export function wrapClass(param: any) {
+    return class Wrapped {
+        foo() {
+            return param;
+        }
+    }
+}
+
+//// [index.ts]
+import { wrapClass } from "./wrapClass";
+
+export default wrapClass(0);
+
+//// [wrapClass.js]
+"use strict";
+exports.__esModule = true;
+function wrapClass(param) {
+    return /** @class */ (function () {
+        function Wrapped() {
+        }
+        Wrapped.prototype.foo = function () {
+            return param;
+        };
+        return Wrapped;
+    }());
+}
+exports.wrapClass = wrapClass;
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+var wrapClass_1 = require("./wrapClass");
+exports["default"] = wrapClass_1.wrapClass(0);
+
+
+//// [wrapClass.d.ts]
+export declare function wrapClass(param: any): {
+    new (): {
+        foo(): any;
+    };
+};
+//// [index.d.ts]
+declare const _default: {
+    new (): {
+        foo(): any;
+    };
+};
+export default _default;

--- a/tests/baselines/reference/anonClassDeclarationEmitIsAnon.symbols
+++ b/tests/baselines/reference/anonClassDeclarationEmitIsAnon.symbols
@@ -15,10 +15,54 @@ export function wrapClass(param: any) {
     }
 }
 
+export type Constructor<T = {}> = new (...args: any[]) => T;
+>Constructor : Symbol(Constructor, Decl(wrapClass.ts, 6, 1))
+>T : Symbol(T, Decl(wrapClass.ts, 8, 24))
+>args : Symbol(args, Decl(wrapClass.ts, 8, 39))
+>T : Symbol(T, Decl(wrapClass.ts, 8, 24))
+
+export function Timestamped<TBase extends Constructor>(Base: TBase) {
+>Timestamped : Symbol(Timestamped, Decl(wrapClass.ts, 8, 60))
+>TBase : Symbol(TBase, Decl(wrapClass.ts, 10, 28))
+>Constructor : Symbol(Constructor, Decl(wrapClass.ts, 6, 1))
+>Base : Symbol(Base, Decl(wrapClass.ts, 10, 55))
+>TBase : Symbol(TBase, Decl(wrapClass.ts, 10, 28))
+
+    return class extends Base {
+>Base : Symbol(Base, Decl(wrapClass.ts, 10, 55))
+
+        timestamp = Date.now();
+>timestamp : Symbol((Anonymous class).timestamp, Decl(wrapClass.ts, 11, 31))
+>Date.now : Symbol(DateConstructor.now, Decl(lib.es5.d.ts, --, --))
+>Date : Symbol(Date, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.scripthost.d.ts, --, --))
+>now : Symbol(DateConstructor.now, Decl(lib.es5.d.ts, --, --))
+
+    };
+}
+
 === tests/cases/compiler/index.ts ===
-import { wrapClass } from "./wrapClass";
+import { wrapClass, Timestamped } from "./wrapClass";
 >wrapClass : Symbol(wrapClass, Decl(index.ts, 0, 8))
+>Timestamped : Symbol(Timestamped, Decl(index.ts, 0, 19))
 
 export default wrapClass(0);
 >wrapClass : Symbol(wrapClass, Decl(index.ts, 0, 8))
 
+// Simple class
+export class User {
+>User : Symbol(User, Decl(index.ts, 2, 28))
+
+    name = '';
+>name : Symbol(User.name, Decl(index.ts, 5, 19))
+}
+
+// User that is Timestamped
+export class TimestampedUser extends Timestamped(User) {
+>TimestampedUser : Symbol(TimestampedUser, Decl(index.ts, 7, 1))
+>Timestamped : Symbol(Timestamped, Decl(index.ts, 0, 19))
+>User : Symbol(User, Decl(index.ts, 2, 28))
+
+    constructor() {
+        super();
+    }
+}

--- a/tests/baselines/reference/anonClassDeclarationEmitIsAnon.symbols
+++ b/tests/baselines/reference/anonClassDeclarationEmitIsAnon.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/wrapClass.ts ===
+export function wrapClass(param: any) {
+>wrapClass : Symbol(wrapClass, Decl(wrapClass.ts, 0, 0))
+>param : Symbol(param, Decl(wrapClass.ts, 0, 26))
+
+    return class Wrapped {
+>Wrapped : Symbol(Wrapped, Decl(wrapClass.ts, 1, 10))
+
+        foo() {
+>foo : Symbol(Wrapped.foo, Decl(wrapClass.ts, 1, 26))
+
+            return param;
+>param : Symbol(param, Decl(wrapClass.ts, 0, 26))
+        }
+    }
+}
+
+=== tests/cases/compiler/index.ts ===
+import { wrapClass } from "./wrapClass";
+>wrapClass : Symbol(wrapClass, Decl(index.ts, 0, 8))
+
+export default wrapClass(0);
+>wrapClass : Symbol(wrapClass, Decl(index.ts, 0, 8))
+

--- a/tests/baselines/reference/anonClassDeclarationEmitIsAnon.types
+++ b/tests/baselines/reference/anonClassDeclarationEmitIsAnon.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/wrapClass.ts ===
+export function wrapClass(param: any) {
+>wrapClass : (param: any) => typeof Wrapped
+>param : any
+
+    return class Wrapped {
+>class Wrapped {        foo() {            return param;        }    } : typeof Wrapped
+>Wrapped : typeof Wrapped
+
+        foo() {
+>foo : () => any
+
+            return param;
+>param : any
+        }
+    }
+}
+
+=== tests/cases/compiler/index.ts ===
+import { wrapClass } from "./wrapClass";
+>wrapClass : (param: any) => typeof Wrapped
+
+export default wrapClass(0);
+>wrapClass(0) : typeof Wrapped
+>wrapClass : (param: any) => typeof Wrapped
+>0 : 0
+

--- a/tests/baselines/reference/anonClassDeclarationEmitIsAnon.types
+++ b/tests/baselines/reference/anonClassDeclarationEmitIsAnon.types
@@ -16,12 +16,57 @@ export function wrapClass(param: any) {
     }
 }
 
+export type Constructor<T = {}> = new (...args: any[]) => T;
+>Constructor : Constructor<T>
+>args : any[]
+
+export function Timestamped<TBase extends Constructor>(Base: TBase) {
+>Timestamped : <TBase extends Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & TBase
+>Base : TBase
+
+    return class extends Base {
+>class extends Base {        timestamp = Date.now();    } : { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & TBase
+>Base : {}
+
+        timestamp = Date.now();
+>timestamp : number
+>Date.now() : number
+>Date.now : () => number
+>Date : DateConstructor
+>now : () => number
+
+    };
+}
+
 === tests/cases/compiler/index.ts ===
-import { wrapClass } from "./wrapClass";
+import { wrapClass, Timestamped } from "./wrapClass";
 >wrapClass : (param: any) => typeof Wrapped
+>Timestamped : <TBase extends import("tests/cases/compiler/wrapClass").Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & TBase
 
 export default wrapClass(0);
 >wrapClass(0) : typeof Wrapped
 >wrapClass : (param: any) => typeof Wrapped
 >0 : 0
 
+// Simple class
+export class User {
+>User : User
+
+    name = '';
+>name : string
+>'' : ""
+}
+
+// User that is Timestamped
+export class TimestampedUser extends Timestamped(User) {
+>TimestampedUser : TimestampedUser
+>Timestamped(User) : Timestamped<typeof User>.(Anonymous class) & User
+>Timestamped : <TBase extends import("tests/cases/compiler/wrapClass").Constructor<{}>>(Base: TBase) => { new (...args: any[]): (Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & TBase
+>User : typeof User
+
+    constructor() {
+        super();
+>super() : void
+>super : { new (...args: any[]): Timestamped<typeof User>.(Anonymous class); prototype: Timestamped<any>.(Anonymous class); } & typeof User
+    }
+}

--- a/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
+++ b/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
@@ -1,0 +1,14 @@
+// @declaration: true
+// @filename: wrapClass.ts
+export function wrapClass(param: any) {
+    return class Wrapped {
+        foo() {
+            return param;
+        }
+    }
+}
+
+// @filename: index.ts
+import { wrapClass } from "./wrapClass";
+
+export default wrapClass(0);

--- a/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
+++ b/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
@@ -8,7 +8,27 @@ export function wrapClass(param: any) {
     }
 }
 
+export type Constructor<T = {}> = new (...args: any[]) => T;
+
+export function Timestamped<TBase extends Constructor>(Base: TBase) {
+    return class extends Base {
+        timestamp = Date.now();
+    };
+}
+
 // @filename: index.ts
-import { wrapClass } from "./wrapClass";
+import { wrapClass, Timestamped } from "./wrapClass";
 
 export default wrapClass(0);
+
+// Simple class
+export class User {
+    name = '';
+}
+
+// User that is Timestamped
+export class TimestampedUser extends Timestamped(User) {
+    constructor() {
+        super();
+    }
+}


### PR DESCRIPTION
Fixes #33739

Just removes a line of code added alongside the js declaration emitter whose purpose should be duplicated by the `isValueSymbolAccessible` on the following line, and so only served to break people ❤️ 