### PR TITLE
Fixes broken emit with useDefineForClassFields + private field

### DIFF
--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -777,8 +777,9 @@ namespace ts {
                 return undefined;
             }
 
+            const propertyOriginalNode = getOriginalNode(property);
             const initializer = property.initializer || emitAssignment ? visitNode(property.initializer, visitor, isExpression)
-                : hasModifier(getOriginalNode(property), ModifierFlags.ParameterPropertyModifier) && isIdentifier(propertyName) && isParameter(getOriginalNode(property)) ? propertyName
+                : isParameterPropertyDeclaration(propertyOriginalNode, propertyOriginalNode.parent) && isIdentifier(propertyName) ? propertyName
                 : createVoidZero();
 
             if (emitAssignment || isPrivateIdentifier(propertyName)) {

--- a/src/compiler/transformers/classFields.ts
+++ b/src/compiler/transformers/classFields.ts
@@ -778,7 +778,7 @@ namespace ts {
             }
 
             const initializer = property.initializer || emitAssignment ? visitNode(property.initializer, visitor, isExpression)
-                : hasModifier(getOriginalNode(property), ModifierFlags.ParameterPropertyModifier) && isIdentifier(propertyName) ? propertyName
+                : hasModifier(getOriginalNode(property), ModifierFlags.ParameterPropertyModifier) && isIdentifier(propertyName) && isParameter(getOriginalNode(property)) ? propertyName
                 : createVoidZero();
 
             if (emitAssignment || isPrivateIdentifier(propertyName)) {

--- a/tests/baselines/reference/defineProperty(target=es5).js
+++ b/tests/baselines/reference/defineProperty(target=es5).js
@@ -3,6 +3,7 @@ var x: "p" = "p"
 class A {
     a = this.y
     b
+    public c;
     ["computed"] = 13
     ;[x] = 14
     m() { }
@@ -11,8 +12,10 @@ class A {
     declare notEmitted;
 }
 class B {
+    public a;
 }
 class C extends B {
+    declare public a;
     z = this.ka
     constructor(public ka: number) {
         super()
@@ -57,6 +60,12 @@ var A = /** @class */ (function () {
             writable: true,
             value: void 0
         });
+        Object.defineProperty(this, "c", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
         Object.defineProperty(this, "computed", {
             enumerable: true,
             configurable: true,
@@ -87,6 +96,12 @@ var A = /** @class */ (function () {
 _a = x;
 var B = /** @class */ (function () {
     function B() {
+        Object.defineProperty(this, "a", {
+            enumerable: true,
+            configurable: true,
+            writable: true,
+            value: void 0
+        });
     }
     return B;
 }());

--- a/tests/baselines/reference/defineProperty(target=es5).symbols
+++ b/tests/baselines/reference/defineProperty(target=es5).symbols
@@ -7,59 +7,68 @@ class A {
 
     a = this.y
 >a : Symbol(A.a, Decl(defineProperty.ts, 1, 9))
->this.y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>this.y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 >this : Symbol(A, Decl(defineProperty.ts, 0, 16))
->y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 
     b
 >b : Symbol(A.b, Decl(defineProperty.ts, 2, 14))
 
+    public c;
+>c : Symbol(A.c, Decl(defineProperty.ts, 3, 5))
+
     ["computed"] = 13
->["computed"] : Symbol(A["computed"], Decl(defineProperty.ts, 3, 5))
->"computed" : Symbol(A["computed"], Decl(defineProperty.ts, 3, 5))
+>["computed"] : Symbol(A["computed"], Decl(defineProperty.ts, 4, 13))
+>"computed" : Symbol(A["computed"], Decl(defineProperty.ts, 4, 13))
 
     ;[x] = 14
->[x] : Symbol(A[x], Decl(defineProperty.ts, 5, 5))
+>[x] : Symbol(A[x], Decl(defineProperty.ts, 6, 5))
 >x : Symbol(x, Decl(defineProperty.ts, 0, 3))
 
     m() { }
->m : Symbol(A.m, Decl(defineProperty.ts, 5, 13))
+>m : Symbol(A.m, Decl(defineProperty.ts, 6, 13))
 
     constructor(public readonly y: number) { }
->y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 
     z = this.y
->z : Symbol(A.z, Decl(defineProperty.ts, 7, 46))
->this.y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>z : Symbol(A.z, Decl(defineProperty.ts, 8, 46))
+>this.y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 >this : Symbol(A, Decl(defineProperty.ts, 0, 16))
->y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 
     declare notEmitted;
->notEmitted : Symbol(A.notEmitted, Decl(defineProperty.ts, 8, 14))
+>notEmitted : Symbol(A.notEmitted, Decl(defineProperty.ts, 9, 14))
 }
 class B {
->B : Symbol(B, Decl(defineProperty.ts, 10, 1))
+>B : Symbol(B, Decl(defineProperty.ts, 11, 1))
+
+    public a;
+>a : Symbol(B.a, Decl(defineProperty.ts, 12, 9))
 }
 class C extends B {
->C : Symbol(C, Decl(defineProperty.ts, 12, 1))
->B : Symbol(B, Decl(defineProperty.ts, 10, 1))
+>C : Symbol(C, Decl(defineProperty.ts, 14, 1))
+>B : Symbol(B, Decl(defineProperty.ts, 11, 1))
+
+    declare public a;
+>a : Symbol(C.a, Decl(defineProperty.ts, 15, 19))
 
     z = this.ka
->z : Symbol(C.z, Decl(defineProperty.ts, 13, 19))
->this.ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
->this : Symbol(C, Decl(defineProperty.ts, 12, 1))
->ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
+>z : Symbol(C.z, Decl(defineProperty.ts, 16, 21))
+>this.ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
+>this : Symbol(C, Decl(defineProperty.ts, 14, 1))
+>ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
 
     constructor(public ka: number) {
->ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
+>ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
 
         super()
->super : Symbol(B, Decl(defineProperty.ts, 10, 1))
+>super : Symbol(B, Decl(defineProperty.ts, 11, 1))
     }
     ki = this.ka
->ki : Symbol(C.ki, Decl(defineProperty.ts, 17, 5))
->this.ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
->this : Symbol(C, Decl(defineProperty.ts, 12, 1))
->ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
+>ki : Symbol(C.ki, Decl(defineProperty.ts, 20, 5))
+>this.ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
+>this : Symbol(C, Decl(defineProperty.ts, 14, 1))
+>ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
 }
 

--- a/tests/baselines/reference/defineProperty(target=es5).types
+++ b/tests/baselines/reference/defineProperty(target=es5).types
@@ -15,6 +15,9 @@ class A {
     b
 >b : any
 
+    public c;
+>c : any
+
     ["computed"] = 13
 >["computed"] : number
 >"computed" : "computed"
@@ -42,10 +45,16 @@ class A {
 }
 class B {
 >B : B
+
+    public a;
+>a : any
 }
 class C extends B {
 >C : C
 >B : B
+
+    declare public a;
+>a : any
 
     z = this.ka
 >z : number

--- a/tests/baselines/reference/defineProperty(target=esnext).js
+++ b/tests/baselines/reference/defineProperty(target=esnext).js
@@ -3,6 +3,7 @@ var x: "p" = "p"
 class A {
     a = this.y
     b
+    public c;
     ["computed"] = 13
     ;[x] = 14
     m() { }
@@ -11,8 +12,10 @@ class A {
     declare notEmitted;
 }
 class B {
+    public a;
 }
 class C extends B {
+    declare public a;
     z = this.ka
     constructor(public ka: number) {
         super()
@@ -27,6 +30,7 @@ class A {
     y;
     a = this.y;
     b;
+    c;
     ["computed"] = 13;
     [x] = 14;
     m() { }
@@ -36,6 +40,7 @@ class A {
     z = this.y;
 }
 class B {
+    a;
 }
 class C extends B {
     ka;

--- a/tests/baselines/reference/defineProperty(target=esnext).symbols
+++ b/tests/baselines/reference/defineProperty(target=esnext).symbols
@@ -7,59 +7,68 @@ class A {
 
     a = this.y
 >a : Symbol(A.a, Decl(defineProperty.ts, 1, 9))
->this.y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>this.y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 >this : Symbol(A, Decl(defineProperty.ts, 0, 16))
->y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 
     b
 >b : Symbol(A.b, Decl(defineProperty.ts, 2, 14))
 
+    public c;
+>c : Symbol(A.c, Decl(defineProperty.ts, 3, 5))
+
     ["computed"] = 13
->["computed"] : Symbol(A["computed"], Decl(defineProperty.ts, 3, 5))
->"computed" : Symbol(A["computed"], Decl(defineProperty.ts, 3, 5))
+>["computed"] : Symbol(A["computed"], Decl(defineProperty.ts, 4, 13))
+>"computed" : Symbol(A["computed"], Decl(defineProperty.ts, 4, 13))
 
     ;[x] = 14
->[x] : Symbol(A[x], Decl(defineProperty.ts, 5, 5))
+>[x] : Symbol(A[x], Decl(defineProperty.ts, 6, 5))
 >x : Symbol(x, Decl(defineProperty.ts, 0, 3))
 
     m() { }
->m : Symbol(A.m, Decl(defineProperty.ts, 5, 13))
+>m : Symbol(A.m, Decl(defineProperty.ts, 6, 13))
 
     constructor(public readonly y: number) { }
->y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 
     z = this.y
->z : Symbol(A.z, Decl(defineProperty.ts, 7, 46))
->this.y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>z : Symbol(A.z, Decl(defineProperty.ts, 8, 46))
+>this.y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 >this : Symbol(A, Decl(defineProperty.ts, 0, 16))
->y : Symbol(A.y, Decl(defineProperty.ts, 7, 16))
+>y : Symbol(A.y, Decl(defineProperty.ts, 8, 16))
 
     declare notEmitted;
->notEmitted : Symbol(A.notEmitted, Decl(defineProperty.ts, 8, 14))
+>notEmitted : Symbol(A.notEmitted, Decl(defineProperty.ts, 9, 14))
 }
 class B {
->B : Symbol(B, Decl(defineProperty.ts, 10, 1))
+>B : Symbol(B, Decl(defineProperty.ts, 11, 1))
+
+    public a;
+>a : Symbol(B.a, Decl(defineProperty.ts, 12, 9))
 }
 class C extends B {
->C : Symbol(C, Decl(defineProperty.ts, 12, 1))
->B : Symbol(B, Decl(defineProperty.ts, 10, 1))
+>C : Symbol(C, Decl(defineProperty.ts, 14, 1))
+>B : Symbol(B, Decl(defineProperty.ts, 11, 1))
+
+    declare public a;
+>a : Symbol(C.a, Decl(defineProperty.ts, 15, 19))
 
     z = this.ka
->z : Symbol(C.z, Decl(defineProperty.ts, 13, 19))
->this.ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
->this : Symbol(C, Decl(defineProperty.ts, 12, 1))
->ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
+>z : Symbol(C.z, Decl(defineProperty.ts, 16, 21))
+>this.ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
+>this : Symbol(C, Decl(defineProperty.ts, 14, 1))
+>ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
 
     constructor(public ka: number) {
->ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
+>ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
 
         super()
->super : Symbol(B, Decl(defineProperty.ts, 10, 1))
+>super : Symbol(B, Decl(defineProperty.ts, 11, 1))
     }
     ki = this.ka
->ki : Symbol(C.ki, Decl(defineProperty.ts, 17, 5))
->this.ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
->this : Symbol(C, Decl(defineProperty.ts, 12, 1))
->ka : Symbol(C.ka, Decl(defineProperty.ts, 15, 16))
+>ki : Symbol(C.ki, Decl(defineProperty.ts, 20, 5))
+>this.ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
+>this : Symbol(C, Decl(defineProperty.ts, 14, 1))
+>ka : Symbol(C.ka, Decl(defineProperty.ts, 18, 16))
 }
 

--- a/tests/baselines/reference/defineProperty(target=esnext).types
+++ b/tests/baselines/reference/defineProperty(target=esnext).types
@@ -15,6 +15,9 @@ class A {
     b
 >b : any
 
+    public c;
+>c : any
+
     ["computed"] = 13
 >["computed"] : number
 >"computed" : "computed"
@@ -42,10 +45,16 @@ class A {
 }
 class B {
 >B : B
+
+    public a;
+>a : any
 }
 class C extends B {
 >C : C
 >B : B
+
+    declare public a;
+>a : any
 
     z = this.ka
 >z : number

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts
@@ -4,6 +4,7 @@ var x: "p" = "p"
 class A {
     a = this.y
     b
+    public c;
     ["computed"] = 13
     ;[x] = 14
     m() { }
@@ -12,8 +13,10 @@ class A {
     declare notEmitted;
 }
 class B {
+    public a;
 }
 class C extends B {
+    declare public a;
     z = this.ka
     constructor(public ka: number) {
         super()


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
Add check for whether the class property is originated from a parameter.
Fixes #35590
