### PR TITLE
createPrivateIdentifier: names must start with #

### DIFF
--- a/src/compiler/factoryPublic.ts
+++ b/src/compiler/factoryPublic.ts
@@ -218,6 +218,9 @@ namespace ts {
 
     // Private Identifiers
     export function createPrivateIdentifier(text: string): PrivateIdentifier {
+        if (text[0] !== "#") {
+            Debug.fail("First character of private identifier must be #: " + text);
+        }
         const node = createSynthesizedNode(SyntaxKind.PrivateIdentifier) as PrivateIdentifier;
         node.escapedText = escapeLeadingUnderscores(text);
         return node;

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -46,3 +46,8 @@ describe("Public APIs:: token to string", () => {
         assertDefinedTokenToString(ts.SyntaxKind.FirstKeyword, ts.SyntaxKind.LastKeyword);
     });
 });
+describe("Public APIs:: createPrivateIdentifier", () => {
+    it("throws when name doesn't start with #", () => {
+            assert.throw(() => ts.createPrivateIdentifier("not"), "Debug Failure. First character of private identifier must be #: not");
+    });
+});


### PR DESCRIPTION
Initial fix for #36044, although it's possible that we should instead add the '#' prefix if it's missing.