### PR TITLE
Token hints for missing closing braces: classes, enums, jsx, modules, types

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -15,7 +15,7 @@
         "category": "Error",
         "code": 1006
     },
-    "The parser expected to find a '}' to match the '{' token here.": {
+    "The parser expected to find a '{0}' to match the '{1}' token here.": {
         "category": "Error",
         "code": 1007
     },

--- a/tests/baselines/reference/classMemberWithMissingIdentifier.errors.txt
+++ b/tests/baselines/reference/classMemberWithMissingIdentifier.errors.txt
@@ -10,6 +10,7 @@ tests/cases/compiler/classMemberWithMissingIdentifier.ts(3,1): error TS1128: Dec
 !!! error TS1146: Declaration expected.
                ~
 !!! error TS1005: ';' expected.
+!!! related TS1007 tests/cases/compiler/classMemberWithMissingIdentifier.ts:1:9: The parser expected to find a '}' to match the '{' token here.
     }
     ~
 !!! error TS1128: Declaration or statement expected.

--- a/tests/baselines/reference/classMemberWithMissingIdentifier2.errors.txt
+++ b/tests/baselines/reference/classMemberWithMissingIdentifier2.errors.txt
@@ -14,6 +14,7 @@ tests/cases/compiler/classMemberWithMissingIdentifier2.ts(3,1): error TS1128: De
 !!! error TS1146: Declaration expected.
                ~
 !!! error TS1005: ';' expected.
+!!! related TS1007 tests/cases/compiler/classMemberWithMissingIdentifier2.ts:1:9: The parser expected to find a '}' to match the '{' token here.
                      ~
 !!! error TS1005: ',' expected.
                       ~~~~~~

