### PR TITLE
Check for undefined `source.symbol` when elaborating unmatched properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16239,6 +16239,7 @@ namespace ts {
                 if (unmatchedProperty.valueDeclaration
                     && isNamedDeclaration(unmatchedProperty.valueDeclaration)
                     && isPrivateIdentifier(unmatchedProperty.valueDeclaration.name)
+                    && source.symbol
                     && source.symbol.flags & SymbolFlags.Class) {
                     const privateIdentifierDescription = unmatchedProperty.valueDeclaration.name.escapedText;
                     const symbolTableKey = getSymbolNameForPrivateIdentifier(source.symbol, privateIdentifierDescription);

--- a/tests/baselines/reference/privateFieldAssignabilityFromUnknown.errors.txt
+++ b/tests/baselines/reference/privateFieldAssignabilityFromUnknown.errors.txt
@@ -1,0 +1,16 @@
+tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts(2,3): error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
+tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts(5,7): error TS2741: Property '#field' is missing in type '{}' but required in type 'Class'.
+
+
+==== tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts (2 errors) ====
+    export class Class {
+      #field: any
+      ~~~~~~
+!!! error TS18028: Private identifiers are only available when targeting ECMAScript 2015 and higher.
+    }
+    
+    const task: Class = {} as unknown;
+          ~~~~
+!!! error TS2741: Property '#field' is missing in type '{}' but required in type 'Class'.
+!!! related TS2728 tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts:2:3: '#field' is declared here.
+    

--- a/tests/baselines/reference/privateFieldAssignabilityFromUnknown.js
+++ b/tests/baselines/reference/privateFieldAssignabilityFromUnknown.js
@@ -1,0 +1,21 @@
+//// [privateFieldAssignabilityFromUnknown.ts]
+export class Class {
+  #field: any
+}
+
+const task: Class = {} as unknown;
+
+
+//// [privateFieldAssignabilityFromUnknown.js]
+"use strict";
+var _field;
+exports.__esModule = true;
+var Class = /** @class */ (function () {
+    function Class() {
+        _field.set(this, void 0);
+    }
+    return Class;
+}());
+exports.Class = Class;
+_field = new WeakMap();
+var task = {};

--- a/tests/baselines/reference/privateFieldAssignabilityFromUnknown.symbols
+++ b/tests/baselines/reference/privateFieldAssignabilityFromUnknown.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts ===
+export class Class {
+>Class : Symbol(Class, Decl(privateFieldAssignabilityFromUnknown.ts, 0, 0))
+
+  #field: any
+>#field : Symbol(Class.#field, Decl(privateFieldAssignabilityFromUnknown.ts, 0, 20))
+}
+
+const task: Class = {} as unknown;
+>task : Symbol(task, Decl(privateFieldAssignabilityFromUnknown.ts, 4, 5))
+>Class : Symbol(Class, Decl(privateFieldAssignabilityFromUnknown.ts, 0, 0))
+

--- a/tests/baselines/reference/privateFieldAssignabilityFromUnknown.types
+++ b/tests/baselines/reference/privateFieldAssignabilityFromUnknown.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts ===
+export class Class {
+>Class : Class
+
+  #field: any
+>#field : any
+}
+
+const task: Class = {} as unknown;
+>task : Class
+>{} as unknown : unknown
+>{} : {}
+

--- a/tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts
+++ b/tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts
@@ -1,0 +1,5 @@
+export class Class {
+  #field: any
+}
+
+const task: Class = {} as unknown;


### PR DESCRIPTION
Fixes #37014