### PR TITLE
Defer generic awaited type

### DIFF
--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -961,6 +961,7 @@ namespace FourSlashInterface {
             typeEntry("PropertyDecorator"),
             typeEntry("MethodDecorator"),
             typeEntry("ParameterDecorator"),
+            typeEntry("Awaited"),
             typeEntry("PromiseConstructorLike"),
             interfaceEntry("PromiseLike"),
             interfaceEntry("Promise"),

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1378,6 +1378,11 @@ declare type PropertyDecorator = (target: Object, propertyKey: string | symbol) 
 declare type MethodDecorator = <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void;
 declare type ParameterDecorator = (target: Object, propertyKey: string | symbol, parameterIndex: number) => void;
 
+// The undefined case is for strictNullChecks false, in which case
+// undefined extends PromiseLike<infer U> is true, which would otherwise
+// make Awaited<undefined> -> unknown.
+type Awaited<T> = T extends undefined ? T : T extends PromiseLike<infer U> ? U : T extends { then: Function } ? unknown : T;
+
 declare type PromiseConstructorLike = new <T>(executor: (resolve: (value?: T | PromiseLike<T>) => void, reject: (reason?: any) => void) => void) => PromiseLike<T>;
 
 interface PromiseLike<T> {

--- a/tests/baselines/reference/asyncArrowFunctionCapturesThis_es2017.types
+++ b/tests/baselines/reference/asyncArrowFunctionCapturesThis_es2017.types
@@ -6,9 +6,9 @@ class C {
 >method : () => void
 
       var fn = async () => await this;      
->fn : () => Promise<this>
->async () => await this : () => Promise<this>
->await this : this
+>fn : () => Promise<Awaited<this>>
+>async () => await this : () => Promise<Awaited<this>>
+>await this : Awaited<this>
 >this : this
    }
 }

--- a/tests/baselines/reference/asyncArrowFunctionCapturesThis_es5.types
+++ b/tests/baselines/reference/asyncArrowFunctionCapturesThis_es5.types
@@ -6,9 +6,9 @@ class C {
 >method : () => void
 
       var fn = async () => await this;
->fn : () => Promise<this>
->async () => await this : () => Promise<this>
->await this : this
+>fn : () => Promise<Awaited<this>>
+>async () => await this : () => Promise<Awaited<this>>
+>await this : Awaited<this>
 >this : this
    }
 }

--- a/tests/baselines/reference/asyncArrowFunctionCapturesThis_es6.types
+++ b/tests/baselines/reference/asyncArrowFunctionCapturesThis_es6.types
@@ -6,9 +6,9 @@ class C {
 >method : () => void
 
       var fn = async () => await this;      
->fn : () => Promise<this>
->async () => await this : () => Promise<this>
->await this : this
+>fn : () => Promise<Awaited<this>>
+>async () => await this : () => Promise<Awaited<this>>
+>await this : Awaited<this>
 >this : this
    }
 }

--- a/tests/baselines/reference/asyncFunctionReturnType.js
+++ b/tests/baselines/reference/asyncFunctionReturnType.js
@@ -63,7 +63,7 @@ async function fGenericIndexedTypeForExplicitPromiseOfAnyProp<TObj extends Obj>(
     return Promise.resolve<TObj["anyProp"]>(obj.anyProp);
 }
 
-async function fGenericIndexedTypeForKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<TObj[K]> {
+async function fGenericIndexedTypeForKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<Awaited<TObj[K]>> {
     return obj[key];
 }
 
@@ -74,6 +74,7 @@ async function fGenericIndexedTypeForPromiseOfKProp<TObj extends Obj, K extends 
 async function fGenericIndexedTypeForExplicitPromiseOfKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<TObj[K]> {
     return Promise.resolve<TObj[K]>(obj[key]);
 }
+
 
 //// [asyncFunctionReturnType.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {

--- a/tests/baselines/reference/asyncFunctionReturnType.js
+++ b/tests/baselines/reference/asyncFunctionReturnType.js
@@ -75,6 +75,13 @@ async function fGenericIndexedTypeForExplicitPromiseOfKProp<TObj extends Obj, K 
     return Promise.resolve<TObj[K]>(obj[key]);
 }
 
+// #27711
+
+async function fGeneric<T>(x: T) {
+    return x;
+}
+const expected: Promise<string> = fGeneric(undefined as Promise<string>);
+
 
 //// [asyncFunctionReturnType.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -173,3 +180,10 @@ function fGenericIndexedTypeForExplicitPromiseOfKProp(obj, key) {
         return Promise.resolve(obj[key]);
     });
 }
+// #27711
+function fGeneric(x) {
+    return __awaiter(this, void 0, void 0, function* () {
+        return x;
+    });
+}
+const expected = fGeneric(undefined);

--- a/tests/baselines/reference/asyncFunctionReturnType.symbols
+++ b/tests/baselines/reference/asyncFunctionReturnType.symbols
@@ -221,7 +221,7 @@ async function fGenericIndexedTypeForExplicitPromiseOfAnyProp<TObj extends Obj>(
 >anyProp : Symbol(Obj.anyProp, Decl(asyncFunctionReturnType.ts, 12, 23))
 }
 
-async function fGenericIndexedTypeForKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<TObj[K]> {
+async function fGenericIndexedTypeForKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<Awaited<TObj[K]>> {
 >fGenericIndexedTypeForKProp : Symbol(fGenericIndexedTypeForKProp, Decl(asyncFunctionReturnType.ts, 62, 1))
 >TObj : Symbol(TObj, Decl(asyncFunctionReturnType.ts, 64, 43))
 >Obj : Symbol(Obj, Decl(asyncFunctionReturnType.ts, 8, 1))
@@ -232,6 +232,7 @@ async function fGenericIndexedTypeForKProp<TObj extends Obj, K extends keyof TOb
 >key : Symbol(key, Decl(asyncFunctionReturnType.ts, 64, 93))
 >K : Symbol(K, Decl(asyncFunctionReturnType.ts, 64, 60))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>Awaited : Symbol(Awaited, Decl(lib.es5.d.ts, --, --))
 >TObj : Symbol(TObj, Decl(asyncFunctionReturnType.ts, 64, 43))
 >K : Symbol(K, Decl(asyncFunctionReturnType.ts, 64, 60))
 
@@ -285,3 +286,4 @@ async function fGenericIndexedTypeForExplicitPromiseOfKProp<TObj extends Obj, K 
 >obj : Symbol(obj, Decl(asyncFunctionReturnType.ts, 72, 100))
 >key : Symbol(key, Decl(asyncFunctionReturnType.ts, 72, 110))
 }
+

--- a/tests/baselines/reference/asyncFunctionReturnType.symbols
+++ b/tests/baselines/reference/asyncFunctionReturnType.symbols
@@ -287,3 +287,21 @@ async function fGenericIndexedTypeForExplicitPromiseOfKProp<TObj extends Obj, K 
 >key : Symbol(key, Decl(asyncFunctionReturnType.ts, 72, 110))
 }
 
+// #27711
+
+async function fGeneric<T>(x: T) {
+>fGeneric : Symbol(fGeneric, Decl(asyncFunctionReturnType.ts, 74, 1))
+>T : Symbol(T, Decl(asyncFunctionReturnType.ts, 78, 24))
+>x : Symbol(x, Decl(asyncFunctionReturnType.ts, 78, 27))
+>T : Symbol(T, Decl(asyncFunctionReturnType.ts, 78, 24))
+
+    return x;
+>x : Symbol(x, Decl(asyncFunctionReturnType.ts, 78, 27))
+}
+const expected: Promise<string> = fGeneric(undefined as Promise<string>);
+>expected : Symbol(expected, Decl(asyncFunctionReturnType.ts, 81, 5))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>fGeneric : Symbol(fGeneric, Decl(asyncFunctionReturnType.ts, 74, 1))
+>undefined : Symbol(undefined)
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+

--- a/tests/baselines/reference/asyncFunctionReturnType.types
+++ b/tests/baselines/reference/asyncFunctionReturnType.types
@@ -221,3 +221,19 @@ async function fGenericIndexedTypeForExplicitPromiseOfKProp<TObj extends Obj, K 
 >key : K
 }
 
+// #27711
+
+async function fGeneric<T>(x: T) {
+>fGeneric : <T>(x: T) => Promise<Awaited<T>>
+>x : T
+
+    return x;
+>x : T
+}
+const expected: Promise<string> = fGeneric(undefined as Promise<string>);
+>expected : Promise<string>
+>fGeneric(undefined as Promise<string>) : Promise<string>
+>fGeneric : <T>(x: T) => Promise<Awaited<T>>
+>undefined as Promise<string> : Promise<string>
+>undefined : undefined
+

--- a/tests/baselines/reference/asyncFunctionReturnType.types
+++ b/tests/baselines/reference/asyncFunctionReturnType.types
@@ -180,8 +180,8 @@ async function fGenericIndexedTypeForExplicitPromiseOfAnyProp<TObj extends Obj>(
 >anyProp : any
 }
 
-async function fGenericIndexedTypeForKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<TObj[K]> {
->fGenericIndexedTypeForKProp : <TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K) => Promise<TObj[K]>
+async function fGenericIndexedTypeForKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<Awaited<TObj[K]>> {
+>fGenericIndexedTypeForKProp : <TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K) => Promise<Awaited<TObj[K]>>
 >obj : TObj
 >key : K
 
@@ -220,3 +220,4 @@ async function fGenericIndexedTypeForExplicitPromiseOfKProp<TObj extends Obj, K 
 >obj : TObj
 >key : K
 }
+

--- a/tests/baselines/reference/compareTypeParameterConstrainedByLiteralToLiteral.errors.txt
+++ b/tests/baselines/reference/compareTypeParameterConstrainedByLiteralToLiteral.errors.txt
@@ -9,5 +9,6 @@ tests/cases/compiler/compareTypeParameterConstrainedByLiteralToLiteral.ts(5,5): 
         t === "x";  // Should be error
         ~~~~~~~~~
 !!! error TS2367: This condition will always return 'false' since the types 'T' and '"x"' have no overlap.
+!!! related TS2773 tests/cases/compiler/compareTypeParameterConstrainedByLiteralToLiteral.ts:5:5: Did you forget to use 'await'?
     }
     

