### PR TITLE
Remove ordering restrictions in control flow analysis

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3238,7 +3238,7 @@ namespace ts {
             // If this is a property-parameter, then also declare the property symbol into the
             // containing class.
             if (isParameterPropertyDeclaration(node, node.parent)) {
-                const classDeclaration = <ClassLikeDeclaration>node.parent.parent;
+                const classDeclaration = node.parent.parent;
                 declareSymbol(classDeclaration.symbol.members!, classDeclaration.symbol, node, SymbolFlags.Property | (node.questionToken ? SymbolFlags.Optional : SymbolFlags.None), SymbolFlags.PropertyExcludes);
             }
         }

--- a/tests/baselines/reference/narrowingOrderIndependent.js
+++ b/tests/baselines/reference/narrowingOrderIndependent.js
@@ -1,0 +1,66 @@
+//// [narrowingOrderIndependent.ts]
+// Repro from #36709
+
+class A {
+    constructor(public stringOrUndefined: string | undefined) {}
+}
+
+class B {
+    constructor(public str: string) {}
+}
+
+const a = new A("123");
+
+if (a instanceof A && a.stringOrUndefined) {
+    new B(a.stringOrUndefined)
+}
+
+if (a.stringOrUndefined && a instanceof A) {
+    new B(a.stringOrUndefined)
+}
+
+if (a instanceof A) {
+    if (a.stringOrUndefined) {
+        new B(a.stringOrUndefined)
+    }
+}
+
+if (a.stringOrUndefined) {
+    if (a instanceof A) {
+        new B(a.stringOrUndefined)
+    }
+}
+
+
+//// [narrowingOrderIndependent.js]
+"use strict";
+// Repro from #36709
+var A = /** @class */ (function () {
+    function A(stringOrUndefined) {
+        this.stringOrUndefined = stringOrUndefined;
+    }
+    return A;
+}());
+var B = /** @class */ (function () {
+    function B(str) {
+        this.str = str;
+    }
+    return B;
+}());
+var a = new A("123");
+if (a instanceof A && a.stringOrUndefined) {
+    new B(a.stringOrUndefined);
+}
+if (a.stringOrUndefined && a instanceof A) {
+    new B(a.stringOrUndefined);
+}
+if (a instanceof A) {
+    if (a.stringOrUndefined) {
+        new B(a.stringOrUndefined);
+    }
+}
+if (a.stringOrUndefined) {
+    if (a instanceof A) {
+        new B(a.stringOrUndefined);
+    }
+}

--- a/tests/baselines/reference/narrowingOrderIndependent.symbols
+++ b/tests/baselines/reference/narrowingOrderIndependent.symbols
@@ -1,0 +1,83 @@
+=== tests/cases/compiler/narrowingOrderIndependent.ts ===
+// Repro from #36709
+
+class A {
+>A : Symbol(A, Decl(narrowingOrderIndependent.ts, 0, 0))
+
+    constructor(public stringOrUndefined: string | undefined) {}
+>stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+}
+
+class B {
+>B : Symbol(B, Decl(narrowingOrderIndependent.ts, 4, 1))
+
+    constructor(public str: string) {}
+>str : Symbol(B.str, Decl(narrowingOrderIndependent.ts, 7, 16))
+}
+
+const a = new A("123");
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>A : Symbol(A, Decl(narrowingOrderIndependent.ts, 0, 0))
+
+if (a instanceof A && a.stringOrUndefined) {
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>A : Symbol(A, Decl(narrowingOrderIndependent.ts, 0, 0))
+>a.stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+
+    new B(a.stringOrUndefined)
+>B : Symbol(B, Decl(narrowingOrderIndependent.ts, 4, 1))
+>a.stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+}
+
+if (a.stringOrUndefined && a instanceof A) {
+>a.stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>A : Symbol(A, Decl(narrowingOrderIndependent.ts, 0, 0))
+
+    new B(a.stringOrUndefined)
+>B : Symbol(B, Decl(narrowingOrderIndependent.ts, 4, 1))
+>a.stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+}
+
+if (a instanceof A) {
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>A : Symbol(A, Decl(narrowingOrderIndependent.ts, 0, 0))
+
+    if (a.stringOrUndefined) {
+>a.stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+
+        new B(a.stringOrUndefined)
+>B : Symbol(B, Decl(narrowingOrderIndependent.ts, 4, 1))
+>a.stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+    }
+}
+
+if (a.stringOrUndefined) {
+>a.stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+
+    if (a instanceof A) {
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>A : Symbol(A, Decl(narrowingOrderIndependent.ts, 0, 0))
+
+        new B(a.stringOrUndefined)
+>B : Symbol(B, Decl(narrowingOrderIndependent.ts, 4, 1))
+>a.stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+>a : Symbol(a, Decl(narrowingOrderIndependent.ts, 10, 5))
+>stringOrUndefined : Symbol(A.stringOrUndefined, Decl(narrowingOrderIndependent.ts, 3, 16))
+    }
+}
+

