### PR TITLE
Add a list of PR owners for tooling to use

### DIFF
--- a/.github/pr_owners.txt
+++ b/.github/pr_owners.txt
@@ -1,0 +1,8 @@
+sandersn
+elibarzilay
+weswigham
+andrewbranch
+RyanCavanaugh
+sheetalkamat
+orta
+rbuckton


### PR DESCRIPTION
This is a list of the internal folks who are on the compiler team (and not PMing) which we can use in tooling ( see [microsoft/typescript-repos-automation](https://github.com/microsoft/TypeScript-repos-automation) )