### PR TITLE
Add asserts to narrow down position issue

### DIFF
--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -623,8 +623,7 @@ namespace ts.server {
 
         positionToLineOffset(position: number): protocol.Location {
             const location = this.textStorage.positionToLineOffset(position);
-            Debug.assert(typeof location.line === "number" && location.line > 0, `Expected line ${location.line} to be greater than 0.`);
-            Debug.assert(typeof location.offset === "number" && location.offset > 0, `Expected offset ${location.offset} to be greater than 0.`);
+            failIfInvalidLocation(location);
             return location;
         }
 
@@ -644,5 +643,14 @@ namespace ts.server {
                 this.sourceMapFilePath = undefined;
             }
         }
+    }
+
+    /*@internal*/
+    function failIfInvalidLocation(location: protocol.Location) {
+        Debug.assert(typeof location.line === "number", `Expected line ${location.line} to be a number.`);
+        Debug.assert(typeof location.offset === "number", `Expected offset ${location.offset} to be a number.`);
+
+        Debug.assert(location.line > 0, `Expected line to be non-${location.line === 0 ? "zero" : "negative"}`);
+        Debug.assert(location.offset > 0, `Expected offset to be non-${location.offset === 0 ? "zero" : "negative"}`);
     }
 }

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -622,6 +622,7 @@ namespace ts.server {
         }
 
         positionToLineOffset(position: number): protocol.Location {
+            failIfInvalidPosition(position);
             const location = this.textStorage.positionToLineOffset(position);
             failIfInvalidLocation(location);
             return location;
@@ -645,7 +646,11 @@ namespace ts.server {
         }
     }
 
-    /*@internal*/
+    function failIfInvalidPosition(position: number) {
+        Debug.assert(typeof position === "number", `Expected position ${position} to be a number.`);
+        Debug.assert(position >= 0, `Expected position to be non-negative.`);
+    }
+
     function failIfInvalidLocation(location: protocol.Location) {
         Debug.assert(typeof location.line === "number", `Expected line ${location.line} to be a number.`);
         Debug.assert(typeof location.offset === "number", `Expected offset ${location.offset} to be a number.`);

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -622,7 +622,10 @@ namespace ts.server {
         }
 
         positionToLineOffset(position: number): protocol.Location {
-            return this.textStorage.positionToLineOffset(position);
+            const location = this.textStorage.positionToLineOffset(position);
+            Debug.assert(typeof location.line === "number" && location.line > 0, `Expected line ${location.line} to be greater than 0.`);
+            Debug.assert(typeof location.offset === "number" && location.offset > 0, `Expected offset ${location.offset} to be greater than 0.`);
+            return location;
         }
 
         public isJavaScript() {


### PR DESCRIPTION
In Visual Studio, we're seeing hundreds of hits where a location returned in `semanticDiagnosticsSync` has either a non-positive line or non-positive offset.

To narrow down the investigation, I'm adding these asserts so that we have just a little more context to help the investigation (that is, I think it would be helpful to know whether the bad value is null/undefined, 0, or negative).