### PR TITLE
fix(33054): allow variables starting with an underscore in for/of statement / update types baseline

### DIFF
--- a/tests/baselines/reference/unusedVariablesWithUnderscoreInForOfLoop.types
+++ b/tests/baselines/reference/unusedVariablesWithUnderscoreInForOfLoop.types
@@ -12,9 +12,9 @@ function f() {
 
         console.log(b);
 >console.log(b) : void
->console.log : (message?: any, ...optionalParams: any[]) => void
+>console.log : (...data: any[]) => void
 >console : Console
->log : (message?: any, ...optionalParams: any[]) => void
+>log : (...data: any[]) => void
 >b : string | number
     }
 
@@ -28,9 +28,9 @@ function f() {
 
         console.log(a);
 >console.log(a) : void
->console.log : (message?: any, ...optionalParams: any[]) => void
+>console.log : (...data: any[]) => void
 >console : Console
->log : (message?: any, ...optionalParams: any[]) => void
+>log : (...data: any[]) => void
 >a : string | number
     }
 


### PR DESCRIPTION
Fixes #36739
