### PR TITLE
JSDoc type reference understands require with entity name

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10765,11 +10765,15 @@ namespace ts {
             let typeType = valueType;
             if (symbol.valueDeclaration) {
                 const decl = getRootDeclaration(symbol.valueDeclaration);
-                const isRequireAlias = isVariableDeclaration(decl)
-                    && decl.initializer
-                    && isCallExpression(decl.initializer)
-                    && isRequireCall(decl.initializer, /*requireStringLiteralLikeArgument*/ true)
-                    && valueType.symbol;
+                let isRequireAlias = false;
+                if (isVariableDeclaration(decl) && decl.initializer) {
+                    let expr = decl.initializer;
+                    // skip past entity names, eg `require("x").a.b.c`
+                    while (isPropertyAccessExpression(expr)) {
+                        expr = expr.expression;
+                    }
+                    isRequireAlias = isCallExpression(expr) && isRequireCall(expr, /*requireStringLiteralLikeArgument*/ true) && !!valueType.symbol;
+                }
                 if (isRequireAlias || node.kind === SyntaxKind.ImportType) {
                     typeType = getTypeReferenceType(node, valueType.symbol);
                 }

--- a/tests/baselines/reference/jsdocTypeReferenceToImport.symbols
+++ b/tests/baselines/reference/jsdocTypeReferenceToImport.symbols
@@ -1,6 +1,8 @@
 === tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.js ===
+// #34802
+
 const C = require('./ex').C;
->C : Symbol(C, Decl(jsdocTypeReferenceToImport.js, 0, 5))
+>C : Symbol(C, Decl(jsdocTypeReferenceToImport.js, 2, 5))
 >require('./ex').C : Symbol(C, Decl(ex.d.ts, 0, 0))
 >require : Symbol(require)
 >'./ex' : Symbol("tests/cases/conformance/jsdoc/ex", Decl(ex.d.ts, 0, 0))
@@ -8,17 +10,17 @@ const C = require('./ex').C;
 
 /** @type {C} c */
 var c = new C()
->c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 2, 3))
->C : Symbol(C, Decl(jsdocTypeReferenceToImport.js, 0, 5))
+>c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 4, 3))
+>C : Symbol(C, Decl(jsdocTypeReferenceToImport.js, 2, 5))
 
 c.start
 >c.start : Symbol(C.start, Decl(ex.d.ts, 0, 16))
->c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 2, 3))
+>c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 4, 3))
 >start : Symbol(C.start, Decl(ex.d.ts, 0, 16))
 
 c.end
 >c.end : Symbol(C.end, Decl(ex.d.ts, 1, 17))
->c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 2, 3))
+>c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 4, 3))
 >end : Symbol(C.end, Decl(ex.d.ts, 1, 17))
 
 === tests/cases/conformance/jsdoc/ex.d.ts ===

--- a/tests/baselines/reference/jsdocTypeReferenceToImport.symbols
+++ b/tests/baselines/reference/jsdocTypeReferenceToImport.symbols
@@ -8,19 +8,41 @@ const C = require('./ex').C;
 >'./ex' : Symbol("tests/cases/conformance/jsdoc/ex", Decl(ex.d.ts, 0, 0))
 >C : Symbol(C, Decl(ex.d.ts, 0, 0))
 
+const D = require('./ex')?.C;
+>D : Symbol(D, Decl(jsdocTypeReferenceToImport.js, 3, 5))
+>require('./ex')?.C : Symbol(C, Decl(ex.d.ts, 0, 0))
+>require : Symbol(require)
+>'./ex' : Symbol("tests/cases/conformance/jsdoc/ex", Decl(ex.d.ts, 0, 0))
+>C : Symbol(C, Decl(ex.d.ts, 0, 0))
+
 /** @type {C} c */
 var c = new C()
->c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 4, 3))
+>c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 5, 3))
 >C : Symbol(C, Decl(jsdocTypeReferenceToImport.js, 2, 5))
 
 c.start
 >c.start : Symbol(C.start, Decl(ex.d.ts, 0, 16))
->c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 4, 3))
+>c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 5, 3))
 >start : Symbol(C.start, Decl(ex.d.ts, 0, 16))
 
 c.end
 >c.end : Symbol(C.end, Decl(ex.d.ts, 1, 17))
->c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 4, 3))
+>c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 5, 3))
+>end : Symbol(C.end, Decl(ex.d.ts, 1, 17))
+
+/** @type {D} c */
+var d = new D()
+>d : Symbol(d, Decl(jsdocTypeReferenceToImport.js, 10, 3))
+>D : Symbol(D, Decl(jsdocTypeReferenceToImport.js, 3, 5))
+
+d.start
+>d.start : Symbol(C.start, Decl(ex.d.ts, 0, 16))
+>d : Symbol(d, Decl(jsdocTypeReferenceToImport.js, 10, 3))
+>start : Symbol(C.start, Decl(ex.d.ts, 0, 16))
+
+d.end
+>d.end : Symbol(C.end, Decl(ex.d.ts, 1, 17))
+>d : Symbol(d, Decl(jsdocTypeReferenceToImport.js, 10, 3))
 >end : Symbol(C.end, Decl(ex.d.ts, 1, 17))
 
 === tests/cases/conformance/jsdoc/ex.d.ts ===

