### PR TITLE
Don’t auto-import undefined

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -854,9 +854,9 @@ namespace FourSlash {
                 }
             }
 
-            assert.equal(actual.hasAction, hasAction);
-            assert.equal(actual.isRecommended, isRecommended);
-            assert.equal(actual.source, source);
+            assert.equal(actual.hasAction, hasAction, `Expected 'hasAction' value '${actual.hasAction}' to equal '${hasAction}'`);
+            assert.equal(actual.isRecommended, isRecommended, `Expected 'isRecommended' value '${actual.source}' to equal '${isRecommended}'`);
+            assert.equal(actual.source, source, `Expected 'source' value '${actual.source}' to equal '${source}'`);
             assert.equal(actual.sortText, sortText || ts.Completions.SortText.LocationPriority, this.messageAtLastKnownMarker(`Actual entry: ${JSON.stringify(actual)}`));
 
             if (text !== undefined) {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -117,12 +117,12 @@ namespace ts.Completions {
                     // If the symbol/moduleSymbol was a merged symbol, it will have a new identity
                     // in the checker, even though the symbols to merge are the same (guaranteed by
                     // cache invalidation in synchronizeHostData).
-                    if (suggestion.symbol.declarations) {
+                    if (suggestion.symbol.declarations?.length) {
                         suggestion.symbol = checker.getMergedSymbol(suggestion.origin.isDefaultExport
-                            ? suggestion.symbol.declarations[0].localSymbol || suggestion.symbol.declarations[0].symbol
+                            ? suggestion.symbol.declarations[0].localSymbol ?? suggestion.symbol.declarations[0].symbol
                             : suggestion.symbol.declarations[0].symbol);
                     }
-                    if (suggestion.origin.moduleSymbol.declarations) {
+                    if (suggestion.origin.moduleSymbol.declarations?.length) {
                         suggestion.origin.moduleSymbol = checker.getMergedSymbol(suggestion.origin.moduleSymbol.declarations[0].symbol);
                     }
                 });
@@ -1623,6 +1623,9 @@ namespace ts.Completions {
                 const isDefaultExport = symbol.escapedName === InternalSymbolName.Default;
                 if (isDefaultExport) {
                     symbol = getLocalSymbolForExportDefault(symbol) || symbol;
+                }
+                if (typeChecker.isUndefinedSymbol(symbol)) {
+                    return;
                 }
                 addToSeen(resultSymbolIds, getSymbolId(symbol));
                 const origin: SymbolOriginInfoExport = { kind: SymbolOriginInfoKind.Export, moduleSymbol, isDefaultExport };

--- a/tests/cases/fourslash/server/importSuggestionsCache_exportUndefined.ts
+++ b/tests/cases/fourslash/server/importSuggestionsCache_exportUndefined.ts
@@ -1,0 +1,43 @@
+/// <reference path="../fourslash.ts" />
+
+// @Filename: /tsconfig.json
+////{ "compilerOptions": { "module": "esnext" } }
+
+// @Filename: /undefined.ts
+////export = undefined;
+
+// @Filename: /undefinedAlias.ts
+////const x = undefined;
+////export = x;
+
+// @Filename: /index.ts
+//// /**/
+
+// Would throw error if undefined appears twice
+goTo.marker("");
+verify.completions({
+  includes: [{
+    name: "x",
+     hasAction: true,
+     sortText: completion.SortText.AutoImportSuggestions,
+     source: "/undefinedAlias"
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true
+  }
+});
+
+// Do it again for cache test
+verify.completions({
+  includes: [{
+    name: "x",
+     hasAction: true,
+     sortText: completion.SortText.AutoImportSuggestions,
+     source: "/undefinedAlias"
+  }],
+  preferences: {
+    includeCompletionsForModuleExports: true,
+    includeInsertTextCompletions: true
+  }
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #35458 

An external module that exports `undefined` caused some code added in #32517 to crash. It turns out I was unable to actually reproduce that exact crash in a failing test because the test harness throws immediately upon discovering multiple completions for `undefined`, which is pretty fair, so I 
now filter `undefined` from being considered as an auto-import altogether.