### PR TITLE
fix(lib/es5): Preserve `Omit` in output

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1463,7 +1463,9 @@ type Extract<T, U> = T extends U ? T : never;
 /**
  * Construct a type with the properties of T except for those in type K.
  */
-type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;
+type Omit<T, K extends keyof any> = {
+    [P in Exclude<keyof T, K>]: T[P];
+};
 
 /**
  * Exclude null and undefined from T

--- a/tests/baselines/reference/genericIsNeverEmptyObject.types
+++ b/tests/baselines/reference/genericIsNeverEmptyObject.types
@@ -2,18 +2,18 @@
 // Repro from #29067
 
 function test<T extends { a: string }>(obj: T) {
->test : <T extends { a: string; }>(obj: T) => Pick<T, Exclude<keyof T, "a">> & { b: string; }
+>test : <T extends { a: string; }>(obj: T) => Omit<T, "a"> & { b: string; }
 >a : string
 >obj : T
 
     let { a, ...rest } = obj;
 >a : string
->rest : Pick<T, Exclude<keyof T, "a">>
+>rest : Omit<T, "a">
 >obj : T
 
     return { ...rest, b: a };
->{ ...rest, b: a } : Pick<T, Exclude<keyof T, "a">> & { b: string; }
->rest : Pick<T, Exclude<keyof T, "a">>
+>{ ...rest, b: a } : Omit<T, "a"> & { b: string; }
+>rest : Omit<T, "a">
 >b : string
 >a : string
 }
@@ -30,7 +30,7 @@ let o2: { b: string, x: number } = test(o1);
 >o2 : { b: string; x: number; }
 >b : string
 >x : number
->test(o1) : Pick<{ a: string; x: number; }, "x"> & { b: string; }
->test : <T extends { a: string; }>(obj: T) => Pick<T, Exclude<keyof T, "a">> & { b: string; }
+>test(o1) : Omit<{ a: string; x: number; }, "a"> & { b: string; }
+>test : <T extends { a: string; }>(obj: T) => Omit<T, "a"> & { b: string; }
 >o1 : { a: string; x: number; }
 

--- a/tests/baselines/reference/genericObjectRest.types
+++ b/tests/baselines/reference/genericObjectRest.types
@@ -16,7 +16,7 @@ function f1<T extends { a: string, b: number }>(obj: T) {
     let { a: a1, ...r1 } = obj;
 >a : any
 >a1 : string
->r1 : Pick<T, Exclude<keyof T, "a">>
+>r1 : Omit<T, "a">
 >obj : T
 
     let { a: a2, b: b2, ...r2 } = obj;
@@ -24,24 +24,24 @@ function f1<T extends { a: string, b: number }>(obj: T) {
 >a2 : string
 >b : any
 >b2 : number
->r2 : Pick<T, Exclude<keyof T, "a" | "b">>
+>r2 : Omit<T, "a" | "b">
 >obj : T
 
     let { 'a': a3, ...r3 } = obj;
 >a3 : string
->r3 : Pick<T, Exclude<keyof T, "a">>
+>r3 : Omit<T, "a">
 >obj : T
 
     let { ['a']: a4, ...r4 } = obj;
 >'a' : "a"
 >a4 : string
->r4 : Pick<T, Exclude<keyof T, "a">>
+>r4 : Omit<T, "a">
 >obj : T
 
     let { [a]: a5, ...r5 } = obj;
 >a : "a"
 >a5 : string
->r5 : Pick<T, Exclude<keyof T, "a">>
+>r5 : Omit<T, "a">
 >obj : T
 }
 
@@ -68,7 +68,7 @@ function f2<T extends { [sa]: string, [sb]: number }>(obj: T) {
 >a1 : string
 >sb : unique symbol
 >b1 : number
->r1 : Pick<T, Exclude<keyof T, unique symbol | unique symbol>>
+>r1 : Omit<T, unique symbol | unique symbol>
 >obj : T
 }
 
@@ -83,7 +83,7 @@ function f3<T, K1 extends keyof T, K2 extends keyof T>(obj: T, k1: K1, k2: K2) {
 >a1 : T[K1]
 >k2 : K2
 >a2 : T[K2]
->r1 : Pick<T, Exclude<keyof T, K1 | K2>>
+>r1 : Omit<T, K1 | K2>
 >obj : T
 }
 
@@ -104,7 +104,7 @@ function f4<K1 extends keyof Item, K2 extends keyof Item>(obj: Item, k1: K1, k2:
 >a1 : Item[K1]
 >k2 : K2
 >a2 : Item[K2]
->r1 : Pick<Item, Exclude<"a", K1 | K2> | Exclude<"b", K1 | K2> | Exclude<"c", K1 | K2>>
+>r1 : Omit<Item, K1 | K2>
 >obj : Item
 }
 

--- a/tests/baselines/reference/literalTypeWidening.types
+++ b/tests/baselines/reference/literalTypeWidening.types
@@ -443,15 +443,15 @@ function test<T extends { a: string, b: string }>(obj: T): T {
 
     let { a, ...rest } = obj;
 >a : string
->rest : Pick<T, Exclude<keyof T, "a">>
+>rest : Omit<T, "a">
 >obj : T
 
     return { a: 'hello', ...rest } as T;
 >{ a: 'hello', ...rest } as T : T
->{ a: 'hello', ...rest } : { a: string; } & Pick<T, Exclude<keyof T, "a">>
+>{ a: 'hello', ...rest } : { a: string; } & Omit<T, "a">
 >a : string
 >'hello' : "hello"
->rest : Pick<T, Exclude<keyof T, "a">>
+>rest : Omit<T, "a">
 }
 
 // Repro from #32169

--- a/tests/baselines/reference/mappedTypeConstraints.symbols
+++ b/tests/baselines/reference/mappedTypeConstraints.symbols
@@ -132,9 +132,9 @@ const modifier = <T extends TargetProps>(targetProps: T) => {
 >targetProps : Symbol(targetProps, Decl(mappedTypeConstraints.ts, 30, 41))
 
     rest.foo;
->rest.foo : Symbol(foo, Decl(mappedTypeConstraints.ts, 25, 20))
+>rest.foo : Symbol(foo)
 >rest : Symbol(rest, Decl(mappedTypeConstraints.ts, 31, 13))
->foo : Symbol(foo, Decl(mappedTypeConstraints.ts, 25, 20))
+>foo : Symbol(foo)
 
 };
 

--- a/tests/baselines/reference/mappedTypeConstraints.types
+++ b/tests/baselines/reference/mappedTypeConstraints.types
@@ -98,12 +98,12 @@ const modifier = <T extends TargetProps>(targetProps: T) => {
 
     let {bar, ...rest} = targetProps;
 >bar : string
->rest : Pick<T, Exclude<keyof T, "bar">>
+>rest : Omit<T, "bar">
 >targetProps : T
 
     rest.foo;
 >rest.foo : T["foo"]
->rest : Pick<T, Exclude<keyof T, "bar">>
+>rest : Omit<T, "bar">
 >foo : T["foo"]
 
 };

--- a/tests/baselines/reference/objectRestNegative.types
+++ b/tests/baselines/reference/objectRestNegative.types
@@ -36,18 +36,18 @@ function stillMustBeLast({ ...mustBeLast, a }: { a: number, b: string }): void {
 >b : string
 }
 function generic<T extends { x, y }>(t: T) {
->generic : <T extends { x: any; y: any; }>(t: T) => Pick<T, Exclude<keyof T, "x">>
+>generic : <T extends { x: any; y: any; }>(t: T) => Omit<T, "x">
 >x : any
 >y : any
 >t : T
 
     let { x, ...rest } = t;
 >x : any
->rest : Pick<T, Exclude<keyof T, "x">>
+>rest : Omit<T, "x">
 >t : T
 
     return rest;
->rest : Pick<T, Exclude<keyof T, "x">>
+>rest : Omit<T, "x">
 }
 
 let rest: { b: string }

--- a/tests/baselines/reference/omitTypeHelperModifiers01.symbols
+++ b/tests/baselines/reference/omitTypeHelperModifiers01.symbols
@@ -28,42 +28,42 @@ function f(x: B) {
 
     const b = x.b;
 >b : Symbol(b, Decl(omitTypeHelperModifiers01.ts, 10, 9))
->x.b : Symbol(b, Decl(omitTypeHelperModifiers01.ts, 1, 14))
+>x.b : Symbol(b)
 >x : Symbol(x, Decl(omitTypeHelperModifiers01.ts, 9, 11))
->b : Symbol(b, Decl(omitTypeHelperModifiers01.ts, 1, 14))
+>b : Symbol(b)
 
     x.b = "hello";
->x.b : Symbol(b, Decl(omitTypeHelperModifiers01.ts, 1, 14))
+>x.b : Symbol(b)
 >x : Symbol(x, Decl(omitTypeHelperModifiers01.ts, 9, 11))
->b : Symbol(b, Decl(omitTypeHelperModifiers01.ts, 1, 14))
+>b : Symbol(b)
 
     x.b = undefined;
->x.b : Symbol(b, Decl(omitTypeHelperModifiers01.ts, 1, 14))
+>x.b : Symbol(b)
 >x : Symbol(x, Decl(omitTypeHelperModifiers01.ts, 9, 11))
->b : Symbol(b, Decl(omitTypeHelperModifiers01.ts, 1, 14))
+>b : Symbol(b)
 >undefined : Symbol(undefined)
 
     const c = x.c;
 >c : Symbol(c, Decl(omitTypeHelperModifiers01.ts, 14, 9))
->x.c : Symbol(c, Decl(omitTypeHelperModifiers01.ts, 2, 15))
+>x.c : Symbol(c)
 >x : Symbol(x, Decl(omitTypeHelperModifiers01.ts, 9, 11))
->c : Symbol(c, Decl(omitTypeHelperModifiers01.ts, 2, 15))
+>c : Symbol(c)
 
     x.c = true;
->x.c : Symbol(c, Decl(omitTypeHelperModifiers01.ts, 2, 15))
+>x.c : Symbol(c)
 >x : Symbol(x, Decl(omitTypeHelperModifiers01.ts, 9, 11))
->c : Symbol(c, Decl(omitTypeHelperModifiers01.ts, 2, 15))
+>c : Symbol(c)
 
     const d = x.d;
 >d : Symbol(d, Decl(omitTypeHelperModifiers01.ts, 17, 9))
->x.d : Symbol(d, Decl(omitTypeHelperModifiers01.ts, 3, 24))
+>x.d : Symbol(d)
 >x : Symbol(x, Decl(omitTypeHelperModifiers01.ts, 9, 11))
->d : Symbol(d, Decl(omitTypeHelperModifiers01.ts, 3, 24))
+>d : Symbol(d)
 
     x.d = d;
->x.d : Symbol(d, Decl(omitTypeHelperModifiers01.ts, 3, 24))
+>x.d : Symbol(d)
 >x : Symbol(x, Decl(omitTypeHelperModifiers01.ts, 9, 11))
->d : Symbol(d, Decl(omitTypeHelperModifiers01.ts, 3, 24))
+>d : Symbol(d)
 >d : Symbol(d, Decl(omitTypeHelperModifiers01.ts, 17, 9))
 }
 

--- a/tests/baselines/reference/omitTypeHelperModifiers01.types
+++ b/tests/baselines/reference/omitTypeHelperModifiers01.types
@@ -17,55 +17,55 @@ type A = {
 };
 
 type B = Omit<A, 'a'>;
->B : Pick<A, "b" | "c" | "d">
+>B : Omit<A, "a">
 
 function f(x: B) {
->f : (x: Pick<A, "b" | "c" | "d">) => void
->x : Pick<A, "b" | "c" | "d">
+>f : (x: Omit<A, "a">) => void
+>x : Omit<A, "a">
 
     const b = x.b;
 >b : string | undefined
 >x.b : string | undefined
->x : Pick<A, "b" | "c" | "d">
+>x : Omit<A, "a">
 >b : string | undefined
 
     x.b = "hello";
 >x.b = "hello" : "hello"
 >x.b : string | undefined
->x : Pick<A, "b" | "c" | "d">
+>x : Omit<A, "a">
 >b : string | undefined
 >"hello" : "hello"
 
     x.b = undefined;
 >x.b = undefined : undefined
 >x.b : string | undefined
->x : Pick<A, "b" | "c" | "d">
+>x : Omit<A, "a">
 >b : string | undefined
 >undefined : undefined
 
     const c = x.c;
 >c : boolean
 >x.c : boolean
->x : Pick<A, "b" | "c" | "d">
+>x : Omit<A, "a">
 >c : boolean
 
     x.c = true;
 >x.c = true : true
->x.c : any
->x : Pick<A, "b" | "c" | "d">
->c : any
+>x.c : boolean
+>x : Omit<A, "a">
+>c : boolean
 >true : true
 
     const d = x.d;
 >d : unknown
 >x.d : unknown
->x : Pick<A, "b" | "c" | "d">
+>x : Omit<A, "a">
 >d : unknown
 
     x.d = d;
 >x.d = d : unknown
 >x.d : unknown
->x : Pick<A, "b" | "c" | "d">
+>x : Omit<A, "a">
 >d : unknown
 >d : unknown
 }

--- a/tests/baselines/reference/omitTypeTestErrors01.errors.txt
+++ b/tests/baselines/reference/omitTypeTestErrors01.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/omitTypeTestErrors01.ts(11,16): error TS2339: Property 'c' does not exist on type 'Pick<Foo, "a" | "b">'.
-tests/cases/compiler/omitTypeTestErrors01.ts(15,16): error TS2339: Property 'b' does not exist on type 'Pick<Foo, "a">'.
+tests/cases/compiler/omitTypeTestErrors01.ts(11,16): error TS2339: Property 'c' does not exist on type 'Omit<Foo, "c">'.
+tests/cases/compiler/omitTypeTestErrors01.ts(15,16): error TS2339: Property 'b' does not exist on type 'Omit<Foo, "c" | "b">'.
 
 
 ==== tests/cases/compiler/omitTypeTestErrors01.ts (2 errors) ====
@@ -15,13 +15,13 @@ tests/cases/compiler/omitTypeTestErrors01.ts(15,16): error TS2339: Property 'b' 
     export function getBarC(bar: Bar) {
         return bar.c;
                    ~
-!!! error TS2339: Property 'c' does not exist on type 'Pick<Foo, "a" | "b">'.
+!!! error TS2339: Property 'c' does not exist on type 'Omit<Foo, "c">'.
     }
     
     export function getBazB(baz: Baz) {
         return baz.b;
                    ~
-!!! error TS2339: Property 'b' does not exist on type 'Pick<Foo, "a">'.
+!!! error TS2339: Property 'b' does not exist on type 'Omit<Foo, "c" | "b">'.
     }
     
     

--- a/tests/baselines/reference/omitTypeTestErrors01.types
+++ b/tests/baselines/reference/omitTypeTestErrors01.types
@@ -11,28 +11,28 @@ interface Foo {
 }
 
 export type Bar = Omit<Foo, "c">;
->Bar : Pick<Foo, "a" | "b">
+>Bar : Omit<Foo, "c">
 
 export type Baz = Omit<Foo, "b" | "c">;
->Baz : Pick<Foo, "a">
+>Baz : Omit<Foo, "c" | "b">
 
 export function getBarC(bar: Bar) {
->getBarC : (bar: Pick<Foo, "a" | "b">) => any
->bar : Pick<Foo, "a" | "b">
+>getBarC : (bar: Omit<Foo, "c">) => any
+>bar : Omit<Foo, "c">
 
     return bar.c;
 >bar.c : any
->bar : Pick<Foo, "a" | "b">
+>bar : Omit<Foo, "c">
 >c : any
 }
 
 export function getBazB(baz: Baz) {
->getBazB : (baz: Pick<Foo, "a">) => any
->baz : Pick<Foo, "a">
+>getBazB : (baz: Omit<Foo, "c" | "b">) => any
+>baz : Omit<Foo, "c" | "b">
 
     return baz.b;
 >baz.b : any
->baz : Pick<Foo, "a">
+>baz : Omit<Foo, "c" | "b">
 >b : any
 }
 

--- a/tests/baselines/reference/omitTypeTests01.symbols
+++ b/tests/baselines/reference/omitTypeTests01.symbols
@@ -28,9 +28,9 @@ export function getBarA(bar: Bar) {
 >Bar : Symbol(Bar, Decl(omitTypeTests01.ts, 4, 1))
 
     return bar.a;
->bar.a : Symbol(a, Decl(omitTypeTests01.ts, 0, 15))
+>bar.a : Symbol(a)
 >bar : Symbol(bar, Decl(omitTypeTests01.ts, 9, 24))
->a : Symbol(a, Decl(omitTypeTests01.ts, 0, 15))
+>a : Symbol(a)
 }
 
 export function getBazA(baz: Baz) {
@@ -39,9 +39,9 @@ export function getBazA(baz: Baz) {
 >Baz : Symbol(Baz, Decl(omitTypeTests01.ts, 6, 33))
 
     return baz.a;
->baz.a : Symbol(a, Decl(omitTypeTests01.ts, 0, 15))
+>baz.a : Symbol(a)
 >baz : Symbol(baz, Decl(omitTypeTests01.ts, 13, 24))
->a : Symbol(a, Decl(omitTypeTests01.ts, 0, 15))
+>a : Symbol(a)
 }
 
 

--- a/tests/baselines/reference/omitTypeTests01.types
+++ b/tests/baselines/reference/omitTypeTests01.types
@@ -11,28 +11,28 @@ interface Foo {
 }
 
 export type Bar = Omit<Foo, "c">;
->Bar : Pick<Foo, "a" | "b">
+>Bar : Omit<Foo, "c">
 
 export type Baz = Omit<Foo, "b" | "c">;
->Baz : Pick<Foo, "a">
+>Baz : Omit<Foo, "c" | "b">
 
 export function getBarA(bar: Bar) {
->getBarA : (bar: Pick<Foo, "a" | "b">) => string
->bar : Pick<Foo, "a" | "b">
+>getBarA : (bar: Omit<Foo, "c">) => string
+>bar : Omit<Foo, "c">
 
     return bar.a;
 >bar.a : string
->bar : Pick<Foo, "a" | "b">
+>bar : Omit<Foo, "c">
 >a : string
 }
 
 export function getBazA(baz: Baz) {
->getBazA : (baz: Pick<Foo, "a">) => string
->baz : Pick<Foo, "a">
+>getBazA : (baz: Omit<Foo, "c" | "b">) => string
+>baz : Omit<Foo, "c" | "b">
 
     return baz.a;
 >baz.a : string
->baz : Pick<Foo, "a">
+>baz : Omit<Foo, "c" | "b">
 >a : string
 }
 

--- a/tests/baselines/reference/unionAndIntersectionInference3.types
+++ b/tests/baselines/reference/unionAndIntersectionInference3.types
@@ -157,7 +157,7 @@ export interface RouteComponentProps { route: string }
 >route : string
 
 declare function withRouter<
->withRouter : <P extends RouteComponentProps, C extends ComponentType<P>>(component: (C & FunctionComponent<P>) | (C & ComponentClass<P>)) => ComponentClass<Pick<P, Exclude<keyof P, "route">>>
+>withRouter : <P extends RouteComponentProps, C extends ComponentType<P>>(component: (C & FunctionComponent<P>) | (C & ComponentClass<P>)) => ComponentClass<Omit<P, "route">>
 
   P extends RouteComponentProps,
   C extends ComponentType<P>
@@ -174,8 +174,8 @@ declare const MyComponent: ComponentType<Props>;
 >MyComponent : ComponentType<Props>
 
 withRouter(MyComponent);
->withRouter(MyComponent) : ComponentClass<Pick<Props, "username">>
->withRouter : <P extends RouteComponentProps, C extends ComponentType<P>>(component: (C & FunctionComponent<P>) | (C & ComponentClass<P>)) => ComponentClass<Pick<P, Exclude<keyof P, "route">>>
+>withRouter(MyComponent) : ComponentClass<Omit<Props, "route">>
+>withRouter : <P extends RouteComponentProps, C extends ComponentType<P>>(component: (C & FunctionComponent<P>) | (C & ComponentClass<P>)) => ComponentClass<Omit<P, "route">>
 >MyComponent : ComponentType<Props>
 
 // Repro from #33490


### PR DESCRIPTION
I’ve&nbsp;been&nbsp;using this&nbsp;without&nbsp;problems in&nbsp;my&nbsp;local&nbsp;version of&nbsp;the&nbsp;**TypeScript**&nbsp;library.

---

Fixes #34793