### PR TITLE
Completions for `asserts` and `declare`

### DIFF
--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1058,7 +1058,7 @@ namespace FourSlashInterface {
         }
 
         export const classElementKeywords: readonly ExpectedCompletionEntryObject[] =
-            ["private", "protected", "public", "static", "abstract", "async", "constructor", "get", "readonly", "set"].map(keywordEntry);
+            ["private", "protected", "public", "static", "abstract", "async", "constructor", "declare", "get", "readonly", "set"].map(keywordEntry);
 
         export const classElementInJsKeywords = getInJsKeywords(classElementKeywords);
 

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -902,7 +902,7 @@ namespace FourSlashInterface {
         export const keywords: readonly ExpectedCompletionEntryObject[] = keywordsWithUndefined.filter(k => k.name !== "undefined");
 
         export const typeKeywords: readonly ExpectedCompletionEntryObject[] =
-            ["false", "null", "true", "void", "any", "boolean", "keyof", "never", "readonly", "number", "object", "string", "symbol", "undefined", "unique", "unknown", "bigint"].map(keywordEntry);
+            ["false", "null", "true", "void", "asserts", "any", "boolean", "keyof", "never", "readonly", "number", "object", "string", "symbol", "undefined", "unique", "unknown", "bigint"].map(keywordEntry);
 
         const globalTypeDecls: readonly ExpectedCompletionEntryObject[] = [
             interfaceEntry("Symbol"),
@@ -1152,6 +1152,7 @@ namespace FourSlashInterface {
             "let",
             "package",
             "yield",
+            "asserts",
             "any",
             "async",
             "await",
@@ -1351,6 +1352,7 @@ namespace FourSlashInterface {
             "let",
             "package",
             "yield",
+            "asserts",
             "any",
             "async",
             "await",

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2525,6 +2525,7 @@ namespace ts.Completions {
             case SyntaxKind.GetKeyword:
             case SyntaxKind.SetKeyword:
             case SyntaxKind.AsyncKeyword:
+            case SyntaxKind.DeclareKeyword:
                 return true;
             default:
                 return isClassMemberModifier(kind);

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1278,6 +1278,7 @@ namespace ts {
 
     export const typeKeywords: readonly SyntaxKind[] = [
         SyntaxKind.AnyKeyword,
+        SyntaxKind.AssertsKeyword,
         SyntaxKind.BigIntKeyword,
         SyntaxKind.BooleanKeyword,
         SyntaxKind.FalseKeyword,

--- a/tests/cases/fourslash/completionAmbientPropertyDeclaration.ts
+++ b/tests/cases/fourslash/completionAmbientPropertyDeclaration.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+//// class C {
+////     /*1*/ declare property: number;
+////     /*2*/
+//// }
+
+verify.completions({marker: "1", exact: completion.classElementKeywords, isNewIdentifierLocation: true});
+verify.completions({marker: "2", exact: completion.classElementKeywords, isNewIdentifierLocation: true});

--- a/tests/cases/fourslash/completionEntryForClassMembers.ts
+++ b/tests/cases/fourslash/completionEntryForClassMembers.ts
@@ -146,7 +146,7 @@ verify.completions(
             "classThatStartedWritingIdentifierAfterPrivateModifier",
             "classThatStartedWritingIdentifierAfterPrivateStaticModifier",
         ],
-        exact: ["private", "protected", "public", "static", "abstract", "async", "constructor", "get", "readonly", "set"].map(
+        exact: ["private", "protected", "public", "static", "abstract", "async", "constructor", "declare", "get", "readonly", "set"].map(
             name => ({ name, sortText: completion.SortText.GlobalsOrKeywords })
             ),
         isNewIdentifierLocation: true,

--- a/tests/cases/fourslash/completionListInNamedClassExpression.ts
+++ b/tests/cases/fourslash/completionListInNamedClassExpression.ts
@@ -11,7 +11,7 @@ verify.completions(
     { marker: "0", includes: { name: "myClass", text: "(local class) myClass", kind: "local class" } },
     {
         marker: "1",
-        exact: ["private", "protected", "public", "static", "abstract", "async", "constructor", "get", "readonly", "set"].map(
+        exact: ["private", "protected", "public", "static", "abstract", "async", "constructor", "declare", "get", "readonly", "set"].map(
             name => ({ name, sortText: completion.SortText.GlobalsOrKeywords })
         ),
         isNewIdentifierLocation: true,

--- a/tests/cases/fourslash/completionTypeGuard.ts
+++ b/tests/cases/fourslash/completionTypeGuard.ts
@@ -2,7 +2,10 @@
 
 //// const x = "str";
 //// function assert1(condition: any, msg?: string): /*1*/ ;
-//// function assert1(condition: any, msg?: string): /*2*/ { }
+//// function assert2(condition: any, msg?: string): /*2*/ { }
+//// function assert3(condition: any, msg?: string): /*3*/
+//// hi
 
 verify.completions({marker: "1", exact: completion.globalTypes});
 verify.completions({marker: "2", exact: completion.globalTypes});
+verify.completions({marker: "3", exact: completion.globalTypes});

--- a/tests/cases/fourslash/completionTypeGuard.ts
+++ b/tests/cases/fourslash/completionTypeGuard.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts" />
+
+//// const x = "str";
+//// function assert1(condition: any, msg?: string): /*1*/ ;
+//// function assert1(condition: any, msg?: string): /*2*/ { }
+
+verify.completions({marker: "1", exact: completion.globalTypes});
+verify.completions({marker: "2", exact: completion.globalTypes});


### PR DESCRIPTION
I'm not 100% sure that `asserts` should go into `typeKeywords` instead of an ad-hoc addition to `KeywordCompletion.TypeKeywords` in `getTypescriptKeywordCompletions`. But this makes the tests easier to update, which is a good sign that it's more predictable for users as well.

Fixes #35187
