### PR TITLE
fix(35410): showConfig printing help if no config is found

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3325,6 +3325,10 @@
         "category": "Error",
         "code": 5080
     },
+    "Cannot find a tsconfig.json file at the current directory: {0}.": {
+        "category": "Error",
+        "code": 5081
+    },
 
     "Generates a sourcemap for each corresponding '.d.ts' file.": {
         "category": "Message",

--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -240,9 +240,15 @@ namespace ts {
         }
 
         if (commandLine.fileNames.length === 0 && !configFileName) {
-            printVersion(sys);
-            printHelp(sys, getOptionsForHelp(commandLine));
-            return sys.exit(ExitStatus.Success);
+            if (commandLine.options.showConfig) {
+                reportDiagnostic(createCompilerDiagnostic(Diagnostics.Cannot_find_a_tsconfig_json_file_at_the_current_directory_Colon_0, normalizePath(sys.getCurrentDirectory())));
+                return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
+            }
+            else {
+                printVersion(sys);
+                printHelp(sys, getOptionsForHelp(commandLine));
+                return sys.exit(ExitStatus.Success);
+            }
         }
 
         const currentDirectory = sys.getCurrentDirectory();


### PR DESCRIPTION
Fixes #35410 