### PR TITLE
@typedef's nested Object syntax disallows type arguments

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -7133,7 +7133,7 @@ namespace ts {
                         case SyntaxKind.ArrayType:
                             return isObjectOrObjectArrayTypeReference((node as ArrayTypeNode).elementType);
                         default:
-                            return isTypeReferenceNode(node) && ts.isIdentifier(node.typeName) && node.typeName.escapedText === "Object";
+                            return isTypeReferenceNode(node) && ts.isIdentifier(node.typeName) && node.typeName.escapedText === "Object" && !node.typeArguments;
                     }
                 }
 

--- a/tests/baselines/reference/typedefTagExtraneousProperty.symbols
+++ b/tests/baselines/reference/typedefTagExtraneousProperty.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/typedefTagExtraneousProperty.js ===
+/** @typedef {Object.<string,string>} Mmap
+ * @property {string} ignoreMe - should be ignored
+ */
+
+/** @type {Mmap} */
+var y = { bye: "no" };
+>y : Symbol(y, Decl(typedefTagExtraneousProperty.js, 5, 3), Decl(typedefTagExtraneousProperty.js, 6, 1), Decl(typedefTagExtraneousProperty.js, 7, 57))
+>bye : Symbol(bye, Decl(typedefTagExtraneousProperty.js, 5, 9))
+
+y
+>y : Symbol(y, Decl(typedefTagExtraneousProperty.js, 5, 3), Decl(typedefTagExtraneousProperty.js, 6, 1), Decl(typedefTagExtraneousProperty.js, 7, 57))
+
+y.ignoreMe = "ok but just because of the index signature"
+>y : Symbol(y, Decl(typedefTagExtraneousProperty.js, 5, 3), Decl(typedefTagExtraneousProperty.js, 6, 1), Decl(typedefTagExtraneousProperty.js, 7, 57))
+
+y['hi'] = "yes"
+>y : Symbol(y, Decl(typedefTagExtraneousProperty.js, 5, 3), Decl(typedefTagExtraneousProperty.js, 6, 1), Decl(typedefTagExtraneousProperty.js, 7, 57))
+

--- a/tests/baselines/reference/typedefTagExtraneousProperty.types
+++ b/tests/baselines/reference/typedefTagExtraneousProperty.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/jsdoc/typedefTagExtraneousProperty.js ===
+/** @typedef {Object.<string,string>} Mmap
+ * @property {string} ignoreMe - should be ignored
+ */
+
+/** @type {Mmap} */
+var y = { bye: "no" };
+>y : { [x: string]: string; }
+>{ bye: "no" } : { bye: string; }
+>bye : string
+>"no" : "no"
+
+y
+>y : { [x: string]: string; }
+
+y.ignoreMe = "ok but just because of the index signature"
+>y.ignoreMe = "ok but just because of the index signature" : "ok but just because of the index signature"
+>y.ignoreMe : string
+>y : { [x: string]: string; }
+>ignoreMe : string
+>"ok but just because of the index signature" : "ok but just because of the index signature"
+
+y['hi'] = "yes"
+>y['hi'] = "yes" : "yes"
+>y['hi'] : string
+>y : { [x: string]: string; }
+>'hi' : "hi"
+>"yes" : "yes"
+

--- a/tests/cases/conformance/jsdoc/typedefTagExtraneousProperty.ts
+++ b/tests/cases/conformance/jsdoc/typedefTagExtraneousProperty.ts
@@ -1,0 +1,15 @@
+// @lib: es5
+// @allowjs: true
+// @checkjs: true
+// @noemit: true
+// @Filename: typedefTagExtraneousProperty.js
+
+/** @typedef {Object.<string,string>} Mmap
+ * @property {string} ignoreMe - should be ignored
+ */
+
+/** @type {Mmap} */
+var y = { bye: "no" };
+y
+y.ignoreMe = "ok but just because of the index signature"
+y['hi'] = "yes"


### PR DESCRIPTION
Previously the jsdoc index signature syntax was incorrectly treated the same as Object:

```js
/** @typedef {Object} AllowsNesting
 * @property ... */
/** @typedef {Object.<string,string>} IncorrectlyAllowsNesting */
```

Fixes #34911

The creator of the issue expected `@property` to work with `Object.<string,string>` as well, but that's not documented on jsdoc.app.
For example, `@typedef` could allow combining `@typedef {Object<string,string>} X` with `@property {string} p` to create `type X = { [s: string]: string, p: string }`. 