### PR TITLE
Avoid expensive relationship checking in mapped type member resolution

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9589,7 +9589,7 @@ namespace ts {
                     // When creating an optional property in strictNullChecks mode, if 'undefined' isn't assignable to the
                     // type, we include 'undefined' in the type. Similarly, when creating a non-optional property in strictNullChecks
                     // mode, if the underlying property is optional we remove 'undefined' from the type.
-                    prop.type = strictNullChecks && isOptional && !isTypeAssignableTo(undefinedType, propType) ? getOptionalType(propType) :
+                    prop.type = strictNullChecks && isOptional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType) :
                         strictNullChecks && !isOptional && modifiersProp && modifiersProp.flags & SymbolFlags.Optional ? getTypeWithFacts(propType, TypeFacts.NEUndefined) :
                         propType;
                     if (modifiersProp) {
@@ -13681,7 +13681,7 @@ namespace ts {
             const templateMapper = combineTypeMappers(mapper, createTypeMapper([getTypeParameterFromMappedType(type)], [key]));
             const propType = instantiateType(getTemplateTypeFromMappedType(<MappedType>type.target || type), templateMapper);
             const modifiers = getMappedTypeModifiers(type);
-            return strictNullChecks && modifiers & MappedTypeModifiers.IncludeOptional && !isTypeAssignableTo(undefinedType, propType) ? getOptionalType(propType) :
+            return strictNullChecks && modifiers & MappedTypeModifiers.IncludeOptional && !maybeTypeOfKind(propType, TypeFlags.Undefined | TypeFlags.Void) ? getOptionalType(propType) :
                 strictNullChecks && modifiers & MappedTypeModifiers.ExcludeOptional && isOptional ? getTypeWithFacts(propType, TypeFacts.NEUndefined) :
                 propType;
         }

--- a/tests/baselines/reference/definiteAssignmentOfDestructuredVariable.types
+++ b/tests/baselines/reference/definiteAssignmentOfDestructuredVariable.types
@@ -18,20 +18,20 @@ class C<T extends Options> {
 >method : () => void
 
         let { a, b } = this.foo;
->a : T["a"]
+>a : T["a"] | undefined
 >b : T["b"]
 >this.foo : { [P in keyof T]: T[P]; }
 >this : this
 >foo : { [P in keyof T]: T[P]; }
 
         !(a && b);
->!(a && b) : false
->(a && b) : T["b"]
->a && b : T["b"]
->a : T["a"]
+>!(a && b) : boolean
+>(a && b) : T["b"] | undefined
+>a && b : T["b"] | undefined
+>a : T["a"] | undefined
 >b : T["b"]
 
         a;
->a : T["a"]
+>a : T["a"] | undefined
     }
 }

--- a/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.types
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeNoLib.types
@@ -20,11 +20,11 @@ class Test<T extends A> {
         this.attrs.params!.name;
 >this.attrs.params!.name : any
 >this.attrs.params! : T["params"]
->this.attrs.params : T["params"]
+>this.attrs.params : T["params"] | undefined
 >this.attrs : Readonly<T>
 >this : this
 >attrs : Readonly<T>
->params : T["params"]
+>params : T["params"] | undefined
 >name : any
     }
 }
@@ -66,10 +66,10 @@ class Test2<T extends A> {
 
         return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
 >this.attrs.params! : T["params"]
->this.attrs.params : T["params"]
+>this.attrs.params : T["params"] | undefined
 >this.attrs : Readonly<T>
 >this : this
 >attrs : Readonly<T>
->params : T["params"]
+>params : T["params"] | undefined
     }
 }

--- a/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.types
+++ b/tests/baselines/reference/strictNullNotNullIndexTypeShouldWork.types
@@ -17,11 +17,11 @@ class Test<T extends A> {
         this.attrs.params!.name;
 >this.attrs.params!.name : string
 >this.attrs.params! : NonNullable<T["params"]>
->this.attrs.params : T["params"]
+>this.attrs.params : T["params"] | undefined
 >this.attrs : Readonly<T>
 >this : this
 >attrs : Readonly<T>
->params : T["params"]
+>params : T["params"] | undefined
 >name : string
     }
 }
@@ -63,10 +63,10 @@ class Test2<T extends A> {
 
         return this.attrs.params!; // Return type should maintain relationship with `T` after being not-null-asserted, ideally
 >this.attrs.params! : NonNullable<T["params"]>
->this.attrs.params : T["params"]
+>this.attrs.params : T["params"] | undefined
 >this.attrs : Readonly<T>
 >this : this
 >attrs : Readonly<T>
->params : T["params"]
+>params : T["params"] | undefined
     }
 }

--- a/tests/baselines/reference/typeVariableTypeGuards.types
+++ b/tests/baselines/reference/typeVariableTypeGuards.types
@@ -16,12 +16,12 @@ class A<P extends Partial<Foo>> {
 >doSomething : () => void
 
         this.props.foo && this.props.foo()
->this.props.foo && this.props.foo() : void
->this.props.foo : P["foo"]
+>this.props.foo && this.props.foo() : void | undefined
+>this.props.foo : P["foo"] | undefined
 >this.props : Readonly<P>
 >this : this
 >props : Readonly<P>
->foo : P["foo"]
+>foo : P["foo"] | undefined
 >this.props.foo() : void
 >this.props.foo : () => void
 >this.props : Readonly<P>

--- a/tests/baselines/reference/voidReturnIndexUnionInference.types
+++ b/tests/baselines/reference/voidReturnIndexUnionInference.types
@@ -43,9 +43,9 @@ function bad<P extends Props>(props: Readonly<P>) {
     safeInvoke(props.onFoo, "blah");
 >safeInvoke(props.onFoo, "blah") : boolean | undefined
 >safeInvoke : <A1, R>(func: ((arg1: A1) => R) | null | undefined, arg1: A1) => R | undefined
->props.onFoo : P["onFoo"]
+>props.onFoo : P["onFoo"] | undefined
 >props : Readonly<P>
->onFoo : P["onFoo"]
+>onFoo : P["onFoo"] | undefined
 >"blah" : "blah"
 
     // ERROR HERE!!!
@@ -53,9 +53,9 @@ function bad<P extends Props>(props: Readonly<P>) {
     safeInvoke(props.onBar, "blah");
 >safeInvoke(props.onBar, "blah") : void | undefined
 >safeInvoke : <A1, R>(func: ((arg1: A1) => R) | null | undefined, arg1: A1) => R | undefined
->props.onBar : P["onBar"]
+>props.onBar : P["onBar"] | undefined
 >props : Readonly<P>
->onBar : P["onBar"]
+>onBar : P["onBar"] | undefined
 >"blah" : "blah"
 }
 


### PR DESCRIPTION
This PR removes an expensive `isTypeAssignableTo` check from mapped type member resolution and replaces it with a shallower `maybeTypeOfKind`. The full relationship check can generate a lot of work exploring simplifications and constraints. Replacing it with the shallow check improves total compile time of the repro in #36564 by 8-10% and also resolves circularities I'm seeing in another PR.