--- a/tests/baselines/reference/jsdocTypeReferenceToImport.symbols
+++ b/tests/baselines/reference/jsdocTypeReferenceToImport.symbols
@@ -1,0 +1,34 @@
+=== tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.js ===
+const C = require('./ex').C;
+>C : Symbol(C, Decl(jsdocTypeReferenceToImport.js, 0, 5))
+>require('./ex').C : Symbol(C, Decl(ex.d.ts, 0, 0))
+>require : Symbol(require)
+>'./ex' : Symbol("tests/cases/conformance/jsdoc/ex", Decl(ex.d.ts, 0, 0))
+>C : Symbol(C, Decl(ex.d.ts, 0, 0))
+
+/** @type {C} c */
+var c = new C()
+>c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 2, 3))
+>C : Symbol(C, Decl(jsdocTypeReferenceToImport.js, 0, 5))
+
+c.start
+>c.start : Symbol(C.start, Decl(ex.d.ts, 0, 16))
+>c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 2, 3))
+>start : Symbol(C.start, Decl(ex.d.ts, 0, 16))
+
+c.end
+>c.end : Symbol(C.end, Decl(ex.d.ts, 1, 17))
+>c : Symbol(c, Decl(jsdocTypeReferenceToImport.js, 2, 3))
+>end : Symbol(C.end, Decl(ex.d.ts, 1, 17))
+
+=== tests/cases/conformance/jsdoc/ex.d.ts ===
+export class C {
+>C : Symbol(C, Decl(ex.d.ts, 0, 0))
+
+    start: number
+>start : Symbol(C.start, Decl(ex.d.ts, 0, 16))
+
+    end: number
+>end : Symbol(C.end, Decl(ex.d.ts, 1, 17))
+}
+

--- a/tests/baselines/reference/jsdocTypeReferenceToImport.types
+++ b/tests/baselines/reference/jsdocTypeReferenceToImport.types
@@ -9,6 +9,14 @@ const C = require('./ex').C;
 >'./ex' : "./ex"
 >C : typeof import("tests/cases/conformance/jsdoc/ex").C
 
+const D = require('./ex')?.C;
+>D : typeof import("tests/cases/conformance/jsdoc/ex").C
+>require('./ex')?.C : typeof import("tests/cases/conformance/jsdoc/ex").C
+>require('./ex') : typeof import("tests/cases/conformance/jsdoc/ex")
+>require : any
+>'./ex' : "./ex"
+>C : typeof import("tests/cases/conformance/jsdoc/ex").C
+
 /** @type {C} c */
 var c = new C()
 >c : import("tests/cases/conformance/jsdoc/ex").C
@@ -23,6 +31,22 @@ c.start
 c.end
 >c.end : number
 >c : import("tests/cases/conformance/jsdoc/ex").C
+>end : number
+
+/** @type {D} c */
+var d = new D()
+>d : import("tests/cases/conformance/jsdoc/ex").C
+>new D() : import("tests/cases/conformance/jsdoc/ex").C
+>D : typeof import("tests/cases/conformance/jsdoc/ex").C
+
+d.start
+>d.start : number
+>d : import("tests/cases/conformance/jsdoc/ex").C
+>start : number
+
+d.end
+>d.end : number
+>d : import("tests/cases/conformance/jsdoc/ex").C
 >end : number
 
 === tests/cases/conformance/jsdoc/ex.d.ts ===

--- a/tests/baselines/reference/jsdocTypeReferenceToImport.types
+++ b/tests/baselines/reference/jsdocTypeReferenceToImport.types
@@ -1,4 +1,6 @@
 === tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.js ===
+// #34802
+
 const C = require('./ex').C;
 >C : typeof import("tests/cases/conformance/jsdoc/ex").C
 >require('./ex').C : typeof import("tests/cases/conformance/jsdoc/ex").C

--- a/tests/baselines/reference/jsdocTypeReferenceToImport.types
+++ b/tests/baselines/reference/jsdocTypeReferenceToImport.types
@@ -1,0 +1,36 @@
+=== tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.js ===
+const C = require('./ex').C;
+>C : typeof import("tests/cases/conformance/jsdoc/ex").C
+>require('./ex').C : typeof import("tests/cases/conformance/jsdoc/ex").C
+>require('./ex') : typeof import("tests/cases/conformance/jsdoc/ex")
+>require : any
+>'./ex' : "./ex"
+>C : typeof import("tests/cases/conformance/jsdoc/ex").C
+
+/** @type {C} c */
+var c = new C()
+>c : import("tests/cases/conformance/jsdoc/ex").C
+>new C() : import("tests/cases/conformance/jsdoc/ex").C
+>C : typeof import("tests/cases/conformance/jsdoc/ex").C
+
+c.start
+>c.start : number
+>c : import("tests/cases/conformance/jsdoc/ex").C
+>start : number
+
+c.end
+>c.end : number
+>c : import("tests/cases/conformance/jsdoc/ex").C
+>end : number
+
+=== tests/cases/conformance/jsdoc/ex.d.ts ===
+export class C {
+>C : C
+
+    start: number
+>start : number
+
+    end: number
+>end : number
+}
+

--- a/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.ts
@@ -1,3 +1,4 @@
+// #34802
 // @Filename: jsdocTypeReferenceToImport.js
 // @noEmit: true
 // @allowJs: true

--- a/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.ts
@@ -1,0 +1,16 @@
+// @Filename: jsdocTypeReferenceToImport.js
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+
+const C = require('./ex').C;
+/** @type {C} c */
+var c = new C()
+c.start
+c.end
+
+// @Filename: ex.d.ts
+export class C {
+    start: number
+    end: number
+}

--- a/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeReferenceToImport.ts
@@ -5,10 +5,16 @@
 // @checkJs: true
 
 const C = require('./ex').C;
+const D = require('./ex')?.C;
 /** @type {C} c */
 var c = new C()
 c.start
 c.end
+
+/** @type {D} c */
+var d = new D()
+d.start
+d.end
 
 // @Filename: ex.d.ts
 export class C {


### PR DESCRIPTION
For example, `require("x").c`. This is the value equivalent of `import("x").a.b.c`, but the syntax tree is not as nicely designed for this purpose.

Fixes #34802
