### PR TITLE
Add completion property to identify completions from unchecked files

### DIFF
--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -867,9 +867,14 @@ namespace FourSlash {
                 }
             }
 
+            if (isFromUncheckedFile !== undefined) {
+                if (actual.isFromUncheckedFile !== isFromUncheckedFile) {
+                    this.raiseError(`Expected 'isFromUncheckedFile' value '${actual.isFromUncheckedFile}' to equal '${isFromUncheckedFile}'`);
+                }
+            }
+
             assert.equal(actual.hasAction, hasAction, `Expected 'hasAction' value '${actual.hasAction}' to equal '${hasAction}'`);
             assert.equal(actual.isRecommended, isRecommended, `Expected 'isRecommended' value '${actual.isRecommended}' to equal '${isRecommended}'`);
-            assert.equal(actual.isFromUncheckedFile, isFromUncheckedFile, `Expected 'isFromUncheckedFile' value '${actual.isFromUncheckedFile}' to equal '${isFromUncheckedFile}'`);
             assert.equal(actual.source, source, `Expected 'source' value '${actual.source}' to equal '${source}'`);
             assert.equal(actual.sortText, sortText || ts.Completions.SortText.LocationPriority, this.messageAtLastKnownMarker(`Actual entry: ${JSON.stringify(actual)}`));
 

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -843,8 +843,8 @@ namespace FourSlash {
         }
 
         private verifyCompletionEntry(actual: ts.CompletionEntry, expected: FourSlashInterface.ExpectedCompletionEntry) {
-            const { insertText, replacementSpan, hasAction, isRecommended, kind, kindModifiers, text, documentation, tags, source, sourceDisplay, sortText } = typeof expected === "string"
-                ? { insertText: undefined, replacementSpan: undefined, hasAction: undefined, isRecommended: undefined, kind: undefined, kindModifiers: undefined, text: undefined, documentation: undefined, tags: undefined, source: undefined, sourceDisplay: undefined, sortText: undefined }
+            const { insertText, replacementSpan, hasAction, isRecommended, isFromUncheckedFile, kind, kindModifiers, text, documentation, tags, source, sourceDisplay, sortText } = typeof expected === "string"
+                ? { insertText: undefined, replacementSpan: undefined, hasAction: undefined, isRecommended: undefined, isFromUncheckedFile: undefined, kind: undefined, kindModifiers: undefined, text: undefined, documentation: undefined, tags: undefined, source: undefined, sourceDisplay: undefined, sortText: undefined }
                 : expected;
 
             if (actual.insertText !== insertText) {
@@ -868,7 +868,8 @@ namespace FourSlash {
             }
 
             assert.equal(actual.hasAction, hasAction, `Expected 'hasAction' value '${actual.hasAction}' to equal '${hasAction}'`);
-            assert.equal(actual.isRecommended, isRecommended, `Expected 'isRecommended' value '${actual.source}' to equal '${isRecommended}'`);
+            assert.equal(actual.isRecommended, isRecommended, `Expected 'isRecommended' value '${actual.isRecommended}' to equal '${isRecommended}'`);
+            assert.equal(actual.isFromUncheckedFile, isFromUncheckedFile, `Expected 'isFromUncheckedFile' value '${actual.isFromUncheckedFile}' to equal '${isFromUncheckedFile}'`);
             assert.equal(actual.source, source, `Expected 'source' value '${actual.source}' to equal '${source}'`);
             assert.equal(actual.sortText, sortText || ts.Completions.SortText.LocationPriority, this.messageAtLastKnownMarker(`Actual entry: ${JSON.stringify(actual)}`));
 

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1472,7 +1472,7 @@ namespace FourSlashInterface {
         readonly replacementSpan?: FourSlash.Range;
         readonly hasAction?: boolean; // If not specified, will assert that this is false.
         readonly isRecommended?: boolean; // If not specified, will assert that this is false.
-        readonly isFromUncheckedFile?: boolean; // If not specified, will assert that this is false.
+        readonly isFromUncheckedFile?: boolean; // If not specified, won't assert about this
         readonly kind?: string; // If not specified, won't assert about this
         readonly kindModifiers?: string; // Must be paired with 'kind'
         readonly text?: string;

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1472,6 +1472,7 @@ namespace FourSlashInterface {
         readonly replacementSpan?: FourSlash.Range;
         readonly hasAction?: boolean; // If not specified, will assert that this is false.
         readonly isRecommended?: boolean; // If not specified, will assert that this is false.
+        readonly isFromUncheckedFile?: boolean; // If not specified, will assert that this is false.
         readonly kind?: string; // If not specified, won't assert about this
         readonly kindModifiers?: string; // Must be paired with 'kind'
         readonly text?: string;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2086,6 +2086,11 @@ namespace ts.server.protocol {
          * Then either that enum/class or a namespace containing it will be the recommended symbol.
          */
         isRecommended?: true;
+        /**
+         * If true, this completion was generated from traversing the name table of an unchecked JS file,
+         * and therefore may not be accurate.
+         */
+        isUncheckedCompletion?: true;
     }
 
     /**

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2090,7 +2090,7 @@ namespace ts.server.protocol {
          * If true, this completion was generated from traversing the name table of an unchecked JS file,
          * and therefore may not be accurate.
          */
-        isUncheckedCompletion?: true;
+        isFromUncheckedFile?: true;
     }
 
     /**

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -310,7 +310,8 @@ namespace ts.Completions {
                     name: realName,
                     kind: ScriptElementKind.warning,
                     kindModifiers: "",
-                    sortText: SortText.JavascriptIdentifiers
+                    sortText: SortText.JavascriptIdentifiers,
+                    isUncheckedCompletion: true
                 });
             }
         });

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -311,7 +311,7 @@ namespace ts.Completions {
                     kind: ScriptElementKind.warning,
                     kindModifiers: "",
                     sortText: SortText.JavascriptIdentifiers,
-                    isUncheckedCompletion: true
+                    isFromUncheckedFile: true
                 });
             }
         });

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -988,7 +988,7 @@ namespace ts {
         hasAction?: true;
         source?: string;
         isRecommended?: true;
-        isUncheckedCompletion?: true;
+        isFromUncheckedFile?: true;
     }
 
     export interface CompletionEntryDetails {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -988,6 +988,7 @@ namespace ts {
         hasAction?: true;
         source?: string;
         isRecommended?: true;
+        isUncheckedCompletion?: true;
     }
 
     export interface CompletionEntryDetails {

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5652,6 +5652,7 @@ declare namespace ts {
         hasAction?: true;
         source?: string;
         isRecommended?: true;
+        isFromUncheckedFile?: true;
     }
     interface CompletionEntryDetails {
         name: string;
@@ -7644,6 +7645,11 @@ declare namespace ts.server.protocol {
          * Then either that enum/class or a namespace containing it will be the recommended symbol.
          */
         isRecommended?: true;
+        /**
+         * If true, this completion was generated from traversing the name table of an unchecked JS file,
+         * and therefore may not be accurate.
+         */
+        isFromUncheckedFile?: true;
     }
     /**
      * Additional completion entry details, available on demand

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5652,6 +5652,7 @@ declare namespace ts {
         hasAction?: true;
         source?: string;
         isRecommended?: true;
+        isFromUncheckedFile?: true;
     }
     interface CompletionEntryDetails {
         name: string;

--- a/tests/cases/fourslash/completionInUncheckedJSFile.ts
+++ b/tests/cases/fourslash/completionInUncheckedJSFile.ts
@@ -1,0 +1,28 @@
+﻿/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: false
+// @Filename: index.js
+////function hello() {
+////
+////}
+////
+////const goodbye = 5;
+////
+////console./*0*/
+
+verify.completions({
+    marker: "0",
+    includes: [
+        {
+            name: "hello",
+            sortText: completion.SortText.JavascriptIdentifiers,
+            isFromUncheckedFile: true
+        },
+        {
+            name: "goodbye",
+            sortText: completion.SortText.JavascriptIdentifiers,
+            isFromUncheckedFile: true
+        }
+    ]
+});

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -609,6 +609,7 @@ declare namespace FourSlashInterface {
         readonly replacementSpan?: Range;
         readonly hasAction?: boolean;
         readonly isRecommended?: boolean;
+        readonly isFromUncheckedFile?: boolean;
         readonly kind?: string;
         readonly kindModifiers?: string;
         readonly sortText?: completion.SortText;


### PR DESCRIPTION
Supersedes #36043.

Here, we add a property to identify completion entries generated from the name table of an unchecked file, so that consumers can handle them differently from type-checker-based completions.