### PR TITLE
Add --force option to npm install commands in dockerfiles

### DIFF
--- a/tests/cases/docker/office-ui-fabric/Dockerfile
+++ b/tests/cases/docker/office-ui-fabric/Dockerfile
@@ -1,5 +1,5 @@
 FROM node:current
-RUN npm install -g yarn lerna
+RUN npm install -g yarn lerna --force
 RUN git clone https://github.com/OfficeDev/office-ui-fabric-react.git /office-ui-fabric-react
 WORKDIR /office-ui-fabric-react
 RUN git pull

--- a/tests/cases/docker/vscode/Dockerfile
+++ b/tests/cases/docker/vscode/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:10
 RUN apt-get update
 RUN apt-get install libsecret-1-dev libx11-dev libxkbfile-dev -y
-RUN npm i -g yarn
+RUN npm i -g yarn --force
 RUN git clone https://github.com/microsoft/vscode.git /vscode
 WORKDIR /vscode
 RUN git pull


### PR DESCRIPTION
These tests recently started failing on initial build because the latest versions of `npm` issue a hard stop error when you attempt to overwrite a symlink'd `bin` executable without providing the `--force` flag.