### PR TITLE
Fix crash with Object.defineProperty for imported alias (--allowJs)

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2752,7 +2752,7 @@ namespace ts {
 
         function bindObjectDefinePrototypeProperty(node: BindableObjectDefinePropertyCall) {
             const namespaceSymbol = lookupSymbolForPropertyAccess((node.arguments[0] as PropertyAccessExpression).expression as EntityNameExpression);
-            if (namespaceSymbol) {
+            if (namespaceSymbol && namespaceSymbol.valueDeclaration) {
                 // Ensure the namespace symbol becomes class-like
                 addDeclarationToSymbol(namespaceSymbol, namespaceSymbol.valueDeclaration, SymbolFlags.Class);
             }

--- a/tests/baselines/reference/importAliasModuleExports.errors.txt
+++ b/tests/baselines/reference/importAliasModuleExports.errors.txt
@@ -1,8 +1,9 @@
 tests/cases/conformance/salsa/main.js(2,13): error TS2339: Property 'foo' does not exist on type 'Alias'.
 tests/cases/conformance/salsa/main.js(3,13): error TS2339: Property 'func' does not exist on type 'Alias'.
 tests/cases/conformance/salsa/main.js(3,38): error TS2339: Property '_func' does not exist on type 'Alias'.
-tests/cases/conformance/salsa/main.js(5,9): error TS2339: Property 'foo' does not exist on type 'Alias'.
-tests/cases/conformance/salsa/main.js(6,9): error TS2339: Property 'func' does not exist on type 'Alias'.
+tests/cases/conformance/salsa/main.js(6,9): error TS2339: Property 'foo' does not exist on type 'Alias'.
+tests/cases/conformance/salsa/main.js(7,9): error TS2339: Property 'func' does not exist on type 'Alias'.
+tests/cases/conformance/salsa/main.js(8,9): error TS2339: Property 'def' does not exist on type 'Alias'.
 
 
 ==== tests/cases/conformance/salsa/mod1.js (0 errors) ====
@@ -11,7 +12,7 @@ tests/cases/conformance/salsa/main.js(6,9): error TS2339: Property 'func' does n
     }
     module.exports = Alias;
     
-==== tests/cases/conformance/salsa/main.js (5 errors) ====
+==== tests/cases/conformance/salsa/main.js (6 errors) ====
     import A from './mod1'
     A.prototype.foo = 0
                 ~~~
@@ -21,6 +22,7 @@ tests/cases/conformance/salsa/main.js(6,9): error TS2339: Property 'func' does n
 !!! error TS2339: Property 'func' does not exist on type 'Alias'.
                                          ~~~~~
 !!! error TS2339: Property '_func' does not exist on type 'Alias'.
+    Object.defineProperty(A.prototype, "def", { value: 0 });
     new A().bar
     new A().foo
             ~~~
@@ -28,4 +30,7 @@ tests/cases/conformance/salsa/main.js(6,9): error TS2339: Property 'func' does n
     new A().func()
             ~~~~
 !!! error TS2339: Property 'func' does not exist on type 'Alias'.
+    new A().def
+            ~~~
+!!! error TS2339: Property 'def' does not exist on type 'Alias'.
     

--- a/tests/baselines/reference/importAliasModuleExports.symbols
+++ b/tests/baselines/reference/importAliasModuleExports.symbols
@@ -26,6 +26,15 @@ A.prototype.func = function() { this._func = 0; }
 >prototype : Symbol(A.prototype)
 >this : Symbol(A, Decl(mod1.js, 0, 0))
 
+Object.defineProperty(A.prototype, "def", { value: 0 });
+>Object.defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>defineProperty : Symbol(ObjectConstructor.defineProperty, Decl(lib.es5.d.ts, --, --))
+>A.prototype : Symbol(A.prototype)
+>A : Symbol(A, Decl(main.js, 0, 6))
+>prototype : Symbol(A.prototype)
+>value : Symbol(value, Decl(main.js, 3, 43))
+
 new A().bar
 >new A().bar : Symbol(A.bar, Decl(mod1.js, 0, 13))
 >A : Symbol(A, Decl(main.js, 0, 6))
@@ -35,5 +44,8 @@ new A().foo
 >A : Symbol(A, Decl(main.js, 0, 6))
 
 new A().func()
+>A : Symbol(A, Decl(main.js, 0, 6))
+
+new A().def
 >A : Symbol(A, Decl(main.js, 0, 6))
 

--- a/tests/baselines/reference/importAliasModuleExports.types
+++ b/tests/baselines/reference/importAliasModuleExports.types
@@ -40,6 +40,19 @@ A.prototype.func = function() { this._func = 0; }
 >_func : any
 >0 : 0
 
+Object.defineProperty(A.prototype, "def", { value: 0 });
+>Object.defineProperty(A.prototype, "def", { value: 0 }) : any
+>Object.defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
+>Object : ObjectConstructor
+>defineProperty : (o: any, p: string | number | symbol, attributes: PropertyDescriptor & ThisType<any>) => any
+>A.prototype : A
+>A : typeof A
+>prototype : A
+>"def" : "def"
+>{ value: 0 } : { value: number; }
+>value : number
+>0 : 0
+
 new A().bar
 >new A().bar : () => number
 >new A() : A
@@ -58,4 +71,10 @@ new A().func()
 >new A() : A
 >A : typeof A
 >func : any
+
+new A().def
+>new A().def : any
+>new A() : A
+>A : typeof A
+>def : any
 

--- a/tests/cases/conformance/salsa/importAliasModuleExports.ts
+++ b/tests/cases/conformance/salsa/importAliasModuleExports.ts
@@ -12,6 +12,8 @@ module.exports = Alias;
 import A from './mod1'
 A.prototype.foo = 0
 A.prototype.func = function() { this._func = 0; }
+Object.defineProperty(A.prototype, "def", { value: 0 });
 new A().bar
 new A().foo
 new A().func()
+new A().def


### PR DESCRIPTION
Fixes #35196

Follows the same approach as https://github.com/microsoft/TypeScript/pull/34650 and https://github.com/microsoft/TypeScript/pull/34566

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

