### PR TITLE
Fix inference of type arguments when source is 'awaited'

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18471,9 +18471,6 @@ namespace ts {
                     if (i < variances.length && (variances[i] & VarianceFlags.VarianceMask) === VarianceFlags.Contravariant) {
                         inferFromContravariantTypes(sourceTypes[i], targetTypes[i]);
                     }
-                    else if (variances[i] & VarianceFlags.Awaited) {
-                        inferFromTypes(unwrapAwaitedType(sourceTypes[i]), targetTypes[i]);
-                    }
                     else {
                         inferFromTypes(sourceTypes[i], targetTypes[i]);
                     }

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1231,7 +1231,7 @@ namespace ts {
                 enableCPUProfiler,
                 disableCPUProfiler,
                 realpath,
-                debugMode: some(<string[]>process.execArgv, arg => /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(arg)),
+                debugMode: !!process.env.NODE_INSPECTOR_IPC || some(<string[]>process.execArgv, arg => /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(arg)),
                 tryEnableSourceMapsForHost() {
                     try {
                         require("source-map-support").install();

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -641,7 +641,8 @@ namespace ts {
 
         ReportsUnmeasurable = 1 << 3,
         ReportsUnreliable   = 1 << 4,
-        ReportsMask         = ReportsUnmeasurable | ReportsUnreliable
+        ReportsAwaited      = 1 << 5,
+        ReportsMask         = ReportsUnmeasurable | ReportsUnreliable | ReportsAwaited
     }
 
     export interface Node extends TextRange {
@@ -4608,7 +4609,8 @@ namespace ts {
         VarianceMask  = Invariant | Covariant | Contravariant | Independent, // Mask containing all measured variances without the unmeasurable flag
         Unmeasurable  = 1 << 3,  // Variance result is unusable - relationship relies on structural comparisons which are not reflected in generic relationships
         Unreliable    = 1 << 4,  // Variance result is unreliable - checking may produce false negatives, but not false positives
-        AllowsStructuralFallback = Unmeasurable | Unreliable,
+        Awaited       = 1 << 5,  // type argument is awaited
+        AllowsStructuralFallback = Unmeasurable | Unreliable | Awaited,
     }
 
     // Generic class and interface types

--- a/tests/baselines/reference/awaited.types
+++ b/tests/baselines/reference/awaited.types
@@ -391,15 +391,15 @@ f5(makePromise(1)).then(x => x);
 
 f5(makePromise(makePromise(1))).then(x => x);
 >f5(makePromise(makePromise(1))).then(x => x) : Promise<number>
->f5(makePromise(makePromise(1))).then : <TResult1 = Promise<number>, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<awaited TResult1 | awaited TResult2>
->f5(makePromise(makePromise(1))) : Promise<Promise<number>>
+>f5(makePromise(makePromise(1))).then : <TResult1 = number, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<awaited TResult1 | awaited TResult2>
+>f5(makePromise(makePromise(1))) : Promise<number>
 >f5 : <U>(u: Promise<U>) => Promise<U>
 >makePromise(makePromise(1)) : Promise<Promise<number>>
 >makePromise : <T>(x: T) => Promise<T>
 >makePromise(1) : Promise<number>
 >makePromise : <T>(x: T) => Promise<T>
 >1 : 1
->then : <TResult1 = Promise<number>, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<awaited TResult1 | awaited TResult2>
+>then : <TResult1 = number, TResult2 = never>(onfulfilled?: (value: number) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => Promise<awaited TResult1 | awaited TResult2>
 >x => x : (x: number) => number
 >x : number
 >x : number

--- a/tests/baselines/reference/awaitedInference.js
+++ b/tests/baselines/reference/awaitedInference.js
@@ -15,6 +15,11 @@ const x = f<number>(); // number
 const y = f<Promise<number>>(); // number ?
 const z = f<Promise<number> | number>(); // number ?
 
+// https://github.com/microsoft/TypeScript/issues/37526
+function f1<T>(a: T): Promise<awaited T> {
+    return new Promise(r => r(a));
+}
+
 //// [awaitedInference.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -62,3 +67,7 @@ function f() {
 var x = f(); // number
 var y = f(); // number ?
 var z = f(); // number ?
+// https://github.com/microsoft/TypeScript/issues/37526
+function f1(a) {
+    return new Promise(function (r) { return r(a); });
+}

--- a/tests/baselines/reference/awaitedInference.symbols
+++ b/tests/baselines/reference/awaitedInference.symbols
@@ -26,12 +26,12 @@ type UnwrapAwaited<T> = T extends awaited infer Inner ? Inner : T;
 type Result1 = UnwrapAwaited<awaited Promise<number>>; // number
 >Result1 : Symbol(Result1, Decl(awaitedInference.ts, 4, 66))
 >UnwrapAwaited : Symbol(UnwrapAwaited, Decl(awaitedInference.ts, 2, 36))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 type Result2 = UnwrapAwaited<awaited Promise<number> | number>; // number
 >Result2 : Symbol(Result2, Decl(awaitedInference.ts, 5, 54))
 >UnwrapAwaited : Symbol(UnwrapAwaited, Decl(awaitedInference.ts, 2, 36))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 function f<T>() {
 >f : Symbol(f, Decl(awaitedInference.ts, 6, 63))
@@ -58,10 +58,25 @@ const x = f<number>(); // number
 const y = f<Promise<number>>(); // number ?
 >y : Symbol(y, Decl(awaitedInference.ts, 13, 5))
 >f : Symbol(f, Decl(awaitedInference.ts, 6, 63))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
 const z = f<Promise<number> | number>(); // number ?
 >z : Symbol(z, Decl(awaitedInference.ts, 14, 5))
 >f : Symbol(f, Decl(awaitedInference.ts, 6, 63))
->Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
 
+// https://github.com/microsoft/TypeScript/issues/37526
+function f1<T>(a: T): Promise<awaited T> {
+>f1 : Symbol(f1, Decl(awaitedInference.ts, 14, 40))
+>T : Symbol(T, Decl(awaitedInference.ts, 17, 12))
+>a : Symbol(a, Decl(awaitedInference.ts, 17, 15))
+>T : Symbol(T, Decl(awaitedInference.ts, 17, 12))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>T : Symbol(T, Decl(awaitedInference.ts, 17, 12))
+
+    return new Promise(r => r(a));
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --))
+>r : Symbol(r, Decl(awaitedInference.ts, 18, 23))
+>r : Symbol(r, Decl(awaitedInference.ts, 18, 23))
+>a : Symbol(a, Decl(awaitedInference.ts, 17, 15))
+}

--- a/tests/baselines/reference/awaitedInference.types
+++ b/tests/baselines/reference/awaitedInference.types
@@ -53,3 +53,17 @@ const z = f<Promise<number> | number>(); // number ?
 >f<Promise<number> | number>() : [number | Promise<number>, number]
 >f : <T>() => [UnwrapAwaited<T>, UnwrapAwaited<awaited T>]
 
+// https://github.com/microsoft/TypeScript/issues/37526
+function f1<T>(a: T): Promise<awaited T> {
+>f1 : <T>(a: T) => Promise<awaited T>
+>a : T
+
+    return new Promise(r => r(a));
+>new Promise(r => r(a)) : Promise<T>
+>Promise : PromiseConstructor
+>r => r(a) : (r: (value?: T | awaited T | PromiseLike<T>) => void) => void
+>r : (value?: T | awaited T | PromiseLike<T>) => void
+>r(a) : void
+>r : (value?: T | awaited T | PromiseLike<T>) => void
+>a : T
+}

--- a/tests/cases/conformance/types/awaited/awaitedInference.ts
+++ b/tests/cases/conformance/types/awaited/awaitedInference.ts
@@ -1,3 +1,5 @@
+// @lib: es2015
+
 declare function foo<T>(f: () => PromiseLike<T>, x: T): void;
 declare const nullOrNumber: number | null;
 foo(async () => nullOrNumber, null);
@@ -13,3 +15,8 @@ function f<T>() {
 const x = f<number>(); // number
 const y = f<Promise<number>>(); // number ?
 const z = f<Promise<number> | number>(); // number ?
+
+// https://github.com/microsoft/TypeScript/issues/37526
+function f1<T>(a: T): Promise<awaited T> {
+    return new Promise(r => r(a));
+}


### PR DESCRIPTION
This changes inference behavior when inferring a type argument that is `awaited`:

```ts
function f<T>(a: T): Promise<awaited T> {
    // will now infer `Promise<T>` instead of `Promise<awaited T>`
    return new Promise(r => r(a));
}
```

Fixes #37526
