### PR TITLE
Actually use the more complete update function in visitEachChild

### DIFF
--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -702,8 +702,9 @@ namespace ts {
                     visitNode((<TryStatement>node).finallyBlock, visitor, isBlock));
 
             case SyntaxKind.VariableDeclaration:
-                return updateVariableDeclaration(<VariableDeclaration>node,
+                return updateTypeScriptVariableDeclaration(<VariableDeclaration>node,
                     visitNode((<VariableDeclaration>node).name, visitor, isBindingName),
+                    visitNode((<VariableDeclaration>node).exclamationToken, tokenVisitor, isToken),
                     visitNode((<VariableDeclaration>node).type, visitor, isTypeNode),
                     visitNode((<VariableDeclaration>node).initializer, visitor, isExpression));
 

--- a/src/testRunner/unittests/transform.ts
+++ b/src/testRunner/unittests/transform.ts
@@ -97,6 +97,17 @@ namespace ts {
             ]);
         });
 
+        testBaseline("transformDefiniteAssignmentAssertions", () => {
+            return transformSourceFile(`let a!: () => void`, [
+                context => file => visitNode(file, function visitor(node: Node): VisitResult<Node> {
+                    if (node.kind === SyntaxKind.VoidKeyword) {
+                        return createIdentifier("undefined");
+                    }
+                    return visitEachChild(node, visitor, context);
+                })
+            ]);
+        });
+
         testBaseline("fromTranspileModule", () => {
             return transpileModule(`var oldName = undefined;`, {
                 transformers: {

--- a/tests/baselines/reference/transformApi/transformsCorrectly.transformDefiniteAssignmentAssertions.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.transformDefiniteAssignmentAssertions.js
@@ -1,0 +1,1 @@
+let a!: () => undefined;


### PR DESCRIPTION
#35270 was slightly incomplete - it made individual `update` functions work, but because I forgot to update `visitEachChild`, the assignment assertion token would fail to percolate up a transformed tree.
