### PR TITLE
Enable excess property checking on spread assignment

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15589,7 +15589,19 @@ namespace ts {
             }
 
             function shouldCheckAsExcessProperty(prop: Symbol, container: Symbol) {
-                return prop.valueDeclaration && container.valueDeclaration && prop.valueDeclaration.parent === container.valueDeclaration;
+                if (prop.valueDeclaration && container.valueDeclaration) {
+                    let node = prop.valueDeclaration.parent;
+                    if (node === container.valueDeclaration) {
+                        return true;
+                    }
+                    while (node) {
+                        if (node.kind === SyntaxKind.SpreadAssignment && node.parent === container.valueDeclaration) {
+                            return true;
+                        }
+                        node = node.parent;
+                    }
+                }
+                return false;
             }
 
             function eachTypeRelatedToSomeType(source: UnionOrIntersectionType, target: UnionOrIntersectionType): Ternary {

--- a/tests/baselines/reference/spreadExcessProperty.errors.txt
+++ b/tests/baselines/reference/spreadExcessProperty.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/conformance/types/spread/spreadExcessProperty.ts(7,8): error TS2322: Type '{ b2: string; a: string; }' is not assignable to type '{ a?: string; b?: string; }'.
+  Object literal may only specify known properties, and 'b2' does not exist in type '{ a?: string; b?: string; }'.
+
+
+==== tests/cases/conformance/types/spread/spreadExcessProperty.ts (1 errors) ====
+    type A = { a: string; b: string };
+    const extra1 = { a: "a", b: "b", extra: "extra" };
+    const a1: A = { ...extra1 }; // spread should not give excess property errors
+    
+    const b: { a?: string; b?: string } = {
+      a: "",
+      ...{ b2: "" }
+           ~~~~~~
+!!! error TS2322: Type '{ b2: string; a: string; }' is not assignable to type '{ a?: string; b?: string; }'.
+!!! error TS2322:   Object literal may only specify known properties, and 'b2' does not exist in type '{ a?: string; b?: string; }'.
+    };
+    

--- a/tests/baselines/reference/spreadExcessProperty.js
+++ b/tests/baselines/reference/spreadExcessProperty.js
@@ -1,7 +1,12 @@
 //// [spreadExcessProperty.ts]
-type A = { a: string, b: string };
+type A = { a: string; b: string };
 const extra1 = { a: "a", b: "b", extra: "extra" };
 const a1: A = { ...extra1 }; // spread should not give excess property errors
+
+const b: { a?: string; b?: string } = {
+  a: "",
+  ...{ b2: "" }
+};
 
 
 //// [spreadExcessProperty.js]
@@ -18,3 +23,4 @@ var __assign = (this && this.__assign) || function () {
 };
 var extra1 = { a: "a", b: "b", extra: "extra" };
 var a1 = __assign({}, extra1); // spread should not give excess property errors
+var b = __assign({ a: "" }, { b2: "" });

--- a/tests/baselines/reference/spreadExcessProperty.symbols
+++ b/tests/baselines/reference/spreadExcessProperty.symbols
@@ -1,5 +1,5 @@
 === tests/cases/conformance/types/spread/spreadExcessProperty.ts ===
-type A = { a: string, b: string };
+type A = { a: string; b: string };
 >A : Symbol(A, Decl(spreadExcessProperty.ts, 0, 0))
 >a : Symbol(a, Decl(spreadExcessProperty.ts, 0, 10))
 >b : Symbol(b, Decl(spreadExcessProperty.ts, 0, 21))
@@ -14,4 +14,17 @@ const a1: A = { ...extra1 }; // spread should not give excess property errors
 >a1 : Symbol(a1, Decl(spreadExcessProperty.ts, 2, 5))
 >A : Symbol(A, Decl(spreadExcessProperty.ts, 0, 0))
 >extra1 : Symbol(extra1, Decl(spreadExcessProperty.ts, 1, 5))
+
+const b: { a?: string; b?: string } = {
+>b : Symbol(b, Decl(spreadExcessProperty.ts, 4, 5))
+>a : Symbol(a, Decl(spreadExcessProperty.ts, 4, 10))
+>b : Symbol(b, Decl(spreadExcessProperty.ts, 4, 22))
+
+  a: "",
+>a : Symbol(a, Decl(spreadExcessProperty.ts, 4, 39))
+
+  ...{ b2: "" }
+>b2 : Symbol(b2, Decl(spreadExcessProperty.ts, 6, 6))
+
+};
 

--- a/tests/baselines/reference/spreadExcessProperty.types
+++ b/tests/baselines/reference/spreadExcessProperty.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/types/spread/spreadExcessProperty.ts ===
-type A = { a: string, b: string };
+type A = { a: string; b: string };
 >A : A
 >a : string
 >b : string
@@ -18,4 +18,21 @@ const a1: A = { ...extra1 }; // spread should not give excess property errors
 >a1 : A
 >{ ...extra1 } : { a: string; b: string; extra: string; }
 >extra1 : { a: string; b: string; extra: string; }
+
+const b: { a?: string; b?: string } = {
+>b : { a?: string; b?: string; }
+>a : string
+>b : string
+>{  a: "",  ...{ b2: "" }} : { b2: string; a: string; }
+
+  a: "",
+>a : string
+>"" : ""
+
+  ...{ b2: "" }
+>{ b2: "" } : { b2: string; }
+>b2 : string
+>"" : ""
+
+};
 

--- a/tests/cases/conformance/types/spread/spreadExcessProperty.ts
+++ b/tests/cases/conformance/types/spread/spreadExcessProperty.ts
@@ -1,3 +1,8 @@
-type A = { a: string, b: string };
+type A = { a: string; b: string };
 const extra1 = { a: "a", b: "b", extra: "extra" };
 const a1: A = { ...extra1 }; // spread should not give excess property errors
+
+const b: { a?: string; b?: string } = {
+  a: "",
+  ...{ b2: "" }
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
This PR enables excess property checking on spread assignment.

Fixes #32495
