### PR TITLE
fix(37039): Support 'in' type guard of intersections

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20028,7 +20028,7 @@ namespace ts {
             }
 
             function narrowByInKeyword(type: Type, literal: LiteralExpression, assumeTrue: boolean) {
-                if (type.flags & (TypeFlags.Union | TypeFlags.Object) || isThisTypeParameter(type)) {
+                if (type.flags & (TypeFlags.Union | TypeFlags.Object | TypeFlags.Intersection) || isThisTypeParameter(type)) {
                     const propName = escapeLeadingUnderscores(literal.text);
                     return filterType(type, t => isTypePresencePossible(t, propName, assumeTrue));
                 }

--- a/tests/baselines/reference/inKeywordTypeguard.errors.txt
+++ b/tests/baselines/reference/inKeywordTypeguard.errors.txt
@@ -157,3 +157,12 @@ tests/cases/compiler/inKeywordTypeguard.ts(94,26): error TS2339: Property 'a' do
             }
         }
     }
+    
+    function positiveIntersectionTest(x: { a: string } & { b: string }) {
+        if ("a" in x) {
+            let s: string = x.a;
+        } else {
+            let n: never = x;
+        }
+    }
+    

--- a/tests/baselines/reference/inKeywordTypeguard.js
+++ b/tests/baselines/reference/inKeywordTypeguard.js
@@ -97,6 +97,15 @@ class UnreachableCodeDetection {
     }
 }
 
+function positiveIntersectionTest(x: { a: string } & { b: string }) {
+    if ("a" in x) {
+        let s: string = x.a;
+    } else {
+        let n: never = x;
+    }
+}
+
+
 //// [inKeywordTypeguard.js]
 var A = /** @class */ (function () {
     function A() {
@@ -228,3 +237,11 @@ var UnreachableCodeDetection = /** @class */ (function () {
     };
     return UnreachableCodeDetection;
 }());
+function positiveIntersectionTest(x) {
+    if ("a" in x) {
+        var s = x.a;
+    }
+    else {
+        var n = x;
+    }
+}

--- a/tests/baselines/reference/inKeywordTypeguard.symbols
+++ b/tests/baselines/reference/inKeywordTypeguard.symbols
@@ -239,3 +239,26 @@ class UnreachableCodeDetection {
         }
     }
 }
+
+function positiveIntersectionTest(x: { a: string } & { b: string }) {
+>positiveIntersectionTest : Symbol(positiveIntersectionTest, Decl(inKeywordTypeguard.ts, 96, 1))
+>x : Symbol(x, Decl(inKeywordTypeguard.ts, 98, 34))
+>a : Symbol(a, Decl(inKeywordTypeguard.ts, 98, 38))
+>b : Symbol(b, Decl(inKeywordTypeguard.ts, 98, 54))
+
+    if ("a" in x) {
+>x : Symbol(x, Decl(inKeywordTypeguard.ts, 98, 34))
+
+        let s: string = x.a;
+>s : Symbol(s, Decl(inKeywordTypeguard.ts, 100, 11))
+>x.a : Symbol(a, Decl(inKeywordTypeguard.ts, 98, 38))
+>x : Symbol(x, Decl(inKeywordTypeguard.ts, 98, 34))
+>a : Symbol(a, Decl(inKeywordTypeguard.ts, 98, 38))
+
+    } else {
+        let n: never = x;
+>n : Symbol(n, Decl(inKeywordTypeguard.ts, 102, 11))
+>x : Symbol(x, Decl(inKeywordTypeguard.ts, 98, 34))
+    }
+}
+

--- a/tests/baselines/reference/inKeywordTypeguard.types
+++ b/tests/baselines/reference/inKeywordTypeguard.types
@@ -297,3 +297,28 @@ class UnreachableCodeDetection {
         }
     }
 }
+
+function positiveIntersectionTest(x: { a: string } & { b: string }) {
+>positiveIntersectionTest : (x: { a: string; } & { b: string; }) => void
+>x : { a: string; } & { b: string; }
+>a : string
+>b : string
+
+    if ("a" in x) {
+>"a" in x : boolean
+>"a" : "a"
+>x : { a: string; } & { b: string; }
+
+        let s: string = x.a;
+>s : string
+>x.a : string
+>x : { a: string; } & { b: string; }
+>a : string
+
+    } else {
+        let n: never = x;
+>n : never
+>x : never
+    }
+}
+

--- a/tests/cases/compiler/inKeywordTypeguard.ts
+++ b/tests/cases/compiler/inKeywordTypeguard.ts
@@ -95,3 +95,11 @@ class UnreachableCodeDetection {
         }
     }
 }
+
+function positiveIntersectionTest(x: { a: string } & { b: string }) {
+    if ("a" in x) {
+        let s: string = x.a;
+    } else {
+        let n: never = x;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #37039.