### PR TITLE
fix(35944): Debug failure for spell checking of non-existent private named property access

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3484,7 +3484,7 @@ namespace ts {
          */
         /* @internal */ tryGetMemberInModuleExportsAndProperties(memberName: string, moduleSymbol: Symbol): Symbol | undefined;
         getApparentType(type: Type): Type;
-        /* @internal */ getSuggestionForNonexistentProperty(name: Identifier | string, containingType: Type): string | undefined;
+        /* @internal */ getSuggestionForNonexistentProperty(name: Identifier | PrivateIdentifier | string, containingType: Type): string | undefined;
         /* @internal */ getSuggestionForNonexistentSymbol(location: Node, name: string, meaning: SymbolFlags): string | undefined;
         /* @internal */ getSuggestionForNonexistentExport(node: Identifier, target: Symbol): string | undefined;
         getBaseConstraintOfType(type: Type): Type | undefined;

--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -36,12 +36,13 @@ namespace ts.codefix {
 
         let suggestion: string | undefined;
         if (isPropertyAccessExpression(node.parent) && node.parent.name === node) {
-            Debug.assert(node.kind === SyntaxKind.Identifier, "Expected an identifier for spelling (property access)");
+            Debug.assert(isIdentifierOrPrivateIdentifier(node), "Expected an identifier for spelling (property access)");
             let containingType = checker.getTypeAtLocation(node.parent.expression);
             if (node.parent.flags & NodeFlags.OptionalChain) {
                 containingType = checker.getNonNullableType(containingType);
             }
-            suggestion = checker.getSuggestionForNonexistentProperty(node as Identifier, containingType);
+            const name = node as Identifier | PrivateIdentifier;
+            suggestion = checker.getSuggestionForNonexistentProperty(name, containingType);
         }
         else if (isImportSpecifier(node.parent) && node.parent.name === node) {
             Debug.assert(node.kind === SyntaxKind.Identifier, "Expected an identifier for spelling (import)");

--- a/tests/cases/fourslash/codeFixSpellingPropertyAccess.ts
+++ b/tests/cases/fourslash/codeFixSpellingPropertyAccess.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts' />
+
+////const foo = {
+////    bar: 1
+////}
+////
+////const bar = [|foo.#bar|];
+
+verify.codeFixAvailable([
+    { description: "Change spelling to 'bar'" },
+]);
+
+verify.codeFix({
+    index: 0,
+    description: "Change spelling to 'bar'",
+    newRangeContent: "foo.bar"
+});


### PR DESCRIPTION
Fixes #35944
