### PR TITLE
Sort emitted declarations of union types.

### DIFF
--- a/tests/baselines/reference/conditionalTypes1.js
+++ b/tests/baselines/reference/conditionalTypes1.js
@@ -462,10 +462,10 @@ assign(a, { o: 2, c: { 0: { a: 2, c: '213123' } } });
 //// [conditionalTypes1.d.ts]
 declare type T00 = Exclude<"a" | "b" | "c" | "d", "a" | "c" | "f">;
 declare type T01 = Extract<"a" | "b" | "c" | "d", "a" | "c" | "f">;
-declare type T02 = Exclude<string | number | (() => void), Function>;
-declare type T03 = Extract<string | number | (() => void), Function>;
-declare type T04 = NonNullable<string | number | undefined>;
-declare type T05 = NonNullable<(() => string) | string[] | null | undefined>;
+declare type T02 = Exclude<number | string | (() => void), Function>;
+declare type T03 = Extract<number | string | (() => void), Function>;
+declare type T04 = NonNullable<number | string | undefined>;
+declare type T05 = NonNullable<null | undefined | string[] | (() => string)>;
 declare function f1<T>(x: T, y: NonNullable<T>): void;
 declare function f2<T extends string | undefined>(x: T, y: NonNullable<T>): void;
 declare function f3<T>(x: Partial<T>[keyof T], y: NonNullable<Partial<T>[keyof T]>): void;
