### PR TITLE
Avoid testing `isClassDeclaration` if there's no `valueDeclaration`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16014,9 +16014,9 @@ namespace ts {
                 ) {
                     const privateIdentifierDescription = unmatchedProperty.valueDeclaration.name.escapedText;
                     const symbolTableKey = getSymbolNameForPrivateIdentifier(source.symbol, privateIdentifierDescription);
-                    if (symbolTableKey && !!getPropertyOfType(source, symbolTableKey)) {
+                    if (symbolTableKey && getPropertyOfType(source, symbolTableKey)) {
                         const sourceName = source.symbol.valueDeclaration.name;
-                        const targetName = isClassDeclaration(target.symbol.valueDeclaration) ? target.symbol.valueDeclaration.name : undefined;
+                        const targetName = target.symbol.valueDeclaration && isClassDeclaration(target.symbol.valueDeclaration) ? target.symbol.valueDeclaration.name : undefined;
                         reportError(
                             Diagnostics.Property_0_in_type_1_refers_to_a_different_member_that_cannot_be_accessed_from_within_type_2,
                             diagnosticName(privateIdentifierDescription),

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16005,24 +16005,20 @@ namespace ts {
             function reportUnmatchedProperty(source: Type, target: Type, unmatchedProperty: Symbol, requireOptionalProperties: boolean) {
                 let shouldSkipElaboration = false;
                 // give specific error in case where private names have the same description
-                if (
-                    unmatchedProperty.valueDeclaration
+                if (unmatchedProperty.valueDeclaration
                     && isNamedDeclaration(unmatchedProperty.valueDeclaration)
                     && isPrivateIdentifier(unmatchedProperty.valueDeclaration.name)
-                    && source.symbol.valueDeclaration
-                    && isClassDeclaration(source.symbol.valueDeclaration)
-                ) {
+                    && source.symbol.flags & SymbolFlags.Class) {
                     const privateIdentifierDescription = unmatchedProperty.valueDeclaration.name.escapedText;
                     const symbolTableKey = getSymbolNameForPrivateIdentifier(source.symbol, privateIdentifierDescription);
                     if (symbolTableKey && getPropertyOfType(source, symbolTableKey)) {
-                        const sourceName = source.symbol.valueDeclaration.name;
-                        const targetName = target.symbol.valueDeclaration && isClassDeclaration(target.symbol.valueDeclaration) ? target.symbol.valueDeclaration.name : undefined;
+                        const sourceName = getDeclarationName(source.symbol.valueDeclaration);
+                        const targetName = getDeclarationName(target.symbol.valueDeclaration);
                         reportError(
                             Diagnostics.Property_0_in_type_1_refers_to_a_different_member_that_cannot_be_accessed_from_within_type_2,
                             diagnosticName(privateIdentifierDescription),
-                            diagnosticName(sourceName || anon),
-                            diagnosticName(targetName || anon),
-                        );
+                            diagnosticName(sourceName.escapedText === "" ? anon : sourceName),
+                            diagnosticName(targetName.escapedText === "" ? anon : targetName));
                         return;
                     }
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16009,6 +16009,7 @@ namespace ts {
                     unmatchedProperty.valueDeclaration
                     && isNamedDeclaration(unmatchedProperty.valueDeclaration)
                     && isPrivateIdentifier(unmatchedProperty.valueDeclaration.name)
+                    && source.symbol.valueDeclaration
                     && isClassDeclaration(source.symbol.valueDeclaration)
                 ) {
                     const privateIdentifierDescription = unmatchedProperty.valueDeclaration.name.escapedText;

--- a/tests/baselines/reference/privateNamesUnique-4.errors.txt
+++ b/tests/baselines/reference/privateNamesUnique-4.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts(6,7): error TS2741: Property '#something' is missing in type 'A2' but required in type 'C'.
+
+
+==== tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts (1 errors) ====
+    class A1 { }
+    interface A2 extends A1 { }
+    declare const a: A2;
+    
+    class C { #something: number }
+    const c: C = a;
+          ~
+!!! error TS2741: Property '#something' is missing in type 'A2' but required in type 'C'.
+!!! related TS2728 tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts:5:11: '#something' is declared here.
+    

--- a/tests/baselines/reference/privateNamesUnique-4.js
+++ b/tests/baselines/reference/privateNamesUnique-4.js
@@ -1,0 +1,20 @@
+//// [privateNamesUnique-4.ts]
+class A1 { }
+interface A2 extends A1 { }
+declare const a: A2;
+
+class C { #something: number }
+const c: C = a;
+
+
+//// [privateNamesUnique-4.js]
+var _something;
+class A1 {
+}
+class C {
+    constructor() {
+        _something.set(this, void 0);
+    }
+}
+_something = new WeakMap();
+const c = a;

--- a/tests/baselines/reference/privateNamesUnique-4.symbols
+++ b/tests/baselines/reference/privateNamesUnique-4.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts ===
+class A1 { }
+>A1 : Symbol(A1, Decl(privateNamesUnique-4.ts, 0, 0))
+
+interface A2 extends A1 { }
+>A2 : Symbol(A2, Decl(privateNamesUnique-4.ts, 0, 12))
+>A1 : Symbol(A1, Decl(privateNamesUnique-4.ts, 0, 0))
+
+declare const a: A2;
+>a : Symbol(a, Decl(privateNamesUnique-4.ts, 2, 13))
+>A2 : Symbol(A2, Decl(privateNamesUnique-4.ts, 0, 12))
+
+class C { #something: number }
+>C : Symbol(C, Decl(privateNamesUnique-4.ts, 2, 20))
+>#something : Symbol(C.#something, Decl(privateNamesUnique-4.ts, 4, 9))
+
+const c: C = a;
+>c : Symbol(c, Decl(privateNamesUnique-4.ts, 5, 5))
+>C : Symbol(C, Decl(privateNamesUnique-4.ts, 2, 20))
+>a : Symbol(a, Decl(privateNamesUnique-4.ts, 2, 13))
+

--- a/tests/baselines/reference/privateNamesUnique-4.types
+++ b/tests/baselines/reference/privateNamesUnique-4.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts ===
+class A1 { }
+>A1 : A1
+
+interface A2 extends A1 { }
+declare const a: A2;
+>a : A2
+
+class C { #something: number }
+>C : C
+>#something : number
+
+const c: C = a;
+>c : C
+>a : A2
+

--- a/tests/baselines/reference/privateNamesUnique-5.errors.txt
+++ b/tests/baselines/reference/privateNamesUnique-5.errors.txt
@@ -1,0 +1,21 @@
+tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts(12,7): error TS2322: Type 'B' is not assignable to type 'A2'.
+  Property '#foo' in type 'B' refers to a different member that cannot be accessed from within type '(anonymous)'.
+
+
+==== tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts (1 errors) ====
+    // same as privateNamesUnique-1, but with an interface
+    
+    class A {
+        #foo: number;
+    }
+    interface A2 extends A { }
+    
+    class B {
+        #foo: number;
+    }
+    
+    const b: A2 = new B();
+          ~
+!!! error TS2322: Type 'B' is not assignable to type 'A2'.
+!!! error TS2322:   Property '#foo' in type 'B' refers to a different member that cannot be accessed from within type '(anonymous)'.
+    

--- a/tests/baselines/reference/privateNamesUnique-5.js
+++ b/tests/baselines/reference/privateNamesUnique-5.js
@@ -1,0 +1,32 @@
+//// [privateNamesUnique-5.ts]
+// same as privateNamesUnique-1, but with an interface
+
+class A {
+    #foo: number;
+}
+interface A2 extends A { }
+
+class B {
+    #foo: number;
+}
+
+const b: A2 = new B();
+
+
+//// [privateNamesUnique-5.js]
+"use strict";
+// same as privateNamesUnique-1, but with an interface
+var _foo, _foo_1;
+class A {
+    constructor() {
+        _foo.set(this, void 0);
+    }
+}
+_foo = new WeakMap();
+class B {
+    constructor() {
+        _foo_1.set(this, void 0);
+    }
+}
+_foo_1 = new WeakMap();
+const b = new B();

--- a/tests/baselines/reference/privateNamesUnique-5.symbols
+++ b/tests/baselines/reference/privateNamesUnique-5.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts ===
+// same as privateNamesUnique-1, but with an interface
+
+class A {
+>A : Symbol(A, Decl(privateNamesUnique-5.ts, 0, 0))
+
+    #foo: number;
+>#foo : Symbol(A.#foo, Decl(privateNamesUnique-5.ts, 2, 9))
+}
+interface A2 extends A { }
+>A2 : Symbol(A2, Decl(privateNamesUnique-5.ts, 4, 1))
+>A : Symbol(A, Decl(privateNamesUnique-5.ts, 0, 0))
+
+class B {
+>B : Symbol(B, Decl(privateNamesUnique-5.ts, 5, 26))
+
+    #foo: number;
+>#foo : Symbol(B.#foo, Decl(privateNamesUnique-5.ts, 7, 9))
+}
+
+const b: A2 = new B();
+>b : Symbol(b, Decl(privateNamesUnique-5.ts, 11, 5))
+>A2 : Symbol(A2, Decl(privateNamesUnique-5.ts, 4, 1))
+>B : Symbol(B, Decl(privateNamesUnique-5.ts, 5, 26))
+

--- a/tests/baselines/reference/privateNamesUnique-5.types
+++ b/tests/baselines/reference/privateNamesUnique-5.types
@@ -1,0 +1,23 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts ===
+// same as privateNamesUnique-1, but with an interface
+
+class A {
+>A : A
+
+    #foo: number;
+>#foo : number
+}
+interface A2 extends A { }
+
+class B {
+>B : B
+
+    #foo: number;
+>#foo : number
+}
+
+const b: A2 = new B();
+>b : A2
+>new B() : B
+>B : typeof B
+

--- a/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts
@@ -1,0 +1,8 @@
+// @target: es2015
+
+class A1 { }
+interface A2 extends A1 { }
+declare const a: A2;
+
+class C { #something: number }
+const c: C = a;

--- a/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts
@@ -1,0 +1,16 @@
+// @strict: true
+// @target: es6
+// @strictPropertyInitialization: false
+
+// same as privateNamesUnique-1, but with an interface
+
+class A {
+    #foo: number;
+}
+interface A2 extends A { }
+
+class B {
+    #foo: number;
+}
+
+const b: A2 = new B();


### PR DESCRIPTION
Avoid testing `isClassDeclaration` if there's no `valueDeclaration`

I'm not sure if this is enough -- perhaps it's better to make the test dig through the interface/s to the class?

Add a similar test for `target.symbol.valueDeclaration` which was similarly broken (with the same question still open).

Fixes #36059.
