### PR TITLE
Add separate PrivateIdentifier and SourceFile constructors

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -5932,6 +5932,24 @@ namespace ts {
         this.flowNode = undefined;
     }
 
+    function PrivateIdentifier(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
+        this.pos = pos;
+        this.end = end;
+        this.kind = kind;
+        this.id = 0;
+        this.flags = NodeFlags.None;
+        this.transformFlags = TransformFlags.None;
+        this.parent = undefined!;
+        this.original = undefined;
+        this.flowNode = undefined;
+    }
+
+    function SourceFile(this: Mutable<Node>, kind: SyntaxKind, pos: number, end: number) {
+        this.pos = pos;
+        this.end = end;
+        this.kind = kind;
+    }
+
     function SourceMapSource(this: SourceMapSource, fileName: string, text: string, skipTrivia?: (pos: number) => number) {
         this.fileName = fileName;
         this.text = text;
@@ -5943,8 +5961,8 @@ namespace ts {
         getNodeConstructor: () => Node as any,
         getTokenConstructor: () => Token as any,
         getIdentifierConstructor: () => Identifier as any,
-        getPrivateIdentifierConstructor: () => Node as any,
-        getSourceFileConstructor: () => Node as any,
+        getPrivateIdentifierConstructor: () => PrivateIdentifier as any,
+        getSourceFileConstructor: () => SourceFile as any,
         getSymbolConstructor: () => Symbol as any,
         getTypeConstructor: () => Type as any,
         getSignatureConstructor: () => Signature as any,


### PR DESCRIPTION
This lowers the memory usage when compiling `src/compiler`
from **277M** to **273M**, so a modest ~1.5% win.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Same as #33431, this further splits `Node` from `SourceFile`, which reduces the size of `Node`s from **160** bytes to **144**
