### PR TITLE
Improve positioning of the implement interface codefix when there's a constructor

### DIFF
--- a/tests/cases/fourslash/codeFixClassImplementInterfaceEmptyTypeLiteral.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceEmptyTypeLiteral.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+////
 //// interface I {
 ////     x: {};
 //// }
@@ -8,6 +9,15 @@
 ////    |]constructor() { }
 //// }
 
-verify.rangeAfterCodeFix(`
-x: {};
-`);
+verify.codeFix({
+  description: "Implement interface 'I'",
+  newFileContent:`
+interface I {
+    x: {};
+}
+
+class C implements I {
+   constructor() { }
+    x: {};
+}`,
+});

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceSomePropertiesPresent.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceSomePropertiesPresent.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts' />
 
+////
 //// interface I {
 ////     x: number;
 ////     y: number;
@@ -11,6 +12,20 @@
 ////    y: number;
 //// }
 
-verify.rangeAfterCodeFix(`
-z: number & { __iBrand: any; };
-`);
+
+verify.codeFix({
+  description: "Implement interface 'I'",
+  newFileContent:`
+interface I {
+    x: number;
+    y: number;
+    z: number & { __iBrand: any };
+}
+
+class C implements I {
+   constructor(public x: number) { }
+    z: number & { __iBrand: any; };
+   y: number;
+}`,
+});
+

--- a/tests/cases/fourslash/codeFixClassImplementInterface_order.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterface_order.ts
@@ -1,0 +1,28 @@
+/// <reference path='fourslash.ts' />
+
+// #34841
+
+////interface IFoo {
+////  bar(): void;
+////}
+////
+////class Foo implements IFoo {
+////  private x = 1;
+////  constructor() { this.x = 2 }
+////}
+
+verify.codeFix({
+  description: "Implement interface 'IFoo'",
+  index: 0,
+  newFileContent:
+`interface IFoo {
+  bar(): void;
+}
+
+class Foo implements IFoo {
+  private x = 1;
+  constructor() { this.x = 2 }
+    bar(): void {
+        throw new Error("Method not implemented.");
+    }
+}`});


### PR DESCRIPTION
Fixes #34841 by checking to see if we have a constructor on the class being edited, and if we do then putting the new interfaces after that.

I'm also open to the argument that instead they should just always be inserted last in the class? /cc @mjbvz

