### PR TITLE
Handle invalid package.json typings fields when generating specifiers

### DIFF
--- a/src/compiler/moduleSpecifiers.ts
+++ b/src/compiler/moduleSpecifiers.ts
@@ -342,7 +342,7 @@ namespace ts.moduleSpecifiers {
             // If the file is the main module, it can be imported by the package name
             if (packageJsonContent) {
                 const mainFileRelative = packageJsonContent.typings || packageJsonContent.types || packageJsonContent.main;
-                if (mainFileRelative) {
+                if (isString(mainFileRelative)) {
                     const mainExportFile = toPath(mainFileRelative, packageRootPath, getCanonicalFileName);
                     if (removeFileExtension(mainExportFile) === removeFileExtension(getCanonicalFileName(path))) {
                         return packageRootPath;

--- a/tests/baselines/reference/declarationEmitWithInvalidPackageJsonTypings.js
+++ b/tests/baselines/reference/declarationEmitWithInvalidPackageJsonTypings.js
@@ -1,0 +1,46 @@
+//// [tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts] ////
+
+//// [index.d.ts]
+export function bar(): number;
+//// [package.json]
+{
+  "main": "./lib",
+  "name": "csv-parse",
+  "types": [
+    "./lib/index.d.ts",
+    "./lib/sync.d.ts"
+  ],
+  "version": "4.8.2"
+}
+//// [index.ts]
+export interface MutableRefObject<T> {
+    current: T;
+}
+export function useRef<T>(current: T): MutableRefObject<T> {
+    return { current };
+}
+export const useCsvParser = () => {
+    const parserRef = useRef<typeof import("csv-parse")>(null);
+    return parserRef;
+};
+
+
+//// [index.js]
+"use strict";
+exports.__esModule = true;
+function useRef(current) {
+    return { current: current };
+}
+exports.useRef = useRef;
+exports.useCsvParser = function () {
+    var parserRef = useRef(null);
+    return parserRef;
+};
+
+
+//// [index.d.ts]
+export interface MutableRefObject<T> {
+    current: T;
+}
+export declare function useRef<T>(current: T): MutableRefObject<T>;
+export declare const useCsvParser: () => MutableRefObject<typeof import("csv-parse/lib")>;

--- a/tests/baselines/reference/declarationEmitWithInvalidPackageJsonTypings.symbols
+++ b/tests/baselines/reference/declarationEmitWithInvalidPackageJsonTypings.symbols
@@ -1,0 +1,36 @@
+=== /p1/node_modules/csv-parse/lib/index.d.ts ===
+export function bar(): number;
+>bar : Symbol(bar, Decl(index.d.ts, 0, 0))
+
+=== /p1/index.ts ===
+export interface MutableRefObject<T> {
+>MutableRefObject : Symbol(MutableRefObject, Decl(index.ts, 0, 0))
+>T : Symbol(T, Decl(index.ts, 0, 34))
+
+    current: T;
+>current : Symbol(MutableRefObject.current, Decl(index.ts, 0, 38))
+>T : Symbol(T, Decl(index.ts, 0, 34))
+}
+export function useRef<T>(current: T): MutableRefObject<T> {
+>useRef : Symbol(useRef, Decl(index.ts, 2, 1))
+>T : Symbol(T, Decl(index.ts, 3, 23))
+>current : Symbol(current, Decl(index.ts, 3, 26))
+>T : Symbol(T, Decl(index.ts, 3, 23))
+>MutableRefObject : Symbol(MutableRefObject, Decl(index.ts, 0, 0))
+>T : Symbol(T, Decl(index.ts, 3, 23))
+
+    return { current };
+>current : Symbol(current, Decl(index.ts, 4, 12))
+}
+export const useCsvParser = () => {
+>useCsvParser : Symbol(useCsvParser, Decl(index.ts, 6, 12))
+
+    const parserRef = useRef<typeof import("csv-parse")>(null);
+>parserRef : Symbol(parserRef, Decl(index.ts, 7, 9))
+>useRef : Symbol(useRef, Decl(index.ts, 2, 1))
+
+    return parserRef;
+>parserRef : Symbol(parserRef, Decl(index.ts, 7, 9))
+
+};
+

--- a/tests/baselines/reference/declarationEmitWithInvalidPackageJsonTypings.types
+++ b/tests/baselines/reference/declarationEmitWithInvalidPackageJsonTypings.types
@@ -1,0 +1,32 @@
+=== /p1/node_modules/csv-parse/lib/index.d.ts ===
+export function bar(): number;
+>bar : () => number
+
+=== /p1/index.ts ===
+export interface MutableRefObject<T> {
+    current: T;
+>current : T
+}
+export function useRef<T>(current: T): MutableRefObject<T> {
+>useRef : <T>(current: T) => MutableRefObject<T>
+>current : T
+
+    return { current };
+>{ current } : { current: T; }
+>current : T
+}
+export const useCsvParser = () => {
+>useCsvParser : () => MutableRefObject<typeof import("/p1/node_modules/csv-parse/lib/index")>
+>() => {    const parserRef = useRef<typeof import("csv-parse")>(null);    return parserRef;} : () => MutableRefObject<typeof import("/p1/node_modules/csv-parse/lib/index")>
+
+    const parserRef = useRef<typeof import("csv-parse")>(null);
+>parserRef : MutableRefObject<typeof import("/p1/node_modules/csv-parse/lib/index")>
+>useRef<typeof import("csv-parse")>(null) : MutableRefObject<typeof import("/p1/node_modules/csv-parse/lib/index")>
+>useRef : <T>(current: T) => MutableRefObject<T>
+>null : null
+
+    return parserRef;
+>parserRef : MutableRefObject<typeof import("/p1/node_modules/csv-parse/lib/index")>
+
+};
+

--- a/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
+++ b/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
@@ -1,0 +1,24 @@
+// @declaration: true
+// @filename: /p1/node_modules/csv-parse/lib/index.d.ts
+export function bar(): number;
+// @filename: /p1/node_modules/csv-parse/package.json
+{
+  "main": "./lib",
+  "name": "csv-parse",
+  "types": [
+    "./lib/index.d.ts",
+    "./lib/sync.d.ts"
+  ],
+  "version": "4.8.2"
+}
+// @filename: /p1/index.ts
+export interface MutableRefObject<T> {
+    current: T;
+}
+export function useRef<T>(current: T): MutableRefObject<T> {
+    return { current };
+}
+export const useCsvParser = () => {
+    const parserRef = useRef<typeof import("csv-parse")>(null);
+    return parserRef;
+};


### PR DESCRIPTION
Fixes #35437
