### PR TITLE
Adds accept header to the dispatch request when requesting a playground build of monaco

### DIFF
--- a/scripts/post-vsts-artifact-comment.js
+++ b/scripts/post-vsts-artifact-comment.js
@@ -49,7 +49,8 @@ and then running \`npm install\`.
     });
 
     // Send a ping to https://github.com/orta/make-monaco-builds#pull-request-builds
-    await gh.request("POST /repos/orta/make-monaco-builds/dispatches", { event_type: +process.env.SOURCE_ISSUE })
+    await gh.request("POST /repos/orta/make-monaco-builds/dispatches", 
+    { event_type: +process.env.SOURCE_ISSUE, headers: { "Accept": "application/vnd.github.everest-preview+json" }})
 }
 
 main().catch(async e => {


### PR DESCRIPTION
Fixes the deploy build chain from crashing like https://typescript.visualstudio.com/TypeScript/_build/results?buildId=50915
