### PR TITLE
fix(37194): Crash in JS constructors initialized with intermediate `module.exports` assignment

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -252,7 +252,7 @@ namespace ts.GoToDefinition {
         function getConstructSignatureDefinition(): DefinitionInfo[] | undefined {
             // Applicable only if we are in a new expression, or we are on a constructor declaration
             // and in either case the symbol has a construct signature definition, i.e. class
-            if (symbol.flags & SymbolFlags.Class && !(symbol.flags & SymbolFlags.Function) && (isNewExpressionTarget(node) || node.kind === SyntaxKind.ConstructorKeyword)) {
+            if (symbol.flags & SymbolFlags.Class && !(symbol.flags & (SymbolFlags.Function | SymbolFlags.Variable)) && (isNewExpressionTarget(node) || node.kind === SyntaxKind.ConstructorKeyword)) {
                 const cls = find(filteredDeclarations, isClassLike) || Debug.fail("Expected declaration to have at least one class-like declaration");
                 return getSignatureDefinition(cls.members, /*selectConstructors*/ true);
             }

--- a/tests/cases/fourslash/goToDefinitionVariableAssignment.ts
+++ b/tests/cases/fourslash/goToDefinitionVariableAssignment.ts
@@ -1,0 +1,12 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+// @filename: foo.js
+////const Bar;
+////const /*def1*/Foo = /*def2*/Bar = function () {}
+////Foo.prototype.bar = function() {}
+////new [|Foo/*ref*/|]();
+
+goTo.file("foo.js");
+verify.goToDefinition("ref", ["def1", "def2"]);

--- a/tests/cases/fourslash/goToDefinitionVariableAssignment1.ts
+++ b/tests/cases/fourslash/goToDefinitionVariableAssignment1.ts
@@ -1,0 +1,11 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+// @checkJs: true
+// @filename: foo.js
+////const /*def1*/Foo = module./*def2*/exports = function () {}
+////Foo.prototype.bar = function() {}
+////new [|Foo/*ref*/|]();
+
+goTo.file("foo.js");
+verify.goToDefinition("ref", ["def1", "def2"]);

--- a/tests/cases/fourslash/goToDefinitionVariableAssignment2.ts
+++ b/tests/cases/fourslash/goToDefinitionVariableAssignment2.ts
@@ -1,0 +1,10 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: foo.ts
+////const Bar;
+////const /*def1*/Foo = /*def2*/Bar = function () {}
+////Foo.prototype.bar = function() {}
+////new [|Foo/*ref*/|]();
+
+goTo.file("foo.ts");
+verify.goToDefinition("ref", ["def1", "def2"]);

--- a/tests/cases/fourslash/goToDefinitionVariableAssignment3.ts
+++ b/tests/cases/fourslash/goToDefinitionVariableAssignment3.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+// @filename: foo.ts
+////const /*def1*/Foo = module./*def2*/exports = function () {}
+////Foo.prototype.bar = function() {}
+////new [|Foo/*ref*/|]();
+
+goTo.file("foo.ts");
+verify.goToDefinition("ref", ["def1", "def2"]);


### PR DESCRIPTION
Fixes #37194
