### PR TITLE
Don’t recognize non-top-level module.exports as special assignments

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2365,7 +2365,10 @@ namespace ts {
                     }
                     break;
                 case SyntaxKind.BinaryExpression:
-                    const specialKind = getAssignmentDeclarationKind(node as BinaryExpression);
+                    const binaryExpression = node as BinaryExpression;
+                    binaryExpression.left.parent = binaryExpression;
+                    binaryExpression.right.parent = binaryExpression;
+                    const specialKind = getAssignmentDeclarationKind(binaryExpression);
                     switch (specialKind) {
                         case AssignmentDeclarationKind.ExportsProperty:
                             bindExportsPropertyAssignment(node as BindableStaticPropertyAssignmentExpression);

--- a/tests/baselines/reference/nestedModuleExports.errors.txt
+++ b/tests/baselines/reference/nestedModuleExports.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/conformance/jsdoc/not-iife.js(5,9): error TS2580: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i @types/node`.
+tests/cases/conformance/jsdoc/not-iife.js(6,9): error TS2580: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i @types/node`.
+tests/cases/conformance/jsdoc/not-iife.js(8,9): error TS2580: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i @types/node`.
+tests/cases/conformance/jsdoc/test.js(2,1): error TS2304: Cannot find name 'ShouldNotBeGlobal'.
+
+
+==== tests/cases/conformance/jsdoc/not-iife.js (3 errors) ====
+    var ShouldBeGlobal = 0;
+    function f(type, ctor, exports) {
+        if (typeof exports !== "undefined") {
+            exports.a = ctor;
+            module.exports.b = ctor;
+            ~~~~~~
+!!! error TS2580: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i @types/node`.
+            module.exports = { ctor };
+            ~~~~~~
+!!! error TS2580: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i @types/node`.
+            exports = { ctor };
+            module.exports["c"] = type;
+            ~~~~~~
+!!! error TS2580: Cannot find name 'module'. Do you need to install type definitions for node? Try `npm i @types/node`.
+        }
+    }
+    
+==== tests/cases/conformance/jsdoc/iife.js (0 errors) ====
+    var ShouldNotBeGlobal = 0;
+    (function () {
+        exports.a = "b";
+    })();
+    
+==== tests/cases/conformance/jsdoc/test.js (1 errors) ====
+    ShouldBeGlobal;
+    ShouldNotBeGlobal;
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'ShouldNotBeGlobal'.
+    

--- a/tests/baselines/reference/nestedModuleExports.symbols
+++ b/tests/baselines/reference/nestedModuleExports.symbols
@@ -1,0 +1,50 @@
+=== tests/cases/conformance/jsdoc/not-iife.js ===
+var ShouldBeGlobal = 0;
+>ShouldBeGlobal : Symbol(ShouldBeGlobal, Decl(not-iife.js, 0, 3))
+
+function f(type, ctor, exports) {
+>f : Symbol(f, Decl(not-iife.js, 0, 23))
+>type : Symbol(type, Decl(not-iife.js, 1, 11))
+>ctor : Symbol(ctor, Decl(not-iife.js, 1, 16))
+>exports : Symbol(exports, Decl(not-iife.js, 1, 22))
+
+    if (typeof exports !== "undefined") {
+>exports : Symbol(exports, Decl(not-iife.js, 1, 22))
+
+        exports.a = ctor;
+>exports : Symbol(exports, Decl(not-iife.js, 1, 22))
+>ctor : Symbol(ctor, Decl(not-iife.js, 1, 16))
+
+        module.exports.b = ctor;
+>ctor : Symbol(ctor, Decl(not-iife.js, 1, 16))
+
+        module.exports = { ctor };
+>ctor : Symbol(ctor, Decl(not-iife.js, 5, 26))
+
+        exports = { ctor };
+>exports : Symbol(exports, Decl(not-iife.js, 1, 22))
+>ctor : Symbol(ctor, Decl(not-iife.js, 6, 19))
+
+        module.exports["c"] = type;
+>type : Symbol(type, Decl(not-iife.js, 1, 11))
+    }
+}
+
+=== tests/cases/conformance/jsdoc/iife.js ===
+var ShouldNotBeGlobal = 0;
+>ShouldNotBeGlobal : Symbol(ShouldNotBeGlobal, Decl(iife.js, 0, 3))
+
+(function () {
+    exports.a = "b";
+>exports.a : Symbol(a, Decl(iife.js, 1, 14))
+>exports : Symbol(a, Decl(iife.js, 1, 14))
+>a : Symbol(a, Decl(iife.js, 1, 14))
+
+})();
+
+=== tests/cases/conformance/jsdoc/test.js ===
+ShouldBeGlobal;
+>ShouldBeGlobal : Symbol(ShouldBeGlobal, Decl(not-iife.js, 0, 3))
+
+ShouldNotBeGlobal;
+

--- a/tests/baselines/reference/nestedModuleExports.types
+++ b/tests/baselines/reference/nestedModuleExports.types
@@ -1,0 +1,84 @@
+=== tests/cases/conformance/jsdoc/not-iife.js ===
+var ShouldBeGlobal = 0;
+>ShouldBeGlobal : number
+>0 : 0
+
+function f(type, ctor, exports) {
+>f : (type: any, ctor: any, exports: any) => void
+>type : any
+>ctor : any
+>exports : any
+
+    if (typeof exports !== "undefined") {
+>typeof exports !== "undefined" : boolean
+>typeof exports : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>exports : any
+>"undefined" : "undefined"
+
+        exports.a = ctor;
+>exports.a = ctor : any
+>exports.a : any
+>exports : any
+>a : any
+>ctor : any
+
+        module.exports.b = ctor;
+>module.exports.b = ctor : any
+>module.exports.b : any
+>module.exports : any
+>module : any
+>exports : any
+>b : any
+>ctor : any
+
+        module.exports = { ctor };
+>module.exports = { ctor } : { ctor: any; }
+>module.exports : any
+>module : any
+>exports : any
+>{ ctor } : { ctor: any; }
+>ctor : any
+
+        exports = { ctor };
+>exports = { ctor } : { ctor: any; }
+>exports : any
+>{ ctor } : { ctor: any; }
+>ctor : any
+
+        module.exports["c"] = type;
+>module.exports["c"] = type : any
+>module.exports["c"] : any
+>module.exports : any
+>module : any
+>exports : any
+>"c" : "c"
+>type : any
+    }
+}
+
+=== tests/cases/conformance/jsdoc/iife.js ===
+var ShouldNotBeGlobal = 0;
+>ShouldNotBeGlobal : number
+>0 : 0
+
+(function () {
+>(function () {    exports.a = "b";})() : void
+>(function () {    exports.a = "b";}) : () => void
+>function () {    exports.a = "b";} : () => void
+
+    exports.a = "b";
+>exports.a = "b" : "b"
+>exports.a : string
+>exports : typeof import("tests/cases/conformance/jsdoc/iife")
+>a : string
+>"b" : "b"
+
+})();
+
+=== tests/cases/conformance/jsdoc/test.js ===
+ShouldBeGlobal;
+>ShouldBeGlobal : number
+
+ShouldNotBeGlobal;
+>ShouldNotBeGlobal : any
+

--- a/tests/cases/conformance/jsdoc/nestedModuleExports.ts
+++ b/tests/cases/conformance/jsdoc/nestedModuleExports.ts
@@ -1,0 +1,25 @@
+// @noEmit: true
+// @checkJs: true
+// @allowJs: true
+
+// @Filename: not-iife.js
+var ShouldBeGlobal = 0;
+function f(type, ctor, exports) {
+    if (typeof exports !== "undefined") {
+        exports.a = ctor;
+        module.exports.b = ctor;
+        module.exports = { ctor };
+        exports = { ctor };
+        module.exports["c"] = type;
+    }
+}
+
+// @Filename: iife.js
+var ShouldNotBeGlobal = 0;
+(function () {
+    exports.a = "b";
+})();
+
+// @Filename: test.js
+ShouldBeGlobal;
+ShouldNotBeGlobal;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #33765 the rest of the way