### PR TITLE
Add package-lock.json files to user tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,6 @@ internal/
 yarn.lock
 yarn-error.log
 .parallelperf.*
-tests/cases/user/*/package-lock.json
 tests/cases/user/*/node_modules/
 tests/cases/user/*/**/*.js
 tests/cases/user/*/**/*.js.map
@@ -83,7 +82,7 @@ tests/cases/user/*/**/*.d.ts
 tests/baselines/reference/dt
 .failed-tests
 TEST-results.xml
-package-lock.json
+/package-lock.json
 tests/cases/user/TypeScript-React-Starter/TypeScript-React-Starter
 tests/cases/user/TypeScript-Node-Starter/TypeScript-Node-Starter
 tests/cases/user/TypeScript-React-Native-Starter/TypeScript-React-Native-Starter

--- a/src/testRunner/externalCompileRunner.ts
+++ b/src/testRunner/externalCompileRunner.ts
@@ -69,7 +69,7 @@ namespace Harness {
                         cwd = config.path ? path.join(cwd, config.path) : submoduleDir;
                     }
                     if (fs.existsSync(path.join(cwd, "package.json"))) {
-                        if (fs.existsSync(path.join(cwd, "package-lock.json"))) {
+                        if (!process.env.SOURCE_ISSUE && fs.existsSync(path.join(cwd, "package-lock.json"))) {
                             fs.unlinkSync(path.join(cwd, "package-lock.json"));
                         }
                         if (fs.existsSync(path.join(cwd, "node_modules"))) {


### PR DESCRIPTION
Try to use the same package versions that resulted in the baselines. Update the package versions in rolling builds and reuse them in triggered PR associated builds.