### PR TITLE
Add base constraint completions for JSX attributes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21633,7 +21633,7 @@ namespace ts {
         }
 
         function getContextualJsxElementAttributesType(node: JsxOpeningLikeElement, contextFlags?: ContextFlags) {
-            if (isJsxOpeningElement(node) && node.parent.contextualType) {
+            if (isJsxOpeningElement(node) && node.parent.contextualType && contextFlags !== ContextFlags.BaseConstraint) {
                 // Contextually applied type is moved from attributes up to the outer jsx attributes so when walking up from the children they get hit
                 // _However_ to hit them from the _attributes_ we must look for them here; otherwise we'll used the declared type
                 // (as below) instead!

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1279,7 +1279,8 @@ namespace ts.Completions {
             // Cursor is inside a JSX self-closing element or opening element
             const attrsType = jsxContainer && typeChecker.getContextualType(jsxContainer.attributes);
             if (!attrsType) return GlobalsSearch.Continue;
-            symbols = filterJsxAttributes(getPropertiesForObjectExpression(attrsType, /*baseType*/ undefined, jsxContainer!.attributes, typeChecker), jsxContainer!.attributes.properties);
+            const baseType = jsxContainer && typeChecker.getContextualType(jsxContainer.attributes, ContextFlags.BaseConstraint);
+            symbols = filterJsxAttributes(getPropertiesForObjectExpression(attrsType, baseType, jsxContainer!.attributes, typeChecker), jsxContainer!.attributes.properties);
             setSortTextToOptionalMember();
             completionKind = CompletionKind.MemberLike;
             isNewIdentifierLocation = false;

--- a/tests/cases/fourslash/completionsJsxAttributeGeneric2.ts
+++ b/tests/cases/fourslash/completionsJsxAttributeGeneric2.ts
@@ -1,19 +1,34 @@
 /// <reference path="fourslash.ts" />
 
-// @jsx: react
+// @jsx: preserve
 
 // @Filename: index.tsx
+////declare namespace JSX {
+////  interface Element {}
+////  interface IntrinsicElements {}
+////  interface ElementAttributesProperty { props }
+////}
+////
 ////type Props = { a?: string, b?: string };
 ////function Component<T extends Props>(props: T) { return null; }
-////const element = <Component /**/ />
+////const e1 = <Component /*1*/ />;
+////const e2 = <Component /*2*/></Component>
+////
+////declare class Component2<T extends Props> {
+////  props: T;
+////}
+////const e3 = <Component2 /*3*/ />;
+////const e4 = <Component2 /*4*/></Component2>;
 
-verify.completions({
-  marker: "",
-  exact: [{
-    name: "a",
-    sortText: completion.SortText.OptionalMember
-  }, {
-    name: "b",
-    sortText: completion.SortText.OptionalMember
-  }]
+["1", "2", "3", "4"].forEach(marker => {
+  verify.completions({
+    marker,
+    exact: [{
+      name: "a",
+      sortText: completion.SortText.OptionalMember
+    }, {
+      name: "b",
+      sortText: completion.SortText.OptionalMember
+    }]
+  });
 });

--- a/tests/cases/fourslash/completionsJsxAttributeGeneric2.ts
+++ b/tests/cases/fourslash/completionsJsxAttributeGeneric2.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @jsx: react
+
+// @Filename: index.tsx
+////type Props = { a?: string, b?: string };
+////function Component<T extends Props>(props: T) { return null; }
+////const element = <Component /**/ />
+
+verify.completions({
+  marker: "",
+  exact: [{
+    name: "a",
+    sortText: completion.SortText.OptionalMember
+  }, {
+    name: "b",
+    sortText: completion.SortText.OptionalMember
+  }]
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Makes JSX completions work the same way as object literals as of #33937/#34855. Has the same tradeoffs discussed in #35702. @DanielRosenwasser, do you think we can try to get this in the hands of some real users to see how it feels?

Fixes #34957