@@ -473,14 +473,14 @@ declare function f4<T extends {
     x: string | undefined;
 }>(x: T["x"], y: NonNullable<T["x"]>): void;
 declare type Options = {
-    k: "a";
-    a: number;
+    k: "c";
+    c: boolean;
 } | {
     k: "b";
     b: string;
 } | {
-    k: "c";
-    c: boolean;
+    k: "a";
+    a: number;
 };
 declare type T10 = Exclude<Options, {
     k: "a" | "b";
@@ -489,14 +489,14 @@ declare type T11 = Extract<Options, {
     k: "a" | "b";
 }>;
 declare type T12 = Exclude<Options, {
-    k: "a";
-} | {
     k: "b";
+} | {
+    k: "a";
 }>;
 declare type T13 = Extract<Options, {
-    k: "a";
-} | {
     k: "b";
+} | {
+    k: "a";
 }>;
 declare type T14 = Exclude<Options, {
     q: "a";
@@ -565,9 +565,9 @@ declare type DeepReadonlyObject<T> = {
     readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>;
 };
 declare function f10(part: DeepReadonly<Part>): void;
-declare type ZeroOf<T extends number | string | boolean> = T extends number ? 0 : T extends string ? "" : false;
-declare function zeroOf<T extends number | string | boolean>(value: T): ZeroOf<T>;
-declare function f20<T extends string>(n: number, b: boolean, x: number | boolean, y: T): void;
+declare type ZeroOf<T extends boolean | number | string> = T extends number ? 0 : T extends string ? "" : false;
+declare function zeroOf<T extends boolean | number | string>(value: T): ZeroOf<T>;
+declare function f20<T extends string>(n: number, b: boolean, x: boolean | number, y: T): void;
 declare function f21<T extends number | string>(x: T, y: ZeroOf<T>): void;
 declare type T35<T extends {
     a: string;
@@ -703,7 +703,7 @@ interface Foo2 {
 interface Bar2 {
     bar: string;
 }
-declare type FooBar = Foo2 | Bar2;
+declare type FooBar = Bar2 | Foo2;
 declare interface ExtractFooBar<FB extends FooBar> {
 }
 declare type Extracted<Struct> = {

--- a/tests/baselines/reference/conditionalTypes2.js
+++ b/tests/baselines/reference/conditionalTypes2.js
@@ -290,8 +290,8 @@ declare function f3<A, B extends A>(a: Invariant<A>, b: Invariant<B>): void;
 declare function isFunction<T>(value: T): value is Extract<T, Function>;
 declare function getFunction<T>(item: T): Extract<T, Function>;
 declare function f10<T>(x: T): void;
-declare function f11(x: string | (() => string) | undefined): void;
-declare function f12(x: string | (() => string) | undefined): void;
+declare function f11(x: string | undefined | (() => string)): void;
+declare function f12(x: string | undefined | (() => string)): void;
 declare type Foo = {
     foo: string;
 };
@@ -327,7 +327,7 @@ interface B1<T> extends A1<T> {
     bat: B1<B1<T>>;
     boom: T extends any ? true : true;
 }
-declare function toString1(value: object | Function): string;
+declare function toString1(value: Function | object): string;
 declare function toString2(value: Function): string;
 declare function foo<T>(value: T): void;
 declare type A<T, V, E> = T extends object ? {

--- a/tests/baselines/reference/declFileTypeAnnotationParenType.js
+++ b/tests/baselines/reference/declFileTypeAnnotationParenType.js
@@ -27,5 +27,5 @@ declare class c {
 }
 declare var x: (() => c)[];
 declare var y: (() => c)[];
-declare var k: (() => c) | string;
+declare var k: string | (() => c);
 declare var l: string | (() => c);

--- a/tests/baselines/reference/declFileTypeAnnotationStringLiteral.js
+++ b/tests/baselines/reference/declFileTypeAnnotationStringLiteral.js
@@ -22,4 +22,4 @@ function foo(a) {
 //// [declFileTypeAnnotationStringLiteral.d.ts]
 declare function foo(a: "hello"): number;
 declare function foo(a: "name"): string;
-declare function foo(a: string): string | number;
+declare function foo(a: string): number | string;

--- a/tests/baselines/reference/declFileTypeAnnotationTypeAlias.js
+++ b/tests/baselines/reference/declFileTypeAnnotationTypeAlias.js
@@ -64,7 +64,7 @@ var M;
 
 //// [declFileTypeAnnotationTypeAlias.d.ts]
 declare module M {
-    type Value = string | number | boolean;
+    type Value = boolean | number | string;
     var x: Value;
     class c {
     }

--- a/tests/baselines/reference/declarationEmitExportAliasVisibiilityMarking.js
+++ b/tests/baselines/reference/declarationEmitExportAliasVisibiilityMarking.js
@@ -28,8 +28,8 @@ exports.lazyCard = function () { return Promise.resolve().then(function () { ret
 
 
 //// [Types.d.ts]
-declare type Suit = 'Hearts' | 'Spades' | 'Clubs' | 'Diamonds';
-declare type Rank = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 'Jack' | 'Queen' | 'King';
+declare type Suit = 'Clubs' | 'Diamonds' | 'Hearts' | 'Spades';
+declare type Rank = 'Jack' | 'King' | 'Queen' | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10;
 export { Suit, Rank };
 //// [Card.d.ts]
 import { Suit, Rank } from './Types';

--- a/tests/baselines/reference/declarationEmitInferredTypeAlias5.js
+++ b/tests/baselines/reference/declarationEmitInferredTypeAlias5.js
@@ -23,7 +23,7 @@ exports.v = v;
 
 
 //// [0.d.ts]
-export declare type Data = string | boolean;
+export declare type Data = boolean | string;
 //// [1.d.ts]
 import * as Z from "./0";
 declare let v: Z.Data;

--- a/tests/baselines/reference/declarationEmitInferredTypeAlias7.js
+++ b/tests/baselines/reference/declarationEmitInferredTypeAlias7.js
@@ -20,7 +20,7 @@ exports.v = v;
 
 
 //// [0.d.ts]
-export declare type Data = string | boolean;
+export declare type Data = boolean | string;
 //// [1.d.ts]
 declare let v: import("./0").Data;
 export { v };

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
@@ -124,7 +124,7 @@ declare function foo1(x: string | undefined, b: number): void;
 declare function foo2(x: string | undefined, b: number): void;
 declare function foo3(x: string | undefined, b: number): void;
 declare function foo4(x: string | undefined, b: number): void;
-declare type OptionalNullableString = string | null | undefined;
+declare type OptionalNullableString = null | string | undefined;
 declare function allowsNull(val?: OptionalNullableString): void;
 declare function removeUndefinedButNotFalse(x?: boolean): false | undefined;
 declare const cond: boolean;

--- a/tests/baselines/reference/exhaustiveSwitchStatements1.js
+++ b/tests/baselines/reference/exhaustiveSwitchStatements1.js
@@ -408,7 +408,7 @@ interface Triangle {
     kind: "triangle";
     side: number;
 }
-declare type Shape = Square | Rectangle | Circle | Triangle;
+declare type Shape = Circle | Rectangle | Square | Triangle;
 declare function area(s: Shape): number;
 declare function areaWrapped(s: Shape): number;
 declare enum MyEnum {
@@ -431,7 +431,7 @@ interface Circle2 {
     kind: "circle";
     radius: number;
 }
-declare type Shape2 = Square2 | Circle2;
+declare type Shape2 = Circle2 | Square2;
 declare function withDefault(s1: Shape2, s2: Shape2): string;
 declare function withoutDefault(s1: Shape2, s2: Shape2): string;
 declare function test4(value: 1 | 2): string;

--- a/tests/baselines/reference/genericDefaults.js
+++ b/tests/baselines/reference/genericDefaults.js
@@ -902,14 +902,14 @@ declare function f07<T, U = B, V = U>(a?: T, b?: U, c?: V): [T, U, V];
 declare function f08<T extends A, U = T>(a?: T, b?: U): [T, U];
 declare function f09<T, U extends T = T>(a?: T, b?: U): [T, U];
 declare function f10<T extends A, U extends T = T>(a?: T, b?: U): [T, U];
-declare function f11<T, U = T | B>(a?: T, b?: U): [T, U];
+declare function f11<T, U = B | T>(a?: T, b?: U): [T, U];
 declare function f12<T, U = T & B>(a?: T, b?: U): [T, U];
 declare function f13<T = U, U = B>(a?: T, b?: U): [T, U];
 declare function f14<T, U = V, V = C>(a?: T, b?: U, c?: V): [T, U, V];
 declare function f15<T = U, U = T>(a?: T, b?: U): [T, U];
 declare function f16<T, U = V, V = U>(a?: T, b?: U, c?: V): [T, U, V];
-declare function f17<T = U, U = T | B>(a?: T, b?: U): [T, U];
-declare function f18<T, U = V, V = U | C>(a?: T, b?: U, c?: V): [T, U, V];
+declare function f17<T = U, U = B | T>(a?: T, b?: U): [T, U];
+declare function f18<T, U = V, V = C | U>(a?: T, b?: U, c?: V): [T, U, V];
 declare function f19<T = U, U = T & B>(a?: T, b?: U): [T, U];
 declare function f20<T, U = V, V = U & C>(a?: T, b?: U, c?: V): [T, U, V];
 interface i00<T = number> {

--- a/tests/baselines/reference/genericRestParameters1.js
+++ b/tests/baselines/reference/genericRestParameters1.js
@@ -298,7 +298,7 @@ declare const x16: [number, string, boolean];
 declare const x17: [number, string, boolean];
 declare const x18: (string | number | boolean)[];
 declare function g10<U extends string[], V extends [number, number]>(u: U, v: V): void;
-declare function f11<T extends (string | number | boolean)[]>(...args: T): T;
+declare function f11<T extends (boolean | number | string)[]>(...args: T): T;
 declare const z10: [42, "hello", true];
 declare const z11: [42, "hello"];
 declare const z12: [42];
@@ -311,7 +311,7 @@ declare const z18: (string | number | true)[];
 declare function g11<U extends string[], V extends [number, number]>(u: U, v: V): void;
 declare function call<T extends unknown[], U>(f: (...args: T) => U, ...args: T): U;
 declare function callr<T extends unknown[], U>(args: T, f: (...args: T) => U): U;
-declare function f15(a: string, b: number): string | number;
+declare function f15(a: string, b: number): number | string;
 declare function f16<A, B>(a: A, b: B): A | B;
 declare let x20: number;
 declare let x21: string;
@@ -343,7 +343,7 @@ declare type T08<T extends any[]> = ConstructorParameters<new (...args: T) => vo
 declare type T09 = Parameters<Function>;
 declare type Record1 = {
     move: [number, 'left' | 'right'];
-    jump: [number, 'up' | 'down'];
+    jump: [number, 'down' | 'up'];
     stop: string;
     done: [];
 };

--- a/tests/baselines/reference/isomorphicMappedTypeInference.js
+++ b/tests/baselines/reference/isomorphicMappedTypeInference.js
@@ -367,7 +367,7 @@ declare function f20<T, K extends keyof T>(obj: Pick<T, K>): T;
 declare function f21<T, K extends keyof T>(obj: Pick<T, K>): K;
 declare function f22<T, K extends keyof T>(obj: Boxified<Pick<T, K>>): T;
 declare function f23<T, U extends keyof T, K extends U>(obj: Pick<T, K>): T;
-declare function f24<T, U, K extends keyof T | keyof U>(obj: Pick<T & U, K>): T & U;
+declare function f24<T, U, K extends keyof U | keyof T>(obj: Pick<T & U, K>): T & U;
 declare let x0: {
     foo: number;
     bar: string;

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -1111,7 +1111,7 @@ declare class Item {
     price: number;
 }
 declare class Options {
-    visible: "yes" | "no";
+    visible: "no" | "yes";
 }
 declare type Dictionary<T> = {
     [x: string]: T;
@@ -1140,16 +1140,16 @@ declare type K13 = keyof {};
 declare type K14 = keyof Object;
 declare type K15 = keyof E;
 declare type K16 = keyof [string, number];
-declare type K17 = keyof (Shape | Item);
+declare type K17 = keyof (Item | Shape);
 declare type K18 = keyof (Shape & Item);
 declare type K19 = keyof NumericallyIndexed<Shape>;
 declare type KeyOf<T> = keyof T;
 declare type K20 = KeyOf<Shape>;
 declare type K21 = KeyOf<Dictionary<Shape>>;
 declare type NAME = "name";
-declare type WIDTH_OR_HEIGHT = "width" | "height";
+declare type WIDTH_OR_HEIGHT = "height" | "width";
 declare type Q10 = Shape["name"];
-declare type Q11 = Shape["width" | "height"];
+declare type Q11 = Shape["height" | "width"];
 declare type Q12 = Shape["name" | "visible"];
 declare type Q20 = Shape[NAME];
 declare type Q21 = Shape[WIDTH_OR_HEIGHT];
@@ -1160,7 +1160,7 @@ declare type Q33 = [string, number][E.A];
 declare type Q34 = [string, number][E.B];
 declare type Q35 = [string, number]["0"];
 declare type Q36 = [string, number]["1"];
-declare type Q40 = (Shape | Options)["visible"];
+declare type Q40 = (Options | Shape)["visible"];
 declare type Q41 = (Shape & Options)["visible"];
 declare type Q50 = Dictionary<Shape>["howdy"];
 declare type Q51 = Dictionary<Shape>[123];
@@ -1181,7 +1181,7 @@ declare function f20(component: Component<Shape>): void;
 declare function pluck<T, K extends keyof T>(array: T[], key: K): T[K][];
 declare function f30(shapes: Shape[]): void;
 declare function f31<K extends keyof Shape>(key: K): Shape[K];
-declare function f32<K extends "width" | "height">(key: K): Shape[K];
+declare function f32<K extends "height" | "width">(key: K): Shape[K];
 declare function f33<S extends Shape, K extends keyof S>(shape: S, key: K): S[K];
 declare function f34(ts: TaggedShape): void;
 declare class C {
@@ -1203,7 +1203,7 @@ declare function f55<T, K extends keyof T>(obj: T, key: K): void;
 declare function f60<T>(source: T, target: T): void;
 declare function f70(func: <T, U>(k1: keyof (T | U), k2: keyof (T & U)) => void): void;
 declare function f71(func: <T, U>(x: T, y: U) => Partial<T & U>): void;
-declare function f72(func: <T, U, K extends keyof T | keyof U>(x: T, y: U, k: K) => (T & U)[K]): void;
+declare function f72(func: <T, U, K extends keyof U | keyof T>(x: T, y: U, k: K) => (T & U)[K]): void;
 declare function f73(func: <T, U, K extends keyof (T & U)>(x: T, y: U, k: K) => (T & U)[K]): void;
 declare function f74(func: <T, U, K extends keyof (T | U)>(x: T, y: U, k: K) => (T | U)[K]): void;
 declare function f80<T extends {
@@ -1253,7 +1253,7 @@ declare class OtherPerson {
 declare function path<T, K1 extends keyof T>(obj: T, key1: K1): T[K1];
 declare function path<T, K1 extends keyof T, K2 extends keyof T[K1]>(obj: T, key1: K1, key2: K2): T[K1][K2];
 declare function path<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(obj: T, key1: K1, key2: K2, key3: K3): T[K1][K2][K3];
-declare function path(obj: any, ...keys: (string | number)[]): any;
+declare function path(obj: any, ...keys: (number | string)[]): any;
 declare type Thing = {
     a: {
         x: number;
@@ -1292,7 +1292,7 @@ interface Options2<Data, Computed> {
 }
 declare class Component2<Data, Computed> {
     constructor(options: Options2<Data, Computed>);
-    get<K extends keyof Data | keyof Computed>(key: K): (Data & Computed)[K];
+    get<K extends keyof Computed | keyof Data>(key: K): (Data & Computed)[K];
 }
 interface R {
     p: number;
@@ -1401,9 +1401,9 @@ declare type SimpleDBRecord<Flag extends string> = {
 } & DBBoolTable<Flag>;
 declare function getFlagsFromSimpleRecord<Flag extends string>(record: SimpleDBRecord<Flag>, flags: Flag[]): SimpleDBRecord<Flag>[Flag];
 declare type DynamicDBRecord<Flag extends string> = ({
-    dynamicField: number;
-} | {
     dynamicField: string;
+} | {
+    dynamicField: number;
 }) & DBBoolTable<Flag>;
 declare function getFlagsFromDynamicRecord<Flag extends string>(record: DynamicDBRecord<Flag>, flags: Flag[]): DynamicDBRecord<Flag>[Flag];
 interface I {

--- a/tests/baselines/reference/mappedTypeErrors.js
+++ b/tests/baselines/reference/mappedTypeErrors.js
@@ -267,13 +267,13 @@ declare type T02 = {
 declare type T03 = Record<Date, number>;
 declare type T10 = Pick<Shape, "name">;
 declare type T11 = Pick<Shape, "foo">;
-declare type T12 = Pick<Shape, "name" | "foo">;
+declare type T12 = Pick<Shape, "foo" | "name">;
 declare type T13 = Pick<Shape, keyof Named>;
 declare type T14 = Pick<Shape, keyof Point>;
 declare type T15 = Pick<Shape, never>;
 declare type T16 = Pick<Shape, undefined>;
 declare function f1<T>(x: T): void;
-declare function f2<T extends string | number>(x: T): void;
+declare function f2<T extends number | string>(x: T): void;
 declare function f3<T extends keyof Shape>(x: T): void;
 declare function f4<T extends keyof Named>(x: T): void;
 declare function f10<T>(): void;

--- a/tests/baselines/reference/mappedTypes1.js
+++ b/tests/baselines/reference/mappedTypes1.js
@@ -77,7 +77,7 @@ declare type T13 = {
     readonly [P in keyof Item]?: Item[P];
 };
 declare type T20 = {
-    [P in keyof Item]: Item[P] | null;
+    [P in keyof Item]: null | Item[P];
 };
 declare type T21 = {
     [P in keyof Item]: Array<Item[P]>;
@@ -116,10 +116,10 @@ declare type T43 = {
     [P in "a" | "b"]: void;
 };
 declare type T44 = {
-    [P in "a" | "b" | "0" | "1"]: void;
+    [P in "0" | "1" | "a" | "b"]: void;
 };
 declare type T47 = {
-    [P in string | "a" | "b" | "0" | "1"]: void;
+    [P in string | "0" | "1" | "a" | "b"]: void;
 };
 declare function f1<T1>(): {
     [P in keyof T1]: void;

--- a/tests/baselines/reference/mappedTypes4.js
+++ b/tests/baselines/reference/mappedTypes4.js
@@ -109,9 +109,9 @@ declare type C = {
 declare function f1(x: A | B | C | undefined): Boxified<A> | Boxified<B> | Boxified<C> | undefined;
 declare type T00 = Partial<A | B | C>;
 declare type T01 = Readonly<A | B | C | null | undefined>;
-declare type T02 = Boxified<A | B[] | C | string>;
-declare type T03 = Readonly<string | number | boolean | null | undefined | void>;
-declare type T04 = Boxified<string | number | boolean | null | undefined | void>;
+declare type T02 = Boxified<A | C | string | B[]>;
+declare type T03 = Readonly<boolean | null | number | string | undefined | void>;
+declare type T04 = Boxified<boolean | null | number | string | undefined | void>;
 declare type T05 = Partial<"hello" | "world" | 42>;
 declare type BoxifiedWithSentinel<T, U> = {
     [P in keyof T]: Box<T[P]> | U;

--- a/tests/baselines/reference/mappedTypesArraysTuples.js
+++ b/tests/baselines/reference/mappedTypesArraysTuples.js
@@ -154,7 +154,7 @@ declare type A = {
 declare type B = {
     b: string;
 };
-declare type T40 = Boxified<A | A[] | ReadonlyArray<A> | [A, B] | string | string[]>;
+declare type T40 = Boxified<A | ReadonlyArray<A> | [A, B] | string | string[] | A[]>;
 declare type ReadWrite<T> = {
     -readonly [P in keyof T]: T[P];
 };

--- a/tests/baselines/reference/neverType.js
+++ b/tests/baselines/reference/neverType.js
@@ -178,8 +178,8 @@ declare function fail(): never;
 declare function failOrThrow(shouldFail: boolean): never;
 declare function infiniteLoop1(): void;
 declare function infiniteLoop2(): never;
-declare function move1(direction: "up" | "down"): 1 | -1;
-declare function move2(direction: "up" | "down"): 1 | -1;
+declare function move1(direction: "down" | "up"): 1 | -1;
+declare function move2(direction: "down" | "up"): 1 | -1;
 declare function check<T>(x: T | undefined): T;
 declare class C {
     void1(): void;
@@ -187,7 +187,7 @@ declare class C {
     never1(): never;
     never2(): never;
 }
-declare function f1(x: string | number): void;
-declare function f2(x: string | number): never;
+declare function f1(x: number | string): void;
+declare function f2(x: number | string): never;
 declare function test(cb: () => string): string;
 declare let errorCallback: () => never;

--- a/tests/baselines/reference/objectLiteralNormalization.js
+++ b/tests/baselines/reference/objectLiteralNormalization.js
@@ -126,11 +126,11 @@ declare let a2: {
     b?: undefined;
 };
 declare let b1: {
-    a: string;
-    b: string;
-} | {
     b: string;
     c: string;
+} | {
+    a: string;
+    b: string;
 };
 declare let b2: {
     z: number;

--- a/tests/baselines/reference/parenthesisDoesNotBlockAliasSymbolCreation.js
+++ b/tests/baselines/reference/parenthesisDoesNotBlockAliasSymbolCreation.js
@@ -27,10 +27,10 @@ exports.a4 = null;
 
 
 //// [parenthesisDoesNotBlockAliasSymbolCreation.d.ts]
-export declare type InvalidKeys<K extends string | number | symbol> = {
+export declare type InvalidKeys<K extends number | string | symbol> = {
     [P in K]?: never;
 };
-export declare type InvalidKeys2<K extends string | number | symbol> = ({
+export declare type InvalidKeys2<K extends number | string | symbol> = ({
     [P in K]?: never;
 });
 export declare type A<T> = (T & InvalidKeys<"a">);

--- a/tests/baselines/reference/recursiveTypeReferences1.js
+++ b/tests/baselines/reference/recursiveTypeReferences1.js
@@ -215,16 +215,16 @@ function level(h) {
 
 
 //// [recursiveTypeReferences1.d.ts]
-declare type ValueOrArray<T> = T | Array<ValueOrArray<T>>;
+declare type ValueOrArray<T> = Array<ValueOrArray<T>> | T;
 declare const a0: ValueOrArray<number>;
 declare const a1: ValueOrArray<number>;
-declare type HypertextNode = string | [string, {
+declare type HypertextNode = [string, {
     [key: string]: unknown;
-}, ...HypertextNode[]];
+}, ...HypertextNode[]] | string;
 declare const hypertextNode: HypertextNode;
-declare type Json = string | number | boolean | null | Json[] | {
+declare type Json = boolean | null | number | string | {
     [key: string]: Json;
-};
+} | Json[];
 declare let data: Json;
 interface Box<T> {
     value: T;
@@ -241,14 +241,14 @@ declare type Box2 = Box<Box2 | number>;
 declare const b20: Box2;
 declare const b21: Box2;
 declare const b22: Box2;
-declare type RecArray<T> = Array<T | RecArray<T>>;
+declare type RecArray<T> = Array<RecArray<T> | T>;
 declare function flat<T>(a: RecArray<T>): Array<T>;
-declare function flat1<T>(a: Array<T | Array<T>>): Array<T>;
-declare function flat2<T>(a: Array<T | Array<T | Array<T>>>): Array<T>;
+declare function flat1<T>(a: Array<Array<T> | T>): Array<T>;
+declare function flat2<T>(a: Array<Array<T | Array<T>> | T>): Array<T>;
 declare type T10 = T10[];
 declare type T11 = readonly T11[];
 declare type T12 = (T12)[];
-declare type T13 = T13[] | string;
+declare type T13 = string | T13[];
 declare type T14 = T14[] & {
     x: string;
 };

--- a/tests/baselines/reference/restTuplesFromContextualTypes.js
+++ b/tests/baselines/reference/restTuplesFromContextualTypes.js
@@ -359,7 +359,7 @@ declare let g7: (x: any, y: any) => string;
 declare let g8: (x: number, y: string) => string;
 declare var tuple: [number, string];
 declare function take(cb: (a: number, b: string) => void): void;
-declare type ArgsUnion = [number, string] | [number, Error];
+declare type ArgsUnion = [number, Error] | [number, string];
 declare type TupleUnionFunc = (...params: ArgsUnion) => number;
 declare const funcUnionTupleNoRest: TupleUnionFunc;
 declare const funcUnionTupleRest: TupleUnionFunc;

--- a/tests/baselines/reference/strictPropertyInitialization.js
+++ b/tests/baselines/reference/strictPropertyInitialization.js
@@ -195,19 +195,19 @@ var C11 = /** @class */ (function () {
 declare class C1 {
     a: number;
     b: number | undefined;
-    c: number | null;
+    c: null | number;
     d?: number;
 }
 declare class C2 {
     a: number;
     b: number | undefined;
-    c: number | null;
+    c: null | number;
     d?: number;
 }
 declare class C3 {
     static a: number;
     static b: number | undefined;
-    static c: number | null;
+    static c: null | number;
     static d?: number;
 }
 declare class C4 {
@@ -235,7 +235,7 @@ declare class C8 {
 declare abstract class C9 {
     abstract a: number;
     abstract b: number | undefined;
-    abstract c: number | null;
+    abstract c: null | number;
     abstract d?: number;
 }
 declare class C10 {

--- a/tests/baselines/reference/stringLiteralTypesAndLogicalOrExpressions01.js
+++ b/tests/baselines/reference/stringLiteralTypesAndLogicalOrExpressions01.js
@@ -22,4 +22,4 @@ declare let a: "foo";
 declare let b: "foo";
 declare let c: "foo";
 declare let d: string;
-declare let e: "foo" | "bar";
+declare let e: "bar" | "foo";

--- a/tests/baselines/reference/stringLiteralTypesAndParenthesizedExpressions01.js
+++ b/tests/baselines/reference/stringLiteralTypesAndParenthesizedExpressions01.js
@@ -17,6 +17,6 @@ var d = (myRandBool ? "foo" : ("bar"));
 //// [stringLiteralTypesAndParenthesizedExpressions01.d.ts]
 declare function myRandBool(): boolean;
 declare let a: "foo";
-declare let b: "foo" | "bar";
+declare let b: "bar" | "foo";
 declare let c: "foo";
-declare let d: "foo" | "bar";
+declare let d: "bar" | "foo";

--- a/tests/baselines/reference/stringLiteralTypesAndTuples01.js
+++ b/tests/baselines/reference/stringLiteralTypesAndTuples01.js
@@ -36,6 +36,6 @@ function rawr(dino) {
 
 //// [stringLiteralTypesAndTuples01.d.ts]
 declare let hello: string, brave: string, newish: string, world: string;
-declare type RexOrRaptor = "t-rex" | "raptor";
+declare type RexOrRaptor = "raptor" | "t-rex";
 declare let im: "I'm", a: "a", dinosaur: RexOrRaptor;
 declare function rawr(dino: RexOrRaptor): "ROAAAAR!" | "yip yip!";

--- a/tests/baselines/reference/stringLiteralTypesAsTypeParameterConstraint01.js
+++ b/tests/baselines/reference/stringLiteralTypesAsTypeParameterConstraint01.js
@@ -35,7 +35,7 @@ hResult = h("bar");
 
 //// [stringLiteralTypesAsTypeParameterConstraint01.d.ts]
 declare function foo<T extends "foo">(f: (x: T) => T): (x: T) => T;
-declare function bar<T extends "foo" | "bar">(f: (x: T) => T): (x: T) => T;
+declare function bar<T extends "bar" | "foo">(f: (x: T) => T): (x: T) => T;
 declare let f: (x: "foo") => "foo";
 declare let fResult: "foo";
 declare let g: (x: "foo") => "foo";

--- a/tests/baselines/reference/stringLiteralTypesInUnionTypes01.js
+++ b/tests/baselines/reference/stringLiteralTypesInUnionTypes01.js
@@ -38,6 +38,6 @@ y = x;
 
 
 //// [stringLiteralTypesInUnionTypes01.d.ts]
-declare type T = "foo" | "bar" | "baz";
-declare var x: "foo" | "bar" | "baz";
+declare type T = "bar" | "baz" | "foo";
+declare var x: "bar" | "baz" | "foo";
 declare var y: T;

--- a/tests/baselines/reference/stringLiteralTypesInUnionTypes02.js
+++ b/tests/baselines/reference/stringLiteralTypesInUnionTypes02.js
@@ -38,6 +38,6 @@ y = x;
 
 
 //// [stringLiteralTypesInUnionTypes02.d.ts]
-declare type T = string | "foo" | "bar" | "baz";
-declare var x: "foo" | "bar" | "baz" | string;
+declare type T = string | "bar" | "baz" | "foo";
+declare var x: string | "bar" | "baz" | "foo";
 declare var y: T;

--- a/tests/baselines/reference/stringLiteralTypesInUnionTypes03.js
+++ b/tests/baselines/reference/stringLiteralTypesInUnionTypes03.js
@@ -38,6 +38,6 @@ y = x;
 
 
 //// [stringLiteralTypesInUnionTypes03.d.ts]
-declare type T = number | "foo" | "bar";
-declare var x: "foo" | "bar" | number;
+declare type T = number | "bar" | "foo";
+declare var x: number | "bar" | "foo";
 declare var y: T;

--- a/tests/baselines/reference/stringLiteralTypesOverloads01.js
+++ b/tests/baselines/reference/stringLiteralTypesOverloads01.js
@@ -92,14 +92,14 @@ var Consts2;
 
 
 //// [stringLiteralTypesOverloads01.d.ts]
-declare type PrimitiveName = 'string' | 'number' | 'boolean';
+declare type PrimitiveName = 'boolean' | 'number' | 'string';
 declare function getFalsyPrimitive(x: "string"): string;
 declare function getFalsyPrimitive(x: "number"): number;
 declare function getFalsyPrimitive(x: "boolean"): boolean;
 declare function getFalsyPrimitive(x: "boolean" | "string"): boolean | string;
 declare function getFalsyPrimitive(x: "boolean" | "number"): boolean | number;
 declare function getFalsyPrimitive(x: "number" | "string"): number | string;
-declare function getFalsyPrimitive(x: "number" | "string" | "boolean"): number | string | boolean;
+declare function getFalsyPrimitive(x: "boolean" | "number" | "string"): boolean | number | string;
 declare namespace Consts1 {
 }
 declare const string: "string";

--- a/tests/baselines/reference/stringLiteralTypesOverloads02.js
+++ b/tests/baselines/reference/stringLiteralTypesOverloads02.js
@@ -96,7 +96,7 @@ declare function getFalsyPrimitive(x: "boolean"): boolean;
 declare function getFalsyPrimitive(x: "boolean" | "string"): boolean | string;
 declare function getFalsyPrimitive(x: "boolean" | "number"): boolean | number;
 declare function getFalsyPrimitive(x: "number" | "string"): number | string;
-declare function getFalsyPrimitive(x: "number" | "string" | "boolean"): number | string | boolean;
+declare function getFalsyPrimitive(x: "boolean" | "number" | "string"): boolean | number | string;
 declare namespace Consts1 {
 }
 declare const string = "string";

--- a/tests/baselines/reference/stringLiteralTypesOverloads04.js
+++ b/tests/baselines/reference/stringLiteralTypesOverloads04.js
@@ -14,4 +14,4 @@ f(function (y) {
 
 
 //// [stringLiteralTypesOverloads04.d.ts]
-declare function f(x: (p: "foo" | "bar") => "foo"): any;
+declare function f(x: (p: "bar" | "foo") => "foo"): any;

--- a/tests/baselines/reference/stringLiteralTypesWithVariousOperators01.js
+++ b/tests/baselines/reference/stringLiteralTypesWithVariousOperators01.js
@@ -60,7 +60,7 @@ var v = abcOrXyz === abcOrXyzOrNumber;
 declare let abc: "ABC";
 declare let xyz: "XYZ";
 declare let abcOrXyz: "ABC" | "XYZ";
-declare let abcOrXyzOrNumber: "ABC" | "XYZ" | number;
+declare let abcOrXyzOrNumber: number | "ABC" | "XYZ";
 declare let a: string;
 declare let b: string;
 declare let c: string;

--- a/tests/baselines/reference/stringLiteralTypesWithVariousOperators02.js
+++ b/tests/baselines/reference/stringLiteralTypesWithVariousOperators02.js
@@ -40,7 +40,7 @@ var l = abc != xyz;
 declare let abc: "ABC";
 declare let xyz: "XYZ";
 declare let abcOrXyz: "ABC" | "XYZ";
-declare let abcOrXyzOrNumber: "ABC" | "XYZ" | number;
+declare let abcOrXyzOrNumber: number | "ABC" | "XYZ";
 declare let a: any;
 declare let b: any;
 declare let c: any;

--- a/tests/baselines/reference/thisTypeInObjectLiterals2.js
+++ b/tests/baselines/reference/thisTypeInObjectLiterals2.js
@@ -466,7 +466,7 @@ declare let p12: Point & {
     bar: number;
 };
 declare type Accessors<T> = {
-    [K in keyof T]: (() => T[K]) | Computed<T[K]>;
+    [K in keyof T]: Computed<T[K]> | (() => T[K]);
 };
 declare type Dictionary<T> = {
     [x: string]: T;

--- a/tests/baselines/reference/tsbuild/demo/initial-build/in-master-branch-with-everything-setup-correctly-and-reports-no-error.js
+++ b/tests/baselines/reference/tsbuild/demo/initial-build/in-master-branch-with-everything-setup-correctly-and-reports-no-error.js
@@ -22,7 +22,7 @@ exitCode:: ExitStatus.Success
 
 
 //// [/src/lib/animals/animal.d.ts]
-export declare type Size = "small" | "medium" | "large";
+export declare type Size = "large" | "medium" | "small";
 export default interface Animal {
     size: Size;
 }
@@ -83,7 +83,7 @@ exports.createDog = dog_1.createDog;
       },
       "../../animals/animal.ts": {
         "version": "-14984181202-export type Size = \"small\" | \"medium\" | \"large\";\r\nexport default interface Animal {\r\n    size: Size;\r\n}\r\n",
-        "signature": "13427676350-export declare type Size = \"small\" | \"medium\" | \"large\";\r\nexport default interface Animal {\r\n    size: Size;\r\n}\r\n"
+        "signature": "-1606517762-export declare type Size = \"large\" | \"medium\" | \"small\";\r\nexport default interface Animal {\r\n    size: Size;\r\n}\r\n"
       },
       "../../animals/index.ts": {
         "version": "-5382672599-import Animal from './animal';\r\n\r\nexport default Animal;\r\nimport { createDog, Dog } from './dog';\r\nexport { createDog, Dog };\r\n",
@@ -208,8 +208,8 @@ exports.lastElementOf = lastElementOf;
         "signature": "3858781397-/// <reference no-default-lib=\"true\"/>\ninterface Boolean {}\ninterface Function {}\ninterface CallableFunction {}\ninterface NewableFunction {}\ninterface IArguments {}\ninterface Number { toExponential: any; }\ninterface Object {}\ninterface RegExp {}\ninterface String { charAt: any; }\ninterface Array<T> { length: number; [n: number]: T; }\ninterface ReadonlyArray<T> {}\ndeclare const console: { log(msg: any): void; };"
       },
       "../../animals/animal.ts": {
-        "version": "13427676350-export declare type Size = \"small\" | \"medium\" | \"large\";\r\nexport default interface Animal {\r\n    size: Size;\r\n}\r\n",
-        "signature": "13427676350-export declare type Size = \"small\" | \"medium\" | \"large\";\r\nexport default interface Animal {\r\n    size: Size;\r\n}\r\n"
+        "version": "-1606517762-export declare type Size = \"large\" | \"medium\" | \"small\";\r\nexport default interface Animal {\r\n    size: Size;\r\n}\r\n",
+        "signature": "-1606517762-export declare type Size = \"large\" | \"medium\" | \"small\";\r\nexport default interface Animal {\r\n    size: Size;\r\n}\r\n"
       },
       "../../animals/dog.ts": {
         "version": "10854678623-import Animal from '.';\r\nexport interface Dog extends Animal {\r\n    woof(): void;\r\n    name: string;\r\n}\r\nexport declare function createDog(): Dog;\r\n",


### PR DESCRIPTION
Sorted union type members are:
  * TypeReference
  * BooleanLiteral
  * NumericLiteral
  * BigIntLiteral
  * StringLiteral
  * KeywordTypeNode

No new unit tests included, sorting order is arbitrary, postponing after the ordering is finalized.

Fixes #32224

----

Input:

```ts
Dog | Cat | "a" | "c" | "b" | [string] | [string, "b"] | [string, "a"] | [number, "b"] | 1000n | true | 7 | 5 | 19 | 0;
```

Sorted dts:

```ts
Cat | Dog | [string] | [number, "b"] | [string, "a"] | [string, "b"] | true | "a" | "b" | "c" | 0 | 5 | 7 | 19 | 1000n;
```