### PR TITLE
Hide function type missing props if return and target type same.

### DIFF
--- a/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty4.errors.txt
@@ -1,8 +1,6 @@
 tests/cases/conformance/jsx/file.tsx(24,28): error TS2551: Property 'NAme' does not exist on type 'IUser'. Did you mean 'Name'?
 tests/cases/conformance/jsx/file.tsx(36,15): error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | any[] | ReactElement<any>'.
-  Type '(user: IUser) => Element' is missing the following properties from type 'ReactElement<any>': type, props
 tests/cases/conformance/jsx/file.tsx(39,15): error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | any[] | ReactElement<any>'.
-  Type '(user: IUser) => Element' is missing the following properties from type 'ReactElement<any>': type, props
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -51,7 +49,6 @@ tests/cases/conformance/jsx/file.tsx(39,15): error TS2322: Type '(user: IUser) =
                 ) }
     ~~~~~~~~~~~~~
 !!! error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | any[] | ReactElement<any>'.
-!!! error TS2322:   Type '(user: IUser) => Element' is missing the following properties from type 'ReactElement<any>': type, props
 !!! related TS6212 tests/cases/conformance/jsx/file.tsx:36:15: Did you mean to call this expression?
                 { user => (
                   ~~~~~~~~~
@@ -60,7 +57,6 @@ tests/cases/conformance/jsx/file.tsx(39,15): error TS2322: Type '(user: IUser) =
                 ) }
     ~~~~~~~~~~~~~
 !!! error TS2322: Type '(user: IUser) => Element' is not assignable to type 'string | number | boolean | any[] | ReactElement<any>'.
-!!! error TS2322:   Type '(user: IUser) => Element' is missing the following properties from type 'ReactElement<any>': type, props
 !!! related TS6212 tests/cases/conformance/jsx/file.tsx:39:15: Did you mean to call this expression?
             </FetchUser>
         );

--- a/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty5.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/jsx/file.tsx(20,10): error TS2741: Property 'children' is missing in type '{ a: number; b: string; }' but required in type 'Prop'.
 tests/cases/conformance/jsx/file.tsx(25,9): error TS2740: Type 'Element' is missing the following properties from type 'Button': render, setState, forceUpdate, state, and 2 more.
-tests/cases/conformance/jsx/file.tsx(29,10): error TS2740: Type 'typeof Button' is missing the following properties from type 'Button': render, setState, forceUpdate, props, and 3 more.
+tests/cases/conformance/jsx/file.tsx(29,10): error TS2322: Type 'typeof Button' is not assignable to type 'Button'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -40,6 +40,6 @@ tests/cases/conformance/jsx/file.tsx(29,10): error TS2740: Type 'typeof Button' 
         <Comp a={10} b="hi">
             {Button}
              ~~~~~~
-!!! error TS2740: Type 'typeof Button' is missing the following properties from type 'Button': render, setState, forceUpdate, props, and 3 more.
+!!! error TS2322: Type 'typeof Button' is not assignable to type 'Button'.
 !!! related TS6213 tests/cases/conformance/jsx/file.tsx:29:10: Did you mean to use 'new' with this expression?
         </Comp>;

--- a/tests/baselines/reference/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.errors.txt
+++ b/tests/baselines/reference/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(10,8): error TS2741: Property 'x' is missing in type 'typeof Bar' but required in type 'Bar'.
-tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(11,8): error TS2740: Type 'DateConstructor' is missing the following properties from type 'Date': toDateString, toTimeString, toLocaleDateString, toLocaleTimeString, and 37 more.
-tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(17,4): error TS2345: Argument of type '() => number' is not assignable to parameter of type 'number'.
+tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(10,8): error TS2322: Type 'typeof Bar' is not assignable to type 'Bar'.
+tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(11,8): error TS2322: Type 'DateConstructor' is not assignable to type 'Date'.
+tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(17,4): error TS2322: Type '() => number' is not assignable to type 'number'.
 tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(26,5): error TS2322: Type '() => number' is not assignable to type 'number'.
 
 
@@ -16,12 +16,11 @@ tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(2
     foo({
         x: Bar,
            ~~~
-!!! error TS2741: Property 'x' is missing in type 'typeof Bar' but required in type 'Bar'.
-!!! related TS2728 tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts:2:5: 'x' is declared here.
+!!! error TS2322: Type 'typeof Bar' is not assignable to type 'Bar'.
 !!! related TS6213 tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts:10:8: Did you mean to use 'new' with this expression?
         y: Date
            ~~~~
-!!! error TS2740: Type 'DateConstructor' is missing the following properties from type 'Date': toDateString, toTimeString, toLocaleDateString, toLocaleTimeString, and 37 more.
+!!! error TS2322: Type 'DateConstructor' is not assignable to type 'Date'.
 !!! related TS6213 tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts:11:8: Did you mean to use 'new' with this expression?
     }, getNum());
     
@@ -30,7 +29,7 @@ tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts(2
         y: new Date()
     }, getNum);
        ~~~~~~
