### PR TITLE
Make EventListener covariant

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -1863,8 +1863,8 @@ interface txAuthGenericArg {
     contentType: string;
 }
 
-interface EventListener {
-    (evt: Event): void;
+interface EventListener<T extends Event> {
+    (evt: T): void;
 }
 
 type XPathNSResolver = ((prefix: string | null) => string | null) | { lookupNamespaceURI(prefix: string | null): string | null; };
@@ -5457,8 +5457,8 @@ declare var Event: {
     readonly NONE: number;
 };
 
-interface EventListenerObject {
-    handleEvent(evt: Event): void;
+interface EventListenerObject<T extends Event> {
+    handleEvent(evt: T): void;
 }
 
 interface EventSourceEventMap {
@@ -5491,9 +5491,9 @@ interface EventSource extends EventTarget {
     readonly CONNECTING: number;
     readonly OPEN: number;
     addEventListener<K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
-    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject<MessageEvent>, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof EventSourceEventMap>(type: K, listener: (this: EventSource, ev: EventSourceEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
-    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject<MessageEvent>, options?: boolean | EventListenerOptions): void;
 }
 
 declare var EventSource: {
@@ -19076,7 +19076,7 @@ declare var webkitRTCPeerConnection: {
     new(configuration: RTCConfiguration): webkitRTCPeerConnection;
 };
 
-declare type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+declare type EventListenerOrEventListenerObject<T extends Event> = EventListener<T> | EventListenerObject<T>;
 
 declare namespace WebAssembly {
     interface CompileError {


### PR DESCRIPTION
Fixes #28357

Currently, the `EventListener` interface is invariant. As a result, functions that pass a subtype of `Event` fail to compile (e.g. see the `CustomEvent` and `MessageEvent` examples below).

#### CustomEvent handler

```typescript
obj.addEventListener("customEvt", (e: CustomEvent) => {});
```

```
Type '(e: CustomEvent<any>) => void' is not assignable to type 'EventListener'.
    Types of parameters 'e' and 'evt' are incompatible.
        Type 'Event' is missing the following properties from type 'CustomEvent<any>': detail, initCustomEvent  TS2345
```

#### MessageEvent handler

```typescript
eventSource.addEventListener("messageEvt", (e: MessageEvent) => {});
```

```
Type '(e: MessageEvent) => void' is not assignable to type 'EventListener'.
    Types of parameters 'e' and 'evt' are incompatible.
        Type 'Event' is missing the following properties from type 'MessageEvent': data, lastEventId, origin, ports, source  TS2345
```

As a result, it seems like [a lot of people](https://github.com/microsoft/TypeScript/issues/28357#issuecomment-436484705) resort to using the `as EventListener` type assertion.

```typescript
evtSource.addEventListener("messageEvt", ((e: MessageEvent) => {}) as EventListener);
```

Instead of having users resort to the `as` operator, I'm proposing we introduce a generic _type variable_ that extends `Event` to the `EventListener` interface. We could then pass the appropriate sub-type to the `addEventHandler` functions for the respective objects (e.g. `EventSource` below).

```typescript
interface EventSource extends EventTarget {
    addEventListener(type: string, listener: EventListenerOrEventListenerObject<MessageEvent>, options?: boolean | AddEventListenerOptions): void;
}
```

The net result would be to allow users to simply do:

```typescript
evtSource.addEventListener("messageEvt", (e: MessageEvent) => {});
```

11/19/19: Note that the PR currently only implements the changes for the `EventSource` interface. I'd like to get some feedback before porting the change to every other object.
