### PR TITLE
Use watch invoked with `node_modules/.staging` as watch for refreshing complete node_modules, so that npm install is reflected correctly

### DIFF
--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -687,7 +687,7 @@ namespace ts {
                 fileOrDirectory => {
                     Debug.assert(!!configFileName);
 
-                    const fileOrDirectoryPath = toPath(fileOrDirectory);
+                    let fileOrDirectoryPath: Path | undefined = toPath(fileOrDirectory);
 
                     // Since the file existance changed, update the sourceFiles cache
                     if (cachedDirectoryStructureHost) {
@@ -695,7 +695,8 @@ namespace ts {
                     }
                     nextSourceFileVersion(fileOrDirectoryPath);
 
-                    if (isPathIgnored(fileOrDirectoryPath)) return;
+                    fileOrDirectoryPath = removeIgnoredPath(fileOrDirectoryPath);
+                    if (!fileOrDirectoryPath) return;
 
                     // If the the added or created file or directory is not supported file name, ignore the file
                     // But when watched directory is added/removed, we need to reload the file list

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1086,7 +1086,7 @@ namespace ts.server {
                 this.host,
                 directory,
                 fileOrDirectory => {
-                    const fileOrDirectoryPath = this.toPath(fileOrDirectory);
+                    let fileOrDirectoryPath: Path | undefined = this.toPath(fileOrDirectory);
                     const fsResult = project.getCachedDirectoryStructureHost().addOrDeleteFileOrDirectory(fileOrDirectory, fileOrDirectoryPath);
 
                     // don't trigger callback on open, existing files
@@ -1097,7 +1097,8 @@ namespace ts.server {
                         return;
                     }
 
-                    if (isPathIgnored(fileOrDirectoryPath)) return;
+                    fileOrDirectoryPath = removeIgnoredPath(fileOrDirectoryPath);
+                    if (!fileOrDirectoryPath) return;
                     const configFilename = project.getConfigFilePath();
 
                     if (getBaseFileName(fileOrDirectoryPath) === "package.json" && !isInsideNodeModules(fileOrDirectoryPath) &&
@@ -2254,8 +2255,8 @@ namespace ts.server {
                 this.host,
                 watchDir,
                 (fileOrDirectory) => {
-                    const fileOrDirectoryPath = this.toPath(fileOrDirectory);
-                    if (isPathIgnored(fileOrDirectoryPath)) return;
+                    const fileOrDirectoryPath = removeIgnoredPath(this.toPath(fileOrDirectory));
+                    if (!fileOrDirectoryPath) return;
 
                     // Has extension
                     Debug.assert(result.refCount > 0);


### PR DESCRIPTION
In most cases npm install triggers watches with folder additions to `.staging` folder which we ignore. 
Afterwards it moves everything with renames from `.staging` to `node_modules` folder. Many times there is individual watches invoked with those folders which we handle correctly but in some cases it just triggers watch with `node_modules/.staging` which again was ignored. Now when the watch invoked is `.staging` (and not sub folder/file in it) we refresh everything in `node_modules` instead to invalidate resolutions and files accordingly.

Fixes #35966
