### PR TITLE
Allow specifying TReturn and TNext for AsyncIterableIterator and AsyncIterable

### DIFF
--- a/src/lib/es2018.asynciterable.d.ts
+++ b/src/lib/es2018.asynciterable.d.ts
@@ -16,10 +16,10 @@ interface AsyncIterator<T, TReturn = any, TNext = undefined> {
     throw?(e?: any): Promise<IteratorResult<T, TReturn>>;
 }
 
-interface AsyncIterable<T> {
-    [Symbol.asyncIterator](): AsyncIterator<T>;
+interface AsyncIterable<T, TReturn = any, TNext = undefined> {
+    [Symbol.asyncIterator](): AsyncIterator<T, TReturn, TNext>;
 }
 
-interface AsyncIterableIterator<T> extends AsyncIterator<T> {
-    [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+interface AsyncIterableIterator<T, TReturn = any, TNext = undefined> extends AsyncIterator<T, TReturn, TNext> {
+    [Symbol.asyncIterator](): AsyncIterableIterator<T, TReturn, TNext>;
 }

--- a/tests/baselines/reference/forAwaitForUnion.types
+++ b/tests/baselines/reference/forAwaitForUnion.types
@@ -1,11 +1,11 @@
 === tests/cases/compiler/forAwaitForUnion.ts ===
 async function f<T>(source: Iterable<T> | AsyncIterable<T>) {
->f : <T>(source: Iterable<T> | AsyncIterable<T>) => Promise<void>
->source : Iterable<T> | AsyncIterable<T>
+>f : <T>(source: Iterable<T> | AsyncIterable<T, any, undefined>) => Promise<void>
+>source : Iterable<T> | AsyncIterable<T, any, undefined>
 
     for await (const x of source) {
 >x : T
->source : Iterable<T> | AsyncIterable<T>
+>source : Iterable<T> | AsyncIterable<T, any, undefined>
     }
 }
 

--- a/tests/baselines/reference/types.asyncGenerators.es2018.1.types
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.1.types
@@ -74,7 +74,7 @@ async function * inferReturnType8() {
 >1 : 1
 }
 const assignability1: () => AsyncIterableIterator<number> = async function * () {
->assignability1 : () => AsyncIterableIterator<number>
+>assignability1 : () => AsyncIterableIterator<number, any, undefined>
 >async function * () {    yield 1;} : () => AsyncGenerator<number, void, undefined>
 
     yield 1;
@@ -83,7 +83,7 @@ const assignability1: () => AsyncIterableIterator<number> = async function * () 
 
 };
 const assignability2: () => AsyncIterableIterator<number> = async function * () {
->assignability2 : () => AsyncIterableIterator<number>
+>assignability2 : () => AsyncIterableIterator<number, any, undefined>
 >async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, undefined>
 
     yield Promise.resolve(1);
@@ -96,7 +96,7 @@ const assignability2: () => AsyncIterableIterator<number> = async function * () 
 
 };
 const assignability3: () => AsyncIterableIterator<number> = async function * () {
->assignability3 : () => AsyncIterableIterator<number>
+>assignability3 : () => AsyncIterableIterator<number, any, undefined>
 >async function * () {    yield* [1, 2];} : () => AsyncGenerator<number, void, undefined>
 
     yield* [1, 2];
@@ -107,7 +107,7 @@ const assignability3: () => AsyncIterableIterator<number> = async function * () 
 
 };
 const assignability4: () => AsyncIterableIterator<number> = async function * () {
->assignability4 : () => AsyncIterableIterator<number>
+>assignability4 : () => AsyncIterableIterator<number, any, undefined>
 >async function * () {    yield* [Promise.resolve(1)];} : () => AsyncGenerator<number, void, undefined>
 
     yield* [Promise.resolve(1)];
@@ -121,7 +121,7 @@ const assignability4: () => AsyncIterableIterator<number> = async function * () 
 
 };
 const assignability5: () => AsyncIterableIterator<number> = async function * () {
->assignability5 : () => AsyncIterableIterator<number>
+>assignability5 : () => AsyncIterableIterator<number, any, undefined>
 >async function * () {    yield* (async function * () { yield 1; })();} : () => AsyncGenerator<number, void, unknown>
 
     yield* (async function * () { yield 1; })();
@@ -134,7 +134,7 @@ const assignability5: () => AsyncIterableIterator<number> = async function * () 
 
 };
 const assignability6: () => AsyncIterable<number> = async function * () {
->assignability6 : () => AsyncIterable<number>
+>assignability6 : () => AsyncIterable<number, any, undefined>
 >async function * () {    yield 1;} : () => AsyncGenerator<number, void, undefined>
 
     yield 1;
@@ -143,7 +143,7 @@ const assignability6: () => AsyncIterable<number> = async function * () {
 
 };
 const assignability7: () => AsyncIterable<number> = async function * () {
->assignability7 : () => AsyncIterable<number>
+>assignability7 : () => AsyncIterable<number, any, undefined>
 >async function * () {    yield Promise.resolve(1);} : () => AsyncGenerator<number, void, undefined>
 
     yield Promise.resolve(1);
@@ -156,7 +156,7 @@ const assignability7: () => AsyncIterable<number> = async function * () {
 
 };
 const assignability8: () => AsyncIterable<number> = async function * () {
->assignability8 : () => AsyncIterable<number>
+>assignability8 : () => AsyncIterable<number, any, undefined>
 >async function * () {    yield* [1, 2];} : () => AsyncGenerator<number, void, undefined>
 
     yield* [1, 2];
@@ -167,7 +167,7 @@ const assignability8: () => AsyncIterable<number> = async function * () {
 
 };
 const assignability9: () => AsyncIterable<number> = async function * () {
->assignability9 : () => AsyncIterable<number>
+>assignability9 : () => AsyncIterable<number, any, undefined>
 >async function * () {    yield* [Promise.resolve(1)];} : () => AsyncGenerator<number, void, undefined>
 
     yield* [Promise.resolve(1)];
@@ -181,7 +181,7 @@ const assignability9: () => AsyncIterable<number> = async function * () {
 
 };
 const assignability10: () => AsyncIterable<number> = async function * () {
->assignability10 : () => AsyncIterable<number>
+>assignability10 : () => AsyncIterable<number, any, undefined>
 >async function * () {    yield* (async function * () { yield 1; })();} : () => AsyncGenerator<number, void, unknown>
 
     yield* (async function * () { yield 1; })();
@@ -254,14 +254,14 @@ const assignability15: () => AsyncIterator<number> = async function * () {
 
 };
 async function * explicitReturnType1(): AsyncIterableIterator<number> {
->explicitReturnType1 : () => AsyncIterableIterator<number>
+>explicitReturnType1 : () => AsyncIterableIterator<number, any, undefined>
 
     yield 1;
 >yield 1 : undefined
 >1 : 1
 }
 async function * explicitReturnType2(): AsyncIterableIterator<number> {
->explicitReturnType2 : () => AsyncIterableIterator<number>
+>explicitReturnType2 : () => AsyncIterableIterator<number, any, undefined>
 
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
@@ -272,7 +272,7 @@ async function * explicitReturnType2(): AsyncIterableIterator<number> {
 >1 : 1
 }
 async function * explicitReturnType3(): AsyncIterableIterator<number> {
->explicitReturnType3 : () => AsyncIterableIterator<number>
+>explicitReturnType3 : () => AsyncIterableIterator<number, any, undefined>
 
     yield* [1, 2];
 >yield* [1, 2] : any
@@ -281,7 +281,7 @@ async function * explicitReturnType3(): AsyncIterableIterator<number> {
 >2 : 2
 }
 async function * explicitReturnType4(): AsyncIterableIterator<number> {
->explicitReturnType4 : () => AsyncIterableIterator<number>
+>explicitReturnType4 : () => AsyncIterableIterator<number, any, undefined>
 
     yield* [Promise.resolve(1)];
 >yield* [Promise.resolve(1)] : any
@@ -293,7 +293,7 @@ async function * explicitReturnType4(): AsyncIterableIterator<number> {
 >1 : 1
 }
 async function * explicitReturnType5(): AsyncIterableIterator<number> {
->explicitReturnType5 : () => AsyncIterableIterator<number>
+>explicitReturnType5 : () => AsyncIterableIterator<number, any, undefined>
 
     yield* (async function * () { yield 1; })();
 >yield* (async function * () { yield 1; })() : void
@@ -304,14 +304,14 @@ async function * explicitReturnType5(): AsyncIterableIterator<number> {
 >1 : 1
 }
 async function * explicitReturnType6(): AsyncIterable<number> {
->explicitReturnType6 : () => AsyncIterable<number>
+>explicitReturnType6 : () => AsyncIterable<number, any, undefined>
 
     yield 1;
 >yield 1 : undefined
 >1 : 1
 }
 async function * explicitReturnType7(): AsyncIterable<number> {
->explicitReturnType7 : () => AsyncIterable<number>
+>explicitReturnType7 : () => AsyncIterable<number, any, undefined>
 
     yield Promise.resolve(1);
 >yield Promise.resolve(1) : undefined
@@ -322,7 +322,7 @@ async function * explicitReturnType7(): AsyncIterable<number> {
 >1 : 1
 }
 async function * explicitReturnType8(): AsyncIterable<number> {
->explicitReturnType8 : () => AsyncIterable<number>
+>explicitReturnType8 : () => AsyncIterable<number, any, undefined>
 
     yield* [1, 2];
 >yield* [1, 2] : any
@@ -331,7 +331,7 @@ async function * explicitReturnType8(): AsyncIterable<number> {
 >2 : 2
 }
 async function * explicitReturnType9(): AsyncIterable<number> {
->explicitReturnType9 : () => AsyncIterable<number>
+>explicitReturnType9 : () => AsyncIterable<number, any, undefined>
 
     yield* [Promise.resolve(1)];
 >yield* [Promise.resolve(1)] : any
@@ -343,7 +343,7 @@ async function * explicitReturnType9(): AsyncIterable<number> {
 >1 : 1
 }
 async function * explicitReturnType10(): AsyncIterable<number> {
->explicitReturnType10 : () => AsyncIterable<number>
+>explicitReturnType10 : () => AsyncIterable<number, any, undefined>
 
     yield* (async function * () { yield 1; })();
 >yield* (async function * () { yield 1; })() : void

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.errors.txt
@@ -1,27 +1,27 @@
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(2,12): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(8,12): error TS2504: Type 'Promise<number[]>' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(10,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
-  Call signature return types 'AsyncGenerator<string, void, undefined>' and 'AsyncIterableIterator<number>' are incompatible.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(10,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number, any, undefined>'.
+  Call signature return types 'AsyncGenerator<string, void, undefined>' and 'AsyncIterableIterator<number, any, undefined>' are incompatible.
     The types returned by 'next(...)' are incompatible between these types.
       Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         Type 'IteratorResult<string, void>' is not assignable to type 'IteratorResult<number, any>'.
           Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorResult<number, any>'.
             Type 'IteratorYieldResult<string>' is not assignable to type 'IteratorYieldResult<number>'.
               Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(13,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
-  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(16,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
-  Call signature return types 'AsyncGenerator<string, void, unknown>' and 'AsyncIterableIterator<number>' are incompatible.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(13,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number, any, undefined>'.
+  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number, any, undefined>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(16,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number, any, undefined>'.
+  Call signature return types 'AsyncGenerator<string, void, unknown>' and 'AsyncIterableIterator<number, any, undefined>' are incompatible.
     The types returned by 'next(...)' are incompatible between these types.
       Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(19,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
-  Call signature return types 'AsyncGenerator<string, void, undefined>' and 'AsyncIterable<number>' are incompatible.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(19,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number, any, undefined>'.
+  Call signature return types 'AsyncGenerator<string, void, undefined>' and 'AsyncIterable<number, any, undefined>' are incompatible.
     The types returned by '[Symbol.asyncIterator]().next(...)' are incompatible between these types.
       Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(22,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
-  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(25,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
-  Call signature return types 'AsyncGenerator<string, void, unknown>' and 'AsyncIterable<number>' are incompatible.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(22,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number, any, undefined>'.
+  Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number, any, undefined>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(25,7): error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number, any, undefined>'.
+  Call signature return types 'AsyncGenerator<string, void, unknown>' and 'AsyncIterable<number, any, undefined>' are incompatible.
     The types returned by '[Symbol.asyncIterator]().next(...)' are incompatible between these types.
       Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(28,7): error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterator<number, any, undefined>'.
@@ -44,7 +44,7 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(70,42): error TS2322: Type 'AsyncGenerator<number, any, undefined>' is not assignable to type 'Iterator<number, any, undefined>'.
   The types returned by 'next(...)' are incompatible between these types.
     Type 'Promise<IteratorResult<number, any>>' is not assignable to type 'IteratorResult<number, any>'.
-      Property 'value' is missing in type 'Promise<IteratorResult<number, any>>' but required in type 'IteratorYieldResult<number>'.
+      Type 'Promise<IteratorResult<number, any>>' is missing the following properties from type 'IteratorReturnResult<any>': done, value
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(74,12): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 
 
@@ -65,8 +65,8 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     }
     const assignability1: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
-!!! error TS2322:   Call signature return types 'AsyncGenerator<string, void, undefined>' and 'AsyncIterableIterator<number>' are incompatible.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number, any, undefined>'.
+!!! error TS2322:   Call signature return types 'AsyncGenerator<string, void, undefined>' and 'AsyncIterableIterator<number, any, undefined>' are incompatible.
 !!! error TS2322:     The types returned by 'next(...)' are incompatible between these types.
 !!! error TS2322:       Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
 !!! error TS2322:         Type 'IteratorResult<string, void>' is not assignable to type 'IteratorResult<number, any>'.
@@ -77,36 +77,36 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
     };
     const assignability2: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterableIterator<number, any, undefined>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterableIterator<number, any, undefined>'.
         yield* ["a", "b"];
     };
     const assignability3: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number>'.
-!!! error TS2322:   Call signature return types 'AsyncGenerator<string, void, unknown>' and 'AsyncIterableIterator<number>' are incompatible.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterableIterator<number, any, undefined>'.
+!!! error TS2322:   Call signature return types 'AsyncGenerator<string, void, unknown>' and 'AsyncIterableIterator<number, any, undefined>' are incompatible.
 !!! error TS2322:     The types returned by 'next(...)' are incompatible between these types.
 !!! error TS2322:       Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         yield* (async function * () { yield "a"; })();
     };
     const assignability4: () => AsyncIterable<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
-!!! error TS2322:   Call signature return types 'AsyncGenerator<string, void, undefined>' and 'AsyncIterable<number>' are incompatible.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number, any, undefined>'.
+!!! error TS2322:   Call signature return types 'AsyncGenerator<string, void, undefined>' and 'AsyncIterable<number, any, undefined>' are incompatible.
 !!! error TS2322:     The types returned by '[Symbol.asyncIterator]().next(...)' are incompatible between these types.
 !!! error TS2322:       Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         yield "a";
     };
     const assignability5: () => AsyncIterable<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number>'.
-!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number>'.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, undefined>' is not assignable to type '() => AsyncIterable<number, any, undefined>'.
+!!! error TS2322:   Type 'AsyncGenerator<string, void, undefined>' is not assignable to type 'AsyncIterable<number, any, undefined>'.
         yield* ["a", "b"];
     };
     const assignability6: () => AsyncIterable<number> = async function * () {
           ~~~~~~~~~~~~~~
-!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number>'.
-!!! error TS2322:   Call signature return types 'AsyncGenerator<string, void, unknown>' and 'AsyncIterable<number>' are incompatible.
+!!! error TS2322: Type '() => AsyncGenerator<string, void, unknown>' is not assignable to type '() => AsyncIterable<number, any, undefined>'.
+!!! error TS2322:   Call signature return types 'AsyncGenerator<string, void, unknown>' and 'AsyncIterable<number, any, undefined>' are incompatible.
 !!! error TS2322:     The types returned by '[Symbol.asyncIterator]().next(...)' are incompatible between these types.
 !!! error TS2322:       Type 'Promise<IteratorResult<string, void>>' is not assignable to type 'Promise<IteratorResult<number, any>>'.
         yield* (async function * () { yield "a"; })();
@@ -191,8 +191,7 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts(
 !!! error TS2322: Type 'AsyncGenerator<number, any, undefined>' is not assignable to type 'Iterator<number, any, undefined>'.
 !!! error TS2322:   The types returned by 'next(...)' are incompatible between these types.
 !!! error TS2322:     Type 'Promise<IteratorResult<number, any>>' is not assignable to type 'IteratorResult<number, any>'.
-!!! error TS2322:       Property 'value' is missing in type 'Promise<IteratorResult<number, any>>' but required in type 'IteratorYieldResult<number>'.
-!!! related TS2728 /.ts/lib.es2015.iterable.d.ts:33:5: 'value' is declared here.
+!!! error TS2322:       Type 'Promise<IteratorResult<number, any>>' is missing the following properties from type 'IteratorReturnResult<any>': done, value
         yield 1;
     }
     async function * yieldStar() {

--- a/tests/baselines/reference/types.asyncGenerators.es2018.2.types
+++ b/tests/baselines/reference/types.asyncGenerators.es2018.2.types
@@ -28,7 +28,7 @@ async function * inferReturnType3() {
 >2 : 2
 }
 const assignability1: () => AsyncIterableIterator<number> = async function * () {
->assignability1 : () => AsyncIterableIterator<number>
+>assignability1 : () => AsyncIterableIterator<number, any, undefined>
 >async function * () {    yield "a";} : () => AsyncGenerator<string, void, undefined>
 
     yield "a";
@@ -37,7 +37,7 @@ const assignability1: () => AsyncIterableIterator<number> = async function * () 
 
 };
 const assignability2: () => AsyncIterableIterator<number> = async function * () {
->assignability2 : () => AsyncIterableIterator<number>
+>assignability2 : () => AsyncIterableIterator<number, any, undefined>
 >async function * () {    yield* ["a", "b"];} : () => AsyncGenerator<string, void, undefined>
 
     yield* ["a", "b"];
@@ -48,7 +48,7 @@ const assignability2: () => AsyncIterableIterator<number> = async function * () 
 
 };
 const assignability3: () => AsyncIterableIterator<number> = async function * () {
->assignability3 : () => AsyncIterableIterator<number>
+>assignability3 : () => AsyncIterableIterator<number, any, undefined>
 >async function * () {    yield* (async function * () { yield "a"; })();} : () => AsyncGenerator<string, void, unknown>
 
     yield* (async function * () { yield "a"; })();
@@ -61,7 +61,7 @@ const assignability3: () => AsyncIterableIterator<number> = async function * () 
 
 };
 const assignability4: () => AsyncIterable<number> = async function * () {
->assignability4 : () => AsyncIterable<number>
+>assignability4 : () => AsyncIterable<number, any, undefined>
 >async function * () {    yield "a";} : () => AsyncGenerator<string, void, undefined>
 
     yield "a";
@@ -70,7 +70,7 @@ const assignability4: () => AsyncIterable<number> = async function * () {
 
 };
 const assignability5: () => AsyncIterable<number> = async function * () {
->assignability5 : () => AsyncIterable<number>
+>assignability5 : () => AsyncIterable<number, any, undefined>
 >async function * () {    yield* ["a", "b"];} : () => AsyncGenerator<string, void, undefined>
 
     yield* ["a", "b"];
@@ -81,7 +81,7 @@ const assignability5: () => AsyncIterable<number> = async function * () {
 
 };
 const assignability6: () => AsyncIterable<number> = async function * () {
->assignability6 : () => AsyncIterable<number>
+>assignability6 : () => AsyncIterable<number, any, undefined>
 >async function * () {    yield* (async function * () { yield "a"; })();} : () => AsyncGenerator<string, void, unknown>
 
     yield* (async function * () { yield "a"; })();
@@ -127,14 +127,14 @@ const assignability9: () => AsyncIterator<number> = async function * () {
 
 };
 async function * explicitReturnType1(): AsyncIterableIterator<number> {
->explicitReturnType1 : () => AsyncIterableIterator<number>
+>explicitReturnType1 : () => AsyncIterableIterator<number, any, undefined>
 
     yield "a";
 >yield "a" : undefined
 >"a" : "a"
 }
 async function * explicitReturnType2(): AsyncIterableIterator<number> {
->explicitReturnType2 : () => AsyncIterableIterator<number>
+>explicitReturnType2 : () => AsyncIterableIterator<number, any, undefined>
 
     yield* ["a", "b"];
 >yield* ["a", "b"] : any
@@ -143,7 +143,7 @@ async function * explicitReturnType2(): AsyncIterableIterator<number> {
 >"b" : "b"
 }
 async function * explicitReturnType3(): AsyncIterableIterator<number> {
->explicitReturnType3 : () => AsyncIterableIterator<number>
+>explicitReturnType3 : () => AsyncIterableIterator<number, any, undefined>
 
     yield* (async function * () { yield "a"; })();
 >yield* (async function * () { yield "a"; })() : void
@@ -154,14 +154,14 @@ async function * explicitReturnType3(): AsyncIterableIterator<number> {
 >"a" : "a"
 }
 async function * explicitReturnType4(): AsyncIterable<number> {
->explicitReturnType4 : () => AsyncIterable<number>
+>explicitReturnType4 : () => AsyncIterable<number, any, undefined>
 
     yield "a";
 >yield "a" : undefined
 >"a" : "a"
 }
 async function * explicitReturnType5(): AsyncIterable<number> {
->explicitReturnType5 : () => AsyncIterable<number>
+>explicitReturnType5 : () => AsyncIterable<number, any, undefined>
 
     yield* ["a", "b"];
 >yield* ["a", "b"] : any
@@ -170,7 +170,7 @@ async function * explicitReturnType5(): AsyncIterable<number> {
 >"b" : "b"
 }
 async function * explicitReturnType6(): AsyncIterable<number> {
->explicitReturnType6 : () => AsyncIterable<number>
+>explicitReturnType6 : () => AsyncIterable<number, any, undefined>
 
     yield* (async function * () { yield "a"; })();
 >yield* (async function * () { yield "a"; })() : void

--- a/tests/baselines/reference/types.forAwait.es2018.1.types
+++ b/tests/baselines/reference/types.forAwait.es2018.1.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/types/forAwait/types.forAwait.es2018.1.ts ===
 declare const asyncIterable: AsyncIterable<number>;
->asyncIterable : AsyncIterable<number>
+>asyncIterable : AsyncIterable<number, any, undefined>
 
 declare const iterable: Iterable<number>;
 >iterable : Iterable<number>
@@ -16,7 +16,7 @@ async function f1() {
 
     for await (const x of asyncIterable) {
 >x : number
->asyncIterable : AsyncIterable<number>
+>asyncIterable : AsyncIterable<number, any, undefined>
     }
     for await (const x of iterable) {
 >x : number
@@ -28,7 +28,7 @@ async function f1() {
     }
     for await (y of asyncIterable) {
 >y : number
->asyncIterable : AsyncIterable<number>
+>asyncIterable : AsyncIterable<number, any, undefined>
     }
     for await (y of iterable) {
 >y : number
@@ -47,7 +47,7 @@ async function * f2() {
 
     for await (const x of asyncIterable) {
 >x : number
->asyncIterable : AsyncIterable<number>
+>asyncIterable : AsyncIterable<number, any, undefined>
     }
     for await (const x of iterable) {
 >x : number
@@ -59,7 +59,7 @@ async function * f2() {
     }
     for await (y of asyncIterable) {
 >y : number
->asyncIterable : AsyncIterable<number>
+>asyncIterable : AsyncIterable<number, any, undefined>
     }
     for await (y of iterable) {
 >y : number

--- a/tests/baselines/reference/types.forAwait.es2018.2.errors.txt
+++ b/tests/baselines/reference/types.forAwait.es2018.2.errors.txt
@@ -2,8 +2,8 @@ tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts(6,27): error T
 tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts(8,21): error TS2504: Type '{}' must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts(10,16): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts(12,16): error TS2322: Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts(14,21): error TS2488: Type 'AsyncIterable<number>' must have a '[Symbol.iterator]()' method that returns an iterator.
-tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts(16,15): error TS2488: Type 'AsyncIterable<number>' must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts(14,21): error TS2488: Type 'AsyncIterable<number, any, undefined>' must have a '[Symbol.iterator]()' method that returns an iterator.
+tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts(16,15): error TS2488: Type 'AsyncIterable<number, any, undefined>' must have a '[Symbol.iterator]()' method that returns an iterator.
 
 
 ==== tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts (6 errors) ====
@@ -30,11 +30,11 @@ tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts(16,15): error 
         }
         for (const x of asyncIterable) {
                         ~~~~~~~~~~~~~
-!!! error TS2488: Type 'AsyncIterable<number>' must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type 'AsyncIterable<number, any, undefined>' must have a '[Symbol.iterator]()' method that returns an iterator.
         }
         for (y of asyncIterable) {
                   ~~~~~~~~~~~~~
-!!! error TS2488: Type 'AsyncIterable<number>' must have a '[Symbol.iterator]()' method that returns an iterator.
+!!! error TS2488: Type 'AsyncIterable<number, any, undefined>' must have a '[Symbol.iterator]()' method that returns an iterator.
         }
     }
     

--- a/tests/baselines/reference/types.forAwait.es2018.2.types
+++ b/tests/baselines/reference/types.forAwait.es2018.2.types
@@ -1,6 +1,6 @@
 === tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts ===
 declare const asyncIterable: AsyncIterable<number>;
->asyncIterable : AsyncIterable<number>
+>asyncIterable : AsyncIterable<number, any, undefined>
 
 declare const iterable: Iterable<number>;
 >iterable : Iterable<number>
@@ -24,7 +24,7 @@ async function f() {
     }
     for await (z of asyncIterable) {
 >z : string
->asyncIterable : AsyncIterable<number>
+>asyncIterable : AsyncIterable<number, any, undefined>
     }
     for await (z of iterable) {
 >z : string
@@ -32,11 +32,11 @@ async function f() {
     }
     for (const x of asyncIterable) {
 >x : any
->asyncIterable : AsyncIterable<number>
+>asyncIterable : AsyncIterable<number, any, undefined>
     }
     for (y of asyncIterable) {
 >y : number
->asyncIterable : AsyncIterable<number>
+>asyncIterable : AsyncIterable<number, any, undefined>
     }
 }
 

--- a/tests/baselines/reference/uniqueSymbols.types
+++ b/tests/baselines/reference/uniqueSymbols.types
@@ -803,7 +803,7 @@ interface Context {
 >s : unique symbol
 
     method3(): AsyncIterableIterator<typeof s>;
->method3 : () => AsyncIterableIterator<unique symbol>
+>method3 : () => AsyncIterableIterator<unique symbol, any, undefined>
 >s : unique symbol
 
     method4(): IterableIterator<typeof s>;

--- a/tests/baselines/reference/uniqueSymbolsDeclarations.types
+++ b/tests/baselines/reference/uniqueSymbolsDeclarations.types
@@ -796,7 +796,7 @@ interface Context {
 >s : unique symbol
 
     method3(): AsyncIterableIterator<typeof s>;
->method3 : () => AsyncIterableIterator<unique symbol>
+>method3 : () => AsyncIterableIterator<unique symbol, any, undefined>
 >s : unique symbol
 
     method4(): IterableIterator<typeof s>;


### PR DESCRIPTION

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Partially fixes #33932 by giving a way to provide a better type than `any` for TReturn. Implementation is simply adding and plumbing the `TReturn` and `TNext` parameters for both AsyncIterableIterator and AsyncIterable, and updating baselines.
