### PR TITLE
Remove unneeded Array and Promise JS rewrites

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10921,10 +10921,8 @@ namespace ts {
                     case "function":
                         checkNoTypeArguments(node);
                         return globalFunctionType;
-                    case "Array":
                     case "array":
                         return (!typeArgs || !typeArgs.length) && !noImplicitAny ? anyArrayType : undefined;
-                    case "Promise":
                     case "promise":
                         return (!typeArgs || !typeArgs.length) && !noImplicitAny ? createPromiseType(anyType) : undefined;
                     case "Object":


### PR DESCRIPTION
Type-argument defaulting is handled elsewhere in the compiler. This is a small drive-by improvement, so I didn't change the handling of 'array' or 'promise'; they still manually create `any[]` and `Promise<any>`, respectively.