### PR TITLE
Sort the arrays of fileNames in the build info

### DIFF
--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -710,37 +710,39 @@ namespace ts {
         };
         if (state.referencedMap) {
             const referencedMap: MapLike<string[]> = {};
-            state.referencedMap.forEach((value, key) => {
-                referencedMap[relativeToBuildInfo(key)] = arrayFrom(value.keys(), relativeToBuildInfo);
-            });
+            for (const key of arrayFrom(state.referencedMap.keys()).sort()) {
+                referencedMap[relativeToBuildInfo(key)] = arrayFrom(state.referencedMap.get(key)!.keys(), relativeToBuildInfo).sort();
+            }
             result.referencedMap = referencedMap;
         }
 
         if (state.exportedModulesMap) {
             const exportedModulesMap: MapLike<string[]> = {};
-            state.exportedModulesMap.forEach((value, key) => {
+            for (const key of arrayFrom(state.exportedModulesMap.keys()).sort()) {
                 const newValue = state.currentAffectedFilesExportedModulesMap && state.currentAffectedFilesExportedModulesMap.get(key);
                 // Not in temporary cache, use existing value
-                if (newValue === undefined) exportedModulesMap[relativeToBuildInfo(key)] = arrayFrom(value.keys(), relativeToBuildInfo);
+                if (newValue === undefined) exportedModulesMap[relativeToBuildInfo(key)] = arrayFrom(state.exportedModulesMap.get(key)!.keys(), relativeToBuildInfo).sort();
                 // Value in cache and has updated value map, use that
-                else if (newValue) exportedModulesMap[relativeToBuildInfo(key)] = arrayFrom(newValue.keys(), relativeToBuildInfo);
-            });
+                else if (newValue) exportedModulesMap[relativeToBuildInfo(key)] = arrayFrom(newValue.keys(), relativeToBuildInfo).sort();
+            }
             result.exportedModulesMap = exportedModulesMap;
         }
 
         if (state.semanticDiagnosticsPerFile) {
             const semanticDiagnosticsPerFile: ProgramBuildInfoDiagnostic[] = [];
-            // Currently not recording actual errors since those mean no emit for tsc --build
-            state.semanticDiagnosticsPerFile.forEach((value, key) => semanticDiagnosticsPerFile.push(
-                value.length ?
-                    [
-                        relativeToBuildInfo(key),
-                        state.hasReusableDiagnostic ?
-                            value as readonly ReusableDiagnostic[] :
-                            convertToReusableDiagnostics(value as readonly Diagnostic[], relativeToBuildInfo)
-                    ] :
-                    relativeToBuildInfo(key)
-            ));
+            for (const key of arrayFrom(state.semanticDiagnosticsPerFile.keys()).sort()) {
+                const value = state.semanticDiagnosticsPerFile.get(key)!;
+                semanticDiagnosticsPerFile.push(
+                    value.length ?
+                        [
+                            relativeToBuildInfo(key),
+                            state.hasReusableDiagnostic ?
+                                value as readonly ReusableDiagnostic[] :
+                                convertToReusableDiagnostics(value as readonly Diagnostic[], relativeToBuildInfo)
+                        ] :
+                        relativeToBuildInfo(key)
+                );
+            }
             result.semanticDiagnosticsPerFile = semanticDiagnosticsPerFile;
         }
 

