### PR TITLE
Fix `export *` that resolves to something type-only

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2355,7 +2355,10 @@ namespace ts {
 
         function getTargetOfNamespaceExport(node: NamespaceExport, dontResolveAlias: boolean): Symbol | undefined {
             const moduleSpecifier = node.parent.moduleSpecifier;
-            return moduleSpecifier && resolveESModuleSymbol(resolveExternalModuleName(node, moduleSpecifier), moduleSpecifier, dontResolveAlias, /*suppressUsageError*/ false);
+            const immediate = moduleSpecifier && resolveExternalModuleName(node, moduleSpecifier);
+            const resolved = moduleSpecifier && resolveESModuleSymbol(immediate, moduleSpecifier, dontResolveAlias, /*suppressUsageError*/ false);
+            markSymbolOfAliasDeclarationIfTypeOnly(node, immediate, resolved, /*overwriteEmpty*/ false);
+            return resolved;
         }
 
         // This function creates a synthetic symbol that combines the value side of one symbol with the
@@ -2504,7 +2507,9 @@ namespace ts {
         }
 
         function getTargetOfNamespaceExportDeclaration(node: NamespaceExportDeclaration, dontResolveAlias: boolean): Symbol {
-            return resolveExternalModuleSymbol(node.parent.symbol, dontResolveAlias);
+            const resolved = resolveExternalModuleSymbol(node.parent.symbol, dontResolveAlias);
+            markSymbolOfAliasDeclarationIfTypeOnly(node, /*immediateTarget*/ undefined, resolved, /*overwriteEmpty*/ false);
+            return resolved;
         }
 
         function getTargetOfExportSpecifier(node: ExportSpecifier, meaning: SymbolFlags, dontResolveAlias?: boolean) {

--- a/tests/baselines/reference/exportNamespace1.errors.txt
+++ b/tests/baselines/reference/exportNamespace1.errors.txt
@@ -1,0 +1,19 @@
+tests/cases/conformance/externalModules/typeOnly/d.ts(2,5): error TS1362: 'A' cannot be used as a value because it was exported using 'export type'.
+
+
+==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
+    export class A {}
+    
+==== tests/cases/conformance/externalModules/typeOnly/b.ts (0 errors) ====
+    export type { A } from './a';
+    
+==== tests/cases/conformance/externalModules/typeOnly/c.ts (0 errors) ====
+    export * from './b';
+    
+==== tests/cases/conformance/externalModules/typeOnly/d.ts (1 errors) ====
+    import { A } from './c';
+    new A(); // Error
+        ~
+!!! error TS1362: 'A' cannot be used as a value because it was exported using 'export type'.
+!!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:1:15: 'A' was exported here.
+    

--- a/tests/baselines/reference/exportNamespace1.js
+++ b/tests/baselines/reference/exportNamespace1.js
@@ -1,0 +1,39 @@
+//// [tests/cases/conformance/externalModules/typeOnly/exportNamespace1.ts] ////
+
+//// [a.ts]
+export class A {}
+
+//// [b.ts]
+export type { A } from './a';
+
+//// [c.ts]
+export * from './b';
+
+//// [d.ts]
+import { A } from './c';
+new A(); // Error
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+exports.A = A;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+//// [c.js]
+"use strict";
+function __export(m) {
+    for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
+}
+exports.__esModule = true;
+__export(require("./b"));
+//// [d.js]
+"use strict";
+exports.__esModule = true;
+new A(); // Error

--- a/tests/baselines/reference/exportNamespace1.symbols
+++ b/tests/baselines/reference/exportNamespace1.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export class A {}
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+export type { A } from './a';
+>A : Symbol(A, Decl(b.ts, 0, 13))
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+export * from './b';
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+import { A } from './c';
+>A : Symbol(A, Decl(d.ts, 0, 8))
+
+new A(); // Error
+>A : Symbol(A, Decl(d.ts, 0, 8))
+

--- a/tests/baselines/reference/exportNamespace1.types
+++ b/tests/baselines/reference/exportNamespace1.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export class A {}
+>A : A
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+export type { A } from './a';
+>A : import("tests/cases/conformance/externalModules/typeOnly/a").A
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+export * from './b';
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+import { A } from './c';
+>A : typeof A
+
+new A(); // Error
+>new A() : A
+>A : typeof A
+

--- a/tests/baselines/reference/exportNamespace2.errors.txt
+++ b/tests/baselines/reference/exportNamespace2.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/conformance/externalModules/typeOnly/d.ts(2,5): error TS1361: 'a' cannot be used as a value because it was imported using 'import type'.
+
+
+==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
+    export class A {}
+    
+==== tests/cases/conformance/externalModules/typeOnly/b.ts (0 errors) ====
+    export * as a from './a';
+    
+==== tests/cases/conformance/externalModules/typeOnly/c.ts (0 errors) ====
+    import type { a } from './b';
+    export { a };
+    
+==== tests/cases/conformance/externalModules/typeOnly/d.ts (1 errors) ====
+    import { a } from './c';
+    new a.A(); // Error
+        ~
+!!! error TS1361: 'a' cannot be used as a value because it was imported using 'import type'.
+!!! related TS1376 tests/cases/conformance/externalModules/typeOnly/c.ts:1:15: 'a' was imported here.
+    

--- a/tests/baselines/reference/exportNamespace2.js
+++ b/tests/baselines/reference/exportNamespace2.js
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/externalModules/typeOnly/exportNamespace2.ts] ////
+
+//// [a.ts]
+export class A {}
+
+//// [b.ts]
+export * as a from './a';
+
+//// [c.ts]
+import type { a } from './b';
+export { a };
+
+//// [d.ts]
+import { a } from './c';
+new a.A(); // Error
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+exports.A = A;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+exports.a = require("./a");
+//// [c.js]
+"use strict";
+exports.__esModule = true;
+//// [d.js]
+"use strict";
+exports.__esModule = true;
+new a.A(); // Error

--- a/tests/baselines/reference/exportNamespace2.symbols
+++ b/tests/baselines/reference/exportNamespace2.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export class A {}
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+export * as a from './a';
+>a : Symbol(a, Decl(b.ts, 0, 11))
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+import type { a } from './b';
+>a : Symbol(a, Decl(c.ts, 0, 13))
+
+export { a };
+>a : Symbol(a, Decl(c.ts, 1, 8))
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+import { a } from './c';
+>a : Symbol(a, Decl(d.ts, 0, 8))
+
+new a.A(); // Error
+>a.A : Symbol(a.A, Decl(a.ts, 0, 0))
+>a : Symbol(a, Decl(d.ts, 0, 8))
+>A : Symbol(a.A, Decl(a.ts, 0, 0))
+

--- a/tests/baselines/reference/exportNamespace2.types
+++ b/tests/baselines/reference/exportNamespace2.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export class A {}
+>A : A
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+export * as a from './a';
+>a : typeof a
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+import type { a } from './b';
+>a : any
+
+export { a };
+>a : typeof a
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+import { a } from './c';
+>a : typeof a
+
+new a.A(); // Error
+>new a.A() : a.A
+>a.A : typeof a.A
+>a : typeof a
+>A : typeof a.A
+

--- a/tests/baselines/reference/exportNamespace3.errors.txt
+++ b/tests/baselines/reference/exportNamespace3.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/conformance/externalModules/typeOnly/d.ts(2,7): error TS2339: Property 'A' does not exist on type 'typeof import("tests/cases/conformance/externalModules/typeOnly/b")'.
+
+
+==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
+    export class A {}
+    
+==== tests/cases/conformance/externalModules/typeOnly/b.ts (0 errors) ====
+    export type { A } from './a';
+    
+==== tests/cases/conformance/externalModules/typeOnly/c.ts (0 errors) ====
+    export * as a from './b';
+    
+==== tests/cases/conformance/externalModules/typeOnly/d.ts (1 errors) ====
+    import { a } from './c';
+    new a.A(); // Error
+          ~
+!!! error TS2339: Property 'A' does not exist on type 'typeof import("tests/cases/conformance/externalModules/typeOnly/b")'.
+    

--- a/tests/baselines/reference/exportNamespace3.js
+++ b/tests/baselines/reference/exportNamespace3.js
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/externalModules/typeOnly/exportNamespace3.ts] ////
+
+//// [a.ts]
+export class A {}
+
+//// [b.ts]
+export type { A } from './a';
+
+//// [c.ts]
+export * as a from './b';
+
+//// [d.ts]
+import { a } from './c';
+new a.A(); // Error
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+exports.A = A;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+//// [c.js]
+"use strict";
+exports.__esModule = true;
+exports.a = require("./b");
+//// [d.js]
+"use strict";
+exports.__esModule = true;
+var c_1 = require("./c");
+new c_1.a.A(); // Error

