### PR TITLE
convertToAsyncFunction: Fix two-argument then

### DIFF
--- a/src/services/codefixes/convertToAsyncFunction.ts
+++ b/src/services/codefixes/convertToAsyncFunction.ts
@@ -333,8 +333,9 @@ namespace ts.codefix {
             //   }
             //   /* on fulfilled */
             const onRejectedArgumentName = getArgBindingName(onRejected, transformer);
-            const onFulfilledArgType = onFulfilledArgumentName && !transformer.isInJSFile ? transformer.checker.typeToTypeNode(transformer.checker.getTypeAtLocation(getNode(onFulfilledArgumentName))) : undefined;
-            const onFulfilledArgVariableDeclaration = createVariableOrAssignmentOrExpressionStatement(onFulfilledArgumentName, /*rightHandSide*/ undefined, onFulfilledArgType);
+            const onFulfilledArgType = onFulfilledArgumentName && !transformer.isInJSFile && transformer.checker.getTypeAtLocation(getNode(onFulfilledArgumentName));
+            const onFulfilledArgTypeNode = onFulfilledArgType && !(onFulfilledArgType.flags & TypeFlags.Any) ? transformer.checker.typeToTypeNode(onFulfilledArgType) : undefined;
+            const onFulfilledArgVariableDeclaration = createVariableOrAssignmentOrExpressionStatement(onFulfilledArgumentName, /*rightHandSide*/ undefined, onFulfilledArgTypeNode);
             const onFulfilledBody = getTransformationBody(onFulfilled, prevArgName, onFulfilledArgumentName, node, transformer);
             const tryBlock = createBlock(transformExpression(node.expression, transformer, onFulfilledArgumentName));
             const onRejectedBody = ensureReturnOrThrow(getTransformationBody(onRejected, prevArgName, onRejectedArgumentName, node, transformer));

--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -1427,5 +1427,34 @@ function [#|get|]() {
         .catch<APIResponse<{ email: string }>>(() => ({ success: false }));
 }
 `);
+
+        _testConvertToAsyncFunction("convertToAsyncFunction_twoArgumentThen", `
+function [#|fSync|]() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => null);
+};
+`);
+
+        _testConvertToAsyncFunction("convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn", `
+function [#|fSync|]() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => {});
+};
+`);
+
+        _testConvertToAsyncFunction("convertToAsyncFunction_twoArgumentThen_onRejectedThrow", `
+function [#|fSync|]() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => {
+        throw new Error('Thrown from onRejected');
+    });
+};
+`);
     });
 }

--- a/src/testRunner/unittests/services/convertToAsyncFunction.ts
+++ b/src/testRunner/unittests/services/convertToAsyncFunction.ts
@@ -1434,7 +1434,7 @@ function [#|fSync|]() {
         console.log(x); // note: added to illustrate refactor
         throw new Error('Failure!');
     }, () => null);
-};
+}
 `);
 
         _testConvertToAsyncFunction("convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn", `
@@ -1443,7 +1443,7 @@ function [#|fSync|]() {
         console.log(x); // note: added to illustrate refactor
         throw new Error('Failure!');
     }, () => {});
-};
+}
 `);
 
         _testConvertToAsyncFunction("convertToAsyncFunction_twoArgumentThen_onRejectedThrow", `
@@ -1454,7 +1454,20 @@ function [#|fSync|]() {
     }, () => {
         throw new Error('Thrown from onRejected');
     });
-};
+}
+`);
+
+        _testConvertToAsyncFunctionFailed("convertToAsyncFunction_twoArgumentThen_chainedThen", `
+function [#|fSync|]() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => {
+        throw new Error('Thrown from onRejected');
+    }).then(() => {
+        return 0;
+    });
+}
 `);
     });
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRej.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRej.ts
@@ -7,13 +7,15 @@ function /*[#|*/f/*|]*/():Promise<void> {
 
 async function f():Promise<void> {
     try {
+        let result: Response;
         try {
-            const result = await fetch('https://typescriptlang.org');
-            console.log(result);
+            result = await fetch('https://typescriptlang.org');
         }
         catch (rejection) {
             console.log("rejected:", rejection);
+            return;
         }
+        console.log(result);
     }
     catch (err) {
         console.log(err);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRejRef.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRejRef.ts
@@ -16,13 +16,14 @@ function catch_err(err){
 
 async function f():Promise<void> {
     try {
+        let result: any;
         try {
-            const result = await fetch('https://typescriptlang.org');
-            return res(result);
+            result = await fetch('https://typescriptlang.org');
         }
         catch (rejection) {
             return rej(rejection);
         }
+        return res(result);
     }
     catch (err) {
         return catch_err(err);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRejRef.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_CatchAndRejRef.ts
@@ -16,7 +16,7 @@ function catch_err(err){
 
 async function f():Promise<void> {
     try {
-        let result: any;
+        let result;
         try {
             result = await fetch('https://typescriptlang.org');
         }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Rej.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_Rej.ts
@@ -7,11 +7,13 @@ function /*[#|*/f/*|]*/():Promise<void> {
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f():Promise<void> {
+    let result: Response;
     try {
-        const result = await fetch('https://typescriptlang.org');
-        console.log(result);
+        result = await fetch('https://typescriptlang.org');
     }
     catch (rejection) {
         console.log("rejected:", rejection);
+        return;
     }
+    console.log(result);
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_RejNoBrackets.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_RejNoBrackets.ts
@@ -7,11 +7,12 @@ function /*[#|*/f/*|]*/():Promise<void> {
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f():Promise<void> {
+    let result: Response;
     try {
-        const result = await fetch('https://typescriptlang.org');
-        return console.log(result);
+        result = await fetch('https://typescriptlang.org');
     }
     catch (rejection) {
         return console.log("rejected:", rejection);
     }
+    return console.log(result);
 }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_RejRef.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_RejRef.ts
@@ -13,13 +13,14 @@ function rej(err){
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f():Promise<void> {
+    let result: any;
     try {
-        const result = await fetch('https://typescriptlang.org');
-        return res(result);
+        result = await fetch('https://typescriptlang.org');
     }
     catch (err) {
         return rej(err);
     }
+    return res(result);
 }
 function res(result){
     console.log(result);

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_RejRef.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_RejRef.ts
@@ -13,7 +13,7 @@ function rej(err){
 // ==ASYNC FUNCTION::Convert to async function==
 
 async function f():Promise<void> {
-    let result: any;
+    let result;
     try {
         result = await fetch('https://typescriptlang.org');
     }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ResRejNoArgsArrow.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ResRejNoArgsArrow.js
@@ -9,9 +9,9 @@
     async function f() {
         try {
             await Promise.resolve();
-            return 1;
         }
         catch (e) {
             return "a";
         }
+        return 1;
     }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ResRejNoArgsArrow.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_ResRejNoArgsArrow.ts
@@ -9,9 +9,9 @@
     async function f() {
         try {
             await Promise.resolve();
-            return 1;
         }
         catch (e) {
             return "a";
         }
+        return 1;
     }

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen.js
@@ -1,0 +1,22 @@
+// ==ORIGINAL==
+
+function /*[#|*/fSync/*|]*/() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => null);
+};
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function fSync() {
+    let x;
+    try {
+        x = await Promise.resolve(0);
+    }
+    catch (e) {
+        return null;
+    }
+    console.log(x); // note: added to illustrate refactor
+    throw new Error('Failure!');
+};

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen.js
@@ -5,7 +5,7 @@ function /*[#|*/fSync/*|]*/() {
         console.log(x); // note: added to illustrate refactor
         throw new Error('Failure!');
     }, () => null);
-};
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -19,4 +19,4 @@ async function fSync() {
     }
     console.log(x); // note: added to illustrate refactor
     throw new Error('Failure!');
-};
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen.ts
@@ -5,7 +5,7 @@ function /*[#|*/fSync/*|]*/() {
         console.log(x); // note: added to illustrate refactor
         throw new Error('Failure!');
     }, () => null);
-};
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -19,4 +19,4 @@ async function fSync() {
     }
     console.log(x); // note: added to illustrate refactor
     throw new Error('Failure!');
-};
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen.ts
@@ -1,0 +1,22 @@
+// ==ORIGINAL==
+
+function /*[#|*/fSync/*|]*/() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => null);
+};
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function fSync() {
+    let x: number;
+    try {
+        x = await Promise.resolve(0);
+    }
+    catch (e) {
+        return null;
+    }
+    console.log(x); // note: added to illustrate refactor
+    throw new Error('Failure!');
+};

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn.js
@@ -5,7 +5,7 @@ function /*[#|*/fSync/*|]*/() {
         console.log(x); // note: added to illustrate refactor
         throw new Error('Failure!');
     }, () => {});
-};
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -19,4 +19,4 @@ async function fSync() {
     }
     console.log(x); // note: added to illustrate refactor
     throw new Error('Failure!');
-};
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn.js
@@ -1,0 +1,22 @@
+// ==ORIGINAL==
+
+function /*[#|*/fSync/*|]*/() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => {});
+};
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function fSync() {
+    let x;
+    try {
+        x = await Promise.resolve(0);
+    }
+    catch (e) {
+        return;
+    }
+    console.log(x); // note: added to illustrate refactor
+    throw new Error('Failure!');
+};

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn.ts
@@ -5,7 +5,7 @@ function /*[#|*/fSync/*|]*/() {
         console.log(x); // note: added to illustrate refactor
         throw new Error('Failure!');
     }, () => {});
