### PR TITLE
Fix JSDoc param type completions when name hasn’t been written yet

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -854,7 +854,7 @@ namespace ts.Completions {
                         insideJsDocTagTypeExpression = isCurrentlyEditingNode(tag.typeExpression);
                     }
                 }
-                if (isJSDocParameterTag(tag) && (nodeIsMissing(tag.name) || tag.name.pos <= position && position <= tag.name.end)) {
+                if (!insideJsDocTagTypeExpression && isJSDocParameterTag(tag) && (nodeIsMissing(tag.name) || tag.name.pos <= position && position <= tag.name.end)) {
                     return { kind: CompletionDataKind.JsDocParameterName, tag };
                 }
             }

--- a/tests/cases/fourslash/completionsJsdocParamTypeBeforeName.ts
+++ b/tests/cases/fourslash/completionsJsdocParamTypeBeforeName.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts" />
+//// /** @param /*name1*/ {/*type*/} /*name2*/ */
+//// function toString(obj) {}
+
+verify.completions({
+  marker: "type",
+  exact: completion.globalTypes
+});
+
+verify.completions({
+  marker: "name1",
+  exact: ["obj"]
+});
+
+verify.completions({
+  marker: "name2",
+  exact: ["obj"]
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #35582 
