### PR TITLE
Fix copy-paste error in navigateToItemIsEqualTo

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1892,7 +1892,7 @@ namespace ts.server {
                     a.fileName === b.fileName &&
                     a.isCaseSensitive === b.isCaseSensitive &&
                     a.kind === b.kind &&
-                    a.kindModifiers === b.containerName &&
+                    a.kindModifiers === b.kindModifiers &&
                     a.matchKind === b.matchKind &&
                     a.name === b.name &&
                     a.textSpan.start === b.textSpan.start &&


### PR DESCRIPTION
It was preventing de-duping of items found in multiple projects.