### PR TITLE
disallows exponential operator with BigInt for targets lower than ES2016

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28440,6 +28440,12 @@ namespace ts {
                                 case SyntaxKind.GreaterThanGreaterThanGreaterThanToken:
                                 case SyntaxKind.GreaterThanGreaterThanGreaterThanEqualsToken:
                                     reportOperatorError();
+                                    break;
+                                case SyntaxKind.AsteriskAsteriskToken:
+                                case SyntaxKind.AsteriskAsteriskEqualsToken:
+                                    if (languageVersion < ScriptTarget.ES2016) {
+                                        error(errorNode, Diagnostics.Exponentiation_cannot_be_performed_on_bigint_values_unless_the_target_option_is_set_to_es2016_or_later);
+                                    }
                             }
                             resultType = bigintType;
                         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2967,6 +2967,10 @@
         "category": "Error",
         "code": 2790
     },
+    "Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.": {
+        "category": "Error",
+        "code": 2791
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/bigIntWithTargetES2016.js
+++ b/tests/baselines/reference/bigIntWithTargetES2016.js
@@ -1,0 +1,11 @@
+//// [bigIntWithTargetES2016.ts]
+BigInt(1) ** BigInt(1); // should not error
+
+let num = BigInt(2);
+num **= BigInt(2); // should not error
+
+
+//// [bigIntWithTargetES2016.js]
+BigInt(1) ** BigInt(1); // should not error
+let num = BigInt(2);
+num **= BigInt(2); // should not error

--- a/tests/baselines/reference/bigIntWithTargetES2016.symbols
+++ b/tests/baselines/reference/bigIntWithTargetES2016.symbols
@@ -1,13 +1,13 @@
 === tests/cases/compiler/bigIntWithTargetES2016.ts ===
 BigInt(1) ** BigInt(1); // should not error
->BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
->BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 
 let num = BigInt(2);
 >num : Symbol(num, Decl(bigIntWithTargetES2016.ts, 2, 3))
->BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 
 num **= BigInt(2); // should not error
 >num : Symbol(num, Decl(bigIntWithTargetES2016.ts, 2, 3))
->BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 

--- a/tests/baselines/reference/bigIntWithTargetES2016.symbols
+++ b/tests/baselines/reference/bigIntWithTargetES2016.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/bigIntWithTargetES2016.ts ===
+BigInt(1) ** BigInt(1); // should not error
+>BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+
+let num = BigInt(2);
+>num : Symbol(num, Decl(bigIntWithTargetES2016.ts, 2, 3))
+>BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+
+num **= BigInt(2); // should not error
+>num : Symbol(num, Decl(bigIntWithTargetES2016.ts, 2, 3))
+>BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+

--- a/tests/baselines/reference/bigIntWithTargetES2016.types
+++ b/tests/baselines/reference/bigIntWithTargetES2016.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/bigIntWithTargetES2016.ts ===
+BigInt(1) ** BigInt(1); // should not error
+>BigInt(1) ** BigInt(1) : bigint
+>BigInt(1) : bigint
+>BigInt : BigIntConstructor
+>1 : 1
+>BigInt(1) : bigint
+>BigInt : BigIntConstructor
+>1 : 1
+
+let num = BigInt(2);
+>num : bigint
+>BigInt(2) : bigint
+>BigInt : BigIntConstructor
+>2 : 2
+
+num **= BigInt(2); // should not error
+>num **= BigInt(2) : bigint
+>num : bigint
+>BigInt(2) : bigint
+>BigInt : BigIntConstructor
+>2 : 2
+

--- a/tests/baselines/reference/bigIntWithTargetLessThanES2016.errors.txt
+++ b/tests/baselines/reference/bigIntWithTargetLessThanES2016.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/bigIntWithTargetLessThanES2016.ts(1,1): error TS2782: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
+tests/cases/compiler/bigIntWithTargetLessThanES2016.ts(4,1): error TS2782: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
+
+
+==== tests/cases/compiler/bigIntWithTargetLessThanES2016.ts (2 errors) ====
+    BigInt(1) ** BigInt(1); // should error
+    ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2782: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
+    
+    let foo = BigInt(2);
+    foo **= BigInt(2); // should error
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2782: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
+    

--- a/tests/baselines/reference/bigIntWithTargetLessThanES2016.errors.txt
+++ b/tests/baselines/reference/bigIntWithTargetLessThanES2016.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/compiler/bigIntWithTargetLessThanES2016.ts(1,1): error TS2782: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
-tests/cases/compiler/bigIntWithTargetLessThanES2016.ts(4,1): error TS2782: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
+tests/cases/compiler/bigIntWithTargetLessThanES2016.ts(1,1): error TS2791: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
+tests/cases/compiler/bigIntWithTargetLessThanES2016.ts(4,1): error TS2791: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
 
 
 ==== tests/cases/compiler/bigIntWithTargetLessThanES2016.ts (2 errors) ====
     BigInt(1) ** BigInt(1); // should error
     ~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2782: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
+!!! error TS2791: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
     
     let foo = BigInt(2);
     foo **= BigInt(2); // should error
     ~~~~~~~~~~~~~~~~~
-!!! error TS2782: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
+!!! error TS2791: Exponentiation cannot be performed on 'bigint' values unless the 'target' option is set to 'es2016' or later.
     

--- a/tests/baselines/reference/bigIntWithTargetLessThanES2016.js
+++ b/tests/baselines/reference/bigIntWithTargetLessThanES2016.js
@@ -1,0 +1,11 @@
+//// [bigIntWithTargetLessThanES2016.ts]
+BigInt(1) ** BigInt(1); // should error
+
+let foo = BigInt(2);
+foo **= BigInt(2); // should error
+
+
+//// [bigIntWithTargetLessThanES2016.js]
+Math.pow(BigInt(1), BigInt(1)); // should error
+let foo = BigInt(2);
+foo = Math.pow(foo, BigInt(2)); // should error

--- a/tests/baselines/reference/bigIntWithTargetLessThanES2016.symbols
+++ b/tests/baselines/reference/bigIntWithTargetLessThanES2016.symbols
@@ -1,13 +1,13 @@
 === tests/cases/compiler/bigIntWithTargetLessThanES2016.ts ===
 BigInt(1) ** BigInt(1); // should error
->BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
->BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 
 let foo = BigInt(2);
 >foo : Symbol(foo, Decl(bigIntWithTargetLessThanES2016.ts, 2, 3))
->BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 
 foo **= BigInt(2); // should error
 >foo : Symbol(foo, Decl(bigIntWithTargetLessThanES2016.ts, 2, 3))
->BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.es2020.bigint.d.ts, --, --), Decl(lib.es2020.bigint.d.ts, --, --))
 

