### PR TITLE
Make `checkPropertyNotUsedBeforeDeclaration` ignore properties of properties

### DIFF
--- a/tests/baselines/reference/recursiveFieldSetting.js
+++ b/tests/baselines/reference/recursiveFieldSetting.js
@@ -1,0 +1,42 @@
+//// [recursiveFieldSetting.ts]
+// #32721
+
+class Recursive1 {
+    constructor(private readonly parent?: Recursive1) {}
+    private depth: number = this.parent ? this.parent.depth + 1 : 0;
+}
+
+class Recursive2 {
+    parent!: Recursive2;
+    depth: number = this.parent.depth;
+}
+
+class Recursive3 {
+    parent!: Recursive3;
+    depth: number = this.parent.alpha;
+    alpha = 0;
+}
+
+
+//// [recursiveFieldSetting.js]
+// #32721
+var Recursive1 = /** @class */ (function () {
+    function Recursive1(parent) {
+        this.parent = parent;
+        this.depth = this.parent ? this.parent.depth + 1 : 0;
+    }
+    return Recursive1;
+}());
+var Recursive2 = /** @class */ (function () {
+    function Recursive2() {
+        this.depth = this.parent.depth;
+    }
+    return Recursive2;
+}());
+var Recursive3 = /** @class */ (function () {
+    function Recursive3() {
+        this.depth = this.parent.alpha;
+        this.alpha = 0;
+    }
+    return Recursive3;
+}());

--- a/tests/baselines/reference/recursiveFieldSetting.symbols
+++ b/tests/baselines/reference/recursiveFieldSetting.symbols
@@ -1,0 +1,57 @@
+=== tests/cases/compiler/recursiveFieldSetting.ts ===
+// #32721
+
+class Recursive1 {
+>Recursive1 : Symbol(Recursive1, Decl(recursiveFieldSetting.ts, 0, 0))
+
+    constructor(private readonly parent?: Recursive1) {}
+>parent : Symbol(Recursive1.parent, Decl(recursiveFieldSetting.ts, 3, 16))
+>Recursive1 : Symbol(Recursive1, Decl(recursiveFieldSetting.ts, 0, 0))
+
+    private depth: number = this.parent ? this.parent.depth + 1 : 0;
+>depth : Symbol(Recursive1.depth, Decl(recursiveFieldSetting.ts, 3, 56))
+>this.parent : Symbol(Recursive1.parent, Decl(recursiveFieldSetting.ts, 3, 16))
+>this : Symbol(Recursive1, Decl(recursiveFieldSetting.ts, 0, 0))
+>parent : Symbol(Recursive1.parent, Decl(recursiveFieldSetting.ts, 3, 16))
+>this.parent.depth : Symbol(Recursive1.depth, Decl(recursiveFieldSetting.ts, 3, 56))
+>this.parent : Symbol(Recursive1.parent, Decl(recursiveFieldSetting.ts, 3, 16))
+>this : Symbol(Recursive1, Decl(recursiveFieldSetting.ts, 0, 0))
+>parent : Symbol(Recursive1.parent, Decl(recursiveFieldSetting.ts, 3, 16))
+>depth : Symbol(Recursive1.depth, Decl(recursiveFieldSetting.ts, 3, 56))
+}
+
+class Recursive2 {
+>Recursive2 : Symbol(Recursive2, Decl(recursiveFieldSetting.ts, 5, 1))
+
+    parent!: Recursive2;
+>parent : Symbol(Recursive2.parent, Decl(recursiveFieldSetting.ts, 7, 18))
+>Recursive2 : Symbol(Recursive2, Decl(recursiveFieldSetting.ts, 5, 1))
+
+    depth: number = this.parent.depth;
+>depth : Symbol(Recursive2.depth, Decl(recursiveFieldSetting.ts, 8, 24))
+>this.parent.depth : Symbol(Recursive2.depth, Decl(recursiveFieldSetting.ts, 8, 24))
+>this.parent : Symbol(Recursive2.parent, Decl(recursiveFieldSetting.ts, 7, 18))
+>this : Symbol(Recursive2, Decl(recursiveFieldSetting.ts, 5, 1))
+>parent : Symbol(Recursive2.parent, Decl(recursiveFieldSetting.ts, 7, 18))
+>depth : Symbol(Recursive2.depth, Decl(recursiveFieldSetting.ts, 8, 24))
+}
+
+class Recursive3 {
+>Recursive3 : Symbol(Recursive3, Decl(recursiveFieldSetting.ts, 10, 1))
+
+    parent!: Recursive3;
+>parent : Symbol(Recursive3.parent, Decl(recursiveFieldSetting.ts, 12, 18))
+>Recursive3 : Symbol(Recursive3, Decl(recursiveFieldSetting.ts, 10, 1))
+
+    depth: number = this.parent.alpha;
+>depth : Symbol(Recursive3.depth, Decl(recursiveFieldSetting.ts, 13, 24))
+>this.parent.alpha : Symbol(Recursive3.alpha, Decl(recursiveFieldSetting.ts, 14, 38))
+>this.parent : Symbol(Recursive3.parent, Decl(recursiveFieldSetting.ts, 12, 18))
+>this : Symbol(Recursive3, Decl(recursiveFieldSetting.ts, 10, 1))
+>parent : Symbol(Recursive3.parent, Decl(recursiveFieldSetting.ts, 12, 18))
+>alpha : Symbol(Recursive3.alpha, Decl(recursiveFieldSetting.ts, 14, 38))
+
+    alpha = 0;
+>alpha : Symbol(Recursive3.alpha, Decl(recursiveFieldSetting.ts, 14, 38))
+}
+

