### PR TITLE
Fix crash in codefixes re: braces of class body

### DIFF
--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -493,7 +493,7 @@ namespace ts.textChanges {
             if (getMembersOrProperties(cls).length === 0) {
                 if (addToSeen(this.classesWithNodesInsertedAtStart, getNodeId(cls), { node: cls, sourceFile })) {
                     // For `class C {\n}`, don't add the trailing "\n"
-                    const [open, close] = getClassOrObjectBraceEnds(cls, sourceFile)
+                    const [open, close] = getClassOrObjectBraceEnds(cls, sourceFile);
                     const shouldSuffix = open && close && positionsAreOnSameLine(open, close, sourceFile);
                     return { prefix: this.newLineCharacter, suffix: comma + (shouldSuffix ? this.newLineCharacter : "") };
                 }

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -493,7 +493,8 @@ namespace ts.textChanges {
             if (getMembersOrProperties(cls).length === 0) {
                 if (addToSeen(this.classesWithNodesInsertedAtStart, getNodeId(cls), { node: cls, sourceFile })) {
                     // For `class C {\n}`, don't add the trailing "\n"
-                    const shouldSuffix = (positionsAreOnSameLine as any)(...getClassOrObjectBraceEnds(cls, sourceFile), sourceFile); // TODO: GH#4130 remove 'as any'
+                    const [open, close] = getClassOrObjectBraceEnds(cls, sourceFile)
+                    const shouldSuffix = open && close && positionsAreOnSameLine(open, close, sourceFile);
                     return { prefix: this.newLineCharacter, suffix: comma + (shouldSuffix ? this.newLineCharacter : "") };
                 }
                 else {
@@ -726,7 +727,7 @@ namespace ts.textChanges {
             this.classesWithNodesInsertedAtStart.forEach(({ node, sourceFile }) => {
                 const [openBraceEnd, closeBraceEnd] = getClassOrObjectBraceEnds(node, sourceFile);
                 // For `class C { }` remove the whitespace inside the braces.
-                if (positionsAreOnSameLine(openBraceEnd, closeBraceEnd, sourceFile) && openBraceEnd !== closeBraceEnd - 1) {
+                if (openBraceEnd && closeBraceEnd && positionsAreOnSameLine(openBraceEnd, closeBraceEnd, sourceFile) && openBraceEnd !== closeBraceEnd - 1) {
                     this.deleteRange(sourceFile, createRange(openBraceEnd, closeBraceEnd - 1));
                 }
             });
@@ -783,8 +784,10 @@ namespace ts.textChanges {
         return skipTrivia(sourceFile.text, getAdjustedStartPosition(sourceFile, node, { leadingTriviaOption: LeadingTriviaOption.IncludeAll }), /*stopAfterLineBreak*/ false, /*stopAtComments*/ true);
     }
 
-    function getClassOrObjectBraceEnds(cls: ClassLikeDeclaration | InterfaceDeclaration | ObjectLiteralExpression, sourceFile: SourceFile): [number, number] {
-        return [findChildOfKind(cls, SyntaxKind.OpenBraceToken, sourceFile)!.end, findChildOfKind(cls, SyntaxKind.CloseBraceToken, sourceFile)!.end];
+    function getClassOrObjectBraceEnds(cls: ClassLikeDeclaration | InterfaceDeclaration | ObjectLiteralExpression, sourceFile: SourceFile): [number | undefined, number | undefined] {
+        const open = findChildOfKind(cls, SyntaxKind.OpenBraceToken, sourceFile);
+        const close = findChildOfKind(cls, SyntaxKind.CloseBraceToken, sourceFile);
+        return [open?.end, close?.end];
     }
     function getMembersOrProperties(cls: ClassLikeDeclaration | InterfaceDeclaration | ObjectLiteralExpression): NodeArray<Node> {
         return isObjectLiteralExpression(cls) ? cls.properties : cls.members;

--- a/tests/cases/fourslash/codeFixClassImplementInterfaceNoBody.ts
+++ b/tests/cases/fourslash/codeFixClassImplementInterfaceNoBody.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+//// interface I {
+////    m(): void
+//// }
+//// class C/*c*/ implements I
+
+verify.errorExistsBeforeMarker("c")
+goTo.marker("c")
+verify.codeFixAvailable([{ "description": "Implement interface 'I'" }])


### PR DESCRIPTION
Previously, the code that finds braces of a class body assumed they were always there. This is not always the case, so this code checks for that.

Fixes #29515
