### PR TITLE
Fix crash on erroneous enum member merged with exported type alias

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -29257,6 +29257,7 @@ namespace ts {
                             : DeclarationSpaces.ExportNamespace;
                     case SyntaxKind.ClassDeclaration:
                     case SyntaxKind.EnumDeclaration:
+                    case SyntaxKind.EnumMember:
                         return DeclarationSpaces.ExportType | DeclarationSpaces.ExportValue;
                     case SyntaxKind.SourceFile:
                         return DeclarationSpaces.ExportType | DeclarationSpaces.ExportValue | DeclarationSpaces.ExportNamespace;

--- a/tests/baselines/reference/importedEnumMemberMergedWithExportedAliasIsError.errors.txt
+++ b/tests/baselines/reference/importedEnumMemberMergedWithExportedAliasIsError.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/compiler/alias.ts(3,1): error TS2440: Import declaration conflicts with local declaration of 'EnumA'.
+tests/cases/compiler/alias.ts(3,8): error TS2395: Individual declarations in merged declaration 'EnumA' must be all exported or all local.
+tests/cases/compiler/alias.ts(5,13): error TS2395: Individual declarations in merged declaration 'EnumA' must be all exported or all local.
+
+
+==== tests/cases/compiler/enum.ts (0 errors) ====
+    export enum Enum {
+        A,
+        B
+    }
+==== tests/cases/compiler/alias.ts (3 errors) ====
+    import {Enum} from "./enum";
+    
+    import EnumA = Enum.A;
+    ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2440: Import declaration conflicts with local declaration of 'EnumA'.
+           ~~~~~
+!!! error TS2395: Individual declarations in merged declaration 'EnumA' must be all exported or all local.
+    
+    export type EnumA = [string] | [string, number];
+                ~~~~~
+!!! error TS2395: Individual declarations in merged declaration 'EnumA' must be all exported or all local.
+    

--- a/tests/baselines/reference/importedEnumMemberMergedWithExportedAliasIsError.js
+++ b/tests/baselines/reference/importedEnumMemberMergedWithExportedAliasIsError.js
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/importedEnumMemberMergedWithExportedAliasIsError.ts] ////
+
+//// [enum.ts]
+export enum Enum {
+    A,
+    B
+}
+//// [alias.ts]
+import {Enum} from "./enum";
+
+import EnumA = Enum.A;
+
+export type EnumA = [string] | [string, number];
+
+
+//// [enum.js]
+"use strict";
+exports.__esModule = true;
+var Enum;
+(function (Enum) {
+    Enum[Enum["A"] = 0] = "A";
+    Enum[Enum["B"] = 1] = "B";
+})(Enum = exports.Enum || (exports.Enum = {}));
+//// [alias.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/importedEnumMemberMergedWithExportedAliasIsError.symbols
+++ b/tests/baselines/reference/importedEnumMemberMergedWithExportedAliasIsError.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/enum.ts ===
+export enum Enum {
+>Enum : Symbol(Enum, Decl(enum.ts, 0, 0))
+
+    A,
+>A : Symbol(Enum.A, Decl(enum.ts, 0, 18))
+
+    B
+>B : Symbol(Enum.B, Decl(enum.ts, 1, 6))
+}
+=== tests/cases/compiler/alias.ts ===
+import {Enum} from "./enum";
+>Enum : Symbol(Enum, Decl(alias.ts, 0, 8))
+
+import EnumA = Enum.A;
+>EnumA : Symbol(EnumA, Decl(alias.ts, 0, 28), Decl(alias.ts, 2, 22))
+>Enum : Symbol(Enum, Decl(alias.ts, 0, 8))
+>A : Symbol(Enum.A, Decl(enum.ts, 0, 18))
+
+export type EnumA = [string] | [string, number];
+>EnumA : Symbol(EnumA, Decl(alias.ts, 2, 22))
+

--- a/tests/baselines/reference/importedEnumMemberMergedWithExportedAliasIsError.types
+++ b/tests/baselines/reference/importedEnumMemberMergedWithExportedAliasIsError.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/enum.ts ===
+export enum Enum {
+>Enum : Enum
+
+    A,
+>A : Enum.A
+
+    B
+>B : Enum.B
+}
+=== tests/cases/compiler/alias.ts ===
+import {Enum} from "./enum";
+>Enum : typeof Enum
+
+import EnumA = Enum.A;
+>EnumA : Enum.A
+>Enum : Enum
+>A : Enum.A
+
+export type EnumA = [string] | [string, number];
+>EnumA : import("tests/cases/compiler/alias").EnumA
+

--- a/tests/cases/compiler/importedEnumMemberMergedWithExportedAliasIsError.ts
+++ b/tests/cases/compiler/importedEnumMemberMergedWithExportedAliasIsError.ts
@@ -1,0 +1,11 @@
+// @filename: enum.ts
+export enum Enum {
+    A,
+    B
+}
+// @filename: alias.ts
+import {Enum} from "./enum";
+
+import EnumA = Enum.A;
+
+export type EnumA = [string] | [string, number];


### PR DESCRIPTION
This fixes a crash reported in our RWC suite on `master`.
