### PR TITLE
Allow unknown type annotation on catch clause variable

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -32140,7 +32140,7 @@ namespace ts {
             if (catchClause) {
                 // Grammar checking
                 if (catchClause.variableDeclaration) {
-                    if (catchClause.variableDeclaration.type) {
+                    if (catchClause.variableDeclaration.type && catchClause.variableDeclaration.type.kind !== SyntaxKind.UnknownKeyword) {
                         grammarErrorOnFirstToken(catchClause.variableDeclaration.type, Diagnostics.Catch_clause_variable_cannot_have_a_type_annotation);
                     }
                     else if (catchClause.variableDeclaration.initializer) {

--- a/tests/baselines/reference/catchClauseWithUnknownTypeAnnotation.js
+++ b/tests/baselines/reference/catchClauseWithUnknownTypeAnnotation.js
@@ -1,0 +1,11 @@
+//// [catchClauseWithUnknownTypeAnnotation.ts]
+try {
+} catch (e: unknown) {
+}
+
+
+//// [catchClauseWithUnknownTypeAnnotation.js]
+try {
+}
+catch (e) {
+}

--- a/tests/baselines/reference/catchClauseWithUnknownTypeAnnotation.symbols
+++ b/tests/baselines/reference/catchClauseWithUnknownTypeAnnotation.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/catchClauseWithUnknownTypeAnnotation.ts ===
+try {
+} catch (e: unknown) {
+>e : Symbol(e, Decl(catchClauseWithUnknownTypeAnnotation.ts, 1, 9))
+}
+

--- a/tests/baselines/reference/catchClauseWithUnknownTypeAnnotation.types
+++ b/tests/baselines/reference/catchClauseWithUnknownTypeAnnotation.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/catchClauseWithUnknownTypeAnnotation.ts ===
+try {
+} catch (e: unknown) {
+>e : any
+}
+

--- a/tests/cases/compiler/catchClauseWithUnknownTypeAnnotation.ts
+++ b/tests/cases/compiler/catchClauseWithUnknownTypeAnnotation.ts
@@ -1,0 +1,3 @@
+try {
+} catch (e: unknown) {
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #36775
