### PR TITLE
CustomElementConstructor: should be construct signature

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -19255,7 +19255,7 @@ interface BlobCallback {
 }
 
 interface CustomElementConstructor {
-    (): HTMLElement;
+    new (): HTMLElement;
 }
 
 interface DecodeErrorCallback {


### PR DESCRIPTION
Was previously incorrectly a call signature. Had to override it manually.

Broke a few DT packages, eg https://github.com/DefinitelyTyped/DefinitelyTyped/pull/41388