### PR TITLE
Don’t offer `this.` completions on `self`, `window`, `global`, `globalThis`. Disambiguate `this.` completions from others in details requests.

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3608,7 +3608,7 @@ namespace ts {
          * Does not include properties of primitive types.
          */
         /* @internal */ getAllPossiblePropertiesOfTypes(type: readonly Type[]): Symbol[];
-        /* @internal */ resolveName(name: string, location: Node, meaning: SymbolFlags, excludeGlobals: boolean): Symbol | undefined;
+        /* @internal */ resolveName(name: string, location: Node | undefined, meaning: SymbolFlags, excludeGlobals: boolean): Symbol | undefined;
         /* @internal */ getJsxNamespace(location?: Node): string;
 
         /**

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -895,19 +895,19 @@ namespace FourSlash {
                 }
             }
 
-            assert.equal(actual.hasAction, hasAction, `Expected 'hasAction' value '${actual.hasAction}' to equal '${hasAction}'`);
-            assert.equal(actual.isRecommended, isRecommended, `Expected 'isRecommended' value '${actual.isRecommended}' to equal '${isRecommended}'`);
-            assert.equal(actual.source, source, `Expected 'source' value '${actual.source}' to equal '${source}'`);
+            assert.equal(actual.hasAction, hasAction, `Expected 'hasAction' properties to match`);
+            assert.equal(actual.isRecommended, isRecommended, `Expected 'isRecommended' properties to match'`);
+            assert.equal(actual.source, source, `Expected 'source' values to match`);
             assert.equal(actual.sortText, sortText || ts.Completions.SortText.LocationPriority, this.messageAtLastKnownMarker(`Actual entry: ${JSON.stringify(actual)}`));
 
             if (text !== undefined) {
                 const actualDetails = this.getCompletionEntryDetails(actual.name, actual.source)!;
-                assert.equal(ts.displayPartsToString(actualDetails.displayParts), text);
-                assert.equal(ts.displayPartsToString(actualDetails.documentation), documentation || "");
+                assert.equal(ts.displayPartsToString(actualDetails.displayParts), text, "Expected 'text' property to match 'displayParts' string");
+                assert.equal(ts.displayPartsToString(actualDetails.documentation), documentation || "", "Expected 'documentation' property to match 'documentation' display parts string");
                 // TODO: GH#23587
                 // assert.equal(actualDetails.kind, actual.kind);
-                assert.equal(actualDetails.kindModifiers, actual.kindModifiers);
-                assert.equal(actualDetails.source && ts.displayPartsToString(actualDetails.source), sourceDisplay);
+                assert.equal(actualDetails.kindModifiers, actual.kindModifiers, "Expected 'kindModifiers' properties to match");
+                assert.equal(actualDetails.source && ts.displayPartsToString(actualDetails.source), sourceDisplay, "Expected 'sourceDisplay' property to match 'source' display parts string");
                 assert.deepEqual(actualDetails.tags, tags);
             }
             else {

--- a/src/harness/fourslashImpl.ts
+++ b/src/harness/fourslashImpl.ts
@@ -322,6 +322,14 @@ namespace FourSlash {
                 if (!resolvedResult.isLibFile) {
                     this.languageServiceAdapterHost.addScript(Harness.Compiler.defaultLibFileName,
                         Harness.Compiler.getDefaultLibrarySourceFile()!.text, /*isRootFile*/ false);
+
+                    compilationOptions.lib?.forEach(fileName => {
+                        const libFile = Harness.Compiler.getDefaultLibrarySourceFile(fileName);
+                        ts.Debug.assertIsDefined(libFile, `Could not find lib file '${fileName}'`);
+                        if (libFile) {
+                            this.languageServiceAdapterHost.addScript(fileName, libFile.text, /*isRootFile*/ false);
+                        }
+                    });
                 }
             }
             else {
@@ -334,6 +342,14 @@ namespace FourSlash {
                 if (!compilationOptions.noLib) {
                     this.languageServiceAdapterHost.addScript(Harness.Compiler.defaultLibFileName,
                         Harness.Compiler.getDefaultLibrarySourceFile()!.text, /*isRootFile*/ false);
+
+                    compilationOptions.lib?.forEach(fileName => {
+                        const libFile = Harness.Compiler.getDefaultLibrarySourceFile(fileName);
+                        ts.Debug.assertIsDefined(libFile, `Could not find lib file '${fileName}'`);
+                        if (libFile) {
+                            this.languageServiceAdapterHost.addScript(fileName, libFile.text, /*isRootFile*/ false);
+                        }
+                    });
                 }
             }
 

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -1460,6 +1460,8 @@ namespace FourSlashInterface {
                 undefinedVarEntry,
                 ...globalInJsKeywords];
         }
