### PR TITLE
Preserve arity for preserving js optional parameters

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4817,6 +4817,7 @@ namespace ts {
         HasLiteralTypes = 1 << 1,           // Indicates signature is specialized
         IsInnerCallChain = 1 << 2,          // Indicates signature comes from a CallChain nested in an outer OptionalChain
         IsOuterCallChain = 1 << 3,          // Indicates signature comes from a CallChain that is the outermost chain of an optional expression
+        IsUntypedSignatureInJSFile = 1 << 4, // Indicates signature is from a js file and has no types
 
         // We do not propagate `IsInnerCallChain` to instantiated signatures, as that would result in us
         // attempting to add `| undefined` on each recursive call to `getReturnTypeOfSignature` when

--- a/tests/baselines/reference/jsDeclarationsClassLeadingOptional.js
+++ b/tests/baselines/reference/jsDeclarationsClassLeadingOptional.js
@@ -1,0 +1,27 @@
+//// [bar.js]
+export class Z {
+    f(x = 1, y) {
+        return [x, y];
+    }
+}
+
+//// [bar.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.Z = void 0;
+var Z = /** @class */ (function () {
+    function Z() {
+    }
+    Z.prototype.f = function (x, y) {
+        if (x === void 0) { x = 1; }
+        return [x, y];
+    };
+    return Z;
+}());
+exports.Z = Z;
+
+
+//// [bar.d.ts]
+export class Z {
+    f(x: number, y: any): any[];
+}

--- a/tests/baselines/reference/jsDeclarationsClassLeadingOptional.symbols
+++ b/tests/baselines/reference/jsDeclarationsClassLeadingOptional.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/jsdoc/declarations/bar.js ===
+export class Z {
+>Z : Symbol(Z, Decl(bar.js, 0, 0))
+
+    f(x = 1, y) {
+>f : Symbol(Z.f, Decl(bar.js, 0, 16))
+>x : Symbol(x, Decl(bar.js, 1, 6))
+>y : Symbol(y, Decl(bar.js, 1, 12))
+
+        return [x, y];
+>x : Symbol(x, Decl(bar.js, 1, 6))
+>y : Symbol(y, Decl(bar.js, 1, 12))
+    }
+}

--- a/tests/baselines/reference/jsDeclarationsClassLeadingOptional.types
+++ b/tests/baselines/reference/jsDeclarationsClassLeadingOptional.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/jsdoc/declarations/bar.js ===
+export class Z {
+>Z : Z
+
+    f(x = 1, y) {
+>f : (x: number, y: any) => any[]
+>x : number
+>1 : 1
+>y : any
+
+        return [x, y];
+>[x, y] : any[]
+>x : number
+>y : any
+    }
+}

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassLeadingOptional.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassLeadingOptional.ts
@@ -1,0 +1,11 @@
+// @allowJs: true
+// @checkJs: true
+// @target: es5
+// @outDir: ./out
+// @declaration: true
+// @filename: bar.js
+export class Z {
+    f(x = 1, y) {
+        return [x, y];
+    }
+}


### PR DESCRIPTION
Fixes #36507

For relationship checking, we consider untyped signatures from js as only having 0 required arguments; however we also use that minimum argument count for calculating weather an initialized optional parameter is optional or not. In the later case, we would like that "js signatures have 0 required arguments" rule to not apply, so we can actually recover what parameters are optional.