### PR TITLE
Move executeCommandLine ambient code into tsc

### DIFF
--- a/src/executeCommandLine/executeCommandLine.ts
+++ b/src/executeCommandLine/executeCommandLine.ts
@@ -733,15 +733,3 @@ namespace ts {
         return;
     }
 }
-
-if (ts.Debug.isDebugging) {
-    ts.Debug.enableDebugInfo();
-}
-
-if (ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
-    ts.sys.tryEnableSourceMapsForHost();
-}
-
-if (ts.sys.setBlocking) {
-    ts.sys.setBlocking();
-}

--- a/src/tsc/tsc.ts
+++ b/src/tsc/tsc.ts
@@ -1,3 +1,15 @@
 namespace ts {} // empty ts module so the module migration script knows this file depends on the `ts` project namespace
 // This file actually uses arguments passed on commandline and executes it
+if (ts.Debug.isDebugging) {
+    ts.Debug.enableDebugInfo();
+}
+
+if (ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
+    ts.sys.tryEnableSourceMapsForHost();
+}
+
+if (ts.sys.setBlocking) {
+    ts.sys.setBlocking();
+}
+
 ts.executeCommandLine(ts.sys, ts.noop, ts.sys.args);


### PR DESCRIPTION
Fixes `enableDebugInfo` being called before the services objectAllocator was set in the test harness.