### PR TITLE
Set CI=true in the office-ui-fabric docker test so it doesn't use a progress indicator

### DIFF
--- a/tests/cases/docker/office-ui-fabric/Dockerfile
+++ b/tests/cases/docker/office-ui-fabric/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:current
+ENV CI=true
 RUN npm install -g yarn lerna --force
 RUN git clone https://github.com/OfficeDev/office-ui-fabric-react.git /office-ui-fabric-react
 WORKDIR /office-ui-fabric-react


### PR DESCRIPTION
Should fix the _10000_ pointless new lines added to this test's output log.