### PR TITLE
Report time spent in updateGraph

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -1087,6 +1087,7 @@ namespace ts.server {
                 removed => this.detachScriptInfoFromProject(removed)
             );
             const elapsed = timestamp() - start;
+            this.projectService.sendUpdateGraphPerformanceEvent(elapsed);
             this.writeLog(`Finishing updateGraphWorker: Project: ${this.getProjectName()} Version: ${this.getProjectVersion()} structureChanged: ${hasNewProgram} Elapsed: ${elapsed}ms`);
             if (this.hasAddedorRemovedFiles) {
                 this.print();

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -232,6 +232,12 @@ namespace ts.server.protocol {
          * Contains extra information that plugin can include to be passed on
          */
         metadata?: unknown;
+
+        /**
+         * Time spent updating the program graph, in milliseconds.
+         */
+        /* @internal */
+        updateGraphDurationMs?: number;
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -591,6 +591,8 @@ namespace ts.server {
         protected projectService: ProjectService;
         private changeSeq = 0;
 
+        private updateGraphDurationMs: number | undefined;
+
         private currentRequestId!: number;
         private errorCheck: MultistepOperation;
 
@@ -648,11 +650,21 @@ namespace ts.server {
                 syntaxOnly: opts.syntaxOnly,
             };
             this.projectService = new ProjectService(settings);
+            this.projectService.setPerformanceEventHandler(this.performanceEventHandler.bind(this));
             this.gcTimer = new GcTimer(this.host, /*delay*/ 7000, this.logger);
         }
 
         private sendRequestCompletedEvent(requestId: number): void {
             this.event<protocol.RequestCompletedEventBody>({ request_seq: requestId }, "requestCompleted");
+        }
+
+        private performanceEventHandler(event: PerformanceEvent) {
+            switch (event.kind) {
+                case "UpdateGraph": {
+                    this.updateGraphDurationMs = (this.updateGraphDurationMs || 0) + event.durationMs;
+                    break;
+                }
+            }
         }
 
         private defaultEventHandler(event: ProjectServiceEvent) {
@@ -795,7 +807,9 @@ namespace ts.server {
                 command: cmdName,
                 request_seq: reqSeq,
                 success,
+                updateGraphDurationMs: this.updateGraphDurationMs,
             };
+
             if (success) {
                 let metadata: unknown;
                 if (isArray(info)) {
@@ -2549,6 +2563,9 @@ namespace ts.server {
 
         public onMessage(message: string) {
             this.gcTimer.scheduleCollect();
+
+            this.updateGraphDurationMs = undefined;
+
             let start: number[] | undefined;
             if (this.logger.hasLevel(LogLevel.requestTime)) {
                 start = this.hrtime();

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -100,7 +100,8 @@ namespace ts.server {
                     seq: 0,
                     message: "Unrecognized JSON command: foobar",
                     request_seq: 0,
-                    success: false
+                    success: false,
+                    updateGraphDurationMs: undefined,
                 };
                 expect(lastSent).to.deep.equal(expected);
             });
@@ -126,7 +127,8 @@ namespace ts.server {
                     success: true,
                     request_seq: 0,
                     seq: 0,
-                    body: undefined
+                    body: undefined,
+                    updateGraphDurationMs: undefined,
                 });
             });
             it("should handle literal types in request", () => {
@@ -323,7 +325,8 @@ namespace ts.server {
                     success: true,
                     request_seq: 0,
                     seq: 0,
-                    body: undefined
+                    body: undefined,
+                    updateGraphDurationMs: undefined,
                 });
             });
         });
@@ -413,7 +416,8 @@ namespace ts.server {
                     type: "response",
                     command,
                     body,
-                    success: true
+                    success: true,
+                    updateGraphDurationMs: undefined,
                 });
             });
         });
@@ -532,7 +536,8 @@ namespace ts.server {
                 type: "response",
                 command,
                 body,
-                success: true
+                success: true,
+                updateGraphDurationMs: undefined,
             });
         });
         it("can add and respond to new protocol handlers", () => {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9033,6 +9033,7 @@ declare namespace ts.server {
         readonly syntaxOnly?: boolean;
         /** Tracks projects that we have already sent telemetry for. */
         private readonly seenProjects;
+        private performanceEventHandler?;
         constructor(opts: ProjectServiceOptions);
         toPath(fileName: string): Path;
         private loadTypesMap;
@@ -9262,6 +9263,7 @@ declare namespace ts.server {
         private readonly gcTimer;
         protected projectService: ProjectService;
         private changeSeq;
+        private updateGraphDurationMs;
         private currentRequestId;
         private errorCheck;
         protected host: ServerHost;
@@ -9276,6 +9278,7 @@ declare namespace ts.server {
         private readonly noGetErrOnBackgroundUpdate?;
         constructor(opts: SessionOptions);
         private sendRequestCompletedEvent;
+        private performanceEventHandler;
         private defaultEventHandler;
         private projectsUpdatedInBackgroundEvent;
         logError(err: Error, cmd: string): void;


### PR DESCRIPTION
Add a response property indicating how much of the elapsed time (from `onMessage` to `doOutput`) was spent in `updateGraph` calls.  If there'sno `updateGraph` call, the property is undefined, to save space (with the downside that it's harder to tell whether a given telemetry event could have had the property).

Fixes #34774
