### PR TITLE
Handle error reporting of files when new file is created after its opened in editor

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1111,6 +1111,11 @@ namespace ts.server {
                     if (project.fileIsOpen(fileOrDirectoryPath)) {
                         if (project.pendingReload !== ConfigFileProgramReloadLevel.Full) {
                             project.openFileWatchTriggered.set(fileOrDirectoryPath, true);
+                            const info = Debug.assertDefined(this.getScriptInfoForPath(fileOrDirectoryPath));
+                            if (!info.isAttached(project)) {
+                                project.pendingReload = ConfigFileProgramReloadLevel.Partial;
+                                this.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(project);
+                            }
                         }
                         return;
                     }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1110,9 +1110,11 @@ namespace ts.server {
                     // don't trigger callback on open, existing files
                     if (project.fileIsOpen(fileOrDirectoryPath)) {
                         if (project.pendingReload !== ConfigFileProgramReloadLevel.Full) {
-                            project.openFileWatchTriggered.set(fileOrDirectoryPath, true);
                             const info = Debug.assertDefined(this.getScriptInfoForPath(fileOrDirectoryPath));
-                            if (!info.isAttached(project)) {
+                            if (info.isAttached(project)) {
+                                project.openFileWatchTriggered.set(fileOrDirectoryPath, true);
+                            }
+                            else {
                                 project.pendingReload = ConfigFileProgramReloadLevel.Partial;
                                 this.delayUpdateProjectGraphAndEnsureProjectStructureForOpenFiles(project);
                             }

--- a/src/testRunner/unittests/tsserver/cancellationToken.ts
+++ b/src/testRunner/unittests/tsserver/cancellationToken.ts
@@ -84,7 +84,10 @@ namespace ts.projectSystem {
                     command: "geterr",
                     arguments: { files: ["/a/missing"] }
                 });
-                // no files - expect 'completed' event
+                // Queued files
+                assert.equal(host.getOutput().length, 0, "expected 0 message");
+                host.checkTimeoutQueueLengthAndRun(1);
+                // Completed event since file is missing
                 assert.equal(host.getOutput().length, 1, "expect 1 message");
                 verifyRequestCompleted(session.getSeq(), 0);
             }

--- a/src/testRunner/unittests/tsserver/configuredProjects.ts
+++ b/src/testRunner/unittests/tsserver/configuredProjects.ts
@@ -940,13 +940,23 @@ declare var console: {
                 })
             };
             const fooBar: File = {
-                path: `${tscWatch.projectRoot}/src/fooBar.ts`,
+                path: `${tscWatch.projectRoot}/src/sub/fooBar.ts`,
                 content: "export function fooBar() { }"
             };
-            function verifySessionWorker({ openFileBeforeCreating, checkProjectBeforeError, checkProjectAfterError, }: VerifySession, errorOnNewFileBeforeOldFile: boolean) {
-                const host = createServerHost([foo, bar, config, libFile]);
+            function verifySessionWorker({ withExclude, openFileBeforeCreating, checkProjectBeforeError, checkProjectAfterError, }: VerifySession, errorOnNewFileBeforeOldFile: boolean) {
+                const host = createServerHost([
+                    foo, bar, libFile, { path: `${tscWatch.projectRoot}/src/sub` },
+                    withExclude ?
+                        {
+                            path: config.path,
+                            content: JSON.stringify({
+                                include: ["./src"],
+                                exclude: ["./src/sub"]
+                            })
+                        } :
+                        config
+                ]);
                 const session = createSession(host, {
-                    //logger: createLoggerWritingToConsole(),
                     canUseEvents: true
                 });
                 session.executeCommandSeq<protocol.OpenRequest>({
@@ -990,6 +1000,7 @@ declare var console: {
                 checkProjectAfterError(service);
             }
             interface VerifySession {
+                withExclude?: boolean;
                 openFileBeforeCreating: boolean;
                 checkProjectBeforeError: (service: server.ProjectService) => void;
                 checkProjectAfterError: (service: server.ProjectService) => void;
@@ -1003,34 +1014,52 @@ declare var console: {
                     verifySessionWorker(input, /*errorOnNewFileBeforeOldFile*/ false);
                 });
             }
+            function checkFooBarInInferredProject(service: server.ProjectService) {
+                checkNumberOfProjects(service, { configuredProjects: 1, inferredProjects: 1 });
+                checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, libFile.path, config.path]);
+                checkProjectActualFiles(service.inferredProjects[0], [fooBar.path, libFile.path]);
+            }
+            function checkFooBarInConfiguredProject(service: server.ProjectService) {
+                checkNumberOfProjects(service, { configuredProjects: 1 });
+                checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, fooBar.path, libFile.path, config.path]);
+            }
             describe("when new file creation directory watcher is invoked before file is opened in editor", () => {
                 verifySession({
                     openFileBeforeCreating: false,
-                    checkProjectBeforeError: service => {
-                        checkNumberOfProjects(service, { configuredProjects: 1 });
-                        checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, fooBar.path, libFile.path, config.path]);
-                    },
-                    checkProjectAfterError: service => {
-                        checkNumberOfProjects(service, { configuredProjects: 1 });
-                        checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, fooBar.path, libFile.path, config.path]);
-                    }
+                    checkProjectBeforeError: checkFooBarInConfiguredProject,
+                    checkProjectAfterError: checkFooBarInConfiguredProject
+                });
+                describe("when new file is excluded from config", () => {
+                    verifySession({
+                        withExclude: true,
+                        openFileBeforeCreating: false,
+                        checkProjectBeforeError: checkFooBarInInferredProject,
+                        checkProjectAfterError: checkFooBarInInferredProject
+                    });
                 });
             });
 
             describe("when new file creation directory watcher is invoked after file is opened in editor", () => {
                 verifySession({
                     openFileBeforeCreating: true,
-                    checkProjectBeforeError: service => {
-                        checkNumberOfProjects(service, { configuredProjects: 1, inferredProjects: 1 });
-                        checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, libFile.path, config.path]);
-                        checkProjectActualFiles(service.inferredProjects[0], [fooBar.path, libFile.path]);
-                    },
+                    checkProjectBeforeError: checkFooBarInInferredProject,
                     checkProjectAfterError: service => {
+                        // Both projects exist but fooBar is in configured project after the update
+                        // Inferred project is yet to be updated so still has fooBar
                         checkNumberOfProjects(service, { configuredProjects: 1, inferredProjects: 1 });
                         checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, fooBar.path, libFile.path, config.path]);
                         checkProjectActualFiles(service.inferredProjects[0], [fooBar.path, libFile.path]);
                         assert.isTrue(service.inferredProjects[0].dirty);
+                        assert.equal(service.inferredProjects[0].getRootFilesMap().size, 0);
                     }
