### PR TITLE
Increase selectivity of subtype relationship for signatures

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14028,17 +14028,10 @@ namespace ts {
             }
 
             const targetCount = getParameterCount(target);
-            if (checkMode & SignatureCheckMode.StrictArity) {
-                const sourceHasRest = hasEffectiveRestParameter(source);
-                const targetHasRest = hasEffectiveRestParameter(target);
-                if (sourceHasRest && !targetHasRest || sourceHasRest === targetHasRest && getParameterCount(source) > getParameterCount(target)) {
-                    return Ternary.False;
-                }
-            }
-            else {
-                if (!hasEffectiveRestParameter(target) && getMinArgumentCount(source) > targetCount) {
-                    return Ternary.False;
-                }
+            const sourceHasMoreParameters = !hasEffectiveRestParameter(target) &&
+                (checkMode & SignatureCheckMode.StrictArity ? hasEffectiveRestParameter(source) || getParameterCount(source) > targetCount : getMinArgumentCount(source) > targetCount);
+            if (sourceHasMoreParameters) {
+                return Ternary.False;
             }
 
             if (source.typeParameters && source.typeParameters !== target.typeParameters) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3161,7 +3161,7 @@ namespace ts {
         getIdentifierCount(): number;
         getSymbolCount(): number;
         getTypeCount(): number;
-        getRelationCacheSizes(): { assignable: number, identity: number, subtype: number };
+        getRelationCacheSizes(): { assignable: number, identity: number, subtype: number, strictSubtype: number };
 
         /* @internal */ getFileProcessingDiagnostics(): DiagnosticCollection;
         /* @internal */ getResolvedTypeReferenceDirectives(): Map<ResolvedTypeReferenceDirective | undefined>;
@@ -3479,7 +3479,7 @@ namespace ts {
         /* @internal */ getIdentifierCount(): number;
         /* @internal */ getSymbolCount(): number;
         /* @internal */ getTypeCount(): number;
-        /* @internal */ getRelationCacheSizes(): { assignable: number, identity: number, subtype: number };
+        /* @internal */ getRelationCacheSizes(): { assignable: number, identity: number, subtype: number, strictSubtype: number };
 
         /* @internal */ isArrayType(type: Type): boolean;
         /* @internal */ isTupleType(type: Type): boolean;

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -654,6 +654,7 @@ namespace ts {
                 reportCountStatistic("Assignability cache size", caches.assignable);
                 reportCountStatistic("Identity cache size", caches.identity);
                 reportCountStatistic("Subtype cache size", caches.subtype);
+                reportCountStatistic("Strict subtype cache size", caches.strictSubtype);
                 performance.forEachMeasure((name, duration) => reportTimeStatistic(`${name} time`, duration));
             }
             else {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -1919,6 +1919,7 @@ declare namespace ts {
             assignable: number;
             identity: number;
             subtype: number;
+            strictSubtype: number;
         };
         isSourceFileFromExternalLibrary(file: SourceFile): boolean;
         isSourceFileDefaultLibrary(file: SourceFile): boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -1919,6 +1919,7 @@ declare namespace ts {
             assignable: number;
             identity: number;
             subtype: number;
+            strictSubtype: number;
         };
         isSourceFileFromExternalLibrary(file: SourceFile): boolean;
         isSourceFileDefaultLibrary(file: SourceFile): boolean;

--- a/tests/baselines/reference/bestCommonTypeOfConditionalExpressions.types
+++ b/tests/baselines/reference/bestCommonTypeOfConditionalExpressions.types
@@ -64,8 +64,8 @@ var r5 = true ? b : a; // typeof b
 >a : { x: number; y?: number; }
 
 var r6 = true ? (x: number) => { } : (x: Object) => { }; // returns number => void
->r6 : (x: number) => void
->true ? (x: number) => { } : (x: Object) => { } : (x: number) => void
+>r6 : ((x: number) => void) | ((x: Object) => void)
+>true ? (x: number) => { } : (x: Object) => { } : ((x: number) => void) | ((x: Object) => void)
 >true : true
 >(x: number) => { } : (x: number) => void
 >x : number
@@ -75,7 +75,7 @@ var r6 = true ? (x: number) => { } : (x: Object) => { }; // returns number => vo
 var r7: (x: Object) => void = true ? (x: number) => { } : (x: Object) => { }; 
 >r7 : (x: Object) => void
 >x : Object
->true ? (x: number) => { } : (x: Object) => { } : (x: number) => void
+>true ? (x: number) => { } : (x: Object) => { } : ((x: number) => void) | ((x: Object) => void)
 >true : true
 >(x: number) => { } : (x: number) => void
 >x : number
@@ -83,8 +83,8 @@ var r7: (x: Object) => void = true ? (x: number) => { } : (x: Object) => { };
 >x : Object
 
 var r8 = true ? (x: Object) => { } : (x: number) => { }; // returns Object => void
->r8 : (x: Object) => void
->true ? (x: Object) => { } : (x: number) => { } : (x: Object) => void
+>r8 : ((x: Object) => void) | ((x: number) => void)
+>true ? (x: Object) => { } : (x: number) => { } : ((x: Object) => void) | ((x: number) => void)
 >true : true
 >(x: Object) => { } : (x: Object) => void
 >x : Object

--- a/tests/baselines/reference/functionWithMultipleReturnStatements2.types
+++ b/tests/baselines/reference/functionWithMultipleReturnStatements2.types
@@ -58,7 +58,7 @@ function f4() {
 }
 
 function f5() {
->f5 : () => Object
+>f5 : () => Object | 1
 
     return 1;
 >1 : 1
@@ -136,7 +136,7 @@ function f10() {
 
 // returns number => void
 function f11() {
->f11 : () => (x: number) => void
+>f11 : () => ((x: number) => void) | ((x: Object) => void)
 
     if (true) {
 >true : true
@@ -154,7 +154,7 @@ function f11() {
 
 // returns Object => void
 function f12() {
->f12 : () => (x: Object) => void
+>f12 : () => ((x: Object) => void) | ((x: number) => void)
 
     if (true) {
 >true : true

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints2.types
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints2.types
@@ -566,16 +566,16 @@ function f20<T extends Number>(x: T) {
 >x : T
 
     var r19 = true ? new Object() : x; // ok
->r19 : Object
->true ? new Object() : x : Object
+>r19 : Object | T
+>true ? new Object() : x : Object | T
 >true : true
 >new Object() : Object
 >Object : ObjectConstructor
 >x : T
 
     var r19 = true ? x : new Object(); // ok
->r19 : Object
->true ? x : new Object() : Object
+>r19 : Object | T
+>true ? x : new Object() : Object | T
 >true : true
 >x : T
 >new Object() : Object

--- a/tests/baselines/reference/typeGuardRedundancy.types
+++ b/tests/baselines/reference/typeGuardRedundancy.types
@@ -3,8 +3,8 @@ var x: string|number;
 >x : string | number
 
 var r1 = typeof x === "string" && typeof x === "string" ? x.substr : x.toFixed;
->r1 : (from: number, length?: number) => string
->typeof x === "string" && typeof x === "string" ? x.substr : x.toFixed : (from: number, length?: number) => string
+>r1 : ((from: number, length?: number) => string) | ((fractionDigits?: number) => string)
+>typeof x === "string" && typeof x === "string" ? x.substr : x.toFixed : ((from: number, length?: number) => string) | ((fractionDigits?: number) => string)
 >typeof x === "string" && typeof x === "string" : boolean
 >typeof x === "string" : boolean
 >typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
@@ -22,8 +22,8 @@ var r1 = typeof x === "string" && typeof x === "string" ? x.substr : x.toFixed;
 >toFixed : (fractionDigits?: number) => string
 
 var r2 = !(typeof x === "string" && typeof x === "string") ? x.toFixed : x.substr;
->r2 : (from: number, length?: number) => string
->!(typeof x === "string" && typeof x === "string") ? x.toFixed : x.substr : (from: number, length?: number) => string
+>r2 : ((from: number, length?: number) => string) | ((fractionDigits?: number) => string)
+>!(typeof x === "string" && typeof x === "string") ? x.toFixed : x.substr : ((from: number, length?: number) => string) | ((fractionDigits?: number) => string)
 >!(typeof x === "string" && typeof x === "string") : boolean
 >(typeof x === "string" && typeof x === "string") : boolean
 >typeof x === "string" && typeof x === "string" : boolean
@@ -43,8 +43,8 @@ var r2 = !(typeof x === "string" && typeof x === "string") ? x.toFixed : x.subst
 >substr : (from: number, length?: number) => string
 
 var r3 = typeof x === "string" || typeof x === "string" ? x.substr : x.toFixed;
->r3 : (from: number, length?: number) => string
->typeof x === "string" || typeof x === "string" ? x.substr : x.toFixed : (from: number, length?: number) => string
+>r3 : ((from: number, length?: number) => string) | ((fractionDigits?: number) => string)
+>typeof x === "string" || typeof x === "string" ? x.substr : x.toFixed : ((from: number, length?: number) => string) | ((fractionDigits?: number) => string)
 >typeof x === "string" || typeof x === "string" : boolean
 >typeof x === "string" : boolean
 >typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
@@ -62,8 +62,8 @@ var r3 = typeof x === "string" || typeof x === "string" ? x.substr : x.toFixed;
 >toFixed : (fractionDigits?: number) => string
 
 var r4 = !(typeof x === "string" || typeof x === "string") ? x.toFixed : x.substr;
->r4 : (from: number, length?: number) => string
->!(typeof x === "string" || typeof x === "string") ? x.toFixed : x.substr : (from: number, length?: number) => string
+>r4 : ((from: number, length?: number) => string) | ((fractionDigits?: number) => string)
+>!(typeof x === "string" || typeof x === "string") ? x.toFixed : x.substr : ((from: number, length?: number) => string) | ((fractionDigits?: number) => string)
 >!(typeof x === "string" || typeof x === "string") : boolean
 >(typeof x === "string" || typeof x === "string") : boolean
 >typeof x === "string" || typeof x === "string" : boolean

--- a/tests/baselines/reference/unionReductionMutualSubtypes.js
+++ b/tests/baselines/reference/unionReductionMutualSubtypes.js
@@ -1,0 +1,25 @@
+//// [unionReductionMutualSubtypes.ts]
+// Repro from #35414
+
+interface ReturnVal {
+    something(): void;
+}
+
+const k: ReturnVal = { something() { } }
+
+declare const val: ReturnVal;
+function run(options: { something?(b?: string): void }) {
+    const something = options.something ?? val.something;
+    something('');
+}
+
+
+//// [unionReductionMutualSubtypes.js]
+"use strict";
+// Repro from #35414
+var k = { something: function () { } };
+function run(options) {
+    var _a;
+    var something = (_a = options.something) !== null && _a !== void 0 ? _a : val.something;
+    something('');
+}

--- a/tests/baselines/reference/unionReductionMutualSubtypes.symbols
+++ b/tests/baselines/reference/unionReductionMutualSubtypes.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/unionReductionMutualSubtypes.ts ===
+// Repro from #35414
+
+interface ReturnVal {
+>ReturnVal : Symbol(ReturnVal, Decl(unionReductionMutualSubtypes.ts, 0, 0))
+
+    something(): void;
+>something : Symbol(ReturnVal.something, Decl(unionReductionMutualSubtypes.ts, 2, 21))
+}
+
+const k: ReturnVal = { something() { } }
+>k : Symbol(k, Decl(unionReductionMutualSubtypes.ts, 6, 5))
+>ReturnVal : Symbol(ReturnVal, Decl(unionReductionMutualSubtypes.ts, 0, 0))
+>something : Symbol(something, Decl(unionReductionMutualSubtypes.ts, 6, 22))
+
+declare const val: ReturnVal;
+>val : Symbol(val, Decl(unionReductionMutualSubtypes.ts, 8, 13))
+>ReturnVal : Symbol(ReturnVal, Decl(unionReductionMutualSubtypes.ts, 0, 0))
+
+function run(options: { something?(b?: string): void }) {
+>run : Symbol(run, Decl(unionReductionMutualSubtypes.ts, 8, 29))
+>options : Symbol(options, Decl(unionReductionMutualSubtypes.ts, 9, 13))
+>something : Symbol(something, Decl(unionReductionMutualSubtypes.ts, 9, 23))
+>b : Symbol(b, Decl(unionReductionMutualSubtypes.ts, 9, 35))
+
+    const something = options.something ?? val.something;
+>something : Symbol(something, Decl(unionReductionMutualSubtypes.ts, 10, 9))
+>options.something : Symbol(something, Decl(unionReductionMutualSubtypes.ts, 9, 23))
+>options : Symbol(options, Decl(unionReductionMutualSubtypes.ts, 9, 13))
+>something : Symbol(something, Decl(unionReductionMutualSubtypes.ts, 9, 23))
+>val.something : Symbol(ReturnVal.something, Decl(unionReductionMutualSubtypes.ts, 2, 21))
+>val : Symbol(val, Decl(unionReductionMutualSubtypes.ts, 8, 13))
+>something : Symbol(ReturnVal.something, Decl(unionReductionMutualSubtypes.ts, 2, 21))
+
+    something('');
+>something : Symbol(something, Decl(unionReductionMutualSubtypes.ts, 10, 9))
+}
+

--- a/tests/baselines/reference/unionReductionMutualSubtypes.types
+++ b/tests/baselines/reference/unionReductionMutualSubtypes.types
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/unionReductionMutualSubtypes.ts ===
+// Repro from #35414
+
+interface ReturnVal {
+    something(): void;
+>something : () => void
+}
+
+const k: ReturnVal = { something() { } }
+>k : ReturnVal
+>{ something() { } } : { something(): void; }
+>something : () => void
+
+declare const val: ReturnVal;
+>val : ReturnVal
+
+function run(options: { something?(b?: string): void }) {
+>run : (options: { something?(b?: string | undefined): void; }) => void
+>options : { something?(b?: string | undefined): void; }
+>something : ((b?: string | undefined) => void) | undefined
+>b : string | undefined
+
+    const something = options.something ?? val.something;
+>something : (b?: string | undefined) => void
+>options.something ?? val.something : (b?: string | undefined) => void
+>options.something : ((b?: string | undefined) => void) | undefined
+>options : { something?(b?: string | undefined): void; }
+>something : ((b?: string | undefined) => void) | undefined
+>val.something : () => void
+>val : ReturnVal
+>something : () => void
+
+    something('');
+>something('') : void
+>something : (b?: string | undefined) => void
+>'' : ""
+}
+

--- a/tests/baselines/reference/unionTypeReduction2.errors.txt
+++ b/tests/baselines/reference/unionTypeReduction2.errors.txt
@@ -1,0 +1,72 @@
+tests/cases/conformance/types/union/unionTypeReduction2.ts(33,5): error TS2554: Expected 1 arguments, but got 0.
+
+
+==== tests/cases/conformance/types/union/unionTypeReduction2.ts (1 errors) ====
+    function f1(x: { f(): void }, y: { f(x?: string): void }) {
+        let z = !!true ? x : y;  // { f(x?: string): void }
+        z.f();
+        z.f('hello');
+    }
+    
+    function f2(x: { f(x: string | undefined): void }, y: { f(x?: string): void }) {
+        let z = !!true ? x : y;  // { f(x?: string): void }
+        z.f();
+        z.f('hello');
+    }
+    
+    function f3(x: () => void, y: (x?: string) => void) {
+        let f = !!true ? x : y;  // (x?: string) => void
+        f();
+        f('hello');
+    }
+    
+    function f4(x: (x: string | undefined) => void, y: (x?: string) => void) {
+        let f = !!true ? x : y;  // (x?: string) => void
+        f();
+        f('hello');
+    }
+    
+    function f5(x: (x: string | undefined) => void, y: (x?: 'hello') => void) {
+        let f = !!true ? x : y;  // (x?: 'hello') => void
+        f();
+        f('hello');
+    }
+    
+    function f6(x: (x: 'hello' | undefined) => void, y: (x?: string) => void) {
+        let f = !!true ? x : y;  // (x: 'hello' | undefined) => void
+        f();  // Error
+        ~~~
+!!! error TS2554: Expected 1 arguments, but got 0.
+!!! related TS6210 tests/cases/conformance/types/union/unionTypeReduction2.ts:31:17: An argument for 'x' was not provided.
+        f('hello');
+    }
+    
+    type A = {
+        f(): void;
+    }
+    
+    type B = {
+        f(x?: string): void;
+        g(): void;
+    }
+    
+    function f11(a: A, b: B) {
+        let z = !!true ? a : b;  // A | B
+        z.f();
+        z.f('hello');
+    }
+    
+    // Repro from #35414
+    
+    interface ReturnVal {
+        something(): void;
+    }
+    
+    const k: ReturnVal = { something() { } }
+    
+    declare const val: ReturnVal;
+    function run(options: { something?(b?: string): void }) {
+        const something = options.something ?? val.something;
+        something('');
+    }
+    

--- a/tests/baselines/reference/unionTypeReduction2.js
+++ b/tests/baselines/reference/unionTypeReduction2.js
@@ -1,0 +1,110 @@
+//// [unionTypeReduction2.ts]
+function f1(x: { f(): void }, y: { f(x?: string): void }) {
+    let z = !!true ? x : y;  // { f(x?: string): void }
+    z.f();
+    z.f('hello');
+}
+
+function f2(x: { f(x: string | undefined): void }, y: { f(x?: string): void }) {
+    let z = !!true ? x : y;  // { f(x?: string): void }
+    z.f();
+    z.f('hello');
+}
+
+function f3(x: () => void, y: (x?: string) => void) {
+    let f = !!true ? x : y;  // (x?: string) => void
+    f();
+    f('hello');
+}
+
+function f4(x: (x: string | undefined) => void, y: (x?: string) => void) {
+    let f = !!true ? x : y;  // (x?: string) => void
+    f();
+    f('hello');
+}
+
+function f5(x: (x: string | undefined) => void, y: (x?: 'hello') => void) {
+    let f = !!true ? x : y;  // (x?: 'hello') => void
+    f();
+    f('hello');
+}
+
+function f6(x: (x: 'hello' | undefined) => void, y: (x?: string) => void) {
+    let f = !!true ? x : y;  // (x: 'hello' | undefined) => void
+    f();  // Error
+    f('hello');
+}
+
+type A = {
+    f(): void;
+}
+
+type B = {
+    f(x?: string): void;
+    g(): void;
+}
+
+function f11(a: A, b: B) {
+    let z = !!true ? a : b;  // A | B
+    z.f();
+    z.f('hello');
+}
+
+// Repro from #35414
+
+interface ReturnVal {
+    something(): void;
+}
+
+const k: ReturnVal = { something() { } }
+
+declare const val: ReturnVal;
+function run(options: { something?(b?: string): void }) {
+    const something = options.something ?? val.something;
+    something('');
+}
+
+
+//// [unionTypeReduction2.js]
+"use strict";
+function f1(x, y) {
+    var z = !!true ? x : y; // { f(x?: string): void }
+    z.f();
+    z.f('hello');
+}
+function f2(x, y) {
+    var z = !!true ? x : y; // { f(x?: string): void }
+    z.f();
+    z.f('hello');
+}
+function f3(x, y) {
+    var f = !!true ? x : y; // (x?: string) => void
+    f();
+    f('hello');
+}
+function f4(x, y) {
+    var f = !!true ? x : y; // (x?: string) => void
+    f();
+    f('hello');
+}
+function f5(x, y) {
+    var f = !!true ? x : y; // (x?: 'hello') => void
+    f();
+    f('hello');
+}
+function f6(x, y) {
+    var f = !!true ? x : y; // (x: 'hello' | undefined) => void
+    f(); // Error
+    f('hello');
+}
+function f11(a, b) {
+    var z = !!true ? a : b; // A | B
+    z.f();
+    z.f('hello');
+}
+var k = { something: function () { } };
+function run(options) {
+    var _a;
+    var something = (_a = options.something) !== null && _a !== void 0 ? _a : val.something;
+    something('');
+}

--- a/tests/baselines/reference/unionTypeReduction2.symbols
+++ b/tests/baselines/reference/unionTypeReduction2.symbols
@@ -1,0 +1,203 @@
+=== tests/cases/conformance/types/union/unionTypeReduction2.ts ===
+function f1(x: { f(): void }, y: { f(x?: string): void }) {
+>f1 : Symbol(f1, Decl(unionTypeReduction2.ts, 0, 0))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 0, 12))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 0, 16))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 0, 29))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 0, 34))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 0, 37))
+
+    let z = !!true ? x : y;  // { f(x?: string): void }
+>z : Symbol(z, Decl(unionTypeReduction2.ts, 1, 7))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 0, 12))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 0, 29))
+
+    z.f();
+>z.f : Symbol(f, Decl(unionTypeReduction2.ts, 0, 34))
+>z : Symbol(z, Decl(unionTypeReduction2.ts, 1, 7))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 0, 34))
+
+    z.f('hello');
+>z.f : Symbol(f, Decl(unionTypeReduction2.ts, 0, 34))
+>z : Symbol(z, Decl(unionTypeReduction2.ts, 1, 7))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 0, 34))
+}
+
+function f2(x: { f(x: string | undefined): void }, y: { f(x?: string): void }) {
+>f2 : Symbol(f2, Decl(unionTypeReduction2.ts, 4, 1))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 6, 12))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 6, 16))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 6, 19))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 6, 50))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 6, 55))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 6, 58))
+
+    let z = !!true ? x : y;  // { f(x?: string): void }
+>z : Symbol(z, Decl(unionTypeReduction2.ts, 7, 7))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 6, 12))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 6, 50))
+
+    z.f();
+>z.f : Symbol(f, Decl(unionTypeReduction2.ts, 6, 55))
+>z : Symbol(z, Decl(unionTypeReduction2.ts, 7, 7))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 6, 55))
+
+    z.f('hello');
+>z.f : Symbol(f, Decl(unionTypeReduction2.ts, 6, 55))
+>z : Symbol(z, Decl(unionTypeReduction2.ts, 7, 7))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 6, 55))
+}
+
+function f3(x: () => void, y: (x?: string) => void) {
+>f3 : Symbol(f3, Decl(unionTypeReduction2.ts, 10, 1))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 12, 12))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 12, 26))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 12, 31))
+
+    let f = !!true ? x : y;  // (x?: string) => void
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 13, 7))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 12, 12))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 12, 26))
+
+    f();
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 13, 7))
+
+    f('hello');
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 13, 7))
+}
+
+function f4(x: (x: string | undefined) => void, y: (x?: string) => void) {
+>f4 : Symbol(f4, Decl(unionTypeReduction2.ts, 16, 1))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 18, 12))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 18, 16))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 18, 47))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 18, 52))
+
+    let f = !!true ? x : y;  // (x?: string) => void
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 19, 7))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 18, 12))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 18, 47))
+
+    f();
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 19, 7))
+
+    f('hello');
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 19, 7))
+}
+
+function f5(x: (x: string | undefined) => void, y: (x?: 'hello') => void) {
+>f5 : Symbol(f5, Decl(unionTypeReduction2.ts, 22, 1))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 24, 12))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 24, 16))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 24, 47))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 24, 52))
+
+    let f = !!true ? x : y;  // (x?: 'hello') => void
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 25, 7))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 24, 12))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 24, 47))
+
+    f();
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 25, 7))
+
+    f('hello');
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 25, 7))
+}
+
+function f6(x: (x: 'hello' | undefined) => void, y: (x?: string) => void) {
+>f6 : Symbol(f6, Decl(unionTypeReduction2.ts, 28, 1))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 30, 12))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 30, 16))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 30, 48))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 30, 53))
+
+    let f = !!true ? x : y;  // (x: 'hello' | undefined) => void
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 31, 7))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 30, 12))
+>y : Symbol(y, Decl(unionTypeReduction2.ts, 30, 48))
+
+    f();  // Error
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 31, 7))
+
+    f('hello');
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 31, 7))
+}
+
+type A = {
+>A : Symbol(A, Decl(unionTypeReduction2.ts, 34, 1))
+
+    f(): void;
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10))
+}
+
+type B = {
+>B : Symbol(B, Decl(unionTypeReduction2.ts, 38, 1))
+
+    f(x?: string): void;
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 40, 10))
+>x : Symbol(x, Decl(unionTypeReduction2.ts, 41, 6))
+
+    g(): void;
+>g : Symbol(g, Decl(unionTypeReduction2.ts, 41, 24))
+}
+
+function f11(a: A, b: B) {
+>f11 : Symbol(f11, Decl(unionTypeReduction2.ts, 43, 1))
+>a : Symbol(a, Decl(unionTypeReduction2.ts, 45, 13))
+>A : Symbol(A, Decl(unionTypeReduction2.ts, 34, 1))
+>b : Symbol(b, Decl(unionTypeReduction2.ts, 45, 18))
+>B : Symbol(B, Decl(unionTypeReduction2.ts, 38, 1))
+
+    let z = !!true ? a : b;  // A | B
+>z : Symbol(z, Decl(unionTypeReduction2.ts, 46, 7))
+>a : Symbol(a, Decl(unionTypeReduction2.ts, 45, 13))
+>b : Symbol(b, Decl(unionTypeReduction2.ts, 45, 18))
+
+    z.f();
+>z.f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10), Decl(unionTypeReduction2.ts, 40, 10))
+>z : Symbol(z, Decl(unionTypeReduction2.ts, 46, 7))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10), Decl(unionTypeReduction2.ts, 40, 10))
+
+    z.f('hello');
+>z.f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10), Decl(unionTypeReduction2.ts, 40, 10))
+>z : Symbol(z, Decl(unionTypeReduction2.ts, 46, 7))
+>f : Symbol(f, Decl(unionTypeReduction2.ts, 36, 10), Decl(unionTypeReduction2.ts, 40, 10))
+}
+
+// Repro from #35414
+
+interface ReturnVal {
+>ReturnVal : Symbol(ReturnVal, Decl(unionTypeReduction2.ts, 49, 1))
+
+    something(): void;
+>something : Symbol(ReturnVal.something, Decl(unionTypeReduction2.ts, 53, 21))
+}
+
+const k: ReturnVal = { something() { } }
+>k : Symbol(k, Decl(unionTypeReduction2.ts, 57, 5))
+>ReturnVal : Symbol(ReturnVal, Decl(unionTypeReduction2.ts, 49, 1))
+>something : Symbol(something, Decl(unionTypeReduction2.ts, 57, 22))
+
+declare const val: ReturnVal;
+>val : Symbol(val, Decl(unionTypeReduction2.ts, 59, 13))
+>ReturnVal : Symbol(ReturnVal, Decl(unionTypeReduction2.ts, 49, 1))
+
+function run(options: { something?(b?: string): void }) {
+>run : Symbol(run, Decl(unionTypeReduction2.ts, 59, 29))
+>options : Symbol(options, Decl(unionTypeReduction2.ts, 60, 13))
+>something : Symbol(something, Decl(unionTypeReduction2.ts, 60, 23))
+>b : Symbol(b, Decl(unionTypeReduction2.ts, 60, 35))
+
+    const something = options.something ?? val.something;
+>something : Symbol(something, Decl(unionTypeReduction2.ts, 61, 9))
+>options.something : Symbol(something, Decl(unionTypeReduction2.ts, 60, 23))
+>options : Symbol(options, Decl(unionTypeReduction2.ts, 60, 13))
+>something : Symbol(something, Decl(unionTypeReduction2.ts, 60, 23))
+>val.something : Symbol(ReturnVal.something, Decl(unionTypeReduction2.ts, 53, 21))
+>val : Symbol(val, Decl(unionTypeReduction2.ts, 59, 13))
+>something : Symbol(ReturnVal.something, Decl(unionTypeReduction2.ts, 53, 21))
+
+    something('');
+>something : Symbol(something, Decl(unionTypeReduction2.ts, 61, 9))
+}
+

