### PR TITLE
Fix formatting issue when auto implementing interfaces.

### DIFF
--- a/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleMembers1.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleMembers1.ts
@@ -1,0 +1,30 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    m1(): void;
+////    m2(): void;
+////    m3(): void;
+////}
+////class C implements I {}
+
+verify.codeFixAll({
+    fixId: "fixClassIncorrectlyImplementsInterface",
+    fixAllDescription: "Implement all unimplemented interfaces",
+    newFileContent:
+`interface I {
+    m1(): void;
+    m2(): void;
+    m3(): void;
+}
+class C implements I {
+    m1(): void {
+        throw new Error("Method not implemented.");
+    }
+    m2(): void {
+        throw new Error("Method not implemented.");
+    }
+    m3(): void {
+        throw new Error("Method not implemented.");
+    }
+}`,
+});

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleMembers2.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleMembers2.ts
@@ -1,0 +1,31 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    m1(): void;
+////    m2(): void;
+////    m3(): void;
+////}
+////class C implements I {
+////}
+
+verify.codeFixAll({
+    fixId: "fixClassIncorrectlyImplementsInterface",
+    fixAllDescription: "Implement all unimplemented interfaces",
+    newFileContent:
+`interface I {
+    m1(): void;
+    m2(): void;
+    m3(): void;
+}
+class C implements I {
+    m1(): void {
+        throw new Error("Method not implemented.");
+    }
+    m2(): void {
+        throw new Error("Method not implemented.");
+    }
+    m3(): void {
+        throw new Error("Method not implemented.");
+    }
+}`,
+});

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleMembers3.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceMultipleMembers3.ts
@@ -1,0 +1,30 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    m1(): void;
+////    m2(): void;
+////    m3(): void;
+////}
+////class C implements I {    }
+
+verify.codeFixAll({
+    fixId: "fixClassIncorrectlyImplementsInterface",
+    fixAllDescription: "Implement all unimplemented interfaces",
+    newFileContent:
+`interface I {
+    m1(): void;
+    m2(): void;
+    m3(): void;
+}
+class C implements I {
+    m1(): void {
+        throw new Error("Method not implemented.");
+    }
+    m2(): void {
+        throw new Error("Method not implemented.");
+    }
+    m3(): void {
+        throw new Error("Method not implemented.");
+    }
+}`,
+});


### PR DESCRIPTION
Fixes #26550

Originally, when there were multiple nodes being added to the start of a class, we weren't adding a newline at the end of the first node when the class brackets were on different lines. Newlines were expected to be added to the ends of each subsequent node and so the first and second node end up without a newline between them.

If we are inserting nodes between curly braces on the same line, then we should have a newline at the beginning of the first node and the end of all the nodes. If the curly braces are on different lines, then we should do the same thing but omit the newline after the last node. To do this, I keep track of the last node and then remove the newline in the suffix when we cleanup in finishClassesWithNodesInsertedAtStart.
