### PR TITLE
Remove bogus @implements errors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2907,7 +2907,7 @@ namespace ts {
                     return getDeclarationOfJSPrototypeContainer(symbol);
                 }
             }
-            const sig = findJSDocHost(host);
+            const sig = getEffectiveJSDocHost(node);
             if (sig && isFunctionLike(sig)) {
                 const symbol = getSymbolOfNode(sig);
                 return symbol && symbol.valueDeclaration;
@@ -30387,13 +30387,13 @@ namespace ts {
         }
 
         function checkJSDocImplementsTag(node: JSDocImplementsTag): void {
-            const classLike = findJSDocHost(getJSDocHost(node));
+            const classLike = getEffectiveJSDocHost(node);
             if (!classLike || !isClassDeclaration(classLike) && !isClassExpression(classLike)) {
                 error(classLike, Diagnostics.JSDoc_0_is_not_attached_to_a_class, idText(node.tagName));
             }
         }
         function checkJSDocAugmentsTag(node: JSDocAugmentsTag): void {
-            const classLike = findJSDocHost(getJSDocHost(node));
+            const classLike = getEffectiveJSDocHost(node);
             if (!classLike || !isClassDeclaration(classLike) && !isClassExpression(classLike)) {
                 error(classLike, Diagnostics.JSDoc_0_is_not_attached_to_a_class, idText(node.tagName));
                 return;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -30393,20 +30393,20 @@ namespace ts {
             }
         }
         function checkJSDocAugmentsTag(node: JSDocAugmentsTag): void {
-            const host = findJSDocHost(getJSDocHost(node));
-            if (!host || !isClassDeclaration(host) && !isClassExpression(host)) {
-                error(host, Diagnostics.JSDoc_0_is_not_attached_to_a_class, idText(node.tagName));
+            const classLike = findJSDocHost(getJSDocHost(node));
+            if (!classLike || !isClassDeclaration(classLike) && !isClassExpression(classLike)) {
+                error(classLike, Diagnostics.JSDoc_0_is_not_attached_to_a_class, idText(node.tagName));
                 return;
             }
 
-            const augmentsTags = getJSDocTags(host).filter(isJSDocAugmentsTag);
+            const augmentsTags = getJSDocTags(classLike).filter(isJSDocAugmentsTag);
             Debug.assert(augmentsTags.length > 0);
             if (augmentsTags.length > 1) {
                 error(augmentsTags[1], Diagnostics.Class_declarations_cannot_have_more_than_one_augments_or_extends_tag);
             }
 
             const name = getIdentifierFromEntityNameExpression(node.class.expression);
-            const extend = getClassExtendsHeritageElement(host);
+            const extend = getClassExtendsHeritageElement(classLike);
             if (extend) {
                 const className = getIdentifierFromEntityNameExpression(extend.expression);
                 if (className && name.escapedText !== className.escapedText) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2452,17 +2452,18 @@ namespace ts {
     }
 
     export function getHostSignatureFromJSDoc(node: Node): SignatureDeclaration | undefined {
-        return getHostSignatureFromJSDocHost(getJSDocHost(node));
+        const host = findJSDocHost(getJSDocHost(node));
+        return host && isFunctionLike(host) ? host : undefined;
     }
 
-    export function getHostSignatureFromJSDocHost(host: HasJSDoc): SignatureDeclaration | undefined {
+    export function findJSDocHost(host: HasJSDoc): Node | undefined {
         const decl = getSourceOfDefaultedAssignment(host) ||
             getSourceOfAssignment(host) ||
             getSingleInitializerOfVariableStatementOrPropertyDeclaration(host) ||
             getSingleVariableOfVariableStatement(host) ||
             getNestedModuleDeclaration(host) ||
             host;
-        return decl && isFunctionLike(decl) ? decl : undefined;
+        return decl;
     }
 
     export function getJSDocHost(node: Node): HasJSDoc {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2452,11 +2452,12 @@ namespace ts {
     }
 
     export function getHostSignatureFromJSDoc(node: Node): SignatureDeclaration | undefined {
-        const host = findJSDocHost(getJSDocHost(node));
+        const host = getEffectiveJSDocHost(node);
         return host && isFunctionLike(host) ? host : undefined;
     }
 
-    export function findJSDocHost(host: HasJSDoc): Node | undefined {
+    export function getEffectiveJSDocHost(node: Node): Node | undefined {
+        const host = getJSDocHost(node);
         const decl = getSourceOfDefaultedAssignment(host) ||
             getSourceOfAssignment(host) ||
             getSingleInitializerOfVariableStatementOrPropertyDeclaration(host) ||
@@ -2466,6 +2467,7 @@ namespace ts {
         return decl;
     }
 
+    /** Use getEffectiveJSDocHost if you additionally need to look for jsdoc on parent nodes, like assignments.  */
     export function getJSDocHost(node: Node): HasJSDoc {
         return Debug.checkDefined(findAncestor(node.parent, isJSDoc)).parent;
     }

--- a/tests/baselines/reference/jsdocImplements_class.errors.txt
+++ b/tests/baselines/reference/jsdocImplements_class.errors.txt
@@ -33,3 +33,36 @@
 !!! related TS2728 /a.js:3:5: 'method' is declared here.
     }
     
+    
+    var Ns = {};
+    /** @implements {A} */
+    Ns.C1 = class {
+        method() { return 11; }
+    }
+    /** @implements {A} */
+    var C2 = class {
+        method() { return 12; }
+    }
+    var o = {
+        /** @implements {A} */
+        C3: class {
+            method() { return 13; }
+        }
+    }
+    class CC {
+        /** @implements {A} */
+        C4 = class {
+            method() {
+                return 14;
+            }
+        }
+    }
+    
+    var C5;
+    /** @implements {A} */
+    Ns.C5 = C5 || class {
+        method() {
+            return 15;
+        }
+    }
+    

--- a/tests/baselines/reference/jsdocImplements_class.js
+++ b/tests/baselines/reference/jsdocImplements_class.js
@@ -19,6 +19,39 @@ class B3  {
 }
 
 
+var Ns = {};
+/** @implements {A} */
+Ns.C1 = class {
+    method() { return 11; }
+}
+/** @implements {A} */
+var C2 = class {
+    method() { return 12; }
+}
+var o = {
+    /** @implements {A} */
+    C3: class {
+        method() { return 13; }
+    }
+}
+class CC {
+    /** @implements {A} */
+    C4 = class {
+        method() {
+            return 14;
+        }
+    }
+}
+
+var C5;
+/** @implements {A} */
+Ns.C5 = C5 || class {
+    method() {
+        return 15;
+    }
+}
+
+
 
 
 //// [a.d.ts]
@@ -37,4 +70,36 @@ declare class B2 implements A {
 }
 /** @implements {A} */
 declare class B3 implements A {
+}
+declare namespace Ns {
+    export { C1 };
+    const C5: {
+        new (): {
+            method(): number;
+        };
+    };
+}
+/** @implements {A} */
+declare var C2: {
+    new (): {
+        method(): number;
+    };
+};
+declare namespace o {
+    export { C3 };
+}
+declare class CC {
+    /** @implements {A} */
+    C4: {
+        new (): {
+            method(): number;
+        };
+    };
+}
+declare var C5: any;
+declare class C1 implements A {
+    method(): number;
+}
+declare class C3 implements A {
+    method(): number;
 }

--- a/tests/baselines/reference/jsdocImplements_class.symbols
+++ b/tests/baselines/reference/jsdocImplements_class.symbols
@@ -29,3 +29,66 @@ class B3  {
 >B3 : Symbol(B3, Decl(a.js, 13, 1))
 }
 
+
+var Ns = {};
+>Ns : Symbol(Ns, Decl(a.js, 20, 3), Decl(a.js, 20, 12), Decl(a.js, 44, 7))
+
+/** @implements {A} */
+Ns.C1 = class {
+>Ns.C1 : Symbol(Ns.C1, Decl(a.js, 20, 12))
+>Ns : Symbol(Ns, Decl(a.js, 20, 3), Decl(a.js, 20, 12), Decl(a.js, 44, 7))
+>C1 : Symbol(Ns.C1, Decl(a.js, 20, 12))
+
+    method() { return 11; }
+>method : Symbol(C1.method, Decl(a.js, 22, 15))
+}
+/** @implements {A} */
+var C2 = class {
+>C2 : Symbol(C2, Decl(a.js, 26, 3))
+
+    method() { return 12; }
+>method : Symbol(C2.method, Decl(a.js, 26, 16))
+}
+var o = {
+>o : Symbol(o, Decl(a.js, 29, 3))
+
+    /** @implements {A} */
+    C3: class {
+>C3 : Symbol(C3, Decl(a.js, 29, 9))
+
+        method() { return 13; }
+>method : Symbol(C3.method, Decl(a.js, 31, 15))
+    }
+}
+class CC {
+>CC : Symbol(CC, Decl(a.js, 34, 1))
+
+    /** @implements {A} */
+    C4 = class {
+>C4 : Symbol(CC.C4, Decl(a.js, 35, 10))
+
+        method() {
+>method : Symbol((Anonymous class).method, Decl(a.js, 37, 16))
+
+            return 14;
+        }
+    }
+}
+
+var C5;
+>C5 : Symbol(C5, Decl(a.js, 44, 3))
+
+/** @implements {A} */
+Ns.C5 = C5 || class {
+>Ns.C5 : Symbol(Ns.C5, Decl(a.js, 44, 7))
+>Ns : Symbol(Ns, Decl(a.js, 20, 3), Decl(a.js, 20, 12), Decl(a.js, 44, 7))
+>C5 : Symbol(Ns.C5, Decl(a.js, 44, 7))
+>C5 : Symbol(C5, Decl(a.js, 44, 3))
+
+    method() {
+>method : Symbol(C5.method, Decl(a.js, 46, 21))
+
+        return 15;
+    }
+}
+

--- a/tests/baselines/reference/jsdocImplements_class.types
+++ b/tests/baselines/reference/jsdocImplements_class.types
@@ -32,3 +32,81 @@ class B3  {
 >B3 : B3
 }
 
+
+var Ns = {};
+>Ns : typeof Ns
+>{} : {}
+
+/** @implements {A} */
+Ns.C1 = class {
+>Ns.C1 = class {    method() { return 11; }} : typeof C1
+>Ns.C1 : typeof C1
+>Ns : typeof Ns
+>C1 : typeof C1
+>class {    method() { return 11; }} : typeof C1
+
+    method() { return 11; }
+>method : () => number
+>11 : 11
+}
+/** @implements {A} */
+var C2 = class {
+>C2 : typeof C2
+>class {    method() { return 12; }} : typeof C2
+
+    method() { return 12; }
+>method : () => number
+>12 : 12
+}
+var o = {
+>o : { C3: typeof C3; }
+>{    /** @implements {A} */    C3: class {        method() { return 13; }    }} : { C3: typeof C3; }
+
+    /** @implements {A} */
+    C3: class {
+>C3 : typeof C3
+>class {        method() { return 13; }    } : typeof C3
+
+        method() { return 13; }
+>method : () => number
+>13 : 13
+    }
+}
+class CC {
+>CC : CC
+
+    /** @implements {A} */
+    C4 = class {
+>C4 : typeof (Anonymous class)
+>class {        method() {            return 14;        }    } : typeof (Anonymous class)
+
+        method() {
+>method : () => number
+
+            return 14;
+>14 : 14
+        }
+    }
+}
+
+var C5;
+>C5 : any
+
+/** @implements {A} */
+Ns.C5 = C5 || class {
+>Ns.C5 = C5 || class {    method() {        return 15;    }} : typeof C5
+>Ns.C5 : typeof C5
+>Ns : typeof Ns
+>C5 : typeof C5
+>C5 || class {    method() {        return 15;    }} : typeof C5
+>C5 : undefined
+>class {    method() {        return 15;    }} : typeof C5
+
+    method() {
+>method : () => number
+
+        return 15;
+>15 : 15
+    }
+}
+

--- a/tests/cases/conformance/jsdoc/jsdocImplements_class.ts
+++ b/tests/cases/conformance/jsdoc/jsdocImplements_class.ts
@@ -23,3 +23,36 @@ class B2  {
 /** @implements {A} */
 class B3  {
 }
+
+
+var Ns = {};
+/** @implements {A} */
+Ns.C1 = class {
+    method() { return 11; }
+}
+/** @implements {A} */
+var C2 = class {
+    method() { return 12; }
+}
+var o = {
+    /** @implements {A} */
+    C3: class {
+        method() { return 13; }
+    }
+}
+class CC {
+    /** @implements {A} */
+    C4 = class {
+        method() {
+            return 14;
+        }
+    }
+}
+
+var C5;
+/** @implements {A} */
+Ns.C5 = C5 || class {
+    method() {
+        return 15;
+    }
+}


### PR DESCRIPTION
Make the search for the actual host more comprehensive by reusing the
code that previously only searched for functions. I don't know what to
call this function now, since the old name wasn't accurate either.

Fixes #37108