--- a/tests/baselines/reference/unionTypeReduction2.types
+++ b/tests/baselines/reference/unionTypeReduction2.types
@@ -1,0 +1,250 @@
+=== tests/cases/conformance/types/union/unionTypeReduction2.ts ===
+function f1(x: { f(): void }, y: { f(x?: string): void }) {
+>f1 : (x: { f(): void; }, y: { f(x?: string | undefined): void; }) => void
+>x : { f(): void; }
+>f : () => void
+>y : { f(x?: string | undefined): void; }
+>f : (x?: string | undefined) => void
+>x : string | undefined
+
+    let z = !!true ? x : y;  // { f(x?: string): void }
+>z : { f(x?: string | undefined): void; }
+>!!true ? x : y : { f(x?: string | undefined): void; }
+>!!true : true
+>!true : false
+>true : true
+>x : { f(): void; }
+>y : { f(x?: string | undefined): void; }
+
+    z.f();
+>z.f() : void
+>z.f : (x?: string | undefined) => void
+>z : { f(x?: string | undefined): void; }
+>f : (x?: string | undefined) => void
+
+    z.f('hello');
+>z.f('hello') : void
+>z.f : (x?: string | undefined) => void
+>z : { f(x?: string | undefined): void; }
+>f : (x?: string | undefined) => void
+>'hello' : "hello"
+}
+
+function f2(x: { f(x: string | undefined): void }, y: { f(x?: string): void }) {
+>f2 : (x: { f(x: string | undefined): void; }, y: { f(x?: string | undefined): void; }) => void
+>x : { f(x: string | undefined): void; }
+>f : (x: string | undefined) => void
+>x : string | undefined
+>y : { f(x?: string | undefined): void; }
+>f : (x?: string | undefined) => void
+>x : string | undefined
+
+    let z = !!true ? x : y;  // { f(x?: string): void }
+>z : { f(x?: string | undefined): void; }
+>!!true ? x : y : { f(x?: string | undefined): void; }
+>!!true : true
+>!true : false
+>true : true
+>x : { f(x: string | undefined): void; }
+>y : { f(x?: string | undefined): void; }
+
+    z.f();
+>z.f() : void
+>z.f : (x?: string | undefined) => void
+>z : { f(x?: string | undefined): void; }
+>f : (x?: string | undefined) => void
+
+    z.f('hello');
+>z.f('hello') : void
+>z.f : (x?: string | undefined) => void
+>z : { f(x?: string | undefined): void; }
+>f : (x?: string | undefined) => void
+>'hello' : "hello"
+}
+
+function f3(x: () => void, y: (x?: string) => void) {
+>f3 : (x: () => void, y: (x?: string | undefined) => void) => void
+>x : () => void
+>y : (x?: string | undefined) => void
+>x : string | undefined
+
+    let f = !!true ? x : y;  // (x?: string) => void
+>f : (x?: string | undefined) => void
+>!!true ? x : y : (x?: string | undefined) => void
+>!!true : true
+>!true : false
+>true : true
+>x : () => void
+>y : (x?: string | undefined) => void
+
+    f();
+>f() : void
+>f : (x?: string | undefined) => void
+
+    f('hello');
+>f('hello') : void
+>f : (x?: string | undefined) => void
+>'hello' : "hello"
+}
+
+function f4(x: (x: string | undefined) => void, y: (x?: string) => void) {
+>f4 : (x: (x: string | undefined) => void, y: (x?: string | undefined) => void) => void
+>x : (x: string | undefined) => void
+>x : string | undefined
+>y : (x?: string | undefined) => void
+>x : string | undefined
+
+    let f = !!true ? x : y;  // (x?: string) => void
+>f : (x?: string | undefined) => void
+>!!true ? x : y : (x?: string | undefined) => void
+>!!true : true
+>!true : false
+>true : true
+>x : (x: string | undefined) => void
+>y : (x?: string | undefined) => void
+
+    f();
+>f() : void
+>f : (x?: string | undefined) => void
+
+    f('hello');
+>f('hello') : void
+>f : (x?: string | undefined) => void
+>'hello' : "hello"
+}
+
+function f5(x: (x: string | undefined) => void, y: (x?: 'hello') => void) {
+>f5 : (x: (x: string | undefined) => void, y: (x?: "hello" | undefined) => void) => void
+>x : (x: string | undefined) => void
+>x : string | undefined
+>y : (x?: "hello" | undefined) => void
+>x : "hello" | undefined
+
+    let f = !!true ? x : y;  // (x?: 'hello') => void
+>f : (x?: "hello" | undefined) => void
+>!!true ? x : y : (x?: "hello" | undefined) => void
+>!!true : true
+>!true : false
+>true : true
+>x : (x: string | undefined) => void
+>y : (x?: "hello" | undefined) => void
+
+    f();
+>f() : void
+>f : (x?: "hello" | undefined) => void
+
+    f('hello');
+>f('hello') : void
+>f : (x?: "hello" | undefined) => void
+>'hello' : "hello"
+}
+
+function f6(x: (x: 'hello' | undefined) => void, y: (x?: string) => void) {
+>f6 : (x: (x: "hello" | undefined) => void, y: (x?: string | undefined) => void) => void
+>x : (x: "hello" | undefined) => void
+>x : "hello" | undefined
+>y : (x?: string | undefined) => void
+>x : string | undefined
+
+    let f = !!true ? x : y;  // (x: 'hello' | undefined) => void
+>f : (x: "hello" | undefined) => void
+>!!true ? x : y : (x: "hello" | undefined) => void
+>!!true : true
+>!true : false
+>true : true
+>x : (x: "hello" | undefined) => void
+>y : (x?: string | undefined) => void
+
+    f();  // Error
+>f() : void
+>f : (x: "hello" | undefined) => void
+
+    f('hello');
+>f('hello') : void
+>f : (x: "hello" | undefined) => void
+>'hello' : "hello"
+}
+
+type A = {
+>A : A
+
+    f(): void;
+>f : () => void
+}
+
+type B = {
+>B : B
+
+    f(x?: string): void;
+>f : (x?: string | undefined) => void
+>x : string | undefined
+
+    g(): void;
+>g : () => void
+}
+
+function f11(a: A, b: B) {
+>f11 : (a: A, b: B) => void
+>a : A
+>b : B
+
+    let z = !!true ? a : b;  // A | B
+>z : A | B
+>!!true ? a : b : A | B
+>!!true : true
+>!true : false
+>true : true
+>a : A
+>b : B
+
+    z.f();
+>z.f() : void
+>z.f : ((x?: string | undefined) => void) | (() => void)
+>z : A | B
+>f : ((x?: string | undefined) => void) | (() => void)
+
+    z.f('hello');
+>z.f('hello') : void
+>z.f : ((x?: string | undefined) => void) | (() => void)
+>z : A | B
+>f : ((x?: string | undefined) => void) | (() => void)
+>'hello' : "hello"
+}
+
+// Repro from #35414
+
+interface ReturnVal {
+    something(): void;
+>something : () => void
+}
+
+const k: ReturnVal = { something() { } }
+>k : ReturnVal
+>{ something() { } } : { something(): void; }
+>something : () => void
+
+declare const val: ReturnVal;
+>val : ReturnVal
+
+function run(options: { something?(b?: string): void }) {
+>run : (options: { something?(b?: string | undefined): void; }) => void
+>options : { something?(b?: string | undefined): void; }
+>something : ((b?: string | undefined) => void) | undefined
+>b : string | undefined
+
+    const something = options.something ?? val.something;
+>something : (b?: string | undefined) => void
+>options.something ?? val.something : (b?: string | undefined) => void
+>options.something : ((b?: string | undefined) => void) | undefined
+>options : { something?(b?: string | undefined): void; }
+>something : ((b?: string | undefined) => void) | undefined
+>val.something : () => void
+>val : ReturnVal
+>something : () => void
+
+    something('');
+>something('') : void
+>something : (b?: string | undefined) => void
+>'' : ""
+}
+

