### PR TITLE
Add top-level await for esnext and system modules

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3898,9 +3898,12 @@ namespace ts {
 
         switch (kind) {
             case SyntaxKind.AsyncKeyword:
-            case SyntaxKind.AwaitExpression:
-                // async/await is ES2017 syntax, but may be ES2018 syntax (for async generators)
+                // async is ES2017 syntax, but may be ES2018 syntax (for async generators)
                 transformFlags |= TransformFlags.AssertES2018 | TransformFlags.AssertES2017;
+                break;
+            case SyntaxKind.AwaitExpression:
+                // await is ES2017 syntax, but may be ES2018 syntax (for async generators)
+                transformFlags |= TransformFlags.AssertES2018 | TransformFlags.AssertES2017 | TransformFlags.ContainsAwait;
                 break;
 
             case SyntaxKind.TypeAssertionExpression:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26422,21 +26422,41 @@ namespace ts {
             return undefinedWideningType;
         }
 
+        function isTopLevelAwait(node: AwaitExpression) {
+            const container = getThisContainer(node, /*includeArrowFunctions*/ true);
+            return isSourceFile(container);
+        }
+
         function checkAwaitExpression(node: AwaitExpression): Type {
             // Grammar checking
             if (produceDiagnostics) {
                 if (!(node.flags & NodeFlags.AwaitContext)) {
-                    // use of 'await' in non-async function
-                    const sourceFile = getSourceFileOfNode(node);
-                    if (!hasParseDiagnostics(sourceFile)) {
-                        const span = getSpanOfTokenAtPosition(sourceFile, node.pos);
-                        const diagnostic = createFileDiagnostic(sourceFile, span.start, span.length, Diagnostics.await_expression_is_only_allowed_within_an_async_function);
-                        const func = getContainingFunction(node);
-                        if (func && func.kind !== SyntaxKind.Constructor && (getFunctionFlags(func) & FunctionFlags.Async) === 0) {
-                            const relatedInfo = createDiagnosticForNode(func, Diagnostics.Did_you_mean_to_mark_this_function_as_async);
-                            addRelatedInfo(diagnostic, relatedInfo);
+                    if (isTopLevelAwait(node)) {
+                        const sourceFile = getSourceFileOfNode(node);
+                        if ((moduleKind !== ModuleKind.ESNext && moduleKind !== ModuleKind.System) ||
+                            languageVersion < ScriptTarget.ES2017 ||
+                            !isEffectiveExternalModule(sourceFile, compilerOptions)) {
+                            if (!hasParseDiagnostics(sourceFile)) {
+                                const span = getSpanOfTokenAtPosition(sourceFile, node.pos);
+                                const diagnostic = createFileDiagnostic(sourceFile, span.start, span.length,
+                                    Diagnostics.await_outside_of_an_async_function_is_only_allowed_at_the_top_level_of_a_module_when_module_is_esnext_or_system_and_target_is_es2017_or_higher);
+                                diagnostics.add(diagnostic);
+                            }
                         }
-                        diagnostics.add(diagnostic);
+                    }
+                    else {
+                        // use of 'await' in non-async function
+                        const sourceFile = getSourceFileOfNode(node);
+                        if (!hasParseDiagnostics(sourceFile)) {
+                            const span = getSpanOfTokenAtPosition(sourceFile, node.pos);
+                            const diagnostic = createFileDiagnostic(sourceFile, span.start, span.length, Diagnostics.await_expression_is_only_allowed_within_an_async_function);
+                            const func = getContainingFunction(node);
+                            if (func && func.kind !== SyntaxKind.Constructor && (getFunctionFlags(func) & FunctionFlags.Async) === 0) {
+                                const relatedInfo = createDiagnosticForNode(func, Diagnostics.Did_you_mean_to_mark_this_function_as_async);
+                                addRelatedInfo(diagnostic, relatedInfo);
+                            }
+                            diagnostics.add(diagnostic);
+                        }
                     }
                 }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1059,6 +1059,10 @@
         "category": "Error",
         "code": 1360
     },
+    "'await' outside of an async function is only allowed at the top level of a module when '--module' is 'esnext' or 'system' and '--target' is 'es2017' or higher.": {
+        "category": "Error",
+        "code": 1361
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -262,13 +262,16 @@ namespace ts {
             insertStatementsAfterStandardPrologue(statements, endLexicalEnvironment());
 
             const exportStarFunction = addExportStarIfNeeded(statements)!; // TODO: GH#18217
+            const modifiers = node.transformFlags & TransformFlags.ContainsAwait ?
+                createModifiersFromModifierFlags(ModifierFlags.Async) :
+                undefined;
             const moduleObject = createObjectLiteral([
                 createPropertyAssignment("setters",
                     createSettersArray(exportStarFunction, dependencyGroups)
                 ),
                 createPropertyAssignment("execute",
                     createFunctionExpression(
-                        /*modifiers*/ undefined,
+                        modifiers,
                         /*asteriskToken*/ undefined,
                         /*name*/ undefined,
                         /*typeParameters*/ undefined,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -5599,9 +5599,10 @@ namespace ts {
         ContainsBlockScopedBinding = 1 << 15,
         ContainsBindingPattern = 1 << 16,
         ContainsYield = 1 << 17,
-        ContainsHoistedDeclarationOrCompletion = 1 << 18,
-        ContainsDynamicImport = 1 << 19,
-        ContainsClassFields = 1 << 20,
+        ContainsAwait = 1 << 18,
+        ContainsHoistedDeclarationOrCompletion = 1 << 19,
+        ContainsDynamicImport = 1 << 20,
+        ContainsClassFields = 1 << 21,
 
         // Please leave this as 1 << 29.
         // It is the maximum bit we can set before we outgrow the size of a v8 small integer (SMI) on an x86 system.
@@ -5627,10 +5628,10 @@ namespace ts {
         OuterExpressionExcludes = HasComputedFlags,
         PropertyAccessExcludes = OuterExpressionExcludes,
         NodeExcludes = PropertyAccessExcludes,
-        ArrowFunctionExcludes = NodeExcludes | ContainsTypeScriptClassSyntax | ContainsBlockScopedBinding | ContainsYield | ContainsHoistedDeclarationOrCompletion | ContainsBindingPattern | ContainsObjectRestOrSpread,
-        FunctionExcludes = NodeExcludes | ContainsTypeScriptClassSyntax | ContainsLexicalThis | ContainsBlockScopedBinding | ContainsYield | ContainsHoistedDeclarationOrCompletion | ContainsBindingPattern | ContainsObjectRestOrSpread,
-        ConstructorExcludes = NodeExcludes | ContainsLexicalThis | ContainsBlockScopedBinding | ContainsYield | ContainsHoistedDeclarationOrCompletion | ContainsBindingPattern | ContainsObjectRestOrSpread,
-        MethodOrAccessorExcludes = NodeExcludes | ContainsLexicalThis | ContainsBlockScopedBinding | ContainsYield | ContainsHoistedDeclarationOrCompletion | ContainsBindingPattern | ContainsObjectRestOrSpread,
+        ArrowFunctionExcludes = NodeExcludes | ContainsTypeScriptClassSyntax | ContainsBlockScopedBinding | ContainsYield | ContainsAwait | ContainsHoistedDeclarationOrCompletion | ContainsBindingPattern | ContainsObjectRestOrSpread,
+        FunctionExcludes = NodeExcludes | ContainsTypeScriptClassSyntax | ContainsLexicalThis | ContainsBlockScopedBinding | ContainsYield | ContainsAwait | ContainsHoistedDeclarationOrCompletion | ContainsBindingPattern | ContainsObjectRestOrSpread,
+        ConstructorExcludes = NodeExcludes | ContainsLexicalThis | ContainsBlockScopedBinding | ContainsYield | ContainsAwait | ContainsHoistedDeclarationOrCompletion | ContainsBindingPattern | ContainsObjectRestOrSpread,
+        MethodOrAccessorExcludes = NodeExcludes | ContainsLexicalThis | ContainsBlockScopedBinding | ContainsYield | ContainsAwait | ContainsHoistedDeclarationOrCompletion | ContainsBindingPattern | ContainsObjectRestOrSpread,
         PropertyExcludes = NodeExcludes | ContainsLexicalThis,
         ClassExcludes = NodeExcludes | ContainsTypeScriptClassSyntax | ContainsComputedPropertyName,
         ModuleExcludes = NodeExcludes | ContainsTypeScriptClassSyntax | ContainsLexicalThis | ContainsBlockScopedBinding | ContainsHoistedDeclarationOrCompletion,

--- a/tests/baselines/reference/awaitInNonAsyncFunction.errors.txt
+++ b/tests/baselines/reference/awaitInNonAsyncFunction.errors.txt
@@ -13,7 +13,7 @@ tests/cases/compiler/awaitInNonAsyncFunction.ts(31,5): error TS1308: 'await' exp
 tests/cases/compiler/awaitInNonAsyncFunction.ts(34,7): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
 tests/cases/compiler/awaitInNonAsyncFunction.ts(35,5): error TS1308: 'await' expression is only allowed within an async function.
 tests/cases/compiler/awaitInNonAsyncFunction.ts(39,5): error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
-tests/cases/compiler/awaitInNonAsyncFunction.ts(40,1): error TS1308: 'await' expression is only allowed within an async function.
+tests/cases/compiler/awaitInNonAsyncFunction.ts(40,1): error TS1361: 'await' outside of an async function is only allowed at the top level of a module when '--module' is 'esnext' or 'system' and '--target' is 'es2017' or higher.
 
 
 ==== tests/cases/compiler/awaitInNonAsyncFunction.ts (16 errors) ====
@@ -100,4 +100,4 @@ tests/cases/compiler/awaitInNonAsyncFunction.ts(40,1): error TS1308: 'await' exp
 !!! error TS1103: A 'for-await-of' statement is only allowed within an async function or async generator.
     await null;
     ~~~~~
-!!! error TS1308: 'await' expression is only allowed within an async function.
+!!! error TS1361: 'await' outside of an async function is only allowed at the top level of a module when '--module' is 'esnext' or 'system' and '--target' is 'es2017' or higher.

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).errors.txt
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/externalModules/topLevelAwait.ts(2,1): error TS1361: 'await' outside of an async function is only allowed at the top level of a module when '--module' is 'esnext' or 'system' and '--target' is 'es2017' or higher.
+
+
+==== tests/cases/conformance/externalModules/topLevelAwait.ts (1 errors) ====
+    export const x = 1;
+    await x;
+    ~~~~~
+!!! error TS1361: 'await' outside of an async function is only allowed at the top level of a module when '--module' is 'esnext' or 'system' and '--target' is 'es2017' or higher.
+    

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).js
@@ -1,0 +1,8 @@
+//// [topLevelAwait.ts]
+export const x = 1;
+await x;
+
+
+//// [topLevelAwait.js]
+export const x = 1;
+await x;

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).symbols
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/externalModules/topLevelAwait.ts ===
+export const x = 1;
+>x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
+
+await x;
+>x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
+

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).types
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2015).types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/externalModules/topLevelAwait.ts ===
+export const x = 1;
+>x : 1
+>1 : 1
+
+await x;
+>await x : 1
+>x : 1
+

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).js
@@ -1,0 +1,8 @@
+//// [topLevelAwait.ts]
+export const x = 1;
+await x;
+
+
+//// [topLevelAwait.js]
+export const x = 1;
+await x;

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).symbols
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/externalModules/topLevelAwait.ts ===
+export const x = 1;
+>x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
+
+await x;
+>x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
+

--- a/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).types
+++ b/tests/baselines/reference/topLevelAwait(module=esnext,target=es2017).types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/externalModules/topLevelAwait.ts ===
+export const x = 1;
+>x : 1
+>1 : 1
+
+await x;
+>await x : 1
+>x : 1
+

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2015).errors.txt
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2015).errors.txt
@@ -1,0 +1,9 @@
+tests/cases/conformance/externalModules/topLevelAwait.ts(2,1): error TS1361: 'await' outside of an async function is only allowed at the top level of a module when '--module' is 'esnext' or 'system' and '--target' is 'es2017' or higher.
+
+
+==== tests/cases/conformance/externalModules/topLevelAwait.ts (1 errors) ====
+    export const x = 1;
+    await x;
+    ~~~~~
+!!! error TS1361: 'await' outside of an async function is only allowed at the top level of a module when '--module' is 'esnext' or 'system' and '--target' is 'es2017' or higher.
+    

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2015).js
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2015).js
@@ -1,0 +1,18 @@
+//// [topLevelAwait.ts]
+export const x = 1;
+await x;
+
+
+//// [topLevelAwait.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var x;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: async function () {
+            exports_1("x", x = 1);
+            await x;
+        }
+    };
+});

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2015).symbols
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2015).symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/externalModules/topLevelAwait.ts ===
+export const x = 1;
+>x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
+
+await x;
+>x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
+

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2015).types
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2015).types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/externalModules/topLevelAwait.ts ===
+export const x = 1;
+>x : 1
+>1 : 1
+
+await x;
+>await x : 1
+>x : 1
+

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2017).js
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2017).js
@@ -1,0 +1,18 @@
+//// [topLevelAwait.ts]
+export const x = 1;
+await x;
+
+
+//// [topLevelAwait.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var x;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: async function () {
+            exports_1("x", x = 1);
+            await x;
+        }
+    };
+});

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2017).symbols
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2017).symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/externalModules/topLevelAwait.ts ===
+export const x = 1;
+>x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
+
+await x;
+>x : Symbol(x, Decl(topLevelAwait.ts, 0, 12))
+

