### PR TITLE
Fix npm test if os.cpus().length == 1

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -456,7 +456,7 @@ task("runtests").flags = {
     "   --shardId": "1-based ID of this shard (default: 1)",
 };
 
-const runTestsParallel = () => runConsoleTests("built/local/run.js", "min", /*runInParallel*/ true, /*watchMode*/ false);
+const runTestsParallel = () => runConsoleTests("built/local/run.js", "min", /*runInParallel*/ cmdLineOptions.workers > 1, /*watchMode*/ false);
 task("runtests-parallel", series(preBuild, preTest, runTestsParallel, postTest));
 task("runtests-parallel").description = "Runs all the tests in parallel using the built run.js file.";
 task("runtests-parallel").flags = {


### PR DESCRIPTION
Currently it complains
```Shell
[09:10:20] > node built/local/run.js

TypeScript/src/testRunner/runner.ts:232
        beforeEach(() => {
        ^
ReferenceError: beforeEach is not defined
```

This change synchronizes ~`scripts/build/tests.js`~`Gulpfile.js` with the logic in [`src/testRunner/runner.ts`](https://github.com/microsoft/TypeScript/blob/aef2e0a238453c12ee5ca2bc2090c44d13bf8408/src/testRunner/runner.ts#L252).