### PR TITLE
Adds 'did you mean' to the CLI args parser

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3177,6 +3177,10 @@
         "category": "Error",
         "code": 5024
     },
+    "Unknown compiler option '{0}'. Did you mean '{1}'?": {
+        "category": "Error",
+        "code": 5025
+    },
     "Could not write file '{0}': {1}.": {
         "category": "Error",
         "code": 5033

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3301,6 +3301,10 @@
         "category": "Error",
         "code": 5076
     },
+    "Unknown build option '{0}'. Did you mean '{1}'?": {
+        "category": "Error",
+        "code": 5077
+    },
 
     "Generates a sourcemap for each corresponding '.d.ts' file.": {
         "category": "Message",
@@ -4751,7 +4755,10 @@
         "category": "Error",
         "code": 17017
     },
-
+    "Unknown type acquisition option '{0}'. Did you mean '{1}'?": {
+        "category": "Error",
+        "code": 17018
+    },
     "Circularity detected while resolving configuration: {0}": {
         "category": "Error",
         "code": 18000

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5200,10 +5200,16 @@ namespace ts {
     }
 
     /* @internal */
+    export interface DidYouMeanOptionalDiagnostics {
+        unknownOptionDiagnostic: DiagnosticMessage,
+        unknownDidYouMeanDiagnostic: DiagnosticMessage,
+    }
+
+    /* @internal */
     export interface TsConfigOnlyOption extends CommandLineOptionBase {
         type: "object";
         elementOptions?: Map<CommandLineOption>;
-        extraKeyDiagnosticMessage?: DiagnosticMessage;
+        extraKeyDiagnostics?: DidYouMeanOptionalDiagnostics;
     }
 
     /* @internal */

--- a/src/testRunner/unittests/config/commandLineParsing.ts
+++ b/src/testRunner/unittests/config/commandLineParsing.ts
@@ -40,6 +40,33 @@ namespace ts {
                 });
         });
 
+        it("Handles 'did you mean?' for misspelt flags", () => {
+            // --declarations --allowTS
+            assertParseResult(["--declarations", "--allowTS"], {
+                errors: [
+                    {
+                        messageText:"Unknown compiler option '--declarations'. Did you mean 'declaration'?",
+                        category: Diagnostics.Unknown_compiler_option_0_Did_you_mean_1.category,
+                        code: Diagnostics.Unknown_compiler_option_0_Did_you_mean_1.code,
+                        file: undefined,
+                        start: undefined,
+                        length: undefined
+                    },
+                    {
+                        messageText: "Unknown compiler option '--allowTS'. Did you mean 'allowJs'?",
+                        category: Diagnostics.Unknown_compiler_option_0_Did_you_mean_1.category,
+                        code: Diagnostics.Unknown_compiler_option_0_Did_you_mean_1.code,
+                        file: undefined,
+                        start: undefined,
+                        length: undefined
+                    }
+                ],
+                fileNames: [],
+                options: {}
+            });
+        });
+
+
         it("Parse multiple options of library flags ", () => {
             // --lib es5,es2015.symbol.wellknown 0.ts
             assertParseResult(["--lib", "es5,es2015.symbol.wellknown", "0.ts"],
@@ -556,4 +583,6 @@ namespace ts {
             verifyInvalidCombination("watch", "dry");
         });
     });
+
+
 }