--- a/tests/baselines/reference/recursiveFieldSetting.types
+++ b/tests/baselines/reference/recursiveFieldSetting.types
@@ -1,0 +1,59 @@
+=== tests/cases/compiler/recursiveFieldSetting.ts ===
+// #32721
+
+class Recursive1 {
+>Recursive1 : Recursive1
+
+    constructor(private readonly parent?: Recursive1) {}
+>parent : Recursive1
+
+    private depth: number = this.parent ? this.parent.depth + 1 : 0;
+>depth : number
+>this.parent ? this.parent.depth + 1 : 0 : number
+>this.parent : Recursive1
+>this : this
+>parent : Recursive1
+>this.parent.depth + 1 : number
+>this.parent.depth : number
+>this.parent : Recursive1
+>this : this
+>parent : Recursive1
+>depth : number
+>1 : 1
+>0 : 0
+}
+
+class Recursive2 {
+>Recursive2 : Recursive2
+
+    parent!: Recursive2;
+>parent : Recursive2
+
+    depth: number = this.parent.depth;
+>depth : number
+>this.parent.depth : number
+>this.parent : Recursive2
+>this : this
+>parent : Recursive2
+>depth : number
+}
+
+class Recursive3 {
+>Recursive3 : Recursive3
+
+    parent!: Recursive3;
+>parent : Recursive3
+
+    depth: number = this.parent.alpha;
+>depth : number
+>this.parent.alpha : number
+>this.parent : Recursive3
+>this : this
+>parent : Recursive3
+>alpha : number
+
+    alpha = 0;
+>alpha : number
+>0 : 0
+}
+

--- a/tests/cases/compiler/recursiveFieldSetting.ts
+++ b/tests/cases/compiler/recursiveFieldSetting.ts
@@ -1,0 +1,17 @@
+// #32721
+
+class Recursive1 {
+    constructor(private readonly parent?: Recursive1) {}
+    private depth: number = this.parent ? this.parent.depth + 1 : 0;
+}
+
+class Recursive2 {
+    parent!: Recursive2;
+    depth: number = this.parent.depth;
+}
+
+class Recursive3 {
+    parent!: Recursive3;
+    depth: number = this.parent.alpha;
+    alpha = 0;
+}


### PR DESCRIPTION
Use `isAccessExpression` to cover both `PropertyAccess` and
`ElementAccess`.  Also use it in a few other places that used both
explicitly.  (And also fix a random weird formatting.)

Fixes #32721.
