### PR TITLE
Correctly set filesByName map when reusing program to ensure it is same as old program

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3131,6 +3131,8 @@ namespace ts {
         getMissingFilePaths(): readonly Path[];
         /* @internal */
         getRefFileMap(): MultiMap<RefFile> | undefined;
+        /* @internal */
+        getFilesByNameMap(): Map<SourceFile | false | undefined>;
 
         /**
          * Emits the JavaScript and declaration files.  If targetSourceFile is not specified, then


### PR DESCRIPTION
Previously we were setting these with each new sourceFile's  `path` and `resolvedPath` but that's not enough. 
Eg. if its monorepo like setup and we are using sourceOfProjectReferenceRedirect with preserveSymlinks, we would get resolvedFileName of the moduleResolution as `node_modules/projectName/someFile.d.ts` and when creating new program without reusing old program, we would find that this is actually link to say `src/someFile.ts` in referenced project and use that source file. So in that program we have entries for `projectName/src/someFile.ts`, `projectName/lib/someFile.d.ts` as well as  `node_modules/projectName/someFile.d.ts` all pointing to `someFile.ts` sourceFile. 
In new program that uses old program previously we would only set `projectName/src/someFile.ts`, `projectName/lib/someFile.d.ts` to point to the sourceFile of `someFile.ts` and hence in checker we would incorrectly think that module resolution has failed and report the error.

Fixes #35768