### PR TITLE
Make Object.entries more generic

### DIFF
--- a/lib/lib.es2017.object.d.ts
+++ b/lib/lib.es2017.object.d.ts
@@ -35,6 +35,12 @@ interface ObjectConstructor {
      * Returns an array of key/values of the enumerable properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
+    entries<K extends string, T>(o: Record<K, T>): [K, T][];
+
+    /**
+     * Returns an array of key/values of the enumerable properties of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
     entries<T>(o: { [s: string]: T } | ArrayLike<T>): [string, T][];
 
     /**

--- a/src/lib/es2017.object.d.ts
+++ b/src/lib/es2017.object.d.ts
@@ -15,6 +15,12 @@ interface ObjectConstructor {
      * Returns an array of key/values of the enumerable properties of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
+    entries<K extends string, T>(o: Record<K, T>): [K, T][];
+
+    /**
+     * Returns an array of key/values of the enumerable properties of an object
+     * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
+     */
     entries<T>(o: { [s: string]: T } | ArrayLike<T>): [string, T][];
 
     /**
@@ -27,5 +33,9 @@ interface ObjectConstructor {
      * Returns an object containing all own property descriptors of an object
      * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
      */
-    getOwnPropertyDescriptors<T>(o: T): {[P in keyof T]: TypedPropertyDescriptor<T[P]>} & { [x: string]: PropertyDescriptor };
+    getOwnPropertyDescriptors<T>(
+        o: T
+    ): { [P in keyof T]: TypedPropertyDescriptor<T[P]> } & {
+        [x: string]: PropertyDescriptor;
+    };
 }


### PR DESCRIPTION
This changes a bunch of test but I am unsure of how to go about updating them. Before I try too hard I want to verify that a change like this will even be accepted.

I often have code that looks like the following

```ts
interface MyRecord = Record<'a' | 'b', string>

const myRecord: MyRecord = {
  a: 'foo',
  b: 'bar'
}

Object.entries(myRecord).forEach(([key, value]) => {
  console.log({ key, value });
})
```

The types for `key` will be `string` while it could be `'a' | 'b'`.