--- a/tests/baselines/reference/comparisonOperatorWithNoRelationshipTypeParameter.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithNoRelationshipTypeParameter.errors.txt
@@ -161,359 +161,471 @@ tests/cases/conformance/expressions/binaryOperators/comparisonOperator/compariso
         var r1a1 = t < a;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:22:16: Did you forget to use 'await'?
         var r1a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:23:16: Did you forget to use 'await'?
         var r1a3 = t < c;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:24:16: Did you forget to use 'await'?
         var r1a4 = t < d;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:25:16: Did you forget to use 'await'?
         var r1a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'E'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:26:16: Did you forget to use 'await'?
         var r1a6 = t < f;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:27:16: Did you forget to use 'await'?
         var r1a7 = t < g;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:28:16: Did you forget to use 'await'?
     
         var r1b1 = a < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:30:16: Did you forget to use 'await'?
         var r1b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:31:16: Did you forget to use 'await'?
         var r1b3 = c < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:32:16: Did you forget to use 'await'?
         var r1b4 = d < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:33:16: Did you forget to use 'await'?
         var r1b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'E' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:34:16: Did you forget to use 'await'?
         var r1b6 = f < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:35:16: Did you forget to use 'await'?
         var r1b7 = g < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:36:16: Did you forget to use 'await'?
     
         // operator >
         var r2a1 = t < a;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:39:16: Did you forget to use 'await'?
         var r2a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:40:16: Did you forget to use 'await'?
         var r2a3 = t < c;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:41:16: Did you forget to use 'await'?
         var r2a4 = t < d;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:42:16: Did you forget to use 'await'?
         var r2a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'E'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:43:16: Did you forget to use 'await'?
         var r2a6 = t < f;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:44:16: Did you forget to use 'await'?
         var r2a7 = t < g;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:45:16: Did you forget to use 'await'?
     
         var r2b1 = a < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:47:16: Did you forget to use 'await'?
         var r2b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:48:16: Did you forget to use 'await'?
         var r2b3 = c < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:49:16: Did you forget to use 'await'?
         var r2b4 = d < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:50:16: Did you forget to use 'await'?
         var r2b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'E' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:51:16: Did you forget to use 'await'?
         var r2b6 = f < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:52:16: Did you forget to use 'await'?
         var r2b7 = g < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:53:16: Did you forget to use 'await'?
     
         // operator <=
         var r3a1 = t < a;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:56:16: Did you forget to use 'await'?
         var r3a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:57:16: Did you forget to use 'await'?
         var r3a3 = t < c;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:58:16: Did you forget to use 'await'?
         var r3a4 = t < d;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:59:16: Did you forget to use 'await'?
         var r3a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'E'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:60:16: Did you forget to use 'await'?
         var r3a6 = t < f;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:61:16: Did you forget to use 'await'?
         var r3a7 = t < g;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:62:16: Did you forget to use 'await'?
     
         var r3b1 = a < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:64:16: Did you forget to use 'await'?
         var r3b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:65:16: Did you forget to use 'await'?
         var r3b3 = c < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:66:16: Did you forget to use 'await'?
         var r3b4 = d < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:67:16: Did you forget to use 'await'?
         var r3b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'E' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:68:16: Did you forget to use 'await'?
         var r3b6 = f < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:69:16: Did you forget to use 'await'?
         var r3b7 = g < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:70:16: Did you forget to use 'await'?
     
         // operator >=
         var r4a1 = t < a;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:73:16: Did you forget to use 'await'?
         var r4a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:74:16: Did you forget to use 'await'?
         var r4a3 = t < c;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:75:16: Did you forget to use 'await'?
         var r4a4 = t < d;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:76:16: Did you forget to use 'await'?
         var r4a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'E'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:77:16: Did you forget to use 'await'?
         var r4a6 = t < f;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:78:16: Did you forget to use 'await'?
         var r4a7 = t < g;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:79:16: Did you forget to use 'await'?
     
         var r4b1 = a < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:81:16: Did you forget to use 'await'?
         var r4b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:82:16: Did you forget to use 'await'?
         var r4b3 = c < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:83:16: Did you forget to use 'await'?
         var r4b4 = d < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:84:16: Did you forget to use 'await'?
         var r4b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'E' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:85:16: Did you forget to use 'await'?
         var r4b6 = f < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:86:16: Did you forget to use 'await'?
         var r4b7 = g < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:87:16: Did you forget to use 'await'?
     
         // operator ==
         var r5a1 = t < a;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:90:16: Did you forget to use 'await'?
         var r5a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:91:16: Did you forget to use 'await'?
         var r5a3 = t < c;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:92:16: Did you forget to use 'await'?
         var r5a4 = t < d;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:93:16: Did you forget to use 'await'?
         var r5a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'E'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:94:16: Did you forget to use 'await'?
         var r5a6 = t < f;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:95:16: Did you forget to use 'await'?
         var r5a7 = t < g;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:96:16: Did you forget to use 'await'?
     
         var r5b1 = a < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:98:16: Did you forget to use 'await'?
         var r5b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:99:16: Did you forget to use 'await'?
         var r5b3 = c < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:100:16: Did you forget to use 'await'?
         var r5b4 = d < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:101:16: Did you forget to use 'await'?
         var r5b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'E' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:102:16: Did you forget to use 'await'?
         var r5b6 = f < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:103:16: Did you forget to use 'await'?
         var r5b7 = g < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:104:16: Did you forget to use 'await'?
     
         // operator !=
         var r6a1 = t < a;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:107:16: Did you forget to use 'await'?
         var r6a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:108:16: Did you forget to use 'await'?
         var r6a3 = t < c;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:109:16: Did you forget to use 'await'?
         var r6a4 = t < d;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:110:16: Did you forget to use 'await'?
         var r6a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'E'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:111:16: Did you forget to use 'await'?
         var r6a6 = t < f;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:112:16: Did you forget to use 'await'?
         var r6a7 = t < g;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:113:16: Did you forget to use 'await'?
     
         var r6b1 = a < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:115:16: Did you forget to use 'await'?
         var r6b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:116:16: Did you forget to use 'await'?
         var r6b3 = c < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:117:16: Did you forget to use 'await'?
         var r6b4 = d < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:118:16: Did you forget to use 'await'?
         var r6b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'E' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:119:16: Did you forget to use 'await'?
         var r6b6 = f < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:120:16: Did you forget to use 'await'?
         var r6b7 = g < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:121:16: Did you forget to use 'await'?
     
         // operator ===
         var r7a1 = t < a;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:124:16: Did you forget to use 'await'?
         var r7a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:125:16: Did you forget to use 'await'?
         var r7a3 = t < c;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:126:16: Did you forget to use 'await'?
         var r7a4 = t < d;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:127:16: Did you forget to use 'await'?
         var r7a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'E'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:128:16: Did you forget to use 'await'?
         var r7a6 = t < f;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:129:16: Did you forget to use 'await'?
         var r7a7 = t < g;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:130:16: Did you forget to use 'await'?
     
         var r7b1 = a < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:132:16: Did you forget to use 'await'?
         var r7b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:133:16: Did you forget to use 'await'?
         var r7b3 = c < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:134:16: Did you forget to use 'await'?
         var r7b4 = d < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:135:16: Did you forget to use 'await'?
         var r7b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'E' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:136:16: Did you forget to use 'await'?
         var r7b6 = f < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:137:16: Did you forget to use 'await'?
         var r7b7 = g < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:138:16: Did you forget to use 'await'?
     
         // operator !==
         var r8a1 = t < a;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'boolean'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:141:16: Did you forget to use 'await'?
         var r8a2 = t < b;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'number'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:142:16: Did you forget to use 'await'?
         var r8a3 = t < c;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'string'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:143:16: Did you forget to use 'await'?
         var r8a4 = t < d;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'void'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:144:16: Did you forget to use 'await'?
         var r8a5 = t < e;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'E'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:145:16: Did you forget to use 'await'?
         var r8a6 = t < f;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and '{ a: string; }'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:146:16: Did you forget to use 'await'?
         var r8a7 = t < g;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'T' and 'any[]'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:147:16: Did you forget to use 'await'?
     
         var r8b1 = a < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'boolean' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:149:16: Did you forget to use 'await'?
         var r8b2 = b < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'number' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:150:16: Did you forget to use 'await'?
         var r8b3 = c < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'string' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:151:16: Did you forget to use 'await'?
         var r8b4 = d < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'void' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:152:16: Did you forget to use 'await'?
         var r8b5 = e < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'E' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:153:16: Did you forget to use 'await'?
         var r8b6 = f < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types '{ a: string; }' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:154:16: Did you forget to use 'await'?
         var r8b7 = g < t;
                    ~~~~~
 !!! error TS2365: Operator '<' cannot be applied to types 'any[]' and 'T'.
