### PR TITLE
Defer simplification of conditionals on deferred type references

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -4376,6 +4376,10 @@ namespace ts {
         /* @internal */
         Simplifiable = IndexedAccess | Conditional,
         /* @internal */
+        ReducibleNotUnion = Intersection | Conditional,
+        /* @internal */
+        Reducible = ReducibleNotUnion | Union,
+        /* @internal */
         Substructure = Object | Union | Intersection | Index | IndexedAccess | Conditional | Substitution,
         // 'Narrowable' types are types where narrowing actually narrows.
         // This *should* be every type other than null, undefined, void, and never
@@ -4385,7 +4389,7 @@ namespace ts {
         NotPrimitiveUnion = Any | Unknown | Enum | Void | Never | StructuredOrInstantiable,
         // The following flags are aggregated during union and intersection type construction
         /* @internal */
-        IncludesMask = Any | Unknown | Primitive | Never | Object | Union | Intersection | NonPrimitive,
+        IncludesMask = Any | Unknown | Primitive | Never | Object | Union | Intersection | NonPrimitive | Conditional,
         // The following flags are used for different purposes during union and intersection type construction
         /* @internal */
         IncludesStructuredOrInstantiable = TypeParameter,
@@ -4394,7 +4398,7 @@ namespace ts {
         /* @internal */
         IncludesWildcard = IndexedAccess,
         /* @internal */
-        IncludesEmptyObject = Conditional,
+        IncludesEmptyObject = 1 << 27,
     }
 
     export type DestructuringPattern = BindingPattern | ObjectLiteralExpression | ArrayLiteralExpression;
@@ -4511,7 +4515,7 @@ namespace ts {
         /* @internal */
         CouldContainTypeVariables = 1 << 27, // Type could contain a type variable
         /* @internal */
-        ContainsIntersections = 1 << 28, // Union contains intersections
+        ContainsReducibles = 1 << 28, // Union contains intersections
         /* @internal */
         IsNeverIntersectionComputed = 1 << 28, // IsNeverLike flag has been computed
         /* @internal */
@@ -4634,11 +4638,11 @@ namespace ts {
         resolvedStringIndexType: IndexType;
         /* @internal */
         resolvedBaseConstraint: Type;
+        /* @internal */
+        resolvedReducedType: Type;
     }
 
     export interface UnionType extends UnionOrIntersectionType {
-        /* @internal */
-        resolvedReducedType: Type;
     }
 
     export interface IntersectionType extends UnionOrIntersectionType {

--- a/tests/baselines/reference/recursiveArrayNotCircular.js
+++ b/tests/baselines/reference/recursiveArrayNotCircular.js
@@ -1,0 +1,66 @@
+//// [recursiveArrayNotCircular.ts]
+type Action<T, P> = P extends void ? { type : T } : { type: T, payload: P }
+
+enum ActionType {
+    Foo,
+    Bar,
+    Baz,
+    Batch
+}
+
+type ReducerAction =
+  | Action<ActionType.Bar, number>
+  | Action<ActionType.Baz, boolean>
+  | Action<ActionType.Foo, string>
+  | Action<ActionType.Batch, ReducerAction[]>
+
+function assertNever(a: never): never {
+    throw new Error("Unreachable!");
+}
+
+function reducer(action: ReducerAction): void {
+    switch(action.type) {
+        case ActionType.Bar:
+            const x: number = action.payload;
+            break;
+        case ActionType.Baz:
+            const y: boolean = action.payload;
+            break;
+        case ActionType.Foo:
+            const z: string = action.payload;
+            break;
+        case ActionType.Batch:
+            action.payload.map(reducer);
+            break;
+        default: return assertNever(action);
+    }
+}
+
+//// [recursiveArrayNotCircular.js]
+var ActionType;
+(function (ActionType) {
+    ActionType[ActionType["Foo"] = 0] = "Foo";
+    ActionType[ActionType["Bar"] = 1] = "Bar";
+    ActionType[ActionType["Baz"] = 2] = "Baz";
+    ActionType[ActionType["Batch"] = 3] = "Batch";
+})(ActionType || (ActionType = {}));
+function assertNever(a) {
+    throw new Error("Unreachable!");
+}
+function reducer(action) {
+    switch (action.type) {
+        case ActionType.Bar:
+            var x = action.payload;
+            break;
+        case ActionType.Baz:
+            var y = action.payload;
+            break;
+        case ActionType.Foo:
+            var z = action.payload;
+            break;
+        case ActionType.Batch:
+            action.payload.map(reducer);
+            break;
+        default: return assertNever(action);
+    }
+}

--- a/tests/baselines/reference/recursiveArrayNotCircular.symbols
+++ b/tests/baselines/reference/recursiveArrayNotCircular.symbols
@@ -1,0 +1,126 @@
+=== tests/cases/compiler/recursiveArrayNotCircular.ts ===
+type Action<T, P> = P extends void ? { type : T } : { type: T, payload: P }
+>Action : Symbol(Action, Decl(recursiveArrayNotCircular.ts, 0, 0))
+>T : Symbol(T, Decl(recursiveArrayNotCircular.ts, 0, 12))
+>P : Symbol(P, Decl(recursiveArrayNotCircular.ts, 0, 14))
+>P : Symbol(P, Decl(recursiveArrayNotCircular.ts, 0, 14))
+>type : Symbol(type, Decl(recursiveArrayNotCircular.ts, 0, 38))
+>T : Symbol(T, Decl(recursiveArrayNotCircular.ts, 0, 12))
+>type : Symbol(type, Decl(recursiveArrayNotCircular.ts, 0, 53))
+>T : Symbol(T, Decl(recursiveArrayNotCircular.ts, 0, 12))
+>payload : Symbol(payload, Decl(recursiveArrayNotCircular.ts, 0, 62))
+>P : Symbol(P, Decl(recursiveArrayNotCircular.ts, 0, 14))
+
+enum ActionType {
+>ActionType : Symbol(ActionType, Decl(recursiveArrayNotCircular.ts, 0, 75))
+
+    Foo,
+>Foo : Symbol(ActionType.Foo, Decl(recursiveArrayNotCircular.ts, 2, 17))
+
+    Bar,
+>Bar : Symbol(ActionType.Bar, Decl(recursiveArrayNotCircular.ts, 3, 8))
+
+    Baz,
+>Baz : Symbol(ActionType.Baz, Decl(recursiveArrayNotCircular.ts, 4, 8))
+
+    Batch
+>Batch : Symbol(ActionType.Batch, Decl(recursiveArrayNotCircular.ts, 5, 8))
+}
+
+type ReducerAction =
+>ReducerAction : Symbol(ReducerAction, Decl(recursiveArrayNotCircular.ts, 7, 1))
+
+  | Action<ActionType.Bar, number>
+>Action : Symbol(Action, Decl(recursiveArrayNotCircular.ts, 0, 0))
+>ActionType : Symbol(ActionType, Decl(recursiveArrayNotCircular.ts, 0, 75))
+>Bar : Symbol(ActionType.Bar, Decl(recursiveArrayNotCircular.ts, 3, 8))
+
+  | Action<ActionType.Baz, boolean>
+>Action : Symbol(Action, Decl(recursiveArrayNotCircular.ts, 0, 0))
+>ActionType : Symbol(ActionType, Decl(recursiveArrayNotCircular.ts, 0, 75))
+>Baz : Symbol(ActionType.Baz, Decl(recursiveArrayNotCircular.ts, 4, 8))
+
+  | Action<ActionType.Foo, string>
+>Action : Symbol(Action, Decl(recursiveArrayNotCircular.ts, 0, 0))
+>ActionType : Symbol(ActionType, Decl(recursiveArrayNotCircular.ts, 0, 75))
+>Foo : Symbol(ActionType.Foo, Decl(recursiveArrayNotCircular.ts, 2, 17))
+
+  | Action<ActionType.Batch, ReducerAction[]>
+>Action : Symbol(Action, Decl(recursiveArrayNotCircular.ts, 0, 0))
+>ActionType : Symbol(ActionType, Decl(recursiveArrayNotCircular.ts, 0, 75))
+>Batch : Symbol(ActionType.Batch, Decl(recursiveArrayNotCircular.ts, 5, 8))
+>ReducerAction : Symbol(ReducerAction, Decl(recursiveArrayNotCircular.ts, 7, 1))
+
+function assertNever(a: never): never {
+>assertNever : Symbol(assertNever, Decl(recursiveArrayNotCircular.ts, 13, 45))
+>a : Symbol(a, Decl(recursiveArrayNotCircular.ts, 15, 21))
+
+    throw new Error("Unreachable!");
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+}
+
+function reducer(action: ReducerAction): void {
+>reducer : Symbol(reducer, Decl(recursiveArrayNotCircular.ts, 17, 1))
+>action : Symbol(action, Decl(recursiveArrayNotCircular.ts, 19, 17))
+>ReducerAction : Symbol(ReducerAction, Decl(recursiveArrayNotCircular.ts, 7, 1))
+
+    switch(action.type) {
+>action.type : Symbol(type, Decl(recursiveArrayNotCircular.ts, 0, 53), Decl(recursiveArrayNotCircular.ts, 0, 53), Decl(recursiveArrayNotCircular.ts, 0, 53), Decl(recursiveArrayNotCircular.ts, 0, 53), Decl(recursiveArrayNotCircular.ts, 0, 53))
+>action : Symbol(action, Decl(recursiveArrayNotCircular.ts, 19, 17))
+>type : Symbol(type, Decl(recursiveArrayNotCircular.ts, 0, 53), Decl(recursiveArrayNotCircular.ts, 0, 53), Decl(recursiveArrayNotCircular.ts, 0, 53), Decl(recursiveArrayNotCircular.ts, 0, 53), Decl(recursiveArrayNotCircular.ts, 0, 53))
+
+        case ActionType.Bar:
+>ActionType.Bar : Symbol(ActionType.Bar, Decl(recursiveArrayNotCircular.ts, 3, 8))
+>ActionType : Symbol(ActionType, Decl(recursiveArrayNotCircular.ts, 0, 75))
+>Bar : Symbol(ActionType.Bar, Decl(recursiveArrayNotCircular.ts, 3, 8))
+
+            const x: number = action.payload;
+>x : Symbol(x, Decl(recursiveArrayNotCircular.ts, 22, 17))
+>action.payload : Symbol(payload, Decl(recursiveArrayNotCircular.ts, 0, 62))
+>action : Symbol(action, Decl(recursiveArrayNotCircular.ts, 19, 17))
+>payload : Symbol(payload, Decl(recursiveArrayNotCircular.ts, 0, 62))
+
+            break;
+        case ActionType.Baz:
+>ActionType.Baz : Symbol(ActionType.Baz, Decl(recursiveArrayNotCircular.ts, 4, 8))
+>ActionType : Symbol(ActionType, Decl(recursiveArrayNotCircular.ts, 0, 75))
+>Baz : Symbol(ActionType.Baz, Decl(recursiveArrayNotCircular.ts, 4, 8))
+
+            const y: boolean = action.payload;
+>y : Symbol(y, Decl(recursiveArrayNotCircular.ts, 25, 17))
+>action.payload : Symbol(payload, Decl(recursiveArrayNotCircular.ts, 0, 62), Decl(recursiveArrayNotCircular.ts, 0, 62))
+>action : Symbol(action, Decl(recursiveArrayNotCircular.ts, 19, 17))
+>payload : Symbol(payload, Decl(recursiveArrayNotCircular.ts, 0, 62), Decl(recursiveArrayNotCircular.ts, 0, 62))
+
+            break;
+        case ActionType.Foo:
+>ActionType.Foo : Symbol(ActionType.Foo, Decl(recursiveArrayNotCircular.ts, 2, 17))
+>ActionType : Symbol(ActionType, Decl(recursiveArrayNotCircular.ts, 0, 75))
+>Foo : Symbol(ActionType.Foo, Decl(recursiveArrayNotCircular.ts, 2, 17))
+
+            const z: string = action.payload;
+>z : Symbol(z, Decl(recursiveArrayNotCircular.ts, 28, 17))
+>action.payload : Symbol(payload, Decl(recursiveArrayNotCircular.ts, 0, 62))
+>action : Symbol(action, Decl(recursiveArrayNotCircular.ts, 19, 17))
+>payload : Symbol(payload, Decl(recursiveArrayNotCircular.ts, 0, 62))
+
+            break;
+        case ActionType.Batch:
+>ActionType.Batch : Symbol(ActionType.Batch, Decl(recursiveArrayNotCircular.ts, 5, 8))
+>ActionType : Symbol(ActionType, Decl(recursiveArrayNotCircular.ts, 0, 75))
+>Batch : Symbol(ActionType.Batch, Decl(recursiveArrayNotCircular.ts, 5, 8))
+
+            action.payload.map(reducer);
+>action.payload.map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>action.payload : Symbol(payload, Decl(recursiveArrayNotCircular.ts, 0, 62))
+>action : Symbol(action, Decl(recursiveArrayNotCircular.ts, 19, 17))
+>payload : Symbol(payload, Decl(recursiveArrayNotCircular.ts, 0, 62))
+>map : Symbol(Array.map, Decl(lib.es5.d.ts, --, --))
+>reducer : Symbol(reducer, Decl(recursiveArrayNotCircular.ts, 17, 1))
+
+            break;
+        default: return assertNever(action);
+>assertNever : Symbol(assertNever, Decl(recursiveArrayNotCircular.ts, 13, 45))
+>action : Symbol(action, Decl(recursiveArrayNotCircular.ts, 19, 17))
+    }
+}

--- a/tests/baselines/reference/recursiveArrayNotCircular.types
+++ b/tests/baselines/reference/recursiveArrayNotCircular.types
@@ -1,0 +1,114 @@
+=== tests/cases/compiler/recursiveArrayNotCircular.ts ===
+type Action<T, P> = P extends void ? { type : T } : { type: T, payload: P }
+>Action : Action<T, P>
+>type : T
+>type : T
+>payload : P
+
+enum ActionType {
+>ActionType : ActionType
+
+    Foo,
+>Foo : ActionType.Foo
+
+    Bar,
+>Bar : ActionType.Bar
+
+    Baz,
+>Baz : ActionType.Baz
+
+    Batch
+>Batch : ActionType.Batch
+}
+
+type ReducerAction =
+>ReducerAction : { type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; }
+
+  | Action<ActionType.Bar, number>
+>ActionType : any
+
+  | Action<ActionType.Baz, boolean>
+>ActionType : any
+
+  | Action<ActionType.Foo, string>
+>ActionType : any
+
+  | Action<ActionType.Batch, ReducerAction[]>
+>ActionType : any
+
+function assertNever(a: never): never {
+>assertNever : (a: never) => never
+>a : never
+
+    throw new Error("Unreachable!");
+>new Error("Unreachable!") : Error
+>Error : ErrorConstructor
+>"Unreachable!" : "Unreachable!"
+}
+
+function reducer(action: ReducerAction): void {
+>reducer : (action: { type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; }) => void
+>action : { type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; }
+
+    switch(action.type) {
+>action.type : ActionType
+>action : { type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; }
+>type : ActionType
+
+        case ActionType.Bar:
+>ActionType.Bar : ActionType.Bar
+>ActionType : typeof ActionType
+>Bar : ActionType.Bar
+
+            const x: number = action.payload;
+>x : number
+>action.payload : number
+>action : { type: ActionType.Bar; payload: number; }
+>payload : number
+
+            break;
+        case ActionType.Baz:
+>ActionType.Baz : ActionType.Baz
+>ActionType : typeof ActionType
+>Baz : ActionType.Baz
+
+            const y: boolean = action.payload;
+>y : boolean
+>action.payload : boolean
+>action : { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; }
+>payload : boolean
+
+            break;
+        case ActionType.Foo:
+>ActionType.Foo : ActionType.Foo
+>ActionType : typeof ActionType
+>Foo : ActionType.Foo
+
+            const z: string = action.payload;
+>z : string
+>action.payload : string
+>action : { type: ActionType.Foo; payload: string; }
+>payload : string
+
+            break;
+        case ActionType.Batch:
+>ActionType.Batch : ActionType.Batch
+>ActionType : typeof ActionType
+>Batch : ActionType.Batch
+
+            action.payload.map(reducer);
+>action.payload.map(reducer) : void[]
+>action.payload.map : <U>(callbackfn: (value: { type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; }, index: number, array: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; })[]) => U, thisArg?: any) => U[]
+>action.payload : ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; })[]
+>action : { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; }
+>payload : ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; })[]
+>map : <U>(callbackfn: (value: { type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; }, index: number, array: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; })[]) => U, thisArg?: any) => U[]
+>reducer : (action: { type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | { type: ActionType.Batch; payload: ({ type: ActionType.Bar; payload: number; } | { type: ActionType.Baz; payload: false; } | { type: ActionType.Baz; payload: true; } | { type: ActionType.Foo; payload: string; } | any)[]; }) => void
+
+            break;
+        default: return assertNever(action);
+>assertNever(action) : never
+>assertNever : (a: never) => never
+>action : never
+    }
+}

