### PR TITLE
Support property declarations in jsdoc template generation

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -251,7 +251,6 @@ namespace ts.JsDoc {
      * @param position The (character-indexed) position in the file where the check should
      * be performed.
      */
-
     export function getDocCommentTemplateAtPosition(newLine: string, sourceFile: SourceFile, position: number): TextInsertion | undefined {
         const tokenAtPos = getTokenAtPosition(sourceFile, position);
         const existingDocComment = findAncestor(tokenAtPos, isJSDoc);
@@ -370,6 +369,11 @@ namespace ts.JsDoc {
                 const parameters = isFunctionLike(be.right) ? be.right.parameters : emptyArray;
                 return { commentOwner, parameters };
             }
+            case SyntaxKind.PropertyDeclaration:
+                const init = (commentOwner as PropertyDeclaration).initializer;
+                if (init && (isFunctionExpression(init) || isArrowFunction(init))) {
+                    return { commentOwner, parameters: init.parameters  };
+                }
         }
     }
 

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -372,7 +372,7 @@ namespace ts.JsDoc {
             case SyntaxKind.PropertyDeclaration:
                 const init = (commentOwner as PropertyDeclaration).initializer;
                 if (init && (isFunctionExpression(init) || isArrowFunction(init))) {
-                    return { commentOwner, parameters: init.parameters  };
+                    return { commentOwner, parameters: init.parameters };
                 }
         }
     }

--- a/tests/cases/fourslash/docCommentTemplateClassDeclProperty01.ts
+++ b/tests/cases/fourslash/docCommentTemplateClassDeclProperty01.ts
@@ -1,0 +1,28 @@
+/// <reference path='fourslash.ts' />
+
+const singleLineOffset = 3;
+const multiLineOffset = 12;
+
+
+////class C {
+////    /** /*0*/  */
+////    foo = (p0) => {
+////        return p0;
+////    };
+////    /*1*/
+////    bar = (p1) => {
+////        return p1;
+////    }
+////}
+
+verify.docCommentTemplateAt("0", multiLineOffset,
+   `/**
+     * 
+     * @param p0
+     */`);
+verify.docCommentTemplateAt("1", multiLineOffset,
+   `/**
+     * 
+     * @param p1
+     */`);
+

--- a/tests/cases/fourslash/docCommentTemplateClassDeclProperty01.ts
+++ b/tests/cases/fourslash/docCommentTemplateClassDeclProperty01.ts
@@ -13,6 +13,10 @@ const multiLineOffset = 12;
 ////    bar = (p1) => {
 ////        return p1;
 ////    }
+////    /*2*/
+////    baz = function (p2, p3) {
+////        return p2;
+////    }
 ////}
 
 verify.docCommentTemplateAt("0", multiLineOffset,
@@ -25,4 +29,11 @@ verify.docCommentTemplateAt("1", multiLineOffset,
      * 
      * @param p1
      */`);
+verify.docCommentTemplateAt("2", multiLineOffset,
+   `/**
+     * 
+     * @param p2
+     * @param p3
+     */`);
+
 


### PR DESCRIPTION
JSDoc template generation now supports property declarations with function initialisers.

Fixes #28786
