### PR TITLE
fix(36247): disallow 'constructor' as a parameter property name

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -28780,6 +28780,9 @@ namespace ts {
                 if (!(func.kind === SyntaxKind.Constructor && nodeIsPresent(func.body))) {
                     error(node, Diagnostics.A_parameter_property_is_only_allowed_in_a_constructor_implementation);
                 }
+                if (func.kind === SyntaxKind.Constructor && isIdentifier(node.name) && node.name.escapedText === "constructor") {
+                    error(node.name, Diagnostics.constructor_cannot_be_used_as_a_parameter_property_name);
+                }
             }
             if (node.questionToken && isBindingPattern(node.name) && (func as FunctionLikeDeclaration).body) {
                 error(node, Diagnostics.A_binding_pattern_parameter_cannot_be_optional_in_an_implementation_signature);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1569,6 +1569,10 @@
         "category": "Error",
         "code": 2397
     },
+    "'constructor' cannot be used as a parameter property name.": {
+        "category": "Error",
+        "code": 2398
+    },
     "Duplicate identifier '_this'. Compiler uses variable declaration '_this' to capture 'this' reference.": {
         "category": "Error",
         "code": 2399

--- a/tests/baselines/reference/parameterPropertyInConstructor3.errors.txt
+++ b/tests/baselines/reference/parameterPropertyInConstructor3.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/parameterPropertyInConstructor3.ts(2,22): error TS2398: 'constructor' cannot be used as a parameter property name.
+
+
+==== tests/cases/compiler/parameterPropertyInConstructor3.ts (1 errors) ====
+    class Foo {
+      constructor(public constructor: string) {}
+                         ~~~~~~~~~~~
+!!! error TS2398: 'constructor' cannot be used as a parameter property name.
+    }
+    

--- a/tests/baselines/reference/parameterPropertyInConstructor3.js
+++ b/tests/baselines/reference/parameterPropertyInConstructor3.js
@@ -1,0 +1,13 @@
+//// [parameterPropertyInConstructor3.ts]
+class Foo {
+  constructor(public constructor: string) {}
+}
+
+
+//// [parameterPropertyInConstructor3.js]
+var Foo = /** @class */ (function () {
+    function Foo(constructor) {
+        this.constructor = constructor;
+    }
+    return Foo;
+}());

--- a/tests/baselines/reference/parameterPropertyInConstructor3.symbols
+++ b/tests/baselines/reference/parameterPropertyInConstructor3.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/parameterPropertyInConstructor3.ts ===
+class Foo {
+>Foo : Symbol(Foo, Decl(parameterPropertyInConstructor3.ts, 0, 0))
+
+  constructor(public constructor: string) {}
+>constructor : Symbol(Foo.constructor, Decl(parameterPropertyInConstructor3.ts, 1, 14))
+}
+

--- a/tests/baselines/reference/parameterPropertyInConstructor3.types
+++ b/tests/baselines/reference/parameterPropertyInConstructor3.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/parameterPropertyInConstructor3.ts ===
+class Foo {
+>Foo : Foo
+
+  constructor(public constructor: string) {}
+>constructor : string
+}
+

--- a/tests/cases/compiler/parameterPropertyInConstructor3.ts
+++ b/tests/cases/compiler/parameterPropertyInConstructor3.ts
@@ -1,0 +1,3 @@
+class Foo {
+  constructor(public constructor: string) {}
+}


### PR DESCRIPTION
Fixes #36247

cc @RyanCavanaugh
