### PR TITLE
Fix import type resolution in jsdoc, mark 2

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10852,7 +10852,8 @@ namespace ts {
                     }
                     isRequireAlias = isCallExpression(expr) && isRequireCall(expr, /*requireStringLiteralLikeArgument*/ true) && !!valueType.symbol;
                 }
-                if (isRequireAlias || node.kind === SyntaxKind.ImportType) {
+                const isImportTypeWithQualifier = node.kind === SyntaxKind.ImportType && (node as ImportTypeNode).qualifier;
+                if (isRequireAlias || isImportTypeWithQualifier) {
                     typeType = getTypeReferenceType(node, valueType.symbol);
                 }
             }

--- a/tests/baselines/reference/jsdocImportTypeReferenceToCommonjsModule.symbols
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToCommonjsModule.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/jsdoc/ex.d.ts ===
+declare var config: {
+>config : Symbol(config, Decl(ex.d.ts, 0, 11))
+
+    fix: boolean
+>fix : Symbol(fix, Decl(ex.d.ts, 0, 21))
+}
+export = config;
+>config : Symbol(config, Decl(ex.d.ts, 0, 11))
+
+=== tests/cases/conformance/jsdoc/test.js ===
+/** @param {import('./ex')} a */
+function demo(a) {
+>demo : Symbol(demo, Decl(test.js, 0, 0))
+>a : Symbol(a, Decl(test.js, 1, 14))
+
+    a.fix
+>a.fix : Symbol(fix, Decl(ex.d.ts, 0, 21))
+>a : Symbol(a, Decl(test.js, 1, 14))
+>fix : Symbol(fix, Decl(ex.d.ts, 0, 21))
+}
+

--- a/tests/baselines/reference/jsdocImportTypeReferenceToCommonjsModule.types
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToCommonjsModule.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/jsdoc/ex.d.ts ===
+declare var config: {
+>config : { fix: boolean; }
+
+    fix: boolean
+>fix : boolean
+}
+export = config;
+>config : { fix: boolean; }
+
+=== tests/cases/conformance/jsdoc/test.js ===
+/** @param {import('./ex')} a */
+function demo(a) {
+>demo : (a: { fix: boolean; }) => void
+>a : { fix: boolean; }
+
+    a.fix
+>a.fix : boolean
+>a : { fix: boolean; }
+>fix : boolean
+}
+

--- a/tests/baselines/reference/jsdocImportTypeReferenceToESModule.symbols
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToESModule.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/jsdoc/ex.d.ts ===
+export var config: {}
+>config : Symbol(config, Decl(ex.d.ts, 0, 10))
+
+=== tests/cases/conformance/jsdoc/test.js ===
+/** @param {import('./ex')} a */
+function demo(a) {
+>demo : Symbol(demo, Decl(test.js, 0, 0))
+>a : Symbol(a, Decl(test.js, 1, 14))
+
+    a.config
+>a.config : Symbol(config, Decl(ex.d.ts, 0, 10))
+>a : Symbol(a, Decl(test.js, 1, 14))
+>config : Symbol(config, Decl(ex.d.ts, 0, 10))
+}
+

--- a/tests/baselines/reference/jsdocImportTypeReferenceToESModule.types
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToESModule.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/jsdoc/ex.d.ts ===
+export var config: {}
+>config : {}
+
+=== tests/cases/conformance/jsdoc/test.js ===
+/** @param {import('./ex')} a */
+function demo(a) {
+>demo : (a: typeof import("tests/cases/conformance/jsdoc/ex")) => void
+>a : typeof import("tests/cases/conformance/jsdoc/ex")
+
+    a.config
+>a.config : {}
+>a : typeof import("tests/cases/conformance/jsdoc/ex")
+>config : {}
+}
+

--- a/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToCommonjsModule.ts
+++ b/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToCommonjsModule.ts
@@ -1,0 +1,14 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: ex.d.ts
+declare var config: {
+    fix: boolean
+}
+export = config;
+
+// @Filename: test.js
+/** @param {import('./ex')} a */
+function demo(a) {
+    a.fix
+}

--- a/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToESModule.ts
+++ b/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToESModule.ts
@@ -1,0 +1,11 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: ex.d.ts
+export var config: {}
+
+// @Filename: test.js
+/** @param {import('./ex')} a */
+function demo(a) {
+    a.config
+}


### PR DESCRIPTION
Fake alias resolution only applies when the import type is followed by a qualified name. Otherwise the alias is sufficiently resolved already. The previous fix over-applied.

Fixes #34926