+!!! related TS2773 tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts:155:16: Did you forget to use 'await'?
     }

--- a/tests/baselines/reference/forAwaitForUnion.types
+++ b/tests/baselines/reference/forAwaitForUnion.types
@@ -4,7 +4,7 @@ async function f<T>(source: Iterable<T> | AsyncIterable<T>) {
 >source : Iterable<T> | AsyncIterable<T>
 
     for await (const x of source) {
->x : T
+>x : T | Awaited<T>
 >source : Iterable<T> | AsyncIterable<T>
     }
 }

--- a/tests/baselines/reference/mappedTypesArraysTuples.js
+++ b/tests/baselines/reference/mappedTypesArraysTuples.js
@@ -58,7 +58,6 @@ let y21 = nonpartial(x21);
 declare let x22: { a: number | undefined, b?: string[] };
 let y22 = nonpartial(x22);
 
-type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 type Awaitified<T> = { [P in keyof T]: Awaited<T[P]> };
 
 declare function all<T extends any[]>(...values: T): Promise<Awaitified<T>>;
@@ -189,7 +188,6 @@ declare let y22: {
     a: number;
     b: string[];
 };
-declare type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 declare type Awaitified<T> = {
     [P in keyof T]: Awaited<T[P]>;
 };

--- a/tests/baselines/reference/mappedTypesArraysTuples.symbols
+++ b/tests/baselines/reference/mappedTypesArraysTuples.symbols
@@ -214,173 +214,164 @@ let y22 = nonpartial(x22);
 >nonpartial : Symbol(nonpartial, Decl(mappedTypesArraysTuples.ts, 46, 24))
 >x22 : Symbol(x22, Decl(mappedTypesArraysTuples.ts, 56, 11))
 
-type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
->Awaited : Symbol(Awaited, Decl(mappedTypesArraysTuples.ts, 57, 26))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 59, 13))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 59, 13))
->PromiseLike : Symbol(PromiseLike, Decl(lib.es5.d.ts, --, --))
->U : Symbol(U, Decl(mappedTypesArraysTuples.ts, 59, 45))
->U : Symbol(U, Decl(mappedTypesArraysTuples.ts, 59, 45))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 59, 13))
-
 type Awaitified<T> = { [P in keyof T]: Awaited<T[P]> };
->Awaitified : Symbol(Awaitified, Decl(mappedTypesArraysTuples.ts, 59, 57))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 60, 16))
->P : Symbol(P, Decl(mappedTypesArraysTuples.ts, 60, 24))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 60, 16))
->Awaited : Symbol(Awaited, Decl(mappedTypesArraysTuples.ts, 57, 26))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 60, 16))
->P : Symbol(P, Decl(mappedTypesArraysTuples.ts, 60, 24))
+>Awaitified : Symbol(Awaitified, Decl(mappedTypesArraysTuples.ts, 57, 26))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 59, 16))
+>P : Symbol(P, Decl(mappedTypesArraysTuples.ts, 59, 24))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 59, 16))
+>Awaited : Symbol(Awaited, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 59, 16))
+>P : Symbol(P, Decl(mappedTypesArraysTuples.ts, 59, 24))
 
 declare function all<T extends any[]>(...values: T): Promise<Awaitified<T>>;
->all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 60, 55))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 62, 21))
->values : Symbol(values, Decl(mappedTypesArraysTuples.ts, 62, 38))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 62, 21))
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 59, 55))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 61, 21))
+>values : Symbol(values, Decl(mappedTypesArraysTuples.ts, 61, 38))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 61, 21))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
->Awaitified : Symbol(Awaitified, Decl(mappedTypesArraysTuples.ts, 59, 57))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 62, 21))
+>Awaitified : Symbol(Awaitified, Decl(mappedTypesArraysTuples.ts, 57, 26))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 61, 21))
 
 function f1(a: number, b: Promise<number>, c: string[], d: Promise<string[]>) {
->f1 : Symbol(f1, Decl(mappedTypesArraysTuples.ts, 62, 76))
->a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 64, 12))
->b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 64, 22))
+>f1 : Symbol(f1, Decl(mappedTypesArraysTuples.ts, 61, 76))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 63, 12))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 63, 22))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
->c : Symbol(c, Decl(mappedTypesArraysTuples.ts, 64, 42))
->d : Symbol(d, Decl(mappedTypesArraysTuples.ts, 64, 55))
+>c : Symbol(c, Decl(mappedTypesArraysTuples.ts, 63, 42))
+>d : Symbol(d, Decl(mappedTypesArraysTuples.ts, 63, 55))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
 
     let x1 = all(a);
