### PR TITLE
Fixes non-null assertion applied to type narrowed to never not issuing an error.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22185,7 +22185,7 @@ namespace ts {
             // on empty arrays are possible without implicit any errors and new element types can be inferred without
             // type mismatch errors.
             const resultType = getObjectFlags(evolvedType) & ObjectFlags.EvolvingArray && isEvolvingArrayOperationTarget(reference) ? autoArrayType : finalizeEvolvingArrayType(evolvedType);
-            if (resultType === unreachableNeverType || reference.parent && reference.parent.kind === SyntaxKind.NonNullExpression && getTypeWithFacts(resultType, TypeFacts.NEUndefinedOrNull).flags & TypeFlags.Never) {
+            if (resultType === unreachableNeverType || reference.parent && reference.parent.kind === SyntaxKind.NonNullExpression && !(resultType.flags & TypeFlags.Never) && getTypeWithFacts(resultType, TypeFacts.NEUndefinedOrNull).flags & TypeFlags.Never) {
                 return declaredType;
             }
             return resultType;

--- a/tests/baselines/reference/exhaustiveSwitchStatements1.errors.txt
+++ b/tests/baselines/reference/exhaustiveSwitchStatements1.errors.txt
@@ -1,8 +1,9 @@
 tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts(7,9): error TS7027: Unreachable code detected.
 tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts(235,5): error TS2367: This condition will always return 'false' since the types 'keyof O' and '"c"' have no overlap.
+tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts(247,10): error TS2339: Property 'kind' does not exist on type 'never'.
 
 
-==== tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts (2 errors) ====
+==== tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts (3 errors) ====
     function f1(x: 1 | 2): string {
         if (!!true) {
             switch (x) {
@@ -245,3 +246,16 @@ tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts(235,5): error
         return o[k];
     }
     
+    // Repro from #35431
+    type A = { kind: "abc" } | { kind: "def" };
+    
+    function f35431(a: A) {
+      switch (a.kind) {
+        case "abc":
+        case "def": return;
+        default:
+          a!.kind; // Error expected
+             ~~~~
+!!! error TS2339: Property 'kind' does not exist on type 'never'.
+      }
+    }

--- a/tests/baselines/reference/exhaustiveSwitchStatements1.js
+++ b/tests/baselines/reference/exhaustiveSwitchStatements1.js
@@ -237,6 +237,17 @@ function ff(o: O, k: K) {
     return o[k];
 }
 
+// Repro from #35431
+type A = { kind: "abc" } | { kind: "def" };
+
+function f35431(a: A) {
+  switch (a.kind) {
+    case "abc":
+    case "def": return;
+    default:
+      a!.kind; // Error expected
+  }
+}
 
 //// [exhaustiveSwitchStatements1.js]
 "use strict";
@@ -453,6 +464,14 @@ function ff(o, k) {
     k === 'c'; // Error
     return o[k];
 }
+function f35431(a) {
+    switch (a.kind) {
+        case "abc":
+        case "def": return;
+        default:
+            a.kind; // Error expected
+    }
+}
 
 
 //// [exhaustiveSwitchStatements1.d.ts]
@@ -524,3 +543,9 @@ declare type O = {
 };
 declare type K = keyof O | 'c';
 declare function ff(o: O, k: K): number;
+declare type A = {
+    kind: "abc";
+} | {
+    kind: "def";
+};
+declare function f35431(a: A): void;

--- a/tests/baselines/reference/exhaustiveSwitchStatements1.symbols
+++ b/tests/baselines/reference/exhaustiveSwitchStatements1.symbols
@@ -603,3 +603,26 @@ function ff(o: O, k: K) {
 >k : Symbol(k, Decl(exhaustiveSwitchStatements1.ts, 229, 17))
 }
 
+// Repro from #35431
+type A = { kind: "abc" } | { kind: "def" };
+>A : Symbol(A, Decl(exhaustiveSwitchStatements1.ts, 236, 1))
+>kind : Symbol(kind, Decl(exhaustiveSwitchStatements1.ts, 239, 10))
+>kind : Symbol(kind, Decl(exhaustiveSwitchStatements1.ts, 239, 28))
+
+function f35431(a: A) {
+>f35431 : Symbol(f35431, Decl(exhaustiveSwitchStatements1.ts, 239, 43))
+>a : Symbol(a, Decl(exhaustiveSwitchStatements1.ts, 241, 16))
+>A : Symbol(A, Decl(exhaustiveSwitchStatements1.ts, 236, 1))
+
+  switch (a.kind) {
+>a.kind : Symbol(kind, Decl(exhaustiveSwitchStatements1.ts, 239, 10), Decl(exhaustiveSwitchStatements1.ts, 239, 28))
+>a : Symbol(a, Decl(exhaustiveSwitchStatements1.ts, 241, 16))
+>kind : Symbol(kind, Decl(exhaustiveSwitchStatements1.ts, 239, 10), Decl(exhaustiveSwitchStatements1.ts, 239, 28))
+
+    case "abc":
+    case "def": return;
+    default:
+      a!.kind; // Error expected
+>a : Symbol(a, Decl(exhaustiveSwitchStatements1.ts, 241, 16))
+  }
+}

--- a/tests/baselines/reference/exhaustiveSwitchStatements1.types
+++ b/tests/baselines/reference/exhaustiveSwitchStatements1.types
@@ -704,3 +704,32 @@ function ff(o: O, k: K) {
 >k : keyof O
 }
 
+// Repro from #35431
+type A = { kind: "abc" } | { kind: "def" };
+>A : A
+>kind : "abc"
+>kind : "def"
+
+function f35431(a: A) {
+>f35431 : (a: A) => void
+>a : A
+
+  switch (a.kind) {
+>a.kind : "abc" | "def"
+>a : A
+>kind : "abc" | "def"
+
+    case "abc":
+>"abc" : "abc"
+
+    case "def": return;
+>"def" : "def"
+
+    default:
+      a!.kind; // Error expected
+>a!.kind : any
+>a! : never
+>a : never
+>kind : any
+  }
+}

--- a/tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts
+++ b/tests/cases/conformance/controlFlow/exhaustiveSwitchStatements1.ts
@@ -239,3 +239,15 @@ function ff(o: O, k: K) {
     k === 'c';  // Error
     return o[k];
 }
+
+// Repro from #35431
+type A = { kind: "abc" } | { kind: "def" };
+
+function f35431(a: A) {
+  switch (a.kind) {
+    case "abc":
+    case "def": return;
+    default:
+      a!.kind; // Error expected
+  }
+}


### PR DESCRIPTION
Fixed issue where non null assertion caused `getFlowTypeOfReference` to return the declared type if the type was already narrowed to never.

This was caused by the fact that `getTypeWithFacts(resultType, TypeFacts.NEUndefinedOrNull)` will return never both if `resultType` was already `never` and if `resultType` does not contain `undefined` or `null`. In the latter case returning the declaring type is correct, in the former case this causes something narrowed to `never` to still be typed as the original declared type.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #35431
