### PR TITLE
Fix crash when trying to import a non-exported type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2530,7 +2530,7 @@ namespace ts {
                     : error(name, Diagnostics.Module_0_declares_1_locally_but_it_is_not_exported, moduleName, declarationName);
 
                 addRelatedInfo(diagnostic,
-                    createDiagnosticForNode(localSymbol.valueDeclaration, Diagnostics._0_is_declared_here, declarationName)
+                    createDiagnosticForNode(localSymbol.valueDeclaration ?? localSymbol.declarations[0], Diagnostics._0_is_declared_here, declarationName)
                 );
             }
             else {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2530,8 +2530,8 @@ namespace ts {
                     : error(name, Diagnostics.Module_0_declares_1_locally_but_it_is_not_exported, moduleName, declarationName);
 
                 addRelatedInfo(diagnostic,
-                    createDiagnosticForNode(localSymbol.valueDeclaration ?? localSymbol.declarations[0], Diagnostics._0_is_declared_here, declarationName)
-                );
+                    ...map(localSymbol.declarations, (decl, index) =>
+                        createDiagnosticForNode(decl, index === 0 ? Diagnostics._0_is_declared_here : Diagnostics.and_here, declarationName)));
             }
             else {
                 error(name, Diagnostics.Module_0_has_no_exported_member_1, moduleName, declarationName);

--- a/tests/baselines/reference/importNonExportedMember2.errors.txt
+++ b/tests/baselines/reference/importNonExportedMember2.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/b.ts(1,10): error TS2459: Module '"./a"' declares 'Foo' locally, but it is not exported.
+
+
+==== tests/cases/compiler/a.ts (0 errors) ====
+    export {}
+    interface Foo {}
+    
+==== tests/cases/compiler/b.ts (1 errors) ====
+    import { Foo } from './a';
+             ~~~
+!!! error TS2459: Module '"./a"' declares 'Foo' locally, but it is not exported.
+!!! related TS2728 tests/cases/compiler/a.ts:2:11: 'Foo' is declared here.
+    

--- a/tests/baselines/reference/importNonExportedMember2.js
+++ b/tests/baselines/reference/importNonExportedMember2.js
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/importNonExportedMember2.ts] ////
+
+//// [a.ts]
+export {}
+interface Foo {}
+
+//// [b.ts]
+import { Foo } from './a';
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+//// [b.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/importNonExportedMember2.symbols
+++ b/tests/baselines/reference/importNonExportedMember2.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/a.ts ===
+export {}
+interface Foo {}
+>Foo : Symbol(Foo, Decl(a.ts, 0, 9))
+
+=== tests/cases/compiler/b.ts ===
+import { Foo } from './a';
+>Foo : Symbol(Foo, Decl(b.ts, 0, 8))
+

--- a/tests/baselines/reference/importNonExportedMember2.types
+++ b/tests/baselines/reference/importNonExportedMember2.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/a.ts ===
+export {}
+No type information for this code.interface Foo {}
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/b.ts ===
+import { Foo } from './a';
+>Foo : any
+

--- a/tests/baselines/reference/importNonExportedMember3.errors.txt
+++ b/tests/baselines/reference/importNonExportedMember3.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/b.ts(1,10): error TS2459: Module '"./a"' declares 'Foo' locally, but it is not exported.
+
+
+==== tests/cases/compiler/a.ts (0 errors) ====
+    export {}
+    interface Foo {}
+    interface Foo {}
+    namespace Foo {}
+    
+==== tests/cases/compiler/b.ts (1 errors) ====
+    import { Foo } from './a';
+             ~~~
+!!! error TS2459: Module '"./a"' declares 'Foo' locally, but it is not exported.
+!!! related TS2728 tests/cases/compiler/a.ts:2:11: 'Foo' is declared here.
+!!! related TS6204 tests/cases/compiler/a.ts:3:11: and here.
+!!! related TS6204 tests/cases/compiler/a.ts:4:11: and here.
+    

--- a/tests/baselines/reference/importNonExportedMember3.js
+++ b/tests/baselines/reference/importNonExportedMember3.js
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/importNonExportedMember3.ts] ////
+
+//// [a.ts]
+export {}
+interface Foo {}
+interface Foo {}
+namespace Foo {}
+
+//// [b.ts]
+import { Foo } from './a';
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+//// [b.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/importNonExportedMember3.symbols
+++ b/tests/baselines/reference/importNonExportedMember3.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/a.ts ===
+export {}
+interface Foo {}
+>Foo : Symbol(Foo, Decl(a.ts, 0, 9), Decl(a.ts, 1, 16), Decl(a.ts, 2, 16))
+
+interface Foo {}
+>Foo : Symbol(Foo, Decl(a.ts, 0, 9), Decl(a.ts, 1, 16), Decl(a.ts, 2, 16))
+
+namespace Foo {}
+>Foo : Symbol(Foo, Decl(a.ts, 0, 9), Decl(a.ts, 1, 16), Decl(a.ts, 2, 16))
+
+=== tests/cases/compiler/b.ts ===
+import { Foo } from './a';
+>Foo : Symbol(Foo, Decl(b.ts, 0, 8))
+

--- a/tests/baselines/reference/importNonExportedMember3.types
+++ b/tests/baselines/reference/importNonExportedMember3.types
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/a.ts ===
+export {}
+No type information for this code.interface Foo {}
+No type information for this code.interface Foo {}
+No type information for this code.namespace Foo {}
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/b.ts ===
+import { Foo } from './a';
+>Foo : any
+

--- a/tests/cases/compiler/importNonExportedMember2.ts
+++ b/tests/cases/compiler/importNonExportedMember2.ts
@@ -1,0 +1,6 @@
+// @Filename: a.ts
+export {}
+interface Foo {}
+
+// @Filename: b.ts
+import { Foo } from './a';

--- a/tests/cases/compiler/importNonExportedMember3.ts
+++ b/tests/cases/compiler/importNonExportedMember3.ts
@@ -1,0 +1,8 @@
+// @Filename: a.ts
+export {}
+interface Foo {}
+interface Foo {}
+namespace Foo {}
+
+// @Filename: b.ts
+import { Foo } from './a';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #36592
Fixes #36614 
