### PR TITLE
Disable timeout when debugging

### DIFF
--- a/scripts/build/tests.js
+++ b/scripts/build/tests.js
@@ -91,9 +91,11 @@ async function runConsoleTests(runJs, defaultReporter, runInParallel, watchMode,
         }
         if (inspect !== undefined) {
             args.unshift(inspect == "" ? "--inspect-brk" : "--inspect-brk="+inspect);
+            args.push("-t", "0");
         }
         else if (debug) {
             args.unshift("--debug-brk");
+            args.push("-t", "0");
         }
         else {
             args.push("-t", "" + testTimeout);


### PR DESCRIPTION
Use `-t 0` since somewhere a default timeout is set otherwise.

This is the smallest version of #35764.