### PR TITLE
Filter out self-fulfilling object literal member completions

### DIFF
--- a/tests/cases/fourslash/completionsSelfDeclaring1.ts
+++ b/tests/cases/fourslash/completionsSelfDeclaring1.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+////interface Test {
+////  keyPath?: string;
+////  autoIncrement?: boolean;
+////}
+////
+////function test<T extends Record<string, Test>>(opt: T) { }
+////
+////test({
+////  a: {
+////    keyPath: '',
+////    a/**/
+////  }
+////})
+
+verify.completions({
+  marker: "",
+  exact: [{
+    name: "autoIncrement",
+    sortText: completion.SortText.OptionalMember
+  }]
+});

--- a/tests/cases/fourslash/completionsSelfDeclaring2.ts
+++ b/tests/cases/fourslash/completionsSelfDeclaring2.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+
+////function f1<T>(x: T) {}
+////f1({ abc/*1*/ });
+////
+////function f2<T extends { xyz: number }>(x: T) {}
+////f2({ x/*2*/ });
+
+
+verify.completions({
+  marker: "1",
+  exact: []
+});
+
+verify.completions({
+  marker: "2",
+  exact: ["xyz"]
+});

--- a/tests/cases/fourslash/completionsSelfDeclaring3.ts
+++ b/tests/cases/fourslash/completionsSelfDeclaring3.ts
@@ -1,0 +1,25 @@
+/// <reference path="fourslash.ts" />
+
+////function f<T extends { x: number }>(p: T & (T extends { hello: string } ? { goodbye: number } : {})) {}
+////f({ x/*x*/: 0, hello/*hello*/: "", goodbye/*goodbye*/: 0, abc/*abc*/: "" })
+
+
+verify.completions({
+  marker: "x",
+  exact: ["x"]
+});
+
+verify.completions({
+  marker: "hello",
+  exact: []
+});
+
+verify.completions({
+  marker: "goodbye",
+  exact: ["goodbye"]
+});
+
+verify.completions({
+  marker: "abc",
+  exact: []
+});


### PR DESCRIPTION
Ever been typing in a generic object literal and with every other keystroke, it seems you have magically just finished typing a member name that the checker suddenly knows about and wants to “complete” for you?

**(Before)**

![Kapture 2019-12-16 at 13 13 25](https://user-images.githubusercontent.com/3277153/70943495-de04c000-2005-11ea-84bc-72cd812f3993.gif)

This removes completions for object literal members that are self-declaring.

Fixes #35268 

Note: this doesn’t currently affect JSX attributes because we didn’t include them in the changes in #33937/#34855. It’s probably worth considering doing that separately, but I want to test with some real-world component libraries that are heavy on HOCs and generics.
