### PR TITLE
Fix formatting scanner on multiline JSX attribute strings

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -31,6 +31,7 @@ namespace ts {
         reScanTemplateToken(): SyntaxKind;
         scanJsxIdentifier(): SyntaxKind;
         scanJsxAttributeValue(): SyntaxKind;
+        reScanJsxAttributeValue(): SyntaxKind;
         reScanJsxToken(): JsxTokenSyntaxKind;
         reScanLessThanToken(): SyntaxKind;
         reScanQuestionToken(): SyntaxKind;
@@ -902,6 +903,7 @@ namespace ts {
             reScanTemplateToken,
             scanJsxIdentifier,
             scanJsxAttributeValue,
+            reScanJsxAttributeValue,
             reScanJsxToken,
             reScanLessThanToken,
             reScanQuestionToken,
@@ -2131,6 +2133,11 @@ namespace ts {
                     // If this scans anything other than `{`, it's a parse error.
                     return scan();
             }
+        }
+
+        function reScanJsxAttributeValue(): SyntaxKind {
+            pos = tokenPos = startPos;
+            return scanJsxAttributeValue();
         }
 
         function scanJsDocToken(): JSDocSyntaxKind {

--- a/src/services/formatting/formattingScanner.ts
+++ b/src/services/formatting/formattingScanner.ts
@@ -21,6 +21,7 @@ namespace ts.formatting {
         RescanTemplateToken,
         RescanJsxIdentifier,
         RescanJsxText,
+        RescanJsxAttributeValue,
     }
 
     export function getFormattingScanner<T>(text: string, languageVariant: LanguageVariant, startPos: number, endPos: number, cb: (scanner: FormattingScanner) => T): T {
@@ -133,6 +134,10 @@ namespace ts.formatting {
                 container.kind === SyntaxKind.TemplateTail;
         }
 
+        function shouldRescanJsxAttributeValue(node: Node): boolean {
+            return node.parent && isJsxAttribute(node.parent) && node.parent.initializer === node;
+        }
+
         function startsWithSlashToken(t: SyntaxKind): boolean {
             return t === SyntaxKind.SlashToken || t === SyntaxKind.SlashEqualsToken;
         }
@@ -147,6 +152,7 @@ namespace ts.formatting {
                 shouldRescanTemplateToken(n) ? ScanAction.RescanTemplateToken :
                 shouldRescanJsxIdentifier(n) ? ScanAction.RescanJsxIdentifier :
                 shouldRescanJsxText(n) ? ScanAction.RescanJsxText :
+                shouldRescanJsxAttributeValue(n) ? ScanAction.RescanJsxAttributeValue :
                 ScanAction.Scan;
 
             if (lastTokenInfo && expectedScanAction === lastScanAction) {
@@ -239,6 +245,9 @@ namespace ts.formatting {
                 case ScanAction.RescanJsxText:
                     lastScanAction = ScanAction.RescanJsxText;
                     return scanner.reScanJsxToken();
+                case ScanAction.RescanJsxAttributeValue:
+                    lastScanAction = ScanAction.RescanJsxAttributeValue;
+                    return scanner.reScanJsxAttributeValue();
                 case ScanAction.Scan:
                     break;
                 default:

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -3291,6 +3291,7 @@ declare namespace ts {
         reScanTemplateToken(): SyntaxKind;
         scanJsxIdentifier(): SyntaxKind;
         scanJsxAttributeValue(): SyntaxKind;
+        reScanJsxAttributeValue(): SyntaxKind;
         reScanJsxToken(): JsxTokenSyntaxKind;
         reScanLessThanToken(): SyntaxKind;
         reScanQuestionToken(): SyntaxKind;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -3291,6 +3291,7 @@ declare namespace ts {
         reScanTemplateToken(): SyntaxKind;
         scanJsxIdentifier(): SyntaxKind;
         scanJsxAttributeValue(): SyntaxKind;
+        reScanJsxAttributeValue(): SyntaxKind;
         reScanJsxToken(): JsxTokenSyntaxKind;
         reScanLessThanToken(): SyntaxKind;
         reScanQuestionToken(): SyntaxKind;

--- a/tests/cases/fourslash/formatTsxMultilineAttributeString.ts
+++ b/tests/cases/fourslash/formatTsxMultilineAttributeString.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: foo.tsx
+////(
+////    <input
+////        value="x
+////        x"
+////    />
+////);
+
+format.document();
+verify.currentFileContentIs(`(
+    <input
+        value="x
+        x"
+    />
+);`);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #34982 