->x1 : Symbol(x1, Decl(mappedTypesArraysTuples.ts, 65, 7))
->all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 60, 55))
->a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 64, 12))
+>x1 : Symbol(x1, Decl(mappedTypesArraysTuples.ts, 64, 7))
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 59, 55))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 63, 12))
 
     let x2 = all(a, b);
->x2 : Symbol(x2, Decl(mappedTypesArraysTuples.ts, 66, 7))
->all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 60, 55))
->a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 64, 12))
->b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 64, 22))
+>x2 : Symbol(x2, Decl(mappedTypesArraysTuples.ts, 65, 7))
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 59, 55))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 63, 12))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 63, 22))
 
     let x3 = all(a, b, c);
->x3 : Symbol(x3, Decl(mappedTypesArraysTuples.ts, 67, 7))
->all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 60, 55))
->a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 64, 12))
->b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 64, 22))
->c : Symbol(c, Decl(mappedTypesArraysTuples.ts, 64, 42))
+>x3 : Symbol(x3, Decl(mappedTypesArraysTuples.ts, 66, 7))
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 59, 55))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 63, 12))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 63, 22))
+>c : Symbol(c, Decl(mappedTypesArraysTuples.ts, 63, 42))
 
     let x4 = all(a, b, c, d);
->x4 : Symbol(x4, Decl(mappedTypesArraysTuples.ts, 68, 7))
->all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 60, 55))
->a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 64, 12))
->b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 64, 22))
->c : Symbol(c, Decl(mappedTypesArraysTuples.ts, 64, 42))
->d : Symbol(d, Decl(mappedTypesArraysTuples.ts, 64, 55))
+>x4 : Symbol(x4, Decl(mappedTypesArraysTuples.ts, 67, 7))
+>all : Symbol(all, Decl(mappedTypesArraysTuples.ts, 59, 55))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 63, 12))
+>b : Symbol(b, Decl(mappedTypesArraysTuples.ts, 63, 22))
+>c : Symbol(c, Decl(mappedTypesArraysTuples.ts, 63, 42))
+>d : Symbol(d, Decl(mappedTypesArraysTuples.ts, 63, 55))
 }
 
 function f2<T extends any[]>(a: Boxified<T>) {
->f2 : Symbol(f2, Decl(mappedTypesArraysTuples.ts, 69, 1))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 71, 12))
->a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 71, 29))
+>f2 : Symbol(f2, Decl(mappedTypesArraysTuples.ts, 68, 1))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 70, 12))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 70, 29))
 >Boxified : Symbol(Boxified, Decl(mappedTypesArraysTuples.ts, 0, 27))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 71, 12))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 70, 12))
 
     let x: Box<any> | undefined = a.pop();
->x : Symbol(x, Decl(mappedTypesArraysTuples.ts, 72, 7))
+>x : Symbol(x, Decl(mappedTypesArraysTuples.ts, 71, 7))
 >Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
 >a.pop : Symbol(Array.pop, Decl(lib.es5.d.ts, --, --))
->a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 71, 29))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 70, 29))
 >pop : Symbol(Array.pop, Decl(lib.es5.d.ts, --, --))
 
     let y: Box<any>[] = a.concat(a);
->y : Symbol(y, Decl(mappedTypesArraysTuples.ts, 73, 7))
+>y : Symbol(y, Decl(mappedTypesArraysTuples.ts, 72, 7))
 >Box : Symbol(Box, Decl(mappedTypesArraysTuples.ts, 0, 0))
 >a.concat : Symbol(Array.concat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 71, 29))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 70, 29))
 >concat : Symbol(Array.concat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 71, 29))
+>a : Symbol(a, Decl(mappedTypesArraysTuples.ts, 70, 29))
 }
 
 // Repro from #26163
 
 type ElementType<T> = T extends Array<infer U> ? U : never;
->ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 74, 1))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 78, 17))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 78, 17))
+>ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 73, 1))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 77, 17))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 77, 17))
 >Array : Symbol(Array, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
->U : Symbol(U, Decl(mappedTypesArraysTuples.ts, 78, 43))
->U : Symbol(U, Decl(mappedTypesArraysTuples.ts, 78, 43))
+>U : Symbol(U, Decl(mappedTypesArraysTuples.ts, 77, 43))
+>U : Symbol(U, Decl(mappedTypesArraysTuples.ts, 77, 43))
 
 type Mapped<T> = { [K in keyof T]: T[K] };
->Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 78, 59))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 79, 12))
->K : Symbol(K, Decl(mappedTypesArraysTuples.ts, 79, 20))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 79, 12))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 79, 12))
->K : Symbol(K, Decl(mappedTypesArraysTuples.ts, 79, 20))
+>Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 77, 59))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 78, 12))
+>K : Symbol(K, Decl(mappedTypesArraysTuples.ts, 78, 20))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 78, 12))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 78, 12))
+>K : Symbol(K, Decl(mappedTypesArraysTuples.ts, 78, 20))
 
 type F<T> = ElementType<Mapped<T>>;
->F : Symbol(F, Decl(mappedTypesArraysTuples.ts, 79, 42))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 81, 7))
->ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 74, 1))
->Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 78, 59))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 81, 7))
+>F : Symbol(F, Decl(mappedTypesArraysTuples.ts, 78, 42))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 80, 7))
+>ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 73, 1))
+>Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 77, 59))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 80, 7))
 
 type R1 = F<[string, number, boolean]>;  // string | number | boolean
