### PR TITLE
Add nested global member creation to shim

### DIFF
--- a/src/services/globalThisShim.ts
+++ b/src/services/globalThisShim.ts
@@ -39,6 +39,11 @@
 // @ts-ignore
 if (typeof process === "undefined" || process.browser) {
     /// TODO: this is used by VS, clean this up on both sides of the interface
+
+    //@ts-ignore
+    globalThis.TypeScript = globalThis.TypeScript || {};
+    //@ts-ignore
+    globalThis.TypeScript.Services = globalThis.TypeScript.Services || {};
     //@ts-ignore
     globalThis.TypeScript.Services.TypeScriptServicesFactory = ts.TypeScriptServicesFactory;
 


### PR DESCRIPTION
Since literally nowhere else do we reference a `TypeScript` namespace anymore, it wasn't getting made.

Fixes #35469
