### PR TITLE
[release-3.8] Allow --composite false or --composite null on the command line (#36997)

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3630,7 +3630,7 @@
         "category": "Message",
         "code": 6061
     },
-    "Option '{0}' can only be specified in 'tsconfig.json' file.": {
+    "Option '{0}' can only be specified in 'tsconfig.json' file or set to 'null' on command line.": {
         "category": "Error",
         "code": 6064
     },
@@ -4279,6 +4279,10 @@
     "Synchronously call callbacks and update the state of directory watchers on platforms that don't support recursive watching natively.": {
         "category": "Message",
         "code": 6228
+    },
+    "Option '{0}' can only be specified in 'tsconfig.json' file or set to 'false' or 'null' on command line.": {
+        "category": "Error",
+        "code": 6230
     },
 
     "Projects to reference": {

--- a/src/testRunner/tsconfig.json
+++ b/src/testRunner/tsconfig.json
@@ -126,6 +126,7 @@
         "unittests/tsbuild/transitiveReferences.ts",
         "unittests/tsbuild/watchEnvironment.ts",
         "unittests/tsbuild/watchMode.ts",
+        "unittests/tsc/composite.ts",
         "unittests/tsc/declarationEmit.ts",
         "unittests/tsc/incremental.ts",
         "unittests/tsc/listFilesOnly.ts",

--- a/src/testRunner/unittests/tsc/composite.ts
+++ b/src/testRunner/unittests/tsc/composite.ts
@@ -1,0 +1,85 @@
+namespace ts {
+    describe("unittests:: tsc:: composite::", () => {
+        verifyTsc({
+            scenario: "composite",
+            subScenario: "when setting composite false on command line",
+            fs: () => loadProjectFromFiles({
+                "/src/project/src/main.ts": "export const x = 10;",
+                "/src/project/tsconfig.json": Utils.dedent`
+                    {
+                        "compilerOptions": {
+                            "target": "es5",
+                            "module": "commonjs",
+                            "composite": true,
+                        },
+                        "include": [
+                            "src/**/*.ts"
+                        ]
+                    }`,
+            }),
+            commandLineArgs: ["--composite", "false", "--p", "src/project"],
+        });
+
+        verifyTsc({
+            scenario: "composite",
+            subScenario: "when setting composite null on command line",
+            fs: () => loadProjectFromFiles({
+                "/src/project/src/main.ts": "export const x = 10;",
+                "/src/project/tsconfig.json": Utils.dedent`
+                    {
+                        "compilerOptions": {
+                            "target": "es5",
+                            "module": "commonjs",
+                            "composite": true,
+                        },
+                        "include": [
+                            "src/**/*.ts"
+                        ]
+                    }`,
+            }),
+            commandLineArgs: ["--composite", "null", "--p", "src/project"],
+        });
+
+        verifyTsc({
+            scenario: "composite",
+            subScenario: "when setting composite false on command line but has tsbuild info in config",
+            fs: () => loadProjectFromFiles({
+                "/src/project/src/main.ts": "export const x = 10;",
+                "/src/project/tsconfig.json": Utils.dedent`
+                    {
+                        "compilerOptions": {
+                            "target": "es5",
+                            "module": "commonjs",
+                            "composite": true,
+                            "tsBuildInfoFile": "tsconfig.json.tsbuildinfo"
+                        },
+                        "include": [
+                            "src/**/*.ts"
+                        ]
+                    }`,
+            }),
+            commandLineArgs: ["--composite", "false", "--p", "src/project"],
+        });
+
+        verifyTsc({
+            scenario: "composite",
+            subScenario: "when setting composite false and tsbuildinfo as null on command line but has tsbuild info in config",
+            fs: () => loadProjectFromFiles({
+                "/src/project/src/main.ts": "export const x = 10;",
+                "/src/project/tsconfig.json": Utils.dedent`
+                    {
+                        "compilerOptions": {
+                            "target": "es5",
+                            "module": "commonjs",
+                            "composite": true,
+                            "tsBuildInfoFile": "tsconfig.json.tsbuildinfo"
+                        },
+                        "include": [
+                            "src/**/*.ts"
+                        ]
+                    }`,
+            }),
+            commandLineArgs: ["--composite", "false", "--p", "src/project", "--tsBuildInfoFile", "null"],
+        });
+    });
+}

--- a/tests/baselines/reference/tsc/composite/initial-build/when-setting-composite-false-and-tsbuildinfo-as-null-on-command-line-but-has-tsbuild-info-in-config.js
+++ b/tests/baselines/reference/tsc/composite/initial-build/when-setting-composite-false-and-tsbuildinfo-as-null-on-command-line-but-has-tsbuild-info-in-config.js
@@ -1,0 +1,11 @@
+//// [/lib/initial-buildOutput.txt]
+/lib/tsc --composite false --p src/project --tsBuildInfoFile null
+exitCode:: ExitStatus.Success
+
+
+//// [/src/project/src/main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.x = 10;
+
+

--- a/tests/baselines/reference/tsc/composite/initial-build/when-setting-composite-false-on-command-line-but-has-tsbuild-info-in-config.js
+++ b/tests/baselines/reference/tsc/composite/initial-build/when-setting-composite-false-on-command-line-but-has-tsbuild-info-in-config.js
@@ -1,0 +1,12 @@
+//// [/lib/initial-buildOutput.txt]
+/lib/tsc --composite false --p src/project
+src/project/tsconfig.json(6,9): error TS5069: Option 'tsBuildInfoFile' cannot be specified without specifying option 'incremental' or option 'composite'.
+exitCode:: ExitStatus.DiagnosticsPresent_OutputsGenerated
+
+
+//// [/src/project/src/main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.x = 10;
+
+

--- a/tests/baselines/reference/tsc/composite/initial-build/when-setting-composite-false-on-command-line.js
+++ b/tests/baselines/reference/tsc/composite/initial-build/when-setting-composite-false-on-command-line.js
@@ -1,0 +1,11 @@
+//// [/lib/initial-buildOutput.txt]
+/lib/tsc --composite false --p src/project
+exitCode:: ExitStatus.Success
+
+
+//// [/src/project/src/main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.x = 10;
+
+

--- a/tests/baselines/reference/tsc/composite/initial-build/when-setting-composite-null-on-command-line.js
+++ b/tests/baselines/reference/tsc/composite/initial-build/when-setting-composite-null-on-command-line.js
@@ -1,0 +1,11 @@
+//// [/lib/initial-buildOutput.txt]
+/lib/tsc --composite null --p src/project
+exitCode:: ExitStatus.Success
+
+
+//// [/src/project/src/main.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.x = 10;
+
+


### PR DESCRIPTION
* Add tests for specifying composite as command line option

* Allow passing --composite false on commandline

* Add test to verify tsc --composite false from command line

* Handle "undefined" as option value to be set to undefined for that option

* Support "null" as option to be converted to undefined which is normally end result from our config file as well

* Support null as option for any tsconfig only option as well, and dont support undefined

* Fix public api test case

* Validates objects instead of stringify result

* Add composite true to base source

Cherry pick of #36997 to release-3.8