### PR TITLE
Native support for PnP

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -110,6 +110,10 @@ import {
     versionMajorMinor,
     VersionRange,
 } from "./_namespaces/ts";
+import {
+    getPnpApi,
+    getPnpTypeRoots,
+} from "./pnp";
 
 /** @internal */
 export function trace(host: ModuleResolutionHost, message: DiagnosticMessage, ...args: any[]): void {
@@ -471,7 +475,7 @@ export function getEffectiveTypeRoots(options: CompilerOptions, host: GetEffecti
  * Returns the path to every node_modules/@types directory from some ancestor directory.
  * Returns undefined if there are none.
  */
-function getDefaultTypeRoots(currentDirectory: string): string[] | undefined {
+function getNodeModulesTypeRoots(currentDirectory: string) {
     let typeRoots: string[] | undefined;
     forEachAncestorDirectory(normalizePath(currentDirectory), directory => {
         const atTypes = combinePaths(directory, nodeModulesAtTypes);
@@ -484,6 +488,18 @@ const nodeModulesAtTypes = combinePaths("node_modules", "@types");
 function arePathsEqual(path1: string, path2: string, host: ModuleResolutionHost): boolean {
     const useCaseSensitiveFileNames = typeof host.useCaseSensitiveFileNames === "function" ? host.useCaseSensitiveFileNames() : host.useCaseSensitiveFileNames;
     return comparePaths(path1, path2, !useCaseSensitiveFileNames) === Comparison.EqualTo;
+}
+
+function getDefaultTypeRoots(currentDirectory: string): string[] | undefined {
+    const nmTypes = getNodeModulesTypeRoots(currentDirectory);
+    const pnpTypes = getPnpTypeRoots(currentDirectory);
+
+    if (nmTypes?.length) {
+        return [...nmTypes, ...pnpTypes];
+    }
+    else if (pnpTypes.length) {
+        return pnpTypes;
+    }
 }
 
 function getOriginalAndResolvedFileName(fileName: string, host: ModuleResolutionHost, traceEnabled: boolean) {
@@ -769,6 +785,18 @@ export function resolvePackageNameToPackageJson(
     cache: ModuleResolutionCache | undefined,
 ): PackageJsonInfo | undefined {
     const moduleResolutionState = getTemporaryModuleResolutionState(cache?.getPackageJsonInfoCache(), host, options);
+
+    const pnpapi = getPnpApi(containingDirectory);
+    if (pnpapi) {
+        try {
+            const resolution = pnpapi.resolveToUnqualified(packageName, `${containingDirectory}/`, { considerBuiltins: false });
+            const candidate = normalizeSlashes(resolution).replace(/\/$/, "");
+            return getPackageJsonInfo(candidate, /*onlyRecordFailures*/ false, moduleResolutionState);
+        }
+        catch {
+            return;
+        }
+    }
 
     return forEachAncestorDirectory(containingDirectory, ancestorDirectory => {
         if (getBaseFileName(ancestorDirectory) !== "node_modules") {
@@ -2938,7 +2966,16 @@ function loadModuleFromNearestNodeModulesDirectoryWorker(extensions: Extensions,
     }
 
     function lookup(extensions: Extensions) {
-        return forEachAncestorDirectory(normalizeSlashes(directory), ancestorDirectory => {
+        const issuer = normalizeSlashes(directory);
+        if (getPnpApi(issuer)) {
+            const resolutionFromCache = tryFindNonRelativeModuleNameInCache(cache, moduleName, mode, issuer, redirectedReference, state);
+            if (resolutionFromCache) {
+                return resolutionFromCache;
+            }
+            return toSearchResult(loadModuleFromImmediateNodeModulesDirectoryPnP(extensions, moduleName, issuer, state, typesScopeOnly, cache, redirectedReference));
+        }
+
+        return forEachAncestorDirectory(issuer, ancestorDirectory => {
             if (getBaseFileName(ancestorDirectory) !== "node_modules") {
                 const resolutionFromCache = tryFindNonRelativeModuleNameInCache(cache, moduleName, mode, ancestorDirectory, redirectedReference, state);
                 if (resolutionFromCache) {
@@ -2977,11 +3014,34 @@ function loadModuleFromImmediateNodeModulesDirectory(extensions: Extensions, mod
     }
 }
 
+function loadModuleFromImmediateNodeModulesDirectoryPnP(extensions: Extensions, moduleName: string, directory: string, state: ModuleResolutionState, typesScopeOnly: boolean, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined): Resolved | undefined {
+    const issuer = normalizeSlashes(directory);
+
+    if (!typesScopeOnly) {
+        const packageResult = tryLoadModuleUsingPnpResolution(extensions, moduleName, issuer, state, cache, redirectedReference);
+        if (packageResult) {
+            return packageResult;
+        }
+    }
+
+    if (extensions & Extensions.Declaration) {
+        return tryLoadModuleUsingPnpResolution(Extensions.Declaration, `@types/${mangleScopedPackageNameWithTrace(moduleName, state)}`, issuer, state, cache, redirectedReference);
+    }
+}
+
 function loadModuleFromSpecificNodeModulesDirectory(extensions: Extensions, moduleName: string, nodeModulesDirectory: string, nodeModulesDirectoryExists: boolean, state: ModuleResolutionState, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined): Resolved | undefined {
     const candidate = normalizePath(combinePaths(nodeModulesDirectory, moduleName));
     const { packageName, rest } = parsePackageName(moduleName);
     const packageDirectory = combinePaths(nodeModulesDirectory, packageName);
+    return loadModuleFromSpecificNodeModulesDirectoryImpl(extensions, nodeModulesDirectoryExists, state, cache, redirectedReference, candidate, rest, packageDirectory);
+}
 
+function loadModuleFromPnpResolution(extensions: Extensions, packageDirectory: string, rest: string, state: ModuleResolutionState, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined): Resolved | undefined {
+    const candidate = normalizePath(combinePaths(packageDirectory, rest));
+    return loadModuleFromSpecificNodeModulesDirectoryImpl(extensions, /*nodeModulesDirectoryExists*/ true, state, cache, redirectedReference, candidate, rest, packageDirectory);
+}
+
+function loadModuleFromSpecificNodeModulesDirectoryImpl(extensions: Extensions, nodeModulesDirectoryExists: boolean, state: ModuleResolutionState, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined, candidate: string, rest: string, packageDirectory: string): Resolved | undefined {
     let rootPackageInfo: PackageJsonInfo | undefined;
     // First look for a nested package.json, as in `node_modules/foo/bar/package.json`.
     let packageInfo = getPackageJsonInfo(candidate, !nodeModulesDirectoryExists, state);
@@ -3305,4 +3365,23 @@ function useCaseSensitiveFileNames(state: ModuleResolutionState) {
     return !state.host.useCaseSensitiveFileNames ? true :
         typeof state.host.useCaseSensitiveFileNames === "boolean" ? state.host.useCaseSensitiveFileNames :
         state.host.useCaseSensitiveFileNames();
+}
+
+function loadPnpPackageResolution(packageName: string, containingDirectory: string) {
+    try {
+        const resolution = getPnpApi(containingDirectory).resolveToUnqualified(packageName, `${containingDirectory}/`, { considerBuiltins: false });
+        return normalizeSlashes(resolution).replace(/\/$/, "");
+    }
+    catch {
+        // Nothing to do
+    }
+}
+
+function tryLoadModuleUsingPnpResolution(extensions: Extensions, moduleName: string, containingDirectory: string, state: ModuleResolutionState, cache: ModuleResolutionCache | undefined, redirectedReference: ResolvedProjectReference | undefined) {
+    const { packageName, rest } = parsePackageName(moduleName);
+
+    const packageResolution = loadPnpPackageResolution(packageName, containingDirectory);
+    return packageResolution
+        ? loadModuleFromPnpResolution(extensions, packageResolution, rest, state, cache, redirectedReference)
+        : undefined;
 }

--- a/src/compiler/pnp.ts
+++ b/src/compiler/pnp.ts
@@ -1,0 +1,80 @@
+import {
+    getDirectoryPath,
+    resolvePath,
+} from "./path";
+
+export function getPnpApi(path: string) {
+    if (typeof process.versions.pnp === "undefined") {
+        return;
+    }
+
+    const { findPnpApi } = require("module");
+    if (findPnpApi) {
+        return findPnpApi(`${path}/`);
+    }
+}
+
+export function getPnpApiPath(path: string): string | undefined {
+    // eslint-disable-next-line no-null/no-null
+    return getPnpApi(path)?.resolveRequest("pnpapi", /*issuer*/ null);
+}
+
+export function getPnpTypeRoots(currentDirectory: string) {
+    const pnpApi = getPnpApi(currentDirectory);
+    if (!pnpApi) {
+        return [];
+    }
+
+    // Some TS consumers pass relative paths that aren't normalized
+    currentDirectory = resolvePath(currentDirectory);
+
+    const currentPackage = pnpApi.findPackageLocator(`${currentDirectory}/`);
+    if (!currentPackage) {
+        return [];
+    }
+
+    const { packageDependencies } = pnpApi.getPackageInformation(currentPackage);
+
+    const typeRoots: string[] = [];
+    for (const [name, referencish] of Array.from<any>(packageDependencies.entries())) {
+        // eslint-disable-next-line no-null/no-null
+        if (name.startsWith(`@types/`) && referencish !== null) {
+            const dependencyLocator = pnpApi.getLocator(name, referencish);
+            const { packageLocation } = pnpApi.getPackageInformation(dependencyLocator);
+
+            typeRoots.push(getDirectoryPath(packageLocation));
+        }
+    }
+
+    return typeRoots;
+}
+
+export function isImportablePathPnp(fromPath: string, toPath: string): boolean {
+    const pnpApi = getPnpApi(fromPath);
+
+    const fromLocator = pnpApi.findPackageLocator(fromPath);
+    const toLocator = pnpApi.findPackageLocator(toPath);
+
+    // eslint-disable-next-line no-null/no-null
+    if (toLocator === null) {
+        return false;
+    }
+
+    const fromInfo = pnpApi.getPackageInformation(fromLocator);
+    const toReference = fromInfo.packageDependencies.get(toLocator.name);
+
+    if (toReference) {
+        return toReference === toLocator.reference;
+    }
+
+    // Aliased dependencies
+    for (const reference of fromInfo.packageDependencies.values()) {
+        if (Array.isArray(reference)) {
+            if (reference[0] === toLocator.name && reference[1] === toLocator.reference) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1728,6 +1728,10 @@ export let sys: System = (() => {
         }
 
         function isFileSystemCaseSensitive(): boolean {
+            // The PnP runtime is always case-sensitive
+            if (typeof process.versions.pnp !== `undefined`) {
+                return true;
+            }
             // win32\win64 are case insensitive platforms
             if (platform === "win32" || platform === "win64") {
                 return false;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -10230,6 +10230,15 @@ export interface NodeModulePathParts {
     readonly packageRootIndex: number;
     readonly fileNameIndex: number;
 }
+
+/** @internal */
+export interface PackagePathParts {
+    readonly topLevelNodeModulesIndex: undefined;
+    readonly topLevelPackageNameIndex: undefined;
+    readonly packageRootIndex: number;
+    readonly fileNameIndex: number;
+}
+
 /** @internal */
 export function getNodeModulePathParts(fullPath: string): NodeModulePathParts | undefined {
     // If fullPath can't be valid module file within node_modules, returns undefined.

--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -95,6 +95,9 @@ import {
     WatchTypeRegistry,
     WildcardDirectoryWatcher,
 } from "./_namespaces/ts";
+import {
+    getPnpApiPath,
+} from "./pnp";
 
 export interface ReadBuildProgramHost {
     useCaseSensitiveFileNames(): boolean;
@@ -484,6 +487,12 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
         configFileWatcher = watchFile(configFileName, scheduleProgramReload, PollingInterval.High, watchOptions, WatchType.ConfigFile);
     }
 
+    let pnpFileWatcher: FileWatcher | undefined;
+    const pnpApiPath = getPnpApiPath(__filename);
+    if (pnpApiPath) {
+        pnpFileWatcher = watchFile(pnpApiPath, scheduleResolutionReload, PollingInterval.High, watchOptions, WatchType.ConfigFile);
+    }
+
     const compilerHost = createCompilerHostFromProgramHost(host, () => compilerOptions!, directoryStructureHost) as CompilerHost & ResolutionCacheHost;
     setGetSourceFileAsHashVersioned(compilerHost);
     // Members for CompilerHost
@@ -571,6 +580,10 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
             configFileWatcher.close();
             configFileWatcher = undefined;
         }
+        if (pnpFileWatcher) {
+            pnpFileWatcher.close();
+            pnpFileWatcher = undefined;
+        }
         extendedConfigCache?.clear();
         extendedConfigCache = undefined;
         if (sharedExtendedConfigFileWatchers) {
@@ -608,7 +621,7 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
         return builderProgram && builderProgram.getProgramOrUndefined();
     }
 
-    function synchronizeProgram() {
+    function synchronizeProgram(forceAllFilesAsInvalidated = false) {
         writeLog(`Synchronizing program`);
 
         Debug.assert(compilerOptions);
@@ -624,7 +637,7 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
             }
         }
 
-        const { hasInvalidatedResolutions, hasInvalidatedLibResolutions } = resolutionCache.createHasInvalidatedResolutions(customHasInvalidatedResolutions, customHasInvalidLibResolutions);
+        const { hasInvalidatedResolutions, hasInvalidatedLibResolutions } = resolutionCache.createHasInvalidatedResolutions(forceAllFilesAsInvalidated ? returnTrue : customHasInvalidatedResolutions, customHasInvalidLibResolutions);
         const {
             originalReadFile,
             originalFileExists,
@@ -876,6 +889,13 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
         scheduleProgramUpdate();
     }
 
+    function scheduleResolutionReload() {
+        writeLog("Clearing resolutions");
+        resolutionCache.clear();
+        reloadLevel = ConfigFileProgramReloadLevel.Resolutions;
+        scheduleProgramUpdate();
+    }
+
     function updateProgramWithWatchStatus() {
         timerToUpdateProgram = undefined;
         reportFileChangeDetectedOnCreateProgram = true;
@@ -891,6 +911,10 @@ export function createWatchProgram<T extends BuilderProgram>(host: WatchCompiler
             case ConfigFileProgramReloadLevel.Full:
                 perfLogger?.logStartUpdateProgram("FullConfigReload");
                 reloadConfigFile();
+                break;
+            case ConfigFileProgramReloadLevel.Resolutions:
+                perfLogger?.logStartUpdateProgram("SynchronizeProgramWithResolutions");
+                synchronizeProgram(/*forceAllFilesAsInvalidated*/ true);
                 break;
             default:
                 perfLogger?.logStartUpdateProgram("SynchronizeProgram");

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -372,6 +372,8 @@ export enum ConfigFileProgramReloadLevel {
     Partial,
     /** Reload completely by re-reading contents of config file from disk and updating program */
     Full,
+    /** Reload the resolutions */
+    Resolutions,
 }
 
 /** @internal */

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1,4 +1,7 @@
 import {
+    getPnpApiPath,
+} from "../compiler/pnp";
+import {
     addToSeen,
     arrayFrom,
     arrayToMap,
@@ -1123,6 +1126,8 @@ export class ProjectService {
     readonly session: Session<unknown> | undefined;
 
     private performanceEventHandler?: PerformanceEventHandler;
+    /** @internal */
+    private pnpWatcher?: FileWatcher;
 
     private pendingPluginEnablements?: Map<Project, Promise<BeginEnablePluginResult>[]>;
     private currentPluginEnablementPromise?: Promise<void>;
@@ -1200,6 +1205,8 @@ export class ProjectService {
                 log,
                 getDetailWatchInfo,
             );
+
+        this.pnpWatcher = this.watchPnpFile();
         opts.incrementalVerifier?.(this);
     }
 
@@ -3420,6 +3427,9 @@ export class ProjectService {
             if (args.watchOptions) {
                 this.hostConfiguration.watchOptions = convertWatchOptions(args.watchOptions)?.watchOptions;
                 this.logger.info(`Host watch options changed to ${JSON.stringify(this.hostConfiguration.watchOptions)}, it will be take effect for next watches.`);
+
+                this.pnpWatcher?.close();
+                this.watchPnpFile();
             }
         }
     }
@@ -4641,6 +4651,31 @@ export class ProjectService {
                         : undefined;
             }
         });
+    }
+
+    /** @internal */
+    private watchPnpFile() {
+        const pnpApiPath = getPnpApiPath(__filename);
+        if (!pnpApiPath) {
+            return;
+        }
+
+        return this.watchFactory.watchFile(
+            pnpApiPath,
+            () => {
+                this.forEachProject(project => {
+                    for (const info of project.getScriptInfos()) {
+                        project.resolutionCache.invalidateResolutionOfFile(info.path);
+                    }
+                    project.markAsDirty();
+                    updateProjectIfDirty(project);
+                });
+                this.delayEnsureProjectForOpenFiles();
+            },
+            PollingInterval.Low,
+            this.hostConfiguration.watchOptions,
+            WatchType.ConfigFile,
+        );
     }
 
     /** @internal */

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1,3 +1,6 @@
+import {
+    getPnpApi,
+} from "../compiler/pnp";
 import * as ts from "./_namespaces/ts";
 import {
     addRange,
@@ -62,6 +65,7 @@ import {
     getNormalizedAbsolutePath,
     getOrUpdate,
     GetPackageJsonEntrypointsHost,
+    getRelativePathFromDirectory,
     getStringComparer,
     HasInvalidatedLibResolutions,
     HasInvalidatedResolutions,
@@ -2813,6 +2817,45 @@ export class ConfiguredProject extends Project {
     }
 
     updateReferences(refs: readonly ProjectReference[] | undefined) {
+        if (typeof process.versions.pnp !== `undefined`) {
+            // With Plug'n'Play, dependencies that list peer dependencies
+            // are "virtualized": they are resolved to a unique (virtual)
+            // path that the underlying filesystem layer then resolve back
+            // to the original location.
+            //
+            // When a workspace depends on another workspace with peer
+            // dependencies, this other workspace will thus be resolved to
+            // a unique path that won't match what the initial project has
+            // listed in its `references` field, and TS thus won't leverage
+            // the reference at all.
+            //
+            // To avoid that, we compute here the virtualized paths for the
+            // user-provided references in our references by directly querying
+            // the PnP API. This way users don't have to know the virtual paths,
+            // but we still support them just fine even through references.
+
+            const basePath = this.getCurrentDirectory();
+
+            const getPnpPath = (path: string) => {
+                try {
+                    const pnpApi = getPnpApi(`${path}/`);
+                    if (!pnpApi) {
+                        return path;
+                    }
+                    const targetLocator = pnpApi.findPackageLocator(`${path}/`);
+                    const { packageLocation } = pnpApi.getPackageInformation(targetLocator);
+                    const request = combinePaths(targetLocator.name, getRelativePathFromDirectory(packageLocation, path, /*ignoreCase*/ false));
+                    return pnpApi.resolveToUnqualified(request, `${basePath}/`);
+                }
+                catch {
+                    // something went wrong with the resolution, try not to fail
+                    return path;
+                }
+            };
+
+            refs = refs?.map(r => ({ ...r, path: getPnpPath(r.path) }));
+        }
+
         this.projectReferences = refs;
         this.potentialProjectReferences = undefined;
     }

--- a/src/services/exportInfoMap.ts
+++ b/src/services/exportInfoMap.ts
@@ -1,4 +1,8 @@
 import {
+    getPnpApi,
+    isImportablePathPnp,
+} from "../compiler/pnp";
+import {
     __String,
     addToSeen,
     arrayIsEqualTo,
@@ -403,6 +407,10 @@ export function isImportableFile(
  * A relative import to node_modules is usually a bad idea.
  */
 function isImportablePath(fromPath: string, toPath: string, getCanonicalFileName: GetCanonicalFileName, globalCachePath?: string): boolean {
+    if (getPnpApi(fromPath)) {
+        return isImportablePathPnp(fromPath, toPath);
+    }
+
     // If it's in a `node_modules` but is not reachable from here via a global import, don't bother.
     const toNodeModules = forEachAncestorDirectory(toPath, ancestor => getBaseFileName(ancestor) === "node_modules" ? ancestor : undefined);
     const toNodeModulesParent = toNodeModules && getDirectoryPath(getCanonicalFileName(toNodeModules));

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1,4 +1,7 @@
 import {
+    getPnpApi,
+} from "../compiler/pnp";
+import {
     __String,
     addEmitFlags,
     addSyntheticLeadingComment,
@@ -3854,9 +3857,18 @@ export function createPackageJsonImportFilter(fromFile: SourceFile, preferences:
     }
 
     function getNodeModulesPackageNameFromFileName(importedFileName: string, moduleSpecifierResolutionHost: ModuleSpecifierResolutionHost): string | undefined {
-        if (!importedFileName.includes("node_modules")) {
+        const pnpapi = getPnpApi(importedFileName);
+        if (pnpapi) {
+            const fromLocator = pnpapi.findPackageLocator(fromFile.fileName);
+            const toLocator = pnpapi.findPackageLocator(importedFileName);
+            if (!(fromLocator && toLocator)) {
+                return undefined;
+            }
+        }
+        else if (!importedFileName.includes("node_modules")) {
             return undefined;
         }
+
         const specifier = moduleSpecifiers.getNodeModulesPackageName(
             host.getCompilationSettings(),
             fromFile,

--- a/src/tsserver/nodeServer.ts
+++ b/src/tsserver/nodeServer.ts
@@ -1,3 +1,6 @@
+import {
+    getPnpApiPath,
+} from "../compiler/pnp";
 import * as protocol from "../server/protocol";
 import * as ts from "./_namespaces/ts";
 import {
@@ -332,6 +335,10 @@ export function initializeNodeSystem(): StartInput {
                 }
                 try {
                     const args = [combinePaths(libDirectory, "watchGuard.js"), path];
+                    const pnpApiPath = getPnpApiPath(__filename);
+                    if (pnpApiPath) {
+                        args.unshift("-r", pnpApiPath);
+                    }
                     if (logger.hasLevel(LogLevel.verbose)) {
                         logger.info(`Starting ${process.execPath} with args:${stringifyIndented(args)}`);
                     }
@@ -619,6 +626,11 @@ function startNodeSession(options: StartSessionOptions, logger: Logger, cancella
                     execArgv.push(`--${match[1]}=${currentPort + 1}`);
                     break;
                 }
+            }
+
+            const pnpApiPath = getPnpApiPath(__filename);
+            if (pnpApiPath) {
+                execArgv.unshift("-r", pnpApiPath);
             }
 
             const typingsInstaller = combinePaths(getDirectoryPath(sys.getExecutingFilePath()), "typingsInstaller.js");


### PR DESCRIPTION
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There is an associated issue in the `Backlog` milestone (**required**):
  Although not in the Backlog milestone, this PR is in reference to #28289
* [ ] There are new or updated unit tests validating the change:
  Not yet because it's just a PoC for now and I wanted to hear the opinion of the TS team first

**What is PnP?** (you can skip if you already know)

It's an alternate install strategy where instead of installing the files within the node_modules, we instead tell Node to directly reference them from a flat location on the disk. The resulting installs are more space-efficient and faster, but aren't compatible with programs that reimplement the node_modules traversal algorithm.

Because it involves a different resolution algorithm than the default Node one it can be seen as a relatively high-risk endeavour. Conscious of that, we've made significant progress during this past year to remove obstacles one by one. We welcomed new community members, helped many project to fix their package definitions, improved our implementation to provide more detailed errors, and thanks to everyone's collaboration the remaining blockers are only a handful. My point here is: PnP isn't just a phase - just like Yarn itself didn't end up just a phase.

**PnP and TypeScript**

We've discussed a bit with TS not so long ago, and from my understanding some tools might appear in the future to make it easier to implement this kind of logic outside of the core. Given that Yarn will likely be the prime consumer, I figured it could be interesting to try and see how PnP support could be implemented natively - to get a better idea of the tradeoffs involved, etc. A basic analysis yielded https://github.com/yarnpkg/berry/issues/589, and I decided to spent a couple of hours trying to actually make it work.

This diff makes TS able to query the PnP runtime to obtain the location of the file dependencies. Because it doesn't require files that haven't been executed already (cf `isPnpAvailable`) I believe it should also address the security concerns initially raised by the TS team. I tested it with the Berry repository itself and it typechecked everything correctly:

```
git clone git@github.com:yarnpkg/berry berry
git clone git@github.com:arcanis/typescript arca-ts
(cd arca-ts && git checkout mael/pnp && yarn && yarn gulp)
(cd berry && yarn node ../arca-ts/built/local/tsc.js --noEmit -p .)
```

The one missing part is watch support; adding or removing packages requires restarting the server. This part seemed fairly different from the module resolution, so I thought I should first get your opinion on this PR as it is before going any further 😊