### PR TITLE
Fix `getTypeFromJSDocValueReference`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10840,7 +10840,8 @@ namespace ts {
                     isRequireAlias = isCallExpression(expr) && isRequireCall(expr, /*requireStringLiteralLikeArgument*/ true) && !!valueType.symbol;
                 }
                 const isImportTypeWithQualifier = node.kind === SyntaxKind.ImportType && (node as ImportTypeNode).qualifier;
-                if (isRequireAlias || isImportTypeWithQualifier) {
+                // valueType might not have a symbol, eg, {import('./b').STRING_LITERAL}
+                if (valueType.symbol && (isRequireAlias || isImportTypeWithQualifier)) {
                     typeType = getTypeReferenceType(node, valueType.symbol);
                 }
             }

--- a/tests/baselines/reference/jsdocImportTypeReferenceToStringLiteral.symbols
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToStringLiteral.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/jsdoc/b.js ===
+export const FOO = "foo";
+>FOO : Symbol(FOO, Decl(b.js, 0, 12))
+
+=== tests/cases/conformance/jsdoc/a.js ===
+/** @type {import('./b').FOO} */
+let x;
+>x : Symbol(x, Decl(a.js, 1, 3))
+

--- a/tests/baselines/reference/jsdocImportTypeReferenceToStringLiteral.types
+++ b/tests/baselines/reference/jsdocImportTypeReferenceToStringLiteral.types
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/jsdoc/b.js ===
+export const FOO = "foo";
+>FOO : "foo"
+>"foo" : "foo"
+
+=== tests/cases/conformance/jsdoc/a.js ===
+/** @type {import('./b').FOO} */
+let x;
+>x : "foo"
+

--- a/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToStringLiteral.ts
+++ b/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToStringLiteral.ts
@@ -1,0 +1,9 @@
+// @noEmit: true
+// @allowJs: true
+// @checkJs: true
+// @Filename: b.js
+export const FOO = "foo";
+
+// @Filename: a.js
+/** @type {import('./b').FOO} */
+let x;


### PR DESCRIPTION
When using `{import('./b').FOO}` which is defined as a string literal,
`valueType` doesn't have a `symbol`.

This was exposed in 8223c0752.

Fixes #34869.
