### PR TITLE
Add support for Inverse Offset and Range types

### DIFF
--- a/src/compiler/debug.ts
+++ b/src/compiler/debug.ts
@@ -10,7 +10,7 @@ namespace ts {
             return currentAssertionLevel >= level;
         }
 
-        export function assert(expression: boolean, message?: string, verboseDebugInfo?: string | (() => string), stackCrawlMark?: AnyFunction): void {
+        export function assert(expression: boolean, message?: string, verboseDebugInfo?: string | (() => string), stackCrawlMark?: AnyFunction): asserts expression {
             if (!expression) {
                 if (verboseDebugInfo) {
                     message += "\r\nVerbose Debug Information: " + (typeof verboseDebugInfo === "string" ? verboseDebugInfo : verboseDebugInfo());

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2879,6 +2879,10 @@
         "category": "Message",
         "code": 2782
     },
+    "Type '{0}' cannot be used as an index type in an offset or range type.": {
+        "category": "Error",
+        "code": 2783
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1332,6 +1332,8 @@ namespace ts {
                         return emitConditionalType(<ConditionalTypeNode>node);
                     case SyntaxKind.InferType:
                         return emitInferType(<InferTypeNode>node);
+                    case SyntaxKind.InverseOffsetType:
+                        return emitOffsetType(<InverseOffsetTypeNode>node);
                     case SyntaxKind.ParenthesizedType:
                         return emitParenthesizedType(<ParenthesizedTypeNode>node);
                     case SyntaxKind.ExpressionWithTypeArguments:
@@ -1344,6 +1346,8 @@ namespace ts {
                         return emitIndexedAccessType(<IndexedAccessTypeNode>node);
                     case SyntaxKind.MappedType:
                         return emitMappedType(<MappedTypeNode>node);
+                    case SyntaxKind.RangeType:
+                        return emitRangeType(<RangeTypeNode>node);
                     case SyntaxKind.LiteralType:
                         return emitLiteralType(<LiteralTypeNode>node);
                     case SyntaxKind.ImportType:
@@ -2131,6 +2135,11 @@ namespace ts {
             emit(node.typeParameter);
         }
 
+        function emitOffsetType(node: InverseOffsetTypeNode) {
+            writePunctuation("^");
+            emit(node.indexType);
+        }
+
         function emitParenthesizedType(node: ParenthesizedTypeNode) {
             writePunctuation("(");
             emit(node.type);
@@ -2194,6 +2203,15 @@ namespace ts {
                 decreaseIndent();
             }
             writePunctuation("}");
+        }
+
+        function emitRangeType(node: RangeTypeNode) {
+            emit(node.objectType);
+            writePunctuation("[");
+            emit(node.startType);
+            writePunctuation(":");
+            emit(node.endType);
+            writePunctuation("]");
         }
 
         function emitLiteralType(node: LiteralTypeNode) {

--- a/src/compiler/factoryPublic.ts
+++ b/src/compiler/factoryPublic.ts
@@ -904,6 +904,18 @@ namespace ts {
             : node;
     }
 
+    export function createInverseOffsetTypeNode(indexType: TypeNode) {
+        const node = <InverseOffsetTypeNode>createSynthesizedNode(SyntaxKind.InverseOffsetType);
+        node.indexType = parenthesizeElementTypeMember(indexType);
+        return node;
+    }
+
+    export function updateInverseOffsetTypeNode(node: InverseOffsetTypeNode, indexType: TypeNode) {
+        return node.indexType !== indexType
+            ? updateNode(createInverseOffsetTypeNode(indexType), node)
+            : node;
+    }
+
     export function createImportTypeNode(argument: TypeNode, qualifier?: EntityName, typeArguments?: readonly TypeNode[], isTypeOf?: boolean) {
         const node = <ImportTypeNode>createSynthesizedNode(SyntaxKind.ImportType);
         node.argument = argument;
@@ -958,7 +970,7 @@ namespace ts {
         return node;
     }
 
-    export function updateIndexedAccessTypeNode(node: IndexedAccessTypeNode, objectType: TypeNode, indexType: TypeNode) {
+    export function updateIndexedAccessTypeNode(node: IndexedAccessTypeNode, objectType: TypeNode, indexType: TypeNode): IndexedAccessTypeNode {
         return node.objectType !== objectType
             || node.indexType !== indexType
             ? updateNode(createIndexedAccessTypeNode(objectType, indexType), node)
@@ -980,6 +992,22 @@ namespace ts {
             || node.questionToken !== questionToken
             || node.type !== type
             ? updateNode(createMappedTypeNode(readonlyToken, typeParameter, questionToken, type), node)
+            : node;
+    }
+
+    export function createRangeTypeNode(objectType: TypeNode, startType: TypeNode | undefined, endType: TypeNode | undefined) {
+        const node = createSynthesizedNode(SyntaxKind.RangeType) as RangeTypeNode;
+        node.objectType = objectType;
+        node.startType = startType;
+        node.endType = endType;
+        return node;
+    }
+    
+    export function updateRangeTypeNode(node: RangeTypeNode, objectType: TypeNode, startType: TypeNode | undefined, endType: TypeNode | undefined) {
+        return node.objectType !== objectType
+            || node.startType !== startType
+            || node.endType !== endType
+            ? updateNode(createRangeTypeNode(objectType, startType, endType), node)
             : node;
     }
 

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1000,6 +1000,10 @@ namespace ts {
         return node.kind === SyntaxKind.InferType;
     }
 
+    export function isOffsetTypeNode(node: Node): node is InverseOffsetTypeNode {
+        return node.kind === SyntaxKind.InverseOffsetType;
+    }
+
     export function isParenthesizedTypeNode(node: Node): node is ParenthesizedTypeNode {
         return node.kind === SyntaxKind.ParenthesizedType;
     }

--- a/src/compiler/visitorPublic.ts
+++ b/src/compiler/visitorPublic.ts
@@ -398,6 +398,10 @@ namespace ts {
                 return updateInferTypeNode(<InferTypeNode>node,
                     visitNode((<InferTypeNode>node).typeParameter, visitor, isTypeParameterDeclaration));
 
+            case SyntaxKind.InverseOffsetType:
+                return updateInverseOffsetTypeNode(<InverseOffsetTypeNode>node,
+                    visitNode((<InverseOffsetTypeNode>node).indexType, visitor, isTypeNode));
+
             case SyntaxKind.ImportType:
                 return updateImportTypeNode(<ImportTypeNode>node,
                     visitNode((<ImportTypeNode>node).argument, visitor, isTypeNode),
@@ -425,6 +429,12 @@ namespace ts {
                     visitNode((<MappedTypeNode>node).typeParameter, visitor, isTypeParameterDeclaration),
                     visitNode((<MappedTypeNode>node).questionToken, tokenVisitor, isToken),
                     visitNode((<MappedTypeNode>node).type, visitor, isTypeNode));
+
+            case SyntaxKind.RangeType:
+                return updateRangeTypeNode((<RangeTypeNode>node),
+                    visitNode((<RangeTypeNode>node).objectType, visitor, isTypeNode),
+                    visitNode((<RangeTypeNode>node).startType, visitor, isTypeNode),
+                    visitNode((<RangeTypeNode>node).endType, visitor, isTypeNode));
 
             case SyntaxKind.LiteralType:
                 return updateLiteralTypeNode(<LiteralTypeNode>node,

--- a/src/services/codefixes/fixSpelling.ts
+++ b/src/services/codefixes/fixSpelling.ts
@@ -35,16 +35,17 @@ namespace ts.codefix {
         const checker = context.program.getTypeChecker();
 
         let suggestedSymbol: Symbol | undefined;
-        if (isPropertyAccessExpression(node.parent) && node.parent.name === node) {
+        const { parent } = node;
+        if (isPropertyAccessExpression(parent) && parent.name === node) {
             Debug.assert(isIdentifierOrPrivateIdentifier(node), "Expected an identifier for spelling (property access)");
-            let containingType = checker.getTypeAtLocation(node.parent.expression);
+            let containingType = checker.getTypeAtLocation(parent.expression);
             if (node.parent.flags & NodeFlags.OptionalChain) {
                 containingType = checker.getNonNullableType(containingType);
             }
             const name = node as Identifier | PrivateIdentifier;
             suggestedSymbol = checker.getSuggestedSymbolForNonexistentProperty(name, containingType);
         }
-        else if (isImportSpecifier(node.parent) && node.parent.name === node) {
+        else if (isImportSpecifier(parent) && parent.name === node) {
             Debug.assert(node.kind === SyntaxKind.Identifier, "Expected an identifier for spelling (import)");
             const importDeclaration = findAncestor(node, isImportDeclaration)!;
             const resolvedSourceFile = getResolvedSourceFileFromImportDeclaration(sourceFile, context, importDeclaration);

--- a/tests/baselines/reference/ranges.errors.txt
+++ b/tests/baselines/reference/ranges.errors.txt
@@ -1,0 +1,196 @@
+tests/cases/conformance/types/range/semantics.ts(14,15): error TS2461: Type '{}' is not an array type.
+tests/cases/conformance/types/range/semantics.ts(21,25): error TS2536: Type 'true' cannot be used to index type '[1, 2, 3]'.
+
+
+==== tests/cases/conformance/types/range/semantics.ts (2 errors) ====
+    // Rules (from https://gist.github.com/rbuckton/5fd81582fdf86a34b45bae82d842304c)
+    
+    // Semantic Rules
+    {
+        // - The result of a *Range Type* has the same mutability as its *object type*.
+        type T1 = [1, 2, 3][0:2];
+        type T2 = (readonly [1, 2, 3])[0:2];
+    }
+    
+    {
+        // - The *object type* of a *Range Type* is constrained to be an *Array Type* or a *Tuple Type*.
+        type T1 = [1, 2, 3][0:2];
+        type T2 = number[][0:2];
+        type T3 = {}[0:2]; // error
+                  ~~~~~~~
+!!! error TS2461: Type '{}' is not an array type.
+    }
+    
+    {
+        // - The *start type* and *end type* of a *Range Type* are constrained to `string | number`.
+        type T1 = [1, 2, 3][0:2];
+        type T2 = [1, 2, 3]["0":"2"];
+        type T3 = [1, 2, 3][true:false]; // error
+                            ~~~~
+!!! error TS2536: Type 'true' cannot be used to index type '[1, 2, 3]'.
+    }
+    
+    {
+        // - The *start type* of a *Range Type* is optional. If not present, the *lower bound type* (`0`) is used.
+        type T2 = [1, 2, 3][:1];
+    
+        // - The *end type* of a *Range Type* is optional. If not present, the *upper bound type* (`^0`) is used.
+        type T3 = [1, 2, 3][1:];
+        type T1 = [1, 2, 3][:];
+    }
+    
+    {
+        // - If the *start type* or *end type* of a *Range Type* are negative-valued *Numeric Literal Types* (or numeric index-valued *String Literal Types*), they are treated
+        //   as an *Inverse Offset Type* for the absolute value of the numeric index value of the respective type.
+        //     - NOTE: This does not work for `-0` as JavaScript generally treats `-0` and `0` as the same value except for a few small corner cases and we must 
+        //       align with this behavior.
+        type T1 = [1, 2, 3, 4][1:-1];
+        type T2 = [1, 2, 3, 4][1:-0];
+    }
+    
+    {
+        // - If the *object type* is a "generic object type", or if either of the *start type* or *end type* are
+        //   "generic index types", then the operation is deferred until it they can be instantiated.
+        type T1<A extends any[]> = A[0:2];
+        type T2 = T1<[1, 2, 3]>;
+        type T3 = T1<number[]>;
+    
+        type T4<X extends number> = [1, 2, 3][X:];
+        type T5 = T4<1>;
+    
+        type T6<Y extends number> = [1, 2, 3][:Y];
+        type T7 = T6<^1>;
+    }
+    
+    {
+        // - If either the *object type*, *start type*, or *end type* are *Union Types*, the result is distributed over
+        //   each constituent in the following manner:
+        //   - The *object type* is distributed over any *Inverse Offset Type* constituent of *start type* or *end type*.
+        //     This is necessary as an *Inverse Offset Type* can have a different outcome depending on the *object type*
+        //     it is resolved against.
+        //   - The *start type* and *end type* are distributed over each constituent of the *object type*.
+        //   - The *object type* is distributed over each constituent of the *start type* and *end type*.
+        //   - The results of the distribution are either an *Intersection Type* (if the *Range Type* was a "write"
+        //     location), or a *Union Type* (if the *Range Type* was a "read" location).
+        type T1 = ([1, 2, 3] | [2, 3, 4])[0:2];
+        type T2 = [1, 2, 3][0|1:2];
+        type T3 = [1, 2, 3][0:1|2];
+        type T4 = ([1, 2, 3] | [2, 3, 4])[0|1:2|3];
+        type T5 = ([1, 2, 3] | [9, 8])[0:^1];
+    }
+    
+    {
+        // - Otherwise (or for each constituent of the distribution),
+        {
+            // - If neither the *start type* nor the *end type* are *String Literal Types* or a *Numeric Literal Types*, then
+            //   - Return an *Array Type* for the union of each element of the *object type*: `T[any:any] -> T[number][]`.
+            type T1 = [1, 2, 3][number:number];
+            type T2 = [1, 2, 3][string:string];
+            type T3 = [1, 2, 3][any:any];
+            type T4 = [1, 2, 3][never:never];
+        }
+        {
+            // - If the *start type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+            //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+            //     *end type*, but with a *start type* of `0`: `T[any:Y] -> T[:Y][number][]`.
+            type T1 = [1, 2, 3][number:2];
+            type T2 = [1, 2, 3][string:2];
+            type T3 = [1, 2, 3][any:2];
+            type T4 = [1, 2, 3][never:2];
+        }
+        {
+            // - If the *end type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+            //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+            //     *start type*, but with an *end type* of `^0`: `T[X:any] -> T[X:][number][]`.
+            type T1 = [1, 2, 3][1:number];
+            type T2 = [1, 2, 3][1:string];
+            type T3 = [1, 2, 3][1:any];
+            type T4 = [1, 2, 3][1:never];
+        }
+        {
+            // - If the *start type* is the *lower bound type* (`0`) and the *end type* is the *upper bound type* (`^0`),
+            //   then we are including all elements: return the *object type* of the *Range Type*.
+            type T1 = [1, 2, 3][0:^0];
+        }
+        {
+            // - If the *start type* is the *upper bound type* (`^0`) or the *end type* is the *lower bound type* (`0`),
+            //   then we are including no elements: return the empty *Tuple Type* (`[]`).
+            type T1 = [1, 2, 3][^0:^0];
+            type T2 = [1, 2, 3][0:0];
+        }
+        {
+            // - If the *object type* is an *Array Type*, then
+            {
+                // - If the signs of both the *start type* and *end type* agree, then return
+                //   a fixed-length *Tuple Type* with a minimum length of `0` for the difference between the *end type* and
+                //   the *start type* whose elements are the element type of the *object type*: `T[][0:1] -> [T?]`.
+                type T1 = number[][0:2];
+                type T2 = number[][^2:^0];
+            }
+            {
+                // - If the *start type* is an *Inverse Offset Type* and the *end type* is not, we can create a tuple of
+                //   `min(abs(start), end)` optional elements.
+                type T1 = number[][^2:4];
+            }
+            {
+                // - Otherwise, we cannot derive a fixed length: return the *object type* of the *Range Type*.
+                type T1 = number[][0:^2];
+            }
+        }
+        {
+            // - Otherwise, the *object type* is a *Tuple Type*:
+            {
+                // - If the *object type* has a rest element, then
+                {
+                    // - If the *start type* is an *Inverse Offset Type*, return an *Array Type* for the union of each
+                    //   *optional type* and the *rest element type*, along with the set of `n` right-most required
+                    //   elements of the *object type* where `n` is the absolute value of the *start type*.
+                    type T1 = [1, 2, 3, ...4[]][^1:];
+                    type T2 = [1, 2, 3, ...4[]][^2:];
+                    type T3 = [1, 2, 3, ...4[]][^3:];
+                    type T4 = [1, 2, 3?, ...4[]][^1:];
+                    type T5 = [1, 2, 3?, ...4[]][^2:];
+                    type T6 = [1, 2, 3?, ...4[]][^3:];
+                }
+                {
+                    // - If the *end type* is an *Inverse Offset Type*, return a *Tuple Type* of the elements of the
+                    //   *object type* starting from the index at *start type*, but whose minimum length is reduced by the
+                    //   absolute value of the *end type*.
+                    type T1 = [1, 2, 3, ...4[]][1:^1];
+                    type T2 = [1, 2, 3, ...4[]][1:^2];
+                    type T3 = [1, 2, 3, ...4[]][1:^3];
+                    type T4 = [1, 2, 3?, ...4[]][1:^1];
+                    type T5 = [1, 2, 3?, ...4[]][1:^2];
+                    type T6 = [1, 2, 3?, ...4[]][1:^3];
+                }
+            }
+            {
+                // - Otherwise,
+                {
+                    // - Clamp the *start type* and *end type* to values between `0` and the length of *object type*.
+                    type T1 = [1, 2, 3][^5:10];
+                }
+                {
+                    // - Return a *Tuple Type* for the elements of *object type* starting at *start type* and ending at
+                    //   *end type*.
+                    type T1 = [1, 2, 3][1: 2];
+                }
+            }
+        }
+    }
+    
+==== tests/cases/conformance/types/range/assignability.ts (0 errors) ====
+    // - `S` is assignable to `T[X:Y]` if `S` is assignable to `C`, where `C` is the base constraint of `T[X:Y]` for writing.
+    function f1<T extends [1, 2, 3, 4], U extends 1 | 2>(t: T[U:^1], s: [3] & [2, 3]) {
+        t = s;
+    }
+    
+    // - `S[X:Y]` is assignable to `T[]` if `S[number]` is assignable to `T`.
+    function f2<T, S extends [T, T, T]>(t: T[], s: S[0:2]) {
+        t = s;
+    }
+    
+    // - `S[XS:YS]` is assignable to `T[XT:YT]` if `S` is assignable to `T`, `XS` is assignable to `XT`, and `YS` is assignable to `YT`.
+    function f3<T extends [1 | 9, 2 | 8, 3 | 7, 4 | 6], S extends T>(t: T[1 | 2:3], s: S[1:3]) {
+        t = s;
+    }

--- a/tests/baselines/reference/ranges.js
+++ b/tests/baselines/reference/ranges.js
@@ -1,0 +1,262 @@
+//// [tests/cases/conformance/types/range/ranges.ts] ////
+
+//// [semantics.ts]
+// Rules (from https://gist.github.com/rbuckton/5fd81582fdf86a34b45bae82d842304c)
+
+// Semantic Rules
+{
+    // - The result of a *Range Type* has the same mutability as its *object type*.
+    type T1 = [1, 2, 3][0:2];
+    type T2 = (readonly [1, 2, 3])[0:2];
+}
+
+{
+    // - The *object type* of a *Range Type* is constrained to be an *Array Type* or a *Tuple Type*.
+    type T1 = [1, 2, 3][0:2];
+    type T2 = number[][0:2];
+    type T3 = {}[0:2]; // error
+}
+
+{
+    // - The *start type* and *end type* of a *Range Type* are constrained to `string | number`.
+    type T1 = [1, 2, 3][0:2];
+    type T2 = [1, 2, 3]["0":"2"];
+    type T3 = [1, 2, 3][true:false]; // error
+}
+
+{
+    // - The *start type* of a *Range Type* is optional. If not present, the *lower bound type* (`0`) is used.
+    type T2 = [1, 2, 3][:1];
+
+    // - The *end type* of a *Range Type* is optional. If not present, the *upper bound type* (`^0`) is used.
+    type T3 = [1, 2, 3][1:];
+    type T1 = [1, 2, 3][:];
+}
+
+{
+    // - If the *start type* or *end type* of a *Range Type* are negative-valued *Numeric Literal Types* (or numeric index-valued *String Literal Types*), they are treated
+    //   as an *Inverse Offset Type* for the absolute value of the numeric index value of the respective type.
+    //     - NOTE: This does not work for `-0` as JavaScript generally treats `-0` and `0` as the same value except for a few small corner cases and we must 
+    //       align with this behavior.
+    type T1 = [1, 2, 3, 4][1:-1];
+    type T2 = [1, 2, 3, 4][1:-0];
+}
+
+{
+    // - If the *object type* is a "generic object type", or if either of the *start type* or *end type* are
+    //   "generic index types", then the operation is deferred until it they can be instantiated.
+    type T1<A extends any[]> = A[0:2];
+    type T2 = T1<[1, 2, 3]>;
+    type T3 = T1<number[]>;
+
+    type T4<X extends number> = [1, 2, 3][X:];
+    type T5 = T4<1>;
+
+    type T6<Y extends number> = [1, 2, 3][:Y];
+    type T7 = T6<^1>;
+}
+
+{
+    // - If either the *object type*, *start type*, or *end type* are *Union Types*, the result is distributed over
+    //   each constituent in the following manner:
+    //   - The *object type* is distributed over any *Inverse Offset Type* constituent of *start type* or *end type*.
+    //     This is necessary as an *Inverse Offset Type* can have a different outcome depending on the *object type*
+    //     it is resolved against.
+    //   - The *start type* and *end type* are distributed over each constituent of the *object type*.
+    //   - The *object type* is distributed over each constituent of the *start type* and *end type*.
+    //   - The results of the distribution are either an *Intersection Type* (if the *Range Type* was a "write"
+    //     location), or a *Union Type* (if the *Range Type* was a "read" location).
+    type T1 = ([1, 2, 3] | [2, 3, 4])[0:2];
+    type T2 = [1, 2, 3][0|1:2];
+    type T3 = [1, 2, 3][0:1|2];
+    type T4 = ([1, 2, 3] | [2, 3, 4])[0|1:2|3];
+    type T5 = ([1, 2, 3] | [9, 8])[0:^1];
+}
+
+{
+    // - Otherwise (or for each constituent of the distribution),
+    {
+        // - If neither the *start type* nor the *end type* are *String Literal Types* or a *Numeric Literal Types*, then
+        //   - Return an *Array Type* for the union of each element of the *object type*: `T[any:any] -> T[number][]`.
+        type T1 = [1, 2, 3][number:number];
+        type T2 = [1, 2, 3][string:string];
+        type T3 = [1, 2, 3][any:any];
+        type T4 = [1, 2, 3][never:never];
+    }
+    {
+        // - If the *start type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+        //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+        //     *end type*, but with a *start type* of `0`: `T[any:Y] -> T[:Y][number][]`.
+        type T1 = [1, 2, 3][number:2];
+        type T2 = [1, 2, 3][string:2];
+        type T3 = [1, 2, 3][any:2];
+        type T4 = [1, 2, 3][never:2];
+    }
+    {
+        // - If the *end type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+        //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+        //     *start type*, but with an *end type* of `^0`: `T[X:any] -> T[X:][number][]`.
+        type T1 = [1, 2, 3][1:number];
+        type T2 = [1, 2, 3][1:string];
+        type T3 = [1, 2, 3][1:any];
+        type T4 = [1, 2, 3][1:never];
+    }
+    {
+        // - If the *start type* is the *lower bound type* (`0`) and the *end type* is the *upper bound type* (`^0`),
+        //   then we are including all elements: return the *object type* of the *Range Type*.
+        type T1 = [1, 2, 3][0:^0];
+    }
+    {
+        // - If the *start type* is the *upper bound type* (`^0`) or the *end type* is the *lower bound type* (`0`),
+        //   then we are including no elements: return the empty *Tuple Type* (`[]`).
+        type T1 = [1, 2, 3][^0:^0];
+        type T2 = [1, 2, 3][0:0];
+    }
+    {
+        // - If the *object type* is an *Array Type*, then
+        {
+            // - If the signs of both the *start type* and *end type* agree, then return
+            //   a fixed-length *Tuple Type* with a minimum length of `0` for the difference between the *end type* and
+            //   the *start type* whose elements are the element type of the *object type*: `T[][0:1] -> [T?]`.
+            type T1 = number[][0:2];
+            type T2 = number[][^2:^0];
+        }
+        {
+            // - If the *start type* is an *Inverse Offset Type* and the *end type* is not, we can create a tuple of
+            //   `min(abs(start), end)` optional elements.
+            type T1 = number[][^2:4];
+        }
+        {
+            // - Otherwise, we cannot derive a fixed length: return the *object type* of the *Range Type*.
+            type T1 = number[][0:^2];
+        }
+    }
+    {
+        // - Otherwise, the *object type* is a *Tuple Type*:
+        {
+            // - If the *object type* has a rest element, then
+            {
+                // - If the *start type* is an *Inverse Offset Type*, return an *Array Type* for the union of each
+                //   *optional type* and the *rest element type*, along with the set of `n` right-most required
+                //   elements of the *object type* where `n` is the absolute value of the *start type*.
+                type T1 = [1, 2, 3, ...4[]][^1:];
+                type T2 = [1, 2, 3, ...4[]][^2:];
+                type T3 = [1, 2, 3, ...4[]][^3:];
+                type T4 = [1, 2, 3?, ...4[]][^1:];
+                type T5 = [1, 2, 3?, ...4[]][^2:];
+                type T6 = [1, 2, 3?, ...4[]][^3:];
+            }
+            {
+                // - If the *end type* is an *Inverse Offset Type*, return a *Tuple Type* of the elements of the
+                //   *object type* starting from the index at *start type*, but whose minimum length is reduced by the
+                //   absolute value of the *end type*.
+                type T1 = [1, 2, 3, ...4[]][1:^1];
+                type T2 = [1, 2, 3, ...4[]][1:^2];
+                type T3 = [1, 2, 3, ...4[]][1:^3];
+                type T4 = [1, 2, 3?, ...4[]][1:^1];
+                type T5 = [1, 2, 3?, ...4[]][1:^2];
+                type T6 = [1, 2, 3?, ...4[]][1:^3];
+            }
+        }
+        {
+            // - Otherwise,
+            {
+                // - Clamp the *start type* and *end type* to values between `0` and the length of *object type*.
+                type T1 = [1, 2, 3][^5:10];
+            }
+            {
+                // - Return a *Tuple Type* for the elements of *object type* starting at *start type* and ending at
+                //   *end type*.
+                type T1 = [1, 2, 3][1: 2];
+            }
+        }
+    }
+}
+
+//// [assignability.ts]
+// - `S` is assignable to `T[X:Y]` if `S` is assignable to `C`, where `C` is the base constraint of `T[X:Y]` for writing.
+function f1<T extends [1, 2, 3, 4], U extends 1 | 2>(t: T[U:^1], s: [3] & [2, 3]) {
+    t = s;
+}
+
+// - `S[X:Y]` is assignable to `T[]` if `S[number]` is assignable to `T`.
+function f2<T, S extends [T, T, T]>(t: T[], s: S[0:2]) {
+    t = s;
+}
+
+// - `S[XS:YS]` is assignable to `T[XT:YT]` if `S` is assignable to `T`, `XS` is assignable to `XT`, and `YS` is assignable to `YT`.
+function f3<T extends [1 | 9, 2 | 8, 3 | 7, 4 | 6], S extends T>(t: T[1 | 2:3], s: S[1:3]) {
+    t = s;
+}
+
+//// [semantics.js]
+"use strict";
+// Rules (from https://gist.github.com/rbuckton/5fd81582fdf86a34b45bae82d842304c)
+// Semantic Rules
+{
+}
+{
+}
+{
+}
+{
+}
+{
+}
+{
+}
+{
+}
+{
+    // - Otherwise (or for each constituent of the distribution),
+    {
+    }
+    {
+    }
+    {
+    }
+    {
+    }
+    {
+    }
+    {
+        // - If the *object type* is an *Array Type*, then
+        {
+        }
+        {
+        }
+        {
+        }
+    }
+    {
+        // - Otherwise, the *object type* is a *Tuple Type*:
+        {
+            // - If the *object type* has a rest element, then
+            {
+            }
+            {
+            }
+        }
+        {
+            // - Otherwise,
+            {
+            }
+            {
+            }
+        }
+    }
+}
+//// [assignability.js]
+"use strict";
+// - `S` is assignable to `T[X:Y]` if `S` is assignable to `C`, where `C` is the base constraint of `T[X:Y]` for writing.
+function f1(t, s) {
+    t = s;
+}
+// - `S[X:Y]` is assignable to `T[]` if `S[number]` is assignable to `T`.
+function f2(t, s) {
+    t = s;
+}
+// - `S[XS:YS]` is assignable to `T[XT:YT]` if `S` is assignable to `T`, `XS` is assignable to `XT`, and `YS` is assignable to `YT`.
+function f3(t, s) {
+    t = s;
+}

--- a/tests/baselines/reference/ranges.symbols
+++ b/tests/baselines/reference/ranges.symbols
@@ -1,0 +1,326 @@
+=== tests/cases/conformance/types/range/semantics.ts ===
+// Rules (from https://gist.github.com/rbuckton/5fd81582fdf86a34b45bae82d842304c)
+
+// Semantic Rules
+{
+    // - The result of a *Range Type* has the same mutability as its *object type*.
+    type T1 = [1, 2, 3][0:2];
+>T1 : Symbol(T1, Decl(semantics.ts, 3, 1))
+
+    type T2 = (readonly [1, 2, 3])[0:2];
+>T2 : Symbol(T2, Decl(semantics.ts, 5, 29))
+}
+
+{
+    // - The *object type* of a *Range Type* is constrained to be an *Array Type* or a *Tuple Type*.
+    type T1 = [1, 2, 3][0:2];
+>T1 : Symbol(T1, Decl(semantics.ts, 9, 1))
+
+    type T2 = number[][0:2];
+>T2 : Symbol(T2, Decl(semantics.ts, 11, 29))
+
+    type T3 = {}[0:2]; // error
+>T3 : Symbol(T3, Decl(semantics.ts, 12, 28))
+}
+
+{
+    // - The *start type* and *end type* of a *Range Type* are constrained to `string | number`.
+    type T1 = [1, 2, 3][0:2];
+>T1 : Symbol(T1, Decl(semantics.ts, 16, 1))
+
+    type T2 = [1, 2, 3]["0":"2"];
+>T2 : Symbol(T2, Decl(semantics.ts, 18, 29))
+
+    type T3 = [1, 2, 3][true:false]; // error
+>T3 : Symbol(T3, Decl(semantics.ts, 19, 33))
+}
+
+{
+    // - The *start type* of a *Range Type* is optional. If not present, the *lower bound type* (`0`) is used.
+    type T2 = [1, 2, 3][:1];
+>T2 : Symbol(T2, Decl(semantics.ts, 23, 1))
+
+    // - The *end type* of a *Range Type* is optional. If not present, the *upper bound type* (`^0`) is used.
+    type T3 = [1, 2, 3][1:];
+>T3 : Symbol(T3, Decl(semantics.ts, 25, 28))
+
+    type T1 = [1, 2, 3][:];
+>T1 : Symbol(T1, Decl(semantics.ts, 28, 28))
+}
+
+{
+    // - If the *start type* or *end type* of a *Range Type* are negative-valued *Numeric Literal Types* (or numeric index-valued *String Literal Types*), they are treated
+    //   as an *Inverse Offset Type* for the absolute value of the numeric index value of the respective type.
+    //     - NOTE: This does not work for `-0` as JavaScript generally treats `-0` and `0` as the same value except for a few small corner cases and we must 
+    //       align with this behavior.
+    type T1 = [1, 2, 3, 4][1:-1];
+>T1 : Symbol(T1, Decl(semantics.ts, 32, 1))
+
+    type T2 = [1, 2, 3, 4][1:-0];
+>T2 : Symbol(T2, Decl(semantics.ts, 37, 33))
+}
+
+{
+    // - If the *object type* is a "generic object type", or if either of the *start type* or *end type* are
+    //   "generic index types", then the operation is deferred until it they can be instantiated.
+    type T1<A extends any[]> = A[0:2];
+>T1 : Symbol(T1, Decl(semantics.ts, 41, 1))
+>A : Symbol(A, Decl(semantics.ts, 44, 12))
+>A : Symbol(A, Decl(semantics.ts, 44, 12))
+
+    type T2 = T1<[1, 2, 3]>;
+>T2 : Symbol(T2, Decl(semantics.ts, 44, 38))
+>T1 : Symbol(T1, Decl(semantics.ts, 41, 1))
+
+    type T3 = T1<number[]>;
+>T3 : Symbol(T3, Decl(semantics.ts, 45, 28))
+>T1 : Symbol(T1, Decl(semantics.ts, 41, 1))
+
+    type T4<X extends number> = [1, 2, 3][X:];
+>T4 : Symbol(T4, Decl(semantics.ts, 46, 27))
+>X : Symbol(X, Decl(semantics.ts, 48, 12))
+>X : Symbol(X, Decl(semantics.ts, 48, 12))
+
+    type T5 = T4<1>;
+>T5 : Symbol(T5, Decl(semantics.ts, 48, 46))
+>T4 : Symbol(T4, Decl(semantics.ts, 46, 27))
+
+    type T6<Y extends number> = [1, 2, 3][:Y];
+>T6 : Symbol(T6, Decl(semantics.ts, 49, 20))
+>Y : Symbol(Y, Decl(semantics.ts, 51, 12))
+>Y : Symbol(Y, Decl(semantics.ts, 51, 12))
+
+    type T7 = T6<^1>;
+>T7 : Symbol(T7, Decl(semantics.ts, 51, 46))
+>T6 : Symbol(T6, Decl(semantics.ts, 49, 20))
+}
+
+{
+    // - If either the *object type*, *start type*, or *end type* are *Union Types*, the result is distributed over
+    //   each constituent in the following manner:
+    //   - The *object type* is distributed over any *Inverse Offset Type* constituent of *start type* or *end type*.
+    //     This is necessary as an *Inverse Offset Type* can have a different outcome depending on the *object type*
+    //     it is resolved against.
+    //   - The *start type* and *end type* are distributed over each constituent of the *object type*.
+    //   - The *object type* is distributed over each constituent of the *start type* and *end type*.
+    //   - The results of the distribution are either an *Intersection Type* (if the *Range Type* was a "write"
+    //     location), or a *Union Type* (if the *Range Type* was a "read" location).
+    type T1 = ([1, 2, 3] | [2, 3, 4])[0:2];
+>T1 : Symbol(T1, Decl(semantics.ts, 55, 1))
+
+    type T2 = [1, 2, 3][0|1:2];
+>T2 : Symbol(T2, Decl(semantics.ts, 65, 43))
+
+    type T3 = [1, 2, 3][0:1|2];
+>T3 : Symbol(T3, Decl(semantics.ts, 66, 31))
+
+    type T4 = ([1, 2, 3] | [2, 3, 4])[0|1:2|3];
+>T4 : Symbol(T4, Decl(semantics.ts, 67, 31))
+
+    type T5 = ([1, 2, 3] | [9, 8])[0:^1];
+>T5 : Symbol(T5, Decl(semantics.ts, 68, 47))
+}
+
+{
+    // - Otherwise (or for each constituent of the distribution),
+    {
+        // - If neither the *start type* nor the *end type* are *String Literal Types* or a *Numeric Literal Types*, then
+        //   - Return an *Array Type* for the union of each element of the *object type*: `T[any:any] -> T[number][]`.
+        type T1 = [1, 2, 3][number:number];
+>T1 : Symbol(T1, Decl(semantics.ts, 74, 5))
+
+        type T2 = [1, 2, 3][string:string];
+>T2 : Symbol(T2, Decl(semantics.ts, 77, 43))
+
+        type T3 = [1, 2, 3][any:any];
+>T3 : Symbol(T3, Decl(semantics.ts, 78, 43))
+
+        type T4 = [1, 2, 3][never:never];
+>T4 : Symbol(T4, Decl(semantics.ts, 79, 37))
+    }
+    {
+        // - If the *start type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+        //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+        //     *end type*, but with a *start type* of `0`: `T[any:Y] -> T[:Y][number][]`.
+        type T1 = [1, 2, 3][number:2];
+>T1 : Symbol(T1, Decl(semantics.ts, 82, 5))
+
+        type T2 = [1, 2, 3][string:2];
+>T2 : Symbol(T2, Decl(semantics.ts, 86, 38))
+
+        type T3 = [1, 2, 3][any:2];
+>T3 : Symbol(T3, Decl(semantics.ts, 87, 38))
+
+        type T4 = [1, 2, 3][never:2];
+>T4 : Symbol(T4, Decl(semantics.ts, 88, 35))
+    }
+    {
+        // - If the *end type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+        //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+        //     *start type*, but with an *end type* of `^0`: `T[X:any] -> T[X:][number][]`.
+        type T1 = [1, 2, 3][1:number];
+>T1 : Symbol(T1, Decl(semantics.ts, 91, 5))
+
+        type T2 = [1, 2, 3][1:string];
+>T2 : Symbol(T2, Decl(semantics.ts, 95, 38))
+
+        type T3 = [1, 2, 3][1:any];
+>T3 : Symbol(T3, Decl(semantics.ts, 96, 38))
+
+        type T4 = [1, 2, 3][1:never];
+>T4 : Symbol(T4, Decl(semantics.ts, 97, 35))
+    }
+    {
+        // - If the *start type* is the *lower bound type* (`0`) and the *end type* is the *upper bound type* (`^0`),
+        //   then we are including all elements: return the *object type* of the *Range Type*.
+        type T1 = [1, 2, 3][0:^0];
+>T1 : Symbol(T1, Decl(semantics.ts, 100, 5))
+    }
+    {
+        // - If the *start type* is the *upper bound type* (`^0`) or the *end type* is the *lower bound type* (`0`),
+        //   then we are including no elements: return the empty *Tuple Type* (`[]`).
+        type T1 = [1, 2, 3][^0:^0];
+>T1 : Symbol(T1, Decl(semantics.ts, 105, 5))
+
+        type T2 = [1, 2, 3][0:0];
+>T2 : Symbol(T2, Decl(semantics.ts, 108, 35))
+    }
+    {
+        // - If the *object type* is an *Array Type*, then
+        {
+            // - If the signs of both the *start type* and *end type* agree, then return
+            //   a fixed-length *Tuple Type* with a minimum length of `0` for the difference between the *end type* and
+            //   the *start type* whose elements are the element type of the *object type*: `T[][0:1] -> [T?]`.
+            type T1 = number[][0:2];
+>T1 : Symbol(T1, Decl(semantics.ts, 113, 9))
+
+            type T2 = number[][^2:^0];
+>T2 : Symbol(T2, Decl(semantics.ts, 117, 36))
+        }
+        {
+            // - If the *start type* is an *Inverse Offset Type* and the *end type* is not, we can create a tuple of
+            //   `min(abs(start), end)` optional elements.
+            type T1 = number[][^2:4];
+>T1 : Symbol(T1, Decl(semantics.ts, 120, 9))
+        }
+        {
+            // - Otherwise, we cannot derive a fixed length: return the *object type* of the *Range Type*.
+            type T1 = number[][0:^2];
+>T1 : Symbol(T1, Decl(semantics.ts, 125, 9))
+        }
+    }
+    {
+        // - Otherwise, the *object type* is a *Tuple Type*:
+        {
+            // - If the *object type* has a rest element, then
+            {
+                // - If the *start type* is an *Inverse Offset Type*, return an *Array Type* for the union of each
+                //   *optional type* and the *rest element type*, along with the set of `n` right-most required
+                //   elements of the *object type* where `n` is the absolute value of the *start type*.
+                type T1 = [1, 2, 3, ...4[]][^1:];
+>T1 : Symbol(T1, Decl(semantics.ts, 134, 13))
+
+                type T2 = [1, 2, 3, ...4[]][^2:];
+>T2 : Symbol(T2, Decl(semantics.ts, 138, 49))
+
+                type T3 = [1, 2, 3, ...4[]][^3:];
+>T3 : Symbol(T3, Decl(semantics.ts, 139, 49))
+
+                type T4 = [1, 2, 3?, ...4[]][^1:];
+>T4 : Symbol(T4, Decl(semantics.ts, 140, 49))
+
+                type T5 = [1, 2, 3?, ...4[]][^2:];
+>T5 : Symbol(T5, Decl(semantics.ts, 141, 50))
+
+                type T6 = [1, 2, 3?, ...4[]][^3:];
+>T6 : Symbol(T6, Decl(semantics.ts, 142, 50))
+            }
+            {
+                // - If the *end type* is an *Inverse Offset Type*, return a *Tuple Type* of the elements of the
+                //   *object type* starting from the index at *start type*, but whose minimum length is reduced by the
+                //   absolute value of the *end type*.
+                type T1 = [1, 2, 3, ...4[]][1:^1];
+>T1 : Symbol(T1, Decl(semantics.ts, 145, 13))
+
+                type T2 = [1, 2, 3, ...4[]][1:^2];
+>T2 : Symbol(T2, Decl(semantics.ts, 149, 50))
+
+                type T3 = [1, 2, 3, ...4[]][1:^3];
+>T3 : Symbol(T3, Decl(semantics.ts, 150, 50))
+
+                type T4 = [1, 2, 3?, ...4[]][1:^1];
+>T4 : Symbol(T4, Decl(semantics.ts, 151, 50))
+
+                type T5 = [1, 2, 3?, ...4[]][1:^2];
+>T5 : Symbol(T5, Decl(semantics.ts, 152, 51))
+
+                type T6 = [1, 2, 3?, ...4[]][1:^3];
+>T6 : Symbol(T6, Decl(semantics.ts, 153, 51))
+            }
+        }
+        {
+            // - Otherwise,
+            {
+                // - Clamp the *start type* and *end type* to values between `0` and the length of *object type*.
+                type T1 = [1, 2, 3][^5:10];
+>T1 : Symbol(T1, Decl(semantics.ts, 159, 13))
+            }
+            {
+                // - Return a *Tuple Type* for the elements of *object type* starting at *start type* and ending at
+                //   *end type*.
+                type T1 = [1, 2, 3][1: 2];
+>T1 : Symbol(T1, Decl(semantics.ts, 163, 13))
+            }
+        }
+    }
+}
+
+=== tests/cases/conformance/types/range/assignability.ts ===
+// - `S` is assignable to `T[X:Y]` if `S` is assignable to `C`, where `C` is the base constraint of `T[X:Y]` for writing.
+function f1<T extends [1, 2, 3, 4], U extends 1 | 2>(t: T[U:^1], s: [3] & [2, 3]) {
+>f1 : Symbol(f1, Decl(assignability.ts, 0, 0))
+>T : Symbol(T, Decl(assignability.ts, 1, 12))
+>U : Symbol(U, Decl(assignability.ts, 1, 35))
+>t : Symbol(t, Decl(assignability.ts, 1, 53))
+>T : Symbol(T, Decl(assignability.ts, 1, 12))
+>U : Symbol(U, Decl(assignability.ts, 1, 35))
+>s : Symbol(s, Decl(assignability.ts, 1, 64))
+
+    t = s;
+>t : Symbol(t, Decl(assignability.ts, 1, 53))
+>s : Symbol(s, Decl(assignability.ts, 1, 64))
+}
+
+// - `S[X:Y]` is assignable to `T[]` if `S[number]` is assignable to `T`.
+function f2<T, S extends [T, T, T]>(t: T[], s: S[0:2]) {
+>f2 : Symbol(f2, Decl(assignability.ts, 3, 1))
+>T : Symbol(T, Decl(assignability.ts, 6, 12))
+>S : Symbol(S, Decl(assignability.ts, 6, 14))
+>T : Symbol(T, Decl(assignability.ts, 6, 12))
+>T : Symbol(T, Decl(assignability.ts, 6, 12))
+>T : Symbol(T, Decl(assignability.ts, 6, 12))
+>t : Symbol(t, Decl(assignability.ts, 6, 36))
+>T : Symbol(T, Decl(assignability.ts, 6, 12))
+>s : Symbol(s, Decl(assignability.ts, 6, 43))
+>S : Symbol(S, Decl(assignability.ts, 6, 14))
+
+    t = s;
+>t : Symbol(t, Decl(assignability.ts, 6, 36))
+>s : Symbol(s, Decl(assignability.ts, 6, 43))
+}
+
+// - `S[XS:YS]` is assignable to `T[XT:YT]` if `S` is assignable to `T`, `XS` is assignable to `XT`, and `YS` is assignable to `YT`.
+function f3<T extends [1 | 9, 2 | 8, 3 | 7, 4 | 6], S extends T>(t: T[1 | 2:3], s: S[1:3]) {
+>f3 : Symbol(f3, Decl(assignability.ts, 8, 1))
+>T : Symbol(T, Decl(assignability.ts, 11, 12))
+>S : Symbol(S, Decl(assignability.ts, 11, 51))
+>T : Symbol(T, Decl(assignability.ts, 11, 12))
+>t : Symbol(t, Decl(assignability.ts, 11, 65))
+>T : Symbol(T, Decl(assignability.ts, 11, 12))
+>s : Symbol(s, Decl(assignability.ts, 11, 79))
+>S : Symbol(S, Decl(assignability.ts, 11, 51))
+
+    t = s;
+>t : Symbol(t, Decl(assignability.ts, 11, 65))
+>s : Symbol(s, Decl(assignability.ts, 11, 79))
+}

--- a/tests/baselines/reference/ranges.types
+++ b/tests/baselines/reference/ranges.types
@@ -1,0 +1,309 @@
+=== tests/cases/conformance/types/range/semantics.ts ===
+// Rules (from https://gist.github.com/rbuckton/5fd81582fdf86a34b45bae82d842304c)
+
+// Semantic Rules
+{
+    // - The result of a *Range Type* has the same mutability as its *object type*.
+    type T1 = [1, 2, 3][0:2];
+>T1 : [1, 2]
+
+    type T2 = (readonly [1, 2, 3])[0:2];
+>T2 : readonly [1, 2]
+}
+
+{
+    // - The *object type* of a *Range Type* is constrained to be an *Array Type* or a *Tuple Type*.
+    type T1 = [1, 2, 3][0:2];
+>T1 : [1, 2]
+
+    type T2 = number[][0:2];
+>T2 : [number?, number?]
+
+    type T3 = {}[0:2]; // error
+>T3 : any
+}
+
+{
+    // - The *start type* and *end type* of a *Range Type* are constrained to `string | number`.
+    type T1 = [1, 2, 3][0:2];
+>T1 : [1, 2]
+
+    type T2 = [1, 2, 3]["0":"2"];
+>T2 : [1, 2]
+
+    type T3 = [1, 2, 3][true:false]; // error
+>T3 : any
+>true : true
+>false : false
+}
+
+{
+    // - The *start type* of a *Range Type* is optional. If not present, the *lower bound type* (`0`) is used.
+    type T2 = [1, 2, 3][:1];
+>T2 : [1]
+
+    // - The *end type* of a *Range Type* is optional. If not present, the *upper bound type* (`^0`) is used.
+    type T3 = [1, 2, 3][1:];
+>T3 : [2, 3]
+
+    type T1 = [1, 2, 3][:];
+>T1 : [1, 2, 3]
+}
+
+{
+    // - If the *start type* or *end type* of a *Range Type* are negative-valued *Numeric Literal Types* (or numeric index-valued *String Literal Types*), they are treated
+    //   as an *Inverse Offset Type* for the absolute value of the numeric index value of the respective type.
+    //     - NOTE: This does not work for `-0` as JavaScript generally treats `-0` and `0` as the same value except for a few small corner cases and we must 
+    //       align with this behavior.
+    type T1 = [1, 2, 3, 4][1:-1];
+>T1 : [2, 3]
+>-1 : -1
+>1 : 1
+
+    type T2 = [1, 2, 3, 4][1:-0];
+>T2 : []
+>-0 : 0
+>0 : 0
+}
+
+{
+    // - If the *object type* is a "generic object type", or if either of the *start type* or *end type* are
+    //   "generic index types", then the operation is deferred until it they can be instantiated.
+    type T1<A extends any[]> = A[0:2];
+>T1 : A[0:2]
+
+    type T2 = T1<[1, 2, 3]>;
+>T2 : [1, 2]
+
+    type T3 = T1<number[]>;
+>T3 : [number?, number?]
+
+    type T4<X extends number> = [1, 2, 3][X:];
+>T4 : [1, 2, 3][X:]
+
+    type T5 = T4<1>;
+>T5 : [2, 3]
+
+    type T6<Y extends number> = [1, 2, 3][:Y];
+>T6 : [1, 2, 3][:Y]
+
+    type T7 = T6<^1>;
+>T7 : [1, 2]
+}
+
+{
+    // - If either the *object type*, *start type*, or *end type* are *Union Types*, the result is distributed over
+    //   each constituent in the following manner:
+    //   - The *object type* is distributed over any *Inverse Offset Type* constituent of *start type* or *end type*.
+    //     This is necessary as an *Inverse Offset Type* can have a different outcome depending on the *object type*
+    //     it is resolved against.
+    //   - The *start type* and *end type* are distributed over each constituent of the *object type*.
+    //   - The *object type* is distributed over each constituent of the *start type* and *end type*.
+    //   - The results of the distribution are either an *Intersection Type* (if the *Range Type* was a "write"
+    //     location), or a *Union Type* (if the *Range Type* was a "read" location).
+    type T1 = ([1, 2, 3] | [2, 3, 4])[0:2];
+>T1 : [1, 2] | [2, 3]
+
+    type T2 = [1, 2, 3][0|1:2];
+>T2 : [1, 2] | [2]
+
+    type T3 = [1, 2, 3][0:1|2];
+>T3 : [1, 2] | [1]
+
+    type T4 = ([1, 2, 3] | [2, 3, 4])[0|1:2|3];
+>T4 : [1, 2, 3] | [1, 2] | [2, 3] | [2, 3, 4] | [2] | [3, 4] | [3]
+
+    type T5 = ([1, 2, 3] | [9, 8])[0:^1];
+>T5 : [1, 2] | [9]
+}
+
+{
+    // - Otherwise (or for each constituent of the distribution),
+    {
+        // - If neither the *start type* nor the *end type* are *String Literal Types* or a *Numeric Literal Types*, then
+        //   - Return an *Array Type* for the union of each element of the *object type*: `T[any:any] -> T[number][]`.
+        type T1 = [1, 2, 3][number:number];
+>T1 : (3 | 1 | 2)[]
+
+        type T2 = [1, 2, 3][string:string];
+>T2 : (3 | 1 | 2)[]
+
+        type T3 = [1, 2, 3][any:any];
+>T3 : (3 | 1 | 2)[]
+
+        type T4 = [1, 2, 3][never:never];
+>T4 : (3 | 1 | 2)[]
+    }
+    {
+        // - If the *start type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+        //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+        //     *end type*, but with a *start type* of `0`: `T[any:Y] -> T[:Y][number][]`.
+        type T1 = [1, 2, 3][number:2];
+>T1 : (1 | 2)[]
+
+        type T2 = [1, 2, 3][string:2];
+>T2 : (1 | 2)[]
+
+        type T3 = [1, 2, 3][any:2];
+>T3 : (1 | 2)[]
+
+        type T4 = [1, 2, 3][never:2];
+>T4 : (1 | 2)[]
+    }
+    {
+        // - If the *end type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+        //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+        //     *start type*, but with an *end type* of `^0`: `T[X:any] -> T[X:][number][]`.
+        type T1 = [1, 2, 3][1:number];
+>T1 : (3 | 2)[]
+
+        type T2 = [1, 2, 3][1:string];
+>T2 : (3 | 2)[]
+
+        type T3 = [1, 2, 3][1:any];
+>T3 : (3 | 2)[]
+
+        type T4 = [1, 2, 3][1:never];
+>T4 : (3 | 2)[]
+    }
+    {
+        // - If the *start type* is the *lower bound type* (`0`) and the *end type* is the *upper bound type* (`^0`),
+        //   then we are including all elements: return the *object type* of the *Range Type*.
+        type T1 = [1, 2, 3][0:^0];
+>T1 : [1, 2, 3]
+    }
+    {
+        // - If the *start type* is the *upper bound type* (`^0`) or the *end type* is the *lower bound type* (`0`),
+        //   then we are including no elements: return the empty *Tuple Type* (`[]`).
+        type T1 = [1, 2, 3][^0:^0];
+>T1 : []
+
+        type T2 = [1, 2, 3][0:0];
+>T2 : []
+    }
+    {
+        // - If the *object type* is an *Array Type*, then
+        {
+            // - If the signs of both the *start type* and *end type* agree, then return
+            //   a fixed-length *Tuple Type* with a minimum length of `0` for the difference between the *end type* and
+            //   the *start type* whose elements are the element type of the *object type*: `T[][0:1] -> [T?]`.
+            type T1 = number[][0:2];
+>T1 : [number?, number?]
+
+            type T2 = number[][^2:^0];
+>T2 : [number?, number?]
+        }
+        {
+            // - If the *start type* is an *Inverse Offset Type* and the *end type* is not, we can create a tuple of
+            //   `min(abs(start), end)` optional elements.
+            type T1 = number[][^2:4];
+>T1 : [number?, number?]
+        }
+        {
+            // - Otherwise, we cannot derive a fixed length: return the *object type* of the *Range Type*.
+            type T1 = number[][0:^2];
+>T1 : number[]
+        }
+    }
+    {
+        // - Otherwise, the *object type* is a *Tuple Type*:
+        {
+            // - If the *object type* has a rest element, then
+            {
+                // - If the *start type* is an *Inverse Offset Type*, return an *Array Type* for the union of each
+                //   *optional type* and the *rest element type*, along with the set of `n` right-most required
+                //   elements of the *object type* where `n` is the absolute value of the *start type*.
+                type T1 = [1, 2, 3, ...4[]][^1:];
+>T1 : 4[]
+
+                type T2 = [1, 2, 3, ...4[]][^2:];
+>T2 : (3 | 4)[]
+
+                type T3 = [1, 2, 3, ...4[]][^3:];
+>T3 : (3 | 2 | 4)[]
+
+                type T4 = [1, 2, 3?, ...4[]][^1:];
+>T4 : (3 | 4 | undefined)[]
+
+                type T5 = [1, 2, 3?, ...4[]][^2:];
+>T5 : (3 | 2 | 4 | undefined)[]
+
+                type T6 = [1, 2, 3?, ...4[]][^3:];
+>T6 : (3 | 2 | 4 | undefined)[]
+            }
+            {
+                // - If the *end type* is an *Inverse Offset Type*, return a *Tuple Type* of the elements of the
+                //   *object type* starting from the index at *start type*, but whose minimum length is reduced by the
+                //   absolute value of the *end type*.
+                type T1 = [1, 2, 3, ...4[]][1:^1];
+>T1 : [2, 3?, ...4[]]
+
+                type T2 = [1, 2, 3, ...4[]][1:^2];
+>T2 : [2?, 3?, ...4[]]
+
+                type T3 = [1, 2, 3, ...4[]][1:^3];
+>T3 : [2?, 3?, ...4[]]
+
+                type T4 = [1, 2, 3?, ...4[]][1:^1];
+>T4 : [2?, (3 | undefined)?, ...4[]]
+
+                type T5 = [1, 2, 3?, ...4[]][1:^2];
+>T5 : [2?, (3 | undefined)?, ...4[]]
+
+                type T6 = [1, 2, 3?, ...4[]][1:^3];
+>T6 : [2?, (3 | undefined)?, ...4[]]
+            }
+        }
+        {
+            // - Otherwise,
+            {
+                // - Clamp the *start type* and *end type* to values between `0` and the length of *object type*.
+                type T1 = [1, 2, 3][^5:10];
+>T1 : [1, 2, 3]
+            }
+            {
+                // - Return a *Tuple Type* for the elements of *object type* starting at *start type* and ending at
+                //   *end type*.
+                type T1 = [1, 2, 3][1: 2];
+>T1 : [2]
+            }
+        }
+    }
+}
+
+=== tests/cases/conformance/types/range/assignability.ts ===
+// - `S` is assignable to `T[X:Y]` if `S` is assignable to `C`, where `C` is the base constraint of `T[X:Y]` for writing.
+function f1<T extends [1, 2, 3, 4], U extends 1 | 2>(t: T[U:^1], s: [3] & [2, 3]) {
+>f1 : <T extends [1, 2, 3, 4], U extends 1 | 2>(t: T[U:^1], s: [3] & [2, 3]) => void
+>t : T[U:^1]
+>s : [3] & [2, 3]
+
+    t = s;
+>t = s : [3] & [2, 3]
+>t : T[U:^1]
+>s : [3] & [2, 3]
+}
+
+// - `S[X:Y]` is assignable to `T[]` if `S[number]` is assignable to `T`.
+function f2<T, S extends [T, T, T]>(t: T[], s: S[0:2]) {
+>f2 : <T, S extends [T, T, T]>(t: T[], s: S[0:2]) => void
+>t : T[]
+>s : S[0:2]
+
+    t = s;
+>t = s : S[0:2]
+>t : T[]
+>s : S[0:2]
+}
+
+// - `S[XS:YS]` is assignable to `T[XT:YT]` if `S` is assignable to `T`, `XS` is assignable to `XT`, and `YS` is assignable to `YT`.
+function f3<T extends [1 | 9, 2 | 8, 3 | 7, 4 | 6], S extends T>(t: T[1 | 2:3], s: S[1:3]) {
+>f3 : <T extends [1 | 9, 2 | 8, 3 | 7, 4 | 6], S extends T>(t: T[1 | 2:3], s: S[1:3]) => void
+>t : T[1 | 2:3]
+>s : S[1:3]
+
+    t = s;
+>t = s : S[1:3]
+>t : T[1 | 2:3]
+>s : S[1:3]
+}

--- a/tests/cases/conformance/types/inverseOffset/inverseOffsets.ts
+++ b/tests/cases/conformance/types/inverseOffset/inverseOffsets.ts
@@ -1,0 +1,52 @@
+// @strict: true
+// Rules (from https://gist.github.com/rbuckton/53e335ce3d63686e229bc4ae25017756)
+
+// @filename: parsing.ts
+// Parsing Rules
+type A = 0;
+type B = 1;
+type T0 = ^A;
+type T1 = ^A | B;
+type T2 = ^(A | B);
+type T3 = keyof ^A;
+type T4 = ^A[]; // error
+type T5 = (^A)[];
+
+// @filename: semantics.ts
+// Semantic Rules
+// - An *Inverse Offset Type*'s *index type* is constrained to `string | number`.
+type T6 = ^0;
+type T7 = ^"0";
+type T8 = ^true; // error
+
+// - The *Inverse Offset Type* of an *Inverse Offset Type* `I` is the *index type* of `I`: `^^I -> I`
+type T9 = ^^0; // inverse rule (double negation = non-negated)
+
+// - An *Inverse Offset Type* for negative *index type* is instead a *Literal Type* for the absolute value of the *index type*: `^-1 -> 1`
+type T10 = ^-1; // inverse rule (double negation = non-negated)
+
+// - If the *index type* of an *Inverse Offset Type* is a union, the *Inverse Offset Type* is distributed over the union: `^(A | B) -> ^A | ^B`
+type T11 = ^(0 | 1); // distributes
+
+// - An *Inverse Offset Type* is deferred until applied as the *index type* of an *Indexed Access Type* or *Range Type*.
+type T12 = ^0;
+
+// - An *Inverse Offset Type* is deferred if its *index type* is generic.
+type T13<A extends string | number> = ^A;
+type T14 = T13<1>;
+
+type AR = [1, 2, 3];
+type X = AR[^1]; // 3
+
+// @filename: assignability.ts
+// Assignability Rules
+// - `^S` is assignable to `string | number`.
+type Constrained0<T extends string | number> = never;
+type Constrained1<T extends boolean | bigint | symbol | undefined | null | object> = never;
+type T15 = Constrained0<^0>;
+type T16 = Constrained1<^0>; // error
+
+// - `^S` is assignable to `^T` if `S` is assignable to `T`.
+function f<T extends string | number, S extends T>(s: ^S, t: ^T) {
+    t = s;
+}

--- a/tests/cases/conformance/types/range/ranges.ts
+++ b/tests/cases/conformance/types/range/ranges.ts
@@ -1,0 +1,189 @@
+// @strict: true
+// Rules (from https://gist.github.com/rbuckton/5fd81582fdf86a34b45bae82d842304c)
+
+// @filename: semantics.ts
+// Semantic Rules
+{
+    // - The result of a *Range Type* has the same mutability as its *object type*.
+    type T1 = [1, 2, 3][0:2];
+    type T2 = (readonly [1, 2, 3])[0:2];
+}
+
+{
+    // - The *object type* of a *Range Type* is constrained to be an *Array Type* or a *Tuple Type*.
+    type T1 = [1, 2, 3][0:2];
+    type T2 = number[][0:2];
+    type T3 = {}[0:2]; // error
+}
+
+{
+    // - The *start type* and *end type* of a *Range Type* are constrained to `string | number`.
+    type T1 = [1, 2, 3][0:2];
+    type T2 = [1, 2, 3]["0":"2"];
+    type T3 = [1, 2, 3][true:false]; // error
+}
+
+{
+    // - The *start type* of a *Range Type* is optional. If not present, the *lower bound type* (`0`) is used.
+    type T2 = [1, 2, 3][:1];
+
+    // - The *end type* of a *Range Type* is optional. If not present, the *upper bound type* (`^0`) is used.
+    type T3 = [1, 2, 3][1:];
+    type T1 = [1, 2, 3][:];
+}
+
+{
+    // - If the *start type* or *end type* of a *Range Type* are negative-valued *Numeric Literal Types* (or numeric index-valued *String Literal Types*), they are treated
+    //   as an *Inverse Offset Type* for the absolute value of the numeric index value of the respective type.
+    //     - NOTE: This does not work for `-0` as JavaScript generally treats `-0` and `0` as the same value except for a few small corner cases and we must 
+    //       align with this behavior.
+    type T1 = [1, 2, 3, 4][1:-1];
+    type T2 = [1, 2, 3, 4][1:-0];
+}
+
+{
+    // - If the *object type* is a "generic object type", or if either of the *start type* or *end type* are
+    //   "generic index types", then the operation is deferred until it they can be instantiated.
+    type T1<A extends any[]> = A[0:2];
+    type T2 = T1<[1, 2, 3]>;
+    type T3 = T1<number[]>;
+
+    type T4<X extends number> = [1, 2, 3][X:];
+    type T5 = T4<1>;
+
+    type T6<Y extends number> = [1, 2, 3][:Y];
+    type T7 = T6<^1>;
+}
+
+{
+    // - If either the *object type*, *start type*, or *end type* are *Union Types*, the result is distributed over
+    //   each constituent in the following manner:
+    //   - The *object type* is distributed over any *Inverse Offset Type* constituent of *start type* or *end type*.
+    //     This is necessary as an *Inverse Offset Type* can have a different outcome depending on the *object type*
+    //     it is resolved against.
+    //   - The *start type* and *end type* are distributed over each constituent of the *object type*.
+    //   - The *object type* is distributed over each constituent of the *start type* and *end type*.
+    //   - The results of the distribution are either an *Intersection Type* (if the *Range Type* was a "write"
+    //     location), or a *Union Type* (if the *Range Type* was a "read" location).
+    type T1 = ([1, 2, 3] | [2, 3, 4])[0:2];
+    type T2 = [1, 2, 3][0|1:2];
+    type T3 = [1, 2, 3][0:1|2];
+    type T4 = ([1, 2, 3] | [2, 3, 4])[0|1:2|3];
+    type T5 = ([1, 2, 3] | [9, 8])[0:^1];
+}
+
+{
+    // - Otherwise (or for each constituent of the distribution),
+    {
+        // - If neither the *start type* nor the *end type* are *String Literal Types* or a *Numeric Literal Types*, then
+        //   - Return an *Array Type* for the union of each element of the *object type*: `T[any:any] -> T[number][]`.
+        type T1 = [1, 2, 3][number:number];
+        type T2 = [1, 2, 3][string:string];
+        type T3 = [1, 2, 3][any:any];
+        type T4 = [1, 2, 3][never:never];
+    }
+    {
+        // - If the *start type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+        //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+        //     *end type*, but with a *start type* of `0`: `T[any:Y] -> T[:Y][number][]`.
+        type T1 = [1, 2, 3][number:2];
+        type T2 = [1, 2, 3][string:2];
+        type T3 = [1, 2, 3][any:2];
+        type T4 = [1, 2, 3][never:2];
+    }
+    {
+        // - If the *end type* is neither a *String Literal Type* nor a *Numeric Literal Type*, then
+        //   - Return an *Array Type* for the union of each element of the *Range Type* for the same *object type* and
+        //     *start type*, but with an *end type* of `^0`: `T[X:any] -> T[X:][number][]`.
+        type T1 = [1, 2, 3][1:number];
+        type T2 = [1, 2, 3][1:string];
+        type T3 = [1, 2, 3][1:any];
+        type T4 = [1, 2, 3][1:never];
+    }
+    {
+        // - If the *start type* is the *lower bound type* (`0`) and the *end type* is the *upper bound type* (`^0`),
+        //   then we are including all elements: return the *object type* of the *Range Type*.
+        type T1 = [1, 2, 3][0:^0];
+    }
+    {
+        // - If the *start type* is the *upper bound type* (`^0`) or the *end type* is the *lower bound type* (`0`),
+        //   then we are including no elements: return the empty *Tuple Type* (`[]`).
+        type T1 = [1, 2, 3][^0:^0];
+        type T2 = [1, 2, 3][0:0];
+    }
+    {
+        // - If the *object type* is an *Array Type*, then
+        {
+            // - If the signs of both the *start type* and *end type* agree, then return
+            //   a fixed-length *Tuple Type* with a minimum length of `0` for the difference between the *end type* and
+            //   the *start type* whose elements are the element type of the *object type*: `T[][0:1] -> [T?]`.
+            type T1 = number[][0:2];
+            type T2 = number[][^2:^0];
+        }
+        {
+            // - If the *start type* is an *Inverse Offset Type* and the *end type* is not, we can create a tuple of
+            //   `min(abs(start), end)` optional elements.
+            type T1 = number[][^2:4];
+        }
+        {
+            // - Otherwise, we cannot derive a fixed length: return the *object type* of the *Range Type*.
+            type T1 = number[][0:^2];
+        }
+    }
+    {
+        // - Otherwise, the *object type* is a *Tuple Type*:
+        {
+            // - If the *object type* has a rest element, then
+            {
+                // - If the *start type* is an *Inverse Offset Type*, return an *Array Type* for the union of each
+                //   *optional type* and the *rest element type*, along with the set of `n` right-most required
+                //   elements of the *object type* where `n` is the absolute value of the *start type*.
+                type T1 = [1, 2, 3, ...4[]][^1:];
+                type T2 = [1, 2, 3, ...4[]][^2:];
+                type T3 = [1, 2, 3, ...4[]][^3:];
+                type T4 = [1, 2, 3?, ...4[]][^1:];
+                type T5 = [1, 2, 3?, ...4[]][^2:];
+                type T6 = [1, 2, 3?, ...4[]][^3:];
+            }
+            {
+                // - If the *end type* is an *Inverse Offset Type*, return a *Tuple Type* of the elements of the
+                //   *object type* starting from the index at *start type*, but whose minimum length is reduced by the
+                //   absolute value of the *end type*.
+                type T1 = [1, 2, 3, ...4[]][1:^1];
+                type T2 = [1, 2, 3, ...4[]][1:^2];
+                type T3 = [1, 2, 3, ...4[]][1:^3];
+                type T4 = [1, 2, 3?, ...4[]][1:^1];
+                type T5 = [1, 2, 3?, ...4[]][1:^2];
+                type T6 = [1, 2, 3?, ...4[]][1:^3];
+            }
+        }
+        {
+            // - Otherwise,
+            {
+                // - Clamp the *start type* and *end type* to values between `0` and the length of *object type*.
+                type T1 = [1, 2, 3][^5:10];
+            }
+            {
+                // - Return a *Tuple Type* for the elements of *object type* starting at *start type* and ending at
+                //   *end type*.
+                type T1 = [1, 2, 3][1: 2];
+            }
+        }
+    }
+}
+
+// @filename: assignability.ts
+// - `S` is assignable to `T[X:Y]` if `S` is assignable to `C`, where `C` is the base constraint of `T[X:Y]` for writing.
+function f1<T extends [1, 2, 3, 4], U extends 1 | 2>(t: T[U:^1], s: [3] & [2, 3]) {
+    t = s;
+}
+
+// - `S[X:Y]` is assignable to `T[]` if `S[number]` is assignable to `T`.
+function f2<T, S extends [T, T, T]>(t: T[], s: S[0:2]) {
+    t = s;
+}
+
+// - `S[XS:YS]` is assignable to `T[XT:YT]` if `S` is assignable to `T`, `XS` is assignable to `XT`, and `YS` is assignable to `YT`.
+function f3<T extends [1 | 9, 2 | 8, 3 | 7, 4 | 6], S extends T>(t: T[1 | 2:3], s: S[1:3]) {
+    t = s;
+}


### PR DESCRIPTION
This PR adds support for two new proposed TypeScript language features:

- [Range Types](https://gist.github.com/rbuckton/5fd81582fdf86a34b45bae82d842304c)
- [Inverse Offset Types](https://gist.github.com/rbuckton/53e335ce3d63686e229bc4ae25017756)

Both are type-space only additions (they have no runtime evaluation behavior).

## Range Types (`T[X:Y]`)

> NOTE: You can read more about *Range Types* at https://gist.github.com/rbuckton/5fd81582fdf86a34b45bae82d842304c.

A *Range Type* is a type that produces a new tuple or array type that derives from `T` by dropping the excess ordered elements of `T` outside of the range starting at offset `X` (inclusive) through offset `Y` (exclusive).

A *Range Type* is denoted using a `:` operator in what would otherwise be an *Indexed Access Type*:

```ts
type T = [1, 2, 3][0:2];
```

### Motivations

- Support for slicing a number of elements from anywhere within a *Tuple Type*.
    - Current approaches for this depend on the use of *Conditional Types*, *Infer Types*, and recursion hacks using *Indexed Access Types* and *Type Literals*. This means they have limited use as they quickly run into recursion limits and have almost no support for type relationships.
- Improve expression level support when using `Array.prototype.slice` on a *Tuple Type*.
- Support converting an *Array Type* into a *Tuple Type* when the size of the *Tuple Type* is known.
- With other future proposals, is intended to further improve type checking for `Function.prototype.bind` and other high-order "pipe" or "chain"-like behaviors.

### Prior Art

- C# 8: [Ranges](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/ranges#systemrange)
- ECMAScript: [Slice notation proposal](https://github.com/tc39/proposal-slice-notation)

## Inverse Offset Types (`^N`)

> NOTE: You can read more about *Inverse Offset Types* at https://gist.github.com/rbuckton/53e335ce3d63686e229bc4ae25017756.

An *Inverse Offset Type* is a type notation used to indicate that *Type* should be considered as an offset from the end of an *Array Type* or *Tuple Type*.

An *Inverse Offset Type* is denoted using a "hat" operator (`^`) preceding a type:

```ts
type T = ^0;
```

### Motivations

- Support for "negative" indexes in *Indexed Access Types* against *Array Types* and *Tuple Types*, since `-1` already has a valid meaning in an *Indexed Access Type*.
- A mechanism for representing the exclusive upper bound of an *Array Type* or *Tuple Type* (`^0`), since the numeric literal type `-0` is equivalent to `0`.
- A mechanism for *negating* a numeric generic type.

### Prior Art

- C# 8.0: [Index types](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/ranges#systemindex)

## Examples

```ts
declare function slice<A extends readonly any[], S extends number>(array: A, start: S): A[S:];
declare function slice<A extends readonly any[], S extends number, E extends number>(array: A, start: S, end: E): A[S:E];
declare function slice<A extends readonly any[], S extends number, E extends number | undefined>(array: A, start: S, end: E): A[S:E extends undefined ? ^0 : E];

const a = [1, 2, 3] as [1, 2, 3];
const b = slice(a, 0); // [1, 2, 3]
const c = slice(a, 1); // [2, 3]
const d = slice(a, 0, 2); // [1, 2]
const e = slice(a, 0, -2); // [1]
```
