### PR TITLE
Fix find-refs crash on JSDocNamepath

### DIFF
--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -2469,7 +2469,7 @@ namespace ts {
 
     /** True if node is of a kind that may contain comment text. */
     export function isJSDocCommentContainingNode(node: Node): boolean {
-        return node.kind === SyntaxKind.JSDocComment || isJSDocTag(node) || isJSDocTypeLiteral(node) || isJSDocSignature(node);
+        return node.kind === SyntaxKind.JSDocComment || node.kind === SyntaxKind.JSDocNamepathType || isJSDocTag(node) || isJSDocTypeLiteral(node) || isJSDocSignature(node);
     }
 
     // TODO: determine what this does before making it public.

--- a/tests/baselines/reference/renameJSDocNamepath.baseline
+++ b/tests/baselines/reference/renameJSDocNamepath.baseline
@@ -1,0 +1,7 @@
+/*====== /tests/cases/fourslash/renameJSDocNamepath.ts ======*/
+
+/**
+ * @type {module:foo/A} x
+ */
+var x = 1
+var [|RENAME|] = 0;

--- a/tests/cases/fourslash/renameJSDocNamepath.ts
+++ b/tests/cases/fourslash/renameJSDocNamepath.ts
@@ -1,0 +1,11 @@
+// @noLib: true
+
+/// <reference path='fourslash.ts'/>
+
+//// /**
+////  * @type {module:foo/A} x
+////  */
+//// var x = 1
+//// var /*0*/A = 0;
+
+verify.baselineRename("0", {});


### PR DESCRIPTION
JSDocNamepaths span a lot of identifiers that we don't actually care about, so it's incorrect for createChildren to add its children as synthetic nodes.

Fixes #36338

Not sure who is best to review this, so I'm going with @andrewbranch and @orta since I believe @orta wrote support for JSDocNamepaths and I think @andrewbranch has worked with services a bit.
