### PR TITLE
Added quick-fix to rewrite index access as call to get/set method.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -640,6 +640,7 @@ namespace ts {
             getSuggestionForNonexistentSymbol: (location, name, meaning) => getSuggestionForNonexistentSymbol(location, escapeLeadingUnderscores(name), meaning),
             getSuggestedSymbolForNonexistentModule,
             getSuggestionForNonexistentExport,
+            getSuggestionForNonexistentIndexSignatureMethod,
             getBaseConstraintOfType,
             getDefaultFromTypeParameter: type => type && type.flags & TypeFlags.TypeParameter ? getDefaultFromTypeParameter(type as TypeParameter) : undefined,
             resolveName(name, location, meaning, excludeGlobals) {
@@ -26674,7 +26675,7 @@ namespace ts {
             return suggestion && symbolName(suggestion);
         }
 
-        function getSuggestionForNonexistentIndexSignature(objectType: Type, expr: ElementAccessExpression, keyedType: Type): string | undefined {
+        function getSuggestionForNonexistentIndexSignatureMethod(objectType: Type, expr: ElementAccessExpression, keyedType: Type): string | undefined {
             // check if object type has setter or getter
             function hasProp(name: "set" | "get") {
                 const prop = getPropertyOfObjectType(objectType, <__String>name);
@@ -26689,7 +26690,13 @@ namespace ts {
             if (!hasProp(suggestedMethod)) {
                 return undefined;
             }
-
+            return suggestedMethod;
+        }
+        function getSuggestionForNonexistentIndexSignature(objectType: Type, expr: ElementAccessExpression, keyedType: Type): string | undefined {
+            const suggestedMethod = getSuggestionForNonexistentIndexSignatureMethod(objectType, expr, keyedType);
+            if(suggestedMethod === undefined) {
+                return undefined
+            }
             let suggestion = tryGetPropertyAccessOrIdentifierToString(expr.expression);
             if (suggestion === undefined) {
                 suggestion = suggestedMethod;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -26695,7 +26695,7 @@ namespace ts {
         function getSuggestionForNonexistentIndexSignature(objectType: Type, expr: ElementAccessExpression, keyedType: Type): string | undefined {
             const suggestedMethod = getSuggestionForNonexistentIndexSignatureMethod(objectType, expr, keyedType);
             if(suggestedMethod === undefined) {
-                return undefined
+                return undefined;
             }
             let suggestion = tryGetPropertyAccessOrIdentifierToString(expr.expression);
             if (suggestion === undefined) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -5609,6 +5609,14 @@
         "category": "Message",
         "code": 90053
     },
+    "Rewrite index access as call to '{0}'": {
+        "category": "Message",
+        "code": 90054
+    },
+    "Rewrite all invalid index access expressions as calls to 'get'/'set' where possible": {
+        "category": "Message",
+        "code": 90055
+    },
     "Convert function to an ES2015 class": {
         "category": "Message",
         "code": 95001

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4137,6 +4137,7 @@ namespace ts {
         /* @internal */ getSuggestionForNonexistentSymbol(location: Node, name: string, meaning: SymbolFlags): string | undefined;
         /* @internal */ getSuggestedSymbolForNonexistentModule(node: Identifier, target: Symbol): Symbol | undefined;
         /* @internal */ getSuggestionForNonexistentExport(node: Identifier, target: Symbol): string | undefined;
+        /* @internal */ getSuggestionForNonexistentIndexSignatureMethod(objectType: Type, expr: ElementAccessExpression, keyedType: Type): string | undefined
         getBaseConstraintOfType(type: Type): Type | undefined;
         getDefaultFromTypeParameter(type: Type): Type | undefined;
 

--- a/src/services/codefixes/fixMapIndexSignature.ts
+++ b/src/services/codefixes/fixMapIndexSignature.ts
@@ -1,0 +1,68 @@
+/* @internal */
+namespace ts.codefix {
+    export const fixMapIndexSignatureFixId = "fixMapIndexSignature";
+    const errorCodes: number[] = [
+        Diagnostics.Element_implicitly_has_an_any_type_because_type_0_has_no_index_signature_Did_you_mean_to_call_1.code
+    ];
+
+    registerCodeFix({
+        errorCodes,
+        getCodeActions(context) {
+            const { sourceFile, span } = context;
+            const info = getInfo(sourceFile, span.start, context.program.getTypeChecker());
+            if (!info) return undefined;
+
+            const changes = textChanges.ChangeTracker.with(context, t => doChange(t, sourceFile, info.node, info.method));
+            return [
+                createCodeFixAction(
+                    "mapIndex", changes,
+                    [Diagnostics.Rewrite_index_access_as_call_to_0, info.method],
+                    fixMapIndexSignatureFixId,
+                    Diagnostics.Rewrite_all_invalid_index_access_expressions_as_calls_to_get_Slash_set_where_possible)
+            ];
+        },
+        fixIds: [fixMapIndexSignatureFixId],
+        getAllCodeActions: context => codeFixAll(context, errorCodes, (changes, diag) => {
+            const info = getInfo(diag.file, diag.start, context.program.getTypeChecker());
+            if (info) doChange(changes, context.sourceFile, info.node, info.method);
+        }),
+    });
+
+    function getInfo(sourceFile: SourceFile, pos: number, checker: TypeChecker){
+        const node = getTokenAtPosition(sourceFile, pos);
+        if(!isElementAccessExpression(node.parent)) return undefined;
+
+        const targetSymbol = checker.getSymbolAtLocation(node.parent.expression);
+        if(!targetSymbol) return undefined;
+
+        const targetType = checker.getTypeOfSymbolAtLocation(targetSymbol, node.parent);
+        if(!targetType) return undefined;
+
+        const indexType = checker.getTypeAtLocation(node.parent.argumentExpression);
+        if(!indexType) return undefined;
+        // const target = node.parent;
+        // const method = isAssignmentExpression(target.parent, /*excludeCompoundAssignment*/ true)? "set" :"get";
+        const method = checker.getSuggestionForNonexistentIndexSignatureMethod(targetType, node.parent, indexType) as "get" | "set" | undefined;
+        if(method !== "get" && method !== "set") return undefined;
+
+        const property = checker.getPropertyOfType(targetType, method);
+        if(!property) return undefined;
+
+        return { node: node.parent, method, type: checker.typeToString(targetType) } as const;
+    }
+    function doChange(changes: textChanges.ChangeTracker, sourceFile: SourceFile, node: ElementAccessExpression, method: "get" | "set"){
+        if(method === "get") {
+            changes.replaceNode(sourceFile, node,factory.createCallExpression(
+                factory.createPropertyAccessExpression(node.expression, "get"),
+                /*typeArguments*/ undefined,
+                [node.argumentExpression]));
+        }
+        else {
+            const assignment = <AssignmentExpression<EqualsToken>>node.parent;
+            changes.replaceNode(sourceFile, assignment, factory.createCallExpression(
+                factory.createPropertyAccessExpression(node.expression, "set"),
+                /*typeArguments*/ undefined,
+                [node.argumentExpression, assignment.right]));
+        }
+    }
+}

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -64,6 +64,7 @@
         "codefixes/convertToTypeOnlyImport.ts",
         "codefixes/convertLiteralTypeToMappedType.ts",
         "codefixes/fixClassIncorrectlyImplementsInterface.ts",
+        "codefixes/fixMapIndexSignature.ts",
         "codefixes/importFixes.ts",
         "codefixes/fixNoPropertyAccessFromIndexSignature.ts",
         "codefixes/fixImplicitThis.ts",

--- a/tests/cases/fourslash/codeFixMapIndexSignature.ts
+++ b/tests/cases/fourslash/codeFixMapIndexSignature.ts
@@ -6,7 +6,7 @@
 // target and lib do not actually work in four slash tests, so we define Map manually
 //// declare class Map<K, V> { get(key: string): V; }
 ////[|let map = new Map<string, string>();
-////map['a'] = map['b']|];
+////const x = map['af123'];|]
 
 verify.rangeAfterCodeFix(`let map = new Map<string, string>();
-map.set('a', map.get('b'))`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 0);
+const x = map.get('af123');`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 0);

--- a/tests/cases/fourslash/codeFixMapIndexSignature.ts
+++ b/tests/cases/fourslash/codeFixMapIndexSignature.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts' />
+
+// @target:ES2015
+// @strict:true
+
+// target and lib do not actually work in four slash tests, so we define Map manually
+//// declare class Map<K, V> { get(key: string): V; }
+////[|let map = new Map<string, string>();
+////map['a'] = map['b']|];
+
+verify.rangeAfterCodeFix(`let map = new Map<string, string>();
+map.set('a', map.get('b'))`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 0);

--- a/tests/cases/fourslash/codeFixMapIndexSignatureAll.ts
+++ b/tests/cases/fourslash/codeFixMapIndexSignatureAll.ts
@@ -6,7 +6,11 @@
 // target and lib do not actually work in four slash tests, so we define Map manually
 ////declare class Map<K, V> { get(key: K): V; set(key:K, value: V): void; }
 ////let map = new Map<string, string>();
-////map['a'] = map['b']
+////map['a'] = map['b'];
+////map['a'] = (map['b'] = map['c']);
+////let mapobj = = new Map<string, { foo: string }>();
+////mapobj['a'].foo = "a";
+////map['a'] //f
 
 
 verify.codeFixAll({
@@ -14,5 +18,9 @@ verify.codeFixAll({
     fixAllDescription: "Rewrite all invalid index access expressions as calls to 'get'/'set' where possible",
     newFileContent: `declare class Map<K, V> { get(key: K): V; set(key:K, value: V): void; }
 let map = new Map<string, string>();
-map.set('a', map.get('b'))`
+map.set('a', map.get('b'));
+map.set('a', (map.set('b', map.get('c'))));
+let mapobj = = new Map<string, { foo: string }>();
+mapobj.get('a').foo = "a";
+map.get('a') //f`
 });

--- a/tests/cases/fourslash/codeFixMapIndexSignatureAll.ts
+++ b/tests/cases/fourslash/codeFixMapIndexSignatureAll.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+// @target:ES2015
+// @strict:true
+
+// target and lib do not actually work in four slash tests, so we define Map manually
+////declare class Map<K, V> { get(key: K): V; set(key:K, value: V): void; }
+////let map = new Map<string, string>();
+////map['a'] = map['b']
+
+
+verify.codeFixAll({
+    fixId: "fixMapIndexSignature",
+    fixAllDescription: "Rewrite all invalid index access expressions as calls to 'get'/'set' where possible",
+    newFileContent: `declare class Map<K, V> { get(key: K): V; set(key:K, value: V): void; }
+let map = new Map<string, string>();
+map.set('a', map.get('b'))`
+});

--- a/tests/cases/fourslash/codeFixMapIndexSignatureSet.ts
+++ b/tests/cases/fourslash/codeFixMapIndexSignatureSet.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts' />
+
+// @target:ES2015
+// @strict:true
+
+// target and lib do not actually work in four slash tests, so we define Map manually
+//// declare class Map<K, V> { get(key: K): V; set(key: K, value: V): void;}
+////[|let map = new Map<string, string>();
+////map['af123'] = "";|]
+
+verify.rangeAfterCodeFix(`let map = new Map<string, string>();
+map.set('af123', "");`, /*includeWhiteSpace*/false, /*errorCode*/ undefined, /*index*/ 0);


### PR DESCRIPTION

Fixes #32925

Added quick-fix to rewrite index access as call to get/set method where the target type the appropriate method

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

