### PR TITLE
Optimize deferred type references

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11090,7 +11090,7 @@ namespace ts {
                         return errorType;
                     }
                 }
-                if (node.kind === SyntaxKind.TypeReference && isDeferredTypeReferenceNode(<TypeReferenceNode>node)) {
+                if (node.kind === SyntaxKind.TypeReference && isDeferredTypeReferenceNode(<TypeReferenceNode>node, length(node.typeArguments) !== typeParameters.length)) {
                     return createDeferredTypeReference(<GenericType>type, <TypeReferenceNode>node, /*mapper*/ undefined);
                 }
                 // In a type reference, the outer type parameters of the referenced class or interface are automatically
@@ -11554,11 +11554,11 @@ namespace ts {
 
         // Return true if the given type reference node is directly aliased or if it needs to be deferred
         // because it is possibly contained in a circular chain of eagerly resolved types.
-        function isDeferredTypeReferenceNode(node: TypeReferenceNode | ArrayTypeNode | TupleTypeNode) {
-            return !!getAliasSymbolForTypeNode(node) || isResolvedByTypeAlias(node) &&
-                (node.kind === SyntaxKind.ArrayType ?
-                    mayResolveTypeAlias(node.elementType) :
-                    some(node.kind === SyntaxKind.TypeReference ? node.typeArguments : node.elementTypes, mayResolveTypeAlias));
+        function isDeferredTypeReferenceNode(node: TypeReferenceNode | ArrayTypeNode | TupleTypeNode, hasDefaultTypeArguments?: boolean) {
+            return !!getAliasSymbolForTypeNode(node) || isResolvedByTypeAlias(node) && (
+                node.kind === SyntaxKind.ArrayType ? mayResolveTypeAlias(node.elementType) :
+                node.kind === SyntaxKind.TupleType ? some(node.elementTypes, mayResolveTypeAlias) :
+                hasDefaultTypeArguments || some(node.typeArguments, mayResolveTypeAlias));
         }
 
         // Return true when the given node is transitively contained in type constructs that eagerly

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11556,9 +11556,9 @@ namespace ts {
         // because it is possibly contained in a circular chain of eagerly resolved types.
         function isDeferredTypeReferenceNode(node: TypeReferenceNode | ArrayTypeNode | TupleTypeNode) {
             return !!getAliasSymbolForTypeNode(node) || isResolvedByTypeAlias(node) &&
-                node.kind === SyntaxKind.ArrayType ?
-                    mayResolveTypeAlias((<ArrayTypeNode>node).elementType) :
-                    some(node.kind === SyntaxKind.TypeReference ? (<TypeReferenceNode>node).typeArguments : (<TupleTypeNode>node).elementTypes, mayResolveTypeAlias);
+                (node.kind === SyntaxKind.ArrayType ?
+                    mayResolveTypeAlias(node.elementType) :
+                    some(node.kind === SyntaxKind.TypeReference ? node.typeArguments : node.elementTypes, mayResolveTypeAlias));
         }
 
         // Return true when the given node is transitively contained in type constructs that eagerly
@@ -11590,14 +11590,14 @@ namespace ts {
                 case SyntaxKind.TypeQuery:
                     return true;
                 case SyntaxKind.TypeOperator:
-                    if ((<TypeOperatorNode>node).operator === SyntaxKind.UniqueKeyword) break;
+                    return (<TypeOperatorNode>node).operator !== SyntaxKind.UniqueKeyword && mayResolveTypeAlias((<TypeOperatorNode>node).type);
                 case SyntaxKind.ParenthesizedType:
                 case SyntaxKind.OptionalType:
                 case SyntaxKind.JSDocOptionalType:
                 case SyntaxKind.JSDocNullableType:
                 case SyntaxKind.JSDocNonNullableType:
                 case SyntaxKind.JSDocTypeExpression:
-                    return mayResolveTypeAlias((<TypeOperatorNode | ParenthesizedTypeNode | OptionalTypeNode | JSDocTypeReferencingNode>node).type);
+                    return mayResolveTypeAlias((<ParenthesizedTypeNode | OptionalTypeNode | JSDocTypeReferencingNode>node).type);
                 case SyntaxKind.RestType:
                     return (<RestTypeNode>node).type.kind !== SyntaxKind.ArrayType || mayResolveTypeAlias((<ArrayTypeNode>(<RestTypeNode>node).type).elementType);
                 case SyntaxKind.UnionType:

--- a/tests/baselines/reference/checkJsxChildrenProperty3.types
+++ b/tests/baselines/reference/checkJsxChildrenProperty3.types
@@ -31,11 +31,11 @@ class FetchUser extends React.Component<IFetchUserProps, any> {
 
             ? this.props.children(this.state.result)
 >this.props.children(this.state.result) : JSX.Element
->this.props.children : ((user: IUser) => JSX.Element) | (((user: IUser) => JSX.Element) & string) | (((user: IUser) => JSX.Element) & number) | (((user: IUser) => JSX.Element) & false) | (((user: IUser) => JSX.Element) & true) | (((user: IUser) => JSX.Element) & React.ReactElement<any>) | (((user: IUser) => JSX.Element) & (string | number | boolean | React.ReactElement<any> | any[])[])
+>this.props.children : ((user: IUser) => JSX.Element) | (((user: IUser) => JSX.Element) & string) | (((user: IUser) => JSX.Element) & number) | (((user: IUser) => JSX.Element) & false) | (((user: IUser) => JSX.Element) & true) | (((user: IUser) => JSX.Element) & React.ReactElement<any>) | (((user: IUser) => JSX.Element) & (string | number | boolean | any[] | React.ReactElement<any>)[])
 >this.props : IFetchUserProps & { children?: React.ReactNode; }
 >this : this
 >props : IFetchUserProps & { children?: React.ReactNode; }
->children : ((user: IUser) => JSX.Element) | (((user: IUser) => JSX.Element) & string) | (((user: IUser) => JSX.Element) & number) | (((user: IUser) => JSX.Element) & false) | (((user: IUser) => JSX.Element) & true) | (((user: IUser) => JSX.Element) & React.ReactElement<any>) | (((user: IUser) => JSX.Element) & (string | number | boolean | React.ReactElement<any> | any[])[])
+>children : ((user: IUser) => JSX.Element) | (((user: IUser) => JSX.Element) & string) | (((user: IUser) => JSX.Element) & number) | (((user: IUser) => JSX.Element) & false) | (((user: IUser) => JSX.Element) & true) | (((user: IUser) => JSX.Element) & React.ReactElement<any>) | (((user: IUser) => JSX.Element) & (string | number | boolean | any[] | React.ReactElement<any>)[])
 >this.state.result : any
 >this.state : any
 >this : this

--- a/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/conformance/jsx/file.tsx(24,28): error TS2551: Property 'NAme' does not exist on type 'IUser'. Did you mean 'Name'?
-tests/cases/conformance/jsx/file.tsx(36,15): error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | ReactElement<any> | any[]'.
-  Type '(user: IUser) => Element' is missing the following properties from type 'any[]': push, pop, concat, join, and 15 more.
-tests/cases/conformance/jsx/file.tsx(39,15): error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | ReactElement<any> | any[]'.
-  Type '(user: IUser) => Element' is missing the following properties from type 'any[]': push, pop, concat, join, and 15 more.
+tests/cases/conformance/jsx/file.tsx(36,15): error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | any[] | ReactElement<any>'.
+  Type '(user: IUser) => Element' is missing the following properties from type 'ReactElement<any>': type, props
+tests/cases/conformance/jsx/file.tsx(39,15): error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | any[] | ReactElement<any>'.
+  Type '(user: IUser) => Element' is missing the following properties from type 'ReactElement<any>': type, props
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -50,8 +50,8 @@ tests/cases/conformance/jsx/file.tsx(39,15): error TS2322: Type '(user: IUser) =
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 ) }
     ~~~~~~~~~~~~~
-!!! error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | ReactElement<any> | any[]'.
-!!! error TS2322:   Type '(user: IUser) => Element' is missing the following properties from type 'any[]': push, pop, concat, join, and 15 more.
+!!! error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | any[] | ReactElement<any>'.
+!!! error TS2322:   Type '(user: IUser) => Element' is missing the following properties from type 'ReactElement<any>': type, props
 !!! related TS6212 tests/cases/conformance/jsx/file.tsx:36:15: Did you mean to call this expression?
                 { user => (
                   ~~~~~~~~~
@@ -59,8 +59,8 @@ tests/cases/conformance/jsx/file.tsx(39,15): error TS2322: Type '(user: IUser) =
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 ) }
     ~~~~~~~~~~~~~
-!!! error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | ReactElement<any> | any[]'.
-!!! error TS2322:   Type '(user: IUser) => Element' is missing the following properties from type 'any[]': push, pop, concat, join, and 15 more.
+!!! error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | any[] | ReactElement<any>'.
+!!! error TS2322:   Type '(user: IUser) => Element' is missing the following properties from type 'ReactElement<any>': type, props
 !!! related TS6212 tests/cases/conformance/jsx/file.tsx:39:15: Did you mean to call this expression?
             </FetchUser>
         );

--- a/tests/baselines/reference/checkJsxChildrenProperty4.types
+++ b/tests/baselines/reference/checkJsxChildrenProperty4.types
@@ -31,11 +31,11 @@ class FetchUser extends React.Component<IFetchUserProps, any> {
 
             ? this.props.children(this.state.result)
 >this.props.children(this.state.result) : JSX.Element
->this.props.children : ((user: IUser) => JSX.Element) | (((user: IUser) => JSX.Element) & string) | (((user: IUser) => JSX.Element) & number) | (((user: IUser) => JSX.Element) & false) | (((user: IUser) => JSX.Element) & true) | (((user: IUser) => JSX.Element) & React.ReactElement<any>) | (((user: IUser) => JSX.Element) & (string | number | boolean | React.ReactElement<any> | any[])[])
+>this.props.children : ((user: IUser) => JSX.Element) | (((user: IUser) => JSX.Element) & string) | (((user: IUser) => JSX.Element) & number) | (((user: IUser) => JSX.Element) & false) | (((user: IUser) => JSX.Element) & true) | (((user: IUser) => JSX.Element) & React.ReactElement<any>) | (((user: IUser) => JSX.Element) & (string | number | boolean | any[] | React.ReactElement<any>)[])
 >this.props : IFetchUserProps & { children?: React.ReactNode; }
 >this : this
 >props : IFetchUserProps & { children?: React.ReactNode; }
->children : ((user: IUser) => JSX.Element) | (((user: IUser) => JSX.Element) & string) | (((user: IUser) => JSX.Element) & number) | (((user: IUser) => JSX.Element) & false) | (((user: IUser) => JSX.Element) & true) | (((user: IUser) => JSX.Element) & React.ReactElement<any>) | (((user: IUser) => JSX.Element) & (string | number | boolean | React.ReactElement<any> | any[])[])
+>children : ((user: IUser) => JSX.Element) | (((user: IUser) => JSX.Element) & string) | (((user: IUser) => JSX.Element) & number) | (((user: IUser) => JSX.Element) & false) | (((user: IUser) => JSX.Element) & true) | (((user: IUser) => JSX.Element) & React.ReactElement<any>) | (((user: IUser) => JSX.Element) & (string | number | boolean | any[] | React.ReactElement<any>)[])
 >this.state.result : any
 >this.state : any
 >this : this


### PR DESCRIPTION
This PR improves our reasoning about when to (and, more importantly, when not to) create deferred type references. We now create fewer deferred type references which improves overall compile times for the repro in #36566 by around 4%.

Fixes #36566.