### PR TITLE
Add constructor functions for {Symbol,Node}Links

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -242,6 +242,13 @@ namespace ts {
         ExportNamespace = 1 << 2,
     }
 
+    function SymbolLinks(this: SymbolLinks) {
+    }
+
+    function NodeLinks(this: NodeLinks) {
+        this.flags = 0;
+    }
+
     export function getNodeId(node: Node): number {
         if (!node.id) {
             node.id = nextNodeId;
@@ -1255,12 +1262,12 @@ namespace ts {
         function getSymbolLinks(symbol: Symbol): SymbolLinks {
             if (symbol.flags & SymbolFlags.Transient) return <TransientSymbol>symbol;
             const id = getSymbolId(symbol);
-            return symbolLinks[id] || (symbolLinks[id] = {});
+            return symbolLinks[id] || (symbolLinks[id] = new (<any>SymbolLinks)());
         }
 
         function getNodeLinks(node: Node): NodeLinks {
             const nodeId = getNodeId(node);
-            return nodeLinks[nodeId] || (nodeLinks[nodeId] = { flags: 0 } as NodeLinks);
+            return nodeLinks[nodeId] || (nodeLinks[nodeId] = new (<any>NodeLinks)());
         }
 
         function isGlobalSourceFile(node: Node) {


### PR DESCRIPTION
Using a constructor function like this can help node better optimize
object allocation. This improves memory usage when compiling
`src/compiler` from **277M** to **270M**, a nice ~3% win.

<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Inspired by #33431, looking how far I can take this.
