### PR TITLE
Set correct pos for NamespaceExport

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6576,8 +6576,8 @@ namespace ts {
             return finishNode(node);
         }
 
-        function parseNamespaceExport(): NamespaceExport {
-            const node = <NamespaceExport>createNode(SyntaxKind.NamespaceExport);
+        function parseNamespaceExport(pos: number): NamespaceExport {
+            const node = <NamespaceExport>createNode(SyntaxKind.NamespaceExport, pos);
             node.name = parseIdentifier();
             return finishNode(node);
         }
@@ -6585,9 +6585,10 @@ namespace ts {
         function parseExportDeclaration(node: ExportDeclaration): ExportDeclaration {
             node.kind = SyntaxKind.ExportDeclaration;
             node.isTypeOnly = parseOptional(SyntaxKind.TypeKeyword);
+            const namespaceExportPos = scanner.getStartPos();
             if (parseOptional(SyntaxKind.AsteriskToken)) {
                 if (parseOptional(SyntaxKind.AsKeyword)) {
-                    node.exportClause = parseNamespaceExport();
+                    node.exportClause = parseNamespaceExport(namespaceExportPos);
                 }
                 parseExpected(SyntaxKind.FromKeyword);
                 node.moduleSpecifier = parseModuleSpecifier();

--- a/tests/baselines/reference/exportAsNamespace1(module=amd).symbols
+++ b/tests/baselines/reference/exportAsNamespace1(module=amd).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace1(module=commonjs).symbols
+++ b/tests/baselines/reference/exportAsNamespace1(module=commonjs).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace1(module=es2015).symbols
+++ b/tests/baselines/reference/exportAsNamespace1(module=es2015).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace1(module=esnext).symbols
+++ b/tests/baselines/reference/exportAsNamespace1(module=esnext).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace1(module=system).symbols
+++ b/tests/baselines/reference/exportAsNamespace1(module=system).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace1(module=umd).symbols
+++ b/tests/baselines/reference/exportAsNamespace1(module=umd).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace2(module=amd).symbols
+++ b/tests/baselines/reference/exportAsNamespace2(module=amd).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace2(module=commonjs).symbols
+++ b/tests/baselines/reference/exportAsNamespace2(module=commonjs).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace2(module=es2015).symbols
+++ b/tests/baselines/reference/exportAsNamespace2(module=es2015).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace2(module=esnext).symbols
+++ b/tests/baselines/reference/exportAsNamespace2(module=esnext).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace2(module=system).symbols
+++ b/tests/baselines/reference/exportAsNamespace2(module=system).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace2(module=umd).symbols
+++ b/tests/baselines/reference/exportAsNamespace2(module=umd).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 ns.b;
@@ -18,15 +18,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace3(module=amd).symbols
+++ b/tests/baselines/reference/exportAsNamespace3(module=amd).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 >ns.a : Symbol(a, Decl(1.ts, 3, 10))
@@ -40,15 +40,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace3(module=commonjs).symbols
+++ b/tests/baselines/reference/exportAsNamespace3(module=commonjs).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 >ns.a : Symbol(a, Decl(1.ts, 3, 10))
@@ -40,15 +40,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace3(module=es2015).symbols
+++ b/tests/baselines/reference/exportAsNamespace3(module=es2015).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 >ns.a : Symbol(a, Decl(1.ts, 3, 10))
@@ -40,15 +40,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace3(module=esnext).symbols
+++ b/tests/baselines/reference/exportAsNamespace3(module=esnext).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 >ns.a : Symbol(a, Decl(1.ts, 3, 10))
@@ -40,15 +40,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace3(module=system).symbols
+++ b/tests/baselines/reference/exportAsNamespace3(module=system).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 >ns.a : Symbol(a, Decl(1.ts, 3, 10))
@@ -40,15 +40,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportAsNamespace3(module=umd).symbols
+++ b/tests/baselines/reference/exportAsNamespace3(module=umd).symbols
@@ -7,7 +7,7 @@ export const b = 2;
 
 === tests/cases/conformance/es2020/modules/1.ts ===
 export * as ns from './0';
->ns : Symbol(ns, Decl(1.ts, 0, 11))
+>ns : Symbol(ns, Decl(1.ts, 0, 6))
 
 ns.a;
 >ns.a : Symbol(a, Decl(1.ts, 3, 10))
@@ -40,15 +40,15 @@ import * as foo from './1'
 
 foo.ns.a;
 >foo.ns.a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >a : Symbol(foo.ns.a, Decl(0.ts, 0, 12))
 
 foo.ns.b;
 >foo.ns.b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
->foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>foo.ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >foo : Symbol(foo, Decl(2.ts, 0, 6))
->ns : Symbol(foo.ns, Decl(1.ts, 0, 11))
+>ns : Symbol(foo.ns, Decl(1.ts, 0, 6))
 >b : Symbol(foo.ns.b, Decl(0.ts, 1, 12))
 

--- a/tests/baselines/reference/exportNamespace2.symbols
+++ b/tests/baselines/reference/exportNamespace2.symbols
@@ -4,7 +4,7 @@ export class A {}
 
 === tests/cases/conformance/externalModules/typeOnly/b.ts ===
 export * as a from './a';
->a : Symbol(a, Decl(b.ts, 0, 11))
+>a : Symbol(a, Decl(b.ts, 0, 6))
 
 === tests/cases/conformance/externalModules/typeOnly/c.ts ===
 import type { a } from './b';

--- a/tests/baselines/reference/exportNamespace3.symbols
+++ b/tests/baselines/reference/exportNamespace3.symbols
@@ -8,7 +8,7 @@ export type { A } from './a';
 
 === tests/cases/conformance/externalModules/typeOnly/c.ts ===
 export * as a from './b';
->a : Symbol(a, Decl(c.ts, 0, 11))
+>a : Symbol(a, Decl(c.ts, 0, 6))
 
 === tests/cases/conformance/externalModules/typeOnly/d.ts ===
 import { a } from './c';

--- a/tests/cases/fourslash/referencesForStatementKeywords.ts
+++ b/tests/cases/fourslash/referencesForStatementKeywords.ts
@@ -17,7 +17,7 @@
 ////
 ////// export ... from ...
 ////[|{| "id": "exportDecl1" |}[|export|] [|type|] * [|from|] "[|{| "isWriteAccess": false, "isDefinition": false, "contextRangeId": "exportDecl1" |}./g|]";|]
-////[|{| "id": "exportDecl2" |}[|export|] [|type|] * [|as|] [|{| "isWriteAccess": true, "isDefinition": true |}H|] [|from|] "[|{| "isWriteAccess": false, "isDefinition": false, "contextRangeId": "exportDecl2" |}./h|]";|]
+////[|{| "id": "exportDecl2" |}[|export|] [|type|] [|{| "id": "exportDecl2_namespaceExport" |}* [|as|] [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeId": "exportDecl2_namespaceExport" |}H|]|] [|from|] "[|{| "isWriteAccess": false, "isDefinition": false, "contextRangeId": "exportDecl2" |}./h|]";|]
 ////[|{| "id": "exportDecl3" |}[|export|] [|type|] { [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeId": "exportDecl3" |}I|] } [|from|] "[|{| "isWriteAccess": false, "isDefinition": false, "contextRangeId": "exportDecl3" |}./i|]";|]
 ////[|{| "id": "exportDecl4" |}[|export|] [|type|] { j1, j2 [|as|] [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeId": "exportDecl4" |}j3|] } [|from|] "[|{| "isWriteAccess": false, "isDefinition": false, "contextRangeId": "exportDecl4" |}./j|]";|]
 ////[|{| "id": "typeDecl1" |}type [|{| "isWriteAccess": true, "isDefinition": true, "contextRangeId": "typeDecl1" |}Z1|] = 1;|]
@@ -125,6 +125,7 @@ const [
     exportDecl2,
     exportDecl2_exportKeyword,
     exportDecl2_typeKeyword,
+    exportDecl2_namespaceExport,
     exportDecl2_asKeyword,
     exportDecl2_name,
     exportDecl2_fromKeyword,


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #36762 

Baseline changes verify this works, but the output of a simple script is easier to look at:

```
ExportDeclaration (0, 27) 'export * as ns from "test";'
  NamespaceExport (6, 14) ' * as ns'
    Identifier (11, 14) ' ns'
  StringLiteral (19, 26) ' "test"'
EndOfFileToken (27, 27) ''
```
