### PR TITLE
Should Response.performanceData be public?

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -237,11 +237,12 @@ namespace ts.server.protocol {
          */
         metadata?: unknown;
 
-        /* @internal */
+        /**
+         * Exposes information about the performance of this request-response pair.
+         */
         performanceData?: PerformanceData;
     }
 
-    /* @internal */
     export interface PerformanceData {
         /**
          * Time spent updating the program graph, in milliseconds.

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -6253,6 +6253,16 @@ declare namespace ts.server.protocol {
          * Contains extra information that plugin can include to be passed on
          */
         metadata?: unknown;
+        /**
+         * Exposes information about the performance of this request-response pair.
+         */
+        performanceData?: PerformanceData;
+    }
+    interface PerformanceData {
+        /**
+         * Time spent updating the program graph, in milliseconds.
+         */
+        updateGraphDurationMs?: number;
     }
     /**
      * Arguments for FileRequest messages.


### PR DESCRIPTION
I made it internal because I wasn't expecting to have external consumers (and it's a safe default).  Should things like this be public (e.g. if VS Code is going to consume them)?

Fixes #36589
