### PR TITLE
JSDoc: Resolve return type of construct signature

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10762,7 +10762,7 @@ namespace ts {
          */
         function getTypeFromJSDocValueReference(node: NodeWithTypeArguments, symbol: Symbol): Type | undefined {
             const valueType = getTypeOfSymbol(symbol);
-            let typeType = valueType;
+            let typeType;
             if (symbol.valueDeclaration) {
                 const decl = getRootDeclaration(symbol.valueDeclaration);
                 const isRequireAlias = isVariableDeclaration(decl)
@@ -10774,7 +10774,13 @@ namespace ts {
                     typeType = getTypeReferenceType(node, valueType.symbol);
                 }
             }
-            return getSymbolLinks(symbol).resolvedJSDocType = typeType;
+            if (!typeType) {
+                const ctor = getSingleSignature(valueType, SignatureKind.Construct, /*allowMembers*/ true);
+                if (ctor) {
+                    typeType = getReturnTypeOfSignature(ctor);
+                }
+            }
+            return getSymbolLinks(symbol).resolvedJSDocType = typeType || valueType;
         }
 
         function getSubstitutionType(typeVariable: TypeVariable, substitute: Type) {

--- a/tests/baselines/reference/jsdocTypeReferenceToValue.symbols
+++ b/tests/baselines/reference/jsdocTypeReferenceToValue.symbols
@@ -1,10 +1,13 @@
 === tests/cases/conformance/jsdoc/foo.js ===
+// #33106
 /** @param {Image} image */
 function process(image) {
 >process : Symbol(process, Decl(foo.js, 0, 0))
->image : Symbol(image, Decl(foo.js, 1, 17))
+>image : Symbol(image, Decl(foo.js, 2, 17))
 
-    return new image(1, 1)
->image : Symbol(image, Decl(foo.js, 1, 17))
+    return image.accessKey
+>image.accessKey : Symbol(HTMLElement.accessKey, Decl(lib.dom.d.ts, --, --))
+>image : Symbol(image, Decl(foo.js, 2, 17))
+>accessKey : Symbol(HTMLElement.accessKey, Decl(lib.dom.d.ts, --, --))
 }
 

--- a/tests/baselines/reference/jsdocTypeReferenceToValue.types
+++ b/tests/baselines/reference/jsdocTypeReferenceToValue.types
@@ -1,13 +1,13 @@
 === tests/cases/conformance/jsdoc/foo.js ===
+// #33106
 /** @param {Image} image */
 function process(image) {
->process : (image: new (width?: number, height?: number) => HTMLImageElement) => HTMLImageElement
->image : new (width?: number, height?: number) => HTMLImageElement
+>process : (image: HTMLImageElement) => string
+>image : HTMLImageElement
 
-    return new image(1, 1)
->new image(1, 1) : HTMLImageElement
->image : new (width?: number, height?: number) => HTMLImageElement
->1 : 1
->1 : 1
+    return image.accessKey
+>image.accessKey : string
+>image : HTMLImageElement
+>accessKey : string
 }
 

--- a/tests/baselines/reference/jsdocTypeReferenceToValue2.symbols
+++ b/tests/baselines/reference/jsdocTypeReferenceToValue2.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/conformance/jsdoc/jsdocTypeReferenceToValue2.js ===
+// #34803
+/** @type {{
+    new(wuth?: number, thud?: number): HTMLImageElement;
+}} */
+var Im;
+>Im : Symbol(Im, Decl(jsdocTypeReferenceToValue2.js, 4, 3))
+
+/**
+ * @param {Im} i
+ * @param {Element} l
+ */
+function f(i, l) {
+>f : Symbol(f, Decl(jsdocTypeReferenceToValue2.js, 4, 7))
+>i : Symbol(i, Decl(jsdocTypeReferenceToValue2.js, 10, 11))
+>l : Symbol(l, Decl(jsdocTypeReferenceToValue2.js, 10, 13))
+
+    l.appendChild(i);
+>l.appendChild : Symbol(Node.appendChild, Decl(lib.dom.d.ts, --, --))
+>l : Symbol(l, Decl(jsdocTypeReferenceToValue2.js, 10, 13))
+>appendChild : Symbol(Node.appendChild, Decl(lib.dom.d.ts, --, --))
+>i : Symbol(i, Decl(jsdocTypeReferenceToValue2.js, 10, 11))
+
+    i.style.display = 'none';
+>i.style.display : Symbol(CSSStyleDeclaration.display, Decl(lib.dom.d.ts, --, --))
+>i.style : Symbol(ElementCSSInlineStyle.style, Decl(lib.dom.d.ts, --, --))
+>i : Symbol(i, Decl(jsdocTypeReferenceToValue2.js, 10, 11))
+>style : Symbol(ElementCSSInlineStyle.style, Decl(lib.dom.d.ts, --, --))
+>display : Symbol(CSSStyleDeclaration.display, Decl(lib.dom.d.ts, --, --))
+}
+
+

--- a/tests/baselines/reference/jsdocTypeReferenceToValue2.types
+++ b/tests/baselines/reference/jsdocTypeReferenceToValue2.types
@@ -1,0 +1,35 @@
+=== tests/cases/conformance/jsdoc/jsdocTypeReferenceToValue2.js ===
+// #34803
+/** @type {{
+    new(wuth?: number, thud?: number): HTMLImageElement;
+}} */
+var Im;
+>Im : new (wuth?: number, thud?: number) => HTMLImageElement
+
+/**
+ * @param {Im} i
+ * @param {Element} l
+ */
+function f(i, l) {
+>f : (i: HTMLImageElement, l: Element) => void
+>i : HTMLImageElement
+>l : Element
+
+    l.appendChild(i);
+>l.appendChild(i) : HTMLImageElement
+>l.appendChild : <T extends Node>(newChild: T) => T
+>l : Element
+>appendChild : <T extends Node>(newChild: T) => T
+>i : HTMLImageElement
+
+    i.style.display = 'none';
+>i.style.display = 'none' : "none"
+>i.style.display : string
+>i.style : CSSStyleDeclaration
+>i : HTMLImageElement
+>style : CSSStyleDeclaration
+>display : string
+>'none' : "none"
+}
+
+

--- a/tests/cases/conformance/jsdoc/jsdocTypeReferenceToValue.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeReferenceToValue.ts
@@ -1,8 +1,9 @@
+// #33106
 // @Filename: foo.js
 // @noEmit: true
 // @allowJs: true
 // @checkJs: true
 /** @param {Image} image */
 function process(image) {
-    return new image(1, 1)
+    return image.accessKey
 }

--- a/tests/cases/conformance/jsdoc/jsdocTypeReferenceToValue2.ts
+++ b/tests/cases/conformance/jsdoc/jsdocTypeReferenceToValue2.ts
@@ -1,0 +1,19 @@
+// #34803
+// @Filename: jsdocTypeReferenceToValue2.js
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+/** @type {{
+    new(wuth?: number, thud?: number): HTMLImageElement;
+}} */
+var Im;
+
+/**
+ * @param {Im} i
+ * @param {Element} l
+ */
+function f(i, l) {
+    l.appendChild(i);
+    i.style.display = 'none';
+}
+


### PR DESCRIPTION
Pre-3.7, this was handled by the weird try-again catchall case. Now we need to explicitly handle the case of value that has a constructable type:

```ts
declare var Image: { new (): HTMLImageElement }
```

This is not a commonly written construction, but the DOM uses it for Image, so that means it's widely consumed. In Typescript, the reference must be `typeof Image`, but in Javascript, JSDoc references should allow `Image` as well.

Fixes #34803

Two notes:

1. This needs to be in 3.7 too.
2. The existing test was just testing that the type resolved at all. But it assumed the Typescript semantics for the reference, which is not correct. You'll see the types change accordingly, plus I changed the test to avoid a compile error.