### PR TITLE
Move individual duration properties into a `performanceData` object

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -237,10 +237,15 @@ namespace ts.server.protocol {
          */
         metadata?: unknown;
 
+        /* @internal */
+        performanceData?: PerformanceData;
+    }
+
+    /* @internal */
+    export interface PerformanceData {
         /**
          * Time spent updating the program graph, in milliseconds.
          */
-        /* @internal */
         updateGraphDurationMs?: number;
     }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -807,7 +807,11 @@ namespace ts.server {
                 command: cmdName,
                 request_seq: reqSeq,
                 success,
-                updateGraphDurationMs: this.updateGraphDurationMs,
+                performanceData: !this.updateGraphDurationMs
+                    ? undefined
+                    : {
+                        updateGraphDurationMs: this.updateGraphDurationMs,
+                    },
             };
 
             if (success) {

--- a/src/testRunner/unittests/tsserver/session.ts
+++ b/src/testRunner/unittests/tsserver/session.ts
@@ -101,7 +101,7 @@ namespace ts.server {
                     message: "Unrecognized JSON command: foobar",
                     request_seq: 0,
                     success: false,
-                    updateGraphDurationMs: undefined,
+                    performanceData: undefined,
                 };
                 expect(lastSent).to.deep.equal(expected);
             });
@@ -128,7 +128,7 @@ namespace ts.server {
                     request_seq: 0,
                     seq: 0,
                     body: undefined,
-                    updateGraphDurationMs: undefined,
+                    performanceData: undefined,
                 });
             });
             it("should handle literal types in request", () => {
@@ -329,7 +329,7 @@ namespace ts.server {
                     request_seq: 0,
                     seq: 0,
                     body: undefined,
-                    updateGraphDurationMs: undefined,
+                    performanceData: undefined,
                 });
             });
         });
@@ -420,7 +420,7 @@ namespace ts.server {
                     command,
                     body,
                     success: true,
-                    updateGraphDurationMs: undefined,
+                    performanceData: undefined,
                 });
             });
         });
@@ -540,7 +540,7 @@ namespace ts.server {
                 command,
                 body,
                 success: true,
-                updateGraphDurationMs: undefined,
+                performanceData: undefined,
             });
         });
         it("can add and respond to new protocol handlers", () => {


### PR DESCRIPTION
This was supposed to be part of #35675, but I forgot to push the last commit.  Good catch, @mjbvz!