### PR TITLE
Fix Number.is* to accept unknown again

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -204,13 +204,13 @@ interface NumberConstructor {
      * number. Only finite values of the type number, result in true.
      * @param number A numeric value.
      */
-    isFinite(number: number): boolean;
+    isFinite(number: unknown): boolean;
 
     /**
      * Returns true if the value passed is an integer, false otherwise.
      * @param number A numeric value.
      */
-    isInteger(number: number): boolean;
+    isInteger(number: unknown): boolean;
 
     /**
      * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a
@@ -218,13 +218,13 @@ interface NumberConstructor {
      * to a number. Only values of the type number, that are also NaN, result in true.
      * @param number A numeric value.
      */
-    isNaN(number: number): boolean;
+    isNaN(number: unknown): boolean;
 
     /**
      * Returns true if the value passed is a safe integer.
      * @param number A numeric value.
      */
-    isSafeInteger(number: number): boolean;
+    isSafeInteger(number: unknown): boolean;
 
     /**
      * The value of the largest integer n such that n and n + 1 are both exactly representable as


### PR DESCRIPTION
Fixes #34931

This essentially reapplies #24436 which incorrectly updated the generated files rather than the sources, and so was wiped out by 2f73986b44a4ec10c7ebe7188e23863c3879d54e.

Note that this is specifically _not_ the same as #4002, which pertains to the global functions that coerce their arguments and therefore should _not_ accept `unknown`.  This change was already accepted 18 months ago, but was applied incorrectly.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->