### PR TITLE
Always emit `any` for `get` accessors

### DIFF
--- a/tests/baselines/reference/ambientAccessors(target=es3).js
+++ b/tests/baselines/reference/ambientAccessors(target=es3).js
@@ -21,10 +21,10 @@ declare class C {
 declare class C {
     static get a(): string;
     static set a(value: string);
-    private static get b();
+    private static get b(): any;
     private static set b(value);
     get x(): string;
     set x(value: string);
-    private get y();
+    private get y(): any;
     private set y(value);
 }

--- a/tests/baselines/reference/ambientAccessors(target=es5).js
+++ b/tests/baselines/reference/ambientAccessors(target=es5).js
@@ -21,10 +21,10 @@ declare class C {
 declare class C {
     static get a(): string;
     static set a(value: string);
-    private static get b();
+    private static get b(): any;
     private static set b(value);
     get x(): string;
     set x(value: string);
-    private get y();
+    private get y(): any;
     private set y(value);
 }

--- a/tests/baselines/reference/classdecl.js
+++ b/tests/baselines/reference/classdecl.js
@@ -225,7 +225,7 @@ declare class a {
         y: number;
     };
     private static d2;
-    private static get p3();
+    private static get p3(): any;
     private pv3;
     private foo;
 }

--- a/tests/baselines/reference/commentsClassMembers.js
+++ b/tests/baselines/reference/commentsClassMembers.js
@@ -494,7 +494,7 @@ declare class c1 {
     /** sum with property*/
     private pp2;
     /** getter property*/
-    private get pp3();
+    private get pp3(): any;
     /** setter property*/
     private set pp3(value);
     /** Constructor method*/
@@ -513,7 +513,7 @@ declare class c1 {
     set nc_p3(value: number);
     private nc_pp1;
     private nc_pp2;
-    private get nc_pp3();
+    private get nc_pp3(): any;
     private set nc_pp3(value);
     static nc_s1: number;
     static nc_s2(b: number): number;
@@ -525,7 +525,7 @@ declare class c1 {
     set a_p3(value: number);
     private a_pp1;
     private a_pp2;
-    private get a_pp3();
+    private get a_pp3(): any;
     private set a_pp3(value);
     static a_s1: number;
     static a_s2(b: number): number;
@@ -544,7 +544,7 @@ declare class c1 {
     /** sum with property */
     private b_pp2;
     /** getter property */
-    private get b_pp3();
+    private get b_pp3(): any;
     /** setter property */
     private set b_pp3(value);
     /** s1 is static property of c1 */

--- a/tests/baselines/reference/declFileAccessors.js
+++ b/tests/baselines/reference/declFileAccessors.js
@@ -277,7 +277,7 @@ export declare class c1 {
     /** setter property*/
     set p3(/** this is value*/ value: number);
     /** private getter property*/
-    private get pp3();
+    private get pp3(): any;
     /** private setter property*/
     private set pp3(value);
     /** static getter property*/
@@ -286,7 +286,7 @@ export declare class c1 {
     static set s3(/** this is value*/ value: number);
     get nc_p3(): number;
     set nc_p3(value: number);
-    private get nc_pp3();
+    private get nc_pp3(): any;
     private set nc_pp3(value);
     static get nc_s3(): string;
     static set nc_s3(value: string);
@@ -301,7 +301,7 @@ declare class c2 {
     /** setter property*/
     set p3(/** this is value*/ value: number);
     /** private getter property*/
-    private get pp3();
+    private get pp3(): any;
     /** private setter property*/
     private set pp3(value);
     /** static getter property*/
@@ -310,7 +310,7 @@ declare class c2 {
     static set s3(/** this is value*/ value: number);
     get nc_p3(): number;
     set nc_p3(value: number);
-    private get nc_pp3();
+    private get nc_pp3(): any;
     private set nc_pp3(value);
     static get nc_s3(): string;
     static set nc_s3(value: string);

--- a/tests/baselines/reference/declFilePrivateStatic.js
+++ b/tests/baselines/reference/declFilePrivateStatic.js
@@ -51,7 +51,7 @@ declare class C {
     static y: number;
     private static a;
     static b(): void;
-    private static get c();
+    private static get c(): any;
     static get d(): number;
     private static set e(value);
     static set f(v: any);

--- a/tests/baselines/reference/giant.js
+++ b/tests/baselines/reference/giant.js
@@ -1124,7 +1124,7 @@ export declare class eC {
     psF(param: any): void;
     set psF(param: any);
     private rgF;
-    private get rgF();
+    private get rgF(): any;
     private rsF;
     private set rsF(value);
     static tV: any;
@@ -1176,7 +1176,7 @@ export declare module eM {
         psF(param: any): void;
         set psF(param: any);
         private rgF;
-        private get rgF();
+        private get rgF(): any;
         private rsF;
         private set rsF(value);
         static tV: any;
@@ -1241,7 +1241,7 @@ export declare module eM {
         psF(param: any): void;
         set psF(param: any);
         private rgF;
-        private get rgF();
+        private get rgF(): any;
         private rsF;
         private set rsF(value);
         static tV: any;
@@ -1281,7 +1281,7 @@ export declare class eaC {
     psF(param: any): void;
     set psF(param: any);
     private rgF;
-    private get rgF();
+    private get rgF(): any;
     private rsF;
     private set rsF(value);
     static tV: any;

--- a/tests/baselines/reference/moduledecl.js
+++ b/tests/baselines/reference/moduledecl.js
@@ -457,7 +457,7 @@ declare module exportTests {
     class C3_public {
         private getC2_private;
         private setC2_private;
-        private get c2();
+        private get c2(): any;
         getC1_public(): C1_public;
         setC1_public(arg: C1_public): void;
         get c1(): C1_public;

--- a/tests/baselines/reference/privacyAccessorDeclFile.js
+++ b/tests/baselines/reference/privacyAccessorDeclFile.js
@@ -3563,23 +3563,23 @@ export declare class publicClass {
 }
 export declare class publicClassWithWithPrivateGetAccessorTypes {
     static get myPublicStaticMethod(): privateClass;
-    private static get myPrivateStaticMethod();
+    private static get myPrivateStaticMethod(): any;
     get myPublicMethod(): privateClass;
-    private get myPrivateMethod();
+    private get myPrivateMethod(): any;
     static get myPublicStaticMethod1(): privateClass;
-    private static get myPrivateStaticMethod1();
+    private static get myPrivateStaticMethod1(): any;
     get myPublicMethod1(): privateClass;
-    private get myPrivateMethod1();
+    private get myPrivateMethod1(): any;
 }
 export declare class publicClassWithWithPublicGetAccessorTypes {
     static get myPublicStaticMethod(): publicClass;
-    private static get myPrivateStaticMethod();
+    private static get myPrivateStaticMethod(): any;
     get myPublicMethod(): publicClass;
-    private get myPrivateMethod();
+    private get myPrivateMethod(): any;
     static get myPublicStaticMethod1(): publicClass;
-    private static get myPrivateStaticMethod1();
+    private static get myPrivateStaticMethod1(): any;
     get myPublicMethod1(): publicClass;
-    private get myPrivateMethod1();
+    private get myPrivateMethod1(): any;
 }
 export declare class publicClassWithWithPrivateSetAccessorTypes {
     static set myPublicStaticMethod(param: privateClass);
@@ -3610,23 +3610,23 @@ export declare module publicModule {
     }
     export class publicClassWithWithPrivateGetAccessorTypes {
         static get myPublicStaticMethod(): privateClass;
-        private static get myPrivateStaticMethod();
+        private static get myPrivateStaticMethod(): any;
         get myPublicMethod(): privateClass;
-        private get myPrivateMethod();
+        private get myPrivateMethod(): any;
         static get myPublicStaticMethod1(): privateClass;
-        private static get myPrivateStaticMethod1();
+        private static get myPrivateStaticMethod1(): any;
         get myPublicMethod1(): privateClass;
-        private get myPrivateMethod1();
+        private get myPrivateMethod1(): any;
     }
     export class publicClassWithWithPublicGetAccessorTypes {
         static get myPublicStaticMethod(): publicClass;
-        private static get myPrivateStaticMethod();
+        private static get myPrivateStaticMethod(): any;
         get myPublicMethod(): publicClass;
-        private get myPrivateMethod();
+        private get myPrivateMethod(): any;
         static get myPublicStaticMethod1(): publicClass;
-        private static get myPrivateStaticMethod1();
+        private static get myPrivateStaticMethod1(): any;
         get myPublicMethod1(): publicClass;
-        private get myPrivateMethod1();
+        private get myPrivateMethod1(): any;
     }
     export class publicClassWithWithPrivateSetAccessorTypes {
         static set myPublicStaticMethod(param: privateClass);
@@ -3659,23 +3659,23 @@ declare module privateModule {
     }
     export class publicClassWithWithPrivateGetAccessorTypes {
         static get myPublicStaticMethod(): privateClass;
-        private static get myPrivateStaticMethod();
+        private static get myPrivateStaticMethod(): any;
         get myPublicMethod(): privateClass;
-        private get myPrivateMethod();
+        private get myPrivateMethod(): any;
         static get myPublicStaticMethod1(): privateClass;
-        private static get myPrivateStaticMethod1();
+        private static get myPrivateStaticMethod1(): any;
         get myPublicMethod1(): privateClass;
-        private get myPrivateMethod1();
+        private get myPrivateMethod1(): any;
     }
     export class publicClassWithWithPublicGetAccessorTypes {
         static get myPublicStaticMethod(): publicClass;
-        private static get myPrivateStaticMethod();
+        private static get myPrivateStaticMethod(): any;
         get myPublicMethod(): publicClass;
-        private get myPrivateMethod();
+        private get myPrivateMethod(): any;
         static get myPublicStaticMethod1(): publicClass;
-        private static get myPrivateStaticMethod1();
+        private static get myPrivateStaticMethod1(): any;
         get myPublicMethod1(): publicClass;
-        private get myPrivateMethod1();
+        private get myPrivateMethod1(): any;
     }
     export class publicClassWithWithPrivateSetAccessorTypes {
         static set myPublicStaticMethod(param: privateClass);
@@ -3707,13 +3707,13 @@ declare class publicClassInGlobal {
 }
 declare class publicClassInGlobalWithPublicGetAccessorTypes {
     static get myPublicStaticMethod(): publicClassInGlobal;
-    private static get myPrivateStaticMethod();
+    private static get myPrivateStaticMethod(): any;
     get myPublicMethod(): publicClassInGlobal;
-    private get myPrivateMethod();
+    private get myPrivateMethod(): any;
     static get myPublicStaticMethod1(): publicClassInGlobal;
-    private static get myPrivateStaticMethod1();
+    private static get myPrivateStaticMethod1(): any;
     get myPublicMethod1(): publicClassInGlobal;
-    private get myPrivateMethod1();
+    private get myPrivateMethod1(): any;
 }
 declare class publicClassInGlobalWithWithPublicSetAccessorTypes {
     static set myPublicStaticMethod(param: publicClassInGlobal);
@@ -3733,23 +3733,23 @@ declare module publicModuleInGlobal {
         }
         export class publicClassWithWithPrivateGetAccessorTypes {
             static get myPublicStaticMethod(): privateClass;
-            private static get myPrivateStaticMethod();
+            private static get myPrivateStaticMethod(): any;
             get myPublicMethod(): privateClass;
-            private get myPrivateMethod();
+            private get myPrivateMethod(): any;
             static get myPublicStaticMethod1(): privateClass;
-            private static get myPrivateStaticMethod1();
+            private static get myPrivateStaticMethod1(): any;
             get myPublicMethod1(): privateClass;
-            private get myPrivateMethod1();
+            private get myPrivateMethod1(): any;
         }
         export class publicClassWithWithPublicGetAccessorTypes {
             static get myPublicStaticMethod(): publicClass;
-            private static get myPrivateStaticMethod();
+            private static get myPrivateStaticMethod(): any;
             get myPublicMethod(): publicClass;
-            private get myPrivateMethod();
+            private get myPrivateMethod(): any;
             static get myPublicStaticMethod1(): publicClass;
-            private static get myPrivateStaticMethod1();
+            private static get myPrivateStaticMethod1(): any;
             get myPublicMethod1(): publicClass;
-            private get myPrivateMethod1();
+            private get myPrivateMethod1(): any;
         }
         export class publicClassWithWithPrivateSetAccessorTypes {
             static set myPublicStaticMethod(param: privateClass);
@@ -3777,23 +3777,23 @@ declare module publicModuleInGlobal {
     }
     export class publicClassWithWithPrivateGetAccessorTypes {
         static get myPublicStaticMethod(): privateClass;
-        private static get myPrivateStaticMethod();
+        private static get myPrivateStaticMethod(): any;
         get myPublicMethod(): privateClass;
-        private get myPrivateMethod();
+        private get myPrivateMethod(): any;
         static get myPublicStaticMethod1(): privateClass;
-        private static get myPrivateStaticMethod1();
+        private static get myPrivateStaticMethod1(): any;
         get myPublicMethod1(): privateClass;
-        private get myPrivateMethod1();
+        private get myPrivateMethod1(): any;
     }
     export class publicClassWithWithPublicGetAccessorTypes {
         static get myPublicStaticMethod(): publicClass;
-        private static get myPrivateStaticMethod();
+        private static get myPrivateStaticMethod(): any;
         get myPublicMethod(): publicClass;
-        private get myPrivateMethod();
+        private get myPrivateMethod(): any;
         static get myPublicStaticMethod1(): publicClass;
-        private static get myPrivateStaticMethod1();
+        private static get myPrivateStaticMethod1(): any;
         get myPublicMethod1(): publicClass;
-        private get myPrivateMethod1();
+        private get myPrivateMethod1(): any;
     }
     export class publicClassWithWithPrivateSetAccessorTypes {
         static set myPublicStaticMethod(param: privateClass);

--- a/tests/baselines/reference/privacyCannotNameAccessorDeclFile.js
+++ b/tests/baselines/reference/privacyCannotNameAccessorDeclFile.js
@@ -418,13 +418,13 @@ export declare function createExportedWidget4(): Widgets1.SpecializedGlobalWidge
 /// <reference path="privacyCannotNameAccessorDeclFile_GlobalWidgets.d.ts" />
 export declare class publicClassWithWithPrivateGetAccessorTypes {
     static get myPublicStaticMethod(): import("./privacyCannotNameAccessorDeclFile_Widgets").Widget1;
-    private static get myPrivateStaticMethod();
+    private static get myPrivateStaticMethod(): any;
     get myPublicMethod(): import("./privacyCannotNameAccessorDeclFile_Widgets").Widget1;
-    private get myPrivateMethod();
+    private get myPrivateMethod(): any;
     static get myPublicStaticMethod1(): import("GlobalWidgets").Widget3;
-    private static get myPrivateStaticMethod1();
+    private static get myPrivateStaticMethod1(): any;
     get myPublicMethod1(): import("GlobalWidgets").Widget3;
-    private get myPrivateMethod1();
+    private get myPrivateMethod1(): any;
 }
 export declare class publicClassWithPrivateModuleGetAccessorTypes {
     static get myPublicStaticMethod(): import("./privacyCannotNameAccessorDeclFile_Widgets").SpecializedWidget.Widget2;

--- a/tests/baselines/reference/readonlyInDeclarationFile.js
+++ b/tests/baselines/reference/readonlyInDeclarationFile.js
@@ -149,10 +149,10 @@ declare class C {
     private readonly a1;
     protected readonly a2: number;
     readonly a3: number;
-    private get b1();
+    private get b1(): any;
     protected get b2(): number;
     get b3(): number;
-    private get c1();
+    private get c1(): any;
     private set c1(value);
     protected get c2(): number;
     protected set c2(value: number);
@@ -161,10 +161,10 @@ declare class C {
     private static readonly s1;
     protected static readonly s2: number;
     static readonly s3: number;
-    private static get t1();
+    private static get t1(): any;
     protected static get t2(): number;
     static get t3(): number;
-    private static get u1();
+    private static get u1(): any;
     private static set u1(value);
     protected static get u2(): number;
     protected static set u2(value: number);


### PR DESCRIPTION
Fixes at least half of #36216 by always emitting `any` for `get` accessors.

Note that `set` accessors stil emit without parameter types, and from what I can tell TypeScript 3.6 is okay with that under `noImplicitAny`.