### PR TITLE
Fix handling of templates in preProcessFile

### DIFF
--- a/src/services/preProcess.ts
+++ b/src/services/preProcess.ts
@@ -16,6 +16,7 @@ namespace ts {
         let lastToken: SyntaxKind;
         let currentToken: SyntaxKind;
         let braceNesting = 0;
+        let templateNesting = 0;
         // assume that text represent an external module if it contains at least one top level import/export
         // ambient modules that are found inside external modules are interpreted as module augmentations
         let externalModule = false;
@@ -23,12 +24,23 @@ namespace ts {
         function nextToken() {
             lastToken = currentToken;
             currentToken = scanner.scan();
-            if (currentToken === SyntaxKind.OpenBraceToken) {
+            if (currentToken === SyntaxKind.CloseBraceToken && templateNesting > 0) {
+                currentToken = scanner.reScanTemplateToken(/* isTaggedTemplate */ true);
+            }
+
+            if (currentToken === SyntaxKind.TemplateHead) {
+                templateNesting++;
+            }
+            else if (currentToken === SyntaxKind.TemplateTail) {
+                templateNesting--;
+            }
+            else if (currentToken === SyntaxKind.OpenBraceToken) {
                 braceNesting++;
             }
             else if (currentToken === SyntaxKind.CloseBraceToken) {
                 braceNesting--;
             }
+
             return currentToken;
         }
 

--- a/src/testRunner/unittests/services/preProcessFile.ts
+++ b/src/testRunner/unittests/services/preProcessFile.ts
@@ -659,5 +659,49 @@ describe("unittests:: services:: PreProcessFile:", () => {
                 isLibFile: false
             });
         });
+
+        it("Correctly ignores ES6 imports in string templates", () => {
+            test("`import def from 'm1'`;",
+            /*readImportFile*/ true,
+            /*detectJavaScriptImports*/ false,
+            {
+                referencedFiles: [],
+                typeReferenceDirectives: [],
+                libReferenceDirectives: [],
+                importedFiles: [],
+                ambientExternalModules: undefined,
+                isLibFile: false
+            });
+        });
+        it("Correctly ignores ES6 imports in string templates following another template", () => {
+            // eslint-disable-next-line no-template-curly-in-string
+            test("`${foo}`;\n`import def from 'm1'`;",
+            /*readImportFile*/ true,
+            /*detectJavaScriptImports*/ false,
+            {
+                referencedFiles: [],
+                typeReferenceDirectives: [],
+                libReferenceDirectives: [],
+                importedFiles: [],
+                ambientExternalModules: undefined,
+                isLibFile: false
+            });
+        });
+        it("Correctly recognizes ES6 imports after template", () => {
+            // eslint-disable-next-line no-template-curly-in-string
+            test("`${foo}`;\nimport def from 'm1';",
+            /*readImportFile*/ true,
+            /*detectJavaScriptImports*/ false,
+            {
+                referencedFiles: [],
+                typeReferenceDirectives: [],
+                libReferenceDirectives: [],
+                importedFiles: [
+                    { fileName: "m1", pos: 26, end: 28 },
+                ],
+                ambientExternalModules: undefined,
+                isLibFile: false
+            });
+        });
     });
 });


### PR DESCRIPTION
Previously, the preProcessFile function would erroneously identify import statements inside template literals if they occurred _after_ a template literal that contained a placeholder.

```
`${1}`
`import module from "m1"`
```

Would report `m1` as being an imported file. 

Inversely, it would fail to find valid imports in the similar situation:

```
`${1}`
import module from "m1"
```

This is because the code is failing to recognize the `}\`` as the end of the first template literal.

This PR fixes that by keeping track of if we are inside a template, if so, we run the "rescanTemplateToken" when we encounter a close brace.

Fixes #30878