### PR TITLE
Typo at Uint8Array[Symbol.toStringTag]

### DIFF
--- a/lib/lib.es2015.symbol.wellknown.d.ts
+++ b/lib/lib.es2015.symbol.wellknown.d.ts
@@ -274,7 +274,7 @@ interface Int8Array {
 }
 
 interface Uint8Array {
-    readonly [Symbol.toStringTag]: "UInt8Array";
+    readonly [Symbol.toStringTag]: "Uint8Array";
 }
 
 interface Uint8ClampedArray {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
Case issue
readonly [Symbol.toStringTag]: "U`I`nt8Array";
readonly [Symbol.toStringTag]: "U`i`nt8Array";