### PR TITLE
Narrowing from truthy unknown to object

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18947,10 +18947,11 @@ namespace ts {
             return false;
         }
 
-        function containsTruthyCheck(source: Node, target: Node) {
+        // Given a source x, check if target matches x or is an && operation with an operand that matches x.
+        function containsTruthyCheck(source: Node, target: Node): boolean {
             return isMatchingReference(source, target) ||
                 (target.kind === SyntaxKind.BinaryExpression && (<BinaryExpression>target).operatorToken.kind === SyntaxKind.AmpersandAmpersandToken &&
-                (isMatchingReference(source, (<BinaryExpression>target).left) || isMatchingReference(source, (<BinaryExpression>target).right)));
+                (containsTruthyCheck(source, (<BinaryExpression>target).left) || containsTruthyCheck(source, (<BinaryExpression>target).right)));
         }
 
         function getAccessedPropertyName(access: AccessExpression): __String | undefined {
@@ -20350,7 +20351,8 @@ namespace ts {
                     return type;
                 }
                 if (assumeTrue && type.flags & TypeFlags.Unknown && literal.text === "object") {
-                    // The pattern x && typeof x === 'object', where x is of type unknown, narrows x to type object.
+                    // The pattern x && typeof x === 'object', where x is of type unknown, narrows x to type object. We don't
+                    // need to check for the reverse typeof x === 'object' && x since that already narrows correctly.
                     if (typeOfExpr.parent.parent.kind === SyntaxKind.BinaryExpression) {
                         const expr = <BinaryExpression>typeOfExpr.parent.parent;
                         if (expr.operatorToken.kind === SyntaxKind.AmpersandAmpersandToken && expr.right === typeOfExpr.parent && containsTruthyCheck(reference, expr.left)) {

--- a/tests/baselines/reference/narrowingTruthyObject.errors.txt
+++ b/tests/baselines/reference/narrowingTruthyObject.errors.txt
@@ -20,6 +20,12 @@ tests/cases/compiler/narrowingTruthyObject.ts(3,9): error TS2531: Object is poss
         if (x && b && typeof x === 'object') {
             x.toString();
         }
+        if (x && b && b && typeof x === 'object') {
+            x.toString();
+        }
+        if (b && b && x && b && b && typeof x === 'object') {
+            x.toString();
+        }
     }
     
     // Repro from #36870

--- a/tests/baselines/reference/narrowingTruthyObject.errors.txt
+++ b/tests/baselines/reference/narrowingTruthyObject.errors.txt
@@ -1,0 +1,30 @@
+tests/cases/compiler/narrowingTruthyObject.ts(3,9): error TS2531: Object is possibly 'null'.
+
+
+==== tests/cases/compiler/narrowingTruthyObject.ts (1 errors) ====
+    function foo(x: unknown, b: boolean) {
+        if (typeof x === 'object') {
+            x.toString();
+            ~
+!!! error TS2531: Object is possibly 'null'.
+        }
+        if (typeof x === 'object' && x) {
+            x.toString();
+        }
+        if (x && typeof x === 'object') {
+            x.toString();
+        }
+        if (b && x && typeof x === 'object') {
+            x.toString();
+        }
+        if (x && b && typeof x === 'object') {
+            x.toString();
+        }
+    }
+    
+    // Repro from #36870
+    
+    function f1(x: unknown): any {
+        return x && typeof x === 'object' && x.hasOwnProperty('x');
+    }
+    

--- a/tests/baselines/reference/narrowingTruthyObject.js
+++ b/tests/baselines/reference/narrowingTruthyObject.js
@@ -15,6 +15,12 @@ function foo(x: unknown, b: boolean) {
     if (x && b && typeof x === 'object') {
         x.toString();
     }
+    if (x && b && b && typeof x === 'object') {
+        x.toString();
+    }
+    if (b && b && x && b && b && typeof x === 'object') {
+        x.toString();
+    }
 }
 
 // Repro from #36870
@@ -40,6 +46,12 @@ function foo(x, b) {
         x.toString();
     }
     if (x && b && typeof x === 'object') {
+        x.toString();
+    }
+    if (x && b && b && typeof x === 'object') {
+        x.toString();
+    }
+    if (b && b && x && b && b && typeof x === 'object') {
         x.toString();
     }
 }

--- a/tests/baselines/reference/narrowingTruthyObject.js
+++ b/tests/baselines/reference/narrowingTruthyObject.js
@@ -1,0 +1,49 @@
+//// [narrowingTruthyObject.ts]
+function foo(x: unknown, b: boolean) {
+    if (typeof x === 'object') {
+        x.toString();
+    }
+    if (typeof x === 'object' && x) {
+        x.toString();
+    }
+    if (x && typeof x === 'object') {
+        x.toString();
+    }
+    if (b && x && typeof x === 'object') {
+        x.toString();
+    }
+    if (x && b && typeof x === 'object') {
+        x.toString();
+    }
+}
+
+// Repro from #36870
+
+function f1(x: unknown): any {
+    return x && typeof x === 'object' && x.hasOwnProperty('x');
+}
+
+
+//// [narrowingTruthyObject.js]
+"use strict";
+function foo(x, b) {
+    if (typeof x === 'object') {
+        x.toString();
+    }
+    if (typeof x === 'object' && x) {
+        x.toString();
+    }
+    if (x && typeof x === 'object') {
+        x.toString();
+    }
+    if (b && x && typeof x === 'object') {
+        x.toString();
+    }
+    if (x && b && typeof x === 'object') {
+        x.toString();
+    }
+}
+// Repro from #36870
+function f1(x) {
+    return x && typeof x === 'object' && x.hasOwnProperty('x');
+}

--- a/tests/baselines/reference/narrowingTruthyObject.symbols
+++ b/tests/baselines/reference/narrowingTruthyObject.symbols
@@ -50,19 +50,43 @@ function foo(x: unknown, b: boolean) {
 >x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
 >toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
     }
+    if (x && b && b && typeof x === 'object') {
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>b : Symbol(b, Decl(narrowingTruthyObject.ts, 0, 24))
+>b : Symbol(b, Decl(narrowingTruthyObject.ts, 0, 24))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+
+        x.toString();
+>x.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+    }
+    if (b && b && x && b && b && typeof x === 'object') {
+>b : Symbol(b, Decl(narrowingTruthyObject.ts, 0, 24))
+>b : Symbol(b, Decl(narrowingTruthyObject.ts, 0, 24))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>b : Symbol(b, Decl(narrowingTruthyObject.ts, 0, 24))
+>b : Symbol(b, Decl(narrowingTruthyObject.ts, 0, 24))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+
+        x.toString();
+>x.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+    }
 }
 
 // Repro from #36870
 
 function f1(x: unknown): any {
->f1 : Symbol(f1, Decl(narrowingTruthyObject.ts, 16, 1))
->x : Symbol(x, Decl(narrowingTruthyObject.ts, 20, 12))
+>f1 : Symbol(f1, Decl(narrowingTruthyObject.ts, 22, 1))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 26, 12))
 
     return x && typeof x === 'object' && x.hasOwnProperty('x');
