### PR TITLE
Don't filter away private completions if in the same context

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1826,8 +1826,14 @@ namespace ts.Completions {
                 if (canGetType) {
                     const typeForObject = typeChecker.getTypeAtLocation(objectLikeContainer);
                     if (!typeForObject) return GlobalsSearch.Fail;
-                    // In a binding pattern, get only known properties. Everywhere else we will get all possible properties.
-                    typeMembers = typeChecker.getPropertiesOfType(typeForObject).filter((symbol) => !(getDeclarationModifierFlagsFromSymbol(symbol) & ModifierFlags.NonPublicAccessibilityModifier));
+                    // In a binding pattern, get only known properties (unless in the same scope).
+                    // Everywhere else we will get all possible properties.
+                    const containerClass = getContainingClass(objectLikeContainer);
+                    typeMembers = typeChecker.getPropertiesOfType(typeForObject).filter(symbol =>
+                        // either public
+                        !(getDeclarationModifierFlagsFromSymbol(symbol) & ModifierFlags.NonPublicAccessibilityModifier)
+                        // or we're in it
+                        || containerClass && contains(typeForObject.symbol.declarations, containerClass));
                     existingMembers = objectLikeContainer.elements;
                 }
             }

--- a/tests/cases/fourslash/completionListInObjectBindingPattern15.ts
+++ b/tests/cases/fourslash/completionListInObjectBindingPattern15.ts
@@ -1,0 +1,22 @@
+/// <reference path="fourslash.ts"/>
+
+////class Foo {
+////    private   xxx1 = 1;
+////    protected xxx2 = 2;
+////    public    xxx3 = 3;
+////    private   static xxx4 = 4;
+////    protected static xxx5 = 5;
+////    public    static xxx6 = 6;
+////    foo() {
+////        const { /*1*/ } = this;
+////        const { /*2*/ } = Foo;
+////    }
+////}
+////
+////const { /*3*/ } = new Foo();
+////const { /*4*/ } = Foo;
+
+verify.completions({ marker: "1", exact: ["xxx1", "xxx2", "xxx3", "foo"] });
+verify.completions({ marker: "2", exact: ["prototype", "xxx4", "xxx5", "xxx6"] });
+verify.completions({ marker: "3", exact: ["xxx3", "foo"] });
+verify.completions({ marker: "4", exact: ["prototype", "xxx6"] });


### PR DESCRIPTION
Fixes #34405, which was introduced in PR #16953.