+                });
+                describe("when new file is excluded from config", () => {
+                    verifySession({
+                        withExclude: true,
+                        openFileBeforeCreating: true,
+                        checkProjectBeforeError: checkFooBarInInferredProject,
+                        checkProjectAfterError: checkFooBarInInferredProject
+                    });
                 });
             });
         });

--- a/src/testRunner/unittests/tsserver/configuredProjects.ts
+++ b/src/testRunner/unittests/tsserver/configuredProjects.ts
@@ -923,6 +923,116 @@ declare var console: {
             const service = createProjectService(host);
             service.openClientFile(file.path);
         });
+
+        describe("when creating new file", () => {
+            const foo: File = {
+                path: `${tscWatch.projectRoot}/src/foo.ts`,
+                content: "export function foo() { }"
+            };
+            const bar: File = {
+                path: `${tscWatch.projectRoot}/src/bar.ts`,
+                content: "export function bar() { }"
+            };
+            const config: File = {
+                path: `${tscWatch.projectRoot}/tsconfig.json`,
+                content: JSON.stringify({
+                    include: ["./src"]
+                })
+            };
+            const fooBar: File = {
+                path: `${tscWatch.projectRoot}/src/fooBar.ts`,
+                content: "export function fooBar() { }"
+            };
+            function verifySessionWorker({ openFileBeforeCreating, checkProjectBeforeError, checkProjectAfterError, }: VerifySession, errorOnNewFileBeforeOldFile: boolean) {
+                const host = createServerHost([foo, bar, config, libFile]);
+                const session = createSession(host, {
+                    //logger: createLoggerWritingToConsole(),
+                    canUseEvents: true
+                });
+                session.executeCommandSeq<protocol.OpenRequest>({
+                    command: protocol.CommandTypes.Open,
+                    arguments: {
+                        file: foo.path,
+                        fileContent: foo.content,
+                        projectRootPath: tscWatch.projectRoot
+                    }
+                });
+                if (!openFileBeforeCreating) {
+                    host.writeFile(fooBar.path, fooBar.content);
+                }
+                session.executeCommandSeq<protocol.OpenRequest>({
+                    command: protocol.CommandTypes.Open,
+                    arguments: {
+                        file: fooBar.path,
+                        fileContent: fooBar.content,
+                        projectRootPath: tscWatch.projectRoot
+                    }
+                });
+                if (openFileBeforeCreating) {
+                    host.writeFile(fooBar.path, fooBar.content);
+                }
+                const service = session.getProjectService();
+                checkProjectBeforeError(service);
+                verifyGetErrRequest({
+                    session,
+                    host,
+                    expected: errorOnNewFileBeforeOldFile ?
+                        [
+                            { file: fooBar, syntax: [], semantic: [], suggestion: [] },
+                            { file: foo, syntax: [], semantic: [], suggestion: [] },
+                        ] :
+                        [
+                            { file: foo, syntax: [], semantic: [], suggestion: [] },
+                            { file: fooBar, syntax: [], semantic: [], suggestion: [] },
+                        ],
+                    existingTimeouts: 2
+                });
+                checkProjectAfterError(service);
+            }
+            interface VerifySession {
+                openFileBeforeCreating: boolean;
+                checkProjectBeforeError: (service: server.ProjectService) => void;
+                checkProjectAfterError: (service: server.ProjectService) => void;
+            }
+            function verifySession(input: VerifySession) {
+                it("when error on new file are asked before old one", () => {
+                    verifySessionWorker(input, /*errorOnNewFileBeforeOldFile*/ true);
+                });
+
+                it("when error on new file are asked after old one", () => {
+                    verifySessionWorker(input, /*errorOnNewFileBeforeOldFile*/ false);
+                });
+            }
+            describe("when new file creation directory watcher is invoked before file is opened in editor", () => {
+                verifySession({
+                    openFileBeforeCreating: false,
+                    checkProjectBeforeError: service => {
+                        checkNumberOfProjects(service, { configuredProjects: 1 });
+                        checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, fooBar.path, libFile.path, config.path]);
+                    },
+                    checkProjectAfterError: service => {
+                        checkNumberOfProjects(service, { configuredProjects: 1 });
+                        checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, fooBar.path, libFile.path, config.path]);
+                    }
+                });
+            });
+
+            describe("when new file creation directory watcher is invoked after file is opened in editor", () => {
+                verifySession({
+                    openFileBeforeCreating: true,
+                    checkProjectBeforeError: service => {
+                        checkNumberOfProjects(service, { configuredProjects: 1, inferredProjects: 1 });
+                        checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, libFile.path, config.path]);
+                        checkProjectActualFiles(service.inferredProjects[0], [fooBar.path, libFile.path]);
+                    },
+                    checkProjectAfterError: service => {
+                        checkNumberOfProjects(service, { configuredProjects: 1, inferredProjects: 1 });
+                        checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, fooBar.path, libFile.path, config.path]);
+                        checkProjectActualFiles(service.inferredProjects[0], [fooBar.path, libFile.path]);
+                    }
+                });
+            });
+        });
     });
 
     describe("unittests:: tsserver:: ConfiguredProjects:: non-existing directories listed in config file input array", () => {

--- a/src/testRunner/unittests/tsserver/configuredProjects.ts
+++ b/src/testRunner/unittests/tsserver/configuredProjects.ts
@@ -1029,6 +1029,7 @@ declare var console: {
                         checkNumberOfProjects(service, { configuredProjects: 1, inferredProjects: 1 });
                         checkProjectActualFiles(service.configuredProjects.get(config.path)!, [foo.path, bar.path, fooBar.path, libFile.path, config.path]);
                         checkProjectActualFiles(service.inferredProjects[0], [fooBar.path, libFile.path]);
+                        assert.isTrue(service.inferredProjects[0].dirty);
                     }
                 });
             });

