### PR TITLE
Add tsserver live reload as reccomended vscode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,11 @@
 {
     "recommendations": [
-        "dbaeumer.vscode-eslint"
+        "dbaeumer.vscode-eslint",
+        "rbuckton.tsserver-live-reload"
     ],
 
     "unwantedRecommendations": [
-        "ms-vscode.vscode-typescript-tslint-plugin"
+        "ms-vscode.vscode-typescript-tslint-plugin",
+        "dbaeumer.jshint"
     ]
 }


### PR DESCRIPTION
And remove jshint reccomendation just because we don't use jshint and I saw it was recommended.
