### PR TITLE
Exempt ambient private properties from noImplicitAny

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28944,7 +28944,7 @@ namespace ts {
         }
 
         function isPrivateWithinAmbient(node: Node): boolean {
-            return hasModifier(node, ModifierFlags.Private) && !!(node.flags & NodeFlags.Ambient);
+            return (hasModifier(node, ModifierFlags.Private) || isPrivateIdentifierPropertyDeclaration(node)) && !!(node.flags & NodeFlags.Ambient);
         }
 
         function getEffectiveDeclarationFlags(n: Declaration, flagsToCheck: ModifierFlags): ModifierFlags {

--- a/tests/baselines/reference/privateNameAmbientNoImplicitAny.errors.txt
+++ b/tests/baselines/reference/privateNameAmbientNoImplicitAny.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts(5,5): error TS7008: Member '#prop' implicitly has an 'any' type.
+
+
+==== tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts (1 errors) ====
+    declare class A {
+        #prop;
+    }
+    class B {
+        #prop;
+        ~~~~~
+!!! error TS7008: Member '#prop' implicitly has an 'any' type.
+    }

--- a/tests/baselines/reference/privateNameAmbientNoImplicitAny.js
+++ b/tests/baselines/reference/privateNameAmbientNoImplicitAny.js
@@ -1,0 +1,12 @@
+//// [privateNameAmbientNoImplicitAny.ts]
+declare class A {
+    #prop;
+}
+class B {
+    #prop;
+}
+
+//// [privateNameAmbientNoImplicitAny.js]
+class B {
+    #prop;
+}

--- a/tests/baselines/reference/privateNameAmbientNoImplicitAny.symbols
+++ b/tests/baselines/reference/privateNameAmbientNoImplicitAny.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts ===
+declare class A {
+>A : Symbol(A, Decl(privateNameAmbientNoImplicitAny.ts, 0, 0))
+
+    #prop;
+>#prop : Symbol(A.#prop, Decl(privateNameAmbientNoImplicitAny.ts, 0, 17))
+}
+class B {
+>B : Symbol(B, Decl(privateNameAmbientNoImplicitAny.ts, 2, 1))
+
+    #prop;
+>#prop : Symbol(B.#prop, Decl(privateNameAmbientNoImplicitAny.ts, 3, 9))
+}

--- a/tests/baselines/reference/privateNameAmbientNoImplicitAny.types
+++ b/tests/baselines/reference/privateNameAmbientNoImplicitAny.types
@@ -1,0 +1,13 @@
+=== tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts ===
+declare class A {
+>A : A
+
+    #prop;
+>#prop : any
+}
+class B {
+>B : B
+
+    #prop;
+>#prop : any
+}

--- a/tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts
+++ b/tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts
@@ -1,0 +1,8 @@
+// @noImplicitAny: true
+// @target: ESNext
+declare class A {
+    #prop;
+}
+class B {
+    #prop;
+}


### PR DESCRIPTION
Fixes: #36630
