### PR TITLE
Subtypes of ErrorConstructor extend it

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -966,7 +966,7 @@ declare var Error: ErrorConstructor;
 interface EvalError extends Error {
 }
 
-interface EvalErrorConstructor {
+interface EvalErrorConstructor extends ErrorConstructor {
     new(message?: string): EvalError;
     (message?: string): EvalError;
     readonly prototype: EvalError;
@@ -977,7 +977,7 @@ declare var EvalError: EvalErrorConstructor;
 interface RangeError extends Error {
 }
 
-interface RangeErrorConstructor {
+interface RangeErrorConstructor extends ErrorConstructor {
     new(message?: string): RangeError;
     (message?: string): RangeError;
     readonly prototype: RangeError;
@@ -988,7 +988,7 @@ declare var RangeError: RangeErrorConstructor;
 interface ReferenceError extends Error {
 }
 
-interface ReferenceErrorConstructor {
+interface ReferenceErrorConstructor extends ErrorConstructor {
     new(message?: string): ReferenceError;
     (message?: string): ReferenceError;
     readonly prototype: ReferenceError;
@@ -999,7 +999,7 @@ declare var ReferenceError: ReferenceErrorConstructor;
 interface SyntaxError extends Error {
 }
 
-interface SyntaxErrorConstructor {
+interface SyntaxErrorConstructor extends ErrorConstructor {
     new(message?: string): SyntaxError;
     (message?: string): SyntaxError;
     readonly prototype: SyntaxError;
@@ -1010,7 +1010,7 @@ declare var SyntaxError: SyntaxErrorConstructor;
 interface TypeError extends Error {
 }
 
-interface TypeErrorConstructor {
+interface TypeErrorConstructor extends ErrorConstructor {
     new(message?: string): TypeError;
     (message?: string): TypeError;
     readonly prototype: TypeError;
@@ -1021,7 +1021,7 @@ declare var TypeError: TypeErrorConstructor;
 interface URIError extends Error {
 }
 
-interface URIErrorConstructor {
+interface URIErrorConstructor extends ErrorConstructor {
     new(message?: string): URIError;
     (message?: string): URIError;
     readonly prototype: URIError;

--- a/tests/baselines/reference/errorConstructorSubtypes.js
+++ b/tests/baselines/reference/errorConstructorSubtypes.js
@@ -1,0 +1,18 @@
+//// [errorConstructorSubtypes.ts]
+// In Node, ErrorConstructor is augmented with extra properties. Excerpted below.
+interface ErrorConstructor {
+  captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+}
+
+declare var x: ErrorConstructor
+x = Error; // OK
+x = RangeError;
+new x().message
+x.captureStackTrace
+
+
+//// [errorConstructorSubtypes.js]
+x = Error; // OK
+x = RangeError;
+new x().message;
+x.captureStackTrace;

--- a/tests/baselines/reference/errorConstructorSubtypes.symbols
+++ b/tests/baselines/reference/errorConstructorSubtypes.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/errorConstructorSubtypes.ts ===
+// In Node, ErrorConstructor is augmented with extra properties. Excerpted below.
+interface ErrorConstructor {
+>ErrorConstructor : Symbol(ErrorConstructor, Decl(lib.es5.d.ts, --, --), Decl(errorConstructorSubtypes.ts, 0, 0))
+
+  captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+>captureStackTrace : Symbol(ErrorConstructor.captureStackTrace, Decl(errorConstructorSubtypes.ts, 1, 28))
+>targetObject : Symbol(targetObject, Decl(errorConstructorSubtypes.ts, 2, 20))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>constructorOpt : Symbol(constructorOpt, Decl(errorConstructorSubtypes.ts, 2, 41))
+>Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+}
+
+declare var x: ErrorConstructor
+>x : Symbol(x, Decl(errorConstructorSubtypes.ts, 5, 11))
+>ErrorConstructor : Symbol(ErrorConstructor, Decl(lib.es5.d.ts, --, --), Decl(errorConstructorSubtypes.ts, 0, 0))
+
+x = Error; // OK
+>x : Symbol(x, Decl(errorConstructorSubtypes.ts, 5, 11))
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+x = RangeError;
+>x : Symbol(x, Decl(errorConstructorSubtypes.ts, 5, 11))
+>RangeError : Symbol(RangeError, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+new x().message
+>new x().message : Symbol(Error.message, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(errorConstructorSubtypes.ts, 5, 11))
+>message : Symbol(Error.message, Decl(lib.es5.d.ts, --, --))
+
+x.captureStackTrace
+>x.captureStackTrace : Symbol(ErrorConstructor.captureStackTrace, Decl(errorConstructorSubtypes.ts, 1, 28))
+>x : Symbol(x, Decl(errorConstructorSubtypes.ts, 5, 11))
+>captureStackTrace : Symbol(ErrorConstructor.captureStackTrace, Decl(errorConstructorSubtypes.ts, 1, 28))
+

--- a/tests/baselines/reference/errorConstructorSubtypes.types
+++ b/tests/baselines/reference/errorConstructorSubtypes.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/errorConstructorSubtypes.ts ===
+// In Node, ErrorConstructor is augmented with extra properties. Excerpted below.
+interface ErrorConstructor {
+  captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+>captureStackTrace : (targetObject: Object, constructorOpt?: Function) => void
+>targetObject : Object
+>constructorOpt : Function
+}
+
+declare var x: ErrorConstructor
+>x : ErrorConstructor
+
+x = Error; // OK
+>x = Error : ErrorConstructor
+>x : ErrorConstructor
+>Error : ErrorConstructor
+
+x = RangeError;
+>x = RangeError : RangeErrorConstructor
+>x : ErrorConstructor
+>RangeError : RangeErrorConstructor
+
+new x().message
+>new x().message : string
+>new x() : Error
+>x : ErrorConstructor
+>message : string
+
+x.captureStackTrace
+>x.captureStackTrace : (targetObject: Object, constructorOpt?: Function) => void
+>x : ErrorConstructor
+>captureStackTrace : (targetObject: Object, constructorOpt?: Function) => void
+

--- a/tests/cases/compiler/errorConstructorSubtypes.ts
+++ b/tests/cases/compiler/errorConstructorSubtypes.ts
@@ -1,0 +1,11 @@
+// @lib: es5,dom
+// In Node, ErrorConstructor is augmented with extra properties. Excerpted below.
+interface ErrorConstructor {
+  captureStackTrace(targetObject: Object, constructorOpt?: Function): void;
+}
+
+declare var x: ErrorConstructor
+x = Error; // OK
+x = RangeError;
+new x().message
+x.captureStackTrace


### PR DESCRIPTION
Previously subtypes of Error extended Error, but the matching subtypes of ErrorConstructor did not extend ErrorConstructor. The members in es5.d.ts are identical, so there's no need except for allowing interface merging into ErrorConstructor to affect subtypes as well.

Fixes #29943
