### PR TITLE
Fix a case with invalid JS crashing when getting outlines

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -182,7 +182,8 @@ namespace ts.OutliningElementsCollector {
                             return spanForNode(n.parent);
                         }
                         else if (tryStatement.finallyBlock === n) {
-                            return spanForNode(findChildOfKind(tryStatement, SyntaxKind.FinallyKeyword, sourceFile)!);
+                            const node = findChildOfKind(tryStatement, SyntaxKind.FinallyKeyword, sourceFile);
+                            if (node) return spanForNode(node);
                         }
                         // falls through
                     default:

--- a/tests/cases/fourslash/correuptedTryExpressionsDontCrashGettingOutlineSpans.ts
+++ b/tests/cases/fourslash/correuptedTryExpressionsDontCrashGettingOutlineSpans.ts
@@ -1,0 +1,13 @@
+/// <reference path="fourslash.ts"/>
+
+// #33102
+
+//// try[| {
+////   var x = [
+////     {% try[||] %}|][|{% except %}|] 
+////   ]
+//// } catch (e)[| {
+////   
+//// }|]
+
+verify.outliningSpansInCurrentFile(test.ranges());

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -433,6 +433,7 @@ declare namespace FourSlashInterface {
         printNavigationBar(): void;
         printNavigationItems(searchValue?: string): void;
         printScriptLexicalStructureItems(): void;
+        printOutliningSpans(): void;
         printReferences(): void;
         printContext(): void;
     }


### PR DESCRIPTION
When looking at outlines for `try` expressions, when handling garbage JS (below), the AST can give some strange results and accidentally pass a nil `node` down into `spanForNode`.

```ts
try {
  var x = [
    {% try %}{% except %} 
  ]
} catch (e) { 
}
```

Fixes #33102