### PR TITLE
Clean up convert-to-async refactor

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -32,7 +32,8 @@ namespace ts.codefix {
         readonly kind: SynthBindingNameKind.Identifier;
         readonly identifier: Identifier;
         readonly types: Type[];
-        numberOfAssignmentsOriginal: number; // number of times the variable should be assigned in the refactor
+        /** A declaration for this identifier has already been generated */
+        hasBeenDeclared: boolean;
     }
 
     interface SymbolAndIdentifier {
@@ -43,10 +44,7 @@ namespace ts.codefix {
     interface Transformer {
         readonly checker: TypeChecker;
         readonly synthNamesMap: Map<SynthIdentifier>; // keys are the symbol id of the identifier
-        readonly allVarNames: readonly SymbolAndIdentifier[];
         readonly setOfExpressionsToReturn: ReadonlyMap<true>; // keys are the node ids of the expressions
-        readonly constIdentifiers: Identifier[];
-        readonly originalTypeMap: ReadonlyMap<Type>; // keys are the node id of the identifier
         readonly isInJSFile: boolean;
     }
 
@@ -69,14 +67,11 @@ namespace ts.codefix {
         }
 
         const synthNamesMap: Map<SynthIdentifier> = createMap();
-        const originalTypeMap: Map<Type> = createMap();
-        const allVarNames: SymbolAndIdentifier[] = [];
         const isInJavascript = isInJSFile(functionToConvert);
         const setOfExpressionsToReturn = getAllPromiseExpressionsToReturn(functionToConvert, checker);
-        const functionToConvertRenamed = renameCollidingVarNames(functionToConvert, checker, synthNamesMap, context, setOfExpressionsToReturn, originalTypeMap, allVarNames);
-        const constIdentifiers = getConstIdentifiers(synthNamesMap);
+        const functionToConvertRenamed = renameCollidingVarNames(functionToConvert, checker, synthNamesMap, context.sourceFile);
         const returnStatements = functionToConvertRenamed.body && isBlock(functionToConvertRenamed.body) ? getReturnStatementsWithPromiseHandlers(functionToConvertRenamed.body) : emptyArray;
-        const transformer: Transformer = { checker, synthNamesMap, allVarNames, setOfExpressionsToReturn, constIdentifiers, originalTypeMap, isInJSFile: isInJavascript };
+        const transformer: Transformer = { checker, synthNamesMap, setOfExpressionsToReturn, isInJSFile: isInJavascript };
 
         if (!returnStatements.length) {
             return;
@@ -88,7 +83,7 @@ namespace ts.codefix {
         for (const returnStatement of returnStatements) {
             forEachChild(returnStatement, function visit(node) {
                 if (isCallExpression(node)) {
-                    const newNodes = transformExpression(node, transformer, node);
+                    const newNodes = transformExpression(node, transformer);
                     changes.replaceNodeWithNodes(sourceFile, returnStatement, newNodes);
                 }
                 else if (!isFunctionLike(node)) {
@@ -106,18 +101,6 @@ namespace ts.codefix {
         return res;
     }
 
-    // Returns the identifiers that are never reassigned in the refactor
-    function getConstIdentifiers(synthNamesMap: ReadonlyMap<SynthIdentifier>): Identifier[] {
-        const constIdentifiers: Identifier[] = [];
-        synthNamesMap.forEach((val) => {
-            if (val.numberOfAssignmentsOriginal === 0) {
-                constIdentifiers.push(val.identifier);
-            }
-        });
-        return constIdentifiers;
-    }
-
-
     /*
         Finds all of the expressions of promise type that should not be saved in a variable during the refactor
     */
@@ -127,18 +110,17 @@ namespace ts.codefix {
         }
 
         const setOfExpressionsToReturn: Map<true> = createMap<true>();
-
         forEachChild(func.body, function visit(node: Node) {
-            if (isPromiseReturningExpression(node, checker, "then")) {
+            if (isPromiseReturningCallExpression(node, checker, "then")) {
                 setOfExpressionsToReturn.set(getNodeId(node).toString(), true);
-                forEach((<CallExpression>node).arguments, visit);
+                forEach(node.arguments, visit);
             }
-            else if (isPromiseReturningExpression(node, checker, "catch")) {
+            else if (isPromiseReturningCallExpression(node, checker, "catch")) {
                 setOfExpressionsToReturn.set(getNodeId(node).toString(), true);
                 // if .catch() is the last call in the chain, move leftward in the chain until we hit something else that should be returned
                 forEachChild(node, visit);
             }
-            else if (isPromiseReturningExpression(node, checker)) {
+            else if (isPromiseTypedExpression(node, checker)) {
                 setOfExpressionsToReturn.set(getNodeId(node).toString(), true);
                 // don't recurse here, since we won't refactor any children or arguments of the expression
             }
@@ -150,18 +132,22 @@ namespace ts.codefix {
         return setOfExpressionsToReturn;
     }
 
-
-    /*
-        Returns true if node is a promise returning expression
-        If name is not undefined, node is a promise returning call of name
-    */
-    function isPromiseReturningExpression(node: Node, checker: TypeChecker, name: string): node is CallExpression
-    function isPromiseReturningExpression(node: Node, checker: TypeChecker, name?: string): boolean
-    function isPromiseReturningExpression(node: Node, checker: TypeChecker, name?: string): boolean {
-        const isNodeExpression = name ? isCallExpression(node) : isExpression(node);
-        const isExpressionOfName = isNodeExpression && (!name || hasPropertyAccessExpressionWithName(node as CallExpression, name));
+    function isPromiseReturningCallExpression(node: Node, checker: TypeChecker, name: string): node is CallExpression {
+        if (!isCallExpression(node)) return false;
+        const isExpressionOfName = hasPropertyAccessExpressionWithName(node, name);
         const nodeType = isExpressionOfName && checker.getTypeAtLocation(node);
         return !!(nodeType && checker.getPromisedTypeOfPromise(nodeType));
+    }
+
+    function isParameterOfPromiseCallback(node: Node, checker: TypeChecker): node is ParameterDeclaration {
+        return isParameter(node) && (
+            isPromiseReturningCallExpression(node.parent.parent, checker, "then") ||
+            isPromiseReturningCallExpression(node.parent.parent, checker, "catch"));
+    }
+
+    function isPromiseTypedExpression(node: Node, checker: TypeChecker): node is Expression {
+        if (!isExpression(node)) return false;
+        return !!checker.getPromisedTypeOfPromise(checker.getTypeAtLocation(node));
     }
 
     function declaredInFile(symbol: Symbol, sourceFile: SourceFile): boolean {
@@ -173,10 +159,10 @@ namespace ts.codefix {
         This function collects all existing identifier names and names of identifiers that will be created in the refactor.
         It then checks for any collisions and renames them through getSynthesizedDeepClone
     */
-    function renameCollidingVarNames(nodeToRename: FunctionLikeDeclaration, checker: TypeChecker, synthNamesMap: Map<SynthIdentifier>, context: CodeFixContextBase, setOfAllExpressionsToReturn: Map<true>, originalType: Map<Type>, allVarNames: SymbolAndIdentifier[]): FunctionLikeDeclaration {
-
-        const identsToRenameMap: Map<Identifier> = createMap(); // key is the symbol id
-        const collidingSymbolMap: Map<Symbol[]> = createMap();
+    function renameCollidingVarNames(nodeToRename: FunctionLikeDeclaration, checker: TypeChecker, synthNamesMap: Map<SynthIdentifier>, sourceFile: SourceFile): FunctionLikeDeclaration {
+        const variableNames: SymbolAndIdentifier[] = [];
+        const identsToRenameMap = createMap<Identifier>(); // key is the symbol id
+        const collidingSymbolMap = createMultiMap<Symbol>();
         forEachChild(nodeToRename, function visit(node: Node) {
             if (!isIdentifier(node)) {
                 forEachChild(node, visit);
@@ -184,24 +170,28 @@ namespace ts.codefix {
             }
 
             const symbol = checker.getSymbolAtLocation(node);
-            const isDefinedInFile = symbol && declaredInFile(symbol, context.sourceFile);
+            const isDefinedInFile = symbol && declaredInFile(symbol, sourceFile);
 
             if (symbol && isDefinedInFile) {
                 const type = checker.getTypeAtLocation(node);
+                // Note - the choice of the last call signature is arbitrary
                 const lastCallSignature = getLastCallSignature(type, checker);
                 const symbolIdString = getSymbolId(symbol).toString();
 
-                // if the identifier refers to a function we want to add the new synthesized variable for the declaration (ex. blob in let blob = res(arg))
-                // Note - the choice of the last call signature is arbitrary
+                // If the identifier refers to a function, we want to add the new synthesized variable for the declaration. Example:
+                //   fetch('...').then(response => { ... })
+                // will eventually become
+                //   const response = await fetch('...')
+                // so we push an entry for 'response'.
                 if (lastCallSignature && !isFunctionLikeDeclaration(node.parent) && !synthNamesMap.has(symbolIdString)) {
                     const firstParameter = firstOrUndefined(lastCallSignature.parameters);
                     const ident = firstParameter && isParameter(firstParameter.valueDeclaration) && tryCast(firstParameter.valueDeclaration.name, isIdentifier) || createOptimisticUniqueName("result");
                     const synthName = getNewNameIfConflict(ident, collidingSymbolMap);
                     synthNamesMap.set(symbolIdString, synthName);
-                    allVarNames.push({ identifier: synthName.identifier, symbol });
-                    addNameToFrequencyMap(collidingSymbolMap, ident.text, symbol);
+                    variableNames.push({ identifier: synthName.identifier, symbol });
+                    collidingSymbolMap.add(ident.text, symbol);
                 }
-                // we only care about identifiers that are parameters, declarations, or binding elements (don't care about other uses)
+                // We only care about identifiers that are parameters, variable declarations, or binding elements
                 else if (node.parent && (isParameter(node.parent) || isVariableDeclaration(node.parent) || isBindingElement(node.parent))) {
                     const originalName = node.text;
                     const collidingSymbols = collidingSymbolMap.get(originalName);
@@ -211,103 +201,63 @@ namespace ts.codefix {
                         const newName = getNewNameIfConflict(node, collidingSymbolMap);
                         identsToRenameMap.set(symbolIdString, newName.identifier);
                         synthNamesMap.set(symbolIdString, newName);
-                        allVarNames.push({ identifier: newName.identifier, symbol });
-                        addNameToFrequencyMap(collidingSymbolMap, originalName, symbol);
+                        variableNames.push({ identifier: newName.identifier, symbol });
+                        collidingSymbolMap.add(originalName, symbol);
                     }
                     else {
                         const identifier = getSynthesizedDeepClone(node);
                         identsToRenameMap.set(symbolIdString, identifier);
-                        synthNamesMap.set(symbolIdString, createSynthIdentifier(identifier, [], allVarNames.filter(elem => elem.identifier.text === node.text).length/*, numberOfAssignmentsSynthesized: 0*/));
-                        if ((isParameter(node.parent) && isExpressionOrCallOnTypePromise(node.parent.parent)) || isVariableDeclaration(node.parent)) {
-                            allVarNames.push({ identifier, symbol });
-                            addNameToFrequencyMap(collidingSymbolMap, originalName, symbol);
+                        synthNamesMap.set(symbolIdString, createSynthIdentifier(identifier));
+                        if (isParameterOfPromiseCallback(node.parent, checker) || isVariableDeclaration(node.parent)) {
+                            variableNames.push({ identifier, symbol });
+                            collidingSymbolMap.add(originalName, symbol);
                         }
                     }
                 }
             }
         });
 
-        return getSynthesizedDeepCloneWithRenames(nodeToRename, /*includeTrivia*/ true, identsToRenameMap, checker, deepCloneCallback);
-
-        function isExpressionOrCallOnTypePromise(child: Node): boolean {
-            const node = child.parent;
-            if (isCallExpression(node) || isIdentifier(node) && !setOfAllExpressionsToReturn.get(getNodeId(node).toString())) {
-                const nodeType = checker.getTypeAtLocation(node);
-                const isPromise = nodeType && checker.getPromisedTypeOfPromise(nodeType);
-                return !!isPromise;
-            }
-
-            return false;
-        }
-
-        function deepCloneCallback(node: Node, clone: Node) {
-            if (isIdentifier(node)) {
-                const symbol = checker.getSymbolAtLocation(node);
-                const symboldIdString = symbol && getSymbolId(symbol).toString();
-                const renameInfo = symbol && synthNamesMap.get(symboldIdString!);
-
-                if (renameInfo) {
-                    const type = checker.getTypeAtLocation(node);
-                    originalType.set(getNodeId(clone).toString(), type);
-                }
-            }
-
-            const val = setOfAllExpressionsToReturn.get(getNodeId(node).toString());
-            if (val !== undefined) {
-                setOfAllExpressionsToReturn.delete(getNodeId(node).toString());
-                setOfAllExpressionsToReturn.set(getNodeId(clone).toString(), val);
-            }
-        }
-
-    }
-
-    function addNameToFrequencyMap(renamedVarNameFrequencyMap: Map<Symbol[]>, originalName: string, symbol: Symbol) {
-        if (renamedVarNameFrequencyMap.has(originalName)) {
-            renamedVarNameFrequencyMap.get(originalName)!.push(symbol);
-        }
-        else {
-            renamedVarNameFrequencyMap.set(originalName, [symbol]);
-        }
+        return getSynthesizedDeepCloneWithRenames(nodeToRename, /*includeTrivia*/ true, identsToRenameMap, checker);
     }
 
     function getNewNameIfConflict(name: Identifier, originalNames: ReadonlyMap<Symbol[]>): SynthIdentifier {
         const numVarsSameName = (originalNames.get(name.text) || emptyArray).length;
-        const numberOfAssignmentsOriginal = 0;
         const identifier = numVarsSameName === 0 ? name : createIdentifier(name.text + "_" + numVarsSameName);
-        return createSynthIdentifier(identifier, [], numberOfAssignmentsOriginal);
+        return createSynthIdentifier(identifier);
+    }
+
+    function silentFail() {
+        codeActionSucceeded = false;
+        return emptyArray;
     }
 
     // dispatch function to recursively build the refactoring
     // should be kept up to date with isFixablePromiseHandler in suggestionDiagnostics.ts
-    function transformExpression(node: Expression, transformer: Transformer, outermostParent: CallExpression, prevArgName?: SynthBindingName): readonly Statement[] {
-        if (!node) {
-            return emptyArray;
+    function transformExpression(node: Expression, transformer: Transformer, prevArgName?: SynthBindingName): readonly Statement[] {
+        if (isPromiseReturningCallExpression(node, transformer.checker, "then")) {
+            if (node.arguments.length === 0) return silentFail();
+            return transformThen(node, transformer, prevArgName);
         }
-
-        const originalType = isIdentifier(node) && transformer.originalTypeMap.get(getNodeId(node).toString());
-        const nodeType = originalType || transformer.checker.getTypeAtLocation(node);
-
-        if (isPromiseReturningExpression(node, transformer.checker, "then")) {
-            return transformThen(node, transformer, outermostParent, prevArgName);
-        }
-        else if (isPromiseReturningExpression(node, transformer.checker, "catch")) {
+        if (isPromiseReturningCallExpression(node, transformer.checker, "catch")) {
+            if (node.arguments.length === 0) return silentFail();
             return transformCatch(node, transformer, prevArgName);
         }
-        else if (isPropertyAccessExpression(node)) {
-            return transformExpression(node.expression, transformer, outermostParent, prevArgName);
-        }
-        else if (nodeType && transformer.checker.getPromisedTypeOfPromise(nodeType)) {
-            return transformPromiseCall(node, transformer, prevArgName);
+        if (isPropertyAccessExpression(node)) {
+            return transformExpression(node.expression, transformer, prevArgName);
         }
 
-        codeActionSucceeded = false;
-        return emptyArray;
+        const nodeType = transformer.checker.getTypeAtLocation(node);
+        if (nodeType && transformer.checker.getPromisedTypeOfPromise(nodeType)) {
+            Debug.assertNode(node.original!.parent, isPropertyAccessExpression);
+            return transformPromiseExpressionOfPropertyAccess(node, transformer, prevArgName);
+        }
+
+        return silentFail();
     }
 
     function transformCatch(node: CallExpression, transformer: Transformer, prevArgName?: SynthBindingName): readonly Statement[] {
         const func = node.arguments[0];
         const argName = getArgBindingName(func, transformer);
-        const shouldReturn = transformer.setOfExpressionsToReturn.get(getNodeId(node).toString());
         let possibleNameForVarDecl: SynthIdentifier | undefined;
 
         /*
@@ -315,7 +265,7 @@ namespace ts.codefix {
             To do this, we will need to synthesize a variable that we were not aware of while we were adding identifiers to the synthNamesMap
             We will use the prevArgName and then update the synthNamesMap with a new variable name for the next transformation step
         */
-        if (prevArgName && !shouldReturn) {
+        if (prevArgName && !shouldReturn(node, transformer)) {
             if (isSynthIdentifier(prevArgName)) {
                 possibleNameForVarDecl = prevArgName;
                 transformer.synthNamesMap.forEach((val, key) => {
@@ -329,15 +279,13 @@ namespace ts.codefix {
                 possibleNameForVarDecl = createSynthIdentifier(createOptimisticUniqueName("result"), prevArgName.types);
             }
 
-            possibleNameForVarDecl.numberOfAssignmentsOriginal = 2; // Try block and catch block
-            // update the constIdentifiers list
-            if (transformer.constIdentifiers.some(elem => elem.text === possibleNameForVarDecl!.identifier.text)) {
-                transformer.constIdentifiers.push(createUniqueSynthName(possibleNameForVarDecl).identifier);
-            }
+            // We are about to write a 'let' variable declaration, but `transformExpression` for both
+            // the try block and catch block will assign to this name. Setting this flag indicates
+            // that future assignments should be written as `name = value` instead of `const name = value`.
+            possibleNameForVarDecl.hasBeenDeclared = true;
         }
 
-        const tryBlock = createBlock(transformExpression(node.expression, transformer, node, possibleNameForVarDecl));
-
+        const tryBlock = createBlock(transformExpression(node.expression, transformer, possibleNameForVarDecl));
         const transformationBody = getTransformationBody(func, possibleNameForVarDecl, argName, node, transformer);
         const catchArg = argName ? isSynthIdentifier(argName) ? argName.identifier.text : argName.bindingPattern : "e";
         const catchVariableDeclaration = createVariableDeclaration(catchArg);
@@ -348,7 +296,7 @@ namespace ts.codefix {
         */
         let varDeclList: VariableStatement | undefined;
         let varDeclIdentifier: Identifier | undefined;
-        if (possibleNameForVarDecl && !shouldReturn) {
+        if (possibleNameForVarDecl && !shouldReturn(node, transformer)) {
             varDeclIdentifier = getSynthesizedDeepClone(possibleNameForVarDecl.identifier);
             const typeArray: Type[] = possibleNameForVarDecl.types;
             const unionType = transformer.checker.getUnionType(typeArray, UnionReduction.Subtype);
@@ -363,77 +311,50 @@ namespace ts.codefix {
         return compact([varDeclList, tryStatement, destructuredResult]);
     }
 
-    function getIdentifierTextsFromBindingName(bindingName: BindingName): readonly string[] {
-        if (isIdentifier(bindingName)) return [bindingName.text];
-        return flatMap(bindingName.elements, element => {
-            if (isOmittedExpression(element)) return [];
-            return getIdentifierTextsFromBindingName(element.name);
-        });
-    }
-
     function createUniqueSynthName(prevArgName: SynthIdentifier): SynthIdentifier {
         const renamedPrevArg = createOptimisticUniqueName(prevArgName.identifier.text);
         return createSynthIdentifier(renamedPrevArg);
     }
 
-    function transformThen(node: CallExpression, transformer: Transformer, outermostParent: CallExpression, prevArgName?: SynthBindingName): readonly Statement[] {
-        const [res, rej] = node.arguments;
+    function transformThen(node: CallExpression, transformer: Transformer, prevArgName?: SynthBindingName): readonly Statement[] {
+        const [onFulfilled, onRejected] = node.arguments;
+        const onFulfilledArgumentName = getArgBindingName(onFulfilled, transformer);
+        const transformationBody = getTransformationBody(onFulfilled, prevArgName, onFulfilledArgumentName, node, transformer);
 
-        if (!res) {
-            return transformExpression(node.expression, transformer, outermostParent);
-        }
-
-        const argNameRes = getArgBindingName(res, transformer);
-        const transformationBody = getTransformationBody(res, prevArgName, argNameRes, node, transformer);
-
-        if (rej) {
-            const argNameRej = getArgBindingName(rej, transformer);
-
-            const tryBlock = createBlock(transformExpression(node.expression, transformer, node, argNameRes).concat(transformationBody));
-
-            const transformationBody2 = getTransformationBody(rej, prevArgName, argNameRej, node, transformer);
-
-            const catchArg = argNameRej ? isSynthIdentifier(argNameRej) ? argNameRej.identifier.text : argNameRej.bindingPattern : "e";
+        if (onRejected) {
+            const onRejectedArgumentName = getArgBindingName(onRejected, transformer);
+            const tryBlock = createBlock(transformExpression(node.expression, transformer, onFulfilledArgumentName).concat(transformationBody));
+            const transformationBody2 = getTransformationBody(onRejected, prevArgName, onRejectedArgumentName, node, transformer);
+            const catchArg = onRejectedArgumentName ? isSynthIdentifier(onRejectedArgumentName) ? onRejectedArgumentName.identifier.text : onRejectedArgumentName.bindingPattern : "e";
             const catchVariableDeclaration = createVariableDeclaration(catchArg);
             const catchClause = createCatchClause(catchVariableDeclaration, createBlock(transformationBody2));
 
             return [createTry(tryBlock, catchClause, /* finallyBlock */ undefined)];
         }
 
-        return transformExpression(node.expression, transformer, node, argNameRes).concat(transformationBody);
+        return transformExpression(node.expression, transformer, onFulfilledArgumentName).concat(transformationBody);
     }
 
-    function getFlagOfBindingName(bindingName: SynthBindingName, constIdentifiers: readonly Identifier[]): NodeFlags {
-        const identifiers = getIdentifierTextsFromBindingName(getNode(bindingName));
-        const inArr: boolean = constIdentifiers.some(elem => contains(identifiers, elem.text));
-        return inArr ? NodeFlags.Const : NodeFlags.Let;
-    }
-
-    function transformPromiseCall(node: Expression, transformer: Transformer, prevArgName?: SynthBindingName): readonly Statement[] {
-        const shouldReturn = transformer.setOfExpressionsToReturn.get(getNodeId(node).toString());
-        // the identifier is empty when the handler (.then()) ignores the argument - In this situation we do not need to save the result of the promise returning call
-        const originalNodeParent = node.original ? node.original.parent : node.parent;
-        Debug.assertDefined(originalNodeParent);
-        Debug.assertNode(originalNodeParent, isPropertyAccessExpression);
-        if (prevArgName && !shouldReturn && (!originalNodeParent || isPropertyAccessExpression(originalNodeParent))) {
-            return createTransformedStatement(prevArgName, createAwait(node), transformer);
-        }
-        else if (!prevArgName && !shouldReturn && (!originalNodeParent || isPropertyAccessExpression(originalNodeParent))) {
-            return [createStatement(createAwait(node))];
+    /**
+     * Transforms the 'x' part of `x.then(...)`, or the 'y()' part of `y.catch(...)`, where 'x' and 'y()' are Promises.
+     */
+    function transformPromiseExpressionOfPropertyAccess(node: Expression, transformer: Transformer, prevArgName?: SynthBindingName): readonly Statement[] {
+        if (shouldReturn(node, transformer)) {
+            return [createReturn(getSynthesizedDeepClone(node))];
         }
 
-        return [createReturn(getSynthesizedDeepClone(node))];
+        return createVariableOrAssignmentOrExpressionStatement(prevArgName, createAwait(node));
     }
 
-    function createTransformedStatement(prevArgName: SynthBindingName | undefined, rightHandSide: Expression, transformer: Transformer): readonly Statement[] {
-        if (!prevArgName || isEmpty(prevArgName)) {
+    function createVariableOrAssignmentOrExpressionStatement(variableName: SynthBindingName | undefined, rightHandSide: Expression): readonly Statement[] {
+        if (!variableName || isEmptyBindingName(variableName)) {
             // if there's no argName to assign to, there still might be side effects
-            return [createStatement(rightHandSide)];
+            return [createExpressionStatement(rightHandSide)];
         }
 
-        if (isSynthIdentifier(prevArgName) && prevArgName.types.length < prevArgName.numberOfAssignmentsOriginal) {
+        if (isSynthIdentifier(variableName) && variableName.hasBeenDeclared) {
             // if the variable has already been declared, we don't need "let" or "const"
-            return [createStatement(createAssignment(getSynthesizedDeepClone(prevArgName.identifier), rightHandSide))];
+            return [createExpressionStatement(createAssignment(getSynthesizedDeepClone(variableName.identifier), rightHandSide))];
         }
 
         return [
@@ -441,16 +362,14 @@ namespace ts.codefix {
                 /*modifiers*/ undefined,
                 createVariableDeclarationList([
                     createVariableDeclaration(
-                        getSynthesizedDeepClone(getNode(prevArgName)),
+                        getSynthesizedDeepClone(getNode(variableName)),
                         /*type*/ undefined,
                         rightHandSide)],
-                    getFlagOfBindingName(prevArgName, transformer.constIdentifiers)))];
+                    NodeFlags.Const))];
     }
 
     // should be kept up to date with isFixablePromiseArgument in suggestionDiagnostics.ts
     function getTransformationBody(func: Expression, prevArgName: SynthBindingName | undefined, argName: SynthBindingName | undefined, parent: CallExpression, transformer: Transformer): readonly Statement[] {
-
-        const shouldReturn = transformer.setOfExpressionsToReturn.get(getNodeId(parent).toString());
         switch (func.kind) {
             case SyntaxKind.NullKeyword:
                 // do not produce a transformed statement for a null argument
@@ -462,19 +381,18 @@ namespace ts.codefix {
                 }
 
                 const synthCall = createCall(getSynthesizedDeepClone(func as Identifier), /*typeArguments*/ undefined, isSynthIdentifier(argName) ? [argName.identifier] : []);
-                if (shouldReturn) {
+                if (shouldReturn(parent, transformer)) {
                     return [createReturn(synthCall)];
                 }
 
-                const type = transformer.originalTypeMap.get(getNodeId(func).toString()) || transformer.checker.getTypeAtLocation(func);
+                const type = transformer.checker.getTypeAtLocation(func);
                 const callSignatures = transformer.checker.getSignaturesOfType(type, SignatureKind.Call);
                 if (!callSignatures.length) {
                     // if identifier in handler has no call signatures, it's invalid
-                    codeActionSucceeded = false;
-                    break;
+                    return silentFail();
                 }
                 const returnType = callSignatures[0].getReturnType();
-                const varDeclOrAssignment = createTransformedStatement(prevArgName, createAwait(synthCall), transformer);
+                const varDeclOrAssignment = createVariableOrAssignmentOrExpressionStatement(prevArgName, createAwait(synthCall));
                 if (prevArgName) {
                     prevArgName.types.push(returnType);
                 }
@@ -501,8 +419,9 @@ namespace ts.codefix {
                         }
                     }
 
-                    return shouldReturn ? refactoredStmts.map(s => getSynthesizedDeepClone(s)) :
-                        removeReturns(
+                    return shouldReturn(parent, transformer)
+                        ? refactoredStmts.map(s => getSynthesizedDeepClone(s))
+                        : removeReturns(
                             refactoredStmts,
                             prevArgName,
                             transformer,
@@ -520,8 +439,8 @@ namespace ts.codefix {
                     const returnType = getLastCallSignature(type, transformer.checker)!.getReturnType();
                     const rightHandSide = getSynthesizedDeepClone(funcBody);
                     const possiblyAwaitedRightHandSide = !!transformer.checker.getPromisedTypeOfPromise(returnType) ? createAwait(rightHandSide) : rightHandSide;
-                    if (!shouldReturn) {
-                        const transformedStatement = createTransformedStatement(prevArgName, possiblyAwaitedRightHandSide, transformer);
+                    if (!shouldReturn(parent, transformer)) {
+                        const transformedStatement = createVariableOrAssignmentOrExpressionStatement(prevArgName, possiblyAwaitedRightHandSide);
                         if (prevArgName) {
                             prevArgName.types.push(returnType);
                         }
@@ -534,8 +453,7 @@ namespace ts.codefix {
             }
             default:
                 // If no cases apply, we've found a transformation body we don't know how to handle, so the refactoring should no-op to avoid deleting code.
-                codeActionSucceeded = false;
-                break;
+                return silentFail();
         }
         return emptyArray;
     }
@@ -551,13 +469,13 @@ namespace ts.codefix {
         for (const stmt of stmts) {
             if (isReturnStatement(stmt)) {
                 if (stmt.expression) {
-                    const possiblyAwaitedExpression = isPromiseReturningExpression(stmt.expression, transformer.checker) ? createAwait(stmt.expression) : stmt.expression;
+                    const possiblyAwaitedExpression = isPromiseTypedExpression(stmt.expression, transformer.checker) ? createAwait(stmt.expression) : stmt.expression;
                     if (prevArgName === undefined) {
                         ret.push(createExpressionStatement(possiblyAwaitedExpression));
                     }
                     else {
                         ret.push(createVariableStatement(/*modifiers*/ undefined,
-                            (createVariableDeclarationList([createVariableDeclaration(getNode(prevArgName), /*type*/ undefined, possiblyAwaitedExpression)], getFlagOfBindingName(prevArgName, transformer.constIdentifiers)))));
+                            (createVariableDeclarationList([createVariableDeclaration(getNode(prevArgName), /*type*/ undefined, possiblyAwaitedExpression)], NodeFlags.Const))));
                     }
                 }
             }
@@ -569,7 +487,7 @@ namespace ts.codefix {
         // if block has no return statement, need to define prevArgName as undefined to prevent undeclared variables
         if (!seenReturnStatement && prevArgName !== undefined) {
             ret.push(createVariableStatement(/*modifiers*/ undefined,
-                (createVariableDeclarationList([createVariableDeclaration(getNode(prevArgName), /*type*/ undefined, createIdentifier("undefined"))], getFlagOfBindingName(prevArgName, transformer.constIdentifiers)))));
+                (createVariableDeclarationList([createVariableDeclaration(getNode(prevArgName), /*type*/ undefined, createIdentifier("undefined"))], NodeFlags.Const))));
         }
 
         return ret;
@@ -577,12 +495,11 @@ namespace ts.codefix {
 
 
     function getInnerTransformationBody(transformer: Transformer, innerRetStmts: readonly Node[], prevArgName?: SynthBindingName) {
-
         let innerCbBody: Statement[] = [];
         for (const stmt of innerRetStmts) {
             forEachChild(stmt, function visit(node) {
                 if (isCallExpression(node)) {
-                    const temp = transformExpression(node, transformer, node, prevArgName);
+                    const temp = transformExpression(node, transformer, prevArgName);
                     innerCbBody = innerCbBody.concat(temp);
                     if (innerCbBody.length > 0) {
                         return;
@@ -597,10 +514,7 @@ namespace ts.codefix {
     }
 
     function getArgBindingName(funcNode: Expression, transformer: Transformer): SynthBindingName | undefined {
-
-        const numberOfAssignmentsOriginal = 0;
         const types: Type[] = [];
-
         let name: SynthBindingName | undefined;
 
         if (isFunctionLikeDeclaration(funcNode)) {
@@ -636,11 +550,11 @@ namespace ts.codefix {
             const symbol = getSymbol(originalNode);
 
             if (!symbol) {
-                return createSynthIdentifier(identifier, types, numberOfAssignmentsOriginal);
+                return createSynthIdentifier(identifier, types);
             }
 
             const mapEntry = transformer.synthNamesMap.get(getSymbolId(symbol).toString());
-            return mapEntry || createSynthIdentifier(identifier, types, numberOfAssignmentsOriginal);
+            return mapEntry || createSynthIdentifier(identifier, types);
         }
 
         function getSymbol(node: Node): Symbol | undefined {
@@ -652,22 +566,22 @@ namespace ts.codefix {
         }
     }
 
-    function isEmpty(bindingName: SynthBindingName | undefined): boolean {
+    function isEmptyBindingName(bindingName: SynthBindingName | undefined): boolean {
         if (!bindingName) {
             return true;
         }
         if (isSynthIdentifier(bindingName)) {
             return !bindingName.identifier.text;
         }
-        return every(bindingName.elements, isEmpty);
+        return every(bindingName.elements, isEmptyBindingName);
     }
 
     function getNode(bindingName: SynthBindingName) {
         return isSynthIdentifier(bindingName) ? bindingName.identifier : bindingName.bindingPattern;
     }
 
-    function createSynthIdentifier(identifier: Identifier, types: Type[] = [], numberOfAssignmentsOriginal = 0): SynthIdentifier {
-        return { kind: SynthBindingNameKind.Identifier, identifier, types, numberOfAssignmentsOriginal };
+    function createSynthIdentifier(identifier: Identifier, types: Type[] = []): SynthIdentifier {
+        return { kind: SynthBindingNameKind.Identifier, identifier, types, hasBeenDeclared: false };
     }
 
     function createSynthBindingPattern(bindingPattern: BindingPattern, elements: readonly SynthBindingName[] = emptyArray, types: Type[] = []): SynthBindingPattern {
@@ -680,5 +594,9 @@ namespace ts.codefix {
 
     function isSynthBindingPattern(bindingName: SynthBindingName): bindingName is SynthBindingPattern {
         return bindingName.kind === SynthBindingNameKind.BindingPattern;
+    }
+
+    function shouldReturn(expression: Expression, transformer: Transformer): boolean {
+        return !!expression.original && transformer.setOfExpressionsToReturn.has(getNodeId(expression.original).toString());
     }
 }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2147,11 +2147,13 @@ namespace ts {
             const renameInfo = symbol && renameMap.get(String(getSymbolId(symbol)));
 
             if (renameInfo && renameInfo.text !== (node.name || node.propertyName).getText()) {
-                clone = createBindingElement(
-                    node.dotDotDotToken,
-                    node.propertyName || node.name,
-                    renameInfo,
-                    node.initializer);
+                clone = setOriginalNode(
+                    createBindingElement(
+                        node.dotDotDotToken,
+                        node.propertyName || node.name,
+                        renameInfo,
+                        node.initializer),
+                    node);
             }
         }
         else if (renameMap && checker && isIdentifier(node)) {
@@ -2159,7 +2161,7 @@ namespace ts {
             const renameInfo = symbol && renameMap.get(String(getSymbolId(symbol)));
 
             if (renameInfo) {
-                clone = createIdentifier(renameInfo.text);
+                clone = setOriginalNode(createIdentifier(renameInfo.text), node);
             }
         }
 

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromise.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_InnerPromise.ts
@@ -14,6 +14,6 @@ function /*[#|*/innerPromise/*|]*/(): Promise<string> {
 async function innerPromise(): Promise<string> {
     const resp = await fetch("https://typescriptlang.org");
     var blob2 = resp.blob().then(blob => blob.byteOffset).catch(err => 'Error');
-    const blob_1 = blob2;
+    const blob_1 = await blob2;
     return blob_1.toString();
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicWithComments.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_basicWithComments.ts
@@ -13,7 +13,7 @@ async function f(): Promise<void>{
     /* Note - some of these comments are removed during the refactor. This is not ideal. */
 
     // a
-    /*b*/ const result = await fetch(/*d*/ 'https://typescriptlang.org' /*e*/);
+    /*b*/ const result /*g*/ = await fetch(/*d*/ 'https://typescriptlang.org' /*e*/);
     console.log(result); /*k*/
     // m
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

I have several convert-to-async bugs assigned to me, and as I started to work on them, I was frustrated by vague names, and was also confused about what some blocks of code were doing. To figure it out, I set breakpoints in the confusing code and debugged all the tests, and the breakpoints were never hit. So, as I was unable to determine the utility of large chunks of logic, and they had zero test coverage (and yet the refactor on the whole has pretty good test coverage), I decided to delete those chunks of logic. I think that much of it was predicated on _impossible_ conditions, but I can’t be 100% certain.

There was also a bit of logical branching that I determined was only necessary because identifiers weren’t being properly cloned in `getSynthesizedDeepClone`. After fixing that, two test baselines changed, revealing that they actually contained bugs before. (Remarkably, one was missing an `await` and seemed to be fundamentally broken; the other was just a comment being deleted when it should have been preserved. But otherwise, this PR does not change the behavior of the refactor as observable in any existing test.