-};
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -19,4 +19,4 @@ async function fSync() {
     }
     console.log(x); // note: added to illustrate refactor
     throw new Error('Failure!');
-};
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedNoReturn.ts
@@ -1,0 +1,22 @@
+// ==ORIGINAL==
+
+function /*[#|*/fSync/*|]*/() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => {});
+};
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function fSync() {
+    let x: number;
+    try {
+        x = await Promise.resolve(0);
+    }
+    catch (e) {
+        return;
+    }
+    console.log(x); // note: added to illustrate refactor
+    throw new Error('Failure!');
+};

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedThrow.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedThrow.js
@@ -1,0 +1,24 @@
+// ==ORIGINAL==
+
+function /*[#|*/fSync/*|]*/() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => {
+        throw new Error('Thrown from onRejected');
+    });
+};
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function fSync() {
+    let x;
+    try {
+        x = await Promise.resolve(0);
+    }
+    catch (e) {
+        throw new Error('Thrown from onRejected');
+    }
+    console.log(x); // note: added to illustrate refactor
+    throw new Error('Failure!');
+};

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedThrow.js
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedThrow.js
@@ -7,7 +7,7 @@ function /*[#|*/fSync/*|]*/() {
     }, () => {
         throw new Error('Thrown from onRejected');
     });
