### PR TITLE
Copy diagnostic messages to built/local to fix localization process

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -417,7 +417,15 @@ task("generate-types-map", generateTypesMap);
 const cleanTypesMap = () => del("built/local/typesMap.json");
 cleanTasks.push(cleanTypesMap);
 
-const buildOtherOutputs = parallel(buildCancellationToken, buildTypingsInstaller, buildWatchGuard, generateTypesMap);
+const builtLocalDiagnosticMessagesGeneratedJson = "built/local/diagnosticMessages.generated.json";
+const copyBuiltLocalDiagnosticMessages = () => src(diagnosticMessagesGeneratedJson)
+    .pipe(newer(builtLocalDiagnosticMessagesGeneratedJson))
+    .pipe(dest("built/local"));
+
+const cleanBuiltLocalDiagnosticMessages = () => del(builtLocalDiagnosticMessagesGeneratedJson);
+cleanTasks.push(cleanBuiltLocalDiagnosticMessages);
+
+const buildOtherOutputs = parallel(buildCancellationToken, buildTypingsInstaller, buildWatchGuard, generateTypesMap, copyBuiltLocalDiagnosticMessages);
 task("other-outputs", series(preBuild, buildOtherOutputs));
 task("other-outputs").description = "Builds miscelaneous scripts and documents distributed with the LKG";
 

--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -417,6 +417,9 @@ task("generate-types-map", generateTypesMap);
 const cleanTypesMap = () => del("built/local/typesMap.json");
 cleanTasks.push(cleanTypesMap);
 
+// Drop a copy of diagnosticMessages.generated.json into the built/local folder. This allows
+// it to be synced to the Azure DevOps repo, so that it can get picked up by the build 
+// pipeline that generates the localization artifacts that are then fed into the translation process.
 const builtLocalDiagnosticMessagesGeneratedJson = "built/local/diagnosticMessages.generated.json";
 const copyBuiltLocalDiagnosticMessages = () => src(diagnosticMessagesGeneratedJson)
     .pipe(newer(builtLocalDiagnosticMessagesGeneratedJson))


### PR DESCRIPTION
One of the changes in #24938 was that `diagnosticMessages.generated.json` stopped getting copied to the `built/local` directory. This created a tear in the fabric of space-time that any compiler messages authored after that point would disappear into, never to get localized.

This change repairs that tear by restoring [the behavior of the Jakefile before that change](https://github.com/RyanCavanaugh/TypeScript/blob/640af3f75ed2afab766eb5f7109fd9c8a2d57f76/Jakefile.js#L502) . 

With this, any new compiler messages added since #24938 should get picked up in the next localization pass and checked into the .lcl files.