### PR TITLE
ESNext+[[Define]]: reference to param props illegal

### DIFF
--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.errors.txt
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.errors.txt
@@ -1,21 +1,33 @@
-tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts(2,16): error TS2729: Property 'foo' is used before its initialization.
-tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts(7,16): error TS2729: Property 'foo' is used before its initialization.
+tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts(2,16): error TS2729: Property 'bar' is used before its initialization.
+tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts(3,16): error TS2729: Property 'foo' is used before its initialization.
+tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts(9,17): error TS2729: Property 'baz' is used before its initialization.
+tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts(10,16): error TS2729: Property 'foo' is used before its initialization.
 
 
-==== tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts (2 errors) ====
+==== tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts (4 errors) ====
     class C {
+        qux = this.bar // should error
+                   ~~~
+!!! error TS2729: Property 'bar' is used before its initialization.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts:3:5: 'bar' is declared here.
         bar = this.foo // should error
                    ~~~
 !!! error TS2729: Property 'foo' is used before its initialization.
-!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts:6:17: 'foo' is declared here.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts:8:17: 'foo' is declared here.
+        quiz = this.bar // ok
         m1() {
             this.foo // ok
         }
         constructor(private foo: string) {}
+        quim = this.baz // should error
+                    ~~~
+!!! error TS2729: Property 'baz' is used before its initialization.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts:10:5: 'baz' is declared here.
         baz = this.foo; // should error
                    ~~~
 !!! error TS2729: Property 'foo' is used before its initialization.
-!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts:6:17: 'foo' is declared here.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts:8:17: 'foo' is declared here.
+        quid = this.baz // ok
         m2() {
             this.foo // ok
         }

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.errors.txt
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts(2,16): error TS2729: Property 'foo' is used before its initialization.
+tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts(7,16): error TS2729: Property 'foo' is used before its initialization.
+
+
+==== tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts (2 errors) ====
+    class C {
+        bar = this.foo // should error
+                   ~~~
+!!! error TS2729: Property 'foo' is used before its initialization.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts:6:17: 'foo' is declared here.
+        m1() {
+            this.foo // ok
+        }
+        constructor(private foo: string) {}
+        baz = this.foo; // should error
+                   ~~~
+!!! error TS2729: Property 'foo' is used before its initialization.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts:6:17: 'foo' is declared here.
+        m2() {
+            this.foo // ok
+        }
+    }
+    

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.js
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.js
@@ -1,0 +1,29 @@
+//// [assignParameterPropertyToPropertyDeclarationESNext.ts]
+class C {
+    bar = this.foo // should error
+    m1() {
+        this.foo // ok
+    }
+    constructor(private foo: string) {}
+    baz = this.foo; // should error
+    m2() {
+        this.foo // ok
+    }
+}
+
+
+//// [assignParameterPropertyToPropertyDeclarationESNext.js]
+class C {
+    foo;
+    bar = this.foo; // should error
+    m1() {
+        this.foo; // ok
+    }
+    constructor(foo) {
+        this.foo = foo;
+    }
+    baz = this.foo; // should error
+    m2() {
+        this.foo; // ok
+    }
+}

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.js
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.js
@@ -1,11 +1,15 @@
 //// [assignParameterPropertyToPropertyDeclarationESNext.ts]
 class C {
+    qux = this.bar // should error
     bar = this.foo // should error
+    quiz = this.bar // ok
     m1() {
         this.foo // ok
     }
     constructor(private foo: string) {}
+    quim = this.baz // should error
     baz = this.foo; // should error
+    quid = this.baz // ok
     m2() {
         this.foo // ok
     }
@@ -15,14 +19,18 @@ class C {
 //// [assignParameterPropertyToPropertyDeclarationESNext.js]
 class C {
     foo;
+    qux = this.bar; // should error
     bar = this.foo; // should error
+    quiz = this.bar; // ok
     m1() {
         this.foo; // ok
     }
     constructor(foo) {
         this.foo = foo;
     }
+    quim = this.baz; // should error
     baz = this.foo; // should error
+    quid = this.baz; // ok
     m2() {
         this.foo; // ok
     }

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.symbols
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.symbols
@@ -2,36 +2,60 @@
 class C {
 >C : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
 
-    bar = this.foo // should error
->bar : Symbol(C.bar, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 9))
->this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+    qux = this.bar // should error
+>qux : Symbol(C.qux, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 9))
+>this.bar : Symbol(C.bar, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 1, 18))
 >this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
->foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>bar : Symbol(C.bar, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 1, 18))
+
+    bar = this.foo // should error
+>bar : Symbol(C.bar, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 1, 18))
+>this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 16))
+>this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 16))
+
+    quiz = this.bar // ok
+>quiz : Symbol(C.quiz, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 2, 18))
+>this.bar : Symbol(C.bar, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 1, 18))
+>this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+>bar : Symbol(C.bar, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 1, 18))
 
     m1() {
->m1 : Symbol(C.m1, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 1, 18))
+>m1 : Symbol(C.m1, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 3, 19))
 
         this.foo // ok
->this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 16))
 >this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
->foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 16))
     }
     constructor(private foo: string) {}
->foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 16))
+
+    quim = this.baz // should error
+>quim : Symbol(C.quim, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 39))
+>this.baz : Symbol(C.baz, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 8, 19))
+>this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+>baz : Symbol(C.baz, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 8, 19))
 
     baz = this.foo; // should error
->baz : Symbol(C.baz, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 39))
->this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>baz : Symbol(C.baz, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 8, 19))
+>this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 16))
 >this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
->foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 16))
+
+    quid = this.baz // ok
+>quid : Symbol(C.quid, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 9, 19))
+>this.baz : Symbol(C.baz, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 8, 19))
+>this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+>baz : Symbol(C.baz, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 8, 19))
 
     m2() {
->m2 : Symbol(C.m2, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 6, 19))
+>m2 : Symbol(C.m2, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 10, 19))
 
         this.foo // ok
->this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 16))
 >this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
->foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 7, 16))
     }
 }
 

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.symbols
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts ===
+class C {
+>C : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+
+    bar = this.foo // should error
+>bar : Symbol(C.bar, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 9))
+>this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+
+    m1() {
+>m1 : Symbol(C.m1, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 1, 18))
+
+        this.foo // ok
+>this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+    }
+    constructor(private foo: string) {}
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+
+    baz = this.foo; // should error
+>baz : Symbol(C.baz, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 39))
+>this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+
+    m2() {
+>m2 : Symbol(C.m2, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 6, 19))
+
+        this.foo // ok
+>this.foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+>this : Symbol(C, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(assignParameterPropertyToPropertyDeclarationESNext.ts, 5, 16))
+    }
+}
+

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.types
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.types
@@ -1,0 +1,37 @@
+=== tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts ===
+class C {
+>C : C
+
+    bar = this.foo // should error
+>bar : string
+>this.foo : string
+>this : this
+>foo : string
+
+    m1() {
+>m1 : () => void
+
+        this.foo // ok
+>this.foo : string
+>this : this
+>foo : string
+    }
+    constructor(private foo: string) {}
+>foo : string
+
+    baz = this.foo; // should error
+>baz : string
+>this.foo : string
+>this : this
+>foo : string
+
+    m2() {
+>m2 : () => void
+
+        this.foo // ok
+>this.foo : string
+>this : this
+>foo : string
+    }
+}
+

--- a/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.types
+++ b/tests/baselines/reference/assignParameterPropertyToPropertyDeclarationESNext.types
@@ -2,11 +2,23 @@
 class C {
 >C : C
 
+    qux = this.bar // should error
+>qux : string
+>this.bar : string
+>this : this
+>bar : string
+
     bar = this.foo // should error
 >bar : string
 >this.foo : string
 >this : this
 >foo : string
+
+    quiz = this.bar // ok
+>quiz : string
+>this.bar : string
+>this : this
+>bar : string
 
     m1() {
 >m1 : () => void
@@ -19,11 +31,23 @@ class C {
     constructor(private foo: string) {}
 >foo : string
 
+    quim = this.baz // should error
+>quim : string
+>this.baz : string
+>this : this
+>baz : string
+
     baz = this.foo; // should error
 >baz : string
 >this.foo : string
 >this : this
 >foo : string
+
+    quid = this.baz // ok
+>quid : string
+>this.baz : string
+>this : this
+>baz : string
 
     m2() {
 >m2 : () => void

--- a/tests/baselines/reference/defineProperty(target=esnext).errors.txt
+++ b/tests/baselines/reference/defineProperty(target=esnext).errors.txt
@@ -1,0 +1,43 @@
+tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts(3,14): error TS2729: Property 'y' is used before its initialization.
+tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts(10,14): error TS2729: Property 'y' is used before its initialization.
+tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts(18,14): error TS2729: Property 'ka' is used before its initialization.
+tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts(22,15): error TS2729: Property 'ka' is used before its initialization.
+
+
+==== tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts (4 errors) ====
+    var x: "p" = "p"
+    class A {
+        a = this.y
+                 ~
+!!! error TS2729: Property 'y' is used before its initialization.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts:9:17: 'y' is declared here.
+        b
+        public c;
+        ["computed"] = 13
+        ;[x] = 14
+        m() { }
+        constructor(public readonly y: number) { }
+        z = this.y
+                 ~
+!!! error TS2729: Property 'y' is used before its initialization.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts:9:17: 'y' is declared here.
+        declare notEmitted;
+    }
+    class B {
+        public a;
+    }
+    class C extends B {
+        declare public a;
+        z = this.ka
+                 ~~
+!!! error TS2729: Property 'ka' is used before its initialization.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts:19:17: 'ka' is declared here.
+        constructor(public ka: number) {
+            super()
+        }
+        ki = this.ka
+                  ~~
+!!! error TS2729: Property 'ka' is used before its initialization.
+!!! related TS2728 tests/cases/conformance/classes/propertyMemberDeclarations/defineProperty.ts:19:17: 'ka' is declared here.
+    }
+    

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
@@ -1,0 +1,13 @@
+// @useDefineForClassFields: true
+// @target: esnext
+class C {
+    bar = this.foo // should error
+    m1() {
+        this.foo // ok
+    }
+    constructor(private foo: string) {}
+    baz = this.foo; // should error
+    m2() {
+        this.foo // ok
+    }
+}

--- a/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
+++ b/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
@@ -1,12 +1,16 @@
 // @useDefineForClassFields: true
 // @target: esnext
 class C {
+    qux = this.bar // should error
     bar = this.foo // should error
+    quiz = this.bar // ok
     m1() {
         this.foo // ok
     }
     constructor(private foo: string) {}
+    quim = this.baz // should error
     baz = this.foo; // should error
+    quid = this.baz // ok
     m2() {
         this.foo // ok
     }


### PR DESCRIPTION
When target: "esnext" and useDefineForClassFields: true, property
declaration initialisers should not be able to reference parameter
properties; class fields are initialised before the constructor runs,
but parameter properties are not:

```ts
class C {
  foo = this.bar
  constructor(public bar: string) { }
}
```

emits code that looks like this:

```js
class C {
  bar
  foo = this.bar
  constructor(bar) {
    this.bar = bar
  }
}
new C('x').foo.length // crashes; foo is undefined
```

This PR adds an error on foo's declaration with ESNext+[[Define]].

Fixes #36410
