### PR TITLE
Add trimTrailingWhitespace Editor Option

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -3089,6 +3089,7 @@ namespace ts.server.protocol {
         newLineCharacter?: string;
         convertTabsToSpaces?: boolean;
         indentStyle?: IndentStyle | ts.IndentStyle;
+        trimTrailingWhitespace?: boolean;
     }
 
     export interface FormatCodeSettings extends EditorSettings {

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -427,7 +427,7 @@ namespace ts.formatting {
             if (leadingTrivia) {
                 indentTriviaItems(leadingTrivia, initialIndentation, /*indentNextTokenOrTrivia*/ false,
                     item => processRange(item, sourceFile.getLineAndCharacterOfPosition(item.pos), enclosingNode, enclosingNode, /*dynamicIndentation*/ undefined!));
-                if(options.trimTrailingWhitespace!){
+                if(options.trimTrailingWhitespace !== false){
                     trimTrailingWhitespacesForRemainingRange();
                 }
             }
@@ -980,9 +980,8 @@ namespace ts.formatting {
             formattingContext.updateContext(previousItem, previousParent, currentItem, currentParent, contextNode);
 
             const rules = getRules(formattingContext);
-            const trimTrailingWhitespace = formattingContext.options.trimTrailingWhitespace!;
 
-            let trimTrailingWhitespaces = false;
+            let trimTrailingWhitespaces = formattingContext.options.trimTrailingWhitespace !== false;
             let lineAction = LineAction.None;
             if (rules) {
                 // Apply rules in reverse order so that higher priority rules (which are first in the array)
@@ -1010,11 +1009,11 @@ namespace ts.formatting {
                     }
 
                     // We need to trim trailing whitespace between the tokens if they were on different lines, and no rule was applied to put them on the same line
-                    trimTrailingWhitespaces = trimTrailingWhitespace && !(rule.action & RuleAction.DeleteSpace) && rule.flags !== RuleFlags.CanDeleteNewLines;
+                    trimTrailingWhitespaces = trimTrailingWhitespaces && !(rule.action & RuleAction.DeleteSpace) && rule.flags !== RuleFlags.CanDeleteNewLines;
                 });
             }
             else {
-                trimTrailingWhitespaces = trimTrailingWhitespace && currentItem.kind !== SyntaxKind.EndOfFileToken;
+                trimTrailingWhitespaces = trimTrailingWhitespaces && currentItem.kind !== SyntaxKind.EndOfFileToken;
             }
 
             if (currentStartLine !== previousStartLine && trimTrailingWhitespaces) {

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -427,7 +427,9 @@ namespace ts.formatting {
             if (leadingTrivia) {
                 indentTriviaItems(leadingTrivia, initialIndentation, /*indentNextTokenOrTrivia*/ false,
                     item => processRange(item, sourceFile.getLineAndCharacterOfPosition(item.pos), enclosingNode, enclosingNode, /*dynamicIndentation*/ undefined!));
-                trimTrailingWhitespacesForRemainingRange();
+                if(options.trimTrailingWhitespace!){
+                    trimTrailingWhitespacesForRemainingRange();
+                }
             }
         }
 
@@ -978,6 +980,7 @@ namespace ts.formatting {
             formattingContext.updateContext(previousItem, previousParent, currentItem, currentParent, contextNode);
 
             const rules = getRules(formattingContext);
+            const trimTrailingWhitespace = formattingContext.options.trimTrailingWhitespace!;
 
             let trimTrailingWhitespaces = false;
             let lineAction = LineAction.None;
@@ -1007,11 +1010,11 @@ namespace ts.formatting {
                     }
 
                     // We need to trim trailing whitespace between the tokens if they were on different lines, and no rule was applied to put them on the same line
-                    trimTrailingWhitespaces = !(rule.action & RuleAction.DeleteSpace) && rule.flags !== RuleFlags.CanDeleteNewLines;
+                    trimTrailingWhitespaces = trimTrailingWhitespace && !(rule.action & RuleAction.DeleteSpace) && rule.flags !== RuleFlags.CanDeleteNewLines;
                 });
             }
             else {
-                trimTrailingWhitespaces = currentItem.kind !== SyntaxKind.EndOfFileToken;
+                trimTrailingWhitespaces = trimTrailingWhitespace && currentItem.kind !== SyntaxKind.EndOfFileToken;
             }
 
             if (currentStartLine !== previousStartLine && trimTrailingWhitespaces) {

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -427,7 +427,7 @@ namespace ts.formatting {
             if (leadingTrivia) {
                 indentTriviaItems(leadingTrivia, initialIndentation, /*indentNextTokenOrTrivia*/ false,
                     item => processRange(item, sourceFile.getLineAndCharacterOfPosition(item.pos), enclosingNode, enclosingNode, /*dynamicIndentation*/ undefined!));
-                if(options.trimTrailingWhitespace !== false){
+                if (options.trimTrailingWhitespace !== false) {
                     trimTrailingWhitespacesForRemainingRange();
                 }
             }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -826,7 +826,7 @@ namespace ts {
             placeOpenBraceOnNewLineForFunctions: false,
             placeOpenBraceOnNewLineForControlBlocks: false,
             semicolons: SemicolonPreference.Ignore,
-            trimTrailingWhitespace: false
+            trimTrailingWhitespace: true
         };
     }
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -760,6 +760,7 @@ namespace ts {
         newLineCharacter?: string;
         convertTabsToSpaces?: boolean;
         indentStyle?: IndentStyle;
+        trimTrailingWhitespace?: boolean;
     }
 
     /* @deprecated - consider using FormatCodeSettings instead */
@@ -825,6 +826,7 @@ namespace ts {
             placeOpenBraceOnNewLineForFunctions: false,
             placeOpenBraceOnNewLineForControlBlocks: false,
             semicolons: SemicolonPreference.Ignore,
+            trimTrailingWhitespace: false
         };
     }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -5491,6 +5491,7 @@ declare namespace ts {
         newLineCharacter?: string;
         convertTabsToSpaces?: boolean;
         indentStyle?: IndentStyle;
+        trimTrailingWhitespace?: boolean;
     }
     interface FormatCodeOptions extends EditorOptions {
         InsertSpaceAfterCommaDelimiter: boolean;
@@ -8487,6 +8488,7 @@ declare namespace ts.server.protocol {
         newLineCharacter?: string;
         convertTabsToSpaces?: boolean;
         indentStyle?: IndentStyle | ts.IndentStyle;
+        trimTrailingWhitespace?: boolean;
     }
     interface FormatCodeSettings extends EditorSettings {
         insertSpaceAfterCommaDelimiter?: boolean;

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -5491,6 +5491,7 @@ declare namespace ts {
         newLineCharacter?: string;
         convertTabsToSpaces?: boolean;
         indentStyle?: IndentStyle;
+        trimTrailingWhitespace?: boolean;
     }
     interface FormatCodeOptions extends EditorOptions {
         InsertSpaceAfterCommaDelimiter: boolean;

--- a/tests/cases/fourslash/formatDocumentPreserveTrailingWhitespace.ts
+++ b/tests/cases/fourslash/formatDocumentPreserveTrailingWhitespace.ts
@@ -1,0 +1,26 @@
+/// <reference path="fourslash.ts" />
+
+////
+////var a;     
+////var b     
+////     
+//////     
+////function b(){     
+////    while(true){     
+////    }     
+////}     
+////
+
+format.setOption("trimTrailingWhitespace", false);
+format.document();
+
+verify.currentFileContentIs(`
+var a;     
+var b     
+     
+//     
+function b() {     
+    while (true) {     
+    }     
+}     
+`);

--- a/tests/cases/fourslash/formatSelectionPreserveTrailingWhitespace.ts
+++ b/tests/cases/fourslash/formatSelectionPreserveTrailingWhitespace.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+////
+/////*begin*/;    
+////    
+/////*end*/    
+////    
+////
+
+format.setOption("trimTrailingWhitespace", false);
+
+format.selection('begin', 'end');
+
+verify.currentFileContentIs(`
+;    
+    
+    
+    
+`);

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -126,6 +126,7 @@ declare namespace FourSlashInterface {
         newLineCharacter?: string;
         convertTabsToSpaces?: boolean;
         indentStyle?: IndentStyle;
+        trimTrailingWhitespace?: boolean;
     }
     interface FormatCodeOptions extends EditorOptions {
         InsertSpaceAfterCommaDelimiter: boolean;


### PR DESCRIPTION
[EditorConfig.org](https://editorconfig.org/) describes `trimTrailingWhitespace` as such:

> trim_trailing_whitespace: set to true to remove any whitespace characters preceding newline characters and false to ensure it doesn't.

Currently tsserver always performs formatting operations as though this setting were `true`. This change simply allows `.editorconfig` to setting `trim_triling_whitespace = false` to preserve whitespace so that the trailing whitespace denoted by the cursors below is not removed.

```ts

var a;     |<
     |<
while (true){     |<
     |<
}      |<
```
This change _should not_ change the default formatting behavior. Having `trim_trailing_whitespace = true` or the absence of the `.editorconfig` setting should exhibit the existing behavior.

fourslash tests based on [formatDocumentWithTrivia](https://github.com/microsoft/TypeScript/blob/master/tests/cases/fourslash/formatDocumentWithTrivia.ts) and [formatSelectionWithTrivia](https://github.com/microsoft/TypeScript/blob/master/tests/cases/fourslash/formatSelectionWithTrivia.ts)