### PR TITLE
Fix `Node#getStart(sourceFile, true)` throwing when node has a js doc and no parent

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -491,7 +491,7 @@ namespace ts {
         }
 
         if (includeJsDoc && hasJSDocNodes(node)) {
-            return getTokenPosOfNode(node.jsDoc![0]);
+            return getTokenPosOfNode(node.jsDoc![0], sourceFile);
         }
 
         // For a syntax list, it is possible that one of its children has JSDocComment nodes, while


### PR DESCRIPTION
Fixes #35028

Let me know if tests should be added somewhere... I don't see any tests for `getStart`, but I'm probably not looking hard enough.