->R1 : Symbol(R1, Decl(mappedTypesArraysTuples.ts, 81, 35))
->F : Symbol(F, Decl(mappedTypesArraysTuples.ts, 79, 42))
+>R1 : Symbol(R1, Decl(mappedTypesArraysTuples.ts, 80, 35))
+>F : Symbol(F, Decl(mappedTypesArraysTuples.ts, 78, 42))
 
 type R2 = ElementType<Mapped<[string, number, boolean]>>;  // string | number | boolean
->R2 : Symbol(R2, Decl(mappedTypesArraysTuples.ts, 82, 39))
->ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 74, 1))
->Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 78, 59))
+>R2 : Symbol(R2, Decl(mappedTypesArraysTuples.ts, 81, 39))
+>ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 73, 1))
+>Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 77, 59))
 
 // Repro from #26163
 
 declare function acceptArray(arr: any[]): void;
->acceptArray : Symbol(acceptArray, Decl(mappedTypesArraysTuples.ts, 83, 57))
->arr : Symbol(arr, Decl(mappedTypesArraysTuples.ts, 87, 29))
+>acceptArray : Symbol(acceptArray, Decl(mappedTypesArraysTuples.ts, 82, 57))
+>arr : Symbol(arr, Decl(mappedTypesArraysTuples.ts, 86, 29))
 
 declare function mapArray<T extends any[]>(arr: T): Mapped<T>;
->mapArray : Symbol(mapArray, Decl(mappedTypesArraysTuples.ts, 87, 47))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 88, 26))
->arr : Symbol(arr, Decl(mappedTypesArraysTuples.ts, 88, 43))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 88, 26))
->Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 78, 59))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 88, 26))
+>mapArray : Symbol(mapArray, Decl(mappedTypesArraysTuples.ts, 86, 47))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 87, 26))
+>arr : Symbol(arr, Decl(mappedTypesArraysTuples.ts, 87, 43))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 87, 26))
+>Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 77, 59))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 87, 26))
 
 function acceptMappedArray<T extends any[]>(arr: T) {
->acceptMappedArray : Symbol(acceptMappedArray, Decl(mappedTypesArraysTuples.ts, 88, 62))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 89, 27))
->arr : Symbol(arr, Decl(mappedTypesArraysTuples.ts, 89, 44))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 89, 27))
+>acceptMappedArray : Symbol(acceptMappedArray, Decl(mappedTypesArraysTuples.ts, 87, 62))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 88, 27))
+>arr : Symbol(arr, Decl(mappedTypesArraysTuples.ts, 88, 44))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 88, 27))
 
     acceptArray(mapArray(arr));
->acceptArray : Symbol(acceptArray, Decl(mappedTypesArraysTuples.ts, 83, 57))
->mapArray : Symbol(mapArray, Decl(mappedTypesArraysTuples.ts, 87, 47))
->arr : Symbol(arr, Decl(mappedTypesArraysTuples.ts, 89, 44))
+>acceptArray : Symbol(acceptArray, Decl(mappedTypesArraysTuples.ts, 82, 57))
+>mapArray : Symbol(mapArray, Decl(mappedTypesArraysTuples.ts, 86, 47))
+>arr : Symbol(arr, Decl(mappedTypesArraysTuples.ts, 88, 44))
 }
 
 // Repro from #26163
 
 type Unconstrained<T> = ElementType<Mapped<T>>;
->Unconstrained : Symbol(Unconstrained, Decl(mappedTypesArraysTuples.ts, 91, 1))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 95, 19))
->ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 74, 1))
->Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 78, 59))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 95, 19))
+>Unconstrained : Symbol(Unconstrained, Decl(mappedTypesArraysTuples.ts, 90, 1))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 94, 19))
+>ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 73, 1))
+>Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 77, 59))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 94, 19))
 
 type T1 = Unconstrained<[string, number, boolean]>;  // string | number | boolean
->T1 : Symbol(T1, Decl(mappedTypesArraysTuples.ts, 95, 47))
->Unconstrained : Symbol(Unconstrained, Decl(mappedTypesArraysTuples.ts, 91, 1))
+>T1 : Symbol(T1, Decl(mappedTypesArraysTuples.ts, 94, 47))
+>Unconstrained : Symbol(Unconstrained, Decl(mappedTypesArraysTuples.ts, 90, 1))
 
 type Constrained<T extends any[]> = ElementType<Mapped<T>>;
->Constrained : Symbol(Constrained, Decl(mappedTypesArraysTuples.ts, 96, 51))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 98, 17))
->ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 74, 1))
->Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 78, 59))
->T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 98, 17))
+>Constrained : Symbol(Constrained, Decl(mappedTypesArraysTuples.ts, 95, 51))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 97, 17))
+>ElementType : Symbol(ElementType, Decl(mappedTypesArraysTuples.ts, 73, 1))
+>Mapped : Symbol(Mapped, Decl(mappedTypesArraysTuples.ts, 77, 59))
+>T : Symbol(T, Decl(mappedTypesArraysTuples.ts, 97, 17))
 
 type T2 = Constrained<[string, number, boolean]>;  // string | number | boolean
->T2 : Symbol(T2, Decl(mappedTypesArraysTuples.ts, 98, 59))
->Constrained : Symbol(Constrained, Decl(mappedTypesArraysTuples.ts, 96, 51))
+>T2 : Symbol(T2, Decl(mappedTypesArraysTuples.ts, 97, 59))
+>Constrained : Symbol(Constrained, Decl(mappedTypesArraysTuples.ts, 95, 51))
 

--- a/tests/baselines/reference/mappedTypesArraysTuples.types
+++ b/tests/baselines/reference/mappedTypesArraysTuples.types
@@ -152,9 +152,6 @@ let y22 = nonpartial(x22);
 >nonpartial : <T>(x: Partial<T>) => T
 >x22 : { a: number | undefined; b?: string[] | undefined; }
 
