### PR TITLE
Fix local and exported type alias merging

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29150,7 +29150,7 @@ namespace ts {
             }
         }
 
-        function checkExportsOnMergedDeclarations(node: Node): void {
+        function checkExportsOnMergedDeclarations(node: Declaration): void {
             if (!produceDiagnostics) {
                 return;
             }
@@ -32456,6 +32456,7 @@ namespace ts {
             checkGrammarDecoratorsAndModifiers(node);
 
             checkTypeNameIsReserved(node.name, Diagnostics.Type_alias_name_cannot_be_0);
+            checkExportsOnMergedDeclarations(node);
             checkTypeParameters(node.typeParameters);
             checkSourceElement(node.type);
             registerForUnusedIdentifiersCheck(node);

--- a/tests/baselines/reference/typeAliasesDoNotMerge.errors.txt
+++ b/tests/baselines/reference/typeAliasesDoNotMerge.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts(1,13): error TS2395: Individual declarations in merged declaration 'A' must be all exported or all local.
+tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts(2,6): error TS2395: Individual declarations in merged declaration 'A' must be all exported or all local.
+
+
+==== tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts (2 errors) ====
+    export type A = {}
+                ~
+!!! error TS2395: Individual declarations in merged declaration 'A' must be all exported or all local.
+    type A = {}
+         ~
+!!! error TS2395: Individual declarations in merged declaration 'A' must be all exported or all local.
+    

--- a/tests/baselines/reference/typeAliasesDoNotMerge.js
+++ b/tests/baselines/reference/typeAliasesDoNotMerge.js
@@ -1,0 +1,8 @@
+//// [typeAliasesDoNotMerge.ts]
+export type A = {}
+type A = {}
+
+
+//// [typeAliasesDoNotMerge.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/typeAliasesDoNotMerge.symbols
+++ b/tests/baselines/reference/typeAliasesDoNotMerge.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts ===
+export type A = {}
+>A : Symbol(A, Decl(typeAliasesDoNotMerge.ts, 0, 0))
+
+type A = {}
+>A : Symbol(A, Decl(typeAliasesDoNotMerge.ts, 0, 0), Decl(typeAliasesDoNotMerge.ts, 0, 18))
+

--- a/tests/baselines/reference/typeAliasesDoNotMerge.types
+++ b/tests/baselines/reference/typeAliasesDoNotMerge.types
@@ -1,0 +1,7 @@
+=== tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts ===
+export type A = {}
+>A : import("tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge").A
+
+type A = {}
+>A : import("tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge").A
+

--- a/tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts
+++ b/tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts
@@ -1,3 +1,2 @@
-// @noLib: true
 export type A = {}
 type A = {}

--- a/tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts
+++ b/tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts
@@ -1,0 +1,3 @@
+// @noLib: true
+export type A = {}
+type A = {}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #36196 

The error is weird, but it’s consistent with what you get for every other kind of declaration, including other non-merging declarations like constants. The way the binder works is a little strange; an exported declaration does have a local symbol but it doesn’t get any symbol flags, so anything can merge into it. On the other hand, it runs through `declareSymbol` with a normal, full set of `excludes` flags, so it will not merge _into_ something else—a strange asymmetry that means if you reverse the order of declarations such that the local-only comes first:

```ts
type A = 0;
export type A = 1;
```

you get the more expected “Duplicate identifier” error. It seems like there’s a potential to do some general work around making these collisions symmetrical in the binder, but it would be a much bigger and more dangerous change that can’t happen for 3.8 at this point.