### PR TITLE
Optionally stop looking for the default configured project at node_modules

### DIFF
--- a/src/compiler/path.ts
+++ b/src/compiler/path.ts
@@ -852,4 +852,8 @@ namespace ts {
             directory = parentPath;
         }
     }
+
+    export function isNodeModulesDirectory(dirPath: Path) {
+        return endsWith(dirPath, "/node_modules");
+    }
 }

--- a/src/compiler/resolutionCache.ts
+++ b/src/compiler/resolutionCache.ts
@@ -420,10 +420,6 @@ namespace ts {
             return cache && cache.get(moduleName);
         }
 
-        function isNodeModulesDirectory(dirPath: Path) {
-            return endsWith(dirPath, "/node_modules");
-        }
-
         function isNodeModulesAtTypesDirectory(dirPath: Path) {
             return endsWith(dirPath, "/node_modules/@types");
         }


### PR DESCRIPTION
Should help with #34843.

Basically, if go-to-defintion causes a node_modules file to be opened, it should probably not trigger loading of a new project (typically, the one at the project root, since that's where node_modules is).