### PR TITLE
Scan types of `yield` expressions in classes too

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1221,11 +1221,8 @@ namespace ts {
                 case SyntaxKind.InterfaceDeclaration:
                 case SyntaxKind.ModuleDeclaration:
                 case SyntaxKind.TypeAliasDeclaration:
-                case SyntaxKind.ClassDeclaration:
-                case SyntaxKind.ClassExpression:
                     // These are not allowed inside a generator now, but eventually they may be allowed
-                    // as local types. Regardless, any yield statements contained within them should be
-                    // skipped in this traversal.
+                    // as local types. Regardless, skip them to avoid the work.
                     return;
                 default:
                     if (isFunctionLike(node)) {

--- a/tests/baselines/reference/generatorTypeCheck39.types
+++ b/tests/baselines/reference/generatorTypeCheck39.types
@@ -8,7 +8,7 @@ function decorator(x: any) {
 >y : any
 }
 function* g() {
->g : () => Generator<never, void, unknown>
+>g : () => Generator<number, void, any>
 
     @decorator(yield 0)
 >decorator(yield 0) : (y: any) => void

--- a/tests/baselines/reference/generatorTypeCheck40.types
+++ b/tests/baselines/reference/generatorTypeCheck40.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck40.ts ===
 function* g() {
->g : () => Generator<never, void, unknown>
+>g : () => Generator<number, void, unknown>
 
     class C extends (yield 0) { }
 >C : C

--- a/tests/baselines/reference/generatorTypeCheck55.types
+++ b/tests/baselines/reference/generatorTypeCheck55.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck55.ts ===
 function* g() {
->g : () => Generator<never, void, unknown>
+>g : () => Generator<any, void, unknown>
 
     var x = class C extends (yield) {};
 >x : typeof C

--- a/tests/baselines/reference/generatorTypeCheck56.types
+++ b/tests/baselines/reference/generatorTypeCheck56.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck56.ts ===
 function* g() {
->g : () => Generator<never, void, unknown>
+>g : () => Generator<number, void, unknown>
 
     var x = class C {
 >x : typeof C

--- a/tests/baselines/reference/generatorTypeCheck57.types
+++ b/tests/baselines/reference/generatorTypeCheck57.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck57.ts ===
 function* g() {
->g : () => Generator<never, void, unknown>
+>g : () => Generator<number, void, unknown>
 
     class C {
 >C : C

--- a/tests/baselines/reference/generatorTypeCheck58.types
+++ b/tests/baselines/reference/generatorTypeCheck58.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck58.ts ===
 function* g() {
->g : () => Generator<never, void, unknown>
+>g : () => Generator<number, void, unknown>
 
     class C {
 >C : C

--- a/tests/baselines/reference/generatorTypeCheck60.types
+++ b/tests/baselines/reference/generatorTypeCheck60.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck60.ts ===
 function* g() {
->g : () => Generator<never, void, unknown>
+>g : () => Generator<any, void, unknown>
 
     class C extends (yield) {};
 >C : C

--- a/tests/baselines/reference/generatorTypeCheck61.types
+++ b/tests/baselines/reference/generatorTypeCheck61.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck61.ts ===
 function * g() {
->g : () => Generator<never, void, unknown>
+>g : () => Generator<number, void, unknown>
 
     @(yield 0)
 >(yield 0) : any


### PR DESCRIPTION
Also, drop the other cases where they were ignored, since they're
forbidden in enums, and the others are fine wrt the comment that was
there.

Fixes #34892
