### PR TITLE
Fix `getIntrinsicAttributesTypeFromJsxOpeningLikeElement`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22545,7 +22545,8 @@ namespace ts {
                     return links.resolvedJsxElementAttributesType = getTypeOfSymbol(symbol);
                 }
                 else if (links.jsxFlags & JsxFlags.IntrinsicIndexedElement) {
-                    return links.resolvedJsxElementAttributesType = getIndexInfoOfSymbol(symbol, IndexKind.String)!.type;
+                    return links.resolvedJsxElementAttributesType =
+                        getIndexTypeOfType(getDeclaredTypeOfSymbol(symbol), IndexKind.String)!;
                 }
                 else {
                     return links.resolvedJsxElementAttributesType = errorType;

--- a/tests/baselines/reference/jsxIntrinsicElementsExtendsRecord.js
+++ b/tests/baselines/reference/jsxIntrinsicElementsExtendsRecord.js
@@ -1,0 +1,10 @@
+//// [index.tsx]
+declare namespace JSX {
+  interface IntrinsicElements extends Record<string, any> {}
+}
+
+<a />;
+
+
+//// [index.jsx]
+<a />;

--- a/tests/baselines/reference/jsxIntrinsicElementsExtendsRecord.symbols
+++ b/tests/baselines/reference/jsxIntrinsicElementsExtendsRecord.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/index.tsx ===
+declare namespace JSX {
+>JSX : Symbol(JSX, Decl(index.tsx, 0, 0))
+
+  interface IntrinsicElements extends Record<string, any> {}
+>IntrinsicElements : Symbol(IntrinsicElements, Decl(index.tsx, 0, 23))
+>Record : Symbol(Record, Decl(lib.es5.d.ts, --, --))
+}
+
+<a />;
+>a : Symbol(JSX.IntrinsicElements, Decl(index.tsx, 0, 23))
+

--- a/tests/baselines/reference/jsxIntrinsicElementsExtendsRecord.types
+++ b/tests/baselines/reference/jsxIntrinsicElementsExtendsRecord.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/index.tsx ===
+declare namespace JSX {
+  interface IntrinsicElements extends Record<string, any> {}
+}
+
+<a />;
+><a /> : error
+>a : any
+

--- a/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord.tsx
+++ b/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord.tsx
@@ -1,0 +1,8 @@
+// @jsx: preserve
+
+// @filename: index.tsx
+declare namespace JSX {
+  interface IntrinsicElements extends Record<string, any> {}
+}
+
+<a />;


### PR DESCRIPTION
Use `getIndexTypeOfType`+`getDeclaredTypeOfSymbol` instead of `getIndexInfoOfSymbol`.

Fixes #34730.
