### PR TITLE
Fix sys.debugMode when using VSCode's new preview debugger

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1231,7 +1231,7 @@ namespace ts {
                 enableCPUProfiler,
                 disableCPUProfiler,
                 realpath,
-                debugMode: some(<string[]>process.execArgv, arg => /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(arg)),
+                debugMode: !!process.env.NODE_INSPECTOR_IPC || some(<string[]>process.execArgv, arg => /^--(inspect|debug)(-brk)?(=\d+)?$/i.test(arg)),
                 tryEnableSourceMapsForHost() {
                     try {
                         require("source-map-support").install();


### PR DESCRIPTION
VSCode's new "preview" debug extension doesn't use `--inspect` (or `--inspect-brk`) to launch the debugger, so this adds a new heuristic to detecting whether the compiler was launched from the debugger.

The preview debugger launches the program with something like the following script (this example uses the powershell console):

```powershell
${env:NODE_ENV}='development';
${env:NODE_INSPECTOR_IPC}='\\.\pipe\node-cdp.15176-2.sock';
${env:NODE_INSPECTOR_PPID}='';
${env:NODE_INSPECTOR_WAIT_FOR_DEBUGGER}='';
${env:NODE_OPTIONS}='--require C:\Users\<user>\AppData\Local\Temp\vscode-js-debug-bootloader.js ';
${env:NODE_INSPECTOR_EXEC_PATH}='C:\Users\<user>\AppData\Roaming\nodejs\node.exe';
${env:VSCODE_DEBUGGER_FILE_CALLBACK}='C:\Users\<user>\AppData\Local\Temp\node-debug-callback-<id>';
${env:VSCODE_DEBUGGER_ONLY_ENTRYPOINT}='false';
& 'C:\Users\<user>\AppData\Roaming\nodejs\node.exe' 'C:\dev\TypeScript-bugfix/built/local/tsc.js'
```

The new heuristic checks for the presence of the `NODE_INSPECTOR_IPC` environment variable in addition to checking for `--inspect` or `--debug`.
