### PR TITLE
Add `ignoreInterpolations` util to fourslash for fuzzy diagnostic matching

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -3818,16 +3818,6 @@ ${code}
     }
 
     function templateToRegExp(template: string) {
-        const interpolationRegExp = /\{\d+\}/g;
-        let match;
-        let pos = 0;
-        let regExpString = "";
-        while (match = interpolationRegExp.exec(template)) {
-            regExpString += ts.regExpEscape(template.slice(pos, match.index));
-            regExpString += ".*?";
-            pos = match.index + match[0].length;
-        }
-        regExpString += ts.regExpEscape(template.slice(pos));
-        return new RegExp(`^${regExpString}$`);
+        new RegExp(`^${ts.regExpEscape(template).replace(/\\\{d+\\\}/g, ".*?")}$`);
     }
 }

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -138,7 +138,7 @@ namespace FourSlash {
     }
 
     export function ignoreInterpolations(diagnostic: string | ts.DiagnosticMessage): FourSlashInterface.DiagnosticIgnoredInterpolations {
-        return { template: typeof diagnostic === "string" ? diagnostic : diagnostic.message } as FourSlashInterface.DiagnosticIgnoredInterpolations;
+        return { template: typeof diagnostic === "string" ? diagnostic : diagnostic.message };
     }
 
     // This function creates IScriptSnapshot object for testing getPreProcessedFileInfo

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -3818,6 +3818,6 @@ ${code}
     }
 
     function templateToRegExp(template: string) {
-        return new RegExp(`^${ts.regExpEscape(template).replace(/\\\{d+\\\}/g, ".*?")}$`);
+        return new RegExp(`^${ts.regExpEscape(template).replace(/\\\{\d+\\\}/g, ".*?")}$`);
     }
 }

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -3818,6 +3818,6 @@ ${code}
     }
 
     function templateToRegExp(template: string) {
-        new RegExp(`^${ts.regExpEscape(template).replace(/\\\{d+\\\}/g, ".*?")}$`);
+        return new RegExp(`^${ts.regExpEscape(template).replace(/\\\{d+\\\}/g, ".*?")}$`);
     }
 }

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1543,7 +1543,7 @@ namespace FourSlashInterface {
     }
 
     export interface VerifyCodeFixOptions extends NewContentOptions {
-        readonly description: string;
+        readonly description: string | DiagnosticIgnoredInterpolations;
         readonly errorCode?: number;
         readonly index?: number;
         readonly preferences?: ts.UserPreferences;
@@ -1600,6 +1600,10 @@ namespace FourSlashInterface {
         readonly findInComments?: boolean;
         readonly ranges: readonly RenameLocationOptions[];
         readonly providePrefixAndSuffixTextForRename?: boolean;
+    };
+    export interface DiagnosticIgnoredInterpolations {
+        readonly kind: unique symbol;
+        template: string
     };
     export type RenameLocationOptions = FourSlash.Range | { readonly range: FourSlash.Range, readonly prefixText?: string, readonly suffixText?: string };
 }

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1602,7 +1602,6 @@ namespace FourSlashInterface {
         readonly providePrefixAndSuffixTextForRename?: boolean;
     };
     export interface DiagnosticIgnoredInterpolations {
-        readonly kind: unique symbol;
         template: string
     };
     export type RenameLocationOptions = FourSlash.Range | { readonly range: FourSlash.Range, readonly prefixText?: string, readonly suffixText?: string };

--- a/tests/cases/fourslash/codeFixInPropertyAccess_js.ts
+++ b/tests/cases/fourslash/codeFixInPropertyAccess_js.ts
@@ -16,9 +16,9 @@
 ////   return false;
 //// }
 
-verify.codeFixAll({
-  fixId: "correctQualifiedNameToIndexedAccessType",
-  fixAllDescription: "Rewrite all as indexed access types",
+verify.codeFix({
+  index: 0,
+  description: ignoreInterpolations(ts.Diagnostics.Rewrite_as_the_indexed_access_type_0),
   newFileContent:
 `/**
  * @typedef Foo

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -719,7 +719,7 @@ declare namespace FourSlashInterface {
         readonly providePrefixAndSuffixTextForRename?: boolean;
     };
     type RenameLocationOptions = Range | { readonly range: Range, readonly prefixText?: string, readonly suffixText?: string };
-    type DiagnosticIgnoredInterpolations = { readonly kind: unique symbol, template: string }
+    type DiagnosticIgnoredInterpolations = { template: string }
 }
 /** Wraps a diagnostic message to be compared ignoring interpolated strings */
 declare function ignoreInterpolations(diagnostic: string | ts.DiagnosticMessage): FourSlashInterface.DiagnosticIgnoredInterpolations;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -226,7 +226,7 @@ declare namespace FourSlashInterface {
         jsxClosingTag(map: { [markerName: string]: { readonly newText: string } | undefined }): void;
         isInCommentAtPosition(onlyMultiLineDiverges?: boolean): void;
         codeFix(options: {
-            description: string,
+            description: string | DiagnosticIgnoredInterpolations,
             newFileContent?: NewFileContent,
             newRangeContent?: string,
             errorCode?: number,
@@ -719,7 +719,10 @@ declare namespace FourSlashInterface {
         readonly providePrefixAndSuffixTextForRename?: boolean;
     };
     type RenameLocationOptions = Range | { readonly range: Range, readonly prefixText?: string, readonly suffixText?: string };
+    type DiagnosticIgnoredInterpolations = { readonly kind: unique symbol, template: string }
 }
+/** Wraps a diagnostic message to be compared ignoring interpolated strings */
+declare function ignoreInterpolations(diagnostic: string | ts.DiagnosticMessage): FourSlashInterface.DiagnosticIgnoredInterpolations;
 declare function verifyOperationIsCancelled(f: any): void;
 declare var test: FourSlashInterface.test_;
 declare var plugins: FourSlashInterface.plugins;


### PR DESCRIPTION
Context: working on #32901 to stop returning a fix-all when there’s nothing left to fix led me to discover some fourslash codefix tests that seemed to be using `verify.codeFixAll` instead of `verify.codeFix` purely to avoid having to write out an interpolated diagnostic message for `description`. Writing the interpolation is often redundant with the rest of the test, and it makes it hard to use a constant from `ts.Diagnostics`.

![image](https://user-images.githubusercontent.com/3277153/70740717-9f51cb80-1cce-11ea-8da3-24d8ea2ba225.png)


I wanted to put this functionality in a separate PR because I’m not 100% confident when or if the #32901 PR will land since I’ll need to coordinate with VS Code.