### PR TITLE
Fix timeout flag use and sort out passing the test config file

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -435,7 +435,7 @@ task("watch-local").flags = {
     "   --built": "Compile using the built version of the compiler."
 };
 
-const generateCodeCoverage = () => exec("istanbul", ["cover", "node_modules/mocha/bin/_mocha", "--", "-R", "min", "-t", "" + cmdLineOptions.testTimeout, "built/local/run.js"]);
+const generateCodeCoverage = () => exec("istanbul", ["cover", "node_modules/mocha/bin/_mocha", "--", "-R", "min", "-t", "" + cmdLineOptions.timeout, "built/local/run.js"]);
 task("generate-code-coverage", series(preBuild, buildTests, generateCodeCoverage));
 task("generate-code-coverage").description = "Generates code coverage data via istanbul";
 


### PR DESCRIPTION
* Use `cmdLineOptions.timeout` instead of the nonexistent
  `...testTimeout` in the istanbul call

* Move `testConfigFile` to the toplevel so it's used in
  `writeTestConfigFile` too

* Use `await del` instead of `fs.unlinkSync`

* Call `writeTestConfigFile` unconditionally (didn't make sense since
  there is always at least a timeout value)

* Specify `--config` for the config file so it's actually used

* Replace `-R`, `-O`, `-g`, and `--colors` by config entries, some
  fixed (`tests` => `grep`), and some added; also, added arguments for
  `writeTestConfigFile`

* Dropped `-t` since it was already in the config (which is now used)
