### PR TITLE
Draft: Swap out SymbolTable structure and add a cached path for invalidading…

### DIFF
--- a/src/compiler/corePublic.ts
+++ b/src/compiler/corePublic.ts
@@ -93,4 +93,52 @@ namespace ts {
         EqualTo     = 0,
         GreaterThan = 1
     }
+
+    let symbolTableId = 1;
+    export class SymbolTable implements UnderscoreEscapedMap<Symbol> {
+        private underlying = createMap<Symbol>() as UnderscoreEscapedMap<Symbol>;
+        /* @internal */
+        elements = createMap<true>();
+        /* @internal */
+        id = symbolTableId++;
+        get(key: __String): Symbol | undefined {
+            return this.underlying.get(key);
+        }
+        has(key: __String): boolean {
+            return this.underlying.has(key);
+        }
+        forEach(action: (value: Symbol, key: __String) => void) {
+            return this.underlying.forEach(action);
+        }
+        get size() {
+            return this.underlying.size;
+        }
+        keys(): Iterator<__String> {
+            return this.underlying.keys();
+        }
+        values(): Iterator<Symbol> {
+            return this.underlying.values();
+        }
+        entries(): Iterator<[__String, Symbol]> {
+            return this.underlying.entries();
+        }
+        set(key: __String, value: Symbol): this {
+            this.elements.set("" + getSymbolId(value), true);
+            this.underlying.set(key, value);
+            return this;
+        }
+        /**
+         * It is an error to remove something from a symbol table
+         */
+        delete(_: __String) {
+            return Debug.fail("Symbol tables are immutable and should not have elements deleted from them!");
+        }
+        clear() {
+            return Debug.fail("Symbol tables are immutable and should not be cleared");
+        }
+        /* @internal */
+        hasValue(value: Symbol): boolean {
+            return this.elements.has("" + getSymbolId(value));
+        }
+    }
 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4177,9 +4177,6 @@ namespace ts {
         clear(): void;
     }
 
-    /** SymbolTable based on ES6 Map interface. */
-    export type SymbolTable = UnderscoreEscapedMap<Symbol>;
-
     /** Used to track a `declare module "foo*"`-like declaration. */
     /* @internal */
     export interface PatternAmbientModule {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -30,11 +30,18 @@ namespace ts {
         return !!map && !!map.size;
     }
 
-    export function createSymbolTable(symbols?: readonly Symbol[]): SymbolTable {
-        const result = createMap<Symbol>() as SymbolTable;
+    export function createSymbolTable(symbols?: readonly Symbol[] | readonly [__String, Symbol][]): SymbolTable {
+        const result = new SymbolTable();
         if (symbols) {
-            for (const symbol of symbols) {
-                result.set(symbol.escapedName, symbol);
+            if (symbols[0] && isArray(symbols[0])) {
+                for (const [symbolName, symbol] of (symbols as readonly [__String, Symbol][])) {
+                    result.set(symbolName, symbol);
+                }
+            }
+            else {
+                for (const symbol of (symbols as readonly Symbol[])) {
+                    result.set(symbol.escapedName, symbol);
+                }
             }
         }
         return result;
@@ -192,8 +199,8 @@ namespace ts {
     export function cloneMap<T>(map: ReadonlyMap<T>): Map<T>;
     export function cloneMap<T>(map: ReadonlyUnderscoreEscapedMap<T>): UnderscoreEscapedMap<T>;
     export function cloneMap<T>(map: ReadonlyMap<T> | ReadonlyUnderscoreEscapedMap<T> | SymbolTable): Map<T> | UnderscoreEscapedMap<T> | SymbolTable {
-        const clone = createMap<T>();
-        copyEntries(map as Map<T>, clone);
+        const clone = map instanceof SymbolTable ? createSymbolTable() : createMap<T>();
+        copyEntries(map as Map<T>, clone as Map<T>);
         return clone;
     }
 

--- a/src/services/codefixes/inferFromUsage.ts
+++ b/src/services/codefixes/inferFromUsage.ts
@@ -945,7 +945,7 @@ namespace ts.codefix {
             });
             return checker.createAnonymousType(
                 anons[0].symbol,
-                members as UnderscoreEscapedMap<TransientSymbol>,
+                createSymbolTable(arrayFrom(members.entries()) as [__String, Symbol][]),
                 calls,
                 constructs,
                 stringIndices.length ? checker.createIndexInfo(checker.getUnionType(stringIndices), stringIndexReadonly) : undefined,
@@ -981,7 +981,7 @@ namespace ts.codefix {
         }
 
         function inferStructuralType(usage: Usage) {
-            const members = createUnderscoreEscapedMap<Symbol>();
+            const members = createSymbolTable();
             if (usage.properties) {
                 usage.properties.forEach((u, name) => {
                     const symbol = checker.createSymbol(SymbolFlags.Property, name);

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -61,6 +61,22 @@ declare namespace ts {
     interface Push<T> {
         push(...values: T[]): void;
     }
+    class SymbolTable implements UnderscoreEscapedMap<Symbol> {
+        private underlying;
+        get(key: __String): Symbol | undefined;
+        has(key: __String): boolean;
+        forEach(action: (value: Symbol, key: __String) => void): void;
+        get size(): number;
+        keys(): Iterator<__String>;
+        values(): Iterator<Symbol>;
+        entries(): Iterator<[__String, Symbol]>;
+        set(key: __String, value: Symbol): this;
+        /**
+         * It is an error to remove something from a symbol table
+         */
+        delete(_: __String): never;
+        clear(): never;
+    }
 }
 declare namespace ts {
     export type Path = string & {
@@ -2314,8 +2330,6 @@ declare namespace ts {
         delete(key: __String): boolean;
         clear(): void;
     }
-    /** SymbolTable based on ES6 Map interface. */
-    export type SymbolTable = UnderscoreEscapedMap<Symbol>;
     export enum TypeFlags {
         Any = 1,
         Unknown = 2,

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -61,6 +61,22 @@ declare namespace ts {
     interface Push<T> {
         push(...values: T[]): void;
     }
+    class SymbolTable implements UnderscoreEscapedMap<Symbol> {
+        private underlying;
+        get(key: __String): Symbol | undefined;
+        has(key: __String): boolean;
+        forEach(action: (value: Symbol, key: __String) => void): void;
+        get size(): number;
+        keys(): Iterator<__String>;
+        values(): Iterator<Symbol>;
+        entries(): Iterator<[__String, Symbol]>;
+        set(key: __String, value: Symbol): this;
+        /**
+         * It is an error to remove something from a symbol table
+         */
+        delete(_: __String): never;
+        clear(): never;
+    }
 }
 declare namespace ts {
     export type Path = string & {
@@ -2314,8 +2330,6 @@ declare namespace ts {
         delete(key: __String): boolean;
         clear(): void;
     }
-    /** SymbolTable based on ES6 Map interface. */
-    export type SymbolTable = UnderscoreEscapedMap<Symbol>;
     export enum TypeFlags {
         Any = 1,
         Unknown = 2,


### PR DESCRIPTION
… most symbol visibility results more quickly

This is open so I can collect perf results vs master. This doesn't swap out the whole implementation yet - just swaps out the `SymbolTable` object we use for another one (a wrapper around a `Map` that does some extra bookkeeping assuming no deletions/re-sets) and adds a hopefully fast path to symbol visibility that uses this new information to bail more quickly.
