### PR TITLE
Fix fileExists check for a watch program

### DIFF
--- a/src/compiler/watchPublic.ts
+++ b/src/compiler/watchPublic.ts
@@ -450,7 +450,7 @@ namespace ts {
             // If file is missing on host from cache, we can definitely say file doesnt exist
             // otherwise we need to ensure from the disk
             if (isFileMissingOnHost(sourceFilesCache.get(path))) {
-                return true;
+                return false;
             }
 
             return directoryStructureHost.fileExists(fileName);

--- a/src/testRunner/unittests/tscWatch/programUpdates.ts
+++ b/src/testRunner/unittests/tscWatch/programUpdates.ts
@@ -401,7 +401,7 @@ export class A {
         verifyTscWatch({
             scenario,
             subScenario: "deleted files affect project structure",
-            commandLineArgs: ["-w", "/a/b/f1.ts"],
+            commandLineArgs: ["-w", "/a/b/f1.ts", "--noImplicitAny"],
             sys: () => {
                 const file1 = {
                     path: "/a/b/f1.ts",
@@ -429,7 +429,7 @@ export class A {
         verifyTscWatch({
             scenario,
             subScenario: "deleted files affect project structure-2",
-            commandLineArgs: ["-w", "/a/b/f1.ts", "/a/c/f3.ts"],
+            commandLineArgs: ["-w", "/a/b/f1.ts", "/a/c/f3.ts", "--noImplicitAny"],
             sys: () => {
                 const file1 = {
                     path: "/a/b/f1.ts",

--- a/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure-2.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure-2.js
@@ -110,10 +110,8 @@ Output::
 12:00:28 AM - File change detected. Starting incremental compilation...
 
 
-a/b/f1.ts(1,15): error TS2307: Cannot find module './f2'.
 
-
-12:00:32 AM - Found 1 error. Watching for file changes.
+12:00:32 AM - Found 0 errors. Watching for file changes.
 
 
 Program root files: ["/a/b/f1.ts","/a/c/f3.ts"]
@@ -133,11 +131,11 @@ WatchedFiles::
   {"fileName":"/a/c/f3.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
-/a/b/f2.ts:
-  {"fileName":"/a/b/f2.ts","pollingInterval":250}
 
 FsWatches::
 
 FsWatchesRecursive::
+/a:
+  {"directoryName":"/a","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure-2.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure-2.js
@@ -1,4 +1,4 @@
-/a/lib/tsc.js -w /a/b/f1.ts /a/c/f3.ts
+/a/lib/tsc.js -w /a/b/f1.ts /a/c/f3.ts --noImplicitAny
 //// [/a/b/f1.ts]
 export * from "./f2"
 
@@ -71,7 +71,7 @@ Output::
 
 
 Program root files: ["/a/b/f1.ts","/a/c/f3.ts"]
-Program options: {"watch":true}
+Program options: {"watch":true,"noImplicitAny":true}
 Program files::
 /a/lib/lib.d.ts
 /a/c/f3.ts
@@ -110,12 +110,14 @@ Output::
 12:00:28 AM - File change detected. Starting incremental compilation...
 
 
+a/b/f1.ts(1,15): error TS7016: Could not find a declaration file for module './f2'. '/a/b/f2.js' implicitly has an 'any' type.
 
-12:00:32 AM - Found 0 errors. Watching for file changes.
+
+12:00:32 AM - Found 1 error. Watching for file changes.
 
 
 Program root files: ["/a/b/f1.ts","/a/c/f3.ts"]
-Program options: {"watch":true}
+Program options: {"watch":true,"noImplicitAny":true}
 Program files::
 /a/lib/lib.d.ts
 /a/b/f1.ts

--- a/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure.js
@@ -1,4 +1,4 @@
-/a/lib/tsc.js -w /a/b/f1.ts
+/a/lib/tsc.js -w /a/b/f1.ts --noImplicitAny
 //// [/a/b/f1.ts]
 export * from "./f2"
 
@@ -71,7 +71,7 @@ Output::
 
 
 Program root files: ["/a/b/f1.ts"]
-Program options: {"watch":true}
+Program options: {"watch":true,"noImplicitAny":true}
 Program files::
 /a/lib/lib.d.ts
 /a/c/f3.ts
@@ -110,12 +110,14 @@ Output::
 12:00:28 AM - File change detected. Starting incremental compilation...
 
 
+a/b/f1.ts(1,15): error TS7016: Could not find a declaration file for module './f2'. '/a/b/f2.js' implicitly has an 'any' type.
 
-12:00:32 AM - Found 0 errors. Watching for file changes.
+
+12:00:32 AM - Found 1 error. Watching for file changes.
 
 
 Program root files: ["/a/b/f1.ts"]
-Program options: {"watch":true}
+Program options: {"watch":true,"noImplicitAny":true}
 Program files::
 /a/lib/lib.d.ts
 /a/b/f1.ts

--- a/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/deleted-files-affect-project-structure.js
@@ -110,10 +110,8 @@ Output::
 12:00:28 AM - File change detected. Starting incremental compilation...
 
 
-a/b/f1.ts(1,15): error TS2307: Cannot find module './f2'.
 
-
-12:00:32 AM - Found 1 error. Watching for file changes.
+12:00:32 AM - Found 0 errors. Watching for file changes.
 
 
 Program root files: ["/a/b/f1.ts"]
@@ -130,11 +128,11 @@ WatchedFiles::
   {"fileName":"/a/b/f1.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
-/a/b/f2.ts:
-  {"fileName":"/a/b/f2.ts","pollingInterval":250}
 
 FsWatches::
 
 FsWatchesRecursive::
+/a:
+  {"directoryName":"/a","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
 
 exitCode:: ExitStatus.undefined

--- a/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-inferred-projects.js
+++ b/tests/baselines/reference/tscWatch/programUpdates/rename-a-module-file-and-rename-back-should-restore-the-states-for-inferred-projects.js
@@ -104,12 +104,12 @@ WatchedFiles::
   {"fileName":"/a/b/file1.ts","pollingInterval":250}
 /a/lib/lib.d.ts:
   {"fileName":"/a/lib/lib.d.ts","pollingInterval":250}
-/a/b/modulefile.ts:
-  {"fileName":"/a/b/modulefile.ts","pollingInterval":250}
 
 FsWatches::
 
 FsWatchesRecursive::
+/a:
+  {"directoryName":"/a","fallbackPollingInterval":500,"fallbackOptions":{"watchFile":"PriorityPollingInterval"}}
 
 exitCode:: ExitStatus.undefined
 


### PR DESCRIPTION
Discovered this when investigating repeated program recalculation when invoking `ts.Watch.getProgram()` even when no changes have been made. It seems like the current behavior doesn't actually match the comment (or even seem correct at all, regardless of the comment). That being said, I'm not sure the baseline changes are correct.