### PR TITLE
Update issue config.yml to redirect website/playground issues to the website repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,3 +6,6 @@ contact_links:
   - name: TypeScript FAQ
     url: https://github.com/microsoft/TypeScript/wiki/FAQ
     about: Please check the FAQ before filing new issues
+- name: Website
+    url: https://github.com/microsoft/TypeScript-Website/issues/new
+    about: Please raise issues about the site on it's own repo.


### PR DESCRIPTION
This is mainly so I can keep on top of them, I've been moving them manually, but I don't want people to feel like they did something wrong because I did that.