### PR TITLE
Fix crash on missing parent pointer in binder when transpiling export as ns

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2608,6 +2608,9 @@ namespace ts {
                 declareSymbol(container.symbol.exports, container.symbol, node, SymbolFlags.ExportStar, SymbolFlags.None);
             }
             else if (isNamespaceExport(node.exportClause)) {
+                // declareSymbol walks up parents to find name text, parent _must_ be set
+                // but won't be set by the normal binder walk until `bindChildren` later on.
+                node.exportClause.parent = node;
                 declareSymbol(container.symbol.exports, container.symbol, node.exportClause, SymbolFlags.Alias, SymbolFlags.AliasExcludes);
             }
         }

--- a/src/testRunner/unittests/services/transpile.ts
+++ b/src/testRunner/unittests/services/transpile.ts
@@ -474,5 +474,12 @@ var x = 0;`, {
         transpilesCorrectly("Infer correct file extension", `const fn = <T>(a: T) => a`, {
             noSetFileName: true
         });
+
+        transpilesCorrectly("Export star as ns conflict does not crash", `
+var a;
+export { a as alias };
+export * as alias from './file';`, {
+            noSetFileName: true
+        });
     });
 }

--- a/tests/baselines/reference/transpile/Export star as ns conflict does not crash.js
+++ b/tests/baselines/reference/transpile/Export star as ns conflict does not crash.js
@@ -1,0 +1,6 @@
+"use strict";
+exports.__esModule = true;
+var a;
+exports.alias = a;
+exports.alias = require("./file");
+//# sourceMappingURL=module.js.map

--- a/tests/baselines/reference/transpile/Export star as ns conflict does not crash.oldTranspile.js
+++ b/tests/baselines/reference/transpile/Export star as ns conflict does not crash.oldTranspile.js
@@ -1,0 +1,6 @@
+"use strict";
+exports.__esModule = true;
+var a;
+exports.alias = a;
+exports.alias = require("./file");
+//# sourceMappingURL=module.js.map


### PR DESCRIPTION
This fixes a crash that occurs when attempting to transpile `test262`.