### PR TITLE
Fix checker handling for empty type argument lists

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23435,7 +23435,7 @@ namespace ts {
             // the declared number of type parameters, the call has an incorrect arity.
             const numTypeParameters = length(signature.typeParameters);
             const minTypeArgumentCount = getMinTypeArgumentCount(signature.typeParameters);
-            return !typeArguments ||
+            return !some(typeArguments) ||
                 (typeArguments.length >= minTypeArgumentCount && typeArguments.length <= numTypeParameters);
         }
 
@@ -24195,7 +24195,7 @@ namespace ts {
 
                 if (isSingleNonGenericCandidate) {
                     const candidate = candidates[0];
-                    if (typeArguments || !hasCorrectArity(node, args, candidate, signatureHelpTrailingComma)) {
+                    if (some(typeArguments) || !hasCorrectArity(node, args, candidate, signatureHelpTrailingComma)) {
                         return undefined;
                     }
                     if (getSignatureApplicabilityError(node, args, candidate, relation, CheckMode.Normal, /*reportErrors*/ false, /*containingMessageChain*/ undefined)) {
@@ -24216,7 +24216,7 @@ namespace ts {
 
                     if (candidate.typeParameters) {
                         let typeArgumentTypes: Type[] | undefined;
-                        if (typeArguments) {
+                        if (some(typeArguments)) {
                             typeArgumentTypes = checkTypeArguments(candidate, typeArguments, /*reportErrors*/ false);
                             if (!typeArgumentTypes) {
                                 candidateForTypeArgumentError = candidate;

--- a/tests/baselines/reference/emptyTypeArgumentList.errors.txt
+++ b/tests/baselines/reference/emptyTypeArgumentList.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/emptyTypeArgumentList.ts(2,4): error TS1099: Type argument list cannot be empty.
-tests/cases/compiler/emptyTypeArgumentList.ts(2,5): error TS2558: Expected 1 type arguments, but got 0.
+tests/cases/compiler/emptyTypeArgumentList.ts(6,9): error TS1099: Type argument list cannot be empty.
 
 
 ==== tests/cases/compiler/emptyTypeArgumentList.ts (2 errors) ====
@@ -7,5 +7,9 @@ tests/cases/compiler/emptyTypeArgumentList.ts(2,5): error TS2558: Expected 1 typ
     foo<>();
        ~~
 !!! error TS1099: Type argument list cannot be empty.
-        
-!!! error TS2558: Expected 1 type arguments, but got 0.
+    
+    // https://github.com/microsoft/TypeScript/issues/33041
+    function noParams() {}
+    noParams<>();
+            ~~
+!!! error TS1099: Type argument list cannot be empty.

--- a/tests/baselines/reference/emptyTypeArgumentList.js
+++ b/tests/baselines/reference/emptyTypeArgumentList.js
@@ -2,6 +2,13 @@
 function foo<T>() { }
 foo<>();
 
+// https://github.com/microsoft/TypeScript/issues/33041
+function noParams() {}
+noParams<>();
+
 //// [emptyTypeArgumentList.js]
 function foo() { }
 foo();
+// https://github.com/microsoft/TypeScript/issues/33041
+function noParams() { }
+noParams();

--- a/tests/baselines/reference/emptyTypeArgumentList.symbols
+++ b/tests/baselines/reference/emptyTypeArgumentList.symbols
@@ -6,3 +6,10 @@ function foo<T>() { }
 foo<>();
 >foo : Symbol(foo, Decl(emptyTypeArgumentList.ts, 0, 0))
 
+// https://github.com/microsoft/TypeScript/issues/33041
+function noParams() {}
+>noParams : Symbol(noParams, Decl(emptyTypeArgumentList.ts, 1, 8))
+
+noParams<>();
+>noParams : Symbol(noParams, Decl(emptyTypeArgumentList.ts, 1, 8))
+

--- a/tests/baselines/reference/emptyTypeArgumentList.types
+++ b/tests/baselines/reference/emptyTypeArgumentList.types
@@ -3,6 +3,14 @@ function foo<T>() { }
 >foo : <T>() => void
 
 foo<>();
->foo<>() : any
+>foo<>() : void
 >foo : <T>() => void
+
+// https://github.com/microsoft/TypeScript/issues/33041
+function noParams() {}
+>noParams : () => void
+
+noParams<>();
+>noParams<>() : void
+>noParams : () => void
 

--- a/tests/baselines/reference/emptyTypeArgumentListWithNew.errors.txt
+++ b/tests/baselines/reference/emptyTypeArgumentListWithNew.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/emptyTypeArgumentListWithNew.ts(2,8): error TS1099: Type argument list cannot be empty.
-tests/cases/compiler/emptyTypeArgumentListWithNew.ts(2,9): error TS2558: Expected 1 type arguments, but got 0.
+tests/cases/compiler/emptyTypeArgumentListWithNew.ts(6,13): error TS1099: Type argument list cannot be empty.
 
 
 ==== tests/cases/compiler/emptyTypeArgumentListWithNew.ts (2 errors) ====
@@ -7,5 +7,9 @@ tests/cases/compiler/emptyTypeArgumentListWithNew.ts(2,9): error TS2558: Expecte
     new foo<>();
            ~~
 !!! error TS1099: Type argument list cannot be empty.
-            
-!!! error TS2558: Expected 1 type arguments, but got 0.
+    
+    // https://github.com/microsoft/TypeScript/issues/33041
+    class noParams {}
+    new noParams<>();
+                ~~
+!!! error TS1099: Type argument list cannot be empty.

--- a/tests/baselines/reference/emptyTypeArgumentListWithNew.js
+++ b/tests/baselines/reference/emptyTypeArgumentListWithNew.js
@@ -2,6 +2,10 @@
 class foo<T> { }
 new foo<>();
 
+// https://github.com/microsoft/TypeScript/issues/33041
+class noParams {}
+new noParams<>();
+
 //// [emptyTypeArgumentListWithNew.js]
 var foo = /** @class */ (function () {
     function foo() {
@@ -9,3 +13,10 @@ var foo = /** @class */ (function () {
     return foo;
 }());
 new foo();
+// https://github.com/microsoft/TypeScript/issues/33041
+var noParams = /** @class */ (function () {
+    function noParams() {
+    }
+    return noParams;
+}());
+new noParams();

--- a/tests/baselines/reference/emptyTypeArgumentListWithNew.symbols
+++ b/tests/baselines/reference/emptyTypeArgumentListWithNew.symbols
@@ -6,3 +6,10 @@ class foo<T> { }
 new foo<>();
 >foo : Symbol(foo, Decl(emptyTypeArgumentListWithNew.ts, 0, 0))
 
+// https://github.com/microsoft/TypeScript/issues/33041
+class noParams {}
+>noParams : Symbol(noParams, Decl(emptyTypeArgumentListWithNew.ts, 1, 12))
+
+new noParams<>();
+>noParams : Symbol(noParams, Decl(emptyTypeArgumentListWithNew.ts, 1, 12))
+

--- a/tests/baselines/reference/emptyTypeArgumentListWithNew.types
+++ b/tests/baselines/reference/emptyTypeArgumentListWithNew.types
@@ -3,6 +3,14 @@ class foo<T> { }
 >foo : foo<T>
 
 new foo<>();
->new foo<>() : any
+>new foo<>() : foo<unknown>
 >foo : typeof foo
+
+// https://github.com/microsoft/TypeScript/issues/33041
+class noParams {}
+>noParams : noParams
+
+new noParams<>();
+>new noParams<>() : noParams
+>noParams : typeof noParams
 

--- a/tests/baselines/reference/tsxTypeArgumentResolution.errors.txt
+++ b/tests/baselines/reference/tsxTypeArgumentResolution.errors.txt
@@ -3,9 +3,7 @@ tests/cases/conformance/jsx/file.tsx(18,26): error TS2322: Type 'number' is not 
 tests/cases/conformance/jsx/file.tsx(20,13): error TS2558: Expected 1 type arguments, but got 2.
 tests/cases/conformance/jsx/file.tsx(22,13): error TS2558: Expected 1 type arguments, but got 2.
 tests/cases/conformance/jsx/file.tsx(24,12): error TS1099: Type argument list cannot be empty.
-tests/cases/conformance/jsx/file.tsx(24,13): error TS2558: Expected 1 type arguments, but got 0.
 tests/cases/conformance/jsx/file.tsx(26,12): error TS1099: Type argument list cannot be empty.
-tests/cases/conformance/jsx/file.tsx(26,13): error TS2558: Expected 1 type arguments, but got 0.
 tests/cases/conformance/jsx/file.tsx(39,14): error TS2344: Type 'Prop' does not satisfy the constraint '{ a: string; }'.
   Types of property 'a' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -16,7 +14,7 @@ tests/cases/conformance/jsx/file.tsx(51,47): error TS2322: Type 'string' is not 
 tests/cases/conformance/jsx/file.tsx(53,47): error TS2322: Type 'string' is not assignable to type 'number'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (14 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (12 errors) ====
     import React = require('react');
     
     interface Prop {
@@ -53,14 +51,10 @@ tests/cases/conformance/jsx/file.tsx(53,47): error TS2322: Type 'string' is not 
     x = <MyComp<> a={10} b="hi" />; // error
                ~~
 !!! error TS1099: Type argument list cannot be empty.
-                
-!!! error TS2558: Expected 1 type arguments, but got 0.
     
     x = <MyComp<> a={10} b="hi"></MyComp>; // error
                ~~
 !!! error TS1099: Type argument list cannot be empty.
-                
-!!! error TS2558: Expected 1 type arguments, but got 0.
     
     x= <MyComp<{}> /> // OK
     

--- a/tests/cases/compiler/emptyTypeArgumentList.ts
+++ b/tests/cases/compiler/emptyTypeArgumentList.ts
@@ -1,2 +1,6 @@
 function foo<T>() { }
 foo<>();
+
+// https://github.com/microsoft/TypeScript/issues/33041
+function noParams() {}
+noParams<>();

--- a/tests/cases/compiler/emptyTypeArgumentListWithNew.ts
+++ b/tests/cases/compiler/emptyTypeArgumentListWithNew.ts
@@ -1,2 +1,6 @@
 class foo<T> { }
 new foo<>();
+
+// https://github.com/microsoft/TypeScript/issues/33041
+class noParams {}
+new noParams<>();


### PR DESCRIPTION
Fixes a crash when calling a non-generic function when an empty type argument list.

Fixes #33041