--- a/src/compiler/builder.ts
+++ b/src/compiler/builder.ts
@@ -710,27 +710,27 @@ namespace ts {
         };
         if (state.referencedMap) {
             const referencedMap: MapLike<string[]> = {};
-            for (const key of arrayFrom(state.referencedMap.keys()).sort()) {
-                referencedMap[relativeToBuildInfo(key)] = arrayFrom(state.referencedMap.get(key)!.keys(), relativeToBuildInfo).sort();
+            for (const key of arrayFrom(state.referencedMap.keys()).sort(compareStringsCaseSensitive)) {
+                referencedMap[relativeToBuildInfo(key)] = arrayFrom(state.referencedMap.get(key)!.keys(), relativeToBuildInfo).sort(compareStringsCaseSensitive);
             }
             result.referencedMap = referencedMap;
         }
 
         if (state.exportedModulesMap) {
             const exportedModulesMap: MapLike<string[]> = {};
-            for (const key of arrayFrom(state.exportedModulesMap.keys()).sort()) {
+            for (const key of arrayFrom(state.exportedModulesMap.keys()).sort(compareStringsCaseSensitive)) {
                 const newValue = state.currentAffectedFilesExportedModulesMap && state.currentAffectedFilesExportedModulesMap.get(key);
                 // Not in temporary cache, use existing value
-                if (newValue === undefined) exportedModulesMap[relativeToBuildInfo(key)] = arrayFrom(state.exportedModulesMap.get(key)!.keys(), relativeToBuildInfo).sort();
+                if (newValue === undefined) exportedModulesMap[relativeToBuildInfo(key)] = arrayFrom(state.exportedModulesMap.get(key)!.keys(), relativeToBuildInfo).sort(compareStringsCaseSensitive);
                 // Value in cache and has updated value map, use that
-                else if (newValue) exportedModulesMap[relativeToBuildInfo(key)] = arrayFrom(newValue.keys(), relativeToBuildInfo).sort();
+                else if (newValue) exportedModulesMap[relativeToBuildInfo(key)] = arrayFrom(newValue.keys(), relativeToBuildInfo).sort(compareStringsCaseSensitive);
             }
             result.exportedModulesMap = exportedModulesMap;
         }
 
         if (state.semanticDiagnosticsPerFile) {
             const semanticDiagnosticsPerFile: ProgramBuildInfoDiagnostic[] = [];
-            for (const key of arrayFrom(state.semanticDiagnosticsPerFile.keys()).sort()) {
+            for (const key of arrayFrom(state.semanticDiagnosticsPerFile.keys()).sort(compareStringsCaseSensitive)) {
                 const value = state.semanticDiagnosticsPerFile.get(key)!;
                 semanticDiagnosticsPerFile.push(
                     value.length ?

--- a/src/harness/fakesHosts.ts
+++ b/src/harness/fakesHosts.ts
@@ -496,37 +496,6 @@ ${indentText}${text}`;
         return text;
     }
 
-    function compareProgramBuildInfoDiagnostic(a: ts.ProgramBuildInfoDiagnostic, b: ts.ProgramBuildInfoDiagnostic) {
-        return ts.compareStringsCaseSensitive(ts.isString(a) ? a : a[0], ts.isString(b) ? b : b[0]);
-    }
-
-    export function sanitizeBuildInfoProgram(buildInfo: ts.BuildInfo) {
-        if (buildInfo.program) {
-            // reference Map
-            if (buildInfo.program.referencedMap) {
-                const referencedMap: ts.MapLike<string[]> = {};
-                for (const path of ts.getOwnKeys(buildInfo.program.referencedMap).sort()) {
-                    referencedMap[path] = buildInfo.program.referencedMap[path].sort();
-                }
-                buildInfo.program.referencedMap = referencedMap;
-            }
-
-            // exportedModulesMap
-            if (buildInfo.program.exportedModulesMap) {
-                const exportedModulesMap: ts.MapLike<string[]> = {};
-                for (const path of ts.getOwnKeys(buildInfo.program.exportedModulesMap).sort()) {
-                    exportedModulesMap[path] = buildInfo.program.exportedModulesMap[path].sort();
-                }
-                buildInfo.program.exportedModulesMap = exportedModulesMap;
-            }
-
-            // semanticDiagnosticsPerFile
-            if (buildInfo.program.semanticDiagnosticsPerFile) {
-                buildInfo.program.semanticDiagnosticsPerFile.sort(compareProgramBuildInfoDiagnostic);
-            }
-        }
-    }
-
     export const version = "FakeTSVersion";
 
     export function patchHostForBuildInfoReadWrite<T extends ts.System>(sys: T) {
@@ -547,7 +516,6 @@ ${indentText}${text}`;
             sys.writeFile = (fileName: string, content: string, writeByteOrderMark: boolean) => {
                 if (!ts.isBuildInfoFile(fileName)) return originalWriteFile.call(sys, fileName, content, writeByteOrderMark);
                 const buildInfo = ts.getBuildInfo(content);
-                sanitizeBuildInfoProgram(buildInfo);
                 buildInfo.version = version;
                 originalWriteFile.call(sys, fileName, ts.getBuildInfoText(buildInfo), writeByteOrderMark);
             };

--- a/tests/baselines/reference/tsbuild/demo/initial-build/in-master-branch-with-everything-setup-correctly-and-reports-no-error.js
+++ b/tests/baselines/reference/tsbuild/demo/initial-build/in-master-branch-with-everything-setup-correctly-and-reports-no-error.js
@@ -242,35 +242,35 @@ exports.lastElementOf = lastElementOf;
       "configFilePath": "../../zoo/tsconfig.json"
     },
     "referencedMap": {
-      "../../zoo/zoo.ts": [
-        "../animals/index.d.ts"
-      ],
       "../animals/dog.d.ts": [
         "../animals/index.d.ts"
       ],
       "../animals/index.d.ts": [
         "../animals/animal.d.ts",
         "../animals/dog.d.ts"
+      ],
+      "../../zoo/zoo.ts": [
+        "../animals/index.d.ts"
       ]
     },
     "exportedModulesMap": {
-      "../../zoo/zoo.ts": [
-        "../animals/index.d.ts"
-      ],
       "../animals/dog.d.ts": [
         "../animals/index.d.ts"
       ],
       "../animals/index.d.ts": [
         "../animals/animal.d.ts",
         "../animals/dog.d.ts"
+      ],
+      "../../zoo/zoo.ts": [
+        "../animals/index.d.ts"
       ]
     },
     "semanticDiagnosticsPerFile": [
       "../../../lib/lib.d.ts",
-      "../../zoo/zoo.ts",
       "../animals/animal.d.ts",
       "../animals/dog.d.ts",
-      "../animals/index.d.ts"
+      "../animals/index.d.ts",
+      "../../zoo/zoo.ts"
     ]
   },
   "version": "FakeTSVersion"

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-and-emits-them-correctly.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-and-emits-them-correctly.js
@@ -38,8 +38,8 @@ module.exports = {};
     "referencedMap": {},
     "exportedModulesMap": {},
     "semanticDiagnosticsPerFile": [
-      "../../src/common/nominal.js",
-      "../lib.d.ts"
+      "../lib.d.ts",
+      "../../src/common/nominal.js"
     ]
   },
   "version": "FakeTSVersion"
@@ -98,9 +98,9 @@ exports.__esModule = true;
     },
     "exportedModulesMap": {},
     "semanticDiagnosticsPerFile": [
-      "../../src/sub-project/index.js",
       "../common/nominal.d.ts",
-      "../lib.d.ts"
+      "../lib.d.ts",
+      "../../src/sub-project/index.js"
     ]
   },
   "version": "FakeTSVersion"
@@ -163,9 +163,9 @@ exports.getVar = getVar;
     },
     "exportedModulesMap": {},
     "semanticDiagnosticsPerFile": [
-      "../../src/sub-project-2/index.js",
       "../lib.d.ts",
-      "../sub-project/index.d.ts"
+      "../sub-project/index.d.ts",
+      "../../src/sub-project-2/index.js"
     ]
   },
   "version": "FakeTSVersion"