--- a/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
+++ b/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.errors.txt
@@ -142,6 +142,7 @@ tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts(261,1): error TS
                     if (retValue != 0) {
                                  ~~
 !!! error TS1005: ',' expected.
+!!! related TS1007 tests/cases/compiler/constructorWithIncompleteTypeAnnotation.ts:15:26: The parser expected to find a '}' to match the '{' token here.
                                      ~
 !!! error TS1005: ';' expected.
     

--- a/tests/baselines/reference/derivedClassSuperCallsInNonConstructorMembers.errors.txt
+++ b/tests/baselines/reference/derivedClassSuperCallsInNonConstructorMembers.errors.txt
@@ -50,6 +50,7 @@ tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassS
 !!! error TS2304: Cannot find name 'super'.
                 ~
 !!! error TS1005: ';' expected.
+!!! related TS1007 tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassSuperCallsInNonConstructorMembers.ts:7:28: The parser expected to find a '}' to match the '{' token here.
                  ~
 !!! error TS1109: Expression expected.
         b() {

--- a/tests/baselines/reference/errorRecoveryWithDotFollowedByNamespaceKeyword.errors.txt
+++ b/tests/baselines/reference/errorRecoveryWithDotFollowedByNamespaceKeyword.errors.txt
@@ -18,3 +18,4 @@ tests/cases/compiler/errorRecoveryWithDotFollowedByNamespaceKeyword.ts(9,2): err
 !!! error TS1005: '}' expected.
 !!! related TS1007 tests/cases/compiler/errorRecoveryWithDotFollowedByNamespaceKeyword.ts:3:19: The parser expected to find a '}' to match the '{' token here.
 !!! related TS1007 tests/cases/compiler/errorRecoveryWithDotFollowedByNamespaceKeyword.ts:2:20: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 tests/cases/compiler/errorRecoveryWithDotFollowedByNamespaceKeyword.ts:1:13: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/jsxAndTypeAssertion.errors.txt
+++ b/tests/baselines/reference/jsxAndTypeAssertion.errors.txt
@@ -21,9 +21,11 @@ tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(18,69): error TS1381: Unexpe
 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(18,76): error TS1381: Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: ':' expected.
 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '</' expected.
+tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '</' expected.
+tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '</' expected.
 
 
-==== tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx (23 errors) ====
+==== tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx (25 errors) ====
     declare var createElement: any;
     
     class foo {}
@@ -36,6 +38,7 @@ tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '</' ex
 !!! error TS2582: Cannot find name 'test'. Do you need to install type definitions for a test runner? Try `npm i @types/jest` or `npm i @types/mocha`.
                     ~
 !!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx:6:11: The parser expected to find a '}' to match the '{' token here.
                                   ~
 !!! error TS1381: Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
     
@@ -50,6 +53,7 @@ tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '</' ex
 !!! error TS1381: Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
                                    ~
 !!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx:10:16: The parser expected to find a '}' to match the '{' token here.
     
     x = <foo test={<foo>{}}>hello</foo>;
                           ~
@@ -58,6 +62,7 @@ tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '</' ex
 !!! error TS1382: Unexpected token. Did you mean `{'>'}` or `&gt;`?
                                        ~
 !!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx:12:15: The parser expected to find a '}' to match the '{' token here.
     
     x = <foo test={<foo>{}}>hello{<foo>{}}</foo>;
                     ~~~
@@ -70,6 +75,7 @@ tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '</' ex
 !!! error TS1381: Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
                                                 ~
 !!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx:14:30: The parser expected to find a '}' to match the '{' token here.
     
     x = <foo>x</foo>, x = <foo/>;
     
@@ -89,5 +95,12 @@ tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(21,1): error TS1005: '</' ex
     
     
 !!! error TS1005: ':' expected.
+!!! related TS1007 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx:18:17: The parser expected to find a '}' to match the '{' token here.
+    
+!!! error TS1005: '</' expected.
+!!! related TS1007 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx:14:15: The parser expected to find a '}' to match the '{' token here.
+    
+!!! error TS1005: '</' expected.
+!!! related TS1007 tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx:18:6: The parser expected to find a '}' to match the '{' token here.
     
 !!! error TS1005: '</' expected.

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
@@ -244,6 +244,7 @@ tests/cases/conformance/jsx/9.tsx(1,16): error TS1109: Expression expected.
     <a>{"str";}</a>;
              ~
 !!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/jsx/20.tsx:1:4: The parser expected to find a '}' to match the '{' token here.
               ~
 !!! error TS1381: Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
 ==== tests/cases/conformance/jsx/21.tsx (1 errors) ====

--- a/tests/baselines/reference/missingCloseBraceInClassDeclaration.errors.txt
+++ b/tests/baselines/reference/missingCloseBraceInClassDeclaration.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/missingCloseBraceInClassDeclaration.ts(7,1): error TS1005: '}' expected.
+
+
+==== tests/cases/compiler/missingCloseBraceInClassDeclaration.ts (1 errors) ====
+    class TestCls {
+      prop = 0;
+      method() {
+        return this.prop;
+      }
+    
+    
+    
+!!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/compiler/missingCloseBraceInClassDeclaration.ts:1:15: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/missingCloseBraceInClassDeclaration.js
+++ b/tests/baselines/reference/missingCloseBraceInClassDeclaration.js
@@ -1,0 +1,19 @@
+//// [missingCloseBraceInClassDeclaration.ts]
+class TestCls {
+  prop = 0;
+  method() {
+    return this.prop;
+  }
+
+
+
+//// [missingCloseBraceInClassDeclaration.js]
+var TestCls = /** @class */ (function () {
+    function TestCls() {
+        this.prop = 0;
+    }
+    TestCls.prototype.method = function () {
+        return this.prop;
+    };
+    return TestCls;
+}());

--- a/tests/baselines/reference/missingCloseBraceInClassDeclaration.symbols
+++ b/tests/baselines/reference/missingCloseBraceInClassDeclaration.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/missingCloseBraceInClassDeclaration.ts ===
+class TestCls {
+>TestCls : Symbol(TestCls, Decl(missingCloseBraceInClassDeclaration.ts, 0, 0))
+
+  prop = 0;
+>prop : Symbol(TestCls.prop, Decl(missingCloseBraceInClassDeclaration.ts, 0, 15))
+
+  method() {
+>method : Symbol(TestCls.method, Decl(missingCloseBraceInClassDeclaration.ts, 1, 11))
+
+    return this.prop;
+>this.prop : Symbol(TestCls.prop, Decl(missingCloseBraceInClassDeclaration.ts, 0, 15))
+>this : Symbol(TestCls, Decl(missingCloseBraceInClassDeclaration.ts, 0, 0))
+>prop : Symbol(TestCls.prop, Decl(missingCloseBraceInClassDeclaration.ts, 0, 15))
+  }
+
+

--- a/tests/baselines/reference/missingCloseBraceInClassDeclaration.types
+++ b/tests/baselines/reference/missingCloseBraceInClassDeclaration.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/missingCloseBraceInClassDeclaration.ts ===
+class TestCls {
+>TestCls : TestCls
+
+  prop = 0;
+>prop : number
+>0 : 0
+
+  method() {
+>method : () => number
+
+    return this.prop;
+>this.prop : number
+>this : this
+>prop : number
+  }
+
+

--- a/tests/baselines/reference/missingCloseBraceInEnum.errors.txt
+++ b/tests/baselines/reference/missingCloseBraceInEnum.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/missingCloseBraceInEnum.ts(6,1): error TS1005: '}' expected.
+
+
+==== tests/cases/compiler/missingCloseBraceInEnum.ts (1 errors) ====
+    enum Colors {
+      Red,
+      Green,
+      Blue,
+    
+    
+    
+!!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/compiler/missingCloseBraceInEnum.ts:1:13: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/missingCloseBraceInEnum.js
+++ b/tests/baselines/reference/missingCloseBraceInEnum.js
@@ -1,0 +1,15 @@
+//// [missingCloseBraceInEnum.ts]
+enum Colors {
+  Red,
+  Green,
+  Blue,
+
+
+
+//// [missingCloseBraceInEnum.js]
+var Colors;
+(function (Colors) {
+    Colors[Colors["Red"] = 0] = "Red";
+    Colors[Colors["Green"] = 1] = "Green";
+    Colors[Colors["Blue"] = 2] = "Blue";
+})(Colors || (Colors = {}));

--- a/tests/baselines/reference/missingCloseBraceInEnum.symbols
+++ b/tests/baselines/reference/missingCloseBraceInEnum.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/missingCloseBraceInEnum.ts ===
+enum Colors {
+>Colors : Symbol(Colors, Decl(missingCloseBraceInEnum.ts, 0, 0))
+
+  Red,
+>Red : Symbol(Colors.Red, Decl(missingCloseBraceInEnum.ts, 0, 13))
+
+  Green,
+>Green : Symbol(Colors.Green, Decl(missingCloseBraceInEnum.ts, 1, 6))
+
+  Blue,
+>Blue : Symbol(Colors.Blue, Decl(missingCloseBraceInEnum.ts, 2, 8))
+
+

--- a/tests/baselines/reference/missingCloseBraceInEnum.types
+++ b/tests/baselines/reference/missingCloseBraceInEnum.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/missingCloseBraceInEnum.ts ===
+enum Colors {
+>Colors : Colors
+
+  Red,
+>Red : Colors.Red
+
+  Green,
+>Green : Colors.Green
+
+  Blue,
+>Blue : Colors.Blue
+
+

--- a/tests/baselines/reference/missingCloseBraceInJsxAttributeExpression.errors.txt
+++ b/tests/baselines/reference/missingCloseBraceInJsxAttributeExpression.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx(1,23): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx(1,30): error TS1109: Expression expected.
+tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx(1,31): error TS1109: Expression expected.
+tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx(2,1): error TS1005: '}' expected.
+
+
+==== tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx (4 errors) ====
+    let el = <input prop={'abc' />
+                          ~~~~~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+                                 ~
+!!! error TS1109: Expression expected.
+                                  
+!!! error TS1109: Expression expected.
+    
+    
+!!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx:1:22: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/missingCloseBraceInJsxAttributeExpression.js
+++ b/tests/baselines/reference/missingCloseBraceInJsxAttributeExpression.js
@@ -1,0 +1,7 @@
+//// [missingCloseBraceInJsxAttributeExpression.tsx]
+let el = <input prop={'abc' />
+
+
+//// [missingCloseBraceInJsxAttributeExpression.jsx]
+var el = <input prop={'abc' /  >
+}/>;

--- a/tests/baselines/reference/missingCloseBraceInJsxAttributeExpression.symbols
+++ b/tests/baselines/reference/missingCloseBraceInJsxAttributeExpression.symbols
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx ===
+let el = <input prop={'abc' />
+>el : Symbol(el, Decl(missingCloseBraceInJsxAttributeExpression.tsx, 0, 3))
+>prop : Symbol(prop, Decl(missingCloseBraceInJsxAttributeExpression.tsx, 0, 15))
+

--- a/tests/baselines/reference/missingCloseBraceInJsxAttributeExpression.types
+++ b/tests/baselines/reference/missingCloseBraceInJsxAttributeExpression.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx ===
+let el = <input prop={'abc' />
+>el : any
+><input prop={'abc' /> : any
+>input : any
+>prop : boolean
+>'abc' /> : boolean
+>'abc' / : number
+>'abc' : "abc"
+> : any
+
+> : any
+

--- a/tests/baselines/reference/missingCloseBraceInJsxExpression.errors.txt
+++ b/tests/baselines/reference/missingCloseBraceInJsxExpression.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/compiler/missingCloseBraceInJsxExpression.tsx(1,23): error TS1005: '}' expected.
+
+
+==== tests/cases/compiler/missingCloseBraceInJsxExpression.tsx (1 errors) ====
+    let el = <div>{'hello'</div>
+                          ~~
+!!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/compiler/missingCloseBraceInJsxExpression.tsx:1:15: The parser expected to find a '}' to match the '{' token here.
+    

--- a/tests/baselines/reference/missingCloseBraceInJsxExpression.js
+++ b/tests/baselines/reference/missingCloseBraceInJsxExpression.js
@@ -1,0 +1,6 @@
+//// [missingCloseBraceInJsxExpression.tsx]
+let el = <div>{'hello'</div>
+
+
+//// [missingCloseBraceInJsxExpression.jsx]
+var el = <div>{'hello'}</div>;

--- a/tests/baselines/reference/missingCloseBraceInJsxExpression.symbols
+++ b/tests/baselines/reference/missingCloseBraceInJsxExpression.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/missingCloseBraceInJsxExpression.tsx ===
+let el = <div>{'hello'</div>
+>el : Symbol(el, Decl(missingCloseBraceInJsxExpression.tsx, 0, 3))
+

--- a/tests/baselines/reference/missingCloseBraceInJsxExpression.types
+++ b/tests/baselines/reference/missingCloseBraceInJsxExpression.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/missingCloseBraceInJsxExpression.tsx ===
+let el = <div>{'hello'</div>
+>el : any
+><div>{'hello'</div> : any
+>div : any
+>'hello' : "hello"
+>div : any
+

--- a/tests/baselines/reference/missingCloseBraceInModuleBlock.errors.txt
+++ b/tests/baselines/reference/missingCloseBraceInModuleBlock.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/missingCloseBraceInModuleBlock.ts(4,1): error TS1005: '}' expected.
+
+
+==== tests/cases/compiler/missingCloseBraceInModuleBlock.ts (1 errors) ====
+    module "dummy" {
+      interface Dummy {}
+    
+    
+    
+!!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/compiler/missingCloseBraceInModuleBlock.ts:1:16: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/missingCloseBraceInModuleBlock.js
+++ b/tests/baselines/reference/missingCloseBraceInModuleBlock.js
@@ -1,0 +1,7 @@
+//// [missingCloseBraceInModuleBlock.ts]
+module "dummy" {
+  interface Dummy {}
+
+
+
+//// [missingCloseBraceInModuleBlock.js]

--- a/tests/baselines/reference/missingCloseBraceInModuleBlock.symbols
+++ b/tests/baselines/reference/missingCloseBraceInModuleBlock.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/missingCloseBraceInModuleBlock.ts ===
+module "dummy" {
+>"dummy" : Symbol("dummy", Decl(missingCloseBraceInModuleBlock.ts, 0, 0))
+
+  interface Dummy {}
+>Dummy : Symbol(Dummy, Decl(missingCloseBraceInModuleBlock.ts, 0, 16))
+
+

--- a/tests/baselines/reference/missingCloseBraceInModuleBlock.types
+++ b/tests/baselines/reference/missingCloseBraceInModuleBlock.types
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/missingCloseBraceInModuleBlock.ts ===
+module "dummy" {
+>"dummy" : typeof import("dummy")
+
+  interface Dummy {}
+
+

--- a/tests/baselines/reference/missingCloseBraceInTypeMemberList.errors.txt
+++ b/tests/baselines/reference/missingCloseBraceInTypeMemberList.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/missingCloseBraceInTypeMemberList.ts(3,1): error TS1005: '}' expected.
+
+
+==== tests/cases/compiler/missingCloseBraceInTypeMemberList.ts (1 errors) ====
+    type ITest = {
+      num: number;
+    
+    
+!!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/compiler/missingCloseBraceInTypeMemberList.ts:1:14: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/missingCloseBraceInTypeMemberList.js
+++ b/tests/baselines/reference/missingCloseBraceInTypeMemberList.js
@@ -1,0 +1,6 @@
+//// [missingCloseBraceInTypeMemberList.ts]
+type ITest = {
+  num: number;
+
+
+//// [missingCloseBraceInTypeMemberList.js]

--- a/tests/baselines/reference/missingCloseBraceInTypeMemberList.symbols
+++ b/tests/baselines/reference/missingCloseBraceInTypeMemberList.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/missingCloseBraceInTypeMemberList.ts ===
+type ITest = {
+>ITest : Symbol(ITest, Decl(missingCloseBraceInTypeMemberList.ts, 0, 0))
+
+  num: number;
+>num : Symbol(num, Decl(missingCloseBraceInTypeMemberList.ts, 0, 14))
+

--- a/tests/baselines/reference/missingCloseBraceInTypeMemberList.types
+++ b/tests/baselines/reference/missingCloseBraceInTypeMemberList.types
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/missingCloseBraceInTypeMemberList.ts ===
+type ITest = {
+>ITest : ITest
+
+  num: number;
+>num : number
+

--- a/tests/baselines/reference/parser512084.errors.txt
+++ b/tests/baselines/reference/parser512084.errors.txt
@@ -6,3 +6,4 @@ tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512084.ts(2,1):
     
     
 !!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript5/RegressionTests/parser512084.ts:1:11: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/parserAccessibilityAfterStatic6.errors.txt
+++ b/tests/baselines/reference/parserAccessibilityAfterStatic6.errors.txt
@@ -7,3 +7,4 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStati
     static public
                  
 !!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic6.ts:2:1: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/parserComputedPropertyName33.errors.txt
+++ b/tests/baselines/reference/parserComputedPropertyName33.errors.txt
@@ -15,6 +15,7 @@ tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedP
 !!! error TS2304: Cannot find name 'e2'.
                ~
 !!! error TS1005: ';' expected.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName33.ts:1:9: The parser expected to find a '}' to match the '{' token here.
     }
     ~
 !!! error TS1128: Declaration or statement expected.

--- a/tests/baselines/reference/parserErrorRecoveryIfStatement5.errors.txt
+++ b/tests/baselines/reference/parserErrorRecoveryIfStatement5.errors.txt
@@ -28,3 +28,4 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IfStatements/parserErro
     }
      
 !!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IfStatements/parserErrorRecoveryIfStatement5.ts:1:11: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/parserErrorRecovery_ClassElement3.errors.txt
+++ b/tests/baselines/reference/parserErrorRecovery_ClassElement3.errors.txt
@@ -20,3 +20,5 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErr
 !!! error TS1127: Invalid character.
         
 !!! error TS1005: '}' expected.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts:6:11: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts:1:10: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/parserErrorRecovery_SwitchStatement2.errors.txt
+++ b/tests/baselines/reference/parserErrorRecovery_SwitchStatement2.errors.txt
@@ -17,3 +17,4 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/SwitchStatements/parser
      
 !!! error TS1005: '}' expected.
 !!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/SwitchStatements/parserErrorRecovery_SwitchStatement2.ts:2:17: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/SwitchStatements/parserErrorRecovery_SwitchStatement2.ts:1:9: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/parserUnterminatedGeneric1.errors.txt
+++ b/tests/baselines/reference/parserUnterminatedGeneric1.errors.txt
@@ -12,3 +12,4 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGener
 !!! error TS2304: Cannot find name 'IPromise'.
                                                          
 !!! error TS1005: '>' expected.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric1.ts:1:22: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/parserUnterminatedGeneric2.errors.txt
+++ b/tests/baselines/reference/parserUnterminatedGeneric2.errors.txt
@@ -54,3 +54,5 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGener
 !!! error TS2304: Cannot find name 'IPromise'.
                                                          
 !!! error TS1005: '>' expected.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric2.ts:7:25: The parser expected to find a '}' to match the '{' token here.
+!!! related TS1007 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric2.ts:1:19: The parser expected to find a '}' to match the '{' token here.

--- a/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
+++ b/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
@@ -285,6 +285,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(166,54
 !!! error TS2304: Cannot find name 'p1'.
                             ~~
 !!! error TS1005: ';' expected.
+!!! related TS1007 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts:118:14: The parser expected to find a '}' to match the '{' token here.
                                ~
 !!! error TS1005: ';' expected.
     }

--- a/tests/cases/compiler/missingCloseBraceInClassDeclaration.ts
+++ b/tests/cases/compiler/missingCloseBraceInClassDeclaration.ts
@@ -1,0 +1,6 @@
+class TestCls {
+  prop = 0;
+  method() {
+    return this.prop;
+  }
+

--- a/tests/cases/compiler/missingCloseBraceInEnum.ts
+++ b/tests/cases/compiler/missingCloseBraceInEnum.ts
@@ -1,0 +1,5 @@
+enum Colors {
+  Red,
+  Green,
+  Blue,
+

--- a/tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx
+++ b/tests/cases/compiler/missingCloseBraceInJsxAttributeExpression.tsx
@@ -1,0 +1,3 @@
+// @jsx: preserve
+
+let el = <input prop={'abc' />

--- a/tests/cases/compiler/missingCloseBraceInJsxExpression.tsx
+++ b/tests/cases/compiler/missingCloseBraceInJsxExpression.tsx
@@ -1,0 +1,3 @@
+// @jsx: preserve
+
+let el = <div>{'hello'</div>

--- a/tests/cases/compiler/missingCloseBraceInModuleBlock.ts
+++ b/tests/cases/compiler/missingCloseBraceInModuleBlock.ts
@@ -1,0 +1,3 @@
+module "dummy" {
+  interface Dummy {}
+

--- a/tests/cases/compiler/missingCloseBraceInTypeMemberList.ts
+++ b/tests/cases/compiler/missingCloseBraceInTypeMemberList.ts
@@ -1,0 +1,2 @@
+type ITest = {
+  num: number;


### PR DESCRIPTION
This commit adds token hints for missing close braces in

- Class definitions
- Enum definitions
- JSX expressions
- Module definitions (this includes augmentations and namespaces)
- Type member lists (this includes interfaces)

The token hint refers to the opening brace for which the parser expected
a corresponding closing brace.

Note that this commit *does not* update all occurences of an expectation
for a close brace to provide token hints. Constructs for which this
token hint is not provided include:

- Mapped types
- Switch statements
- Object binding patterns
- JSX spread attributes (`<div {...props}></div>`)
- JSDoc implements/augments tags (`/* @implements {SomeInterface} */`)

Part of #35597.

<!--
Thank you for submitting a pull request!

Please verify that:
* [x] There is an associated issue in the `Backlog` milestone (**required**)
* [x] Code is up-to-date with the `master` branch
* [x] You've successfully run `gulp runtests` locally
* [x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
