### PR TITLE
Fix declaration for Array.prototype[Symbol.unscopables]

### DIFF
--- a/lib/lib.es2015.symbol.wellknown.d.ts
+++ b/lib/lib.es2015.symbol.wellknown.d.ts
@@ -1,14 +1,14 @@
 /*! *****************************************************************************
-Copyright (c) Microsoft Corporation. All rights reserved. 
+Copyright (c) Microsoft Corporation. All rights reserved.
 Licensed under the Apache License, Version 2.0 (the "License"); you may not use
 this file except in compliance with the License. You may obtain a copy of the
-License at http://www.apache.org/licenses/LICENSE-2.0  
- 
+License at http://www.apache.org/licenses/LICENSE-2.0
+
 THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
-WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE, 
-MERCHANTABLITY OR NON-INFRINGEMENT. 
- 
+WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABLITY OR NON-INFRINGEMENT.
+
 See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
@@ -91,7 +91,7 @@ interface Array<T> {
      * Returns an object whose properties have the value 'true'
      * when they will be absent when used in a 'with' statement.
      */
-    [Symbol.unscopables](): {
+    [Symbol.unscopables]: {
         copyWithin: boolean;
         entries: boolean;
         fill: boolean;


### PR DESCRIPTION
Fixes the incorrect definition of `Array.prototype[Symbol.unscopables]`

Fixes #34610
