### PR TITLE
Speed up getAccessibleFileSystemEntries

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1617,7 +1617,7 @@ namespace ts {
             function getAccessibleFileSystemEntries(path: string): FileSystemEntries {
                 perfLogger.logEvent("ReadDir: " + (path || "."));
                 try {
-                    const entries = _fs.readdirSync(path || ".", { withFileTypes: true }).sort();
+                    const entries = _fs.readdirSync(path || ".", { withFileTypes: true });
                     const files: string[] = [];
                     const directories: string[] = [];
                     for (const entry of entries) {
@@ -1634,7 +1634,7 @@ namespace ts {
                             directories.push(entryName);
                         }
                     }
-                    return { files, directories };
+                    return { files: files.sort(), directories: directories.sort() };
                 }
                 catch (e) {
                     return emptyFileSystemEntries;

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1617,30 +1617,21 @@ namespace ts {
             function getAccessibleFileSystemEntries(path: string): FileSystemEntries {
                 perfLogger.logEvent("ReadDir: " + (path || "."));
                 try {
-                    const entries = _fs.readdirSync(path || ".").sort();
+                    const entries = _fs.readdirSync(path || ".", { withFileTypes: true }).sort();
                     const files: string[] = [];
                     const directories: string[] = [];
                     for (const entry of entries) {
+                        const entryName = entry.name;
                         // This is necessary because on some file system node fails to exclude
                         // "." and "..". See https://github.com/nodejs/node/issues/4002
-                        if (entry === "." || entry === "..") {
+                        if (entryName === "." || entryName === "..") {
                             continue;
                         }
-                        const name = combinePaths(path, entry);
-
-                        let stat: any;
-                        try {
-                            stat = _fs.statSync(name);
+                        if (entry.isFile()) {
+                            files.push(entryName);
                         }
-                        catch (e) {
-                            continue;
-                        }
-
-                        if (stat.isFile()) {
-                            files.push(entry);
-                        }
-                        else if (stat.isDirectory()) {
-                            directories.push(entry);
+                        else if (entry.isDirectory()) {
+                            directories.push(entryName);
                         }
                     }
                     return { files, directories };


### PR DESCRIPTION
While writing a benchmark, I happened to notice that (a) the natural
win32 APIs for this task include "isDirectory" in the result and (b)
readDirSync will return entries, rather than strings, if you pass
withFileTypes.  It turns out this version, which allows us to dispense
with path math and stat calls is ~20X faster (enumerating a directory
with 600 children).