### PR TITLE
Make substitution types even if the substitution base isnt a type variable

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4808,8 +4808,8 @@ namespace ts {
     // Thus, if Foo has a 'string' constraint on its type parameter, T will satisfy it. Substitution
     // types disappear upon instantiation (just like type parameters).
     export interface SubstitutionType extends InstantiableType {
-        baseType: Type;          // Target type
-        substitute: Type;            // Type to substitute for type parameter
+        baseType: Type;     // Target type
+        substitute: Type;   // Type to substitute for type parameter
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4808,7 +4808,7 @@ namespace ts {
     // Thus, if Foo has a 'string' constraint on its type parameter, T will satisfy it. Substitution
     // types disappear upon instantiation (just like type parameters).
     export interface SubstitutionType extends InstantiableType {
-        typeVariable: TypeVariable;  // Target type variable
+        baseType: Type;          // Target type
         substitute: Type;            // Type to substitute for type parameter
     }
 

--- a/tests/baselines/reference/api/tsserverlibrary.d.ts
+++ b/tests/baselines/reference/api/tsserverlibrary.d.ts
@@ -2523,7 +2523,7 @@ declare namespace ts {
         resolvedFalseType: Type;
     }
     export interface SubstitutionType extends InstantiableType {
-        typeVariable: TypeVariable;
+        baseType: Type;
         substitute: Type;
     }
     export enum SignatureKind {

--- a/tests/baselines/reference/api/typescript.d.ts
+++ b/tests/baselines/reference/api/typescript.d.ts
@@ -2523,7 +2523,7 @@ declare namespace ts {
         resolvedFalseType: Type;
     }
     export interface SubstitutionType extends InstantiableType {
-        typeVariable: TypeVariable;
+        baseType: Type;
         substitute: Type;
     }
     export enum SignatureKind {

--- a/tests/baselines/reference/inlineConditionalHasSimilarAssignability.js
+++ b/tests/baselines/reference/inlineConditionalHasSimilarAssignability.js
@@ -1,0 +1,29 @@
+//// [inlineConditionalHasSimilarAssignability.ts]
+type MyExtract<T, U> = T extends U ? T : never
+
+function foo<T>(a: T) {
+  const b: Extract<any[], T> = 0 as any;
+  a = b; // ok
+
+  const c: (any[] extends T ? any[] : never) = 0 as any;
+  a = c;
+
+  const d: MyExtract<any[], T> = 0 as any;
+  a = d; // ok
+
+  type CustomType = any[] extends T ? any[] : never;
+  const e: CustomType = 0 as any;
+  a = e;
+}
+
+//// [inlineConditionalHasSimilarAssignability.js]
+function foo(a) {
+    var b = 0;
+    a = b; // ok
+    var c = 0;
+    a = c;
+    var d = 0;
+    a = d; // ok
+    var e = 0;
+    a = e;
+}

--- a/tests/baselines/reference/inlineConditionalHasSimilarAssignability.symbols
+++ b/tests/baselines/reference/inlineConditionalHasSimilarAssignability.symbols
@@ -1,0 +1,53 @@
+=== tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts ===
+type MyExtract<T, U> = T extends U ? T : never
+>MyExtract : Symbol(MyExtract, Decl(inlineConditionalHasSimilarAssignability.ts, 0, 0))
+>T : Symbol(T, Decl(inlineConditionalHasSimilarAssignability.ts, 0, 15))
+>U : Symbol(U, Decl(inlineConditionalHasSimilarAssignability.ts, 0, 17))
+>T : Symbol(T, Decl(inlineConditionalHasSimilarAssignability.ts, 0, 15))
+>U : Symbol(U, Decl(inlineConditionalHasSimilarAssignability.ts, 0, 17))
+>T : Symbol(T, Decl(inlineConditionalHasSimilarAssignability.ts, 0, 15))
+
+function foo<T>(a: T) {
+>foo : Symbol(foo, Decl(inlineConditionalHasSimilarAssignability.ts, 0, 46))
+>T : Symbol(T, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 13))
+>a : Symbol(a, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 16))
+>T : Symbol(T, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 13))
+
+  const b: Extract<any[], T> = 0 as any;
+>b : Symbol(b, Decl(inlineConditionalHasSimilarAssignability.ts, 3, 7))
+>Extract : Symbol(Extract, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 13))
+
+  a = b; // ok
+>a : Symbol(a, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 16))
+>b : Symbol(b, Decl(inlineConditionalHasSimilarAssignability.ts, 3, 7))
+
+  const c: (any[] extends T ? any[] : never) = 0 as any;
+>c : Symbol(c, Decl(inlineConditionalHasSimilarAssignability.ts, 6, 7))
+>T : Symbol(T, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 13))
+
+  a = c;
+>a : Symbol(a, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 16))
+>c : Symbol(c, Decl(inlineConditionalHasSimilarAssignability.ts, 6, 7))
+
+  const d: MyExtract<any[], T> = 0 as any;
+>d : Symbol(d, Decl(inlineConditionalHasSimilarAssignability.ts, 9, 7))
+>MyExtract : Symbol(MyExtract, Decl(inlineConditionalHasSimilarAssignability.ts, 0, 0))
+>T : Symbol(T, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 13))
+
+  a = d; // ok
+>a : Symbol(a, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 16))
+>d : Symbol(d, Decl(inlineConditionalHasSimilarAssignability.ts, 9, 7))
+
+  type CustomType = any[] extends T ? any[] : never;
+>CustomType : Symbol(CustomType, Decl(inlineConditionalHasSimilarAssignability.ts, 10, 8))
+>T : Symbol(T, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 13))
+
+  const e: CustomType = 0 as any;
+>e : Symbol(e, Decl(inlineConditionalHasSimilarAssignability.ts, 13, 7))
+>CustomType : Symbol(CustomType, Decl(inlineConditionalHasSimilarAssignability.ts, 10, 8))
+
+  a = e;
+>a : Symbol(a, Decl(inlineConditionalHasSimilarAssignability.ts, 2, 16))
+>e : Symbol(e, Decl(inlineConditionalHasSimilarAssignability.ts, 13, 7))
+}

