### PR TITLE
Fix `isInJsxText` after JSXOpeningElement with type arguments

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1688,7 +1688,16 @@ namespace ts.Completions {
 
             if (contextToken.kind === SyntaxKind.GreaterThanToken && contextToken.parent) {
                 if (contextToken.parent.kind === SyntaxKind.JsxOpeningElement) {
-                    return true;
+                    // Two possibilities:
+                    //   1. <div>/**/
+                    //      - contextToken: GreaterThanToken (before cursor)
+                    //      - location: JSXElement
+                    //      - different parents (JSXOpeningElement, JSXElement)
+                    //   2. <Component<string> /**/>
+                    //      - contextToken: GreaterThanToken (before cursor)
+                    //      - location: GreaterThanToken (after cursor)
+                    //      - same parent (JSXOpeningElement)
+                    return location.parent !== contextToken.parent;
                 }
 
                 if (contextToken.parent.kind === SyntaxKind.JsxClosingElement || contextToken.parent.kind === SyntaxKind.JsxSelfClosingElement) {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1697,7 +1697,7 @@ namespace ts.Completions {
                     //      - contextToken: GreaterThanToken (before cursor)
                     //      - location: GreaterThanToken (after cursor)
                     //      - same parent (JSXOpeningElement)
-                    return location.parent !== contextToken.parent;
+                    return location.parent.kind !== SyntaxKind.JsxOpeningElement;
                 }
 
                 if (contextToken.parent.kind === SyntaxKind.JsxClosingElement || contextToken.parent.kind === SyntaxKind.JsxSelfClosingElement) {

--- a/tests/cases/fourslash/completionsJsxAttributeGeneric.ts
+++ b/tests/cases/fourslash/completionsJsxAttributeGeneric.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.tsx
+////declare const React: any;
+////declare function CustomComponent<T>(props: { name: string }): JSX.Element;
+////const element1 = <CustomComponent<string> /*1*/></CustomComponent>;
+////const element2 = <CustomComponent<string> /*2*/ />;
+
+['1', '2'].forEach(marker => 
+  verify.completions({
+    marker,
+    exact: [{
+      name: 'name',
+      kind: 'JSX attribute',
+      kindModifiers: 'declare'
+    }]
+  })
+);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #34110
