### PR TITLE
Fix extract type on JS function params

### DIFF
--- a/src/services/refactors/extractType.ts
+++ b/src/services/refactors/extractType.ts
@@ -68,7 +68,7 @@ namespace ts.refactor {
         if (!selection || !isTypeNode(selection)) return undefined;
 
         const checker = context.program.getTypeChecker();
-        const firstStatement = Debug.assertDefined(isJS ? findAncestor(selection, isStatementAndHasJSDoc) : findAncestor(selection, isStatement), "Should find a statement");
+        const firstStatement = Debug.assertDefined(findAncestor(selection, isStatement), "Should find a statement");
         const typeParameters = collectTypeParameters(checker, selection, firstStatement, file);
         if (!typeParameters) return undefined;
 
@@ -98,10 +98,6 @@ namespace ts.refactor {
             return node.members;
         }
         return undefined;
-    }
-
-    function isStatementAndHasJSDoc(n: Node): n is (Statement & HasJSDoc) {
-        return isStatement(n) && hasJSDocNodes(n);
     }
 
     function rangeContainsSkipTrivia(r1: TextRange, node: Node, file: SourceFile): boolean {

--- a/tests/cases/fourslash/refactorExtractType_js7.ts
+++ b/tests/cases/fourslash/refactorExtractType_js7.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+// @Filename: a.js
+////function a(/** @type {/*a*/string/*b*/} */ b) {}
+
+goTo.file('a.js')
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract type",
+    actionName: "Extract to typedef",
+    actionDescription: "Extract to typedef",
+    newContent: `/**
+ * @typedef {string} /*RENAME*/NewType
+ */
+
+function a(/** @type {NewType} */ b) {}`,
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #34580

When the JSDoc is on the function param itself, the JSDoc container isn’t a statement. As far as I could tell, though, there’s no reason those nodes have to be the same. Maybe @Kingwl can think of a test case where this would fail?