+
+        export const thisTypeSource = "" + ts.Completions.SymbolOriginInfoKind.ThisType;
     }
 
     export interface ReferenceGroup {

--- a/src/harness/fourslashInterfaceImpl.ts
+++ b/src/harness/fourslashInterfaceImpl.ts
@@ -845,6 +845,7 @@ namespace FourSlashInterface {
     }
     export namespace Completion {
         export import SortText = ts.Completions.SortText;
+        export import CompletionSource = ts.Completions.CompletionSource;
 
         const functionEntry = (name: string): ExpectedCompletionEntryObject => ({
             name,
@@ -1460,8 +1461,6 @@ namespace FourSlashInterface {
                 undefinedVarEntry,
                 ...globalInJsKeywords];
         }
-
-        export const thisTypeSource = "" + ts.Completions.SymbolOriginInfoKind.ThisType;
     }
 
     export interface ReferenceGroup {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -11,7 +11,23 @@ namespace ts.Completions {
     }
     export type Log = (message: string) => void;
 
-    export const enum SymbolOriginInfoKind {
+    /**
+     * Special values for `CompletionInfo['source']` used to disambiguate
+     * completion items with the same `name`. (Each completion item must
+     * have a unique name/source combination, because those two fields
+     * comprise `CompletionEntryIdentifier` in `getCompletionEntryDetails`.
+     *
+     * When the completion item is an auto-import suggestion, the source
+     * is the module specifier of the suggestion. To avoid collisions,
+     * the values here should not be a module specifier we would ever
+     * generate for an auto-import.
+     */
+    export enum CompletionSource {
+        /** Completions that require `this.` insertion text */
+        ThisProperty = "ThisProperty/"
+    }
+
+    const enum SymbolOriginInfoKind {
         ThisType            = 1 << 0,
         SymbolMember        = 1 << 1,
         Export              = 1 << 2,
@@ -439,7 +455,7 @@ namespace ts.Completions {
             return stripQuotes(origin.moduleSymbol.name);
         }
         if (origin?.kind === SymbolOriginInfoKind.ThisType) {
-            return "" + SymbolOriginInfoKind.ThisType;
+            return CompletionSource.ThisProperty;
         }
     }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -11,7 +11,7 @@ namespace ts.Completions {
     }
     export type Log = (message: string) => void;
 
-    const enum SymbolOriginInfoKind {
+    export const enum SymbolOriginInfoKind {
         ThisType            = 1 << 0,
         SymbolMember        = 1 << 1,
         Export              = 1 << 2,
@@ -430,7 +430,12 @@ namespace ts.Completions {
     }
 
     function getSourceFromOrigin(origin: SymbolOriginInfo | undefined): string | undefined {
-        return origin && originIsExport(origin) ? stripQuotes(origin.moduleSymbol.name) : undefined;
+        if (originIsExport(origin)) {
+            return stripQuotes(origin.moduleSymbol.name);
+        }
+        if (origin?.kind === SymbolOriginInfoKind.ThisType) {
+            return "" + SymbolOriginInfoKind.ThisType;
+        }
     }
 
     export function getCompletionEntriesFromSymbols(

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -2775,5 +2775,19 @@ namespace ts {
         return name.charCodeAt(0) === CharacterCodes._;
     }
 
+    export function isGlobalDeclaration(declaration: Declaration) {
+        return !isNonGlobalDeclaration(declaration);
+    }
+
+    export function isNonGlobalDeclaration(declaration: Declaration) {
+        const sourceFile = declaration.getSourceFile();
+        // If the file is not a module, the declaration is global
+        if (!sourceFile.externalModuleIndicator && !sourceFile.commonJsModuleIndicator) {
+            return false;
+        }
+        // If the file is a module written in TypeScript, it still might be in a `declare global` augmentation
+        return isInJSFile(declaration) || !findAncestor(declaration, isGlobalScopeAugmentation);
+    }
+
     // #endregion
 }

--- a/tests/cases/fourslash/completionsJsxAttributeInitializer.ts
+++ b/tests/cases/fourslash/completionsJsxAttributeInitializer.ts
@@ -9,8 +9,8 @@ verify.completions({
     marker: "",
     includes: [
         { name: "x", text: "(parameter) x: number", kind: "parameter", insertText: "{x}" },
-        { name: "p", text: "(JSX attribute) p: number", kind: "JSX attribute", insertText: "{this.p}", sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
-        { name: "a b", text: '(JSX attribute) "a b": number', kind: "JSX attribute", insertText: '{this["a b"]}', sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
+        { name: "p", text: "(JSX attribute) p: number", kind: "JSX attribute", insertText: "{this.p}", sortText: completion.SortText.SuggestedClassMembers, source: completion.CompletionSource.ThisProperty },
+        { name: "a b", text: '(JSX attribute) "a b": number', kind: "JSX attribute", insertText: '{this["a b"]}', sortText: completion.SortText.SuggestedClassMembers, source: completion.CompletionSource.ThisProperty },
     ],
     preferences: {
         includeInsertTextCompletions: true,

--- a/tests/cases/fourslash/completionsJsxAttributeInitializer.ts
+++ b/tests/cases/fourslash/completionsJsxAttributeInitializer.ts
@@ -9,8 +9,8 @@ verify.completions({
     marker: "",
     includes: [
         { name: "x", text: "(parameter) x: number", kind: "parameter", insertText: "{x}" },
-        { name: "p", text: "(JSX attribute) p: number", kind: "JSX attribute", insertText: "{this.p}", sortText: completion.SortText.SuggestedClassMembers },
-        { name: "a b", text: '(JSX attribute) "a b": number', kind: "JSX attribute", insertText: '{this["a b"]}', sortText: completion.SortText.SuggestedClassMembers },
+        { name: "p", text: "(JSX attribute) p: number", kind: "JSX attribute", insertText: "{this.p}", sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
+        { name: "a b", text: '(JSX attribute) "a b": number', kind: "JSX attribute", insertText: '{this["a b"]}', sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
     ],
     preferences: {
         includeInsertTextCompletions: true,

--- a/tests/cases/fourslash/completionsThisProperties_globalSameName.ts
+++ b/tests/cases/fourslash/completionsThisProperties_globalSameName.ts
@@ -33,7 +33,7 @@ verify.completions({
       insertText: "this.foot",
       kind: "property",
       sortText: completion.SortText.SuggestedClassMembers,
-      source: completion.thisTypeSource,
+      source: completion.CompletionSource.ThisProperty,
       text: "(property) Service.foot: number"
     },
     {
@@ -41,7 +41,7 @@ verify.completions({
       insertText: "this.serve",
       kind: "method",
       sortText: completion.SortText.SuggestedClassMembers,
-      source: completion.thisTypeSource
+      source: completion.CompletionSource.ThisProperty
     },
     ...completion.insideMethodKeywords
   ],

--- a/tests/cases/fourslash/completionsThisProperties_globalSameName.ts
+++ b/tests/cases/fourslash/completionsThisProperties_globalSameName.ts
@@ -1,0 +1,51 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: globals.d.ts
+//// declare var foot: string;
+
+// @Filename: index.ts
+//// class Service {
+////   foot!: number;
+////   serve() {
+////     foot/**/
+////   }
+//// }
+
+
+verify.completions({
+  marker: "",
+  exact: [
+    "arguments",
+    completion.globalThisEntry,
+    ...completion.globalsVars,
+    {
+      name: "foot",
+      insertText: undefined,
+      kind: "var",
+      kindModifiers: "declare",
+      sortText: completion.SortText.GlobalsOrKeywords,
+      text: "var foot: string"
+    },
+    "Service",
+    completion.undefinedVarEntry,
+    {
+      name: "foot",
+      insertText: "this.foot",
+      kind: "property",
+      sortText: completion.SortText.SuggestedClassMembers,
+      source: completion.thisTypeSource,
+      text: "(property) Service.foot: number"
+    },
+    {
+      name: "serve",
+      insertText: "this.serve",
+      kind: "method",
+      sortText: completion.SortText.SuggestedClassMembers,
+      source: completion.thisTypeSource
+    },
+    ...completion.insideMethodKeywords
+  ],
+  preferences: {
+    includeInsertTextCompletions: true
+  }
+});

--- a/tests/cases/fourslash/completionsThisProperties_globalType.ts
+++ b/tests/cases/fourslash/completionsThisProperties_globalType.ts
@@ -1,0 +1,32 @@
+/// <reference path="fourslash.ts" />
+
+// #37091
+
+// @lib: dom
+// @allowJs: true
+
+// @Filename: globals.d.ts
+//// declare var global: { console: Console };
+
+// @Filename: index.js
+//// window.f = function() { console/*1*/ }
+//// self.g = function() { console/*2*/ }
+//// global.h = function() { console/*3*/ }
+//// globalThis.i = function() { console/*4*/ }
+
+test.markerNames().forEach(marker => {
+  verify.completions({
+    marker,
+    includes: [{
+      name: "console",
+      insertText: undefined,
+      kind: "var",
+      kindModifiers: "declare",
+      sortText: completion.SortText.GlobalsOrKeywords
+    }]
+  }, {
+    preferences: {
+      includeInsertTextCompletions: true
+    }
+  });
+});

--- a/tests/cases/fourslash/completionsThisType.ts
+++ b/tests/cases/fourslash/completionsThisType.ts
@@ -14,15 +14,15 @@ verify.completions(
     {
         marker: "",
         includes: [
-            { name: "xyz", text: "(method) C.xyz(): any", kind: "method", insertText: "this.xyz", sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
-            { name: "foo bar", text: '(property) C["foo bar"]: number', kind: "property", insertText: 'this["foo bar"]', sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
+            { name: "xyz", text: "(method) C.xyz(): any", kind: "method", insertText: "this.xyz", sortText: completion.SortText.SuggestedClassMembers, source: completion.CompletionSource.ThisProperty },
+            { name: "foo bar", text: '(property) C["foo bar"]: number', kind: "property", insertText: 'this["foo bar"]', sortText: completion.SortText.SuggestedClassMembers, source: completion.CompletionSource.ThisProperty },
         ],
         isNewIdentifierLocation: true,
         preferences,
     },
     {
         marker: "f",
-        includes: { name: "x", text: "(property) x: number", kind: "property", insertText: "this.x", sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
+        includes: { name: "x", text: "(property) x: number", kind: "property", insertText: "this.x", sortText: completion.SortText.SuggestedClassMembers, source: completion.CompletionSource.ThisProperty },
         preferences,
     },
 );

--- a/tests/cases/fourslash/completionsThisType.ts
+++ b/tests/cases/fourslash/completionsThisType.ts
@@ -14,15 +14,15 @@ verify.completions(
     {
         marker: "",
         includes: [
-            { name: "xyz", text: "(method) C.xyz(): any", kind: "method", insertText: "this.xyz", sortText: completion.SortText.SuggestedClassMembers },
-            { name: "foo bar", text: '(property) C["foo bar"]: number', kind: "property", insertText: 'this["foo bar"]', sortText: completion.SortText.SuggestedClassMembers },
+            { name: "xyz", text: "(method) C.xyz(): any", kind: "method", insertText: "this.xyz", sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
+            { name: "foo bar", text: '(property) C["foo bar"]: number', kind: "property", insertText: 'this["foo bar"]', sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
         ],
         isNewIdentifierLocation: true,
         preferences,
     },
     {
         marker: "f",
-        includes: { name: "x", text: "(property) x: number", kind: "property", insertText: "this.x", sortText: completion.SortText.SuggestedClassMembers },
+        includes: { name: "x", text: "(property) x: number", kind: "property", insertText: "this.x", sortText: completion.SortText.SuggestedClassMembers, source: completion.thisTypeSource },
         preferences,
     },
 );

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -753,6 +753,9 @@ declare namespace completion {
         AutoImportSuggestions = "5",
         JavascriptIdentifiers = "6"
     }
+    export const enum CompletionSource {
+        ThisProperty = "ThisProperty/"
+    }
     export const globalThisEntry: Entry;
     export const undefinedVarEntry: Entry;
     export const globals: ReadonlyArray<Entry>;
@@ -781,5 +784,4 @@ declare namespace completion {
     export const statementKeywordsWithTypes: ReadonlyArray<Entry>;
     export const statementKeywords: ReadonlyArray<Entry>;
     export const statementInJsKeywords: ReadonlyArray<Entry>;
-    export const thisTypeSource: string;
 }

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -781,4 +781,5 @@ declare namespace completion {
     export const statementKeywordsWithTypes: ReadonlyArray<Entry>;
     export const statementKeywords: ReadonlyArray<Entry>;
     export const statementInJsKeywords: ReadonlyArray<Entry>;
+    export const thisTypeSource: string;
 }


### PR DESCRIPTION
Fixes #37091
Fixes #37651

#37091 is interesting, because it exposes that the symbols for, say, `console` and `window.console` are completely different symbols that just happen to have the same type. There’s really no way to know generally that a member on a given `this` type is _actually_ the same thing as a symbol that’s declared globally. And as far as I can tell, there’s nothing special in the type system about symbols like `window`, `self`, or `global`, so there’s no mechanism to determine that a given type _is_ the global object type.

So, I’ve introduced a special case heuristic to reject `this.` completions when the `this` type is the type of a global by the name `self`, `global`, or `globalThis`. It’s possible to construct a strange environment for yourself where this is wrong, but the stakes are fairly low—you won’t get `this.`-inserting completions in methods on that type.

I also discovered and fixed #37651 along the way.