### PR TITLE
Don't crash when there's no class type to derive a 'this' type from

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -21096,8 +21096,10 @@ namespace ts {
                 if (isInJS && className) {
                     const classSymbol = checkExpression(className).symbol;
                     if (classSymbol && classSymbol.members && (classSymbol.flags & SymbolFlags.Function)) {
-                        const classType = (getDeclaredTypeOfSymbol(classSymbol) as InterfaceType).thisType!;
-                        return getFlowTypeOfReference(node, classType);
+                        const classType = (getDeclaredTypeOfSymbol(classSymbol) as InterfaceType).thisType;
+                        if (classType) {
+                            return getFlowTypeOfReference(node, classType);
+                        }
                     }
                 }
                 // Check if it's a constructor definition, can be either a variable decl or function decl

--- a/tests/baselines/reference/allowJsClassThisTypeCrash.symbols
+++ b/tests/baselines/reference/allowJsClassThisTypeCrash.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/app.js ===
+const f = function() {};
+>f : Symbol(f, Decl(app.js, 0, 5))
+
+var g = f;
+>g : Symbol(g, Decl(app.js, 1, 3))
+>f : Symbol(f, Decl(app.js, 0, 5))
+
+g.prototype.m = function () {
+>g.prototype : Symbol(g.m, Decl(app.js, 1, 10))
+>g : Symbol(g, Decl(app.js, 1, 3))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>m : Symbol(g.m, Decl(app.js, 1, 10))
+
+  this;
+};

--- a/tests/baselines/reference/allowJsClassThisTypeCrash.types
+++ b/tests/baselines/reference/allowJsClassThisTypeCrash.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/app.js ===
+const f = function() {};
+>f : () => void
+>function() {} : () => void
+
+var g = f;
+>g : () => void
+>f : () => void
+
+g.prototype.m = function () {
+>g.prototype.m = function () {  this;} : () => void
+>g.prototype.m : any
+>g.prototype : any
+>g : () => void
+>prototype : any
+>m : any
+>function () {  this;} : () => void
+
+  this;
+>this : any
+
+};

--- a/tests/cases/compiler/allowJsClassThisTypeCrash.ts
+++ b/tests/cases/compiler/allowJsClassThisTypeCrash.ts
@@ -1,0 +1,10 @@
+// @checkJs: true
+// @allowJs: true
+// @noEmit: true
+
+// @filename: app.js
+const f = function() {};
+var g = f;
+g.prototype.m = function () {
+  this;
+};


### PR DESCRIPTION
Fixes #37161
