### PR TITLE
Typo at Uint8Array[Symbol.toStringTag]

### DIFF
--- a/src/lib/es2015.symbol.wellknown.d.ts
+++ b/src/lib/es2015.symbol.wellknown.d.ts
@@ -254,7 +254,7 @@ interface Int8Array {
 }
 
 interface Uint8Array {
-    readonly [Symbol.toStringTag]: "UInt8Array";
+    readonly [Symbol.toStringTag]: "Uint8Array";
 }
 
 interface Uint8ClampedArray {


### PR DESCRIPTION
`"UInt8Array"` -> `"Uint8Array"` (lowercased `i`)