### PR TITLE
Fix binding of this-assignments w/computed properties

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2694,7 +2694,10 @@ namespace ts {
                     break;
                 case SyntaxKind.SourceFile:
                     // this.property = assignment in a source file -- declare symbol in exports for a module, in locals for a script
-                    if ((thisContainer as SourceFile).commonJsModuleIndicator) {
+                    if (hasDynamicName(node)) {
+                        break;
+                    }
+                    else if ((thisContainer as SourceFile).commonJsModuleIndicator) {
                         declareSymbol(thisContainer.symbol.exports!, thisContainer.symbol, node, SymbolFlags.Property | SymbolFlags.ExportValue, SymbolFlags.None);
                     }
                     else {

--- a/tests/baselines/reference/thisPropertyAssignmentComputed.errors.txt
+++ b/tests/baselines/reference/thisPropertyAssignmentComputed.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/conformance/salsa/thisPropertyAssignmentComputed.js(1,1): error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'typeof globalThis'.
+  No index signature with a parameter of type 'string' was found on type 'typeof globalThis'.
+
+
+==== tests/cases/conformance/salsa/thisPropertyAssignmentComputed.js (1 errors) ====
+    this["a" + "b"] = 0
+    ~~~~~~~~~~~~~~~
+!!! error TS7053: Element implicitly has an 'any' type because expression of type 'string' can't be used to index type 'typeof globalThis'.
+!!! error TS7053:   No index signature with a parameter of type 'string' was found on type 'typeof globalThis'.
+    

--- a/tests/baselines/reference/thisPropertyAssignmentComputed.symbols
+++ b/tests/baselines/reference/thisPropertyAssignmentComputed.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/salsa/thisPropertyAssignmentComputed.js ===
+this["a" + "b"] = 0
+>this : Symbol(globalThis)
+

--- a/tests/baselines/reference/thisPropertyAssignmentComputed.types
+++ b/tests/baselines/reference/thisPropertyAssignmentComputed.types
@@ -1,0 +1,10 @@
+=== tests/cases/conformance/salsa/thisPropertyAssignmentComputed.js ===
+this["a" + "b"] = 0
+>this["a" + "b"] = 0 : 0
+>this["a" + "b"] : any
+>this : typeof globalThis
+>"a" + "b" : string
+>"a" : "a"
+>"b" : "b"
+>0 : 0
+

--- a/tests/cases/conformance/salsa/thisPropertyAssignmentComputed.ts
+++ b/tests/cases/conformance/salsa/thisPropertyAssignmentComputed.ts
@@ -1,0 +1,6 @@
+// @allowjs: true
+// @checkjs: true
+// @noemit: true
+// @strict: true
+// @filename: thisPropertyAssignmentComputed.js
+this["a" + "b"] = 0


### PR DESCRIPTION
Binding of top-level this-assignments forgets to check for computed properties and tries to bind them normally. Then it hits a helpful assert which prevents that.

This change stops binding this-properties with computed properties at the top-level.  There's nothing sensible we could do with them; we're unable to late-bind entries to the global scope or to modules.

Fixes #35630