### PR TITLE
Treat write-only-access to a class member with setter as a reference.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23535,7 +23535,7 @@ namespace ts {
             if (!hasPrivateModifier && !hasPrivateIdentifier) {
                 return;
             }
-            if (nodeForCheckWriteOnly && isWriteOnlyAccess(nodeForCheckWriteOnly) && !(prop.flags & SymbolFlags.SetAccessor && !(prop.flags & SymbolFlags.GetAccessor))) {
+            if (nodeForCheckWriteOnly && isWriteOnlyAccess(nodeForCheckWriteOnly) && !(prop.flags & SymbolFlags.SetAccessor)) {
                 return;
             }
 

--- a/tests/baselines/reference/unusedPrivateMembers.errors.txt
+++ b/tests/baselines/reference/unusedPrivateMembers.errors.txt
@@ -1,0 +1,70 @@
+tests/cases/compiler/unusedPrivateMembers.ts(56,13): error TS6133: 'b' is declared but its value is never read.
+
+
+==== tests/cases/compiler/unusedPrivateMembers.ts (1 errors) ====
+    class Test1 {
+        private initializeInternal() {
+        }
+    
+        public test() {
+            var x = new Test1();
+            x.initializeInternal();
+        }
+    }
+    
+    class Test2 {
+        private p = 0;
+        public test() {
+            var x = new Test2();
+            x.p;
+        }
+    }
+    
+    class Test3 {
+        private get x () {
+            return 0;
+        }
+    
+        public test() {
+            var x = new Test3();
+            x.x;
+        }
+    }
+    
+    class Test4 {
+        private set x(v) {
+            v;
+        }
+    
+        public test() {
+            var x = new Test4();
+            x.x;
+        }
+    }
+    
+    class Test5<T> {
+        private p: T;
+        public test() {
+            var x = new Test5<number>();
+            x.p;
+        }
+    }
+    
+    class Test6 {
+        private get a() {
+            return 0;
+        }
+        private set a(v) {
+            v;
+        }
+        private b = 0;
+                ~
+!!! error TS6133: 'b' is declared but its value is never read.
+    
+        public test() {
+            var x = new Test6();
+            x.a++;
+            x.b++;
+        }
+    }
+    

--- a/tests/baselines/reference/unusedPrivateMembers.js
+++ b/tests/baselines/reference/unusedPrivateMembers.js
@@ -47,6 +47,22 @@ class Test5<T> {
     }
 }
 
+class Test6 {
+    private get a() {
+        return 0;
+    }
+    private set a(v) {
+        v;
+    }
+    private b = 0;
+
+    public test() {
+        var x = new Test6();
+        x.a++;
+        x.b++;
+    }
+}
+
 
 //// [unusedPrivateMembers.js]
 var Test1 = /** @class */ (function () {
@@ -110,4 +126,25 @@ var Test5 = /** @class */ (function () {
         x.p;
     };
     return Test5;
+}());
+var Test6 = /** @class */ (function () {
+    function Test6() {
+        this.b = 0;
+    }
+    Object.defineProperty(Test6.prototype, "a", {
+        get: function () {
+            return 0;
+        },
+        set: function (v) {
+            v;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    Test6.prototype.test = function () {
+        var x = new Test6();
+        x.a++;
+        x.b++;
+    };
+    return Test6;
 }());

--- a/tests/baselines/reference/unusedPrivateMembers.symbols
+++ b/tests/baselines/reference/unusedPrivateMembers.symbols
@@ -110,3 +110,40 @@ class Test5<T> {
     }
 }
 
+class Test6 {
+>Test6 : Symbol(Test6, Decl(unusedPrivateMembers.ts, 46, 1))
+
+    private get a() {
+>a : Symbol(Test6.a, Decl(unusedPrivateMembers.ts, 48, 13), Decl(unusedPrivateMembers.ts, 51, 5))
+
+        return 0;
+    }
+    private set a(v) {
+>a : Symbol(Test6.a, Decl(unusedPrivateMembers.ts, 48, 13), Decl(unusedPrivateMembers.ts, 51, 5))
+>v : Symbol(v, Decl(unusedPrivateMembers.ts, 52, 18))
+
+        v;
+>v : Symbol(v, Decl(unusedPrivateMembers.ts, 52, 18))
+    }
+    private b = 0;
+>b : Symbol(Test6.b, Decl(unusedPrivateMembers.ts, 54, 5))
+
+    public test() {
+>test : Symbol(Test6.test, Decl(unusedPrivateMembers.ts, 55, 18))
+
+        var x = new Test6();
+>x : Symbol(x, Decl(unusedPrivateMembers.ts, 58, 11))
+>Test6 : Symbol(Test6, Decl(unusedPrivateMembers.ts, 46, 1))
+
+        x.a++;
+>x.a : Symbol(Test6.a, Decl(unusedPrivateMembers.ts, 48, 13), Decl(unusedPrivateMembers.ts, 51, 5))
+>x : Symbol(x, Decl(unusedPrivateMembers.ts, 58, 11))
+>a : Symbol(Test6.a, Decl(unusedPrivateMembers.ts, 48, 13), Decl(unusedPrivateMembers.ts, 51, 5))
+
+        x.b++;
+>x.b : Symbol(Test6.b, Decl(unusedPrivateMembers.ts, 54, 5))
+>x : Symbol(x, Decl(unusedPrivateMembers.ts, 58, 11))
+>b : Symbol(Test6.b, Decl(unusedPrivateMembers.ts, 54, 5))
+    }
+}
+

--- a/tests/baselines/reference/unusedPrivateMembers.types
+++ b/tests/baselines/reference/unusedPrivateMembers.types
@@ -116,3 +116,45 @@ class Test5<T> {
     }
 }
 
+class Test6 {
+>Test6 : Test6
+
+    private get a() {
+>a : number
+
+        return 0;
+>0 : 0
+    }
+    private set a(v) {
+>a : number
+>v : number
+
+        v;
+>v : number
+    }
+    private b = 0;
+>b : number
+>0 : 0
+
+    public test() {
+>test : () => void
+
+        var x = new Test6();
+>x : Test6
+>new Test6() : Test6
+>Test6 : typeof Test6
+
+        x.a++;
+>x.a++ : number
+>x.a : number
+>x : Test6
+>a : number
+
+        x.b++;
+>x.b++ : number
+>x.b : number
+>x : Test6
+>b : number
+    }
+}
+

--- a/tests/cases/compiler/unusedPrivateMembers.ts
+++ b/tests/cases/compiler/unusedPrivateMembers.ts
@@ -49,3 +49,19 @@ class Test5<T> {
         x.p;
     }
 }
+
+class Test6 {
+    private get a() {
+        return 0;
+    }
+    private set a(v) {
+        v;
+    }
+    private b = 0;
+
+    public test() {
+        var x = new Test6();
+        x.a++;
+        x.b++;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
As mentioned in #25476, writing to class member might have side-effect to other variable.
This PR treats write-only-access to a class member with setter as a reference, so `noUnusedLocals` warning won't appear on it.
This PR wouldn't change the accessKind of `BinaryExpression`, `PrefixUnaryExpression`, etc, which means "+= on private property" will still be treated as `WriteOnlyAccess` not `ReadWriteAccess`.

Fixes #25476