-};
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -21,4 +21,4 @@ async function fSync() {
     }
     console.log(x); // note: added to illustrate refactor
     throw new Error('Failure!');
-};
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedThrow.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedThrow.ts
@@ -7,7 +7,7 @@ function /*[#|*/fSync/*|]*/() {
     }, () => {
         throw new Error('Thrown from onRejected');
     });
-};
+}
 
 // ==ASYNC FUNCTION::Convert to async function==
 
@@ -21,4 +21,4 @@ async function fSync() {
     }
     console.log(x); // note: added to illustrate refactor
     throw new Error('Failure!');
-};
+}

--- a/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedThrow.ts
+++ b/tests/baselines/reference/convertToAsyncFunction/convertToAsyncFunction_twoArgumentThen_onRejectedThrow.ts
@@ -1,0 +1,24 @@
+// ==ORIGINAL==
+
+function /*[#|*/fSync/*|]*/() {
+    return Promise.resolve(0).then(x => {
+        console.log(x); // note: added to illustrate refactor
+        throw new Error('Failure!');
+    }, () => {
+        throw new Error('Thrown from onRejected');
+    });
+};
+
+// ==ASYNC FUNCTION::Convert to async function==
+
+async function fSync() {
+    let x: number;
+    try {
+        x = await Promise.resolve(0);
+    }
+    catch (e) {
+        throw new Error('Thrown from onRejected');
+    }
+    console.log(x); // note: added to illustrate refactor
+    throw new Error('Failure!');
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #27621 - a two-argument `then` is supported only if no other `.then` follows it in the chain.