### PR TITLE
Don't parse duplicate JSDoc for ExpressionStatement starting with ParenthesizedExpression

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1335,7 +1335,7 @@ namespace ts {
 
         function createNodeWithJSDoc(kind: SyntaxKind, pos?: number): Node {
             const node = createNode(kind, pos);
-            if (scanner.getTokenFlags() & TokenFlags.PrecedingJSDocComment) {
+            if (scanner.getTokenFlags() & TokenFlags.PrecedingJSDocComment && (kind !== SyntaxKind.ExpressionStatement || token() !== SyntaxKind.OpenParenToken)) {
                 addJSDocComment(<HasJSDoc>node);
             }
             return node;
@@ -5391,7 +5391,7 @@ namespace ts {
             // Avoiding having to do the lookahead for a labeled statement by just trying to parse
             // out an expression, seeing if it is identifier and then seeing if it is followed by
             // a colon.
-            const node = <ExpressionStatement | LabeledStatement>createNodeWithJSDoc(SyntaxKind.Unknown);
+            const node = <ExpressionStatement | LabeledStatement>createNodeWithJSDoc(token() === SyntaxKind.Identifier ? SyntaxKind.Unknown : SyntaxKind.ExpressionStatement);
             const expression = allowInAnd(parseExpression);
             if (expression.kind === SyntaxKind.Identifier && parseOptional(SyntaxKind.ColonToken)) {
                 node.kind = SyntaxKind.LabeledStatement;

--- a/tests/baselines/reference/jsdocTypedefBeforeParenthesizedExpression.symbols
+++ b/tests/baselines/reference/jsdocTypedefBeforeParenthesizedExpression.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/test.js ===
+;
+No type information for this code./** @typedef {object} NotADuplicateIdentifier */
+No type information for this code.
+No type information for this code.(2 * 2);
+No type information for this code.
+No type information for this code./** @typedef {object} AlsoNotADuplicate */
+No type information for this code.
+No type information for this code.(2 * 2) + 1;
+No type information for this code.
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/jsdocTypedefBeforeParenthesizedExpression.symbols
+++ b/tests/baselines/reference/jsdocTypedefBeforeParenthesizedExpression.symbols
@@ -1,12 +1,21 @@
 === tests/cases/compiler/test.js ===
-;
-No type information for this code./** @typedef {object} NotADuplicateIdentifier */
-No type information for this code.
-No type information for this code.(2 * 2);
-No type information for this code.
-No type information for this code./** @typedef {object} AlsoNotADuplicate */
-No type information for this code.
-No type information for this code.(2 * 2) + 1;
-No type information for this code.
-No type information for this code.
-No type information for this code.
+// @ts-check
+/** @typedef {number} NotADuplicateIdentifier */
+
+(2 * 2);
+
+/** @typedef {number} AlsoNotADuplicate */
+
+(2 * 2) + 1;
+
+
+/**
+ * 
+ * @param a {NotADuplicateIdentifier}
+ * @param b {AlsoNotADuplicate}
+ */
+function makeSureTypedefsAreStillRecognized(a, b) {}
+>makeSureTypedefsAreStillRecognized : Symbol(makeSureTypedefsAreStillRecognized, Decl(test.js, 7, 12))
+>a : Symbol(a, Decl(test.js, 15, 44))
+>b : Symbol(b, Decl(test.js, 15, 46))
+

--- a/tests/baselines/reference/jsdocTypedefBeforeParenthesizedExpression.types
+++ b/tests/baselines/reference/jsdocTypedefBeforeParenthesizedExpression.types
@@ -1,6 +1,6 @@
 === tests/cases/compiler/test.js ===
-;
-/** @typedef {object} NotADuplicateIdentifier */
+// @ts-check
+/** @typedef {number} NotADuplicateIdentifier */
 
 (2 * 2);
 >(2 * 2) : number
@@ -8,7 +8,7 @@
 >2 : 2
 >2 : 2
 
-/** @typedef {object} AlsoNotADuplicate */
+/** @typedef {number} AlsoNotADuplicate */
 
 (2 * 2) + 1;
 >(2 * 2) + 1 : number
@@ -18,4 +18,14 @@
 >2 : 2
 >1 : 1
 
+
+/**
+ * 
+ * @param a {NotADuplicateIdentifier}
+ * @param b {AlsoNotADuplicate}
+ */
+function makeSureTypedefsAreStillRecognized(a, b) {}
+>makeSureTypedefsAreStillRecognized : (a: number, b: number) => void
+>a : number
+>b : number
 

--- a/tests/baselines/reference/jsdocTypedefBeforeParenthesizedExpression.types
+++ b/tests/baselines/reference/jsdocTypedefBeforeParenthesizedExpression.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/test.js ===
+;
+/** @typedef {object} NotADuplicateIdentifier */
+
+(2 * 2);
+>(2 * 2) : number
+>2 * 2 : number
+>2 : 2
+>2 : 2
+
+/** @typedef {object} AlsoNotADuplicate */
+
+(2 * 2) + 1;
+>(2 * 2) + 1 : number
+>(2 * 2) : number
+>2 * 2 : number
+>2 : 2
+>2 : 2
+>1 : 1
+
+

--- a/tests/cases/compiler/jsdocTypedefBeforeParenthesizedExpression.ts
+++ b/tests/cases/compiler/jsdocTypedefBeforeParenthesizedExpression.ts
@@ -1,14 +1,20 @@
 // @allowJs: true
-// @checkJs: true
 // @noEmit: true
 
 // @filename: test.js
-;
-/** @typedef {object} NotADuplicateIdentifier */
+// @ts-check
+/** @typedef {number} NotADuplicateIdentifier */
 
 (2 * 2);
 
-/** @typedef {object} AlsoNotADuplicate */
+/** @typedef {number} AlsoNotADuplicate */
 
 (2 * 2) + 1;
 
+
+/**
+ * 
+ * @param a {NotADuplicateIdentifier}
+ * @param b {AlsoNotADuplicate}
+ */
+function makeSureTypedefsAreStillRecognized(a, b) {}

--- a/tests/cases/compiler/jsdocTypedefBeforeParenthesizedExpression.ts
+++ b/tests/cases/compiler/jsdocTypedefBeforeParenthesizedExpression.ts
@@ -1,0 +1,14 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @filename: test.js
+;
+/** @typedef {object} NotADuplicateIdentifier */
+
+(2 * 2);
+
+/** @typedef {object} AlsoNotADuplicate */
+
+(2 * 2) + 1;
+


### PR DESCRIPTION
Fixes: #36179

Before this change the `ExpressionStatement` **and** the `ParenthesizedExpression` had equal JSDoc as they started at the same position. First of all this doesn't make much sense to have the same information on two different nodes. In addition this caused `@typedef` to be bound twice causing a `Duplicate identifier` error.

After this change, we skip parsing JSDoc of ExpressionStatements that start with a ParenthesizedExpression.