### PR TITLE
fix(29565): Add missing super() quickFix errors for constructors with access modifier

### DIFF
--- a/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
+++ b/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
@@ -17,7 +17,7 @@ namespace ts.codefix {
 
     function getNode(sourceFile: SourceFile, pos: number): ConstructorDeclaration {
         const token = getTokenAtPosition(sourceFile, pos);
-        Debug.assert(token.kind === SyntaxKind.ConstructorKeyword, "token should be at the constructor keyword");
+        Debug.assert(isConstructorDeclaration(token.parent), "token should be at the constructor declaration");
         return token.parent as ConstructorDeclaration;
     }
 

--- a/tests/cases/fourslash/codeFixAddMissingSuperCall.ts
+++ b/tests/cases/fourslash/codeFixAddMissingSuperCall.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+////class A {}
+////class B extends A {
+////    [|constructor|]() {}
+////}
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Add_missing_super_call.message }
+])
+
+verify.codeFix({
+    description: ts.Diagnostics.Add_missing_super_call.message,
+    newFileContent:
+`class A {}
+class B extends A {
+    constructor() {
+        super();
+    }
+}`
+});
+

--- a/tests/cases/fourslash/codeFixAddMissingSuperCall1.ts
+++ b/tests/cases/fourslash/codeFixAddMissingSuperCall1.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+////class A {}
+////class B extends A {
+////    [|public constructor|]() {}
+////}
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Add_missing_super_call.message }
+])
+
+verify.codeFix({
+    description: ts.Diagnostics.Add_missing_super_call.message,
+    newFileContent:
+`class A {}
+class B extends A {
+    public constructor() {
+        super();
+    }
+}`
+});
+

--- a/tests/cases/fourslash/codeFixAddMissingSuperCall2.ts
+++ b/tests/cases/fourslash/codeFixAddMissingSuperCall2.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+////class A {}
+////class B extends A {
+////    public [|constructor|]() {}
+////}
+
+verify.codeFixAvailable([
+    { description: ts.Diagnostics.Add_missing_super_call.message }
+])
+
+verify.codeFix({
+    description: ts.Diagnostics.Add_missing_super_call.message,
+    newFileContent:
+`class A {}
+class B extends A {
+    public constructor() {
+        super();
+    }
+}`
+});
+


### PR DESCRIPTION
Fixes #29565
