### PR TITLE
add toString method to URL and URLSearchParams

### DIFF
--- a/lib/lib.dom.iterable.d.ts
+++ b/lib/lib.dom.iterable.d.ts
@@ -274,6 +274,10 @@ interface URLSearchParams {
      * Returns a list of values in the search params.
      */
     values(): IterableIterator<string>;
+    /**
+     * Returns an encoded stringified version of all the parameters
+     */
+    toString(): string; 
 }
 
 interface VRDisplay {


### PR DESCRIPTION
I noticed that for some reason these two functions are not put in the definitions although they're clearly documented in the MDN website.

You can workaround it by doing `String(t)` for both, but maybe we could put the function definitions instead?