### PR TITLE
Added validation for regex literals via RegExp constructor

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -859,6 +859,10 @@
         "category": "Error",
         "code": 1261
     },
+    "Invalid regular expression literal: '{0}'.": {
+        "category": "Error",
+        "code": 1262
+    },
     "'with' statements are not allowed in an async function block.": {
         "category": "Error",
         "code": 1300

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2370,6 +2370,12 @@ namespace ts {
                     const tokenText = scanner.getTokenText();
                     (<TemplateLiteralLikeNode>node).rawText = tokenText.substring(1, tokenText.length - (scanner.isUnterminated() ? 0 : isLast ? 1 : 2));
                     break;
+
+                case SyntaxKind.RegularExpressionLiteral:
+                    if (!isValidRegularExpressionLiteral(node.text)) {
+                        parseErrorAtCurrentToken(Diagnostics.Invalid_regular_expression_literal_Colon_0, node.text);
+                    }
+                    break;
             }
 
             if (scanner.hasExtendedUnicodeEscape()) {
@@ -2394,6 +2400,15 @@ namespace ts {
             finishNode(node);
 
             return node;
+        }
+
+        function isValidRegularExpressionLiteral(text: string) {
+            try {
+                new RegExp(text);
+                return true;
+            } catch {
+                return false;
+            }
         }
 
         // TYPES

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2406,7 +2406,8 @@ namespace ts {
             try {
                 new RegExp(text);
                 return true;
-            } catch {
+            }
+            catch {
                 return false;
             }
         }

--- a/tests/baselines/reference/parser579071.errors.txt
+++ b/tests/baselines/reference/parser579071.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/parser/ecmascript5/RegressionTests/parser579071.ts(1,9): error TS1262: Invalid regular expression literal: '/fo(o/'.
+
+
+==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser579071.ts (1 errors) ====
+    var x = /fo(o/;
+            ~~~~~~
+!!! error TS1262: Invalid regular expression literal: '/fo(o/'.

--- a/tests/baselines/reference/parserRegularExpressionDivideAmbiguity4.errors.txt
+++ b/tests/baselines/reference/parserRegularExpressionDivideAmbiguity4.errors.txt
@@ -1,12 +1,15 @@
 tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts(1,1): error TS2304: Cannot find name 'foo'.
+tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts(1,5): error TS1262: Invalid regular expression literal: '/notregexp);'.
 tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts(1,6): error TS1161: Unterminated regular expression literal.
 tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts(1,17): error TS1005: ')' expected.
 
 
-==== tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts (3 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts (4 errors) ====
     foo(/notregexp);
     ~~~
 !!! error TS2304: Cannot find name 'foo'.
+        ~~~~~~~~~~~~
+!!! error TS1262: Invalid regular expression literal: '/notregexp);'.
          
 !!! error TS1161: Unterminated regular expression literal.
                     


### PR DESCRIPTION
Fixes #3432.

Edit: tests pass in Node 12 but not 8. Filed #35958