### PR TITLE
fix(refactor): keep comments after refactor

### DIFF
--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -57,9 +57,7 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
             suppressLeadingAndTrailingTrivia(body);
             copyLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
             copyTrailingAsLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
-            copyLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
             copyTrailingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
-
         }
         else {
             Debug.fail("invalid action");

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -55,8 +55,9 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
             const actualExpression = expression || createVoidZero();
             body = needsParentheses(actualExpression) ? createParen(actualExpression) : actualExpression;
             suppressLeadingAndTrailingTrivia(body);
-            copyLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
             copyTrailingAsLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
+            copyLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
+
             copyTrailingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
         }
         else {

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -57,7 +57,6 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
             suppressLeadingAndTrailingTrivia(body);
             copyTrailingAsLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
             copyLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
-
             copyTrailingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
         }
         else {

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -87,19 +87,27 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
             // If there are trailing comments
             if (trailingCommentsHolder && trailingCommentsHolder.emitNode && trailingCommentsHolder.emitNode.trailingComments) {
 
-                // First we format our comment
-                // ex. " trailing comment " -> "/* trailing comment */"
-                const formattedComment = formatSynthesizedComment(trailingCommentsHolder.emitNode.trailingComments[0]);
+                // Used to keep track of all the comments
+                let comments = "";
+                // Loop through all the comments
+                trailingCommentsHolder.emitNode.trailingComments.forEach(comment => {
+                    // First we format our comment
+                    // ex. " trailing comment " -> "/* trailing comment */"
+                    const formattedComment = formatSynthesizedComment(comment);
 
-                // Add one space of padding to the comment
-                const paddedComment = ` ${formattedComment}`;
+                    // Add one space of padding to the comment
+                    const paddedComment = ` ${formattedComment}`;
+
+                    // Add comment to our comments string
+                    comments = comments + paddedComment;
+                });
 
                 // If it has a semi colon, we need to account for the extra character (i.e. 1)
                 // otherwise, we use 0
                 const semiColonPositionModifier = hasSemiColon(returnStatement) ? 1 : 0;
 
                 // Creates a text change from end of function body, with length of comment, for the comment.
-                newEdit = createTextChangeFromStartLength(func.body.end + semiColonPositionModifier, paddedComment.length, paddedComment);
+                newEdit = createTextChangeFromStartLength(func.body.end + semiColonPositionModifier, comments.length, comments);
             }
         }
         else {

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -36,6 +36,16 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
         }];
     }
 
+    /**
+     * used to check if the last character in the returnStatement is a semicolon
+     */
+    function hasSemiColon(returnStatement: ReturnStatement) {
+        // Grab the last character from the return statement
+        const lastChar = returnStatement.getFullText().substr(-1);
+        // Check if it is semi-colon
+        // I feel like there has to be a way using SyntaxKind.SemicolonToken
+        return lastChar === ";";
+    }
 
     // Taken from emitter.ts L4798
     function formatSynthesizedComment(comment: SynthesizedComment) {
@@ -84,17 +94,12 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
                 // Add one space of padding to the comment
                 const paddedComment = ` ${formattedComment}`;
 
-                // TODO - add some type of check to know if plus 1 is needed
-                // Could be a function that is like getSemiColonPositionModifier, if true, return 1, else return 0
-                // creates a text change from end of function body, with length of comment, for the comment.
-                // create a new range from end of function body to end of return statement
-                // + 1 accounts for the semi-colon
-                // Add function to check if
-                // function hasSemiColon(/* check next token. If semi colon return true, else false */) {
-                //     return true
-                // }
+                // If it has a semi colon, we need to account for the extra character (i.e. 1)
+                // otherwise, we use 0
+                const semiColonPositionModifier = hasSemiColon(returnStatement) ? 1 : 0;
 
-                newEdit = createTextChangeFromStartLength(func.body.end + 1, paddedComment.length, paddedComment);
+                // Creates a text change from end of function body, with length of comment, for the comment.
+                newEdit = createTextChangeFromStartLength(func.body.end + semiColonPositionModifier, paddedComment.length, paddedComment);
             }
         }
         else {

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -103,8 +103,11 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
 
         const edits = textChanges.ChangeTracker.with(context, t => {
             t.replaceNode(file, func.body, body);
-            // Push the raw change into our array of textChanges
-            t.pushRaw(file, { fileName: file.fileName, textChanges: [newEdit] });
+            // Check if we have a newEdit
+            if (newEdit) {
+                // Push the raw change into our array of textChanges
+                t.pushRaw(file, { fileName: file.fileName, textChanges: [newEdit] });
+            }
         });
 
         return { renameFilename: undefined, renameLocation: undefined, edits };

--- a/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
+++ b/src/services/refactors/addOrRemoveBracesToArrowFunction.ts
@@ -55,6 +55,7 @@ namespace ts.refactor.addOrRemoveBracesToArrowFunction {
             body = needsParentheses(actualExpression) ? createParen(actualExpression) : actualExpression;
             suppressLeadingAndTrailingTrivia(body);
             copyLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
+            copyTrailingAsLeadingComments(returnStatement, body, file, SyntaxKind.MultiLineCommentTrivia, /* hasTrailingNewLine */ false);
         }
         else {
             Debug.fail("invalid action");

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction24.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction24.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts' />
+
+//// const a = (a: number) /*a*/=>/*b*/ {/* comment */ return a; /* comment */};
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Add or remove braces in an arrow function",
+    actionName: "Remove braces from arrow function",
+    actionDescription: "Remove braces from arrow function",
+    newContent: `const a = (a: number) => /* comment */ a; /* comment */`,
+});

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction24.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction24.ts
@@ -1,11 +1,11 @@
 /// <reference path='fourslash.ts' />
 
