### PR TITLE
Use related error spans for "implement abstract class" errors

### DIFF
--- a/tests/baselines/reference/abstractPropertyNegative.errors.txt
+++ b/tests/baselines/reference/abstractPropertyNegative.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/abstractPropertyNegative.ts(10,18): error TS2380: 'get' and 'set' accessor must have the same type.
 tests/cases/compiler/abstractPropertyNegative.ts(11,18): error TS2380: 'get' and 'set' accessor must have the same type.
-tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'm' from class 'B'.
 tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'mismatch' from class 'B'.
-tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'prop' from class 'B'.
-tests/cases/compiler/abstractPropertyNegative.ts(13,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'readonlyProp' from class 'B'.
+  Non-abstract class 'C' does not implement inherited abstract member 'm' from class 'B'.
+    Non-abstract class 'C' does not implement inherited abstract member 'readonlyProp' from class 'B'.
+      Non-abstract class 'C' does not implement inherited abstract member 'prop' from class 'B'.
 tests/cases/compiler/abstractPropertyNegative.ts(15,5): error TS1244: Abstract methods can only appear within an abstract class.
 tests/cases/compiler/abstractPropertyNegative.ts(16,37): error TS1005: '{' expected.
 tests/cases/compiler/abstractPropertyNegative.ts(19,3): error TS2540: Cannot assign to 'ro' because it is a read-only property.
@@ -19,7 +19,7 @@ tests/cases/compiler/abstractPropertyNegative.ts(40,9): error TS2676: Accessors 
 tests/cases/compiler/abstractPropertyNegative.ts(41,18): error TS2676: Accessors must both be abstract or non-abstract.
 
 
-==== tests/cases/compiler/abstractPropertyNegative.ts (16 errors) ====
+==== tests/cases/compiler/abstractPropertyNegative.ts (13 errors) ====
     interface A {
         prop: string;
         m(): string;
@@ -38,13 +38,10 @@ tests/cases/compiler/abstractPropertyNegative.ts(41,18): error TS2676: Accessors
     }
     class C extends B {
           ~
-!!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'm' from class 'B'.
-          ~
 !!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'mismatch' from class 'B'.
-          ~
-!!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'prop' from class 'B'.
-          ~
-!!! error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'readonlyProp' from class 'B'.
+!!! error TS2515:   Non-abstract class 'C' does not implement inherited abstract member 'm' from class 'B'.
+!!! error TS2515:     Non-abstract class 'C' does not implement inherited abstract member 'readonlyProp' from class 'B'.
+!!! error TS2515:       Non-abstract class 'C' does not implement inherited abstract member 'prop' from class 'B'.
         readonly ro = "readonly please";
         abstract notAllowed: string;
         ~~~~~~~~

--- a/tests/baselines/reference/classAbstractGeneric.errors.txt
+++ b/tests/baselines/reference/classAbstractGeneric.errors.txt
@@ -1,12 +1,12 @@
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(10,7): error TS2515: Non-abstract class 'C<T>' does not implement inherited abstract member 'bar' from class 'A<T>'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(10,7): error TS2515: Non-abstract class 'C<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
+  Non-abstract class 'C<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(12,7): error TS2515: Non-abstract class 'D' does not implement inherited abstract member 'bar' from class 'A<number>'.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(12,7): error TS2515: Non-abstract class 'D' does not implement inherited abstract member 'foo' from class 'A<number>'.
+  Non-abstract class 'D' does not implement inherited abstract member 'foo' from class 'A<number>'.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(14,7): error TS2515: Non-abstract class 'E<T>' does not implement inherited abstract member 'bar' from class 'A<T>'.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts(18,7): error TS2515: Non-abstract class 'F<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
 
 
-==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts (6 errors) ====
+==== tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts (4 errors) ====
     abstract class A<T> {
         t: T;
         
@@ -19,14 +19,12 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
     class C<T> extends A<T> {} // error -- inherits abstract methods
           ~
 !!! error TS2515: Non-abstract class 'C<T>' does not implement inherited abstract member 'bar' from class 'A<T>'.
-          ~
-!!! error TS2515: Non-abstract class 'C<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
+!!! error TS2515:   Non-abstract class 'C<T>' does not implement inherited abstract member 'foo' from class 'A<T>'.
     
     class D extends A<number> {} // error -- inherits abstract methods
           ~
 !!! error TS2515: Non-abstract class 'D' does not implement inherited abstract member 'bar' from class 'A<number>'.
-          ~
-!!! error TS2515: Non-abstract class 'D' does not implement inherited abstract member 'foo' from class 'A<number>'.
+!!! error TS2515:   Non-abstract class 'D' does not implement inherited abstract member 'foo' from class 'A<number>'.
     
     class E<T> extends A<T> { // error -- doesn't implement bar
           ~


### PR DESCRIPTION
Fixes #32848

I combine messages using chainDiagnosticMessages.
But I cannot sure this is really good.
Can you give me some opinion?

cc @DanielRosenwasser @mjbvz @crc442
