### PR TITLE
Consider SymbolFlags.Method as function-esque during js declaration emit

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5370,7 +5370,7 @@ namespace ts {
                         symbol.flags & (SymbolFlags.BlockScopedVariable | SymbolFlags.FunctionScopedVariable | SymbolFlags.Property) &&
                         symbol.escapedName !== InternalSymbolName.ExportEquals;
                     const isConstMergedWithNSPrintableAsSignatureMerge = isConstMergedWithNS && isTypeRepresentableAsFunctionNamespaceMerge(getTypeOfSymbol(symbol), symbol);
-                    if (symbol.flags & SymbolFlags.Function || isConstMergedWithNSPrintableAsSignatureMerge) {
+                    if (symbol.flags & (SymbolFlags.Function | SymbolFlags.Method) || isConstMergedWithNSPrintableAsSignatureMerge) {
                         serializeAsFunctionNamespaceMerge(getTypeOfSymbol(symbol), symbol, getInternalSymbolName(symbol, symbolName), modifierFlags);
                     }
                     if (symbol.flags & SymbolFlags.TypeAlias) {

--- a/tests/baselines/reference/jsDeclarationsFunctionPrototypeStatic.js
+++ b/tests/baselines/reference/jsDeclarationsFunctionPrototypeStatic.js
@@ -1,0 +1,44 @@
+//// [source.js]
+module.exports = MyClass;
+
+function MyClass() {}
+MyClass.staticMethod = function() {}
+MyClass.prototype.method = function() {}
+MyClass.staticProperty = 123;
+
+/**
+ * Callback to be invoked when test execution is complete.
+ *
+ * @callback DoneCB
+ * @param {number} failures - Number of failures that occurred.
+ */
+
+//// [source.js]
+module.exports = MyClass;
+function MyClass() { }
+MyClass.staticMethod = function () { };
+MyClass.prototype.method = function () { };
+MyClass.staticProperty = 123;
+/**
+ * Callback to be invoked when test execution is complete.
+ *
+ * @callback DoneCB
+ * @param {number} failures - Number of failures that occurred.
+ */ 
+
+
+//// [source.d.ts]
+export = MyClass;
+declare function MyClass(): void;
+declare class MyClass {
+    method(): void;
+}
+declare namespace MyClass {
+    export { staticMethod, staticProperty, DoneCB };
+}
+declare function staticMethod(): void;
+declare var staticProperty: number;
+/**
+ * Callback to be invoked when test execution is complete.
+ */
+type DoneCB = (failures: number) => any;

--- a/tests/baselines/reference/jsDeclarationsFunctionPrototypeStatic.symbols
+++ b/tests/baselines/reference/jsDeclarationsFunctionPrototypeStatic.symbols
@@ -1,0 +1,32 @@
+=== tests/cases/conformance/jsdoc/declarations/source.js ===
+module.exports = MyClass;
+>module.exports : Symbol("tests/cases/conformance/jsdoc/declarations/source", Decl(source.js, 0, 0))
+>module : Symbol(export=, Decl(source.js, 0, 0))
+>exports : Symbol(export=, Decl(source.js, 0, 0))
+>MyClass : Symbol(MyClass, Decl(source.js, 0, 25), Decl(source.js, 2, 21), Decl(source.js, 4, 40))
+
+function MyClass() {}
+>MyClass : Symbol(MyClass, Decl(source.js, 0, 25), Decl(source.js, 2, 21), Decl(source.js, 4, 40))
+
+MyClass.staticMethod = function() {}
+>MyClass.staticMethod : Symbol(MyClass.staticMethod, Decl(source.js, 2, 21))
+>MyClass : Symbol(MyClass, Decl(source.js, 0, 25), Decl(source.js, 2, 21), Decl(source.js, 4, 40))
+>staticMethod : Symbol(MyClass.staticMethod, Decl(source.js, 2, 21))
+
+MyClass.prototype.method = function() {}
+>MyClass.prototype : Symbol(MyClass.method, Decl(source.js, 3, 36))
+>MyClass : Symbol(MyClass, Decl(source.js, 0, 25), Decl(source.js, 2, 21), Decl(source.js, 4, 40))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>method : Symbol(MyClass.method, Decl(source.js, 3, 36))
+
+MyClass.staticProperty = 123;
+>MyClass.staticProperty : Symbol(MyClass.staticProperty, Decl(source.js, 4, 40))
+>MyClass : Symbol(MyClass, Decl(source.js, 0, 25), Decl(source.js, 2, 21), Decl(source.js, 4, 40))
+>staticProperty : Symbol(MyClass.staticProperty, Decl(source.js, 4, 40))
+
+/**
+ * Callback to be invoked when test execution is complete.
+ *
+ * @callback DoneCB
+ * @param {number} failures - Number of failures that occurred.
+ */

--- a/tests/baselines/reference/jsDeclarationsFunctionPrototypeStatic.types
+++ b/tests/baselines/reference/jsDeclarationsFunctionPrototypeStatic.types
@@ -1,0 +1,40 @@
+=== tests/cases/conformance/jsdoc/declarations/source.js ===
+module.exports = MyClass;
+>module.exports = MyClass : typeof MyClass
+>module.exports : typeof MyClass
+>module : { "\"tests/cases/conformance/jsdoc/declarations/source\"": typeof MyClass; }
+>exports : typeof MyClass
+>MyClass : typeof MyClass
+
+function MyClass() {}
+>MyClass : typeof MyClass
+
+MyClass.staticMethod = function() {}
+>MyClass.staticMethod = function() {} : () => void
+>MyClass.staticMethod : () => void
+>MyClass : typeof MyClass
+>staticMethod : () => void
+>function() {} : () => void
+
+MyClass.prototype.method = function() {}
+>MyClass.prototype.method = function() {} : () => void
+>MyClass.prototype.method : any
+>MyClass.prototype : any
+>MyClass : typeof MyClass
+>prototype : any
+>method : any
+>function() {} : () => void
+
+MyClass.staticProperty = 123;
+>MyClass.staticProperty = 123 : 123
+>MyClass.staticProperty : number
+>MyClass : typeof MyClass
+>staticProperty : number
+>123 : 123
+
+/**
+ * Callback to be invoked when test execution is complete.
+ *
+ * @callback DoneCB
+ * @param {number} failures - Number of failures that occurred.
+ */

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionPrototypeStatic.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsFunctionPrototypeStatic.ts
@@ -1,0 +1,19 @@
+// @allowJs: true
+// @checkJs: true
+// @target: es5
+// @outDir: ./out
+// @declaration: true
+// @filename: source.js
+module.exports = MyClass;
+
+function MyClass() {}
+MyClass.staticMethod = function() {}
+MyClass.prototype.method = function() {}
+MyClass.staticProperty = 123;
+
+/**
+ * Callback to be invoked when test execution is complete.
+ *
+ * @callback DoneCB
+ * @param {number} failures - Number of failures that occurred.
+ */


### PR DESCRIPTION
The binder binds both "instance methods" and "static methods" of js class-like functions with `SymbolFlags.Method`. For instance methods, we recover them while emitting instance members, however for static methods, we rely on serializing the static side as a namespace augmentation on the class; so in those cases, we need to emit the method as a function instead.

Fixes #36270