-!!! error TS2345: Argument of type '() => number' is not assignable to parameter of type 'number'.
+!!! error TS2322: Type '() => number' is not assignable to type 'number'.
 !!! related TS6212 tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts:17:4: Did you mean to call this expression?
     
     

--- a/tests/baselines/reference/elaborationForPossiblyCallableTypeStillReferencesArgumentAtTopLevel.errors.txt
+++ b/tests/baselines/reference/elaborationForPossiblyCallableTypeStillReferencesArgumentAtTopLevel.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/elaborationForPossiblyCallableTypeStillReferencesArgumentAtTopLevel.ts(3,4): error TS2345: Argument of type 'new () => number' is not assignable to parameter of type 'number'.
+tests/cases/compiler/elaborationForPossiblyCallableTypeStillReferencesArgumentAtTopLevel.ts(3,4): error TS2322: Type 'new () => number' is not assignable to type 'number'.
 
 
 ==== tests/cases/compiler/elaborationForPossiblyCallableTypeStillReferencesArgumentAtTopLevel.ts (1 errors) ====
@@ -6,5 +6,5 @@ tests/cases/compiler/elaborationForPossiblyCallableTypeStillReferencesArgumentAt
     declare function ff(t: number): void;
     ff(ohno)
        ~~~~
-!!! error TS2345: Argument of type 'new () => number' is not assignable to parameter of type 'number'.
+!!! error TS2322: Type 'new () => number' is not assignable to type 'number'.
 !!! related TS6213 tests/cases/compiler/elaborationForPossiblyCallableTypeStillReferencesArgumentAtTopLevel.ts:3:4: Did you mean to use 'new' with this expression?

--- a/tests/baselines/reference/functionSignatureAssignmentCompat1.errors.txt
+++ b/tests/baselines/reference/functionSignatureAssignmentCompat1.errors.txt
@@ -1,6 +1,4 @@
 tests/cases/compiler/functionSignatureAssignmentCompat1.ts(10,21): error TS2322: Type '(delimiter?: string) => ParserFunc' is not assignable to type 'ParserFunc'.
-  Types of parameters 'delimiter' and 'eventEmitter' are incompatible.
-    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/functionSignatureAssignmentCompat1.ts (1 errors) ====
@@ -16,7 +14,5 @@ tests/cases/compiler/functionSignatureAssignmentCompat1.ts(10,21): error TS2322:
     var d: ParserFunc = parsers.readline; // not ok
                         ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '(delimiter?: string) => ParserFunc' is not assignable to type 'ParserFunc'.
-!!! error TS2322:   Types of parameters 'delimiter' and 'eventEmitter' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
 !!! related TS6212 tests/cases/compiler/functionSignatureAssignmentCompat1.ts:10:21: Did you mean to call this expression?
     var e: ParserFunc = parsers.readline(); // ok

--- a/tests/baselines/reference/optionalParamAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/optionalParamAssignmentCompat.errors.txt
@@ -1,6 +1,4 @@
 tests/cases/compiler/optionalParamAssignmentCompat.ts(10,13): error TS2322: Type '(p1?: string) => I1' is not assignable to type 'I1'.
-  Types of parameters 'p1' and 'p1' are incompatible.
-    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/optionalParamAssignmentCompat.ts (1 errors) ====
@@ -16,7 +14,5 @@ tests/cases/compiler/optionalParamAssignmentCompat.ts(10,13): error TS2322: Type
     var d: I1 = i2.m1; // should error
                 ~~~~~
 !!! error TS2322: Type '(p1?: string) => I1' is not assignable to type 'I1'.
-!!! error TS2322:   Types of parameters 'p1' and 'p1' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
 !!! related TS6212 tests/cases/compiler/optionalParamAssignmentCompat.ts:10:13: Did you mean to call this expression?
     

