### PR TITLE
Don’t mix in base constraint completions on indexed access types with type parameter index types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21337,11 +21337,19 @@ namespace ts {
             return argIndex === -1 ? undefined : getContextualTypeForArgumentAtIndex(callTarget, argIndex, contextFlags);
         }
 
-        function getContextualTypeForArgumentAtIndex(callTarget: CallLikeExpression, argIndex: number, contextFlags?: ContextFlags): Type {
+        function getContextualTypeForArgumentAtIndex(callTarget: CallLikeExpression, argIndex: number, contextFlags?: ContextFlags): Type | undefined {
             // If we're already in the process of resolving the given signature, don't resolve again as
             // that could cause infinite recursion. Instead, return anySignature.
             let signature = getNodeLinks(callTarget).resolvedSignature === resolvingSignature ? resolvingSignature : getResolvedSignature(callTarget);
-            if (contextFlags && contextFlags & ContextFlags.BaseConstraint && signature.target && !hasTypeArguments(callTarget)) {
+
+            if (contextFlags && contextFlags & ContextFlags.Uninstantiated) {
+                return signature.target ? getTypeAtPosition(signature.target, argIndex) : undefined;
+            }
+
+            if (contextFlags && contextFlags & ContextFlags.BaseConstraint) {
+                if (!signature.target || hasTypeArguments(callTarget)) {
+                    return undefined;
+                }
                 signature = getBaseSignature(signature.target);
             }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3605,6 +3605,7 @@ namespace ts {
         Signature      = 1 << 0, // Obtaining contextual signature
         NoConstraints  = 1 << 1, // Don't obtain type variable constraints
         BaseConstraint = 1 << 2, // Use base constraint type for completions
+        Uninstantiated = 1 << 3, // Attempt to get the type from an uninstantiated signature
     }
 
     // NOTE: If modifying this enum, must modify `TypeFormatFlags` too!

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1279,7 +1279,7 @@ namespace ts.Completions {
             // Cursor is inside a JSX self-closing element or opening element
             const attrsType = jsxContainer && typeChecker.getContextualType(jsxContainer.attributes);
             if (!attrsType) return GlobalsSearch.Continue;
-            const uninstantiatedType = typeChecker.getContextualType(jsxContainer!, ContextFlags.Uninstantiated);
+            const uninstantiatedType = typeChecker.getContextualType(jsxContainer!.attributes, ContextFlags.Uninstantiated);
             let baseType;
             if (uninstantiatedType) {
                 const signature = tryGetContextualTypeProvidingSignature(jsxContainer!, typeChecker)?.target;

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1800,9 +1800,14 @@ namespace ts.Completions {
 
             if (objectLikeContainer.kind === SyntaxKind.ObjectLiteralExpression) {
                 const instantiatedType = typeChecker.getContextualType(objectLikeContainer);
-                const baseType = instantiatedType && typeChecker.getContextualType(objectLikeContainer, ContextFlags.BaseConstraint);
-                if (!instantiatedType || !baseType) return GlobalsSearch.Fail;
-                isNewIdentifierLocation = hasIndexSignature(instantiatedType || baseType);
+                if (!instantiatedType) return GlobalsSearch.Fail;
+                const uninstantiatedType = typeChecker.getContextualType(objectLikeContainer, ContextFlags.Uninstantiated);
+                let baseType;
+                if (!(uninstantiatedType && uninstantiatedType.flags & TypeFlags.IndexedAccess)) {
+                    baseType = typeChecker.getContextualType(objectLikeContainer, ContextFlags.BaseConstraint);
+                }
+
+                isNewIdentifierLocation = hasIndexSignature(instantiatedType);
                 typeMembers = getPropertiesForObjectExpression(instantiatedType, baseType, objectLikeContainer, typeChecker);
                 existingMembers = objectLikeContainer.properties;
             }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1885,7 +1885,7 @@ namespace ts.Completions {
                         break loop;
                 }
             }
-            if (!isCallLikeExpression(node) && !isJsxOpeningLikeElement(node)) {
+            if (!isCallLikeExpression(node)) {
                 return;
             }
             return checker.getResolvedSignature(node);
@@ -1897,6 +1897,12 @@ namespace ts.Completions {
             }
             if (type.flags & TypeFlags.IndexedAccess) {
                 return typeIsTypeParameterFromSignature((type as IndexedAccessType).indexType, signature);
+            }
+            if (getObjectFlags(type) & ObjectFlags.Mapped) {
+                const { constraintType } = (type as MappedType);
+                if (constraintType && constraintType.flags & TypeFlags.Index) {
+                    return isIndexedAccessTypeWithTypeParameterIndex((constraintType as IndexType).type, signature);
+                }
             }
             return false;
         }

--- a/tests/cases/fourslash/completionsGenericIndexedAccess3.ts
+++ b/tests/cases/fourslash/completionsGenericIndexedAccess3.ts
@@ -1,0 +1,35 @@
+/// <reference path="fourslash.ts" />
+
+////interface CustomElements {
+////  'component-one': {
+////      foo?: string;
+////  },
+////  'component-two': {
+////      bar?: string;
+////  }
+////}
+////
+////interface Options<T extends keyof CustomElements> {
+////  props: CustomElements[T];
+////}
+////
+////declare function create<T extends keyof CustomElements>(name: T, options: Options<T>): void;
+////
+////create('component-one', { props: { /*1*/ } });
+////create('component-two', { props: { /*2*/ } });
+
+verify.completions({
+  marker: "1",
+  exact: [{
+    name: "foo",
+    sortText: completion.SortText.OptionalMember
+  }]
+});
+
+verify.completions({
+  marker: "2",
+  exact: [{
+    name: "bar",
+    sortText: completion.SortText.OptionalMember
+  }]
+});

--- a/tests/cases/fourslash/completionsGenericIndexedAccess4.ts
+++ b/tests/cases/fourslash/completionsGenericIndexedAccess4.ts
@@ -1,0 +1,45 @@
+/// <reference path="fourslash.ts" />
+
+////interface CustomElements {
+////  'component-one': {
+////      foo?: string;
+////  },
+////  'component-two': {
+////      bar?: string;
+////  }
+////}
+////
+////interface Options<T extends keyof CustomElements> {
+////  props: CustomElements[T];
+////}
+////
+////declare function create<T extends 'hello' | 'goodbye'>(name: T, options: Options<T extends 'hello' ? 'component-one' : 'component-two'>): void;
+////declare function create<T extends keyof CustomElements>(name: T, options: Options<T>): void;
+////
+////create('hello', { props: { /*1*/ } })
+////create('goodbye', { props: { /*2*/ } })
+////create('component-one', { props: { /*3*/ } });
+
+verify.completions({
+  marker: "1",
+  exact: [{
+    name: "foo",
+    sortText: completion.SortText.OptionalMember
+  }]
+});
+
+verify.completions({
+  marker: "2",
+  exact: [{
+    name: "bar",
+    sortText: completion.SortText.OptionalMember
+  }]
+});
+
+verify.completions({
+  marker: "3",
+  exact: [{
+    name: "foo",
+    sortText: completion.SortText.OptionalMember
+  }]
+});

--- a/tests/cases/fourslash/completionsGenericIndexedAccess5.ts
+++ b/tests/cases/fourslash/completionsGenericIndexedAccess5.ts
@@ -1,0 +1,28 @@
+////interface CustomElements {
+////  'component-one': {
+////      foo?: string;
+////  },
+////  'component-two': {
+////      bar?: string;
+////  }
+////}
+////
+////interface Options<T extends keyof CustomElements> {
+////    props?: {} & { x: CustomElements[(T extends string ? T : never) & string][] }['x'];
+////}
+////
+////declare function f<T extends keyof CustomElements>(k: T, options: Options<T>): void;
+////
+////f("component-one", {
+////    props: [{
+////        /**/
+////    }]
+////})
+
+verify.completions({
+  marker: "",
+  exact: [{
+    name: "foo",
+    sortText: completion.SortText.OptionalMember
+  }]
+});

--- a/tests/cases/fourslash/completionsGenericIndexedAccess6.ts
+++ b/tests/cases/fourslash/completionsGenericIndexedAccess6.ts
@@ -1,0 +1,23 @@
+// @Filename: component.tsx
+
+////interface CustomElements {
+////  'component-one': {
+////      foo?: string;
+////  },
+////  'component-two': {
+////      bar?: string;
+////  }
+////}
+////
+////type Options<T extends keyof CustomElements> = { kind: T } & Required<{ x: CustomElements[(T extends string ? T : never) & string] }['x']>;
+////
+////declare function Component<T extends keyof CustomElements>(props: Options<T>): void;
+////
+////const c = <Component /**/ kind="component-one" />
+
+verify.completions({
+  marker: "",
+  exact: [{
+    name: "foo"
+  }]
+})


### PR DESCRIPTION
Recall #30507, trying to get completions at a position like:

```ts
function f<T extends { x?: string }>(p: T) {}

f({ /**/ });
```

Since an empty object satisfies the constraint `{ x?: string }`, `T` is inferred as an empty object, and therefore getting members of the contextual type at that position yields an empty list. So in #32100, #33937, and #34855, we started instantiating `f`’s call signature with its constraint, getting the type of the argument in that signature, and mixing in properties from that type into the completions list.

Unfortunately, that had some unintended side effects when the signature’s parameter types have a non-linear relationship with a type parameter included in the signature, like conditional types and indexed access types that reference one of the type parameters. In real-world complaints from users, every case I’ve seen has been an indexed access type where the index type is a type parameter:

```ts
type Colors = {
  rgb: { r: number, g: number, b: number };
  hsl: { h: number, s: number, l: number }
};

function createColor<T extends keyof Colors>(kind: T, values: Colors[T]) {}

createColor('rgb', {
  /* oh nooo, I get completions for r, g, b, h, s, and l! */
});
```

In these cases, having more options is wrong and annoying.

This PR special-cases indexed access types where the index type is a type parameter of the contextual-type-providing signature (with some wiggle room to look past unions and intersections and conditional types).

It’s a band-aid fix, but a) I have spent several days trying to think of something better that’s not wildly expensive, and b) it covers the only failure case that people have actually complained about. That said, I don’t love this and am open to suggestions.

Fixes #35702, #36025