-type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
->Awaited : Awaited<T>
-
 type Awaitified<T> = { [P in keyof T]: Awaited<T[P]> };
 >Awaitified : Awaitified<T>
 

--- a/tests/baselines/reference/promisePermutations.errors.txt
+++ b/tests/baselines/reference/promisePermutations.errors.txt
@@ -447,7 +447,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2769: No overload m
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => Promise<number>'.
 !!! error TS2769:       Property 'catch' is missing in type 'IPromise<string>' but required in type 'Promise<number>'.
-!!! related TS2728 /.ts/lib.es5.d.ts:1430:5: 'catch' is declared here.
+!!! related TS2728 /.ts/lib.es5.d.ts:1435:5: 'catch' is declared here.
 !!! related TS2771 tests/cases/compiler/promisePermutations.ts:5:5: The last overload is declared here.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
     

--- a/tests/baselines/reference/promisePermutations2.errors.txt
+++ b/tests/baselines/reference/promisePermutations2.errors.txt
@@ -351,7 +351,7 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
                                        ~~~~~~~~~
 !!! error TS2345: Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => Promise<number>'.
 !!! error TS2345:   Property 'catch' is missing in type 'IPromise<string>' but required in type 'Promise<number>'.
-!!! related TS2728 /.ts/lib.es5.d.ts:1430:5: 'catch' is declared here.
+!!! related TS2728 /.ts/lib.es5.d.ts:1435:5: 'catch' is declared here.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
     
     var r11: IPromise<number>;

--- a/tests/baselines/reference/promisePermutations3.errors.txt
+++ b/tests/baselines/reference/promisePermutations3.errors.txt
@@ -398,7 +398,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
 !!! error TS2769:   The last overload gave the following error.
 !!! error TS2769:     Argument of type '(x: any) => IPromise<string>' is not assignable to parameter of type '(error: any) => Promise<number>'.
 !!! error TS2769:       Property 'catch' is missing in type 'IPromise<string>' but required in type 'Promise<number>'.
-!!! related TS2728 /.ts/lib.es5.d.ts:1430:5: 'catch' is declared here.
+!!! related TS2728 /.ts/lib.es5.d.ts:1435:5: 'catch' is declared here.
 !!! related TS2771 tests/cases/compiler/promisePermutations3.ts:7:5: The last overload is declared here.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
     
@@ -445,5 +445,5 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                         ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ <T>(x: T): IPromise<T>; <T>(x: T, y: T): Promise<T>; }' is not assignable to parameter of type '(value: (x: any) => any) => Promise<unknown>'.
 !!! error TS2345:   Property 'catch' is missing in type 'IPromise<any>' but required in type 'Promise<unknown>'.
-!!! related TS2728 /.ts/lib.es5.d.ts:1430:5: 'catch' is declared here.
+!!! related TS2728 /.ts/lib.es5.d.ts:1435:5: 'catch' is declared here.
     var s12c = s12.then(testFunction12P, testFunction12, testFunction12); // ok

--- a/tests/baselines/reference/promiseType.js
+++ b/tests/baselines/reference/promiseType.js
@@ -218,6 +218,8 @@ const pc7 = p.then(() => Promise.reject("1"), () => {throw 1});
 const pc8 = p.then(() => Promise.reject("1"), () => Promise.resolve(1));
 const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
 
+const expected: undefined = undefined as Awaited<undefined>;
+
 
 //// [promiseType.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
@@ -440,3 +442,4 @@ const pc6 = p.then(() => Promise.reject("1"), () => { });
 const pc7 = p.then(() => Promise.reject("1"), () => { throw 1; });
 const pc8 = p.then(() => Promise.reject("1"), () => Promise.resolve(1));
 const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
+const expected = undefined;

--- a/tests/baselines/reference/promiseType.symbols
+++ b/tests/baselines/reference/promiseType.symbols
@@ -1089,3 +1089,8 @@ const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 >reject : Symbol(PromiseConstructor.reject, Decl(lib.es2015.promise.d.ts, --, --))
 