--- a/tests/baselines/reference/parser536727.errors.txt
+++ b/tests/baselines/reference/parser536727.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts(7,5): error TS2345: Argument of type '() => (x: string) => string' is not assignable to parameter of type '(x: string) => string'.
-  Type '(x: string) => string' is not assignable to type 'string'.
-tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts(8,5): error TS2345: Argument of type '() => (x: string) => string' is not assignable to parameter of type '(x: string) => string'.
-  Type '(x: string) => string' is not assignable to type 'string'.
+tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts(7,5): error TS2322: Type '() => (x: string) => string' is not assignable to type '(x: string) => string'.
+tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts(8,5): error TS2322: Type '() => (x: string) => string' is not assignable to type '(x: string) => string'.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts (2 errors) ====
@@ -13,12 +11,10 @@ tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts(8,5):
     foo(g);
     foo(() => g);
         ~~~~~~~
-!!! error TS2345: Argument of type '() => (x: string) => string' is not assignable to parameter of type '(x: string) => string'.
-!!! error TS2345:   Type '(x: string) => string' is not assignable to type 'string'.
+!!! error TS2322: Type '() => (x: string) => string' is not assignable to type '(x: string) => string'.
 !!! related TS6212 tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts:7:5: Did you mean to call this expression?
     foo(x);
         ~
-!!! error TS2345: Argument of type '() => (x: string) => string' is not assignable to parameter of type '(x: string) => string'.
-!!! error TS2345:   Type '(x: string) => string' is not assignable to type 'string'.
+!!! error TS2322: Type '() => (x: string) => string' is not assignable to type '(x: string) => string'.
 !!! related TS6212 tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts:8:5: Did you mean to call this expression?
     

--- a/tests/baselines/reference/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.errors.txt
+++ b/tests/baselines/reference/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts(12,1): error TS2741: Property 'prop' is missing in type 'C' but required in type 'A'.
-tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts(13,5): error TS2741: Property 'prop' is missing in type 'typeof B' but required in type 'A'.
+tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts(13,5): error TS2322: Type 'typeof B' is not assignable to type 'A'.
 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts(16,5): error TS2741: Property 'prop' is missing in type 'C' but required in type 'B'.
-tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts(17,5): error TS2741: Property 'prop' is missing in type 'typeof B' but required in type 'B'.
+tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts(17,5): error TS2322: Type 'typeof B' is not assignable to type 'B'.
 
 
 ==== tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts (4 errors) ====
@@ -22,8 +22,7 @@ tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.
 !!! related TS2728 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:2:5: 'prop' is declared here.
     a = B; // error prop is missing
         ~
-!!! error TS2741: Property 'prop' is missing in type 'typeof B' but required in type 'A'.
-!!! related TS2728 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:2:5: 'prop' is declared here.
+!!! error TS2322: Type 'typeof B' is not assignable to type 'A'.
 !!! related TS6213 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:13:5: Did you mean to use 'new' with this expression?
     a = C;
     
@@ -33,8 +32,7 @@ tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.
 !!! related TS2728 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:5:12: 'prop' is declared here.
     b = B; // error prop is missing
         ~
-!!! error TS2741: Property 'prop' is missing in type 'typeof B' but required in type 'B'.
-!!! related TS2728 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:5:12: 'prop' is declared here.
+!!! error TS2322: Type 'typeof B' is not assignable to type 'B'.
 !!! related TS6213 tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts:17:5: Did you mean to use 'new' with this expression?
     b = C;
     b = a;

--- a/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations2.errors.txt
+++ b/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations2.errors.txt
@@ -4,8 +4,8 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerCon
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts(24,5): error TS2411: Property 'd' of type 'string' is not assignable to string index type 'A'.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts(31,5): error TS2411: Property 'c' of type 'number' is not assignable to string index type 'A'.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts(32,5): error TS2411: Property 'd' of type 'string' is not assignable to string index type 'A'.
-tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts(37,8): error TS2741: Property 'foo' is missing in type 'typeof A' but required in type 'A'.
-tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts(38,8): error TS2741: Property 'foo' is missing in type 'typeof B' but required in type 'A'.
+tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts(37,8): error TS2322: Type 'typeof A' is not assignable to type 'A'.
+tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts(38,8): error TS2322: Type 'typeof B' is not assignable to type 'A'.
 
 
 ==== tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts (8 errors) ====
@@ -59,12 +59,10 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerCon
     var b: { [x: string]: A } = {
         a: A,
            ~
-!!! error TS2741: Property 'foo' is missing in type 'typeof A' but required in type 'A'.
-!!! related TS2728 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts:4:5: 'foo' is declared here.
+!!! error TS2322: Type 'typeof A' is not assignable to type 'A'.
 !!! related TS6213 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts:37:8: Did you mean to use 'new' with this expression?
         b: B
            ~
-!!! error TS2741: Property 'foo' is missing in type 'typeof B' but required in type 'A'.
-!!! related TS2728 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts:4:5: 'foo' is declared here.
+!!! error TS2322: Type 'typeof B' is not assignable to type 'A'.
 !!! related TS6213 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts:38:8: Did you mean to use 'new' with this expression?
     }

