### PR TITLE
Fix renaming an ExportSpecifier name when propertyName is present

### DIFF
--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -516,6 +516,10 @@ namespace FourSlashInterface {
             this.state.verifyRenameLocations(startRanges, options);
         }
 
+        public baselineRename(marker: string, options: RenameOptions) {
+            this.state.baselineRename(marker, options);
+        }
+
         public verifyQuickInfoDisplayParts(kind: string, kindModifiers: string, textSpan: FourSlash.TextSpan,
             displayParts: ts.SymbolDisplayPart[], documentation: ts.SymbolDisplayPart[], tags: ts.JSDocTagInfo[]) {
             this.state.verifyQuickInfoDisplayParts(kind, kindModifiers, textSpan, displayParts, documentation, tags);
@@ -1623,4 +1627,9 @@ namespace FourSlashInterface {
         template: string
     };
     export type RenameLocationOptions = FourSlash.Range | { readonly range: FourSlash.Range, readonly prefixText?: string, readonly suffixText?: string };
+    export interface RenameOptions {
+        readonly findInStrings?: boolean;
+        readonly findInComments?: boolean;
+        readonly providePrefixAndSuffixTextForRename?: boolean;
+    };
 }

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -1927,10 +1927,12 @@ namespace ts.FindAllReferences {
             }
 
             const exportSpecifier = getDeclarationOfKind<ExportSpecifier>(symbol, SyntaxKind.ExportSpecifier);
-            const localSymbol = exportSpecifier && checker.getExportSpecifierLocalTargetSymbol(exportSpecifier);
-            if (localSymbol) {
-                const res = cbSymbol(localSymbol, /*rootSymbol*/ undefined, /*baseSymbol*/ undefined, EntryKind.Node);
-                if (res) return res;
+            if (!isForRenamePopulateSearchSymbolSet || exportSpecifier && !exportSpecifier.propertyName) {
+                const localSymbol = exportSpecifier && checker.getExportSpecifierLocalTargetSymbol(exportSpecifier);
+                if (localSymbol) {
+                    const res = cbSymbol(localSymbol, /*rootSymbol*/ undefined, /*baseSymbol*/ undefined, EntryKind.Node);
+                    if (res) return res;
+                }
             }
 
             // symbolAtLocation for a binding element is the local symbol. See if the search symbol is the property.

--- a/tests/baselines/reference/renameExportSpecifier.baseline
+++ b/tests/baselines/reference/renameExportSpecifier.baseline
@@ -1,0 +1,9 @@
+/*====== /tests/cases/fourslash/a.ts ======*/
+
+const name = {};
+export { name as [|RENAME|] };
+
+/*====== /tests/cases/fourslash/b.ts ======*/
+
+import { RENAME } from './a';
+const x = RENAME.toString();

--- a/tests/baselines/reference/renameExportSpecifier2.baseline
+++ b/tests/baselines/reference/renameExportSpecifier2.baseline
@@ -1,0 +1,9 @@
+/*====== /tests/cases/fourslash/a.ts ======*/
+
+const RENAME = {};
+export { [|RENAME|] };
+
+/*====== /tests/cases/fourslash/b.ts ======*/
+
+import { RENAME } from './a';
+const x = RENAME.toString();

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -359,6 +359,7 @@ declare namespace FourSlashInterface {
         renameInfoSucceeded(displayName?: string, fullDisplayName?: string, kind?: string, kindModifiers?: string, fileToRename?: string, range?: Range, allowRenameOfImportPath?: boolean): void;
         renameInfoFailed(message?: string, allowRenameOfImportPath?: boolean): void;
         renameLocations(startRanges: ArrayOrSingle<Range>, options: RenameLocationsOptions): void;
+        baselineRename(marker: string, options: RenameOptions): void;
 
         /** Verify the quick info available at the current marker. */
         quickInfoIs(expectedText: string, expectedDocumentation?: string): void;
@@ -723,6 +724,8 @@ declare namespace FourSlashInterface {
         readonly ranges: ReadonlyArray<RenameLocationOptions>;
         readonly providePrefixAndSuffixTextForRename?: boolean;
     };
+
+    type RenameOptions = { readonly findInStrings?: boolean, readonly findInComments?: boolean, readonly providePrefixAndSuffixTextForRename?: boolean };
     type RenameLocationOptions = Range | { readonly range: Range, readonly prefixText?: string, readonly suffixText?: string };
     type DiagnosticIgnoredInterpolations = { template: string }
 }

--- a/tests/cases/fourslash/renameExportSpecifier.ts
+++ b/tests/cases/fourslash/renameExportSpecifier.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a.ts
+////const name = {};
+////export { name as name/**/ };
+
+// @Filename: b.ts
+////import { name } from './a';
+////const x = name.toString();
+
+verify.baselineRename("", { providePrefixAndSuffixTextForRename: false });

--- a/tests/cases/fourslash/renameExportSpecifier2.ts
+++ b/tests/cases/fourslash/renameExportSpecifier2.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a.ts
+////const name = {};
+////export { name/**/ };
+
+// @Filename: b.ts
+////import { name } from './a';
+////const x = name.toString();
+
+verify.baselineRename("", { providePrefixAndSuffixTextForRename: false });


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #36695, which I suspect was a regression from #36490 

