### PR TITLE
Handle this.# completions and add # to completion trigger character,

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1907,11 +1907,12 @@ namespace ts {
                             if (ch === CharacterCodes.backslash) {
                                 tokenValue += scanIdentifierParts();
                             }
-                            return token = SyntaxKind.PrivateIdentifier;
                         }
-                        error(Diagnostics.Invalid_character);
-                        // no `pos++` because already advanced past the '#'
-                        return token = SyntaxKind.Unknown;
+                        else {
+                            tokenValue = "#";
+                            error(Diagnostics.Invalid_character);
+                        }
+                        return token = SyntaxKind.PrivateIdentifier;
                     default:
                         if (isIdentifierStart(ch, languageVersion)) {
                             pos += charSize(ch);

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1972,7 +1972,7 @@ namespace ts.server.protocol {
         arguments: FormatOnKeyRequestArgs;
     }
 
-    export type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
+    export type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<" | "#";
 
     /**
      * Arguments for completions messages.

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -2651,6 +2651,8 @@ namespace ts.Completions {
             case "`":
                 // Only automatically bring up completions if this is an opening quote.
                 return !!contextToken && isStringLiteralOrTemplate(contextToken) && position === contextToken.getStart(sourceFile) + 1;
+            case "#":
+                return !!contextToken && isPrivateIdentifier(contextToken) && !!getContainingClass(contextToken);
             case "<":
                 // Opening JSX tag
                 return !!contextToken && contextToken.kind === SyntaxKind.LessThanToken && (!isBinaryExpression(contextToken.parent) || binaryExpressionMayBeOpenTag(contextToken.parent));

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -418,7 +418,7 @@ namespace ts {
 
     export type OrganizeImportsScope = CombinedCodeFixScope;
 
-    export type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
+    export type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<" | "#";
 
     export interface GetCompletionsAtPositionOptions extends UserPreferences {
         /**

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5198,7 +5198,7 @@ declare namespace ts {
         fileName: string;
     }
     type OrganizeImportsScope = CombinedCodeFixScope;
-    type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
+    type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<" | "#";
     interface GetCompletionsAtPositionOptions extends UserPreferences {
         /**
          * If the editor is asking for completions because a certain character was typed
@@ -7541,7 +7541,7 @@ declare namespace ts.server.protocol {
         command: CommandTypes.Formatonkey;
         arguments: FormatOnKeyRequestArgs;
     }
-    type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
+    type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<" | "#";
     /**
      * Arguments for completions messages.
      */

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5198,7 +5198,7 @@ declare namespace ts {
         fileName: string;
     }
     type OrganizeImportsScope = CombinedCodeFixScope;
-    type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<";
+    type CompletionsTriggerCharacter = "." | '"' | "'" | "`" | "/" | "@" | "<" | "#";
     interface GetCompletionsAtPositionOptions extends UserPreferences {
         /**
          * If the editor is asking for completions because a certain character was typed

--- a/tests/cases/fourslash/completionsECMAPrivateMemberTriggerCharacter.ts
+++ b/tests/cases/fourslash/completionsECMAPrivateMemberTriggerCharacter.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts" />
+
+// @target: esnext
+
+////class K {
+////  #value: number;
+////
+////  foo() {
+////     this.#/**/
+////  }
+////}
+
+verify.completions(
+    { marker: "", exact: ["#value", "foo"] },
+    { marker: "", exact: ["#value", "foo"], triggerCharacter: "#" },
+);


### PR DESCRIPTION
Handle private identifiers little better by creating token for private identifier when its just #
Report same error as invalid character but from language service we can now provide completions for this.#

Fixes #36367, #36250
