### PR TITLE
Allow `--inspect=port` in `gulp runtests`

### DIFF
--- a/scripts/build/options.js
+++ b/scripts/build/options.js
@@ -4,8 +4,8 @@ const os = require("os");
 
 /** @type {CommandLineOptions} */
 module.exports = minimist(process.argv.slice(2), {
-    boolean: ["debug", "dirty", "inspect", "light", "colors", "lint", "lkg", "soft", "fix", "failed", "keepFailed", "force", "built"],
-    string: ["browser", "tests", "host", "reporter", "stackTraceLimit", "timeout", "shards", "shardId"],
+    boolean: ["debug", "dirty", "light", "colors", "lint", "lkg", "soft", "fix", "failed", "keepFailed", "force", "built"],
+    string: ["browser", "tests", "inspect", "host", "reporter", "stackTraceLimit", "timeout", "shards", "shardId"],
     alias: {
         "b": "browser",
         "d": "debug", "debug-brk": "debug",
@@ -49,7 +49,6 @@ if (module.exports.built) {
  * @typedef TypedOptions
  * @property {boolean} debug
  * @property {boolean} dirty
- * @property {boolean} inspect
  * @property {boolean} light
  * @property {boolean} colors
  * @property {boolean} lint
@@ -59,6 +58,7 @@ if (module.exports.built) {
  * @property {boolean} fix
  * @property {string} browser
  * @property {string} tests
+ * @property {string} inspect
  * @property {string} runners
  * @property {string|number} workers
  * @property {string} host

--- a/scripts/build/tests.js
+++ b/scripts/build/tests.js
@@ -89,8 +89,8 @@ async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode,
         else {
             args.push("--no-colors");
         }
-        if (inspect) {
-            args.unshift("--inspect-brk");
+        if (inspect !== undefined) {
+            args.unshift(inspect == "" ? "--inspect-brk" : "--inspect-brk="+inspect);
         }
         else if (debug) {
             args.unshift("--debug-brk");


### PR DESCRIPTION
Makes it possible to run two debuggers side-by-side.
