### PR TITLE
Fixed refactoring and optional chaining failure 

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2288,7 +2288,7 @@ namespace ts {
                 writePunctuation(".");
             }
 
-            emitTokenWithComment(token.kind, node.expression.end, writePunctuation, node);
+            emit(token);
             increaseIndentIf(indentAfterDot, /*writeSpaceIfNotIndenting*/ false);
             emit(node.name);
             decreaseIndentIf(indentBeforeDot, indentAfterDot);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5020,7 +5020,30 @@ namespace ts {
     }
 
     export function getDotOrQuestionDotToken(node: PropertyAccessExpression) {
-        return node.questionDotToken || createNode(SyntaxKind.DotToken, node.expression.end, node.name.pos) as DotToken;
+        if(node.questionDotToken) return node.questionDotToken;
+
+        let pos = node.expression.end;
+        let end = node.name.pos;
+
+        // If the pos or end have synthetic positions, then try to find the original positions.
+        // We do this in order to keep source spacing and comments.
+        if(pos === -1 || end === -1) {
+            const parserTreeNode = getParseTreeNode(node) as PropertyAccessExpression;
+            const isSimilarNode = parserTreeNode && parserTreeNode.kind === parserTreeNode.kind;
+
+            if (isSimilarNode) {
+                // If we find the original node, use those positions.
+                pos = parserTreeNode.expression.end;
+                end = parserTreeNode.name.pos;
+            }
+            else {
+                // If not, just leave the node with both synthetic pos and end.
+                end = -1;
+                pos = -1;
+            }
+        }
+
+        return createNode(SyntaxKind.DotToken, pos, end) as DotToken;
     }
 
     export function isNamedImportsOrExports(node: Node): node is NamedImportsOrExports {

--- a/tests/cases/fourslash/extract-const-optional-chaining.ts
+++ b/tests/cases/fourslash/extract-const-optional-chaining.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+////declare var bar: number | number
+/////*a*/bar?.toString()/*b*/;
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "constant_scope_0",
+    actionDescription: "Extract to constant in enclosing scope",
+    newContent:
+`declare var bar: number | number
+const /*RENAME*/newLocal = bar?.toString();`
+});

--- a/tests/cases/fourslash/extract-method-optional-chaining.ts
+++ b/tests/cases/fourslash/extract-method-optional-chaining.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+////function foo(bar?: number) {
+////    /*a*/bar?.toString();/*b*/
+////}
+
+goTo.select('a', 'b')
+edit.applyRefactor({
+    refactorName: "Extract Symbol",
+    actionName: "function_scope_0",
+    actionDescription: "Extract to inner function in function 'foo'",
+    newContent:
+`function foo(bar?: number) {
+    /*RENAME*/newFunction();
+
+    function newFunction() {
+        bar?.toString();
+    }
+}`
+});


### PR DESCRIPTION
Fixes #35372

Fixed failure when using refactoring on expression that contains an optional chaining expression.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

