### PR TITLE
Fix crash in emitTokenWithComment

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2744,11 +2744,11 @@ namespace ts {
             const node = getParseTreeNode(contextNode);
             const isSimilarNode = node && node.kind === contextNode.kind;
             const startPos = pos;
-            if (isSimilarNode) {
-                pos = skipTrivia(currentSourceFile!.text, pos);
+            if (isSimilarNode && currentSourceFile) {
+                pos = skipTrivia(currentSourceFile.text, pos);
             }
             if (emitLeadingCommentsOfPosition && isSimilarNode && contextNode.pos !== startPos) {
-                const needsIndent = indentLeading && !positionsAreOnSameLine(startPos, pos, currentSourceFile!);
+                const needsIndent = indentLeading && currentSourceFile && !positionsAreOnSameLine(startPos, pos, currentSourceFile);
                 if (needsIndent) {
                     increaseIndent();
                 }

--- a/tests/baselines/reference/crashInEmitTokenWithComment.errors.txt
+++ b/tests/baselines/reference/crashInEmitTokenWithComment.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/crashInEmitTokenWithComment.ts(5,4): error TS2345: Argument of type '({ [foo.bar]: c }: {}) => any' is not assignable to parameter of type 'string'.
+tests/cases/compiler/crashInEmitTokenWithComment.ts(5,7): error TS2537: Type '{}' has no matching index signature for type 'string'.
+
+
+==== tests/cases/compiler/crashInEmitTokenWithComment.ts (2 errors) ====
+    // GH#32358
+    const fn = (param: string) => undefined;
+    
+    const foo = {bar: 'a'};
+    fn(({[foo.bar]: c}) => undefined);
+       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '({ [foo.bar]: c }: {}) => any' is not assignable to parameter of type 'string'.
+          ~~~~~~~
+!!! error TS2537: Type '{}' has no matching index signature for type 'string'.

--- a/tests/baselines/reference/crashInEmitTokenWithComment.js
+++ b/tests/baselines/reference/crashInEmitTokenWithComment.js
@@ -1,0 +1,15 @@
+//// [crashInEmitTokenWithComment.ts]
+// GH#32358
+const fn = (param: string) => undefined;
+
+const foo = {bar: 'a'};
+fn(({[foo.bar]: c}) => undefined);
+
+//// [crashInEmitTokenWithComment.js]
+// GH#32358
+var fn = function (param) { return undefined; };
+var foo = { bar: 'a' };
+fn(function (_a) {
+    var _b = foo.bar, c = _a[_b];
+    return undefined;
+});

--- a/tests/cases/compiler/crashInEmitTokenWithComment.ts
+++ b/tests/cases/compiler/crashInEmitTokenWithComment.ts
@@ -1,0 +1,7 @@
+// @noTypesAndSymbols: true
+
+// GH#32358
+const fn = (param: string) => undefined;
+
+const foo = {bar: 'a'};
+fn(({[foo.bar]: c}) => undefined);


### PR DESCRIPTION
Fixes a crash in `emitTokenWithComment` when called by `typeToString` without a source file.

Fixes #32358
