### PR TITLE
Fix longer type-only property access in non-emitting heritage clauses

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6267,7 +6267,7 @@ namespace ts {
     export function isValidTypeOnlyAliasUseSite(useSite: Node): boolean {
         return !!(useSite.flags & NodeFlags.Ambient)
             || isPartOfTypeQuery(useSite)
-            || isFirstIdentifierOfNonEmittingHeritageClause(useSite)
+            || isIdentifierInNonEmittingHeritageClause(useSite)
             || isPartOfPossiblyValidTypeOrAbstractComputedPropertyName(useSite)
             || !isExpressionNode(useSite);
     }
@@ -6290,8 +6290,8 @@ namespace ts {
         return containerKind === SyntaxKind.InterfaceDeclaration || containerKind === SyntaxKind.TypeLiteral;
     }
 
-    /** Returns true for the first identifier of 1) an `implements` clause, and 2) an `extends` clause of an interface. */
-    function isFirstIdentifierOfNonEmittingHeritageClause(node: Node): boolean {
+    /** Returns true for an identifier in 1) an `implements` clause, and 2) an `extends` clause of an interface. */
+    function isIdentifierInNonEmittingHeritageClause(node: Node): boolean {
         if (node.kind !== SyntaxKind.Identifier) return false;
         const heritageClause = findAncestor(node.parent, parent => {
             switch (parent.kind) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -6292,8 +6292,18 @@ namespace ts {
 
     /** Returns true for the first identifier of 1) an `implements` clause, and 2) an `extends` clause of an interface. */
     function isFirstIdentifierOfNonEmittingHeritageClause(node: Node): boolean {
-        // Number of parents to climb from identifier is 2 for `implements I`, 3 for `implements x.I`
-        const heritageClause = tryCast(node.parent.parent, isHeritageClause) ?? tryCast(node.parent.parent?.parent, isHeritageClause);
+        if (node.kind !== SyntaxKind.Identifier) return false;
+        const heritageClause = findAncestor(node.parent, parent => {
+            switch (parent.kind) {
+                case SyntaxKind.HeritageClause:
+                    return true;
+                case SyntaxKind.PropertyAccessExpression:
+                case SyntaxKind.ExpressionWithTypeArguments:
+                    return false;
+                default:
+                    return "quit";
+            }
+        }) as HeritageClause | undefined;
         return heritageClause?.token === SyntaxKind.ImplementsKeyword || heritageClause?.parent.kind === SyntaxKind.InterfaceDeclaration;
     }
 }

--- a/tests/baselines/reference/nestedNamespace.js
+++ b/tests/baselines/reference/nestedNamespace.js
@@ -1,0 +1,28 @@
+//// [tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts] ////
+
+//// [a.ts]
+export namespace types {
+  export class A {}
+}
+
+//// [b.ts]
+import type * as a from './a';
+interface B extends a.types.A {}
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;
+exports.types = void 0;
+var types;
+(function (types) {
+    var A = /** @class */ (function () {
+        function A() {
+        }
+        return A;
+    }());
+    types.A = A;
+})(types = exports.types || (exports.types = {}));
+//// [b.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/baselines/reference/nestedNamespace.symbols
+++ b/tests/baselines/reference/nestedNamespace.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export namespace types {
+>types : Symbol(types, Decl(a.ts, 0, 0))
+
+  export class A {}
+>A : Symbol(A, Decl(a.ts, 0, 24))
+}
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+import type * as a from './a';
+>a : Symbol(a, Decl(b.ts, 0, 11))
+
+interface B extends a.types.A {}
+>B : Symbol(B, Decl(b.ts, 0, 30))
+>a.types.A : Symbol(a.types.A, Decl(a.ts, 0, 24))
+>a.types : Symbol(a.types, Decl(a.ts, 0, 0))
+>a : Symbol(a, Decl(b.ts, 0, 11))
+>types : Symbol(a.types, Decl(a.ts, 0, 0))
+>A : Symbol(a.types.A, Decl(a.ts, 0, 24))
+

--- a/tests/baselines/reference/nestedNamespace.types
+++ b/tests/baselines/reference/nestedNamespace.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/externalModules/typeOnly/a.ts ===
+export namespace types {
+>types : typeof types
+
+  export class A {}
+>A : A
+}
+
+=== tests/cases/conformance/externalModules/typeOnly/b.ts ===
+import type * as a from './a';
+>a : typeof a
+
+interface B extends a.types.A {}
+>a.types : typeof a.types
+>a : typeof a
+>types : typeof a.types
+

--- a/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
+++ b/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
@@ -1,0 +1,8 @@
+// @Filename: a.ts
+export namespace types {
+  export class A {}
+}
+
+// @Filename: b.ts
+import type * as a from './a';
+interface B extends a.types.A {}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Reported in of https://github.com/microsoft/TypeScript/issues/36478#issuecomment-595879205 / #36496

Would like to get this in 3.8.4 if possible.