+const expected: undefined = undefined as Awaited<undefined>;
+>expected : Symbol(expected, Decl(promiseType.ts, 219, 5))
+>undefined : Symbol(undefined)
+>Awaited : Symbol(Awaited, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/promiseType.types
+++ b/tests/baselines/reference/promiseType.types
@@ -1583,3 +1583,8 @@ const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
 >reject : <T = never>(reason?: any) => Promise<T>
 >1 : 1
 
+const expected: undefined = undefined as Awaited<undefined>;
+>expected : undefined
+>undefined as Awaited<undefined> : undefined
+>undefined : undefined
+

--- a/tests/baselines/reference/promiseTypeInference.errors.txt
+++ b/tests/baselines/reference/promiseTypeInference.errors.txt
@@ -32,7 +32,7 @@ tests/cases/compiler/promiseTypeInference.ts(10,39): error TS2769: No overload m
 !!! error TS2769:           Types of parameters 'success' and 'onfulfilled' are incompatible.
 !!! error TS2769:             Type 'TResult1 | PromiseLike<TResult1>' is not assignable to type 'IPromise<TResult1 | TResult2>'.
 !!! error TS2769:               Type 'TResult1' is not assignable to type 'IPromise<TResult1 | TResult2>'.
-!!! related TS2728 /.ts/lib.es5.d.ts:1430:5: 'catch' is declared here.
+!!! related TS2728 /.ts/lib.es5.d.ts:1435:5: 'catch' is declared here.
 !!! related TS6502 tests/cases/compiler/promiseTypeInference.ts:2:23: The expected type comes from the return type of this signature.
-!!! related TS6502 /.ts/lib.es5.d.ts:1423:57: The expected type comes from the return type of this signature.
+!!! related TS6502 /.ts/lib.es5.d.ts:1428:57: The expected type comes from the return type of this signature.
     

--- a/tests/baselines/reference/unionTypeInference.types
+++ b/tests/baselines/reference/unionTypeInference.types
@@ -221,18 +221,18 @@ async function fun<T>(deepPromised: DeepPromised<T>) {
 >deepPromisedWithIndexer : DeepPromised<{ [name: string]: {} | null | undefined; }>
 
         const awaitedValue = await value;
->awaitedValue : {} | ({ [containsPromises]?: true | undefined; } & {}) | null | undefined
->await value : {} | ({ [containsPromises]?: true | undefined; } & {}) | null | undefined
+>awaitedValue : {} | ({ [containsPromises]?: true | undefined; } & {}) | ({ [containsPromises]?: true | undefined; } & {}) | null | undefined
+>await value : {} | ({ [containsPromises]?: true | undefined; } & {}) | ({ [containsPromises]?: true | undefined; } & {}) | null | undefined
 >value : {} | ({ [containsPromises]?: true | undefined; } & {}) | Promise<{ [containsPromises]?: true | undefined; } & {}> | null | undefined
 
         if (awaitedValue)
->awaitedValue : {} | ({ [containsPromises]?: true | undefined; } & {}) | null | undefined
+>awaitedValue : {} | ({ [containsPromises]?: true | undefined; } & {}) | ({ [containsPromises]?: true | undefined; } & {}) | null | undefined
 
             await fun(awaitedValue);
 >await fun(awaitedValue) : void
 >fun(awaitedValue) : Promise<void>
 >fun : <T>(deepPromised: DeepPromised<T>) => Promise<void>
->awaitedValue : {} | ({ [containsPromises]?: true | undefined; } & {})
+>awaitedValue : {} | ({ [containsPromises]?: true | undefined; } & {}) | ({ [containsPromises]?: true | undefined; } & {})
     }
 }
 

--- a/tests/baselines/reference/user/chrome-devtools-frontend.log
+++ b/tests/baselines/reference/user/chrome-devtools-frontend.log
@@ -1,6 +1,6 @@
 Exit Code: 1
 Standard output:
-../../../../built/local/lib.es5.d.ts(1433,11): error TS2300: Duplicate identifier 'ArrayLike'.
+../../../../built/local/lib.es5.d.ts(1438,11): error TS2300: Duplicate identifier 'ArrayLike'.
 ../../../../node_modules/@types/node/globals.d.ts(168,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 'module' must be of type '{}', but here has type 'NodeModule'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(43,8): error TS2339: Property '_importScriptPathPrefix' does not exist on type 'Window & typeof globalThis'.
 node_modules/chrome-devtools-frontend/front_end/Runtime.js(77,16): error TS7014: Function type, which lacks return-type annotation, implicitly has an 'any' return type.

--- a/tests/cases/compiler/asyncFunctionReturnType.ts
+++ b/tests/cases/compiler/asyncFunctionReturnType.ts
@@ -74,3 +74,10 @@ async function fGenericIndexedTypeForPromiseOfKProp<TObj extends Obj, K extends 
 async function fGenericIndexedTypeForExplicitPromiseOfKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<TObj[K]> {
     return Promise.resolve<TObj[K]>(obj[key]);
 }
+
+// #27711
+
+async function fGeneric<T>(x: T) {
+    return x;
+}
+const expected: Promise<string> = fGeneric(undefined as Promise<string>);

--- a/tests/cases/compiler/asyncFunctionReturnType.ts
+++ b/tests/cases/compiler/asyncFunctionReturnType.ts
@@ -63,7 +63,7 @@ async function fGenericIndexedTypeForExplicitPromiseOfAnyProp<TObj extends Obj>(
     return Promise.resolve<TObj["anyProp"]>(obj.anyProp);
 }
 
-async function fGenericIndexedTypeForKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<TObj[K]> {
+async function fGenericIndexedTypeForKProp<TObj extends Obj, K extends keyof TObj>(obj: TObj, key: K): Promise<Awaited<TObj[K]>> {
     return obj[key];
 }
 

--- a/tests/cases/compiler/promiseType.ts
+++ b/tests/cases/compiler/promiseType.ts
@@ -217,3 +217,5 @@ const pc6 = p.then(() => Promise.reject("1"), () => {});
 const pc7 = p.then(() => Promise.reject("1"), () => {throw 1});
 const pc8 = p.then(() => Promise.reject("1"), () => Promise.resolve(1));
 const pc9 = p.then(() => Promise.reject("1"), () => Promise.reject(1));
+
+const expected: undefined = undefined as Awaited<undefined>;

--- a/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
@@ -60,7 +60,6 @@ let y21 = nonpartial(x21);
 declare let x22: { a: number | undefined, b?: string[] };
 let y22 = nonpartial(x22);
 
-type Awaited<T> = T extends PromiseLike<infer U> ? U : T;
 type Awaitified<T> = { [P in keyof T]: Awaited<T[P]> };
 
 declare function all<T extends any[]>(...values: T): Promise<Awaitified<T>>;


### PR DESCRIPTION
```TypeScript
async function f<T>(x: T) {
    return x;
}
const expected: Promise<number> = f(undefined as Promise<number>);
```

### Before

```
!!! error TS2322: Type 'Promise<Promise<number>>' is not assignable to type 'Promise<number>'.
!!! error TS2322:   Type 'Promise<number>' is not assignable to type 'number'.
```

### After

`getAwaitedType()` returns the awaited type if it's known, or `Awaited<T>` if it's generic.

Fixes #27711

This proposal excludes [non-A+ promises](https://promisesaplus.com), which has the benefit of not requiring a [recursive solution](https://github.com/microsoft/TypeScript/pull/35998) or a new kind of type, since an A+ promise can't resolve to another promise.

@typescript-bot test this
@typescript-bot run dt
@typescript-bot user test this