### PR TITLE
Reduce lerna loglevel

### DIFF
--- a/tests/cases/docker/office-ui-fabric/Dockerfile
+++ b/tests/cases/docker/office-ui-fabric/Dockerfile
@@ -19,4 +19,4 @@ RUN yarn add typescript@../../typescript.tgz --exact --ignore-scripts
 WORKDIR /office-ui-fabric-react
 RUN yarn
 ENTRYPOINT [ "lerna" ]
-CMD [ "run", "build", "--stream", "--concurrency", "1", "--", "--production", "--lint" ]
+CMD [ "run", "build", "--stream", "--concurrency", "1", "--loglevel", "error", "--", "--production", "--lint" ]

--- a/tests/cases/docker/office-ui-fabric/Dockerfile
+++ b/tests/cases/docker/office-ui-fabric/Dockerfile
@@ -19,4 +19,4 @@ RUN yarn add typescript@../../typescript.tgz --exact --ignore-scripts
 WORKDIR /office-ui-fabric-react
 RUN yarn
 ENTRYPOINT [ "lerna" ]
-CMD [ "run", "build", "--stream", "--concurrency", "1", "--loglevel", "error", "--", "--production", "--lint" ]
+CMD [ "run", "build", "--stream", "--concurrency", "1", "--loglevel", "error", "--", "--production", "--lint", "--silent" ]


### PR DESCRIPTION
For the `office-ui-fabric` test (by default it is `info` instead of `error`). This should hopefully trim a ton of output we don't care about.