### PR TITLE
Fix type reference to merged prototype property assignment

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13961,13 +13961,13 @@ namespace ts {
                 // If a signature resolution is already in-flight, skip issuing a circularity error
                 // here and just use the `any` type directly
                 const targetReturnType = isResolvingReturnTypeOfSignature(target) ? anyType
-                    : target.declaration && isJSConstructor(target.declaration) ? getDeclaredTypeOfClassOrInterface(target.declaration.symbol)
+                    : target.declaration && isJSConstructor(target.declaration) ? getDeclaredTypeOfClassOrInterface(getMergedSymbol(target.declaration.symbol))
                     : getReturnTypeOfSignature(target);
                 if (targetReturnType === voidType) {
                     return result;
                 }
                 const sourceReturnType = isResolvingReturnTypeOfSignature(source) ? anyType
-                    : source.declaration && isJSConstructor(source.declaration) ? getDeclaredTypeOfClassOrInterface(source.declaration.symbol)
+                    : source.declaration && isJSConstructor(source.declaration) ? getDeclaredTypeOfClassOrInterface(getMergedSymbol(source.declaration.symbol))
                     : getReturnTypeOfSignature(source);
 
                 // The following block preserves behavior forbidding boolean returning functions from being assignable to type guard returning functions

--- a/tests/baselines/reference/prototypePropertyAssignmentMergedTypeReference.symbols
+++ b/tests/baselines/reference/prototypePropertyAssignmentMergedTypeReference.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/salsa/prototypePropertyAssignmentMergedTypeReference.js ===
+// https://github.com/microsoft/TypeScript/issues/33993
+var f = function() {
+>f : Symbol(f, Decl(prototypePropertyAssignmentMergedTypeReference.js, 1, 3))
+
+    return 12;
+};
+
+f.prototype.a = "a";
+>f.prototype : Symbol(f.a, Decl(prototypePropertyAssignmentMergedTypeReference.js, 3, 2))
+>f : Symbol(f, Decl(prototypePropertyAssignmentMergedTypeReference.js, 1, 3))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>a : Symbol(f.a, Decl(prototypePropertyAssignmentMergedTypeReference.js, 3, 2))
+
+/** @type {new () => f} */
+var x = f;
+>x : Symbol(x, Decl(prototypePropertyAssignmentMergedTypeReference.js, 8, 3))
+>f : Symbol(f, Decl(prototypePropertyAssignmentMergedTypeReference.js, 1, 3))
+
+

--- a/tests/baselines/reference/prototypePropertyAssignmentMergedTypeReference.types
+++ b/tests/baselines/reference/prototypePropertyAssignmentMergedTypeReference.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/salsa/prototypePropertyAssignmentMergedTypeReference.js ===
+// https://github.com/microsoft/TypeScript/issues/33993
+var f = function() {
+>f : typeof f
+>function() {    return 12;} : typeof f
+
+    return 12;
+>12 : 12
+
+};
+
+f.prototype.a = "a";
+>f.prototype.a = "a" : "a"
+>f.prototype.a : any
+>f.prototype : any
+>f : typeof f
+>prototype : any
+>a : any
+>"a" : "a"
+
+/** @type {new () => f} */
+var x = f;
+>x : new () => f
+>f : typeof f
+
+

--- a/tests/cases/conformance/salsa/prototypePropertyAssignmentMergedTypeReference.ts
+++ b/tests/cases/conformance/salsa/prototypePropertyAssignmentMergedTypeReference.ts
@@ -1,0 +1,14 @@
+// https://github.com/microsoft/TypeScript/issues/33993
+// @noEmit: true
+// @allowJs: true
+// @checkJS: true
+// @filename: prototypePropertyAssignmentMergedTypeReference.js
+var f = function() {
+    return 12;
+};
+
+f.prototype.a = "a";
+
+/** @type {new () => f} */
+var x = f;
+


### PR DESCRIPTION
The constructor function code path in the return type checking of signatures needs to pass the *merged* symbol of the declaration to getDeclaredTypeOfClassOrInterface. Other callers of getDeclaredTypeOfClassOrInterface do this, or used an already-merged symbol.

Fixes #33993

For background, this call is new in the code path -- before 3.7, constructor functions were *not* classes and fell through to `getReturnTypeOfSignature`, where they would retrieve the type put there earlier by ad-hoc code. `getDeclaredTypeOfClassOrInterface` invokes the full class creation machinery but asserts that the symbol is correctly marked with the Class flag. If it's not, fails in a number of places. (The assertion postdates the filing of the bug.)