### PR TITLE
loading attribute for iframe and img tags

### DIFF
--- a/tests/lib/react16.d.ts
+++ b/tests/lib/react16.d.ts
@@ -1511,6 +1511,7 @@ declare module "react" {
             allowFullScreen?: boolean;
             allowTransparency?: boolean;
             frameBorder?: number | string;
+            loading?: "lazy" | "eager" | "auto";
             height?: number | string;
             marginHeight?: number;
             marginWidth?: number;
@@ -1527,6 +1528,7 @@ declare module "react" {
             alt?: string;
             crossOrigin?: "anonymous" | "use-credentials" | "";
             decoding?: "async" | "auto" | "sync";
+            loading?: "lazy" | "eager" | "auto";
             height?: number | string;
             sizes?: string;
             src?: string;


### PR DESCRIPTION
Hi, I have noticed there is a missing attribute type for `img` and `iframe` tags for react. This is a relatively new feature yet it already [has support](https://caniuse.com/#feat=loading-lazy-attr) in major chromium based browsers. As of right now one has to use `@ts-ignore` or other trickery to use this attribute. It would be nice to have this built in, specially since the attribute is optional.

There is also a [blog post](https://addyosmani.com/blog/lazy-loading/) by Addy Osmani on this topic.