### PR TITLE
Move json declaration file emit behind a `experimentalJsonDeclarationEmit` flag

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -686,6 +686,13 @@ namespace ts {
             category: Diagnostics.Experimental_Options,
             description: Diagnostics.Enables_experimental_support_for_emitting_type_metadata_for_decorators
         },
+        {
+            name: "experimentalJsonDeclarationEmit",
+            type: "boolean",
+            category: Diagnostics.Advanced_Options, // Under "advanced options" so it's hidden from --init
+            description: Diagnostics.Enables_experimental_declaration_emit_for_json_files,
+            affectsEmit: true,
+        },
 
         // Advanced
         {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -4140,6 +4140,10 @@
         "category": "Message",
         "code": 6223
     },
+    "Enables experimental declaration emit for json files.": {
+        "category": "Message",
+        "code": 6224
+    },
 
     "Projects to reference": {
         "category": "Message",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -143,8 +143,19 @@ namespace ts {
     }
 
     /* @internal */
+    export function hasDeclarationFileOutput(filename: string, options: CompilerOptions) {
+        if (fileExtensionIs(filename, Extension.Json) && !options.experimentalJsonDeclarationEmit) {
+            return false;
+        }
+        return true;
+    }
+
+    /* @internal */
     export function getOutputDeclarationFileName(inputFileName: string, configFile: ParsedCommandLine, ignoreCase: boolean) {
         Debug.assert(!fileExtensionIs(inputFileName, Extension.Dts));
+        if (!hasDeclarationFileOutput(inputFileName, configFile.options)) {
+            return undefined;
+        }
         return changeExtension(
             getOutputPathWithoutChangingExt(inputFileName, configFile, ignoreCase, configFile.options.declarationDir || configFile.options.outDir),
             Extension.Dts
@@ -247,7 +258,10 @@ namespace ts {
             if (jsFilePath) return jsFilePath;
             if (fileExtensionIs(inputFileName, Extension.Json)) continue;
             if (getEmitDeclarations(configFile.options)) {
-                return getOutputDeclarationFileName(inputFileName, configFile, ignoreCase);
+                const result = getOutputDeclarationFileName(inputFileName, configFile, ignoreCase);
+                if (result) {
+                    return result;
+                }
             }
         }
         const buildInfoPath = getTsBuildInfoEmitOutputFilePath(configFile.options);

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -855,7 +855,10 @@ namespace ts {
                             else if (getEmitModuleKind(parsedRef.commandLine.options) === ModuleKind.None) {
                                 for (const fileName of parsedRef.commandLine.fileNames) {
                                     if (!fileExtensionIs(fileName, Extension.Dts)) {
-                                        processSourceFile(getOutputDeclarationFileName(fileName, parsedRef.commandLine, !host.useCaseSensitiveFileNames()), /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false, /*packageId*/ undefined);
+                                        const outputPath = getOutputDeclarationFileName(fileName, parsedRef.commandLine, !host.useCaseSensitiveFileNames());
+                                        if (outputPath) {
+                                            processSourceFile(outputPath, /*isDefaultLib*/ false, /*ignoreNoDefaultLib*/ false, /*packageId*/ undefined);
+                                        }
                                     }
                                 }
                             }
@@ -1434,7 +1437,9 @@ namespace ts {
                     const redirectProject = getProjectReferenceRedirectProject(newSourceFile.fileName);
                     if (redirectProject && !(redirectProject.commandLine.options.outFile || redirectProject.commandLine.options.out)) {
                         const redirect = getProjectReferenceOutputName(redirectProject, newSourceFile.fileName);
-                        addFileToFilesByName(newSourceFile, toPath(redirect), /*redirectedPath*/ undefined);
+                        if (redirect) {
+                            addFileToFilesByName(newSourceFile, toPath(redirect), /*redirectedPath*/ undefined);
+                        }
                     }
                 }
                 // Set the file as found during node modules search if it was found that way in old progra,
@@ -2356,13 +2361,15 @@ namespace ts {
                         return undefined;
                     }
                     const redirect = getProjectReferenceOutputName(redirectProject, fileName);
-                    fileName = redirect;
-                    // Once we start redirecting to a file, we can potentially come back to it
-                    // via a back-reference from another file in the .d.ts folder. If that happens we'll
-                    // end up trying to add it to the program *again* because we were tracking it via its
-                    // original (un-redirected) name. So we have to map both the original path and the redirected path
-                    // to the source file we're about to find/create
-                    redirectedPath = toPath(redirect);
+                    if (redirect) {
+                        fileName = redirect;
+                        // Once we start redirecting to a file, we can potentially come back to it
+                        // via a back-reference from another file in the .d.ts folder. If that happens we'll
+                        // end up trying to add it to the program *again* because we were tracking it via its
+                        // original (un-redirected) name. So we have to map both the original path and the redirected path
+                        // to the source file we're about to find/create
+                        redirectedPath = toPath(redirect);
+                    }
                 }
             }
 
@@ -2533,7 +2540,9 @@ namespace ts {
                             forEach(resolvedRef.commandLine.fileNames, fileName => {
                                 if (!fileExtensionIs(fileName, Extension.Dts)) {
                                     const outputDts = getOutputDeclarationFileName(fileName, resolvedRef.commandLine, host.useCaseSensitiveFileNames());
-                                    mapFromToProjectReferenceRedirectSource!.set(toPath(outputDts), fileName);
+                                    if (outputDts) {
+                                        mapFromToProjectReferenceRedirectSource!.set(toPath(outputDts), fileName);
+                                    }
                                 }
                             });
                         }

--- a/src/compiler/transformers/declarations.ts
+++ b/src/compiler/transformers/declarations.ts
@@ -2,7 +2,7 @@
 namespace ts {
     export function getDeclarationDiagnostics(host: EmitHost, resolver: EmitResolver, file: SourceFile | undefined): DiagnosticWithLocation[] | undefined {
         const compilerOptions = host.getCompilerOptions();
-        const result = transformNodes(resolver, host, compilerOptions, file ? [file] : host.getSourceFiles(), [transformDeclarations], /*allowDtsFiles*/ false);
+        const result = transformNodes(resolver, host, compilerOptions, filter(file ? [file] : host.getSourceFiles(), f => !!getOutputPathsFor(f, host, /*forcedtsPaths*/ false).declarationFilePath), [transformDeclarations], /*allowDtsFiles*/ false);
         return result.diagnostics;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5029,6 +5029,7 @@ namespace ts {
         esModuleInterop?: boolean;
         /* @internal */ showConfig?: boolean;
         useDefineForClassFields?: boolean;
+        /* @internal */ experimentalJsonDeclarationEmit?: boolean;
 
         [option: string]: CompilerOptionsValue | TsConfigSourceFile | undefined;
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3633,7 +3633,10 @@ namespace ts {
         return getDeclarationEmitOutputFilePathWorker(fileName, host.getCompilerOptions(), host.getCurrentDirectory(), host.getCommonSourceDirectory(), f => host.getCanonicalFileName(f));
     }
 
-    export function getDeclarationEmitOutputFilePathWorker(fileName: string, options: CompilerOptions, currentDirectory: string, commonSourceDirectory: string, getCanonicalFileName: GetCanonicalFileName): string {
+    export function getDeclarationEmitOutputFilePathWorker(fileName: string, options: CompilerOptions, currentDirectory: string, commonSourceDirectory: string, getCanonicalFileName: GetCanonicalFileName): string | undefined {
+        if (!hasDeclarationFileOutput(fileName, options)) {
+            return undefined;
+        }
         const outputDir = options.declarationDir || options.outDir; // Prefer declaration folder if specified
 
         const path = outputDir

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -888,7 +888,7 @@ namespace Harness {
                         throw new Error("Only declaration files should be generated when emitDeclarationOnly:true");
                     }
                 }
-                else if (result.dts.size !== result.getNumberOfJsFiles(/*includeJson*/ true)) {
+                else if (result.dts.size !== result.getNumberOfJsFiles(ts.hasDeclarationFileOutput("/foo.json", options))) {
                     throw new Error("There were no errors and declFiles generated did not match number of js files generated");
                 }
             }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1219,8 +1219,8 @@ namespace ts.server {
             };
         }
 
-        private isValidGeneratedFileWatcher(generateFile: string, watcher: GeneratedFileWatcher) {
-            return this.toPath(generateFile) === watcher.generatedFilePath;
+        private isValidGeneratedFileWatcher(generateFile: string | undefined, watcher: GeneratedFileWatcher) {
+            return generateFile !== undefined && this.toPath(generateFile) === watcher.generatedFilePath;
         }
 
         private clearGeneratedFileWatch() {

--- a/src/testRunner/unittests/tsbuild/javascriptProjectEmit.ts
+++ b/src/testRunner/unittests/tsbuild/javascriptProjectEmit.ts
@@ -276,7 +276,8 @@ namespace ts {
                             "checkJs": true,
                             "resolveJsonModule": true,
                             "esModuleInterop": true,
-                            "declaration": true
+                            "declaration": true,
+                            "experimentalJsonDeclarationEmit": true
                         }
                     }`,
             }, symbolLibContent),

--- a/tests/baselines/reference/showConfig/Shows tsconfig for single option/experimentalJsonDeclarationEmit/tsconfig.json
+++ b/tests/baselines/reference/showConfig/Shows tsconfig for single option/experimentalJsonDeclarationEmit/tsconfig.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "experimentalJsonDeclarationEmit": true
+    }
+}

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-with-non-moved-json-files-and-emits-them-correctly.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-with-non-moved-json-files-and-emits-them-correctly.js
@@ -48,6 +48,7 @@ exports.m = common_1["default"];
       "resolveJsonModule": true,
       "esModuleInterop": true,
       "declaration": true,
+      "experimentalJsonDeclarationEmit": true,
       "composite": true,
       "configFilePath": "../../src/sub-project/tsconfig.json"
     },
@@ -127,6 +128,7 @@ exports.getVar = getVar;
       "resolveJsonModule": true,
       "esModuleInterop": true,
       "declaration": true,
+      "experimentalJsonDeclarationEmit": true,
       "composite": true,
       "configFilePath": "../../src/sub-project-2/tsconfig.json"
     },
@@ -204,6 +206,7 @@ export declare const val: number;
       "resolveJsonModule": true,
       "esModuleInterop": true,
       "declaration": true,
+      "experimentalJsonDeclarationEmit": true,
       "composite": true,
       "configFilePath": "./tsconfig.json"
     },

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/files-containing-json-file.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/files-containing-json-file.js
@@ -54,6 +54,7 @@ exports["default"] = hello_json_1["default"].hello;
       "allowSyntheticDefaultImports": true,
       "outDir": "./",
       "skipDefaultLibCheck": true,
+      "experimentalJsonDeclarationEmit": true,
       "configFilePath": "../tsconfig_withFiles.json"
     },
     "referencedMap": {

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/importing-json-module-from-project-reference.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/importing-json-module-from-project-reference.js
@@ -52,6 +52,7 @@ console.log(foo_json_1.foo);
       "resolveJsonModule": true,
       "strict": true,
       "esModuleInterop": true,
+      "experimentalJsonDeclarationEmit": true,
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {
@@ -94,6 +95,7 @@ export declare const foo: string;
       "resolveJsonModule": true,
       "strict": true,
       "esModuleInterop": true,
+      "experimentalJsonDeclarationEmit": true,
       "configFilePath": "./tsconfig.json"
     },
     "referencedMap": {},

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-and-files.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-and-files.js
@@ -54,6 +54,7 @@ exports["default"] = hello_json_1["default"].hello;
       "allowSyntheticDefaultImports": true,
       "outDir": "./",
       "skipDefaultLibCheck": true,
+      "experimentalJsonDeclarationEmit": true,
       "configFilePath": "../tsconfig_withIncludeAndFiles.json"
     },
     "referencedMap": {

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-of-json-along-with-other-include.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/include-of-json-along-with-other-include.js
@@ -54,6 +54,7 @@ exports["default"] = hello_json_1["default"].hello;
       "allowSyntheticDefaultImports": true,
       "outDir": "./",
       "skipDefaultLibCheck": true,
+      "experimentalJsonDeclarationEmit": true,
       "configFilePath": "../tsconfig_withIncludeOfJson.json"
     },
     "referencedMap": {

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/sourcemap.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/sourcemap.js
@@ -65,6 +65,7 @@ exports["default"] = hello_json_1["default"].hello;
       "allowSyntheticDefaultImports": true,
       "outDir": "./",
       "skipDefaultLibCheck": true,
+      "experimentalJsonDeclarationEmit": true,
       "configFilePath": "../tsconfig_withFiles.json"
     },
     "referencedMap": {
@@ -92,7 +93,8 @@ exports["default"] = hello_json_1["default"].hello;
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "experimentalJsonDeclarationEmit": true
   },
   "files": [
     "src/index.ts", "src/hello.json"

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/without-outDir.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/without-outDir.js
@@ -39,7 +39,8 @@ exports["default"] = hello_json_1["default"].hello;
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "experimentalJsonDeclarationEmit": true
   },
   "files": [
     "src/index.ts", "src/hello.json"
@@ -71,6 +72,7 @@ exports["default"] = hello_json_1["default"].hello;
       "esModuleInterop": true,
       "allowSyntheticDefaultImports": true,
       "skipDefaultLibCheck": true,
+      "experimentalJsonDeclarationEmit": true,
       "configFilePath": "./tsconfig_withFiles.json"
     },
     "referencedMap": {

--- a/tests/cases/compiler/requireOfJsonFileTypes.ts
+++ b/tests/cases/compiler/requireOfJsonFileTypes.ts
@@ -5,6 +5,7 @@
 // @fullEmitPaths: true
 // @resolveJsonModule: true
 // @declaration: true
+// @experimentalJsonDeclarationEmit: true
 
 // @Filename: file1.ts
 import b = require('./b.json');

--- a/tests/cases/compiler/requireOfJsonFileWithDeclaration.ts
+++ b/tests/cases/compiler/requireOfJsonFileWithDeclaration.ts
@@ -3,6 +3,7 @@
 // @fullEmitPaths: true
 // @resolveJsonModule: true
 // @declaration: true
+// @experimentalJsonDeclarationEmit: true
 
 // @Filename: file1.ts
 import b1 = require('./b.json');

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsJson.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsJson.ts
@@ -4,6 +4,7 @@
 // @resolveJsonModule: true
 // @outDir: ./out
 // @declaration: true
+// @experimentalJsonDeclarationEmit: true
 // @filename: index.js
 const j = require("./obj.json");
 module.exports = j;

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsPackageJson.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsPackageJson.ts
@@ -4,6 +4,7 @@
 // @resolveJsonModule: true
 // @outDir: ./out
 // @declaration: true
+// @experimentalJsonDeclarationEmit: true
 // @filename: index.js
 const j = require("./package.json");
 module.exports = j;

--- a/tests/projects/importJsonFromProjectReference/tsconfig.json
+++ b/tests/projects/importJsonFromProjectReference/tsconfig.json
@@ -6,7 +6,8 @@
         "composite": true,
         "resolveJsonModule": true,
         "strict": true,
-        "esModuleInterop": true
+        "esModuleInterop": true,
+        "experimentalJsonDeclarationEmit": true
     },
     "references": [
         {

--- a/tests/projects/resolveJsonModuleAndComposite/tsconfig_withFiles.json
+++ b/tests/projects/resolveJsonModuleAndComposite/tsconfig_withFiles.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "experimentalJsonDeclarationEmit": true
   },
   "files": [
     "src/index.ts", "src/hello.json"

--- a/tests/projects/resolveJsonModuleAndComposite/tsconfig_withInclude.json
+++ b/tests/projects/resolveJsonModuleAndComposite/tsconfig_withInclude.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "experimentalJsonDeclarationEmit": true
   },
   "include": [
     "src/**/*"

--- a/tests/projects/resolveJsonModuleAndComposite/tsconfig_withIncludeAndFiles.json
+++ b/tests/projects/resolveJsonModuleAndComposite/tsconfig_withIncludeAndFiles.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "experimentalJsonDeclarationEmit": true
   },
   "files": [
     "src/hello.json"

--- a/tests/projects/resolveJsonModuleAndComposite/tsconfig_withIncludeOfJson.json
+++ b/tests/projects/resolveJsonModuleAndComposite/tsconfig_withIncludeOfJson.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "outDir": "dist",
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "experimentalJsonDeclarationEmit": true
   },
   "include": [
     "src/**/*", "src/**/*.json"


### PR DESCRIPTION
This way it can still be opted in to while we're iterating on it (with the caveat that certain things may change), and we can still track all of the tests related to it while we work. This seems a little nicer than attempting to strip the feature out entirely, as it gives us a way to backport the fixes we make in 3.8 before unflagging it to 3.7 without breaking anyone who didn't opt-in (and allows anyone who started using it with Monday's release to still have a way to use it in the 3.7 branch).