### PR TITLE
Fix `getSignatureOfTypeTag`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10701,7 +10701,9 @@ namespace ts {
         }
 
         function getSignatureOfTypeTag(node: SignatureDeclaration | JSDocSignature) {
-            const typeTag = isInJSFile(node) ? getJSDocTypeTag(node) : undefined;
+            // should be attached to a function declaration or expression
+            if (!(isInJSFile(node) && isFunctionLikeDeclaration(node))) return undefined;
+            const typeTag = getJSDocTypeTag(node);
             const signature = typeTag && typeTag.typeExpression && getSingleCallSignature(getTypeFromTypeNode(typeTag.typeExpression));
             return signature && getErasedSignature(signature);
         }

--- a/tests/baselines/reference/jsdocCallbackAndType.errors.txt
+++ b/tests/baselines/reference/jsdocCallbackAndType.errors.txt
@@ -1,0 +1,15 @@
+/a.js(8,3): error TS2554: Expected 0 arguments, but got 1.
+
+
+==== /a.js (1 errors) ====
+    /**
+     * @template T
+     * @callback B
+     */
+    /** @type {B<string>} */
+    let b;
+    b();
+    b(1);
+      ~
+!!! error TS2554: Expected 0 arguments, but got 1.
+    

--- a/tests/baselines/reference/jsdocCallbackAndType.symbols
+++ b/tests/baselines/reference/jsdocCallbackAndType.symbols
@@ -1,0 +1,15 @@
+=== /a.js ===
+/**
+ * @template T
+ * @callback B
+ */
+/** @type {B<string>} */
+let b;
+>b : Symbol(b, Decl(a.js, 5, 3))
+
+b();
+>b : Symbol(b, Decl(a.js, 5, 3))
+
+b(1);
+>b : Symbol(b, Decl(a.js, 5, 3))
+

--- a/tests/baselines/reference/jsdocCallbackAndType.types
+++ b/tests/baselines/reference/jsdocCallbackAndType.types
@@ -1,0 +1,18 @@
+=== /a.js ===
+/**
+ * @template T
+ * @callback B
+ */
+/** @type {B<string>} */
+let b;
+>b : B<string>
+
+b();
+>b() : any
+>b : B<string>
+
+b(1);
+>b(1) : any
+>b : B<string>
+>1 : 1
+

--- a/tests/cases/compiler/jsdocCallbackAndType.ts
+++ b/tests/cases/compiler/jsdocCallbackAndType.ts
@@ -1,0 +1,13 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+
+// @Filename: /a.js
+/**
+ * @template T
+ * @callback B
+ */
+/** @type {B<string>} */
+let b;
+b();
+b(1);


### PR DESCRIPTION
Prevents infinite looping as in #37265.

Fixes #37265
