### PR TITLE
Cache results of isGenericObjectType and isGenericIndexType

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4336,9 +4336,6 @@ namespace ts {
         IncludesWildcard = Index,
         /* @internal */
         IncludesEmptyObject = IndexedAccess,
-        // The following flag is used for different purposes by maybeTypeOfKind
-        /* @internal */
-        GenericMappedType = Never,
     }
 
     export type DestructuringPattern = BindingPattern | ObjectLiteralExpression | ArrayLiteralExpression;
@@ -4442,6 +4439,14 @@ namespace ts {
         ContainsObjectOrArrayLiteral = 1 << 20, // Type is or contains object literal type
         /* @internal */
         NonInferrableType = 1 << 21, // Type is or contains anyFunctionType or silentNeverType
+        /* @internal */
+        IsGenericObjectTypeComputed = 1 << 22, // IsGenericObjectType flag has been computed
+        /* @internal */
+        IsGenericObjectType = 1 << 23, // Union or intersection contains generic object type
+        /* @internal */
+        IsGenericIndexTypeComputed = 1 << 24, // IsGenericIndexType flag has been computed
+        /* @internal */
+        IsGenericIndexType = 1 << 25, // Union or intersection contains generic index type
         ClassOrInterface = Class | Interface,
         /* @internal */
         RequiresWidening = ContainsWideningType | ContainsObjectOrArrayLiteral,


### PR DESCRIPTION
With this PR we cache the results of `isGenericObjectType` and `isGenericIndexType` for unions and intersections. This improves total compile time of the repro in #36564 by about 6.5%.