->x : Symbol(x, Decl(narrowingTruthyObject.ts, 20, 12))
->x : Symbol(x, Decl(narrowingTruthyObject.ts, 20, 12))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 26, 12))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 26, 12))
 >x.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
->x : Symbol(x, Decl(narrowingTruthyObject.ts, 20, 12))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 26, 12))
 >hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
 }
 

--- a/tests/baselines/reference/narrowingTruthyObject.symbols
+++ b/tests/baselines/reference/narrowingTruthyObject.symbols
@@ -1,0 +1,68 @@
+=== tests/cases/compiler/narrowingTruthyObject.ts ===
+function foo(x: unknown, b: boolean) {
+>foo : Symbol(foo, Decl(narrowingTruthyObject.ts, 0, 0))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>b : Symbol(b, Decl(narrowingTruthyObject.ts, 0, 24))
+
+    if (typeof x === 'object') {
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+
+        x.toString();
+>x.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+    }
+    if (typeof x === 'object' && x) {
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+
+        x.toString();
+>x.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+    }
+    if (x && typeof x === 'object') {
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+
+        x.toString();
+>x.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+    }
+    if (b && x && typeof x === 'object') {
+>b : Symbol(b, Decl(narrowingTruthyObject.ts, 0, 24))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+
+        x.toString();
+>x.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+    }
+    if (x && b && typeof x === 'object') {
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>b : Symbol(b, Decl(narrowingTruthyObject.ts, 0, 24))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+
+        x.toString();
+>x.toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 0, 13))
+>toString : Symbol(Object.toString, Decl(lib.es5.d.ts, --, --))
+    }
+}
+
+// Repro from #36870
+
+function f1(x: unknown): any {
+>f1 : Symbol(f1, Decl(narrowingTruthyObject.ts, 16, 1))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 20, 12))
+
+    return x && typeof x === 'object' && x.hasOwnProperty('x');
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 20, 12))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 20, 12))
+>x.hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(narrowingTruthyObject.ts, 20, 12))
+>hasOwnProperty : Symbol(Object.hasOwnProperty, Decl(lib.es5.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/narrowingTruthyObject.types
+++ b/tests/baselines/reference/narrowingTruthyObject.types
@@ -76,6 +76,46 @@ function foo(x: unknown, b: boolean) {
 >x : object
 >toString : () => string
     }
+    if (x && b && b && typeof x === 'object') {
+>x && b && b && typeof x === 'object' : boolean
+>x && b && b : boolean
+>x && b : boolean
+>x : unknown
+>b : boolean
+>b : true
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        x.toString();
+>x.toString() : string
+>x.toString : () => string
+>x : object
+>toString : () => string
+    }
+    if (b && b && x && b && b && typeof x === 'object') {
+>b && b && x && b && b && typeof x === 'object' : boolean
+>b && b && x && b && b : true
+>b && b && x && b : true
+>b && b && x : unknown
+>b && b : boolean
+>b : boolean
+>b : true
+>x : unknown
+>b : true
+>b : true
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        x.toString();
+>x.toString() : string
+>x.toString : () => string
+>x : object
+>toString : () => string
+    }
 }
 
 // Repro from #36870

--- a/tests/baselines/reference/narrowingTruthyObject.types
+++ b/tests/baselines/reference/narrowingTruthyObject.types
@@ -1,0 +1,101 @@
+=== tests/cases/compiler/narrowingTruthyObject.ts ===
+function foo(x: unknown, b: boolean) {
+>foo : (x: unknown, b: boolean) => void
+>x : unknown
+>b : boolean
+
+    if (typeof x === 'object') {
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        x.toString();
+>x.toString() : string
+>x.toString : () => string
+>x : object | null
+>toString : () => string
+    }
+    if (typeof x === 'object' && x) {
+>typeof x === 'object' && x : false | object | null
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+>x : object | null
+
+        x.toString();
+>x.toString() : string
+>x.toString : () => string
+>x : object
+>toString : () => string
+    }
+    if (x && typeof x === 'object') {
+>x && typeof x === 'object' : boolean
+>x : unknown
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        x.toString();
+>x.toString() : string
+>x.toString : () => string
+>x : object
+>toString : () => string
+    }
+    if (b && x && typeof x === 'object') {
+>b && x && typeof x === 'object' : boolean
+>b && x : unknown
+>b : boolean
+>x : unknown
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        x.toString();
+>x.toString() : string
+>x.toString : () => string
+>x : object
+>toString : () => string
+    }
+    if (x && b && typeof x === 'object') {
+>x && b && typeof x === 'object' : boolean
+>x && b : boolean
+>x : unknown
+>b : boolean
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+
+        x.toString();
+>x.toString() : string
+>x.toString : () => string
+>x : object
+>toString : () => string
+    }
+}
+
+// Repro from #36870
+
+function f1(x: unknown): any {
+>f1 : (x: unknown) => any
+>x : unknown
+
+    return x && typeof x === 'object' && x.hasOwnProperty('x');
+>x && typeof x === 'object' && x.hasOwnProperty('x') : boolean
+>x && typeof x === 'object' : boolean
+>x : unknown
+>typeof x === 'object' : boolean
+>typeof x : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>x : unknown
+>'object' : "object"
+>x.hasOwnProperty('x') : boolean
+>x.hasOwnProperty : (v: string | number | symbol) => boolean
+>x : object
+>hasOwnProperty : (v: string | number | symbol) => boolean
+>'x' : "x"
+}
+

--- a/tests/cases/compiler/narrowingTruthyObject.ts
+++ b/tests/cases/compiler/narrowingTruthyObject.ts
@@ -1,0 +1,25 @@
+// @strict: true
+
+function foo(x: unknown, b: boolean) {
+    if (typeof x === 'object') {
+        x.toString();
+    }
+    if (typeof x === 'object' && x) {
+        x.toString();
+    }
+    if (x && typeof x === 'object') {
+        x.toString();
+    }
+    if (b && x && typeof x === 'object') {
+        x.toString();
+    }
+    if (x && b && typeof x === 'object') {
+        x.toString();
+    }
+}
+
+// Repro from #36870
+
+function f1(x: unknown): any {
+    return x && typeof x === 'object' && x.hasOwnProperty('x');
+}

--- a/tests/cases/compiler/narrowingTruthyObject.ts
+++ b/tests/cases/compiler/narrowingTruthyObject.ts
@@ -16,6 +16,12 @@ function foo(x: unknown, b: boolean) {
     if (x && b && typeof x === 'object') {
         x.toString();
     }
+    if (x && b && b && typeof x === 'object') {
+        x.toString();
+    }
+    if (b && b && x && b && b && typeof x === 'object') {
+        x.toString();
+    }
 }
 
 // Repro from #36870


### PR DESCRIPTION
With this PR, given a variable `x` of type `unknown`, the pattern `x && typeof x === 'object'` narrows `x` to `object`. Previously we'd narrow to `object | null` because a truthiness check applied to `unknown` is still `unknown` (and `unknown` includes `null`).

Note that this is a targeted fix for a relatively common pattern. In an ideal world we'd be able to accurately represent types that are known to be truthy, but we currently don't have that ability.

Fixes #36870.