### PR TITLE
Don’t offer import fix for members of arrays or classes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2877,7 +2877,11 @@ namespace ts {
             }
 
             const type = getTypeOfSymbol(exportEquals);
-            return type.flags & TypeFlags.Primitive ? undefined : getPropertyOfType(type, memberName);
+            return type.flags & TypeFlags.Primitive ||
+                getObjectFlags(type) & ObjectFlags.Class ||
+                isArrayOrTupleLikeType(type)
+                ? undefined
+                : getPropertyOfType(type, memberName);
         }
 
         function getExportsOfSymbol(symbol: Symbol): SymbolTable {

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -434,6 +434,10 @@ namespace FourSlashInterface {
             this.state.verifyImportFixAtPosition(expectedTextArray, errorCode, preferences);
         }
 
+        public importFixModuleSpecifiers(marker: string, moduleSpecifiers: string[]) {
+            this.state.verifyImportFixModuleSpecifiers(marker, moduleSpecifiers);
+        }
+
         public navigationBar(json: any, options?: { checkSpans?: boolean }) {
             this.state.verifyNavigationBar(json, options);
         }

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -330,6 +330,7 @@ declare namespace FourSlashInterface {
         fileAfterApplyingRefactorAtMarker(markerName: string, expectedContent: string, refactorNameToApply: string, formattingOptions?: FormatCodeOptions): void;
         getAndApplyCodeFix(errorCode?: number, index?: number): void;
         importFixAtPosition(expectedTextArray: string[], errorCode?: number, options?: UserPreferences): void;
+        importFixModuleSpecifiers(marker: string, moduleSpecifiers: string[]): void;
 
         navigationBar(json: any, options?: { checkSpans?: boolean }): void;
         navigationTree(json: any, options?: { checkSpans?: boolean }): void;

--- a/tests/cases/fourslash/importNameCodeFix_noDestructureNonObjectLiteral.ts
+++ b/tests/cases/fourslash/importNameCodeFix_noDestructureNonObjectLiteral.ts
@@ -1,0 +1,26 @@
+/// <reference path="fourslash.ts" />
+
+// @target: es2015
+// @strict: true
+// @esModuleInterop: true
+
+// @Filename: /array.ts
+////declare const arr: number[];
+////export = arr;
+
+// @Filename: /class-instance-member.ts
+////class C { filter() {} }
+////export = new C();
+
+// @Filename: /class-static-member.ts
+////class C { static filter() {} }
+////export = C;
+
+// @Filename: /object-literal.ts
+////declare function filter(): void;
+////export = { filter };
+
+// @Filename: /index.ts
+////filter/**/
+
+verify.importFixModuleSpecifiers('', ['./object-literal']);

--- a/tests/cases/fourslash/importNameCodeFix_noDestructureNonObjectLiteral.ts
+++ b/tests/cases/fourslash/importNameCodeFix_noDestructureNonObjectLiteral.ts
@@ -12,15 +12,21 @@
 ////class C { filter() {} }
 ////export = new C();
 
-// @Filename: /class-static-member.ts
-////class C { static filter() {} }
-////export = C;
-
 // @Filename: /object-literal.ts
 ////declare function filter(): void;
 ////export = { filter };
 
+// @Filename: /jquery.d.ts
+////interface JQueryStatic {
+////  filter(): void;
+////}
+////declare const $: JQueryStatic;
+////export = $;
+
+// @Filename: /jquery.js
+////module.exports = {};
+
 // @Filename: /index.ts
 ////filter/**/
 
-verify.importFixModuleSpecifiers('', ['./object-literal']);
+verify.importFixModuleSpecifiers('', ['./object-literal', './jquery']);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

When a module `export = ` something with an array or class instance type, this prevents import fixes for its members from showing up, e.g.

```ts
// @Filename: array.ts
export = [0, 1, 2, 3, 4, 5];

// @Filename: index.ts
filter // `import { filter } from './array'` doesn’t make sense!
```

Fixes #35269 
