### PR TITLE
Ignore @private/@protected on constructor functions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24865,8 +24865,8 @@ namespace ts {
             const declaration = signature.declaration;
             const modifiers = getSelectedModifierFlags(declaration, ModifierFlags.NonPublicAccessibilityModifier);
 
-            // Public constructor is accessible.
-            if (!modifiers) {
+            // (1) Public constructors and (2) constructor functions are always accessible.
+            if (!modifiers || isFunctionLikeDeclaration(declaration)) {
                 return true;
             }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -24866,7 +24866,7 @@ namespace ts {
             const modifiers = getSelectedModifierFlags(declaration, ModifierFlags.NonPublicAccessibilityModifier);
 
             // (1) Public constructors and (2) constructor functions are always accessible.
-            if (!modifiers || isFunctionLikeDeclaration(declaration)) {
+            if (!modifiers || declaration.kind !== SyntaxKind.Constructor) {
                 return true;
             }
 

--- a/tests/baselines/reference/privateConstructorFunction.js
+++ b/tests/baselines/reference/privateConstructorFunction.js
@@ -1,0 +1,31 @@
+//// [privateConstructorFunction.js]
+{
+    // make sure not to crash when parent's a block rather than a source file or some other
+    // symbol-having node.
+
+    /** @private */
+    function C() {
+        this.x = 1
+    }
+    new C()
+}
+
+
+//// [privateConstructorFunction.js]
+{
+    // make sure not to crash when parent's a block rather than a source file or some other
+    // symbol-having node.
+    /** @private */
+    function C() {
+        this.x = 1;
+    }
+    new C();
+}
+
+
+//// [privateConstructorFunction.d.ts]
+/** @private */
+declare function C(): void;
+declare class C {
+    x: number;
+}

--- a/tests/baselines/reference/privateConstructorFunction.symbols
+++ b/tests/baselines/reference/privateConstructorFunction.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/salsa/privateConstructorFunction.js ===
+{
+    // make sure not to crash when parent's a block rather than a source file or some other
+    // symbol-having node.
+
+    /** @private */
+    function C() {
+>C : Symbol(C, Decl(privateConstructorFunction.js, 0, 1))
+
+        this.x = 1
+>x : Symbol(C.x, Decl(privateConstructorFunction.js, 5, 18))
+    }
+    new C()
+>C : Symbol(C, Decl(privateConstructorFunction.js, 0, 1))
+}
+

--- a/tests/baselines/reference/privateConstructorFunction.types
+++ b/tests/baselines/reference/privateConstructorFunction.types
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/salsa/privateConstructorFunction.js ===
+{
+    // make sure not to crash when parent's a block rather than a source file or some other
+    // symbol-having node.
+
+    /** @private */
+    function C() {
+>C : typeof C
+
+        this.x = 1
+>this.x = 1 : 1
+>this.x : any
+>this : any
+>x : any
+>1 : 1
+    }
+    new C()
+>new C() : C
+>C : typeof C
+}
+

--- a/tests/cases/conformance/salsa/privateConstructorFunction.ts
+++ b/tests/cases/conformance/salsa/privateConstructorFunction.ts
@@ -1,0 +1,15 @@
+// @allowjs: true
+// @checkjs: true
+// @outdir: salsa
+// @declaration: true
+// @filename: privateConstructorFunction.js
+{
+    // make sure not to crash when parent's a block rather than a source file or some other
+    // symbol-having node.
+
+    /** @private */
+    function C() {
+        this.x = 1
+    }
+    new C()
+}


### PR DESCRIPTION
This was incorrect in the best of circumstances and caused a crash when the parent of the function had no symbol, because the accessibility check assumed it was operating on a constructor and that the parent was always the containing class.

Fixes #35766