--- a/tests/baselines/reference/bigIntWithTargetLessThanES2016.symbols
+++ b/tests/baselines/reference/bigIntWithTargetLessThanES2016.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/bigIntWithTargetLessThanES2016.ts ===
+BigInt(1) ** BigInt(1); // should error
+>BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+>BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+
+let foo = BigInt(2);
+>foo : Symbol(foo, Decl(bigIntWithTargetLessThanES2016.ts, 2, 3))
+>BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+
+foo **= BigInt(2); // should error
+>foo : Symbol(foo, Decl(bigIntWithTargetLessThanES2016.ts, 2, 3))
+>BigInt : Symbol(BigInt, Decl(lib.esnext.bigint.d.ts, --, --), Decl(lib.esnext.bigint.d.ts, --, --))
+

--- a/tests/baselines/reference/bigIntWithTargetLessThanES2016.types
+++ b/tests/baselines/reference/bigIntWithTargetLessThanES2016.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/bigIntWithTargetLessThanES2016.ts ===
+BigInt(1) ** BigInt(1); // should error
+>BigInt(1) ** BigInt(1) : bigint
+>BigInt(1) : bigint
+>BigInt : BigIntConstructor
+>1 : 1
+>BigInt(1) : bigint
+>BigInt : BigIntConstructor
+>1 : 1
+
+let foo = BigInt(2);
+>foo : bigint
+>BigInt(2) : bigint
+>BigInt : BigIntConstructor
+>2 : 2
+
+foo **= BigInt(2); // should error
+>foo **= BigInt(2) : bigint
+>foo : bigint
+>BigInt(2) : bigint
+>BigInt : BigIntConstructor
+>2 : 2
+

--- a/tests/cases/compiler/bigIntWithTargetES2016.ts
+++ b/tests/cases/compiler/bigIntWithTargetES2016.ts
@@ -1,0 +1,7 @@
+// @target: es2016
+// @lib: esnext
+
+BigInt(1) ** BigInt(1); // should not error
+
+let num = BigInt(2);
+num **= BigInt(2); // should not error

--- a/tests/cases/compiler/bigIntWithTargetLessThanES2016.ts
+++ b/tests/cases/compiler/bigIntWithTargetLessThanES2016.ts
@@ -1,0 +1,7 @@
+// @target: es2015
+// @lib: esnext
+
+BigInt(1) ** BigInt(1); // should error
+
+let foo = BigInt(2);
+foo **= BigInt(2); // should error


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #30398
