### PR TITLE
fix(33600): `Convert function into ES2015 class` quickfix returns empty result 

### DIFF
--- a/tests/cases/fourslash/convertFunctionToEs6Class_noQuickInfoForIIFE.ts
+++ b/tests/cases/fourslash/convertFunctionToEs6Class_noQuickInfoForIIFE.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts' />
+
+// @allowJs: true
+
+// @Filename: /a.js
+////(/*1*/function () {
+////   const foo = () => {
+////        this.x = 10;
+////   };
+////   foo;
+////})();
+
+goTo.marker("1");
+verify.not.codeFixAvailable()


### PR DESCRIPTION
Fixes #33600