-//// const a = (a: number) /*a*/=>/*b*/ {/* comment */ return a; /* comment */};
+//// const a = (a: number) /*a*/=>/*b*/ {/* comment */ return a;};
 
 goTo.select("a", "b");
 edit.applyRefactor({
     refactorName: "Add or remove braces in an arrow function",
     actionName: "Remove braces from arrow function",
     actionDescription: "Remove braces from arrow function",
-    newContent: `const a = (a: number) => /* comment */ a; /* comment */`,
+    newContent: `const a = (a: number) => /* comment */ a;`,
 });

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction25.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction25.ts
@@ -7,5 +7,5 @@ edit.applyRefactor({
     refactorName: "Add or remove braces in an arrow function",
     actionName: "Remove braces from arrow function",
     actionDescription: "Remove braces from arrow function",
-    newContent: `const a = (a: number) => a; /* trailing */`,
+    newContent: `const a = (a: number) => a /* trailing */;`,
 });

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction25.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction25.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+//// const b = (a: number) /*a*/=>/*b*/ { /* missing */
+////    return a; /* missing */
+////  }
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Add or remove braces in an arrow function",
+    actionName: "Remove braces from arrow function",
+    actionDescription: "Remove braces from arrow function",
+    newContent: `const b = (a: number) => /* missing */ a; /* missing */`,
+});

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction26.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction26.ts
@@ -7,5 +7,5 @@ edit.applyRefactor({
     refactorName: "Add or remove braces in an arrow function",
     actionName: "Remove braces from arrow function",
     actionDescription: "Remove braces from arrow function",
-    newContent: `const a = (a: number) => /* leading */ a; /* trailing */`,
+    newContent: `const a = (a: number) => /* leading */ a /* trailing */;`,
 });

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction26.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction26.ts
@@ -1,11 +1,11 @@
 /// <reference path='fourslash.ts' />
 
-//// const a = (a: number) /*a*/=>/*b*/ { return a; /* trailing */};
+//// const a = (a: number) /*a*/=>/*b*/ {/* leading */ return a; /* trailing */};
 
 goTo.select("a", "b");
 edit.applyRefactor({
     refactorName: "Add or remove braces in an arrow function",
     actionName: "Remove braces from arrow function",
     actionDescription: "Remove braces from arrow function",
-    newContent: `const a = (a: number) => a; /* trailing */`,
+    newContent: `const a = (a: number) => /* leading */ a; /* trailing */`,
 });

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction27.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction27.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+//// const b = (a: number) /*a*/=>/*b*/ { /* leading */
+////  return a; /* trailing */
+//// }
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Add or remove braces in an arrow function",
+    actionName: "Remove braces from arrow function",
+    actionDescription: "Remove braces from arrow function",
+    newContent: `const b = (a: number) => /* leading */ a /* trailing */`,
+});

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction28.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction28.ts
@@ -1,11 +1,11 @@
 /// <reference path='fourslash.ts' />
 
-//// const a = (a: number) /*a*/=>/*b*/ { return a; /* trailing */ /* trailing */ };
+//// const a = (a: number) /*a*/=>/*b*/ { return a; /* c */ /* d */ };
 
 goTo.select("a", "b");
 edit.applyRefactor({
     refactorName: "Add or remove braces in an arrow function",
     actionName: "Remove braces from arrow function",
     actionDescription: "Remove braces from arrow function",
-    newContent: `const a = (a: number) => a; /* trailing */ /* trailing */`,
+    newContent: `const a = (a: number) => a /* c */ /* d */;`,
 });

--- a/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction28.ts
+++ b/tests/cases/fourslash/refactorAddOrRemoveBracesToArrowFunction28.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts' />
+
+//// const a = (a: number) /*a*/=>/*b*/ { return a; /* trailing */ /* trailing */ };
+
+goTo.select("a", "b");
+edit.applyRefactor({
+    refactorName: "Add or remove braces in an arrow function",
+    actionName: "Remove braces from arrow function",
+    actionDescription: "Remove braces from arrow function",
+    newContent: `const a = (a: number) => a; /* trailing */ /* trailing */`,
+});


### PR DESCRIPTION
This PR fixes part 1 of "Missing comments after applying refactor/codefix #29972".  Here's how I approached solving the problem:

1. Grab the trailing comment from the end of the return statement and copy to an empty string literal token.
2. Take the comment and format it properly. Add padding if needed. Add space for semicolon if needed.
3. Create a new text change that starts at the end of the function body, and ends after the length of the comment.
4. Add that new edit to the collection of text changes.

## Changes

- add logic in `addOrRemoveBracesToArrowFunction` to grab comments that were originally missing
- add 5 new fourslash tests 

## Screenshots
<img width="439" alt="image" src="https://user-images.githubusercontent.com/3806031/71634690-514c2b80-2bdb-11ea-9a4c-166a5325b305.png">


## Checklist

* [X] There is an associated issue in the `Backlog` milestone (**required**)
* [X] Code is up-to-date with the `master` branch
* [X] You've successfully run `gulp runtests` locally
* [X] There are new or updated unit tests validating the change

Fixes part 1 of #29972 
