### PR TITLE
Adds puppeteer to test whether typescript.js runs in the browser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,6 @@ jobs:
         npm install
         npm update
         npm test
+    - name: Validate the browser can import TypeScript
+      run: gulp test-browser-integration
+    

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -481,6 +481,11 @@ task("runtests-parallel").flags = {
     "   --shardId": "1-based ID of this shard (default: 1)",
 };
 
+
+task("test-browser-integration", () => exec(process.execPath, ["scripts/puppeteerIntegrationTest.js"]));
+task("test-browser-integration").description = "Runs scripts/configurePrerelease.ts to prepare a build for insiders publishing";
+
+
 task("diff", () => exec(getDiffTool(), [refBaseline, localBaseline], { ignoreExitCode: true, waitForExit: false }));
 task("diff").description = "Diffs the compiler baselines using the diff tool specified by the 'DIFF' environment variable";
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -482,8 +482,8 @@ task("runtests-parallel").flags = {
 };
 
 
-task("test-browser-integration", () => exec(process.execPath, ["scripts/puppeteerIntegrationTest.js"]));
-task("test-browser-integration").description = "Runs scripts/configurePrerelease.ts to prepare a build for insiders publishing";
+task("test-browser-integration", () => exec(process.execPath, ["scripts/browserIntegrationTest.js"]));
+task("test-browser-integration").description = "Runs scripts/browserIntegrationTest.ts which tests that typescript.js loads in a browser";
 
 
 task("diff", () => exec(getDiffTool(), [refBaseline, localBaseline], { ignoreExitCode: true, waitForExit: false }));

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
         "through2": "latest",
         "travis-fold": "latest",
         "typescript": "next",
+        "puppeteer": "latest",
         "vinyl": "latest",
         "vinyl-sourcemaps-apply": "latest",
         "xml2js": "^0.4.19"

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "through2": "latest",
         "travis-fold": "latest",
         "typescript": "next",
-        "puppeteer": "latest",
+        "playwright": "latest",
         "vinyl": "latest",
         "vinyl-sourcemaps-apply": "latest",
         "xml2js": "^0.4.19"

--- a/scripts/browserIntegrationTest.js
+++ b/scripts/browserIntegrationTest.js
@@ -1,4 +1,4 @@
-const puppeteer = require("puppeteer");
+const playwright = require("playwright");
 const chalk = require("chalk");
 const { join } = require("path");
 const { readFileSync } = require("fs");
@@ -8,11 +8,13 @@ const { readFileSync } = require("fs");
 const debugging = false;
 
 (async () => {
-    const browser = await puppeteer.launch({ headless: !debugging });
-    const page = await browser.newPage();
+  for (const browserType of ["chromium", "firefox", "webkit"]) {
+    const browser = await playwright[browserType].launch({ headless: !debugging });
+    const context = await browser.newContext();
+    const page = await context.newPage();
 
     const errorCaught = err => {
-        console.error(chalk.red("There was an error running built/typescript.js in a browser"));
+        console.error(chalk.red("There was an error running built/typescript.js in " + browserType));
         console.log(err.toString());
         process.exitCode = 1;
     };
@@ -33,4 +35,5 @@ const debugging = false;
     else {
         console.log("Not closing the browser, you'll need to exit the process in your terminal manually");
     }
+  }
 })();

--- a/scripts/puppeteerIntegrationTest.js
+++ b/scripts/puppeteerIntegrationTest.js
@@ -1,0 +1,36 @@
+const puppeteer = require("puppeteer");
+const chalk = require("chalk");
+const { join } = require("path");
+const { readFileSync } = require("fs");
+
+// Turning this on will leave the Chromium browser open, giving you the
+// chance to open up the web inspector.
+const debugging = false;
+
+(async () => {
+    const browser = await puppeteer.launch({ headless: !debugging });
+    const page = await browser.newPage();
+
+    const errorCaught = err => {
+        console.error(chalk.red("There was an error running built/typescript.js in a browser"));
+        console.log(err.toString());
+        process.exitCode = 1;
+    };
+
+    page.on("error", errorCaught);
+    page.on("pageerror", errorCaught);
+    page.on("console", log => console[log._type](log._text));
+
+    await page.setContent(`
+    <html>
+    <script>${readFileSync(join("built", "local", "typescript.js"), "utf8")}</script>
+    </html>
+    `);
+
+    if (!debugging) {
+        await browser.close();
+    }
+    else {
+        console.log("Not closing the browser, you'll need to exit the process in your terminal manually");
+    }
+})();


### PR DESCRIPTION
Makes it feasible to test for bugs like #35469 

It does this by using the [puppeteer](https://pptr.dev) to run the JS inside a headless copy of chromium. 

It's not on CI, but it fails correctly:

/cc @dsherret 

![Screen Shot 2019-12-03 at 12 41 43 PM](https://user-images.githubusercontent.com/49038/70075210-4a290200-15ca-11ea-8413-7a6d47e2d18b.png)
