### PR TITLE
Handle untitled files from vscode which are of format: untitled:^Untitled-1

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1304,7 +1304,7 @@ namespace ts.server {
             // Closing file should trigger re-reading the file content from disk. This is
             // because the user may chose to discard the buffer content before saving
             // to the disk, and the server's version of the file can be out of sync.
-            const fileExists = this.host.fileExists(info.fileName);
+            const fileExists = info.isDynamic ? false : this.host.fileExists(info.fileName);
             info.close(fileExists);
             this.stopWatchingConfigFilesForClosedScriptInfo(info);
 

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -272,7 +272,8 @@ namespace ts.server {
 
     /*@internal*/
     export function isDynamicFileName(fileName: NormalizedPath) {
-        return fileName[0] === "^";
+        return fileName[0] === "^" ||
+            (stringContains(fileName, ":^") && !stringContains(fileName, directorySeparator));
     }
 
     /*@internal*/

--- a/src/testRunner/unittests/tsserver/externalProjects.ts
+++ b/src/testRunner/unittests/tsserver/externalProjects.ts
@@ -221,6 +221,7 @@ namespace ts.projectSystem {
 
             checkNumberOfExternalProjects(projectService, 1);
             checkNumberOfInferredProjects(projectService, 0);
+            verifyDynamic(projectService, "/^scriptdocument1 file1.ts");
 
             externalFiles[0].content = "let x =1;";
             projectService.applyChangesInOpenFiles(arrayIterator(externalFiles));

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -1094,6 +1094,7 @@ namespace ts.projectSystem {
             const project = projectService.inferredProjects[0];
             checkProjectRootFiles(project, [file.path]);
             checkProjectActualFiles(project, [file.path, libFile.path]);
+            verifyDynamic(projectService, `/${file.path}`);
 
             assert.strictEqual(projectService.ensureDefaultProjectForFile(server.toNormalizedPath(file.path)), project);
             const indexOfX = file.content.indexOf("x");
@@ -1124,6 +1125,7 @@ var x = 10;`
             const host = createServerHost([libFile]);
             const projectService = createProjectService(host);
             projectService.openClientFile(file.path, file.content);
+            verifyDynamic(projectService, projectService.toPath(file.path));
 
             projectService.checkNumberOfProjects({ inferredProjects: 1 });
             const project = projectService.inferredProjects[0];
@@ -1152,6 +1154,7 @@ var x = 10;`
                 const projectService = session.getProjectService();
                 checkNumberOfProjects(projectService, { inferredProjects: 1 });
                 checkProjectActualFiles(projectService.inferredProjects[0], [file.path, libFile.path]);
+                verifyDynamic(projectService, `${tscWatch.projectRoot}/${file.path}`);
 
                 session.executeCommandSeq<protocol.OutliningSpansRequest>({
                     command: protocol.CommandTypes.GetOutliningSpans,


### PR DESCRIPTION
Fixes #36200
Sequel to #36109 (note that before  #36109 unititled files were still not considered dynamic. This change ensures that they are dynamic)
