### PR TITLE
Allow arrow functions without blocks inside to fold be outlined.

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -205,6 +205,8 @@ namespace ts.OutliningElementsCollector {
             case SyntaxKind.TemplateExpression:
             case SyntaxKind.NoSubstitutionTemplateLiteral:
                 return spanForTemplateLiteral(<TemplateExpression | NoSubstitutionTemplateLiteral>n);
+            case SyntaxKind.ArrowFunction:
+                return spanForArrowFunction(<ArrowFunction>n);
         }
 
         function spanForJSXElement(node: JsxElement): OutliningSpan | undefined {
@@ -233,6 +235,18 @@ namespace ts.OutliningElementsCollector {
                 return undefined;
             }
             return createOutliningSpanFromBounds(node.getStart(sourceFile), node.getEnd(), OutliningSpanKind.Code);
+        }
+
+        function spanForArrowFunction(node: ArrowFunction) {
+            if(!isParenthesizedExpression(node.body)) {
+                return undefined;
+            }
+            const openToken = isNodeArrayMultiLine(node.parameters, sourceFile)
+                ? findChildOfKind(node, SyntaxKind.OpenParenToken, sourceFile)
+                : findChildOfKind(node.body, SyntaxKind.OpenParenToken, sourceFile);
+
+            const closeToken = findChildOfKind(node.body, SyntaxKind.CloseParenToken, sourceFile);
+            return openToken && closeToken && spanBetweenTokens(openToken, closeToken, node, sourceFile, /*autoCollapse*/ false);
         }
 
         function spanForObjectOrArrayLiteral(node: Node, open: SyntaxKind.OpenBraceToken | SyntaxKind.OpenBracketToken = SyntaxKind.OpenBraceToken): OutliningSpan | undefined {

--- a/tests/cases/fourslash/getArrowFunctionOutlineSpans.tsx
+++ b/tests/cases/fourslash/getArrowFunctionOutlineSpans.tsx
@@ -1,0 +1,22 @@
+////import React, { Component } from 'react';
+////
+////let component = () =>[| (
+////    [|<div></div>|]
+////)|]
+////
+////let componentParams =[| (
+////    p: any
+////) => (
+////    [|<div></div>|]
+////)|];
+////let a: any[];
+////a.map(() =>[|(
+////    1 + 3
+////)|]);
+////a.map(() =>[|(
+////    1 + 3
+////)|]).filter(() =>[|(
+////    true
+////)|]);
+
+verify.outliningSpansInCurrentFile(test.ranges(), "code");


### PR DESCRIPTION
Fixes #26661

The original code snippet now folds as expected. The extra folding is done only for paranthesized expressions in the body of the arrow function. I would have extended it to any multiline arrow function body but for the following problem:

When dealing with chained calls to functions that take arrow functions, folding gets wonky. Consider this:  

![image](https://user-images.githubusercontent.com/8193316/71520125-4041a880-28c3-11ea-9925-ce7fc7f4a36b.png)


This gets nicely folded to:

![image](https://user-images.githubusercontent.com/8193316/71520145-4a63a700-28c3-11ea-8462-aa338924f581.png)


But this similar code:

![image](https://user-images.githubusercontent.com/8193316/71520110-2bfdab80-28c3-11ea-930f-733ee0b693c0.png)


Is not well folded, even though the spans returned are exactly equal (just `map` was folded below)
![image](https://user-images.githubusercontent.com/8193316/71520107-21431680-28c3-11ea-8e3c-7574029b2932.png)


This is due to the fact that `}` receives special handling in vscode. From `folding.ts`:
```ts
// workaround for #47240
const end = (range.end.character > 0 && document.getText(new vscode.Range(range.end.translate(0, -1), range.end)) === '}')
	? Math.max(range.end.line - 1, range.start.line)
	: range.end.line;
```
I was thinking `)` could receive similar special case treatment, so as for spans to be the same for `{}` or `()`. Alternatively I could special case arrow functions to not not produce spans if they are just 1-2 lines and only include in the span all the lines except the last one. 

cc: @mjbvz 
