### PR TITLE
Fix #35060

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16568,7 +16568,7 @@ namespace ts {
         function isReadonlyArrayType(type: Type): boolean {
             return !!(getObjectFlags(type) & ObjectFlags.Reference) && (<TypeReference>type).target === globalReadonlyArrayType;
         }
-        
+
         function isMutableArrayOrTuple(type: Type): boolean {
             return isArrayType(type) && !isReadonlyArrayType(type) || isTupleType(type) && !type.target.readonly;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14531,25 +14531,24 @@ namespace ts {
              * if we have found an elaboration, or we should ignore
              * any other elaborations when relating the `source` and
              * `target` types.
-             *
-             * @param source
-             * @param target
-             * @param reportErrors
              */
             function tryElaborateArrayLikeErrors(source: Type, target: Type, reportErrors: boolean): boolean {
-                if (isTupleLikeType(source)) {
-                    const sourceTuple: TupleType | undefined  = (source as TupleTypeReference).target;
-                    if (sourceTuple && sourceTuple.readonly && isArrayOrTupleLikeType(target) &&
-                        (!isReadonlyArrayType(target) || isTupleType(target) && !target.target.readonly)) {
+                if (isTupleType(source)) {
+                    // If source is a readonly tuple
+                    // and target is an array or tuple
+                    // and target is not a readonly array
+                    // and target is not a readonly tuple
+                    if (source.target?.readonly && (isTupleType(target) || isArrayType(target)) &&
+                        !isReadonlyArrayType(target) && !(isTupleType(target) && target.target.readonly)) {
                         if (reportErrors) {
                             reportError(Diagnostics.The_type_0_is_readonly_and_cannot_be_assigned_to_the_mutable_type_1, typeToString(source), typeToString(target));
                         }
                         return false;
                     }
-                    return isArrayLikeType(target);
+                    return isTupleType(target) || isArrayType(target);
                 }
-                if (isTupleLikeType(target)) {
-                    return isArrayLikeType(source);
+                if (isTupleType(target)) {
+                    return isArrayType(source);
                 }
                 if (isReadonlyArrayType(source) && isArrayType(target) && !isReadonlyArrayType(target)) {
                     if (reportErrors) {

--- a/tests/baselines/reference/arityAndOrderCompatibility01.errors.txt
+++ b/tests/baselines/reference/arityAndOrderCompatibility01.errors.txt
@@ -2,30 +2,30 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(15,12): erro
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(17,5): error TS2461: Type '{ 0: string; 1: number; length: 2; }' is not an array type.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(18,5): error TS2741: Property '2' is missing in type '[string, number]' but required in type '[number, number, number]'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(19,5): error TS2741: Property '2' is missing in type 'StrNum' but required in type '[number, number, number]'.
-tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(20,5): error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[number, number, number]': 2, pop, push, concat, and 16 more.
+tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(20,5): error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[number, number, number]'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(21,5): error TS2741: Property '2' is missing in type '[string, number]' but required in type '[string, number, number]'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(22,5): error TS2741: Property '2' is missing in type 'StrNum' but required in type '[string, number, number]'.
-tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(23,5): error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[string, number, number]': 2, pop, push, concat, and 16 more.
+tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(23,5): error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[string, number, number]'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(24,5): error TS2322: Type '[string, number]' is not assignable to type '[number]'.
   Types of property '0' are incompatible.
     Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(25,5): error TS2322: Type 'StrNum' is not assignable to type '[number]'.
   Types of property '0' are incompatible.
     Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(26,5): error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[number]': pop, push, concat, join, and 15 more.
+tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(26,5): error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[number]'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(27,5): error TS2322: Type '[string, number]' is not assignable to type '[string]'.
   Types of property 'length' are incompatible.
     Type '2' is not assignable to type '1'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(28,5): error TS2322: Type 'StrNum' is not assignable to type '[string]'.
   Types of property 'length' are incompatible.
     Type '2' is not assignable to type '1'.
-tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(29,5): error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[string]': pop, push, concat, join, and 15 more.
+tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(29,5): error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[string]'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(30,5): error TS2322: Type '[string, number]' is not assignable to type '[number, string]'.
   Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(31,5): error TS2322: Type 'StrNum' is not assignable to type '[number, string]'.
   Types of property '0' are incompatible.
     Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(32,5): error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[number, string]': pop, push, concat, join, and 15 more.
+tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(32,5): error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[number, string]'.
 
 
 ==== tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts (17 errors) ====
@@ -58,7 +58,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(32,5): error
 !!! error TS2741: Property '2' is missing in type 'StrNum' but required in type '[number, number, number]'.
     var j3: [number, number, number] = z;
         ~~
-!!! error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[number, number, number]': 2, pop, push, concat, and 16 more.
+!!! error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[number, number, number]'.
     var k1: [string, number, number] = x;
         ~~
 !!! error TS2741: Property '2' is missing in type '[string, number]' but required in type '[string, number, number]'.
@@ -67,7 +67,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(32,5): error
 !!! error TS2741: Property '2' is missing in type 'StrNum' but required in type '[string, number, number]'.
     var k3: [string, number, number] = z;
         ~~
-!!! error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[string, number, number]': 2, pop, push, concat, and 16 more.
+!!! error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[string, number, number]'.
     var l1: [number] = x;
         ~~
 !!! error TS2322: Type '[string, number]' is not assignable to type '[number]'.
@@ -80,7 +80,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(32,5): error
 !!! error TS2322:     Type 'string' is not assignable to type 'number'.
     var l3: [number] = z;
         ~~
-!!! error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[number]': pop, push, concat, join, and 15 more.
+!!! error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[number]'.
     var m1: [string] = x;
         ~~
 !!! error TS2322: Type '[string, number]' is not assignable to type '[string]'.
@@ -93,7 +93,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(32,5): error
 !!! error TS2322:     Type '2' is not assignable to type '1'.
     var m3: [string] = z;
         ~~
-!!! error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[string]': pop, push, concat, join, and 15 more.
+!!! error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[string]'.
     var n1: [number, string] = x;
         ~~
 !!! error TS2322: Type '[string, number]' is not assignable to type '[number, string]'.
@@ -105,7 +105,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(32,5): error
 !!! error TS2322:     Type 'string' is not assignable to type 'number'.
     var n3: [number, string] = z;
         ~~
-!!! error TS2740: Type '{ 0: string; 1: number; length: 2; }' is missing the following properties from type '[number, string]': pop, push, concat, join, and 15 more.
+!!! error TS2322: Type '{ 0: string; 1: number; length: 2; }' is not assignable to type '[number, string]'.
     var o1: [string, number] = x;
     var o2: [string, number] = y;
     var o3: [string, number] = y;

--- a/tests/baselines/reference/readonlyArraysAndTuples.errors.txt
+++ b/tests/baselines/reference/readonlyArraysAndTuples.errors.txt
@@ -5,7 +5,7 @@ tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(12,12): error TS1
 tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(15,5): error TS4104: The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.
 tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(17,5): error TS4104: The type 'readonly [string, string]' is 'readonly' and cannot be assigned to the mutable type 'string[]'.
 tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(21,5): error TS2739: Type 'string[]' is missing the following properties from type '[string, string]': 0, 1
-tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(22,5): error TS2740: Type 'readonly string[]' is missing the following properties from type '[string, string]': 0, 1, pop, push, and 5 more.
+tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(22,5): error TS4104: The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type '[string, string]'.
 tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(23,5): error TS4104: The type 'readonly [string, string]' is 'readonly' and cannot be assigned to the mutable type '[string, string]'.
 tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(24,5): error TS2739: Type 'string[]' is missing the following properties from type 'readonly [string, string]': 0, 1
 tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(25,5): error TS2739: Type 'readonly string[]' is missing the following properties from type 'readonly [string, string]': 0, 1
@@ -56,7 +56,7 @@ tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts(36,8): error TS25
 !!! error TS2739: Type 'string[]' is missing the following properties from type '[string, string]': 0, 1
         mt = ra;  // Error
         ~~
-!!! error TS2740: Type 'readonly string[]' is missing the following properties from type '[string, string]': 0, 1, pop, push, and 5 more.
+!!! error TS4104: The type 'readonly string[]' is 'readonly' and cannot be assigned to the mutable type '[string, string]'.
         mt = rt;  // Error
         ~~
 !!! error TS4104: The type 'readonly [string, string]' is 'readonly' and cannot be assigned to the mutable type '[string, string]'.

--- a/tests/baselines/reference/readonlyTupleAndArrayElaboration.errors.txt
+++ b/tests/baselines/reference/readonlyTupleAndArrayElaboration.errors.txt
@@ -10,9 +10,37 @@ tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(23,9): error TS2345: Ar
   The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'number[]'.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(24,9): error TS2345: Argument of type 'readonly number[]' is not assignable to parameter of type 'number[]'.
   The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'number[]'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(27,7): error TS2322: Type 'readonly [1]' is not assignable to type 'readonly []'.
+  Types of property 'length' are incompatible.
+    Type '1' is not assignable to type '0'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(30,7): error TS4104: The type 'readonly [1]' is 'readonly' and cannot be assigned to the mutable type '[]'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(33,7): error TS2322: Type '[1]' is not assignable to type 'readonly []'.
+  Types of property 'length' are incompatible.
+    Type '1' is not assignable to type '0'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(36,7): error TS2322: Type '[1]' is not assignable to type '[]'.
+  Types of property 'length' are incompatible.
+    Type '1' is not assignable to type '0'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(39,7): error TS2322: Type 'readonly number[]' is not assignable to type 'readonly boolean[]'.
+  Type 'number' is not assignable to type 'boolean'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(42,7): error TS4104: The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'boolean[]'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(45,7): error TS2322: Type 'number[]' is not assignable to type 'readonly boolean[]'.
+  Type 'number' is not assignable to type 'boolean'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(48,7): error TS2322: Type 'number[]' is not assignable to type 'boolean[]'.
+  Type 'number' is not assignable to type 'boolean'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(51,7): error TS2322: Type 'readonly [1]' is not assignable to type 'readonly boolean[]'.
+  Type '1' is not assignable to type 'boolean'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(54,7): error TS4104: The type 'readonly [1]' is 'readonly' and cannot be assigned to the mutable type 'number[]'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(57,7): error TS2322: Type '[1]' is not assignable to type 'readonly boolean[]'.
+  Type '1' is not assignable to type 'boolean'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(60,7): error TS2322: Type '[1]' is not assignable to type 'boolean[]'.
+  Type '1' is not assignable to type 'boolean'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(63,7): error TS2741: Property '0' is missing in type 'readonly number[]' but required in type 'readonly [1]'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(66,7): error TS2740: Type 'readonly number[]' is missing the following properties from type '[1]': 0, pop, push, reverse, and 4 more.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(69,7): error TS2741: Property '0' is missing in type 'number[]' but required in type 'readonly [1]'.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(72,7): error TS2741: Property '0' is missing in type 'number[]' but required in type '[1]'.
 
 
-==== tests/cases/compiler/readonlyTupleAndArrayElaboration.ts (6 errors) ====
+==== tests/cases/compiler/readonlyTupleAndArrayElaboration.ts (22 errors) ====
     // @strict
     // #Repro from #30839
     
@@ -55,4 +83,96 @@ tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(24,9): error TS2345: Ar
             ~
 !!! error TS2345: Argument of type 'readonly number[]' is not assignable to parameter of type 'number[]'.
 !!! error TS2345:   The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'number[]'.
+    
+    const t1: readonly [1] = [1];
+    const t2: readonly [] = t1;
+          ~~
+!!! error TS2322: Type 'readonly [1]' is not assignable to type 'readonly []'.
+!!! error TS2322:   Types of property 'length' are incompatible.
+!!! error TS2322:     Type '1' is not assignable to type '0'.
+    
+    const t3: readonly [1] = [1];
+    const t4: [] = t3;
+          ~~
+!!! error TS4104: The type 'readonly [1]' is 'readonly' and cannot be assigned to the mutable type '[]'.
+    
+    const t5: [1] = [1];
+    const t6: readonly [] = t5;
+          ~~
+!!! error TS2322: Type '[1]' is not assignable to type 'readonly []'.
+!!! error TS2322:   Types of property 'length' are incompatible.
+!!! error TS2322:     Type '1' is not assignable to type '0'.
+    
+    const t7: [1] = [1];
+    const t8: [] = t7;
+          ~~
+!!! error TS2322: Type '[1]' is not assignable to type '[]'.
+!!! error TS2322:   Types of property 'length' are incompatible.
+!!! error TS2322:     Type '1' is not assignable to type '0'.
+    
+    const a1: readonly number[] = [1];
+    const a2: readonly boolean[] = a1;
+          ~~
+!!! error TS2322: Type 'readonly number[]' is not assignable to type 'readonly boolean[]'.
+!!! error TS2322:   Type 'number' is not assignable to type 'boolean'.
+    
+    const a3: readonly number[] = [1];
+    const a4: boolean[] = a3;
+          ~~
+!!! error TS4104: The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type 'boolean[]'.
+    
+    const a5: number[] = [1];
+    const a6: readonly boolean [] = a5;
+          ~~
+!!! error TS2322: Type 'number[]' is not assignable to type 'readonly boolean[]'.
+!!! error TS2322:   Type 'number' is not assignable to type 'boolean'.
+    
+    const a7: number[] = [1];
+    const a8: boolean[] = a7;
+          ~~
+!!! error TS2322: Type 'number[]' is not assignable to type 'boolean[]'.
+!!! error TS2322:   Type 'number' is not assignable to type 'boolean'.
+    
+    const ta1: readonly [1] = [1];
+    const ta2: readonly boolean[] = ta1;
+          ~~~
+!!! error TS2322: Type 'readonly [1]' is not assignable to type 'readonly boolean[]'.
+!!! error TS2322:   Type '1' is not assignable to type 'boolean'.
+    
+    const ta3: readonly [1] = [1];
+    const ta4: number[] = ta3;
+          ~~~
+!!! error TS4104: The type 'readonly [1]' is 'readonly' and cannot be assigned to the mutable type 'number[]'.
+    
+    const ta5: [1] = [1];
+    const ta6: readonly boolean[] = ta5;
+          ~~~
+!!! error TS2322: Type '[1]' is not assignable to type 'readonly boolean[]'.
+!!! error TS2322:   Type '1' is not assignable to type 'boolean'.
+    
+    const ta7: [1] = [1];
+    const ta8: boolean[] = ta7;
+          ~~~
+!!! error TS2322: Type '[1]' is not assignable to type 'boolean[]'.
+!!! error TS2322:   Type '1' is not assignable to type 'boolean'.
+    
+    const at1: readonly number[] = [1];
+    const at2: readonly [1] = at1;
+          ~~~
+!!! error TS2741: Property '0' is missing in type 'readonly number[]' but required in type 'readonly [1]'.
+    
+    const at3: readonly number[] = [1];
+    const at4: [1] = at3;
+          ~~~
+!!! error TS2740: Type 'readonly number[]' is missing the following properties from type '[1]': 0, pop, push, reverse, and 4 more.
+    
+    const at5: number[] = [1];
+    const at6: readonly [1] = at5;
+          ~~~
+!!! error TS2741: Property '0' is missing in type 'number[]' but required in type 'readonly [1]'.
+    
+    const at7: number[] = [1];
+    const at8: [1] = at7;
+          ~~~
+!!! error TS2741: Property '0' is missing in type 'number[]' but required in type '[1]'.
     

--- a/tests/baselines/reference/readonlyTupleAndArrayElaboration.errors.txt
+++ b/tests/baselines/reference/readonlyTupleAndArrayElaboration.errors.txt
@@ -35,7 +35,7 @@ tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(57,7): error TS2322: Ty
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(60,7): error TS2322: Type '[1]' is not assignable to type 'boolean[]'.
   Type '1' is not assignable to type 'boolean'.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(63,7): error TS2741: Property '0' is missing in type 'readonly number[]' but required in type 'readonly [1]'.
-tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(66,7): error TS2740: Type 'readonly number[]' is missing the following properties from type '[1]': 0, pop, push, reverse, and 4 more.
+tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(66,7): error TS4104: The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type '[1]'.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(69,7): error TS2741: Property '0' is missing in type 'number[]' but required in type 'readonly [1]'.
 tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(72,7): error TS2741: Property '0' is missing in type 'number[]' but required in type '[1]'.
 
@@ -164,7 +164,7 @@ tests/cases/compiler/readonlyTupleAndArrayElaboration.ts(72,7): error TS2741: Pr
     const at3: readonly number[] = [1];
     const at4: [1] = at3;
           ~~~
-!!! error TS2740: Type 'readonly number[]' is missing the following properties from type '[1]': 0, pop, push, reverse, and 4 more.
+!!! error TS4104: The type 'readonly number[]' is 'readonly' and cannot be assigned to the mutable type '[1]'.
     
     const at5: number[] = [1];
     const at6: readonly [1] = at5;

--- a/tests/baselines/reference/readonlyTupleAndArrayElaboration.js
+++ b/tests/baselines/reference/readonlyTupleAndArrayElaboration.js
@@ -24,6 +24,54 @@ arryFn2(a);
 arryFn2(b);
 arryFn2(c);
 
+const t1: readonly [1] = [1];
+const t2: readonly [] = t1;
+
+const t3: readonly [1] = [1];
+const t4: [] = t3;
+
+const t5: [1] = [1];
+const t6: readonly [] = t5;
+
+const t7: [1] = [1];
+const t8: [] = t7;
+
+const a1: readonly number[] = [1];
+const a2: readonly boolean[] = a1;
+
+const a3: readonly number[] = [1];
+const a4: boolean[] = a3;
+
+const a5: number[] = [1];
+const a6: readonly boolean [] = a5;
+
+const a7: number[] = [1];
+const a8: boolean[] = a7;
+
+const ta1: readonly [1] = [1];
+const ta2: readonly boolean[] = ta1;
+
+const ta3: readonly [1] = [1];
+const ta4: number[] = ta3;
+
+const ta5: [1] = [1];
+const ta6: readonly boolean[] = ta5;
+
+const ta7: [1] = [1];
+const ta8: boolean[] = ta7;
+
+const at1: readonly number[] = [1];
+const at2: readonly [1] = at1;
+
+const at3: readonly number[] = [1];
+const at4: [1] = at3;
+
+const at5: number[] = [1];
+const at6: readonly [1] = at5;
+
+const at7: number[] = [1];
+const at8: [1] = at7;
+
 
 //// [readonlyTupleAndArrayElaboration.js]
 // @strict
@@ -39,3 +87,35 @@ arryFn2(point);
 arryFn2(a);
 arryFn2(b);
 arryFn2(c);
+var t1 = [1];
+var t2 = t1;
+var t3 = [1];
+var t4 = t3;
+var t5 = [1];
+var t6 = t5;
+var t7 = [1];
+var t8 = t7;
+var a1 = [1];
+var a2 = a1;
+var a3 = [1];
+var a4 = a3;
+var a5 = [1];
+var a6 = a5;
+var a7 = [1];
+var a8 = a7;
+var ta1 = [1];
+var ta2 = ta1;
+var ta3 = [1];
+var ta4 = ta3;
+var ta5 = [1];
+var ta6 = ta5;
+var ta7 = [1];
+var ta8 = ta7;
+var at1 = [1];
+var at2 = at1;
+var at3 = [1];
+var at4 = at3;
+var at5 = [1];
+var at6 = at5;
+var at7 = [1];
+var at8 = at7;

--- a/tests/baselines/reference/readonlyTupleAndArrayElaboration.symbols
+++ b/tests/baselines/reference/readonlyTupleAndArrayElaboration.symbols
@@ -62,3 +62,115 @@ arryFn2(c);
 >arryFn2 : Symbol(arryFn2, Decl(readonlyTupleAndArrayElaboration.ts, 12, 14))
 >c : Symbol(c, Decl(readonlyTupleAndArrayElaboration.ts, 19, 13))
 
+const t1: readonly [1] = [1];
+>t1 : Symbol(t1, Decl(readonlyTupleAndArrayElaboration.ts, 25, 5))
+
+const t2: readonly [] = t1;
+>t2 : Symbol(t2, Decl(readonlyTupleAndArrayElaboration.ts, 26, 5))
+>t1 : Symbol(t1, Decl(readonlyTupleAndArrayElaboration.ts, 25, 5))
+
+const t3: readonly [1] = [1];
+>t3 : Symbol(t3, Decl(readonlyTupleAndArrayElaboration.ts, 28, 5))
+
+const t4: [] = t3;
+>t4 : Symbol(t4, Decl(readonlyTupleAndArrayElaboration.ts, 29, 5))
+>t3 : Symbol(t3, Decl(readonlyTupleAndArrayElaboration.ts, 28, 5))
+
+const t5: [1] = [1];
+>t5 : Symbol(t5, Decl(readonlyTupleAndArrayElaboration.ts, 31, 5))
+
+const t6: readonly [] = t5;
+>t6 : Symbol(t6, Decl(readonlyTupleAndArrayElaboration.ts, 32, 5))
+>t5 : Symbol(t5, Decl(readonlyTupleAndArrayElaboration.ts, 31, 5))
+
+const t7: [1] = [1];
+>t7 : Symbol(t7, Decl(readonlyTupleAndArrayElaboration.ts, 34, 5))
+
+const t8: [] = t7;
+>t8 : Symbol(t8, Decl(readonlyTupleAndArrayElaboration.ts, 35, 5))
+>t7 : Symbol(t7, Decl(readonlyTupleAndArrayElaboration.ts, 34, 5))
+
+const a1: readonly number[] = [1];
+>a1 : Symbol(a1, Decl(readonlyTupleAndArrayElaboration.ts, 37, 5))
+
+const a2: readonly boolean[] = a1;
+>a2 : Symbol(a2, Decl(readonlyTupleAndArrayElaboration.ts, 38, 5))
+>a1 : Symbol(a1, Decl(readonlyTupleAndArrayElaboration.ts, 37, 5))
+
+const a3: readonly number[] = [1];
+>a3 : Symbol(a3, Decl(readonlyTupleAndArrayElaboration.ts, 40, 5))
+
+const a4: boolean[] = a3;
+>a4 : Symbol(a4, Decl(readonlyTupleAndArrayElaboration.ts, 41, 5))
+>a3 : Symbol(a3, Decl(readonlyTupleAndArrayElaboration.ts, 40, 5))
+
+const a5: number[] = [1];
+>a5 : Symbol(a5, Decl(readonlyTupleAndArrayElaboration.ts, 43, 5))
+
+const a6: readonly boolean [] = a5;
+>a6 : Symbol(a6, Decl(readonlyTupleAndArrayElaboration.ts, 44, 5))
+>a5 : Symbol(a5, Decl(readonlyTupleAndArrayElaboration.ts, 43, 5))
+
+const a7: number[] = [1];
+>a7 : Symbol(a7, Decl(readonlyTupleAndArrayElaboration.ts, 46, 5))
+
+const a8: boolean[] = a7;
+>a8 : Symbol(a8, Decl(readonlyTupleAndArrayElaboration.ts, 47, 5))
+>a7 : Symbol(a7, Decl(readonlyTupleAndArrayElaboration.ts, 46, 5))
+
+const ta1: readonly [1] = [1];
+>ta1 : Symbol(ta1, Decl(readonlyTupleAndArrayElaboration.ts, 49, 5))
+
+const ta2: readonly boolean[] = ta1;
+>ta2 : Symbol(ta2, Decl(readonlyTupleAndArrayElaboration.ts, 50, 5))
+>ta1 : Symbol(ta1, Decl(readonlyTupleAndArrayElaboration.ts, 49, 5))
+
+const ta3: readonly [1] = [1];
+>ta3 : Symbol(ta3, Decl(readonlyTupleAndArrayElaboration.ts, 52, 5))
+
+const ta4: number[] = ta3;
+>ta4 : Symbol(ta4, Decl(readonlyTupleAndArrayElaboration.ts, 53, 5))
+>ta3 : Symbol(ta3, Decl(readonlyTupleAndArrayElaboration.ts, 52, 5))
+
+const ta5: [1] = [1];
+>ta5 : Symbol(ta5, Decl(readonlyTupleAndArrayElaboration.ts, 55, 5))
+
+const ta6: readonly boolean[] = ta5;
+>ta6 : Symbol(ta6, Decl(readonlyTupleAndArrayElaboration.ts, 56, 5))
+>ta5 : Symbol(ta5, Decl(readonlyTupleAndArrayElaboration.ts, 55, 5))
+
+const ta7: [1] = [1];
+>ta7 : Symbol(ta7, Decl(readonlyTupleAndArrayElaboration.ts, 58, 5))
+
+const ta8: boolean[] = ta7;
+>ta8 : Symbol(ta8, Decl(readonlyTupleAndArrayElaboration.ts, 59, 5))
+>ta7 : Symbol(ta7, Decl(readonlyTupleAndArrayElaboration.ts, 58, 5))
+
+const at1: readonly number[] = [1];
+>at1 : Symbol(at1, Decl(readonlyTupleAndArrayElaboration.ts, 61, 5))
+
+const at2: readonly [1] = at1;
+>at2 : Symbol(at2, Decl(readonlyTupleAndArrayElaboration.ts, 62, 5))
+>at1 : Symbol(at1, Decl(readonlyTupleAndArrayElaboration.ts, 61, 5))
+
+const at3: readonly number[] = [1];
+>at3 : Symbol(at3, Decl(readonlyTupleAndArrayElaboration.ts, 64, 5))
+
+const at4: [1] = at3;
+>at4 : Symbol(at4, Decl(readonlyTupleAndArrayElaboration.ts, 65, 5))
+>at3 : Symbol(at3, Decl(readonlyTupleAndArrayElaboration.ts, 64, 5))
+
+const at5: number[] = [1];
+>at5 : Symbol(at5, Decl(readonlyTupleAndArrayElaboration.ts, 67, 5))
+
+const at6: readonly [1] = at5;
+>at6 : Symbol(at6, Decl(readonlyTupleAndArrayElaboration.ts, 68, 5))
+>at5 : Symbol(at5, Decl(readonlyTupleAndArrayElaboration.ts, 67, 5))
+
+const at7: number[] = [1];
+>at7 : Symbol(at7, Decl(readonlyTupleAndArrayElaboration.ts, 70, 5))
+
+const at8: [1] = at7;
+>at8 : Symbol(at8, Decl(readonlyTupleAndArrayElaboration.ts, 71, 5))
+>at7 : Symbol(at7, Decl(readonlyTupleAndArrayElaboration.ts, 70, 5))
+

--- a/tests/baselines/reference/readonlyTupleAndArrayElaboration.types
+++ b/tests/baselines/reference/readonlyTupleAndArrayElaboration.types
@@ -75,3 +75,147 @@ arryFn2(c);
 >arryFn2 : (x: number[]) => void
 >c : readonly number[]
 
+const t1: readonly [1] = [1];
+>t1 : readonly [1]
+>[1] : [1]
+>1 : 1
+
+const t2: readonly [] = t1;
+>t2 : readonly []
+>t1 : readonly [1]
+
+const t3: readonly [1] = [1];
+>t3 : readonly [1]
+>[1] : [1]
+>1 : 1
+
+const t4: [] = t3;
+>t4 : []
+>t3 : readonly [1]
+
+const t5: [1] = [1];
+>t5 : [1]
+>[1] : [1]
+>1 : 1
+
+const t6: readonly [] = t5;
+>t6 : readonly []
+>t5 : [1]
+
+const t7: [1] = [1];
+>t7 : [1]
+>[1] : [1]
+>1 : 1
+
+const t8: [] = t7;
+>t8 : []
+>t7 : [1]
+
+const a1: readonly number[] = [1];
+>a1 : readonly number[]
+>[1] : number[]
+>1 : 1
+
+const a2: readonly boolean[] = a1;
+>a2 : readonly boolean[]
+>a1 : readonly number[]
+
+const a3: readonly number[] = [1];
+>a3 : readonly number[]
+>[1] : number[]
+>1 : 1
+
+const a4: boolean[] = a3;
+>a4 : boolean[]
+>a3 : readonly number[]
+
+const a5: number[] = [1];
+>a5 : number[]
+>[1] : number[]
+>1 : 1
+
+const a6: readonly boolean [] = a5;
+>a6 : readonly boolean[]
+>a5 : number[]
+
+const a7: number[] = [1];
+>a7 : number[]
+>[1] : number[]
+>1 : 1
+
+const a8: boolean[] = a7;
+>a8 : boolean[]
+>a7 : number[]
+
+const ta1: readonly [1] = [1];
+>ta1 : readonly [1]
+>[1] : [1]
+>1 : 1
+
+const ta2: readonly boolean[] = ta1;
+>ta2 : readonly boolean[]
+>ta1 : readonly [1]
+
+const ta3: readonly [1] = [1];
+>ta3 : readonly [1]
+>[1] : [1]
+>1 : 1
+
+const ta4: number[] = ta3;
+>ta4 : number[]
+>ta3 : readonly [1]
+
+const ta5: [1] = [1];
+>ta5 : [1]
+>[1] : [1]
+>1 : 1
+
+const ta6: readonly boolean[] = ta5;
+>ta6 : readonly boolean[]
+>ta5 : [1]
+
+const ta7: [1] = [1];
+>ta7 : [1]
+>[1] : [1]
+>1 : 1
+
+const ta8: boolean[] = ta7;
+>ta8 : boolean[]
+>ta7 : [1]
+
+const at1: readonly number[] = [1];
+>at1 : readonly number[]
+>[1] : number[]
+>1 : 1
+
+const at2: readonly [1] = at1;
+>at2 : readonly [1]
+>at1 : readonly number[]
+
+const at3: readonly number[] = [1];
+>at3 : readonly number[]
+>[1] : number[]
+>1 : 1
+
+const at4: [1] = at3;
+>at4 : [1]
+>at3 : readonly number[]
+
+const at5: number[] = [1];
+>at5 : number[]
+>[1] : number[]
+>1 : 1
+
+const at6: readonly [1] = at5;
+>at6 : readonly [1]
+>at5 : number[]
+
+const at7: number[] = [1];
+>at7 : number[]
+>[1] : number[]
+>1 : 1
+
+const at8: [1] = at7;
+>at8 : [1]
+>at7 : number[]
+

--- a/tests/cases/compiler/readonlyTupleAndArrayElaboration.ts
+++ b/tests/cases/compiler/readonlyTupleAndArrayElaboration.ts
@@ -22,3 +22,51 @@ declare const c: ReadonlyArray<number>;
 arryFn2(a);
 arryFn2(b);
 arryFn2(c);
+
+const t1: readonly [1] = [1];
+const t2: readonly [] = t1;
+
+const t3: readonly [1] = [1];
+const t4: [] = t3;
+
+const t5: [1] = [1];
+const t6: readonly [] = t5;
+
+const t7: [1] = [1];
+const t8: [] = t7;
+
+const a1: readonly number[] = [1];
+const a2: readonly boolean[] = a1;
+
+const a3: readonly number[] = [1];
+const a4: boolean[] = a3;
+
+const a5: number[] = [1];
+const a6: readonly boolean [] = a5;
+
+const a7: number[] = [1];
+const a8: boolean[] = a7;
+
+const ta1: readonly [1] = [1];
+const ta2: readonly boolean[] = ta1;
+
+const ta3: readonly [1] = [1];
+const ta4: number[] = ta3;
+
+const ta5: [1] = [1];
+const ta6: readonly boolean[] = ta5;
+
+const ta7: [1] = [1];
+const ta8: boolean[] = ta7;
+
+const at1: readonly number[] = [1];
+const at2: readonly [1] = at1;
+
+const at3: readonly number[] = [1];
+const at4: [1] = at3;
+
+const at5: number[] = [1];
+const at6: readonly [1] = at5;
+
+const at7: number[] = [1];
+const at8: [1] = at7;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #35060, specifically the bug for ro-tuple to ro-tuple.

Some debate over cases like:
```ts
const t3: readonly [1] = [1];
const t4: [] = t3; // Type 'readonly [1]' is missing the following properties from type '[]': pop, push, reverse, shift, and 6 more. [2740]
```
It might be nice to just report the length delta, but that is for a different day.
