### PR TITLE
Actually use the cached resolvedJSDocType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11063,26 +11063,30 @@ namespace ts {
          * but this function's special-case code fakes alias resolution as well.
          */
         function getTypeFromJSDocValueReference(node: NodeWithTypeArguments, symbol: Symbol): Type | undefined {
-            const valueType = getTypeOfSymbol(symbol);
-            let typeType = valueType;
-            if (symbol.valueDeclaration) {
-                const decl = getRootDeclaration(symbol.valueDeclaration);
-                let isRequireAlias = false;
-                if (isVariableDeclaration(decl) && decl.initializer) {
-                    let expr = decl.initializer;
-                    // skip past entity names, eg `require("x").a.b.c`
-                    while (isPropertyAccessExpression(expr)) {
-                        expr = expr.expression;
+            const links = getSymbolLinks(symbol);
+            if (!links.resolvedJSDocType) {
+                const valueType = getTypeOfSymbol(symbol);
+                let typeType = valueType;
+                if (symbol.valueDeclaration) {
+                    const decl = getRootDeclaration(symbol.valueDeclaration);
+                    let isRequireAlias = false;
+                    if (isVariableDeclaration(decl) && decl.initializer) {
+                        let expr = decl.initializer;
+                        // skip past entity names, eg `require("x").a.b.c`
+                        while (isPropertyAccessExpression(expr)) {
+                            expr = expr.expression;
+                        }
+                        isRequireAlias = isCallExpression(expr) && isRequireCall(expr, /*requireStringLiteralLikeArgument*/ true) && !!valueType.symbol;
                     }
-                    isRequireAlias = isCallExpression(expr) && isRequireCall(expr, /*requireStringLiteralLikeArgument*/ true) && !!valueType.symbol;
+                    const isImportTypeWithQualifier = node.kind === SyntaxKind.ImportType && (node as ImportTypeNode).qualifier;
+                    // valueType might not have a symbol, eg, {import('./b').STRING_LITERAL}
+                    if (valueType.symbol && (isRequireAlias || isImportTypeWithQualifier)) {
+                        typeType = getTypeReferenceType(node, valueType.symbol);
+                    }
                 }
-                const isImportTypeWithQualifier = node.kind === SyntaxKind.ImportType && (node as ImportTypeNode).qualifier;
-                // valueType might not have a symbol, eg, {import('./b').STRING_LITERAL}
-                if (valueType.symbol && (isRequireAlias || isImportTypeWithQualifier)) {
-                    typeType = getTypeReferenceType(node, valueType.symbol);
-                }
+                links.resolvedJSDocType = typeType;
             }
-            return getSymbolLinks(symbol).resolvedJSDocType = typeType;
+            return links.resolvedJSDocType;
         }
 
         function getSubstitutionType(typeVariable: TypeVariable, substitute: Type) {


### PR DESCRIPTION
[This code path](https://github.com/mui-org/material-ui/issues/19113#issuecomment-579943654) was mentioned as a possible performance-impacting path. We have a cache in this codepath that we were failing to ever reuse the value from, so we were recalculating the value on every invocation.

Try turning the whitespace diff off when reviewing 😉 