### PR TITLE
Capture fakes.version instead of the current version string in baselines

### DIFF
--- a/src/harness/fakesHosts.ts
+++ b/src/harness/fakesHosts.ts
@@ -534,6 +534,8 @@ ${indentText}${text}`;
             buildInfo.version = ts.version;
             return ts.getBuildInfoText(buildInfo);
         };
+        const originalWrite = sys.write;
+        sys.write = msg => originalWrite.call(sys, msg.replace(ts.version, version));
 
         if (sys.writeFile) {
             const originalWriteFile = sys.writeFile;

--- a/src/testRunner/unittests/tsc/helpers.ts
+++ b/src/testRunner/unittests/tsc/helpers.ts
@@ -118,7 +118,7 @@ namespace ts {
         sys.baseLine = () => {
             const patch = fs.diff(baseFs, { includeChangedFileWithSameContent: true });
             // eslint-disable-next-line no-null/no-null
-            Harness.Baseline.runBaseline(`${isBuild(commandLineArgs) ? "tsbuild" : "tsc"}/${scenario}/${buildKind || BuildKind.Initial}/${subScenario.split(" ").join("-")}.js`, patch ? vfs.formatPatch(patch).replace(version, "CURRENT.VERSION") : null);
+            Harness.Baseline.runBaseline(`${isBuild(commandLineArgs) ? "tsbuild" : "tsc"}/${scenario}/${buildKind || BuildKind.Initial}/${subScenario.split(" ").join("-")}.js`, patch ? vfs.formatPatch(patch).replace(version, fakes.version) : null);
         };
         return sys;
     }

--- a/src/testRunner/unittests/tsc/helpers.ts
+++ b/src/testRunner/unittests/tsc/helpers.ts
@@ -118,7 +118,7 @@ namespace ts {
         sys.baseLine = () => {
             const patch = fs.diff(baseFs, { includeChangedFileWithSameContent: true });
             // eslint-disable-next-line no-null/no-null
-            Harness.Baseline.runBaseline(`${isBuild(commandLineArgs) ? "tsbuild" : "tsc"}/${scenario}/${buildKind || BuildKind.Initial}/${subScenario.split(" ").join("-")}.js`, patch ? vfs.formatPatch(patch) : null);
+            Harness.Baseline.runBaseline(`${isBuild(commandLineArgs) ? "tsbuild" : "tsc"}/${scenario}/${buildKind || BuildKind.Initial}/${subScenario.split(" ").join("-")}.js`, patch ? vfs.formatPatch(patch).replace(version, "CURRENT.VERSION") : null);
         };
         return sys;
     }

--- a/src/testRunner/unittests/tsc/helpers.ts
+++ b/src/testRunner/unittests/tsc/helpers.ts
@@ -118,7 +118,7 @@ namespace ts {
         sys.baseLine = () => {
             const patch = fs.diff(baseFs, { includeChangedFileWithSameContent: true });
             // eslint-disable-next-line no-null/no-null
-            Harness.Baseline.runBaseline(`${isBuild(commandLineArgs) ? "tsbuild" : "tsc"}/${scenario}/${buildKind || BuildKind.Initial}/${subScenario.split(" ").join("-")}.js`, patch ? vfs.formatPatch(patch).replace(version, fakes.version) : null);
+            Harness.Baseline.runBaseline(`${isBuild(commandLineArgs) ? "tsbuild" : "tsc"}/${scenario}/${buildKind || BuildKind.Initial}/${subScenario.split(" ").join("-")}.js`, patch ? vfs.formatPatch(patch) : null);
         };
         return sys;
     }

--- a/tests/baselines/reference/tsc/runWithoutArgs/initial-build/show-help-with-ExitStatus.DiagnosticsPresent_OutputsSkipped.js
+++ b/tests/baselines/reference/tsc/runWithoutArgs/initial-build/show-help-with-ExitStatus.DiagnosticsPresent_OutputsSkipped.js
@@ -1,6 +1,6 @@
 //// [/lib/initial-buildOutput.txt]
 /lib/tsc 
-Version CURRENT.VERSION
+Version FakeTSVersion
 Syntax:   tsc [options] [file...]
 
 Examples: tsc hello.ts

--- a/tests/baselines/reference/tsc/runWithoutArgs/initial-build/show-help-with-ExitStatus.DiagnosticsPresent_OutputsSkipped.js
+++ b/tests/baselines/reference/tsc/runWithoutArgs/initial-build/show-help-with-ExitStatus.DiagnosticsPresent_OutputsSkipped.js
@@ -1,6 +1,6 @@
 //// [/lib/initial-buildOutput.txt]
 /lib/tsc 
-Version 3.8.0-dev
+Version CURRENT.VERSION
 Syntax:   tsc [options] [file...]
 
 Examples: tsc hello.ts


### PR DESCRIPTION
#36474 broke our nightly publish because it added a test which captured the current version into the baselines. Naturally, this changes when a release is made, making the baseline fail.