--- a/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-with-non-moved-json-files-and-emits-them-correctly.js
+++ b/tests/baselines/reference/tsbuild/javascriptProjectEmit/initial-build/loads-js-based-projects-with-non-moved-json-files-and-emits-them-correctly.js
@@ -134,8 +134,8 @@ exports.getVar = getVar;
     "exportedModulesMap": {},
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
-      "../../src/sub-project-2/index.js",
-      "../sub-project/index.d.ts"
+      "../sub-project/index.d.ts",
+      "../../src/sub-project-2/index.js"
     ]
   },
   "version": "FakeTSVersion"

--- a/tests/baselines/reference/tsbuild/moduleSpecifiers/initial-build/synthesized-module-specifiers-resolve-correctly.js
+++ b/tests/baselines/reference/tsbuild/moduleSpecifiers/initial-build/synthesized-module-specifiers-resolve-correctly.js
@@ -109,8 +109,8 @@ exports.__esModule = true;
     },
     "semanticDiagnosticsPerFile": [
       "../../../../lib/lib.d.ts",
-      "../../../solution/sub-project/index.ts",
-      "../common/nominal.d.ts"
+      "../common/nominal.d.ts",
+      "../../../solution/sub-project/index.ts"
     ]
   },
   "version": "FakeTSVersion"
