### PR TITLE
Fix getTypeAtLocation for `as const` to not issue a diagnostic

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11336,6 +11336,11 @@ namespace ts {
         function getTypeFromTypeReference(node: TypeReferenceType): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
+                // handle LS queries on the `const` in `x as const` by resolving to the type of `x`
+                if (isTypeReferenceNode(node) && isIdentifier(node.typeName) && idText(node.typeName) === "const" && isAssertionExpression(node.parent)) {
+                    links.resolvedSymbol = unknownSymbol;
+                    return links.resolvedType = checkExpressionCached(node.parent.expression);
+                }
                 let symbol: Symbol | undefined;
                 let type: Type | undefined;
                 const meaning = SymbolFlags.Type;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11337,7 +11337,7 @@ namespace ts {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
                 // handle LS queries on the `const` in `x as const` by resolving to the type of `x`
-                if (isTypeReferenceNode(node) && isIdentifier(node.typeName) && idText(node.typeName) === "const" && isAssertionExpression(node.parent)) {
+                if (isConstTypeReference(node) && isAssertionExpression(node.parent)) {
                     links.resolvedSymbol = unknownSymbol;
                     return links.resolvedType = checkExpressionCached(node.parent.expression);
                 }

--- a/src/testRunner/unittests/programApi.ts
+++ b/src/testRunner/unittests/programApi.ts
@@ -182,7 +182,7 @@ namespace ts {
 
     describe("unittests:: programApi:: Program.getDiagnosticsProducingTypeChecker / Program.getSemanticDiagnostics", () => {
         it("does not produce errors on `as const` it would not normally produce on the command line", () => {
-            const main = new documents.TextDocument("/main.ts", '0 as const');
+            const main = new documents.TextDocument("/main.ts", "0 as const");
 
             const fs = vfs.createFromFileSystem(Harness.IO, /*ignoreCase*/ false, { documents: [main], cwd: "/" });
             const program = createProgram(["/main.ts"], {}, new fakes.CompilerHost(fs, { newLine: NewLineKind.LineFeed }));

--- a/src/testRunner/unittests/programApi.ts
+++ b/src/testRunner/unittests/programApi.ts
@@ -178,4 +178,19 @@ namespace ts {
             assert.isNotNaN(program.getIdentifierCount());
         });
     });
+
+
+    describe("unittests:: programApi:: Program.getDiagnosticsProducingTypeChecker / Program.getSemanticDiagnostics", () => {
+        it("does not produce errors on `as const` it would not normally produce on the command line", () => {
+            const main = new documents.TextDocument("/main.ts", '0 as const');
+
+            const fs = vfs.createFromFileSystem(Harness.IO, /*ignoreCase*/ false, { documents: [main], cwd: "/" });
+            const program = createProgram(["/main.ts"], {}, new fakes.CompilerHost(fs, { newLine: NewLineKind.LineFeed }));
+            const typeChecker = program.getDiagnosticsProducingTypeChecker();
+            const sourceFile = program.getSourceFile("main.ts")!;
+            typeChecker.getTypeAtLocation(((sourceFile.statements[0] as ExpressionStatement).expression as AsExpression).type);
+            const diag = program.getSemanticDiagnostics();
+            assert.isEmpty(diag);
+        });
+    });
 }


### PR DESCRIPTION
Fixes #34913

`checkAssertion` in the normal codepath avoids calling into `getTypeFromTypeNode` on the `const` in `as const` expressions, however the checker `getTypeAtLocation` API may invoke it directly. Previously, this'd cause as resolution error, as we'd resolve an (entirely unused) variable named `const` and return its' type. With this change, we instead return the type of the expression associated with the `const` (which should be more useful to API consumers, I hope, and prevents any spurious errors from being added).