### PR TITLE
[FIX] empty-import for the correct operation of intellisense in VScode

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -117,7 +117,7 @@ namespace ts.Completions {
                     // If the symbol/moduleSymbol was a merged symbol, it will have a new identity
                     // in the checker, even though the symbols to merge are the same (guaranteed by
                     // cache invalidation in synchronizeHostData).
-                    if (suggestion.symbol.declarations) {
+                    if (suggestion.symbol.declarations && suggestion.symbol.declarations[0]) {
                         suggestion.symbol = checker.getMergedSymbol(suggestion.origin.isDefaultExport
                             ? suggestion.symbol.declarations[0].localSymbol || suggestion.symbol.declarations[0].symbol
                             : suggestion.symbol.declarations[0].symbol);


### PR DESCRIPTION
Important libraries like firebase for the web have bad practices like `export = undefined` which blocks intellisense and autocomplete in VS code

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #

- Fix Empty arrays symbol declarations