### PR TITLE
No error on `this` expressions in static property declaration initialisers (ESNext+useDefineForClassFields)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20930,7 +20930,7 @@ namespace ts {
                     break;
                 case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.PropertySignature:
-                    if (hasModifier(container, ModifierFlags.Static)) {
+                    if (hasModifier(container, ModifierFlags.Static) && !(compilerOptions.target === ScriptTarget.ESNext && compilerOptions.useDefineForClassFields)) {
                         error(node, Diagnostics.this_cannot_be_referenced_in_a_static_property_initializer);
                         // do not return here so in case if lexical this is captured - it will be reflected in flags on NodeLinks
                     }

--- a/tests/baselines/reference/thisInClassBodyStaticESNext.js
+++ b/tests/baselines/reference/thisInClassBodyStaticESNext.js
@@ -1,0 +1,20 @@
+//// [thisInClassBodyStaticESNext.ts]
+// all are allowed with es-compliant class field emit
+class Foo {
+    x = this
+    static t = this
+    static at = () => this
+    static ft = function () { return this }
+    static mt() { return this }
+}
+
+
+//// [thisInClassBodyStaticESNext.js]
+// all are allowed with es-compliant class field emit
+class Foo {
+    x = this;
+    static t = this;
+    static at = () => this;
+    static ft = function () { return this; };
+    static mt() { return this; }
+}

--- a/tests/baselines/reference/thisInClassBodyStaticESNext.symbols
+++ b/tests/baselines/reference/thisInClassBodyStaticESNext.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/thisInClassBodyStaticESNext.ts ===
+// all are allowed with es-compliant class field emit
+class Foo {
+>Foo : Symbol(Foo, Decl(thisInClassBodyStaticESNext.ts, 0, 0))
+
+    x = this
+>x : Symbol(Foo.x, Decl(thisInClassBodyStaticESNext.ts, 1, 11))
+>this : Symbol(Foo, Decl(thisInClassBodyStaticESNext.ts, 0, 0))
+
+    static t = this
+>t : Symbol(Foo.t, Decl(thisInClassBodyStaticESNext.ts, 2, 12))
+>this : Symbol(Foo, Decl(thisInClassBodyStaticESNext.ts, 0, 0))
+
+    static at = () => this
+>at : Symbol(Foo.at, Decl(thisInClassBodyStaticESNext.ts, 3, 19))
+>this : Symbol(Foo, Decl(thisInClassBodyStaticESNext.ts, 0, 0))
+
+    static ft = function () { return this }
+>ft : Symbol(Foo.ft, Decl(thisInClassBodyStaticESNext.ts, 4, 26))
+
+    static mt() { return this }
+>mt : Symbol(Foo.mt, Decl(thisInClassBodyStaticESNext.ts, 5, 43))
+>this : Symbol(Foo, Decl(thisInClassBodyStaticESNext.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/thisInClassBodyStaticESNext.types
+++ b/tests/baselines/reference/thisInClassBodyStaticESNext.types
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/thisInClassBodyStaticESNext.ts ===
+// all are allowed with es-compliant class field emit
+class Foo {
+>Foo : Foo
+
+    x = this
+>x : this
+>this : this
+
+    static t = this
+>t : typeof Foo
+>this : typeof Foo
+
+    static at = () => this
+>at : () => typeof Foo
+>() => this : () => typeof Foo
+>this : typeof Foo
+
+    static ft = function () { return this }
+>ft : () => any
+>function () { return this } : () => any
+>this : any
+
+    static mt() { return this }
+>mt : () => typeof Foo
+>this : typeof Foo
+}
+

--- a/tests/cases/compiler/thisInClassBodyStaticESNext.ts
+++ b/tests/cases/compiler/thisInClassBodyStaticESNext.ts
@@ -1,0 +1,11 @@
+// @target: esnext
+// @useDefineForClassFields: true
+
+// all are allowed with es-compliant class field emit
+class Foo {
+    x = this
+    static t = this
+    static at = () => this
+    static ft = function () { return this }
+    static mt() { return this }
+}


### PR DESCRIPTION
No error on `this` expressions in static property declaration initialisers when targetting ESNext and with useDefineForClassFields. In this case the emit is correct and the types are correct, so the error should not be issued.

Addresses #36267 but only for ESNext+useDefineForClassFields.
