### PR TITLE
azure-sdk test: move typescript location

### DIFF
--- a/tests/cases/docker/azure-sdk/Dockerfile
+++ b/tests/cases/docker/azure-sdk/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /azure-sdk/sdk/core/core-http
 # Sync up all TS versions used internally so they're all linked from a known location
 RUN rush add -p "typescript@3.5.1" --dev -m
 # Relink installed TSes to built TS
-WORKDIR /azure-sdk/common/temp/node_modules/.registry.npmjs.org/typescript/3.5.1/node_modules
+WORKDIR /azure-sdk/common/temp/node_modules/.pnpm/registry.npmjs.org/typescript/3.5.1/node_modules
 RUN rm -rf typescript
 COPY --from=typescript/typescript /typescript/typescript-*.tgz /typescript.tgz
 RUN mkdir /typescript


### PR DESCRIPTION
Fixes most of the azure-sdk failures by compiling with HEAD rather than 3.5.1.