@@ -166,26 +166,26 @@ exports.getVar = getVar;
       "configFilePath": "../../../solution/sub-project-2/tsconfig.json"
     },
     "referencedMap": {
-      "../../../solution/sub-project-2/index.ts": [
-        "../sub-project/index.d.ts"
-      ],
       "../sub-project/index.d.ts": [
         "../common/nominal.d.ts"
+      ],
+      "../../../solution/sub-project-2/index.ts": [
+        "../sub-project/index.d.ts"
       ]
     },
     "exportedModulesMap": {
-      "../../../solution/sub-project-2/index.ts": [
+      "../sub-project/index.d.ts": [
         "../common/nominal.d.ts"
       ],
-      "../sub-project/index.d.ts": [
+      "../../../solution/sub-project-2/index.ts": [
         "../common/nominal.d.ts"
       ]
     },
     "semanticDiagnosticsPerFile": [
       "../../../../lib/lib.d.ts",
-      "../../../solution/sub-project-2/index.ts",
       "../common/nominal.d.ts",
-      "../sub-project/index.d.ts"
+      "../sub-project/index.d.ts",
+      "../../../solution/sub-project-2/index.ts"
     ]
   },
   "version": "FakeTSVersion"

--- a/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/importing-json-module-from-project-reference.js
+++ b/tests/baselines/reference/tsbuild/resolveJsonModule/initial-build/importing-json-module-from-project-reference.js
@@ -61,8 +61,8 @@ console.log(foo_json_1.foo);
     "exportedModulesMap": {},
     "semanticDiagnosticsPerFile": [
       "../../lib/lib.d.ts",
-      "../strings/foo.json",
-      "./index.ts"
+      "./index.ts",
+      "../strings/foo.json"
     ]
   },
   "version": "FakeTSVersion"

--- a/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-circular-reference.js
+++ b/tests/baselines/reference/tsbuild/watchMode/demo/updates-with-circular-reference.js
@@ -454,35 +454,35 @@ export declare function createZoo(): Array<Dog>;
       "configFilePath": "../../zoo/tsconfig.json"
     },
     "referencedMap": {
-      "../../zoo/zoo.ts": [
-        "../animals/index.d.ts"
-      ],
       "../animals/dog.d.ts": [
         "../animals/index.d.ts"
       ],
       "../animals/index.d.ts": [
         "../animals/animal.d.ts",
         "../animals/dog.d.ts"
+      ],
+      "../../zoo/zoo.ts": [
+        "../animals/index.d.ts"
       ]
     },
     "exportedModulesMap": {
-      "../../zoo/zoo.ts": [
-        "../animals/index.d.ts"
-      ],
       "../animals/dog.d.ts": [
         "../animals/index.d.ts"
       ],
       "../animals/index.d.ts": [
         "../animals/animal.d.ts",
         "../animals/dog.d.ts"
+      ],
+      "../../zoo/zoo.ts": [
+        "../animals/index.d.ts"
       ]
     },
     "semanticDiagnosticsPerFile": [
       "../../../../../../a/lib/lib.d.ts",
-      "../../zoo/zoo.ts",
       "../animals/animal.d.ts",
       "../animals/dog.d.ts",
-      "../animals/index.d.ts"
+      "../animals/index.d.ts",
+      "../../zoo/zoo.ts"
     ]
   },
   "version": "FakeTSVersion"


### PR DESCRIPTION
Earlier we did this in testing to ensure we could baseline now moved to actual build info writing
Fixes #37156