### PR TITLE
Use namespace import for esnext when esModuleInterop is off

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -455,8 +455,8 @@ namespace ts.codefix {
     }
 
     function getExportEqualsImportKind(importingFile: SourceFile, compilerOptions: CompilerOptions, checker: TypeChecker): ImportKind {
-        if (getAllowSyntheticDefaultImports(compilerOptions) && getEmitModuleKind(compilerOptions) >= ModuleKind.ES2015) {
-            return ImportKind.Default;
+        if (getEmitModuleKind(compilerOptions) >= ModuleKind.ES2015) {
+            return getAllowSyntheticDefaultImports(compilerOptions) ? ImportKind.Default : ImportKind.Namespace;
         }
         if (isInJSFile(importingFile)) {
             return isExternalModule(importingFile) ? ImportKind.Default : ImportKind.ConstEquals;

--- a/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESNextInteropOff.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportExportEqualsESNextInteropOff.ts
@@ -12,6 +12,6 @@
 ////foo
 
 goTo.file('/index.ts');
-verify.importFixAtPosition([`import foo = require("foo");
+verify.importFixAtPosition([`import * as foo from "foo";
 
 foo`]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #29038 (more/again)