--- a/tests/baselines/reference/inlineConditionalHasSimilarAssignability.types
+++ b/tests/baselines/reference/inlineConditionalHasSimilarAssignability.types
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts ===
+type MyExtract<T, U> = T extends U ? T : never
+>MyExtract : MyExtract<T, U>
+
+function foo<T>(a: T) {
+>foo : <T>(a: T) => void
+>a : T
+
+  const b: Extract<any[], T> = 0 as any;
+>b : Extract<any[], T>
+>0 as any : any
+>0 : 0
+
+  a = b; // ok
+>a = b : Extract<any[], T>
+>a : T
+>b : Extract<any[], T>
+
+  const c: (any[] extends T ? any[] : never) = 0 as any;
+>c : any[] extends T ? any[] : never
+>0 as any : any
+>0 : 0
+
+  a = c;
+>a = c : any[] extends T ? any[] : never
+>a : T
+>c : any[] extends T ? any[] : never
+
+  const d: MyExtract<any[], T> = 0 as any;
+>d : MyExtract<any[], T>
+>0 as any : any
+>0 : 0
+
+  a = d; // ok
+>a = d : MyExtract<any[], T>
+>a : T
+>d : MyExtract<any[], T>
+
+  type CustomType = any[] extends T ? any[] : never;
+>CustomType : any[] extends T ? any[] : never
+
+  const e: CustomType = 0 as any;
+>e : any[] extends T ? any[] : never
+>0 as any : any
+>0 : 0
+
+  a = e;
+>a = e : any[] extends T ? any[] : never
+>a : T
+>e : any[] extends T ? any[] : never
+}

--- a/tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts
+++ b/tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts
@@ -1,0 +1,16 @@
+type MyExtract<T, U> = T extends U ? T : never
+
+function foo<T>(a: T) {
+  const b: Extract<any[], T> = 0 as any;
+  a = b; // ok
+
+  const c: (any[] extends T ? any[] : never) = 0 as any;
+  a = c;
+
+  const d: MyExtract<any[], T> = 0 as any;
+  a = d; // ok
+
+  type CustomType = any[] extends T ? any[] : never;
+  const e: CustomType = 0 as any;
+  a = e;
+}


### PR DESCRIPTION
Fixes #36135