--- a/tests/baselines/reference/narrowingOrderIndependent.types
+++ b/tests/baselines/reference/narrowingOrderIndependent.types
@@ -1,0 +1,95 @@
+=== tests/cases/compiler/narrowingOrderIndependent.ts ===
+// Repro from #36709
+
+class A {
+>A : A
+
+    constructor(public stringOrUndefined: string | undefined) {}
+>stringOrUndefined : string | undefined
+}
+
+class B {
+>B : B
+
+    constructor(public str: string) {}
+>str : string
+}
+
+const a = new A("123");
+>a : A
+>new A("123") : A
+>A : typeof A
+>"123" : "123"
+
+if (a instanceof A && a.stringOrUndefined) {
+>a instanceof A && a.stringOrUndefined : string | false | undefined
+>a instanceof A : boolean
+>a : A
+>A : typeof A
+>a.stringOrUndefined : string | undefined
+>a : A
+>stringOrUndefined : string | undefined
+
+    new B(a.stringOrUndefined)
+>new B(a.stringOrUndefined) : B
+>B : typeof B
+>a.stringOrUndefined : string
+>a : A
+>stringOrUndefined : string
+}
+
+if (a.stringOrUndefined && a instanceof A) {
+>a.stringOrUndefined && a instanceof A : boolean | "" | undefined
+>a.stringOrUndefined : string | undefined
+>a : A
+>stringOrUndefined : string | undefined
+>a instanceof A : boolean
+>a : A
+>A : typeof A
+
+    new B(a.stringOrUndefined)
+>new B(a.stringOrUndefined) : B
+>B : typeof B
+>a.stringOrUndefined : string
+>a : A
+>stringOrUndefined : string
+}
+
+if (a instanceof A) {
+>a instanceof A : boolean
+>a : A
+>A : typeof A
+
+    if (a.stringOrUndefined) {
+>a.stringOrUndefined : string | undefined
+>a : A
+>stringOrUndefined : string | undefined
+
+        new B(a.stringOrUndefined)
+>new B(a.stringOrUndefined) : B
+>B : typeof B
+>a.stringOrUndefined : string
+>a : A
+>stringOrUndefined : string
+    }
+}
+
+if (a.stringOrUndefined) {
+>a.stringOrUndefined : string | undefined
+>a : A
+>stringOrUndefined : string | undefined
+
+    if (a instanceof A) {
+>a instanceof A : boolean
+>a : A
+>A : typeof A
+
+        new B(a.stringOrUndefined)
+>new B(a.stringOrUndefined) : B
+>B : typeof B
+>a.stringOrUndefined : string
+>a : A
+>stringOrUndefined : string
+    }
+}
+

--- a/tests/cases/compiler/narrowingOrderIndependent.ts
+++ b/tests/cases/compiler/narrowingOrderIndependent.ts
@@ -1,0 +1,33 @@
+// @strict: true
+
+// Repro from #36709
+
+class A {
+    constructor(public stringOrUndefined: string | undefined) {}
+}
+
+class B {
+    constructor(public str: string) {}
+}
+
+const a = new A("123");
+
+if (a instanceof A && a.stringOrUndefined) {
+    new B(a.stringOrUndefined)
+}
+
+if (a.stringOrUndefined && a instanceof A) {
+    new B(a.stringOrUndefined)
+}
+
+if (a instanceof A) {
+    if (a.stringOrUndefined) {
+        new B(a.stringOrUndefined)
+    }
+}
+
+if (a.stringOrUndefined) {
+    if (a instanceof A) {
+        new B(a.stringOrUndefined)
+    }
+}


### PR DESCRIPTION
In #36114 we removed ordering restrictions related to discriminant checks in control flow analysis. With this PR we remove all such remaining restrictions, specifically those related to `instanceof`, `typeof`, and user defined type predicate checks.

A bit of history... In #10028 we introduced logic that would reset control flow analysis types following discriminant and `instanceof` checks. For example, following `obj instanceof Foo` we'd reset all control flow types for properties of `obj`, effectively forgetting about any narrowing operations that occurred before the `instanceof` check. This resetting logic was needed to work around issues related to control flow analysis in loops, but wasn't otherwise justified. In fact, the motivating examples all worked just fine outside of loops. It wasn't until #35332 that we finally fixed the underlying issue (for other reasons), and there is no reason to have these restrictions anymore.

Fixes #36709.