### PR TITLE
Grammar error on `export type *`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2457,12 +2457,7 @@ namespace ts {
                 const name = (specifier.propertyName ?? specifier.name).escapedText;
                 const exportSymbol = getExportsOfSymbol(symbol).get(name);
                 const resolved = resolveSymbol(exportSymbol, dontResolveAlias);
-                if (!markSymbolOfAliasDeclarationIfTypeOnly(specifier, exportSymbol, resolved, /*overwriteEmpty*/ false)) {
-                    if (resolved && symbol.exports && !symbol.exports.has(name)) {
-                        // `resolved` must have come from a namespace export, which could be `export type *`
-                        markSymbolOfAliasDeclarationIfTypeOnly(specifier, symbol.exports.get(InternalSymbolName.ExportStar), /*finalTarget*/ undefined, /*overwriteEmpty*/ true);
-                    }
-                }
+                markSymbolOfAliasDeclarationIfTypeOnly(specifier, exportSymbol, resolved, /*overwriteEmpty*/ false);
                 return resolved;
             }
         }
@@ -3272,7 +3267,6 @@ namespace ts {
                     const lookupTable = createMap<ExportCollisionTracker>() as ExportCollisionTrackerTable;
                     for (const node of exportStars.declarations) {
                         const resolvedModule = resolveExternalModuleName(node, (node as ExportDeclaration).moduleSpecifier!);
-                        markSymbolOfAliasDeclarationIfTypeOnly(node, resolvedModule, /*finalTarget*/ undefined, /*overwriteEmpty*/ false);
                         const exportedSymbols = visit(resolvedModule);
                         extendExportSymbols(
                             nestedSymbols,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2295,11 +2295,9 @@ namespace ts {
                     ? Diagnostics._0_was_exported_here
                     : Diagnostics._0_was_imported_here;
 
-                // Non-null assertion is safe because `markSymbolOfAliasDeclarationIfTypeOnly` cannot return true
-                // for an ImportEqualsDeclaration without also being passed a defined symbol.
-                // `typeOnlyDeclaration.name` will be an Identifier for all valid cases, but may be undefined for
-                // invalid `export type * ...` syntax.
-                const name = unescapeLeadingUnderscores(tryCast(typeOnlyDeclaration.name, isIdentifier)?.escapedText ?? resolved!.escapedName);
+                // Non-null assertion is safe because the optionality comes from ImportClause,
+                // but if an ImportClause was the typeOnlyDeclaration, it had to have a `name`.
+                const name = unescapeLeadingUnderscores(typeOnlyDeclaration.name!.escapedText);
                 addRelatedInfo(error(node.moduleReference, message), createDiagnosticForNode(typeOnlyDeclaration, relatedMessage, name));
             }
         }
@@ -2730,7 +2728,7 @@ namespace ts {
         }
 
         /** Indicates that a symbol directly or indirectly resolves to a type-only import or export. */
-        function getTypeOnlyAliasDeclaration(symbol: Symbol): TypeOnlyCompatibleAliasDeclaration | NamespaceExport | ExportDeclaration | undefined {
+        function getTypeOnlyAliasDeclaration(symbol: Symbol): TypeOnlyCompatibleAliasDeclaration | undefined {
             if (!(symbol.flags & SymbolFlags.Alias)) {
                 return undefined;
             }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1143,6 +1143,10 @@
         "category": "Error",
         "code": 1382
     },
+    "Only named exports may use 'export type'.": {
+        "category": "Error",
+        "code": 1383
+    },
 
     "The types of '{0}' are incompatible between these types.": {
         "category": "Error",

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6215,6 +6215,11 @@ namespace ts {
             || !isExpressionNode(useSite);
     }
 
+    export function typeOnlyDeclarationIsExport(typeOnlyDeclaration: Node) {
+        const kind = typeOnlyDeclaration.kind;
+        return kind === SyntaxKind.ExportSpecifier || kind === SyntaxKind.NamespaceExport || kind === SyntaxKind.ExportDeclaration;
+    }
+
     function isPartOfPossiblyValidTypeOrAbstractComputedPropertyName(node: Node) {
         while (node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.PropertyAccessExpression) {
             node = node.parent;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6216,8 +6216,7 @@ namespace ts {
     }
 
     export function typeOnlyDeclarationIsExport(typeOnlyDeclaration: Node) {
-        const kind = typeOnlyDeclaration.kind;
-        return kind === SyntaxKind.ExportSpecifier || kind === SyntaxKind.NamespaceExport || kind === SyntaxKind.ExportDeclaration;
+        return typeOnlyDeclaration.kind === SyntaxKind.ExportSpecifier;
     }
 
     function isPartOfPossiblyValidTypeOrAbstractComputedPropertyName(node: Node) {

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1727,11 +1727,9 @@ namespace ts {
             case SyntaxKind.ExportSpecifier:
                 return (node as ImportOrExportSpecifier).parent.parent.isTypeOnly;
             case SyntaxKind.NamespaceImport:
-            case SyntaxKind.NamespaceExport:
-                return (node as NamespaceImport | NamespaceExport).parent.isTypeOnly;
+                return (node as NamespaceImport).parent.isTypeOnly;
             case SyntaxKind.ImportClause:
-            case SyntaxKind.ExportDeclaration:
-                return (node as ImportClause | ExportDeclaration).isTypeOnly;
+                return (node as ImportClause).isTypeOnly;
             default:
                 return false;
         }

--- a/src/compiler/utilitiesPublic.ts
+++ b/src/compiler/utilitiesPublic.ts
@@ -1727,9 +1727,11 @@ namespace ts {
             case SyntaxKind.ExportSpecifier:
                 return (node as ImportOrExportSpecifier).parent.parent.isTypeOnly;
             case SyntaxKind.NamespaceImport:
-                return (node as NamespaceImport).parent.isTypeOnly;
+            case SyntaxKind.NamespaceExport:
+                return (node as NamespaceImport | NamespaceExport).parent.isTypeOnly;
             case SyntaxKind.ImportClause:
-                return (node as ImportClause).isTypeOnly;
+            case SyntaxKind.ExportDeclaration:
+                return (node as ImportClause | ExportDeclaration).isTypeOnly;
             default:
                 return false;
         }

--- a/tests/baselines/reference/exportNamespace4.errors.txt
+++ b/tests/baselines/reference/exportNamespace4.errors.txt
@@ -8,12 +8,12 @@ tests/cases/conformance/externalModules/typeOnly/e.ts(2,1): error TS1362: 'ns' c
     export class A {}
     
 ==== tests/cases/conformance/externalModules/typeOnly/b.ts (1 errors) ====
-    export type * from './a';
+    export type * from './a'; // Grammar error
     ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1383: Only named exports may use 'export type'.
     
 ==== tests/cases/conformance/externalModules/typeOnly/c.ts (1 errors) ====
-    export type * as ns from './a';
+    export type * as ns from './a'; // Grammar error
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1383: Only named exports may use 'export type'.
     

--- a/tests/baselines/reference/exportNamespace4.errors.txt
+++ b/tests/baselines/reference/exportNamespace4.errors.txt
@@ -1,7 +1,5 @@
 tests/cases/conformance/externalModules/typeOnly/b.ts(1,1): error TS1383: Only named exports may use 'export type'.
 tests/cases/conformance/externalModules/typeOnly/c.ts(1,1): error TS1383: Only named exports may use 'export type'.
-tests/cases/conformance/externalModules/typeOnly/d.ts(2,1): error TS1362: 'A' cannot be used as a value because it was exported using 'export type'.
-tests/cases/conformance/externalModules/typeOnly/e.ts(2,1): error TS1362: 'ns' cannot be used as a value because it was exported using 'export type'.
 
 
 ==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
@@ -17,17 +15,11 @@ tests/cases/conformance/externalModules/typeOnly/e.ts(2,1): error TS1362: 'ns' c
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1383: Only named exports may use 'export type'.
     
-==== tests/cases/conformance/externalModules/typeOnly/d.ts (1 errors) ====
+==== tests/cases/conformance/externalModules/typeOnly/d.ts (0 errors) ====
     import { A } from './b';
-    A; // Error
-    ~
-!!! error TS1362: 'A' cannot be used as a value because it was exported using 'export type'.
-!!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:1:1: 'A' was exported here.
+    A;
     
-==== tests/cases/conformance/externalModules/typeOnly/e.ts (1 errors) ====
+==== tests/cases/conformance/externalModules/typeOnly/e.ts (0 errors) ====
     import { ns } from './c';
-    ns.A; // Error
-    ~~
-!!! error TS1362: 'ns' cannot be used as a value because it was exported using 'export type'.
-!!! related TS1377 tests/cases/conformance/externalModules/typeOnly/c.ts:1:13: 'ns' was exported here.
+    ns.A;
     

--- a/tests/baselines/reference/exportNamespace4.errors.txt
+++ b/tests/baselines/reference/exportNamespace4.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/conformance/externalModules/typeOnly/b.ts(1,1): error TS1383: Only named exports may use 'export type'.
+tests/cases/conformance/externalModules/typeOnly/c.ts(1,1): error TS1383: Only named exports may use 'export type'.
+tests/cases/conformance/externalModules/typeOnly/d.ts(2,1): error TS1362: 'A' cannot be used as a value because it was exported using 'export type'.
+tests/cases/conformance/externalModules/typeOnly/e.ts(2,1): error TS1362: 'ns' cannot be used as a value because it was exported using 'export type'.
+
+
+==== tests/cases/conformance/externalModules/typeOnly/a.ts (0 errors) ====
+    export class A {}
+    
+==== tests/cases/conformance/externalModules/typeOnly/b.ts (1 errors) ====
+    export type * from './a';
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1383: Only named exports may use 'export type'.
+    
+==== tests/cases/conformance/externalModules/typeOnly/c.ts (1 errors) ====
+    export type * as ns from './a';
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1383: Only named exports may use 'export type'.
+    
+==== tests/cases/conformance/externalModules/typeOnly/d.ts (1 errors) ====
+    import { A } from './b';
+    A; // Error
+    ~
+!!! error TS1362: 'A' cannot be used as a value because it was exported using 'export type'.
+!!! related TS1377 tests/cases/conformance/externalModules/typeOnly/b.ts:1:1: 'A' was exported here.
+    
+==== tests/cases/conformance/externalModules/typeOnly/e.ts (1 errors) ====
+    import { ns } from './c';
+    ns.A; // Error
+    ~~
+!!! error TS1362: 'ns' cannot be used as a value because it was exported using 'export type'.
+!!! related TS1377 tests/cases/conformance/externalModules/typeOnly/c.ts:1:13: 'ns' was exported here.
+    

--- a/tests/baselines/reference/exportNamespace4.js
+++ b/tests/baselines/reference/exportNamespace4.js
@@ -1,0 +1,43 @@
+//// [tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts] ////
+
+//// [a.ts]
+export class A {}
+
+//// [b.ts]
+export type * from './a';
+
+//// [c.ts]
+export type * as ns from './a';
+
+//// [d.ts]
+import { A } from './b';
+A; // Error
+
+//// [e.ts]
+import { ns } from './c';
+ns.A; // Error
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+exports.A = A;
+//// [b.js]
+"use strict";
+exports.__esModule = true;
+//// [c.js]
+"use strict";
+exports.__esModule = true;
+//// [d.js]
+"use strict";
+exports.__esModule = true;
+A; // Error
+//// [e.js]
+"use strict";
+exports.__esModule = true;
+ns.A; // Error

--- a/tests/baselines/reference/exportNamespace4.js
+++ b/tests/baselines/reference/exportNamespace4.js
@@ -4,10 +4,10 @@
 export class A {}
 
 //// [b.ts]
-export type * from './a';
+export type * from './a'; // Grammar error
 
 //// [c.ts]
-export type * as ns from './a';
+export type * as ns from './a'; // Grammar error
 
 //// [d.ts]
 import { A } from './b';

--- a/tests/baselines/reference/exportNamespace4.js
+++ b/tests/baselines/reference/exportNamespace4.js
@@ -11,11 +11,11 @@ export type * as ns from './a'; // Grammar error
 
 //// [d.ts]
 import { A } from './b';
-A; // Error
+A;
 
 //// [e.ts]
 import { ns } from './c';
-ns.A; // Error
+ns.A;
 
 
 //// [a.js]
@@ -36,8 +36,10 @@ exports.__esModule = true;
 //// [d.js]
 "use strict";
 exports.__esModule = true;
-A; // Error
+var b_1 = require("./b");
+b_1.A;
 //// [e.js]
 "use strict";
 exports.__esModule = true;
-ns.A; // Error
+var c_1 = require("./c");
+c_1.ns.A;

--- a/tests/baselines/reference/exportNamespace4.symbols
+++ b/tests/baselines/reference/exportNamespace4.symbols
@@ -13,14 +13,14 @@ export type * as ns from './a'; // Grammar error
 import { A } from './b';
 >A : Symbol(A, Decl(d.ts, 0, 8))
 
-A; // Error
+A;
 >A : Symbol(A, Decl(d.ts, 0, 8))
 
 === tests/cases/conformance/externalModules/typeOnly/e.ts ===
 import { ns } from './c';
 >ns : Symbol(ns, Decl(e.ts, 0, 8))
 
-ns.A; // Error
+ns.A;
 >ns.A : Symbol(ns.A, Decl(a.ts, 0, 0))
 >ns : Symbol(ns, Decl(e.ts, 0, 8))
 >A : Symbol(ns.A, Decl(a.ts, 0, 0))

--- a/tests/baselines/reference/exportNamespace4.symbols
+++ b/tests/baselines/reference/exportNamespace4.symbols
@@ -3,10 +3,10 @@ export class A {}
 >A : Symbol(A, Decl(a.ts, 0, 0))
 
 === tests/cases/conformance/externalModules/typeOnly/b.ts ===
-export type * from './a';
+export type * from './a'; // Grammar error
 No type information for this code.
 No type information for this code.=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
-export type * as ns from './a';
+export type * as ns from './a'; // Grammar error
 >ns : Symbol(ns, Decl(c.ts, 0, 11))
 
 === tests/cases/conformance/externalModules/typeOnly/d.ts ===

--- a/tests/baselines/reference/exportNamespace4.symbols
+++ b/tests/baselines/reference/exportNamespace4.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export class A {}
+>A : Symbol(A, Decl(a.ts, 0, 0))
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+export type * from './a';
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+export type * as ns from './a';
+>ns : Symbol(ns, Decl(c.ts, 0, 11))
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+import { A } from './b';
+>A : Symbol(A, Decl(d.ts, 0, 8))
+
+A; // Error
+>A : Symbol(A, Decl(d.ts, 0, 8))
+
+=== tests/cases/conformance/externalModules/typeOnly/e.ts ===
+import { ns } from './c';
+>ns : Symbol(ns, Decl(e.ts, 0, 8))
+
+ns.A; // Error
+>ns.A : Symbol(ns.A, Decl(a.ts, 0, 0))
+>ns : Symbol(ns, Decl(e.ts, 0, 8))
+>A : Symbol(ns.A, Decl(a.ts, 0, 0))
+

--- a/tests/baselines/reference/exportNamespace4.types
+++ b/tests/baselines/reference/exportNamespace4.types
@@ -3,10 +3,10 @@ export class A {}
 >A : A
 
 === tests/cases/conformance/externalModules/typeOnly/b.ts ===
-export type * from './a';
+export type * from './a'; // Grammar error
 No type information for this code.
 No type information for this code.=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
-export type * as ns from './a';
+export type * as ns from './a'; // Grammar error
 >ns : typeof ns
 
 === tests/cases/conformance/externalModules/typeOnly/d.ts ===

--- a/tests/baselines/reference/exportNamespace4.types
+++ b/tests/baselines/reference/exportNamespace4.types
@@ -13,14 +13,14 @@ export type * as ns from './a'; // Grammar error
 import { A } from './b';
 >A : typeof A
 
-A; // Error
+A;
 >A : typeof A
 
 === tests/cases/conformance/externalModules/typeOnly/e.ts ===
 import { ns } from './c';
 >ns : typeof ns
 
-ns.A; // Error
+ns.A;
 >ns.A : typeof ns.A
 >ns : typeof ns
 >A : typeof ns.A

--- a/tests/baselines/reference/exportNamespace4.types
+++ b/tests/baselines/reference/exportNamespace4.types
@@ -1,0 +1,27 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export class A {}
+>A : A
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+export type * from './a';
+No type information for this code.
+No type information for this code.=== tests/cases/conformance/externalModules/typeOnly/c.ts ===
+export type * as ns from './a';
+>ns : typeof ns
+
+=== tests/cases/conformance/externalModules/typeOnly/d.ts ===
+import { A } from './b';
+>A : typeof A
+
+A; // Error
+>A : typeof A
+
+=== tests/cases/conformance/externalModules/typeOnly/e.ts ===
+import { ns } from './c';
+>ns : typeof ns
+
+ns.A; // Error
+>ns.A : typeof ns.A
+>ns : typeof ns
+>A : typeof ns.A
+

--- a/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
@@ -9,8 +9,8 @@ export type * as ns from './a'; // Grammar error
 
 // @Filename: d.ts
 import { A } from './b';
-A; // Error
+A;
 
 // @Filename: e.ts
 import { ns } from './c';
-ns.A; // Error
+ns.A;

--- a/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
@@ -1,0 +1,16 @@
+// @Filename: a.ts
+export class A {}
+
+// @Filename: b.ts
+export type * from './a';
+
+// @Filename: c.ts
+export type * as ns from './a';
+
+// @Filename: d.ts
+import { A } from './b';
+A; // Error
+
+// @Filename: e.ts
+import { ns } from './c';
+ns.A; // Error

--- a/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
@@ -2,10 +2,10 @@
 export class A {}
 
 // @Filename: b.ts
-export type * from './a';
+export type * from './a'; // Grammar error
 
 // @Filename: c.ts
-export type * as ns from './a';
+export type * as ns from './a'; // Grammar error
 
 // @Filename: d.ts
 import { A } from './b';


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #36966

The first commit added the missing calls to `markSymbolOfAliasDeclarationIfTypeOnly` so as to recognize `export type *` forms as type-only while simultaneously disallowing it with a grammar error. Mostly I was curious how close we were to supporting `export type *`, and it appears that it’s only a couple extra lines. Afterwards, I reverted the extra calls because it created two errors where one would suffice.