--- a/tests/baselines/reference/typeMatch1.errors.txt
+++ b/tests/baselines/reference/typeMatch1.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/typeMatch1.ts(18,1): error TS2322: Type 'D' is not assignable to type 'C'.
   Types have separate declarations of a private property 'x'.
-tests/cases/compiler/typeMatch1.ts(19,4): error TS2741: Property 'x' is missing in type 'typeof C' but required in type 'C'.
+tests/cases/compiler/typeMatch1.ts(19,4): error TS2322: Type 'typeof C' is not assignable to type 'C'.
 tests/cases/compiler/typeMatch1.ts(20,1): error TS2367: This condition will always return 'false' since the types 'typeof C' and 'typeof D' have no overlap.
 
 
@@ -28,8 +28,7 @@ tests/cases/compiler/typeMatch1.ts(20,1): error TS2367: This condition will alwa
 !!! error TS2322:   Types have separate declarations of a private property 'x'.
     x6=C;
        ~
-!!! error TS2741: Property 'x' is missing in type 'typeof C' but required in type 'C'.
-!!! related TS2728 tests/cases/compiler/typeMatch1.ts:12:19: 'x' is declared here.
+!!! error TS2322: Type 'typeof C' is not assignable to type 'C'.
 !!! related TS6213 tests/cases/compiler/typeMatch1.ts:19:4: Did you mean to use 'new' with this expression?
     C==D;
     ~~~~

--- a/tests/baselines/reference/weakType.errors.txt
+++ b/tests/baselines/reference/weakType.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/weakType.ts(15,13): error TS2560: Value of type '() => { timeout: number; }' has no properties in common with type 'Settings'. Did you mean to call it?
-tests/cases/compiler/weakType.ts(16,13): error TS2560: Value of type '() => { timeout: number; }' has no properties in common with type 'Settings'. Did you mean to call it?
-tests/cases/compiler/weakType.ts(17,13): error TS2560: Value of type 'CtorOnly' has no properties in common with type 'Settings'. Did you mean to call it?
+tests/cases/compiler/weakType.ts(15,13): error TS2322: Type '() => { timeout: number; }' is not assignable to type 'Settings'.
+tests/cases/compiler/weakType.ts(16,13): error TS2322: Type '() => { timeout: number; }' is not assignable to type 'Settings'.
+tests/cases/compiler/weakType.ts(17,13): error TS2322: Type 'CtorOnly' is not assignable to type 'Settings'.
 tests/cases/compiler/weakType.ts(18,13): error TS2559: Type '12' has no properties in common with type 'Settings'.
 tests/cases/compiler/weakType.ts(19,13): error TS2559: Type '"completely wrong"' has no properties in common with type 'Settings'.
 tests/cases/compiler/weakType.ts(20,13): error TS2559: Type 'false' has no properties in common with type 'Settings'.
@@ -26,15 +26,15 @@ tests/cases/compiler/weakType.ts(62,5): error TS2326: Types of property 'propert
     // forgot to call `getDefaultSettings`
     doSomething(getDefaultSettings);
                 ~~~~~~~~~~~~~~~~~~
-!!! error TS2560: Value of type '() => { timeout: number; }' has no properties in common with type 'Settings'. Did you mean to call it?
+!!! error TS2322: Type '() => { timeout: number; }' is not assignable to type 'Settings'.
 !!! related TS6212 tests/cases/compiler/weakType.ts:15:13: Did you mean to call this expression?
     doSomething(() => ({ timeout: 1000 }));
                 ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2560: Value of type '() => { timeout: number; }' has no properties in common with type 'Settings'. Did you mean to call it?
+!!! error TS2322: Type '() => { timeout: number; }' is not assignable to type 'Settings'.
 !!! related TS6212 tests/cases/compiler/weakType.ts:16:13: Did you mean to call this expression?
     doSomething(null as CtorOnly);
                 ~~~~~~~~~~~~~~~~
-!!! error TS2560: Value of type 'CtorOnly' has no properties in common with type 'Settings'. Did you mean to call it?
+!!! error TS2322: Type 'CtorOnly' is not assignable to type 'Settings'.
 !!! related TS6213 tests/cases/compiler/weakType.ts:17:13: Did you mean to use 'new' with this expression?
     doSomething(12);
                 ~~


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #35735.

Whenever we find a source function type whose return type matches the target type, we only produce the error message "did you mean to call this expression" without checking their properties.

As mentioned in the linked issue, this should provide a more relevant error message.