--- a/src/testRunner/unittests/tsserver/projectErrors.ts
+++ b/src/testRunner/unittests/tsserver/projectErrors.ts
@@ -382,7 +382,7 @@ namespace ts.projectSystem {
                 }
             });
 
-            host.runQueuedImmediateCallbacks();
+            host.checkTimeoutQueueLengthAndRun(1);
             assert.isFalse(hasError());
             checkCompleteEvent(session, 1, expectedSequenceId);
             session.clearMessages();

--- a/src/testRunner/unittests/tsserver/projects.ts
+++ b/src/testRunner/unittests/tsserver/projects.ts
@@ -1508,7 +1508,7 @@ var x = 10;`
                 host,
                 expected: [
                     { file: fileB, syntax: [], semantic: [], suggestion: [] },
-                    { file: fileSubA },
+                    { file: fileSubA, syntax: [], semantic: [], suggestion: [] },
                 ],
                 existingTimeouts: 2,
                 onErrEvent: () => assert.isFalse(hasErrorMsg())

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9482,7 +9482,7 @@ declare namespace ts.server {
         private getCompileOnSaveAffectedFileList;
         private emitFile;
         private getSignatureHelpItems;
-        private createCheckList;
+        private toPendingErrorCheck;
         private getDiagnostics;
         private change;
         private reload;


### PR DESCRIPTION
- Before this change, if file that is open in editor was added or removed from directory, it would ignore that for re-computing list of files. But that meant if watch for file creation was invoked after file is opened, it wouldn't put that file into configured project. so instead of ignoring the watch all the time, we ignore it only if file is already attached to the project. 
- Now with this fix, the new file will correctly be updated to be part of configured project after project is delay updated. That meant when queuing the errors, project for new file was inferred project which wont contain the file after that project is updated. This was because when `getErr` is queued, file and project are computed.. The actual error checking happens after delay, but that means when changes happen before this invocation (such as watcher invoke to create the file) the updated project wont contain file since we are now correctly putting file in the right project. So instead of precomputing default project for the file, compute it at the time of checking to avoid using wrong project. Note that getErrorForProject wll still queue filename + project instead of just filename since we want to ensure to check errors in context of that project.
Fixes #35794