--- a/tests/baselines/reference/exportNamespace3.symbols
+++ b/tests/baselines/reference/exportNamespace3.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export class A {}
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+export type { A } from './a';
+>A : Symbol(A, Decl(b.ts, 0, 13))
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+export * as a from './b';
+>a : Symbol(a, Decl(c.ts, 0, 11))
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+import { a } from './c';
+>a : Symbol(a, Decl(d.ts, 0, 8))
+
+new a.A(); // Error
+>a : Symbol(a, Decl(d.ts, 0, 8))
+

--- a/tests/baselines/reference/exportNamespace3.types
+++ b/tests/baselines/reference/exportNamespace3.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export class A {}
+>A : A
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+export type { A } from './a';
+>A : import("tests/cases/conformance/externalModules/typeOnly/a").A
+
+=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+export * as a from './b';
+>a : typeof a
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+import { a } from './c';
+>a : typeof a
+
+new a.A(); // Error
+>new a.A() : any
+>a.A : any
+>a : typeof a
+>A : any
+

--- a/tests/cases/conformance/externalModules/typeOnly/exportNamespace1.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/exportNamespace1.ts
@@ -1,0 +1,12 @@
+// @Filename: a.ts
+export class A {}
+
+// @Filename: b.ts
+export type { A } from './a';
+
+// @Filename: c.ts
+export * from './b';
+
+// @Filename: d.ts
+import { A } from './c';
+new A(); // Error

--- a/tests/cases/conformance/externalModules/typeOnly/exportNamespace2.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/exportNamespace2.ts
@@ -1,0 +1,13 @@
+// @Filename: a.ts
+export class A {}
+
+// @Filename: b.ts
+export * as a from './a';
+
+// @Filename: c.ts
+import type { a } from './b';
+export { a };
+
+// @Filename: d.ts
+import { a } from './c';
+new a.A(); // Error

--- a/tests/cases/conformance/externalModules/typeOnly/exportNamespace3.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/exportNamespace3.ts
@@ -1,0 +1,12 @@
+// @Filename: a.ts
+export class A {}
+
+// @Filename: b.ts
+export type { A } from './a';
+
+// @Filename: c.ts
+export * as a from './b';
+
+// @Filename: d.ts
+import { a } from './c';
+new a.A(); // Error


### PR DESCRIPTION
Didn’t touch these functions originally since they can’t _be_ type-only aliases, but they can _resolve to_ type-only aliases, so they need to propagate the marker along the alias resolution.