### PR TITLE
Instead of checking if file exists before file read, handle exceptions from file read

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1559,10 +1559,13 @@ namespace ts {
             }
 
             function readFileWorker(fileName: string, _encoding?: string): string | undefined {
-                if (!fileExists(fileName)) {
+                let buffer: Buffer;
+                try {
+                    buffer = _fs.readFileSync(fileName);
+                }
+                catch (e) {
                     return undefined;
                 }
-                const buffer = _fs.readFileSync(fileName);
                 let len = buffer.length;
                 if (len >= 2 && buffer[0] === 0xFE && buffer[1] === 0xFF) {
                     // Big endian UTF-16 byte order mark detected. Since big endian is not supported by node.js,


### PR DESCRIPTION
Fixes #36236