--- a/tests/baselines/reference/topLevelAwait(module=system,target=es2017).types
+++ b/tests/baselines/reference/topLevelAwait(module=system,target=es2017).types
@@ -1,0 +1,9 @@
+=== tests/cases/conformance/externalModules/topLevelAwait.ts ===
+export const x = 1;
+>x : 1
+>1 : 1
+
+await x;
+>await x : 1
+>x : 1
+

--- a/tests/baselines/reference/topLevelAwaitNonModule.errors.txt
+++ b/tests/baselines/reference/topLevelAwaitNonModule.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/conformance/externalModules/topLevelAwaitNonModule.ts(1,1): error TS1361: 'await' outside of an async function is only allowed at the top level of a module when '--module' is 'esnext' or 'system' and '--target' is 'es2017' or higher.
+tests/cases/conformance/externalModules/topLevelAwaitNonModule.ts(1,7): error TS2304: Cannot find name 'x'.
+
+
+==== tests/cases/conformance/externalModules/topLevelAwaitNonModule.ts (2 errors) ====
+    await x;
+    ~~~~~
+!!! error TS1361: 'await' outside of an async function is only allowed at the top level of a module when '--module' is 'esnext' or 'system' and '--target' is 'es2017' or higher.
+          ~
+!!! error TS2304: Cannot find name 'x'.
+    

