### PR TITLE
feat(36327): libdef args rest type should always be array of any

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1473,22 +1473,22 @@ type NonNullable<T> = T extends null | undefined ? never : T;
 /**
  * Obtain the parameters of a function type in a tuple
  */
-type Parameters<T extends (...args: any) => any> = T extends (...args: infer P) => any ? P : never;
+type Parameters<T extends (...args: any[]) => any> = T extends (...args: infer P) => any ? P : never;
 
 /**
  * Obtain the parameters of a constructor function type in a tuple
  */
-type ConstructorParameters<T extends new (...args: any) => any> = T extends new (...args: infer P) => any ? P : never;
+type ConstructorParameters<T extends new (...args: any[]) => any> = T extends new (...args: infer P) => any ? P : never;
 
 /**
  * Obtain the return type of a function type
  */
-type ReturnType<T extends (...args: any) => any> = T extends (...args: any) => infer R ? R : any;
+type ReturnType<T extends (...args: any[]) => any> = T extends (...args: any) => infer R ? R : any;
 
 /**
  * Obtain the return type of a constructor function type
  */
-type InstanceType<T extends new (...args: any) => any> = T extends new (...args: any) => infer R ? R : any;
+type InstanceType<T extends new (...args: any[]) => any> = T extends new (...args: any) => infer R ? R : any;
 
 /**
  * Marker for contextual 'this' type

--- a/tests/baselines/reference/genericRestParameters1.errors.txt
+++ b/tests/baselines/reference/genericRestParameters1.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/types/rest/genericRestParameters1.ts(22,11): error TS2556: Expected 3 arguments, but got 1 or more.
 tests/cases/conformance/types/rest/genericRestParameters1.ts(31,11): error TS2556: Expected 3 arguments, but got 1 or more.
-tests/cases/conformance/types/rest/genericRestParameters1.ts(135,23): error TS2344: Type 'Function' does not satisfy the constraint '(...args: any) => any'.
-  Type 'Function' provides no match for the signature '(...args: any): any'.
+tests/cases/conformance/types/rest/genericRestParameters1.ts(135,23): error TS2344: Type 'Function' does not satisfy the constraint '(...args: any[]) => any'.
+  Type 'Function' provides no match for the signature '(...args: any[]): any'.
 tests/cases/conformance/types/rest/genericRestParameters1.ts(164,1): error TS2322: Type '(a: never) => void' is not assignable to type '(...args: any[]) => void'.
   Types of parameters 'a' and 'args' are incompatible.
     Type 'any' is not assignable to type 'never'.
@@ -149,8 +149,8 @@ tests/cases/conformance/types/rest/genericRestParameters1.ts(164,1): error TS232
     type T08<T extends any[]> = ConstructorParameters<new (...args: T) => void>;
     type T09 = Parameters<Function>;
                           ~~~~~~~~
-!!! error TS2344: Type 'Function' does not satisfy the constraint '(...args: any) => any'.
-!!! error TS2344:   Type 'Function' provides no match for the signature '(...args: any): any'.
+!!! error TS2344: Type 'Function' does not satisfy the constraint '(...args: any[]) => any'.
+!!! error TS2344:   Type 'Function' provides no match for the signature '(...args: any[]): any'.
     
     type Record1 = {
       move: [number, 'left' | 'right'];

--- a/tests/baselines/reference/inferTypes1.errors.txt
+++ b/tests/baselines/reference/inferTypes1.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/types/conditional/inferTypes1.ts(31,23): error TS2344: Type 'string' does not satisfy the constraint '(...args: any) => any'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(32,23): error TS2344: Type 'Function' does not satisfy the constraint '(...args: any) => any'.
-  Type 'Function' provides no match for the signature '(...args: any): any'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(38,25): error TS2344: Type 'string' does not satisfy the constraint 'new (...args: any) => any'.
-tests/cases/conformance/types/conditional/inferTypes1.ts(39,25): error TS2344: Type 'Function' does not satisfy the constraint 'new (...args: any) => any'.
-  Type 'Function' provides no match for the signature 'new (...args: any): any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(31,23): error TS2344: Type 'string' does not satisfy the constraint '(...args: any[]) => any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(32,23): error TS2344: Type 'Function' does not satisfy the constraint '(...args: any[]) => any'.
+  Type 'Function' provides no match for the signature '(...args: any[]): any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(38,25): error TS2344: Type 'string' does not satisfy the constraint 'new (...args: any[]) => any'.
+tests/cases/conformance/types/conditional/inferTypes1.ts(39,25): error TS2344: Type 'Function' does not satisfy the constraint 'new (...args: any[]) => any'.
+  Type 'Function' provides no match for the signature 'new (...args: any[]): any'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(47,25): error TS2344: Type '(x: string, y: string) => number' does not satisfy the constraint '(x: any) => any'.
 tests/cases/conformance/types/conditional/inferTypes1.ts(48,25): error TS2344: Type 'Function' does not satisfy the constraint '(x: any) => any'.
   Type 'Function' provides no match for the signature '(x: any): any'.
@@ -54,11 +54,11 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(145,40): error TS2322: 
     type T16 = ReturnType<never>;  // never
     type T17 = ReturnType<string>;  // Error
                           ~~~~~~
-!!! error TS2344: Type 'string' does not satisfy the constraint '(...args: any) => any'.
+!!! error TS2344: Type 'string' does not satisfy the constraint '(...args: any[]) => any'.
     type T18 = ReturnType<Function>;  // Error
                           ~~~~~~~~
-!!! error TS2344: Type 'Function' does not satisfy the constraint '(...args: any) => any'.
-!!! error TS2344:   Type 'Function' provides no match for the signature '(...args: any): any'.
+!!! error TS2344: Type 'Function' does not satisfy the constraint '(...args: any[]) => any'.
+!!! error TS2344:   Type 'Function' provides no match for the signature '(...args: any[]): any'.
     type T19<T extends any[]> = ReturnType<(x: string, ...args: T) => T[]>;  // T[]
     
     type U10 = InstanceType<typeof C>;  // C
@@ -66,11 +66,11 @@ tests/cases/conformance/types/conditional/inferTypes1.ts(145,40): error TS2322: 
     type U12 = InstanceType<never>;  // never
     type U13 = InstanceType<string>;  // Error
                             ~~~~~~
-!!! error TS2344: Type 'string' does not satisfy the constraint 'new (...args: any) => any'.
+!!! error TS2344: Type 'string' does not satisfy the constraint 'new (...args: any[]) => any'.
     type U14 = InstanceType<Function>;  // Error
                             ~~~~~~~~
-!!! error TS2344: Type 'Function' does not satisfy the constraint 'new (...args: any) => any'.
-!!! error TS2344:   Type 'Function' provides no match for the signature 'new (...args: any): any'.
+!!! error TS2344: Type 'Function' does not satisfy the constraint 'new (...args: any[]) => any'.
+!!! error TS2344:   Type 'Function' provides no match for the signature 'new (...args: any[]): any'.
     
     type ArgumentType<T extends (x: any) => any> = T extends (a: infer A) => any ? A : any;
     

--- a/tests/baselines/reference/parameterListAsTupleType.errors.txt
+++ b/tests/baselines/reference/parameterListAsTupleType.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/parameterListAsTupleType.ts(8,17): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/parameterListAsTupleType.ts(16,23): error TS2344: Type 'typeof C' does not satisfy the constraint '(...args: any) => any'.
-  Type 'typeof C' provides no match for the signature '(...args: any): any'.
+tests/cases/compiler/parameterListAsTupleType.ts(16,23): error TS2344: Type 'typeof C' does not satisfy the constraint '(...args: any[]) => any'.
+  Type 'typeof C' provides no match for the signature '(...args: any[]): any'.
 
 
 ==== tests/cases/compiler/parameterListAsTupleType.ts (2 errors) ====
@@ -23,8 +23,8 @@ tests/cases/compiler/parameterListAsTupleType.ts(16,23): error TS2344: Type 'typ
     
     type Cps = Parameters<typeof C>; // should not work
                           ~~~~~~~~
-!!! error TS2344: Type 'typeof C' does not satisfy the constraint '(...args: any) => any'.
-!!! error TS2344:   Type 'typeof C' provides no match for the signature '(...args: any): any'.
+!!! error TS2344: Type 'typeof C' does not satisfy the constraint '(...args: any[]) => any'.
+!!! error TS2344:   Type 'typeof C' provides no match for the signature '(...args: any[]): any'.
     type Ccps = ConstructorParameters<typeof C>; // should be [number, string]
     
     class D {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #36327 36327
