### PR TITLE
Reapply contextual type when recalculating array literals as tuples

### DIFF
--- a/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.errors.txt
+++ b/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.errors.txt
@@ -1,0 +1,29 @@
+tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(11,11): error TS2322: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'.
+tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts(16,11): error TS2322: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'.
+
+
+==== tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts (2 errors) ====
+    function minimalExample1() {
+        type Disc =
+            | { kind: "hddvd" }
+            | { kind: "bluray" }
+    
+        function foo(x: Disc[]) {
+        }
+    
+        foo([
+            { kind: "bluray", },
+            { kind: "hdpvd", }
+              ~~~~
+!!! error TS2322: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'.
+!!! related TS6500 tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts:3:13: The expected type comes from property 'kind' which is declared here on type 'Disc'
+        ]);
+    
+        const ds: Disc[] = [
+            { kind: "bluray", },
+            { kind: "hdpvd", }
+              ~~~~
+!!! error TS2322: Type '"hdpvd"' is not assignable to type '"hddvd" | "bluray"'.
+!!! related TS6500 tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts:3:13: The expected type comes from property 'kind' which is declared here on type 'Disc'
+        ];
+    }

--- a/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.js
+++ b/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.js
@@ -1,0 +1,33 @@
+//// [errorsForCallAndAssignmentAreSimilar.ts]
+function minimalExample1() {
+    type Disc =
+        | { kind: "hddvd" }
+        | { kind: "bluray" }
+
+    function foo(x: Disc[]) {
+    }
+
+    foo([
+        { kind: "bluray", },
+        { kind: "hdpvd", }
+    ]);
+
+    const ds: Disc[] = [
+        { kind: "bluray", },
+        { kind: "hdpvd", }
+    ];
+}
+
+//// [errorsForCallAndAssignmentAreSimilar.js]
+function minimalExample1() {
+    function foo(x) {
+    }
+    foo([
+        { kind: "bluray" },
+        { kind: "hdpvd" }
+    ]);
+    var ds = [
+        { kind: "bluray" },
+        { kind: "hdpvd" }
+    ];
+}

--- a/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.symbols
+++ b/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts ===
+function minimalExample1() {
+>minimalExample1 : Symbol(minimalExample1, Decl(errorsForCallAndAssignmentAreSimilar.ts, 0, 0))
+
+    type Disc =
+>Disc : Symbol(Disc, Decl(errorsForCallAndAssignmentAreSimilar.ts, 0, 28))
+
+        | { kind: "hddvd" }
+>kind : Symbol(kind, Decl(errorsForCallAndAssignmentAreSimilar.ts, 2, 11))
+
+        | { kind: "bluray" }
+>kind : Symbol(kind, Decl(errorsForCallAndAssignmentAreSimilar.ts, 3, 11))
+
+    function foo(x: Disc[]) {
+>foo : Symbol(foo, Decl(errorsForCallAndAssignmentAreSimilar.ts, 3, 28))
+>x : Symbol(x, Decl(errorsForCallAndAssignmentAreSimilar.ts, 5, 17))
+>Disc : Symbol(Disc, Decl(errorsForCallAndAssignmentAreSimilar.ts, 0, 28))
+    }
+
+    foo([
+>foo : Symbol(foo, Decl(errorsForCallAndAssignmentAreSimilar.ts, 3, 28))
+
+        { kind: "bluray", },
+>kind : Symbol(kind, Decl(errorsForCallAndAssignmentAreSimilar.ts, 9, 9))
+
+        { kind: "hdpvd", }
+>kind : Symbol(kind, Decl(errorsForCallAndAssignmentAreSimilar.ts, 10, 9))
+
+    ]);
+
+    const ds: Disc[] = [
+>ds : Symbol(ds, Decl(errorsForCallAndAssignmentAreSimilar.ts, 13, 9))
+>Disc : Symbol(Disc, Decl(errorsForCallAndAssignmentAreSimilar.ts, 0, 28))
+
+        { kind: "bluray", },
+>kind : Symbol(kind, Decl(errorsForCallAndAssignmentAreSimilar.ts, 14, 9))
+
+        { kind: "hdpvd", }
+>kind : Symbol(kind, Decl(errorsForCallAndAssignmentAreSimilar.ts, 15, 9))
+
+    ];
+}

--- a/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.types
+++ b/tests/baselines/reference/errorsForCallAndAssignmentAreSimilar.types
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts ===
+function minimalExample1() {
+>minimalExample1 : () => void
+
+    type Disc =
+>Disc : { kind: "hddvd"; } | { kind: "bluray"; }
+
+        | { kind: "hddvd" }
+>kind : "hddvd"
+
+        | { kind: "bluray" }
+>kind : "bluray"
+
+    function foo(x: Disc[]) {
+>foo : (x: ({ kind: "hddvd"; } | { kind: "bluray"; })[]) => void
+>x : ({ kind: "hddvd"; } | { kind: "bluray"; })[]
+    }
+
+    foo([
+>foo([        { kind: "bluray", },        { kind: "hdpvd", }    ]) : void
+>foo : (x: ({ kind: "hddvd"; } | { kind: "bluray"; })[]) => void
+>[        { kind: "bluray", },        { kind: "hdpvd", }    ] : ({ kind: "bluray"; } | { kind: "hdpvd"; })[]
+
+        { kind: "bluray", },
+>{ kind: "bluray", } : { kind: "bluray"; }
+>kind : "bluray"
+>"bluray" : "bluray"
+
+        { kind: "hdpvd", }
+>{ kind: "hdpvd", } : { kind: "hdpvd"; }
+>kind : "hdpvd"
+>"hdpvd" : "hdpvd"
+
+    ]);
+
+    const ds: Disc[] = [
+>ds : ({ kind: "hddvd"; } | { kind: "bluray"; })[]
+>[        { kind: "bluray", },        { kind: "hdpvd", }    ] : ({ kind: "bluray"; } | { kind: "hdpvd"; })[]
+
+        { kind: "bluray", },
+>{ kind: "bluray", } : { kind: "bluray"; }
+>kind : "bluray"
+>"bluray" : "bluray"
+
+        { kind: "hdpvd", }
+>{ kind: "hdpvd", } : { kind: "hdpvd"; }
+>kind : "hdpvd"
+>"hdpvd" : "hdpvd"
+
+    ];
+}

--- a/tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts
+++ b/tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts
@@ -1,0 +1,18 @@
+function minimalExample1() {
+    type Disc =
+        | { kind: "hddvd" }
+        | { kind: "bluray" }
+
+    function foo(x: Disc[]) {
+    }
+
+    foo([
+        { kind: "bluray", },
+        { kind: "hdpvd", }
+    ]);
+
+    const ds: Disc[] = [
+        { kind: "bluray", },
+        { kind: "hdpvd", }
+    ];
+}


### PR DESCRIPTION
Fixes #37037

In `elaborateArrayLiteral`, we called `checkArrayLiteral` with a flag to get the tuple type for the expression, so we can dive into it and elaborate on each member. The differing error message was caused by the contextual type for that expression check not being the same as the one used during the original expression resolution (namely, we didn't apply one, so we did our fallback oif walking up the tree, which, in the case of the call, eventually returns `any`, while in the case of the assignment, eventually returns the declared type). With this change, we reapply the context (the target type) to the expression when recalculate it.