### PR TITLE
Fix spelling codefix for optional chain property access

### DIFF
--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -37,7 +37,10 @@ namespace ts.codefix {
         let suggestion: string | undefined;
         if (isPropertyAccessExpression(node.parent) && node.parent.name === node) {
             Debug.assert(node.kind === SyntaxKind.Identifier, "Expected an identifier for spelling (property access)");
-            const containingType = checker.getTypeAtLocation(node.parent.expression);
+            let containingType = checker.getTypeAtLocation(node.parent.expression);
+            if (node.parent.flags & NodeFlags.OptionalChain) {
+                containingType = checker.getNonNullableType(containingType);
+            }
             suggestion = checker.getSuggestionForNonexistentProperty(node as Identifier, containingType);
         }
         else if (isImportSpecifier(node.parent) && node.parent.name === node) {

--- a/tests/cases/fourslash/codeFixSpelling_optionalChain.ts
+++ b/tests/cases/fourslash/codeFixSpelling_optionalChain.ts
@@ -1,0 +1,13 @@
+/// <reference path="fourslash.ts" />
+
+// @strict: true
+
+////function f(x: string | null) {
+////  [|x?.toLowrCase();|]
+////}
+
+verify.rangeAfterCodeFix(
+  `x?.toLowerCase();`,
+  /*includeWhiteSpace*/ false,
+  /*errorCode*/ undefined,
+  /*index*/ 0);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #34895 
