### PR TITLE
Bring over last 3.9 dom changes

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -19232,7 +19232,7 @@ interface BlobCallback {
 }
 
 interface CustomElementConstructor {
-    new (...params:[]): HTMLElement;
+    new (...params: any[]): HTMLElement;
 }
 
 interface DecodeErrorCallback {

--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -1697,6 +1697,12 @@ interface ShadowRootInit {
     mode: ShadowRootMode;
 }
 
+interface ShareData {
+    text?: string;
+    title?: string;
+    url?: string;
+}
+
 interface SpeechSynthesisErrorEventInit extends SpeechSynthesisEventInit {
     error: SpeechSynthesisErrorCode;
 }
@@ -10733,6 +10739,7 @@ interface Navigator extends MSFileSaver, MSNavigatorDoNotTrack, NavigatorAutomat
     msLaunchUri(uri: string, successCallback?: MSLaunchUriCallback, noHandlerCallback?: MSLaunchUriCallback): void;
     requestMediaKeySystemAccess(keySystem: string, supportedConfigurations: MediaKeySystemConfiguration[]): Promise<MediaKeySystemAccess>;
     sendBeacon(url: string, data?: BodyInit | null): boolean;
+    share(data?: ShareData): Promise<void>;
     vibrate(pattern: number | number[]): boolean;
 }
 
@@ -19225,7 +19232,7 @@ interface BlobCallback {
 }
 
 interface CustomElementConstructor {
-    new (): HTMLElement;
+    new (...params:[]): HTMLElement;
 }
 
 interface DecodeErrorCallback {

--- a/tests/baselines/reference/intersectionsOfLargeUnions2.errors.txt
+++ b/tests/baselines/reference/intersectionsOfLargeUnions2.errors.txt
@@ -10,7 +10,7 @@ tests/cases/compiler/intersectionsOfLargeUnions2.ts(31,15): error TS2536: Type '
         interface ElementTagNameMap {
                   ~~~~~~~~~~~~~~~~~
 !!! error TS2300: Duplicate identifier 'ElementTagNameMap'.
-!!! related TS6203 /.ts/lib.dom.d.ts:19563:6: 'ElementTagNameMap' was also declared here.
+!!! related TS6203 /.ts/lib.dom.d.ts:19570:6: 'ElementTagNameMap' was also declared here.
             [index: number]: HTMLElement
         }
     


### PR DESCRIPTION
Brings in:
- New - https://github.com/microsoft/TypeScript/issues/18642 - `navigator.share`
- Fix - https://github.com/microsoft/TypeScript/issues/36965 - regression with web components API