--- a/tests/cases/compiler/recursiveArrayNotCircular.ts
+++ b/tests/cases/compiler/recursiveArrayNotCircular.ts
@@ -1,0 +1,36 @@
+type Action<T, P> = P extends void ? { type : T } : { type: T, payload: P }
+
+enum ActionType {
+    Foo,
+    Bar,
+    Baz,
+    Batch
+}
+
+type ReducerAction =
+  | Action<ActionType.Bar, number>
+  | Action<ActionType.Baz, boolean>
+  | Action<ActionType.Foo, string>
+  | Action<ActionType.Batch, ReducerAction[]>
+
+function assertNever(a: never): never {
+    throw new Error("Unreachable!");
+}
+
+function reducer(action: ReducerAction): void {
+    switch(action.type) {
+        case ActionType.Bar:
+            const x: number = action.payload;
+            break;
+        case ActionType.Baz:
+            const y: boolean = action.payload;
+            break;
+        case ActionType.Foo:
+            const z: string = action.payload;
+            break;
+        case ActionType.Batch:
+            action.payload.map(reducer);
+            break;
+        default: return assertNever(action);
+    }
+}


### PR DESCRIPTION
Fixes #37344

When we started "normalizing" deferred type aliases at the start of comparisons (#35266), we started to eagerly pull on them when we constructed conditional types around them (as conditionals eagerly check to see if they can simplify to their branches in some cases), which means that that normalization actually broke some very common patterns (like the generic action alias in the linked issue). To avoid that break, while still performing that normalization, in this PR, we now unconditionally defer conditionals where the check or extends type is itself a deferred type reference, and then later on perform the simplification of the conditional as part of `getReducedType` (introduced in #36696), so that deferral isn't witnessed by most consumers of the type.