--- a/src/testRunner/unittests/config/convertTypeAcquisitionFromJson.ts
+++ b/src/testRunner/unittests/config/convertTypeAcquisitionFromJson.ts
@@ -111,8 +111,8 @@ namespace ts {
                     },
                     errors: [
                         {
-                            category: Diagnostics.Unknown_type_acquisition_option_0.category,
-                            code: Diagnostics.Unknown_type_acquisition_option_0.code,
+                            category: Diagnostics.Unknown_type_acquisition_option_0_Did_you_mean_1.category,
+                            code: Diagnostics.Unknown_type_acquisition_option_0_Did_you_mean_1.code,
                             file: undefined,
                             start: 0,
                             length: 0,
@@ -206,8 +206,8 @@ namespace ts {
                     },
                     errors: [
                         {
-                            category: Diagnostics.Unknown_type_acquisition_option_0.category,
-                            code: Diagnostics.Unknown_type_acquisition_option_0.code,
+                            category: Diagnostics.Unknown_type_acquisition_option_0_Did_you_mean_1.category,
+                            code: Diagnostics.Unknown_type_acquisition_option_0_Did_you_mean_1.code,
                             file: undefined,
                             start: 0,
                             length: 0,

--- a/src/testRunner/unittests/tscWatch/helpers.ts
+++ b/src/testRunner/unittests/tscWatch/helpers.ts
@@ -273,6 +273,11 @@ namespace ts.tscWatch {
         return getDiagnosticOfFile(program.getCompilerOptions().configFile!, configFile.content.indexOf(quotedOption), quotedOption.length, Diagnostics.Unknown_compiler_option_0, option);
     }
 
+    export function getUnknownDidYouMeanCompilerOption(program: Program, configFile: File, option: string, didYouMean: string) {
+        const quotedOption = `"${option}"`;
+        return getDiagnosticOfFile(program.getCompilerOptions().configFile!, configFile.content.indexOf(quotedOption), quotedOption.length, Diagnostics.Unknown_compiler_option_0_Did_you_mean_1, option, didYouMean);
+    }
+
     export function getDiagnosticModuleNotFoundOfFile(program: Program, file: File, moduleName: string) {
         const quotedModuleName = `"${moduleName}"`;
         return getDiagnosticOfFileFromProgram(program, file.path, file.content.indexOf(quotedModuleName), quotedModuleName.length, Diagnostics.Cannot_find_module_0, moduleName);

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -757,7 +757,7 @@ namespace ts.tscWatch {
             const watch = createWatchOfConfigFile(configFile.path, host);
             checkOutputErrorsInitial(host, [
                 getUnknownCompilerOption(watch(), configFile, "foo"),
-                getUnknownCompilerOption(watch(), configFile, "allowJS")
+                getUnknownDidYouMeanCompilerOption(watch(), configFile, "allowJS", "allowJs")
             ]);
         });
 

--- a/src/testRunner/unittests/tsserver/projectErrors.ts
+++ b/src/testRunner/unittests/tsserver/projectErrors.ts
@@ -496,14 +496,14 @@ declare module '@custom/plugin' {
     });
 
     describe("unittests:: tsserver:: Project Errors for Configure file diagnostics events", () => {
-        function getUnknownCompilerOptionDiagnostic(configFile: File, prop: string): ConfigFileDiagnostic {
-            const d = Diagnostics.Unknown_compiler_option_0;
+        function getUnknownCompilerOptionDiagnostic(configFile: File, prop: string, didYouMean?: string): ConfigFileDiagnostic {
+            const d = didYouMean ? Diagnostics.Unknown_compiler_option_0_Did_you_mean_1 : Diagnostics.Unknown_compiler_option_0;
             const start = configFile.content.indexOf(prop) - 1; // start at "prop"
             return {
                 fileName: configFile.path,
                 start,
                 length: prop.length + 2,
-                messageText: formatStringFromArgs(d.message, [prop]),
+                messageText: formatStringFromArgs(d.message, didYouMean ? [prop, didYouMean] : [prop]),
                 category: d.category,
                 code: d.code,
                 reportsUnnecessary: undefined
@@ -543,7 +543,7 @@ declare module '@custom/plugin' {
             openFilesForSession([file], serverEventManager.session);
             serverEventManager.checkSingleConfigFileDiagEvent(configFile.path, file.path, [
                 getUnknownCompilerOptionDiagnostic(configFile, "foo"),
-                getUnknownCompilerOptionDiagnostic(configFile, "allowJS")
+                getUnknownCompilerOptionDiagnostic(configFile, "allowJS", "allowJs")
             ]);
         });
 


### PR DESCRIPTION
Catches some of the cases where casing or an "s" is missing in our config options:

```sh
node tsc.js index.js --allowJs  --declarations --sdsffs
error TS5025: Unknown compiler option '--declarations'. Did you mean 'declaration'?
error TS5023: Unknown compiler option '--sdsffs'.
```