### PR TITLE
Handle when default project for file is solution with file actually referenced by one of the project references

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -431,7 +431,7 @@ namespace ts.server {
         Find,
         /** Find existing project or create one for the project reference */
         FindCreate,
-        /** Find existing project or create and loas it for the project reference */
+        /** Find existing project or create and load it for the project reference */
         FindCreateLoad
     }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -425,9 +425,13 @@ namespace ts.server {
     }
 
     /*@internal*/
+    /** Kind of operation to perform to get project reference project */
     export enum ProjectReferenceProjectLoadKind {
+        /** Find existing project for project reference */
         Find,
+        /** Find existing project or create one for the project reference */
         FindCreate,
+        /** Find existing project or create and loas it for the project reference */
         FindCreateLoad
     }
 
@@ -528,6 +532,7 @@ namespace ts.server {
     }
 
     /*@internal*/
+    /** true if script info is part of project and is not in project because it is referenced from project reference source */
     export function projectContainsInfoDirectly(project: Project, info: ScriptInfo) {
         return project.containsScriptInfo(info) &&
             !project.isSourceOfProjectReferenceRedirect(info.path);
@@ -2776,6 +2781,7 @@ namespace ts.server {
                         else {
                             // reload from the disk
                             this.reloadConfiguredProject(project, reason);
+                            // If this is solution, reload the project till the reloaded project contains the script info directly
                             if (!project.containsScriptInfo(info) && project.isSolution()) {
                                 forEachResolvedProjectReferenceProject(
                                     project,
@@ -2881,6 +2887,7 @@ namespace ts.server {
             updateProjectIfDirty(configuredProject);
 
             if (configuredProject.isSolution()) {
+                // Find the project that is referenced from this solution that contains the script info directly
                 configuredProject = forEachResolvedProjectReferenceProject(
                     configuredProject,
                     child => {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2902,6 +2902,7 @@ namespace ts.server {
                                 const configFileName = toNormalizedPath(ref.sourceFile.fileName);
                                 const child = this.findConfiguredProjectByProjectName(configFileName) ||
                                     this.createAndLoadConfiguredProject(configFileName, `Creating project referenced in solution ${defaultConfigProject!.projectName} to find possible configured project for ${info.fileName} to open`);
+                                updateProjectIfDirty(child);
                                 // Retain these projects
                                 if (!isArray(retainProjects)) {
                                     retainProjects = [defaultConfigProject!, child];
@@ -2913,6 +2914,8 @@ namespace ts.server {
                                 if (child.containsScriptInfo(info) &&
                                     !child.isSourceOfProjectReferenceRedirect(info.fileName)) {
                                     defaultConfigProject = child;
+                                    configFileErrors = child.getAllProjectErrors();
+                                    this.sendConfigFileDiagEvent(child, info.fileName);
                                     return true;
                                 }
                             }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -424,7 +424,8 @@ namespace ts.server {
         return !!(infoOrFileNameOrConfig as AncestorConfigFileInfo).configFileInfo;
     }
 
-    function forEachResolvedProjectReference<T>(
+    /*@internal*/
+    export function forEachResolvedProjectReference<T>(
         project: ConfiguredProject,
         cb: (resolvedProjectReference: ResolvedProjectReference | undefined, resolvedProjectReferencePath: Path) => T | undefined
     ): T | undefined {
@@ -1737,7 +1738,8 @@ namespace ts.server {
             this.logger.endGroup();
         }
 
-        private findConfiguredProjectByProjectName(configFileName: NormalizedPath): ConfiguredProject | undefined {
+        /*@internal*/
+        findConfiguredProjectByProjectName(configFileName: NormalizedPath): ConfiguredProject | undefined {
             // make sure that casing of config file name is consistent
             const canonicalConfigFilePath = asNormalizedPath(this.toCanonicalFileName(configFileName));
             return this.getConfiguredProjectByCanonicalConfigFilePath(canonicalConfigFilePath);
@@ -2888,8 +2890,7 @@ namespace ts.server {
                     // If this configured project doesnt contain script info but
                     // it is solution with project references, try those project references
                     if (!project.containsScriptInfo(info) &&
-                        project.getRootFilesMap().size === 0 &&
-                        !project.canConfigFileJsonReportNoInputFiles) {
+                        project.isSolution()) {
 
                         // try to load project from the tree
                         forEachResolvedProjectReference(
@@ -2909,7 +2910,8 @@ namespace ts.server {
                                     retainProjects.push(child);
                                 }
 
-                                if (child.containsScriptInfo(info)) {
+                                if (child.containsScriptInfo(info) &&
+                                    !child.isSourceOfProjectReferenceRedirect(info.fileName)) {
                                     defaultConfigProject = child;
                                     return true;
                                 }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -3052,7 +3052,10 @@ namespace ts.server {
                 if (forEachPotentialProjectReference(
                     project,
                     potentialRefPath => forProjects!.has(potentialRefPath)
-                )) {
+                ) || (project.isSolution() && forEachResolvedProjectReference(
+                    project,
+                    (_ref, resolvedPath) => forProjects!.has(resolvedPath)
+                ))) {
                     // Load children
                     this.ensureProjectChildren(project, seenProjects);
                 }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1687,8 +1687,12 @@ namespace ts.server {
         findDefaultConfiguredProject(info: ScriptInfo) {
             if (!info.isScriptOpen()) return undefined;
             const configFileName = this.getConfigFileNameForFile(info);
-            return configFileName &&
+            const project = configFileName &&
                 this.findConfiguredProjectByProjectName(configFileName);
+
+            return project?.isSolution() ?
+                project.getDefaultChildProjectFromSolution(info) :
+                project;
         }
 
         /**

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2171,6 +2171,7 @@ namespace ts.server {
         }
 
         /* @internal */
+        /** Find the configured project from the project references in this solution which contains the info directly */
         getDefaultChildProjectFromSolution(info: ScriptInfo) {
             Debug.assert(this.isSolution());
             return forEachResolvedProjectReferenceProject(

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -2173,16 +2173,13 @@ namespace ts.server {
         /* @internal */
         getDefaultChildProjectFromSolution(info: ScriptInfo) {
             Debug.assert(this.isSolution());
-            return forEachResolvedProjectReference(this, ref => {
-                if (!ref) return undefined;
-                const configFileName = toNormalizedPath(ref.sourceFile.fileName);
-                const child = this.projectService.findConfiguredProjectByProjectName(configFileName);
-                return child &&
-                    child.containsScriptInfo(info) &&
-                    !child.isSourceOfProjectReferenceRedirect(info.path) ?
+            return forEachResolvedProjectReferenceProject(
+                this,
+                child => projectContainsInfoDirectly(child, info) ?
                     child :
-                    undefined;
-            });
+                    undefined,
+                ProjectReferenceProjectLoadKind.Find
+            );
         }
 
         /** Returns true if the project is needed by any of the open script info/external project */

--- a/src/testRunner/unittests/publicApi.ts
+++ b/src/testRunner/unittests/publicApi.ts
@@ -1,4 +1,4 @@
-describe("Public APIs", () => {
+describe("unittests:: Public APIs", () => {
     function verifyApi(fileName: string) {
         const builtFile = `built/local/${fileName}`;
         const api = `api/${fileName}`;
@@ -32,7 +32,7 @@ describe("Public APIs", () => {
     });
 });
 
-describe("Public APIs:: token to string", () => {
+describe("unittests:: Public APIs:: token to string", () => {
     function assertDefinedTokenToString(initial: ts.SyntaxKind, last: ts.SyntaxKind) {
         for (let t = initial; t <= last; t++) {
             assert.isDefined(ts.tokenToString(t), `Expected tokenToString defined for ${ts.Debug.formatSyntaxKind(t)}`);
@@ -47,13 +47,13 @@ describe("Public APIs:: token to string", () => {
     });
 });
 
-describe("Public APIs:: createPrivateIdentifier", () => {
+describe("unittests:: Public APIs:: createPrivateIdentifier", () => {
     it("throws when name doesn't start with #", () => {
         assert.throw(() => ts.createPrivateIdentifier("not"), "Debug Failure. First character of private identifier must be #: not");
     });
 });
 
-describe("Public APIs:: isPropertyName", () => {
+describe("unittests:: Public APIs:: isPropertyName", () => {
     it("checks if a PrivateIdentifier is a valid property name", () => {
         const prop = ts.createPrivateIdentifier("#foo");
         assert.isTrue(ts.isPropertyName(prop), "PrivateIdentifier must be a valid property name.");

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -1891,6 +1891,10 @@ export { foo };`
                 service.openClientFile(main.path);
                 verifyProjects(/*includeConfigured*/ true, /*includeDummy*/ false);
                 checkEvents(session, expectedOpenEvents);
+                const info = service.getScriptInfoForPath(mainPath as Path)!;
+                const project = service.configuredProjects.get(tsconfigSrc.path)!;
+                assert.equal(info.getDefaultProject(), project);
+                assert.equal(service.findDefaultConfiguredProject(info), project);
 
                 verifyGetErrRequest({
                     session,
@@ -1959,9 +1963,26 @@ export { foo };`
                     content: `import { foo } from 'main';
 foo;`
                 };
+                const tsconfigIndirect2: File = {
+                    path: `${tscWatch.projectRoot}/tsconfig-indirect2.json`,
+                    content: JSON.stringify({
+                        compilerOptions: {
+                            composite: true,
+                            outDir: "./target/",
+                            baseUrl: "./src/"
+                        },
+                        files: ["./indirect2/main2.ts"],
+                        references: [{ path: "./tsconfig-src.json" }]
+                    })
+                };
+                const indirect2: File = {
+                    path: `${tscWatch.projectRoot}/indirect2/main2.ts`,
+                    content: `import { foo } from 'main';
+foo;`
+                };
                 verifySolutionScenario({
-                    configRefs: ["./tsconfig-indirect.json"],
-                    additionalFiles: [tsconfigIndirect, indirect],
+                    configRefs: ["./tsconfig-indirect.json", "./tsconfig-indirect2.json"],
+                    additionalFiles: [tsconfigIndirect, indirect, tsconfigIndirect2, indirect2],
                     additionalProjects: [{
                         projectName: tsconfigIndirect.path,
                         files: [tsconfigIndirect.path, mainPath, helperPath, indirect.path, libFile.path]

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -1848,6 +1848,7 @@ bar();
                 expectedOpenEvents: protocol.Event[];
                 expectedReloadEvents: protocol.Event[];
                 expectedReferences: protocol.ReferencesResponseBody;
+                expectedReferencesFromDtsProject: protocol.ReferencesResponseBody;
             }
             const main: File = {
                 path: `${tscWatch.projectRoot}/src/main.ts`,
@@ -1858,11 +1859,44 @@ export { foo };`
                 path: `${tscWatch.projectRoot}/src/helpers/functions.ts`,
                 content: `export const foo = 1;`
             };
+            const mainDts: File = {
+                path: `${tscWatch.projectRoot}/target/src/main.d.ts`,
+                content: `import { foo } from 'helpers/functions';
+export { foo };
+//# sourceMappingURL=main.d.ts.map`
+            };
+            const mainDtsMap: File = {
+                path: `${tscWatch.projectRoot}/target/src/main.d.ts.map`,
+                content: `{"version":3,"file":"main.d.ts","sourceRoot":"","sources":["../../src/main.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,GAAG,EAAE,MAAM,mBAAmB,CAAC;AAExC,OAAO,EAAC,GAAG,EAAC,CAAC"}`
+            };
+            const helperDts: File = {
+                path: `${tscWatch.projectRoot}/target/src/helpers/functions.d.ts`,
+                content: `export declare const foo = 1;
+//# sourceMappingURL=functions.d.ts.map`
+            };
+            const helperDtsMap: File = {
+                path: `${tscWatch.projectRoot}/target/src/helpers/functions.d.ts.map`,
+                content: `{"version":3,"file":"functions.d.ts","sourceRoot":"","sources":["../../../src/helpers/functions.ts"],"names":[],"mappings":"AAAA,eAAO,MAAM,GAAG,IAAI,CAAC"}`
+            };
+            const tsconfigIndirect3: File = {
+                path: `${tscWatch.projectRoot}/indirect3/tsconfig.json`,
+                content: JSON.stringify({
+                    compilerOptions: {
+                        baseUrl: "../target/src/"
+                    },
+                })
+            };
+            const fileResolvingToMainDts: File = {
+                path: `${tscWatch.projectRoot}/indirect3/main.ts`,
+                content: `import { foo } from 'main';
+foo;`
+            };
             const tsconfigSrcPath = `${tscWatch.projectRoot}/tsconfig-src.json`;
             const tsconfigPath = `${tscWatch.projectRoot}/tsconfig.json`;
             function verifySolutionScenario({
                 configRefs, additionalFiles, additionalProjects,
-                expectedOpenEvents, expectedReloadEvents, expectedReferences
+                expectedOpenEvents, expectedReloadEvents,
+                expectedReferences, expectedReferencesFromDtsProject
             }: VerifySolutionScenario) {
                 const tsconfigSrc: File = {
                     path: tsconfigSrcPath,
@@ -1886,7 +1920,12 @@ export { foo };`
                     path: "/dummy/dummy.ts",
                     content: "let a = 10;"
                 };
-                const host = createServerHost([tsconfigSrc, tsconfig, main, helper, libFile, dummyFile, ...additionalFiles]);
+                const host = createServerHost([
+                    tsconfigSrc, tsconfig, main, helper,
+                    libFile, dummyFile,
+                    mainDts, mainDtsMap, helperDts, helperDtsMap,
+                    tsconfigIndirect3, fileResolvingToMainDts,
+                    ...additionalFiles]);
                 const session = createSession(host, { canUseEvents: true });
                 const service = session.getProjectService();
                 service.openClientFile(main.path);
@@ -1935,7 +1974,18 @@ export { foo };`
 
                 service.closeClientFile(main.path);
                 service.closeClientFile(dummyFile.path);
-                service.openClientFile(dummyFile.path);
+
+                // Verify when declaration map references the file
+                service.openClientFile(fileResolvingToMainDts.path);
+                checkNumberOfProjects(service, { configuredProjects: 1 });
+                checkProjectActualFiles(service.configuredProjects.get(tsconfigIndirect3.path)!, [tsconfigIndirect3.path, fileResolvingToMainDts.path, mainDts.path, helperDts.path, libFile.path]);
+
+                // Find all refs from dts include
+                const response2 = session.executeCommandSeq<protocol.ReferencesRequest>({
+                    command: protocol.CommandTypes.References,
+                    arguments: protocolFileLocationFromSubstring(fileResolvingToMainDts, "foo")
+                }).response as protocol.ReferencesResponseBody;
+                assert.deepEqual(response2, expectedReferencesFromDtsProject);
 
                 function verifyProjects(includeConfigured: boolean, includeDummy: boolean) {
                     const inferredProjects = includeDummy ? 1 : 0;
@@ -2033,7 +2083,7 @@ export { foo };`
                 ];
             }
 
-            function getIndirectProject(postfix = "") {
+            function getIndirectProject(postfix: string) {
                 const tsconfigIndirect: File = {
                     path: `${tscWatch.projectRoot}/tsconfig-indirect${postfix}.json`,
                     content: JSON.stringify({
@@ -2048,13 +2098,13 @@ export { foo };`
                 };
                 const indirect: File = {
                     path: `${tscWatch.projectRoot}/indirect${postfix}/main.ts`,
-                    content: `import { foo } from 'main';
-foo;`
+                    content: fileResolvingToMainDts.content
                 };
                 return { tsconfigIndirect, indirect };
             }
 
             it("when project is directly referenced by solution", () => {
+                const expectedReferences = expectedReferencesResponse();
                 verifySolutionScenario({
                     configRefs: ["./tsconfig-src.json"],
                     additionalFiles: emptyArray,
@@ -2068,16 +2118,24 @@ foo;`
                         ...expectedReloadEvent(tsconfigPath),
                         ...expectedReloadEvent(tsconfigSrcPath),
                     ],
-                    expectedReferences: expectedReferencesResponse()
+                    expectedReferences,
+                    expectedReferencesFromDtsProject: {
+                        ...expectedReferences,
+                        refs: [
+                            ...expectedIndirectRefs(fileResolvingToMainDts),
+                            ...expectedReferences.refs
+                        ],
+                        symbolDisplayString: "(alias) const foo: 1\nimport foo",
+                    }
                 });
             });
 
             it("when project is indirectly referenced by solution", () => {
-                const { tsconfigIndirect, indirect } = getIndirectProject();
+                const { tsconfigIndirect, indirect } = getIndirectProject("1");
                 const { tsconfigIndirect: tsconfigIndirect2, indirect: indirect2 } = getIndirectProject("2");
                 const { refs, ...rest } = expectedReferencesResponse();
                 verifySolutionScenario({
-                    configRefs: ["./tsconfig-indirect.json", "./tsconfig-indirect2.json"],
+                    configRefs: ["./tsconfig-indirect1.json", "./tsconfig-indirect2.json"],
                     additionalFiles: [tsconfigIndirect, indirect, tsconfigIndirect2, indirect2],
                     additionalProjects: [{
                         projectName: tsconfigIndirect.path,
@@ -2101,6 +2159,16 @@ foo;`
                             ...expectedIndirectRefs(indirect2),
                         ],
                         ...rest
+                    },
+                    expectedReferencesFromDtsProject: {
+                        ...rest,
+                        refs: [
+                            ...expectedIndirectRefs(fileResolvingToMainDts),
+                            ...refs,
+                            ...expectedIndirectRefs(indirect2),
+                            ...expectedIndirectRefs(indirect),
+                        ],
+                        symbolDisplayString: "(alias) const foo: 1\nimport foo",
                     }
                 });
             });

--- a/src/testRunner/unittests/tsserver/projectReferences.ts
+++ b/src/testRunner/unittests/tsserver/projectReferences.ts
@@ -1872,26 +1872,15 @@ foo;`
             const session = createSession(host, { canUseEvents: true });
             const service = session.getProjectService();
             service.openClientFile(main.path);
-            checkNumberOfProjects(service, { configuredProjects: 1, inferredProjects: 1 });
-            checkProjectActualFiles(service.inferredProjects[0], [main.path, libFile.path]);
+            checkNumberOfProjects(service, { configuredProjects: 2 });
+            checkProjectActualFiles(service.configuredProjects.get(tsconfigSrc.path)!, [tsconfigSrc.path, main.path, helper.path, libFile.path]);
             checkProjectActualFiles(service.configuredProjects.get(tsconfig.path)!, [tsconfig.path]);
 
-            const location = protocolTextSpanFromSubstring(main.content, `'helpers/functions'`);
             verifyGetErrRequest({
                 session,
                 host,
                 expected: [
-                    {
-                        file: main,
-                        syntax: [],
-                        semantic: [createDiagnostic(
-                            location.start,
-                            location.end,
-                            Diagnostics.Cannot_find_module_0,
-                            ["helpers/functions"]
-                        )],
-                        suggestion: []
-                    },
+                    { file: main, syntax: [], semantic: [], suggestion: [] },
                 ]
             });
         });

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9310,7 +9310,6 @@ declare namespace ts.server {
          */
         private getConfigFileNameForFile;
         private printProjects;
-        private findConfiguredProjectByProjectName;
         private getConfiguredProjectByCanonicalConfigFilePath;
         private findExternalProjectByProjectName;
         /** Get a filename if the language service exceeds the maximum allowed program size; otherwise returns undefined. */

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -9316,7 +9316,6 @@ declare namespace ts.server {
         private getFilenameForExceededTotalSizeLimitForNonTsFiles;
         private createExternalProject;
         private addFilesToNonInferredProject;
-        private createConfiguredProject;
         private updateNonInferredProjectFiles;
         private updateRootAndOptionsOfNonInferredProject;
         private sendConfigFileDiagEvent;


### PR DESCRIPTION
Fixes #36708, #27372

Now when we find that the project is a solution project, we try to open referenced projects to see if we can find project that contains the opened file.
