### PR TITLE
Remove redundant checker functions and use patterns more friendly to modules

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -546,7 +546,6 @@ namespace ts {
             getNeverType: () => neverType,
             getOptionalType: () => optionalType,
             isSymbolAccessible,
-            getObjectFlags,
             isArrayType,
             isTupleType,
             isArrayLikeType,

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -336,6 +336,7 @@ namespace ts {
                 emitSkipped = true;
                 return;
             }
+            const version = ts.version; // Extracted into a const so the form is stable between namespace and module
             writeFile(host, emitterDiagnostics, buildInfoPath, getBuildInfoText({ bundle, program, version }), /*writeByteOrderMark*/ false);
         }
 

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -383,6 +383,11 @@ namespace ts {
     export let sysLog: (s: string) => void = noop; // eslint-disable-line prefer-const
 
     /*@internal*/
+    export function setSysLog(logger: typeof sysLog) {
+        sysLog = logger;
+    }
+
+    /*@internal*/
     export interface RecursiveDirectoryWatcherHost {
         watchDirectory: HostWatchDirectory;
         useCaseSensitiveFileNames: boolean;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3473,7 +3473,6 @@ namespace ts {
         /* @internal */ isArrayType(type: Type): boolean;
         /* @internal */ isTupleType(type: Type): boolean;
         /* @internal */ isArrayLikeType(type: Type): boolean;
-        /* @internal */ getObjectFlags(type: Type): ObjectFlags;
 
         /**
          * True if `contextualType` should not be considered for completions because

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4964,6 +4964,11 @@ namespace ts {
 
     export let localizedDiagnosticMessages: MapLike<string> | undefined;
 
+    /* @internal */
+    export function setLocalizedDiagnosticMessages(messages: typeof localizedDiagnosticMessages) {
+        localizedDiagnosticMessages = messages;
+    }
+
     export function getLocaleSpecificMessage(message: DiagnosticMessage) {
         return localizedDiagnosticMessages && localizedDiagnosticMessages[message.key] || message.message;
     }

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -371,7 +371,7 @@ namespace ts {
             }
             try {
                 // this is a global mutation (or live binding update)!
-                localizedDiagnosticMessages = JSON.parse(fileContents!);
+                setLocalizedDiagnosticMessages(JSON.parse(fileContents!));
             }
             catch {
                 if (errors) {

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -370,9 +370,8 @@ namespace ts {
                 return false;
             }
             try {
-                // making clear this is a global mutation!
-                // eslint-disable-next-line @typescript-eslint/no-unnecessary-qualifier
-                ts.localizedDiagnosticMessages = JSON.parse(fileContents!);
+                // this is a global mutation (or live binding update)!
+                localizedDiagnosticMessages = JSON.parse(fileContents!);
             }
             catch {
                 if (errors) {

--- a/src/compiler/watchUtilities.ts
+++ b/src/compiler/watchUtilities.ts
@@ -371,7 +371,7 @@ namespace ts {
         const createFilePathWatcher: CreateFileWatcher<WatchFileHost, PollingInterval, FileWatcherEventKind, Path, X, Y> = watchLogLevel === WatchLogLevel.None ? watchFilePath : createFileWatcher;
         const createDirectoryWatcher: CreateFileWatcher<WatchDirectoryHost, WatchDirectoryFlags, undefined, never, X, Y> = getCreateFileWatcher(watchLogLevel, watchDirectory);
         if (watchLogLevel === WatchLogLevel.Verbose && sysLog === noop) {
-            sysLog = s => log(s);
+            setSysLog(s => log(s));
         }
         return {
             watchFile: (host, file, callback, pollingInterval, detailInfo1, detailInfo2) =>

--- a/src/jsTyping/shared.ts
+++ b/src/jsTyping/shared.ts
@@ -1,13 +1,27 @@
-/* @internal */
 namespace ts.server {
+    export type ActionSet = "action::set";
+    export type ActionInvalidate = "action::invalidate";
+    export type ActionPackageInstalled = "action::packageInstalled";
+    export type EventTypesRegistry = "event::typesRegistry";
+    export type EventBeginInstallTypes = "event::beginInstallTypes";
+    export type EventEndInstallTypes = "event::endInstallTypes";
+    export type EventInitializationFailed = "event::initializationFailed";
+    /* @internal */
     export const ActionSet: ActionSet = "action::set";
+    /* @internal */
     export const ActionInvalidate: ActionInvalidate = "action::invalidate";
+    /* @internal */
     export const ActionPackageInstalled: ActionPackageInstalled = "action::packageInstalled";
+    /* @internal */
     export const EventTypesRegistry: EventTypesRegistry = "event::typesRegistry";
+    /* @internal */
     export const EventBeginInstallTypes: EventBeginInstallTypes = "event::beginInstallTypes";
+    /* @internal */
     export const EventEndInstallTypes: EventEndInstallTypes = "event::endInstallTypes";
+    /* @internal */
     export const EventInitializationFailed: EventInitializationFailed = "event::initializationFailed";
-
+    
+    /* @internal */
     export namespace Arguments {
         export const GlobalCacheLocation = "--globalTypingsCacheLocation";
         export const LogFile = "--logFile";
@@ -26,10 +40,12 @@ namespace ts.server {
         export const ValidateDefaultNpmLocation = "--validateDefaultNpmLocation";
     }
 
+    /* @internal */
     export function hasArgument(argumentName: string) {
         return sys.args.indexOf(argumentName) >= 0;
     }
 
+    /* @internal */
     export function findArgument(argumentName: string): string | undefined {
         const index = sys.args.indexOf(argumentName);
         return index >= 0 && index < sys.args.length - 1
@@ -37,6 +53,7 @@ namespace ts.server {
             : undefined;
     }
 
+    /* @internal */
     export function nowString() {
         // E.g. "12:34:56.789"
         const d = new Date();

--- a/src/jsTyping/shared.ts
+++ b/src/jsTyping/shared.ts
@@ -20,7 +20,7 @@ namespace ts.server {
     export const EventEndInstallTypes: EventEndInstallTypes = "event::endInstallTypes";
     /* @internal */
     export const EventInitializationFailed: EventInitializationFailed = "event::initializationFailed";
-    
+
     /* @internal */
     export namespace Arguments {
         export const GlobalCacheLocation = "--globalTypingsCacheLocation";

--- a/src/jsTyping/types.ts
+++ b/src/jsTyping/types.ts
@@ -1,12 +1,4 @@
 declare namespace ts.server {
-    export type ActionSet = "action::set";
-    export type ActionInvalidate = "action::invalidate";
-    export type ActionPackageInstalled = "action::packageInstalled";
-    export type EventTypesRegistry = "event::typesRegistry";
-    export type EventBeginInstallTypes = "event::beginInstallTypes";
-    export type EventEndInstallTypes = "event::endInstallTypes";
-    export type EventInitializationFailed = "event::initializationFailed";
-
     export interface TypingInstallerResponse {
         readonly kind: ActionSet | ActionInvalidate | EventTypesRegistry | ActionPackageInstalled | EventBeginInstallTypes | EventEndInstallTypes | EventInitializationFailed;
     }

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -899,13 +899,13 @@ namespace ts.codefix {
                     low: t => !!(t.flags & (TypeFlags.Any | TypeFlags.Void))
                 },
                 {
-                    high: t => !(t.flags & (TypeFlags.Nullable | TypeFlags.Any | TypeFlags.Void)) && !(checker.getObjectFlags(t) & ObjectFlags.Anonymous),
-                    low: t => !!(checker.getObjectFlags(t) & ObjectFlags.Anonymous)
+                    high: t => !(t.flags & (TypeFlags.Nullable | TypeFlags.Any | TypeFlags.Void)) && !(getObjectFlags(t) & ObjectFlags.Anonymous),
+                    low: t => !!(getObjectFlags(t) & ObjectFlags.Anonymous)
                 }];
             let good = removeLowPriorityInferences(inferences, priorities);
-            const anons = good.filter(i => checker.getObjectFlags(i) & ObjectFlags.Anonymous) as AnonymousType[];
+            const anons = good.filter(i => getObjectFlags(i) & ObjectFlags.Anonymous) as AnonymousType[];
             if (anons.length) {
-                good = good.filter(i => !(checker.getObjectFlags(i) & ObjectFlags.Anonymous));
+                good = good.filter(i => !(getObjectFlags(i) & ObjectFlags.Anonymous));
                 good.push(combineAnonymousTypes(anons));
             }
             return checker.getWidenedType(checker.getUnionType(good.map(checker.getBaseTypeOfLiteralType), UnionReduction.Subtype));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1145,7 +1145,7 @@ namespace ts {
         const currentDirectory = host.getCurrentDirectory();
         // Check if the localized messages json is set, otherwise query the host for it
         if (!localizedDiagnosticMessages && host.getLocalizedDiagnosticMessages) {
-            localizedDiagnosticMessages = host.getLocalizedDiagnosticMessages();
+            setLocalizedDiagnosticMessages(host.getLocalizedDiagnosticMessages());
         }
 
         function log(message: string) {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -4783,6 +4783,8 @@ declare namespace ts.server {
     type EventBeginInstallTypes = "event::beginInstallTypes";
     type EventEndInstallTypes = "event::endInstallTypes";
     type EventInitializationFailed = "event::initializationFailed";
+}
+declare namespace ts.server {
     interface TypingInstallerResponse {
         readonly kind: ActionSet | ActionInvalidate | EventTypesRegistry | ActionPackageInstalled | EventBeginInstallTypes | EventEndInstallTypes | EventInitializationFailed;
     }

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -4783,6 +4783,8 @@ declare namespace ts.server {
     type EventBeginInstallTypes = "event::beginInstallTypes";
     type EventEndInstallTypes = "event::endInstallTypes";
     type EventInitializationFailed = "event::initializationFailed";
+}
+declare namespace ts.server {
     interface TypingInstallerResponse {
         readonly kind: ActionSet | ActionInvalidate | EventTypesRegistry | ActionPackageInstalled | EventBeginInstallTypes | EventEndInstallTypes | EventInitializationFailed;
     }


### PR DESCRIPTION
So there's a couple small things bundled in here:

1. `getObjectFlags` on checker was redundant. There's a `ts.getObjectFlags` that it was just a copy of. So it's gone now.
2. A shorthand reference to a namespace variable is kind of a pain to track and transform - fortunately we don't do it often, so it's easier to just change the one instance of it in our codebase (after `checker.getObjectFlags` is removed) to use a local variable.
3. (Module) Namespace members are not writable, though they are mutable - this means we can't actually assign to a namespace member, but we _can_ can assign to the variable backing that namespace member and see it update. Two instances of this were changed. The assignments were in a separate file, so we had to introduce a helper function to perform the actual set.

Do note that I'm just opening PRs to fix/work around these things as they come up while I'm working on the module transition, and I figured it's much easier to review them in little bits like this, before the big switch over, assuming the new code still works both before and after the change.