### PR TITLE
Emit an `any` for namepath types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6330,7 +6330,8 @@ namespace ts {
                     return result;
 
                     function visitExistingNodeTreeSymbols<T extends Node>(node: T): Node {
-                        if (isJSDocAllType(node)) {
+                        // We don't _actually_ support jsdoc namepath types, emit `any` instead
+                        if (isJSDocAllType(node) || node.kind === SyntaxKind.JSDocNamepathType) {
                             return createKeywordTypeNode(SyntaxKind.AnyKeyword);
                         }
                         if (isJSDocUnknownType(node)) {

--- a/tests/baselines/reference/jsDeclarationsModuleReferenceHasEmit.js
+++ b/tests/baselines/reference/jsDeclarationsModuleReferenceHasEmit.js
@@ -1,0 +1,47 @@
+//// [index.js]
+/**
+ * @module A
+ */
+class A {}
+
+
+/**
+ * Target element
+ * @type {module:A}
+ */
+export let el = null;
+
+export default A;
+
+//// [index.js]
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.el = void 0;
+/**
+ * @module A
+ */
+var A = /** @class */ (function () {
+    function A() {
+    }
+    return A;
+}());
+/**
+ * Target element
+ * @type {module:A}
+ */
+exports.el = null;
+exports.default = A;
+
+
+//// [index.d.ts]
+/**
+ * Target element
+ * @type {module:A}
+ */
+export let el: any;
+export default A;
+/**
+ * @module A
+ */
+declare class A {
+}

--- a/tests/baselines/reference/jsDeclarationsModuleReferenceHasEmit.symbols
+++ b/tests/baselines/reference/jsDeclarationsModuleReferenceHasEmit.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/jsdoc/declarations/index.js ===
+/**
+ * @module A
+ */
+class A {}
+>A : Symbol(A, Decl(index.js, 0, 0))
+
+
+/**
+ * Target element
+ * @type {module:A}
+ */
+export let el = null;
+>el : Symbol(el, Decl(index.js, 10, 10))
+
+export default A;
+>A : Symbol(A, Decl(index.js, 0, 0))
+

--- a/tests/baselines/reference/jsDeclarationsModuleReferenceHasEmit.types
+++ b/tests/baselines/reference/jsDeclarationsModuleReferenceHasEmit.types
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/jsdoc/declarations/index.js ===
+/**
+ * @module A
+ */
+class A {}
+>A : A
+
+
+/**
+ * Target element
+ * @type {module:A}
+ */
+export let el = null;
+>el : error
+>null : null
+
+export default A;
+>A : A
+

--- a/tests/cases/conformance/jsdoc/declarations/jsDeclarationsModuleReferenceHasEmit.ts
+++ b/tests/cases/conformance/jsdoc/declarations/jsDeclarationsModuleReferenceHasEmit.ts
@@ -1,0 +1,19 @@
+// @allowJs: true
+// @checkJs: true
+// @target: es5
+// @outDir: ./out
+// @declaration: true
+// @filename: index.js
+/**
+ * @module A
+ */
+class A {}
+
+
+/**
+ * Target element
+ * @type {module:A}
+ */
+export let el = null;
+
+export default A;


### PR DESCRIPTION
Fixes #36690

When we added an AST node to parse over namepaths in https://github.com/microsoft/TypeScript/pull/32563, we didn't add any checker code to handle the new type node anywhere - in many cases, this meant a fallback to the `errorType` (which is fine), but here we needed to explicitly map the namepath type node into an `any` type node.