--- a/tests/cases/compiler/unionReductionMutualSubtypes.ts
+++ b/tests/cases/compiler/unionReductionMutualSubtypes.ts
@@ -1,0 +1,15 @@
+// @strict: true
+
+// Repro from #35414
+
+interface ReturnVal {
+    something(): void;
+}
+
+const k: ReturnVal = { something() { } }
+
+declare const val: ReturnVal;
+function run(options: { something?(b?: string): void }) {
+    const something = options.something ?? val.something;
+    something('');
+}

--- a/tests/cases/conformance/types/union/unionTypeReduction2.ts
+++ b/tests/cases/conformance/types/union/unionTypeReduction2.ts
@@ -1,0 +1,66 @@
+// @strict: true
+
+function f1(x: { f(): void }, y: { f(x?: string): void }) {
+    let z = !!true ? x : y;  // { f(x?: string): void }
+    z.f();
+    z.f('hello');
+}
+
+function f2(x: { f(x: string | undefined): void }, y: { f(x?: string): void }) {
+    let z = !!true ? x : y;  // { f(x?: string): void }
+    z.f();
+    z.f('hello');
+}
+
+function f3(x: () => void, y: (x?: string) => void) {
+    let f = !!true ? x : y;  // (x?: string) => void
+    f();
+    f('hello');
+}
+
+function f4(x: (x: string | undefined) => void, y: (x?: string) => void) {
+    let f = !!true ? x : y;  // (x?: string) => void
+    f();
+    f('hello');
+}
+
+function f5(x: (x: string | undefined) => void, y: (x?: 'hello') => void) {
+    let f = !!true ? x : y;  // (x?: 'hello') => void
+    f();
+    f('hello');
+}
+
+function f6(x: (x: 'hello' | undefined) => void, y: (x?: string) => void) {
+    let f = !!true ? x : y;  // (x: 'hello' | undefined) => void
+    f();  // Error
+    f('hello');
+}
+
+type A = {
+    f(): void;
+}
+
+type B = {
+    f(x?: string): void;
+    g(): void;
+}
+
+function f11(a: A, b: B) {
+    let z = !!true ? a : b;  // A | B
+    z.f();
+    z.f('hello');
+}
+
+// Repro from #35414
+
+interface ReturnVal {
+    something(): void;
+}
+
+const k: ReturnVal = { something() { } }
+
+declare const val: ReturnVal;
+function run(options: { something?(b?: string): void }) {
+    const something = options.something ?? val.something;
+    something('');
+}


### PR DESCRIPTION
This PR introduces a new strict subtype relationship and uses this relationship in union subtype reduction. The new strict subtype relationship increases selectivity for signatures which in turn increases the stability of subtype reduction in union types. Specifically

* the signature `() => void` is now always considered a strict subtype of `(x?: string) => void` (it previously was only for strictly checked function types, see #18654), and
* the signature `(x: string | undefined) => void` is now considered a strict subtype of `(x?: string) => void`.

Beyond these differences, the strict subtype relationship is the same as our existing subtype relationship. Ideally we'd use the new strict subtype relationship everywhere, but to reduce breaking changes we're only using it for union subtype reduction.

An example:

```ts
function f1(x: { f(): void }, y: { f(x?: string): void }) {
    let z = !!true ? x : y;
    z.f();
    z.f("hello");  // Previously error, now ok
}

function f2(x: { f(x: string | undefined): void }, y: { f(x?: string): void }) {
    let z = !!true ? x : y;
    z.f();         // Previously error, now ok
    z.f("hello");
}
```

Previously errors were reported in both functions above.

Fixes #35414.