--- a/tests/baselines/reference/topLevelAwaitNonModule.js
+++ b/tests/baselines/reference/topLevelAwaitNonModule.js
@@ -1,0 +1,6 @@
+//// [topLevelAwaitNonModule.ts]
+await x;
+
+
+//// [topLevelAwaitNonModule.js]
+await x;

--- a/tests/baselines/reference/topLevelAwaitNonModule.symbols
+++ b/tests/baselines/reference/topLevelAwaitNonModule.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/externalModules/topLevelAwaitNonModule.ts ===
+await x;
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/topLevelAwaitNonModule.types
+++ b/tests/baselines/reference/topLevelAwaitNonModule.types
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/externalModules/topLevelAwaitNonModule.ts ===
+await x;
+>await x : any
+>x : any
+

--- a/tests/cases/conformance/externalModules/topLevelAwait.ts
+++ b/tests/cases/conformance/externalModules/topLevelAwait.ts
@@ -1,0 +1,4 @@
+// @target: es2015,es2017
+// @module: esnext,system
+export const x = 1;
+await x;

--- a/tests/cases/conformance/externalModules/topLevelAwaitNonModule.ts
+++ b/tests/cases/conformance/externalModules/topLevelAwaitNonModule.ts
@@ -1,0 +1,3 @@
+// @target: esnext
+// @module: esnext
+await x;


### PR DESCRIPTION
This removes our restriction around using an `await` expression at the top level of a file when the following conditions are met:

- The containing file is an external module (or `--isolatedModules` is provided)
- The `--target` is >= `ScriptTarget.ES2017` (minimum version required for `await` keyword)
- The `--module` is either `esnext` or `system`.

This is not currently supported for earlier script targets (e.g., ES2016, ES2015, ES5, ES3) as the `system` transform currently happens *after* async functions and generators have been transformed, so it is too late to transform the `async function` that is created as part of the `system` module transform. This also ensures it is consistent with `--target es5 --module esnext`, as there would be no way to down-level the `await` in that context either.

Fixes #25988, #32793
