### PR TITLE
Fix index type for CSSStyleDeclaration

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -3277,7 +3277,7 @@ interface CSSStyleDeclaration {
     item(index: number): string;
     removeProperty(propertyName: string): string;
     setProperty(propertyName: string, value: string | null, priority?: string | null): void;
-    [index: number]: string;
+    [key: string]: string;
 }
 
 declare var CSSStyleDeclaration: {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Partially fixes #17827
