### PR TITLE
Fix overzealous renaming of emit helpers in es module emit

### DIFF
--- a/src/compiler/transformers/module/esnextAnd2015.ts
+++ b/src/compiler/transformers/module/esnextAnd2015.ts
@@ -105,7 +105,9 @@ namespace ts {
          */
         function onEmitNode(hint: EmitHint, node: Node, emitCallback: (hint: EmitHint, node: Node) => void): void {
             if (isSourceFile(node)) {
-                helperNameSubstitutions = createMap<Identifier>();
+                if ((isExternalModule(node) || compilerOptions.isolatedModules) && compilerOptions.importHelpers) {
+                    helperNameSubstitutions = createMap<Identifier>();
+                }
                 previousOnEmitNode(hint, node, emitCallback);
                 helperNameSubstitutions = undefined;
             }

--- a/tests/baselines/reference/emitHelpersWithLocalCollisions(module=amd).js
+++ b/tests/baselines/reference/emitHelpersWithLocalCollisions(module=amd).js
@@ -1,0 +1,28 @@
+//// [a.ts]
+declare var dec: any, __decorate: any;
+@dec export class A {
+}
+
+const o = { a: 1 };
+const y = { ...o };
+
+
+//// [a.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    let A = class A {
+    };
+    A = __decorate([
+        dec
+    ], A);
+    exports.A = A;
+    const o = { a: 1 };
+    const y = Object.assign({}, o);
+});

--- a/tests/baselines/reference/emitHelpersWithLocalCollisions(module=commonjs).js
+++ b/tests/baselines/reference/emitHelpersWithLocalCollisions(module=commonjs).js
@@ -1,0 +1,26 @@
+//// [a.ts]
+declare var dec: any, __decorate: any;
+@dec export class A {
+}
+
+const o = { a: 1 };
+const y = { ...o };
+
+
+//// [a.js]
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+let A = class A {
+};
+A = __decorate([
+    dec
+], A);
+exports.A = A;
+const o = { a: 1 };
+const y = Object.assign({}, o);

--- a/tests/baselines/reference/emitHelpersWithLocalCollisions(module=es2020).js
+++ b/tests/baselines/reference/emitHelpersWithLocalCollisions(module=es2020).js
@@ -1,0 +1,24 @@
+//// [a.ts]
+declare var dec: any, __decorate: any;
+@dec export class A {
+}
+
+const o = { a: 1 };
+const y = { ...o };
+
+
+//// [a.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+let A = class A {
+};
+A = __decorate([
+    dec
+], A);
+export { A };
+const o = { a: 1 };
+const y = Object.assign({}, o);

--- a/tests/baselines/reference/emitHelpersWithLocalCollisions(module=es6).js
+++ b/tests/baselines/reference/emitHelpersWithLocalCollisions(module=es6).js
@@ -1,0 +1,24 @@
+//// [a.ts]
+declare var dec: any, __decorate: any;
+@dec export class A {
+}
+
+const o = { a: 1 };
+const y = { ...o };
+
+
+//// [a.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+let A = class A {
+};
+A = __decorate([
+    dec
+], A);
+export { A };
+const o = { a: 1 };
+const y = Object.assign({}, o);

--- a/tests/baselines/reference/emitHelpersWithLocalCollisions(module=esnext).js
+++ b/tests/baselines/reference/emitHelpersWithLocalCollisions(module=esnext).js
@@ -1,0 +1,24 @@
+//// [a.ts]
+declare var dec: any, __decorate: any;
+@dec export class A {
+}
+
+const o = { a: 1 };
+const y = { ...o };
+
+
+//// [a.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+let A = class A {
+};
+A = __decorate([
+    dec
+], A);
+export { A };
+const o = { a: 1 };
+const y = Object.assign({}, o);

--- a/tests/baselines/reference/emitHelpersWithLocalCollisions(module=none).js
+++ b/tests/baselines/reference/emitHelpersWithLocalCollisions(module=none).js
@@ -1,0 +1,26 @@
+//// [a.ts]
+declare var dec: any, __decorate: any;
+@dec export class A {
+}
+
+const o = { a: 1 };
+const y = { ...o };
+
+
+//// [a.js]
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+let A = class A {
+};
+A = __decorate([
+    dec
+], A);
+exports.A = A;
+const o = { a: 1 };
+const y = Object.assign({}, o);

--- a/tests/baselines/reference/emitHelpersWithLocalCollisions(module=system).js
+++ b/tests/baselines/reference/emitHelpersWithLocalCollisions(module=system).js
@@ -1,0 +1,34 @@
+//// [a.ts]
+declare var dec: any, __decorate: any;
+@dec export class A {
+}
+
+const o = { a: 1 };
+const y = { ...o };
+
+
+//// [a.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+    var A, o, y;
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters: [],
+        execute: function () {
+            A = class A {
+            };
+            A = __decorate([
+                dec
+            ], A);
+            exports_1("A", A);
+            o = { a: 1 };
+            y = Object.assign({}, o);
+        }
+    };
+});

--- a/tests/baselines/reference/emitHelpersWithLocalCollisions(module=umd).js
+++ b/tests/baselines/reference/emitHelpersWithLocalCollisions(module=umd).js
@@ -1,0 +1,36 @@
+//// [a.ts]
+declare var dec: any, __decorate: any;
+@dec export class A {
+}
+
+const o = { a: 1 };
+const y = { ...o };
+
+
+//// [a.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+(function (factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        var v = factory(require, exports);
+        if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === "function" && define.amd) {
+        define(["require", "exports"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", { value: true });
+    let A = class A {
+    };
+    A = __decorate([
+        dec
+    ], A);
+    exports.A = A;
+    const o = { a: 1 };
+    const y = Object.assign({}, o);
+});

--- a/tests/cases/compiler/emitHelpersWithLocalCollisions.ts
+++ b/tests/cases/compiler/emitHelpersWithLocalCollisions.ts
@@ -1,0 +1,12 @@
+// @target: es6
+// @module: *
+// @moduleResolution: classic
+// @experimentalDecorators: true
+// @filename: a.ts
+// @noTypesAndSymbols: true
+declare var dec: any, __decorate: any;
+@dec export class A {
+}
+
+const o = { a: 1 };
+const y = { ...o };


### PR DESCRIPTION
We were always renaming helpers for es module emit targets when they should only be renamed in a module when `importHelpers` is `true`.

Fixes #33269
