### PR TITLE
fix(lib/es2015): Fix definition of `ProxyHandler`

### DIFF
--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -1,17 +1,17 @@
 interface ProxyHandler<T extends object> {
-    getPrototypeOf? (target: T): object | null;
-    setPrototypeOf? (target: T, v: any): boolean;
-    isExtensible? (target: T): boolean;
-    preventExtensions? (target: T): boolean;
-    getOwnPropertyDescriptor? (target: T, p: PropertyKey): PropertyDescriptor | undefined;
-    has? (target: T, p: PropertyKey): boolean;
-    get? (target: T, p: PropertyKey, receiver: any): any;
-    set? (target: T, p: PropertyKey, value: any, receiver: any): boolean;
-    deleteProperty? (target: T, p: PropertyKey): boolean;
-    defineProperty? (target: T, p: PropertyKey, attributes: PropertyDescriptor): boolean;
-    ownKeys? (target: T): PropertyKey[];
-    apply? (target: T, thisArg: any, argArray?: any): any;
-    construct? (target: T, argArray: any, newTarget?: any): object;
+    apply?(target: T, thisArg: any, argArray: any[]): any;
+    construct?(target: T, argArray: any[], newTarget: Function): object;
+    defineProperty?(target: T, p: string | symbol, attributes: PropertyDescriptor): boolean;
+    deleteProperty?(target: T, p: string | symbol): boolean;
+    get?(target: T, p: string | symbol, receiver: any): any;
+    getOwnPropertyDescriptor?(target: T, p: string | symbol): PropertyDescriptor | undefined;
+    getPrototypeOf?(target: T): object | null;
+    has?(target: T, p: string | symbol): boolean;
+    isExtensible?(target: T): boolean;
+    ownKeys?(target: T): ArrayLike<string | symbol>;
+    preventExtensions?(target: T): boolean;
+    set?(target: T, p: string | symbol, value: any, receiver: any): boolean;
+    setPrototypeOf?(target: T, v: object | null): boolean;
 }
 
 interface ProxyConstructor {


### PR DESCRIPTION
This fixes several issues I found while comparing the definition of `ProxyHandler` to [what’s actually defined in the specification](https://tc39.es/ecma262/#sec-proxy-object-internal-methods-and-internal-slots).

## Depends on:
- [x] <https://github.com/microsoft/TypeScript/pull/38967> (merged)
- [x] <https://github.com/microsoft/TypeScript/pull/41987> (merged)