### PR TITLE
Get jsdoc host from chained assignment

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2317,9 +2317,8 @@ namespace ts {
     }
 
     function getSourceOfAssignment(node: Node): Node | undefined {
-        getInitializerOfBinaryExpression
         if(isExpressionStatement(node) && isBinaryExpression(node.expression) && node.expression.operatorToken.kind === SyntaxKind.EqualsToken) {
-            let cur = node.expression
+            let cur = node.expression;
             while (isBinaryExpression(cur.right) && cur.right.operatorToken.kind === SyntaxKind.EqualsToken) {
                 cur = cur.right;
             }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2317,14 +2317,11 @@ namespace ts {
     }
 
     function getSourceOfAssignment(node: Node): Node | undefined {
-        if(isExpressionStatement(node) && isBinaryExpression(node.expression) && node.expression.operatorToken.kind === SyntaxKind.EqualsToken) {
-            let cur = node.expression;
-            while (isBinaryExpression(cur.right) && cur.right.operatorToken.kind === SyntaxKind.EqualsToken) {
-                cur = cur.right;
-            }
-            return cur.right;
-        }
-        return undefined;
+        return isExpressionStatement(node) &&
+            isBinaryExpression(node.expression) &&
+            node.expression.operatorToken.kind === SyntaxKind.EqualsToken
+            ? getRightMostAssignedExpression(node.expression)
+            : undefined;
     }
 
     function getSourceOfDefaultedAssignment(node: Node): Node | undefined {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2317,11 +2317,15 @@ namespace ts {
     }
 
     function getSourceOfAssignment(node: Node): Node | undefined {
-        return isExpressionStatement(node) &&
-            node.expression && isBinaryExpression(node.expression) &&
-            node.expression.operatorToken.kind === SyntaxKind.EqualsToken
-            ? node.expression.right
-            : undefined;
+        getInitializerOfBinaryExpression
+        if(isExpressionStatement(node) && isBinaryExpression(node.expression) && node.expression.operatorToken.kind === SyntaxKind.EqualsToken) {
+            let cur = node.expression
+            while (isBinaryExpression(cur.right) && cur.right.operatorToken.kind === SyntaxKind.EqualsToken) {
+                cur = cur.right;
+            }
+            return cur.right;
+        }
+        return undefined;
     }
 
     function getSourceOfDefaultedAssignment(node: Node): Node | undefined {

--- a/tests/baselines/reference/constructorTagOnNestedBinaryExpression.symbols
+++ b/tests/baselines/reference/constructorTagOnNestedBinaryExpression.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/constructorTagOnNestedBinaryExpression.js ===
+// Fixes #35021
+/** @constructor */
+a = b = function c () {
+>c : Symbol(c, Decl(constructorTagOnNestedBinaryExpression.js, 2, 7))
+
+    console.log(this)
+>console.log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>console : Symbol(console, Decl(lib.dom.d.ts, --, --))
+>log : Symbol(Console.log, Decl(lib.dom.d.ts, --, --))
+>this : Symbol(c, Decl(constructorTagOnNestedBinaryExpression.js, 2, 7))
+
+};
+

--- a/tests/baselines/reference/constructorTagOnNestedBinaryExpression.types
+++ b/tests/baselines/reference/constructorTagOnNestedBinaryExpression.types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/jsdoc/constructorTagOnNestedBinaryExpression.js ===
+// Fixes #35021
+/** @constructor */
+a = b = function c () {
+>a = b = function c () {    console.log(this)} : typeof c
+>a : error
+>b = function c () {    console.log(this)} : typeof c
+>b : error
+>function c () {    console.log(this)} : typeof c
+>c : typeof c
+
+    console.log(this)
+>console.log(this) : void
+>console.log : (message?: any, ...optionalParams: any[]) => void
+>console : Console
+>log : (message?: any, ...optionalParams: any[]) => void
+>this : this
+
+};
+

--- a/tests/cases/conformance/jsdoc/constructorTagOnNestedBinaryExpression.ts
+++ b/tests/cases/conformance/jsdoc/constructorTagOnNestedBinaryExpression.ts
@@ -1,0 +1,8 @@
+// @allowjs: true
+// @noemit: true
+// @Filename: constructorTagOnNestedBinaryExpression.js
+// Fixes #35021
+/** @constructor */
+a = b = function c () {
+    console.log(this)
+};


### PR DESCRIPTION
getSourceOfAssignment previously only checked one level of binary
expression instead of following binary expressions all the way to the
right. This meant that binding of `@constructor` would fail in the
following example:

```js
/** @constructor */
a = b = function () { }
```

Fixes #35021