### PR TITLE
Shrink Size of Contributing.md, re #34785

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,49 +1,6 @@
-# Instructions for Logging Issues
+# Creating Issues
 
-## 1. Read the FAQ
-
-Please [read the FAQ](https://github.com/Microsoft/TypeScript/wiki/FAQ) before logging new issues, even if you think you have found a bug.
-
-Issues that ask questions answered in the FAQ will be closed without elaboration.
-
-## 2. Search for Duplicates
-
-[Search the existing issues](https://github.com/Microsoft/TypeScript/search?type=Issues) before logging a new one.
-
-Some search tips:
- * *Don't* restrict your search to only open issues. An issue with a title similar to yours may have been closed as a duplicate of one with a less-findable title.
- * Check for synonyms. For example, if your bug involves an interface, it likely also occurs with type aliases or classes.
- * Search for the title of the issue you're about to log. This sounds obvious but 80% of the time this is sufficient to find a duplicate when one exists.
- * Read more than the first page of results. Many bugs here use the same words so relevancy sorting is not particularly strong.
- * If you have a crash, search for the first few topmost function names shown in the call stack.
-
-## 3. Do you have a question?
-
-The issue tracker is for **issues**, in other words, bugs and suggestions.
-If you have a *question*, please use [Stack Overflow](http://stackoverflow.com/questions/tagged/typescript), [Gitter](https://gitter.im/Microsoft/TypeScript), your favorite search engine, or other resources.
-Due to increased traffic, we can no longer answer questions in the issue tracker.
-
-## 4. Did you find a bug?
-
-When logging a bug, please be sure to include the following:
- * What version of TypeScript you're using (run `tsc --v`)
- * If at all possible, an *isolated* way to reproduce the behavior
- * The behavior you expect to see, and the actual behavior
-
-You can try out the nightly build of TypeScript (`npm install typescript@next`) to see if the bug has already been fixed.
-
-## 5. Do you have a suggestion?
-
-We also accept suggestions in the issue tracker.
-Be sure to [check the FAQ](https://github.com/Microsoft/TypeScript/wiki/FAQ) and [search](https://github.com/Microsoft/TypeScript/issues?utf8=%E2%9C%93&q=is%3Aissue) first.
-
-In general, things we find useful when reviewing suggestions are:
-* A description of the problem you're trying to solve
-* An overview of the suggested solution
-* Examples of how the suggestion would work in various places
-  * Code examples showing e.g. "this would be an error, this wouldn't"
-  * Code examples showing the generated JavaScript (if applicable)
-* If relevant, precedent in other languages can be useful for establishing context and expected behavior
+Please select an issue category within [New Issue](https://github.com/microsoft/TypeScript/issues/new/choose) and note the instructions after opening the relevant page.
 
 # Instructions for Contributing Code
 
@@ -59,7 +16,7 @@ Run `gulp` to build a version of the compiler/language service that reflects cha
 
 ## Contributing bug fixes
 
-TypeScript is currently accepting contributions in the form of bug fixes. A bug must have an issue tracking it in the issue tracker that has been approved (labelled ["help wanted"](https://github.com/Microsoft/TypeScript/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or in the "Backlog milestone") by the TypeScript team. Your pull request should include a link to the bug that you are fixing. If you've submitted a PR for a bug, please post a comment in the bug to avoid duplication of effort.
+TypeScript is currently accepting contributions in the form of bug fixes. A bug must have an issue tracking it in the issue tracker that has been approved (labelled ["help wanted"](https://github.com/Microsoft/TypeScript/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) or in the [Backlog Milestone](https://github.com/microsoft/TypeScript/issues?q=is%3Aopen+is%3Aissue+milestone%3ABacklog)) by the TypeScript team. Your pull request should include a link to the bug that you are fixing. If you've submitted a PR for a bug, please post a comment in the bug to avoid duplication of effort.
 
 ## Contributing features
 


### PR DESCRIPTION
trivial

* replacing section in contributing.md, as this information is given within the issue-templates
  * could be complemented by introduction of a "help" issue-template, which provides the relevant info (e.g. link to stackoverflow etc.)f
* (not directly relevant) Added the backlog-milestone link

(please feel free to close this PR and just take this as a template to rework the contributing.md)