### PR TITLE
Fix crash from missing valueDeclaration on intersection property

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10314,7 +10314,7 @@ namespace ts {
                 if (!firstValueDeclaration) {
                     firstValueDeclaration = prop.valueDeclaration;
                 }
-                else if (prop.valueDeclaration !== firstValueDeclaration) {
+                else if (prop.valueDeclaration && prop.valueDeclaration !== firstValueDeclaration) {
                     hasNonUniformValueDeclaration = true;
                 }
                 declarations = addRange(declarations, prop.declarations);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5964,14 +5964,18 @@ namespace ts {
                     ];
                     const symbolProps = getPropertiesOfType(classType);
                     const publicSymbolProps = filter(symbolProps, s => {
+                        // `valueDeclaration` could be undefined if inherited from
+                        // a union/intersection base type, but inherited properties
+                        // don't matter here.
                         const valueDecl = s.valueDeclaration;
-                        Debug.assertIsDefined(valueDecl);
-                        return !(isNamedDeclaration(valueDecl) && isPrivateIdentifier(valueDecl.name));
+                        return valueDecl && !(isNamedDeclaration(valueDecl) && isPrivateIdentifier(valueDecl.name));
                     });
                     const hasPrivateIdentifier = some(symbolProps, s => {
+                        // `valueDeclaration` could be undefined if inherited from
+                        // a union/intersection base type, but inherited properties
+                        // don't matter here.
                         const valueDecl = s.valueDeclaration;
-                        Debug.assertIsDefined(valueDecl);
-                        return isNamedDeclaration(valueDecl) && isPrivateIdentifier(valueDecl.name);
+                        return valueDecl && isNamedDeclaration(valueDecl) && isPrivateIdentifier(valueDecl.name);
                     });
                     // Boil down all private properties into a single one.
                     const privateProperties = hasPrivateIdentifier ?

--- a/tests/baselines/reference/jsEmitIntersectionProperty.js
+++ b/tests/baselines/reference/jsEmitIntersectionProperty.js
@@ -1,14 +1,9 @@
+//// [tests/cases/compiler/jsEmitIntersectionProperty.ts] ////
+
+//// [globals.d.ts]
 // #37015 - test asserts lack of crash
 
-// @allowJs: true
-// @checkJs: true
-// @declaration: true
-// @emitDeclarationOnly: true
-// @incremental: true
-// @tsBuildInfoFile: .tsbuildinfo
-// @noTypesAndSymbols: true
 
-// @Filename: globals.d.ts
 
 declare class CoreObject {
   static extend<
@@ -34,8 +29,14 @@ declare class EmberObject extends CoreObject.extend(Observable) {}
 declare class CoreView extends EmberObject.extend({}) {}
 declare class Component extends CoreView.extend({}) {}
 
-// @Filename: index.js
-
+//// [index.js]
 export class MyComponent extends Component {
   
+}
+
+
+
+
+//// [index.d.ts]
+export class MyComponent extends Component {
 }

--- a/tests/baselines/reference/narrowingByTypeofInSwitch.symbols
+++ b/tests/baselines/reference/narrowingByTypeofInSwitch.symbols
@@ -404,9 +404,9 @@ function exhaustiveChecksGenerics<T extends L | R | number | string>(x: T): stri
 >x : Symbol(x, Decl(narrowingByTypeofInSwitch.ts, 146, 69))
 
         case 'number': return x.toString(2);
->x.toString : Symbol(toString, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 2 more)
+>x.toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 2 more)
 >x : Symbol(x, Decl(narrowingByTypeofInSwitch.ts, 146, 69))
->toString : Symbol(toString, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 2 more)
+>toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --) ... and 2 more)
 
         case 'string': return x;
 >x : Symbol(x, Decl(narrowingByTypeofInSwitch.ts, 146, 69))

--- a/tests/cases/compiler/jsEmitIntersectionProperty.ts
+++ b/tests/cases/compiler/jsEmitIntersectionProperty.ts
@@ -1,0 +1,40 @@
+// #37015 - test asserts lack of crash
+
+// @allowJs: true
+// @checkJs: true
+// @declaration: true
+// @emitDeclarationOnly: true
+// @incremental: true
+// @noTypesAndSymbols: true
+
+// @Filename: globals.d.ts
+
+declare class CoreObject {
+  static extend<
+    Statics,
+    Instance extends B1,
+    T1,
+    B1
+  >(
+    this: Statics & { new(): Instance },
+    arg1: T1
+  ): Readonly<Statics> & { new(): T1 & Instance };
+
+  toString(): string;
+}
+
+declare class Mixin<T> {
+  static create<T>(
+      args?: T
+  ): Mixin<T>;
+}
+declare const Observable: Mixin<{}>
+declare class EmberObject extends CoreObject.extend(Observable) {}
+declare class CoreView extends EmberObject.extend({}) {}
+declare class Component extends CoreView.extend({}) {}
+
+// @Filename: index.js
+
+export class MyComponent extends Component {
+  
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #37015

The error was occurring when trying to serialize a JS symbol into a class declaration, because one of its inherited property symbols was missing a `valueDeclaration`, which was the target of a `Debug.assertIsDefined`.

When two object types were unioned/intersectioned, the order of types was having an observable effect on whether the resulting property symbol had a `valueDeclaration` set. If the first type’s property didn’t have a `valueDeclaration` but a later type’s property did, we’d take the later one. But in the inverse case, we’d say that there was a non-uniform value declaration so we wouldn’t attach one at all.

Fixing this fixed the real-world repro at #37015 and improved one types baseline, but my minimal repro was still failing because the intersection property for `toString` had two different _defined_ declarations, which seemed like a legitimate violation of the assertion’s assumption, so I removed the assertion. My understanding of this code is that inherited properties could _all_ be filtered out, and if `valueDeclaration` is undefined, the property _must_ be inherited.
