### PR TITLE
Fix narrow-by-constructor logic

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4432,13 +4432,6 @@ namespace ts {
         return isPropertyAccessExpression(node) && isEntityNameExpression(node.expression);
     }
 
-    export function isConstructorAccessExpression(expr: Expression): expr is AccessExpression {
-        return (
-            isPropertyAccessExpression(expr) && idText(expr.name) === "constructor" ||
-            isElementAccessExpression(expr) && isStringLiteralLike(expr.argumentExpression) && expr.argumentExpression.text === "constructor"
-        );
-    }
-
     export function tryGetPropertyAccessOrIdentifierToString(expr: Expression): string | undefined {
         if (isPropertyAccessExpression(expr)) {
             const baseStr = tryGetPropertyAccessOrIdentifierToString(expr.expression);

--- a/tests/baselines/reference/typeGuardConstructorClassAndNumber.errors.txt
+++ b/tests/baselines/reference/typeGuardConstructorClassAndNumber.errors.txt
@@ -161,3 +161,13 @@ tests/cases/compiler/typeGuardConstructorClassAndNumber.ts(115,10): error TS2339
         var1; // C1
     }
     
+    // Repro from #37660
+    
+    function foo(instance: Function | object) {
+        if (typeof instance === 'function') {
+            if (instance.prototype == null || instance.prototype.constructor == null) {
+                return instance.length;
+            }
+        }
+    }
+    

--- a/tests/baselines/reference/typeGuardConstructorClassAndNumber.js
+++ b/tests/baselines/reference/typeGuardConstructorClassAndNumber.js
@@ -119,6 +119,16 @@ else {
     var1; // C1
 }
 
+// Repro from #37660
+
+function foo(instance: Function | object) {
+    if (typeof instance === 'function') {
+        if (instance.prototype == null || instance.prototype.constructor == null) {
+            return instance.length;
+        }
+    }
+}
+
 
 //// [typeGuardConstructorClassAndNumber.js]
 // Typical case
@@ -239,4 +249,12 @@ if (C1 !== var1["constructor"]) {
 }
 else {
     var1; // C1
+}
+// Repro from #37660
+function foo(instance) {
+    if (typeof instance === 'function') {
+        if (instance.prototype == null || instance.prototype.constructor == null) {
+            return instance.length;
+        }
+    }
 }

--- a/tests/baselines/reference/typeGuardConstructorClassAndNumber.symbols
+++ b/tests/baselines/reference/typeGuardConstructorClassAndNumber.symbols
@@ -277,3 +277,29 @@ else {
 >var1 : Symbol(var1, Decl(typeGuardConstructorClassAndNumber.ts, 5, 3))
 }
 
+// Repro from #37660
+
+function foo(instance: Function | object) {
+>foo : Symbol(foo, Decl(typeGuardConstructorClassAndNumber.ts, 118, 1))
+>instance : Symbol(instance, Decl(typeGuardConstructorClassAndNumber.ts, 122, 13))
+>Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+
+    if (typeof instance === 'function') {
+>instance : Symbol(instance, Decl(typeGuardConstructorClassAndNumber.ts, 122, 13))
+
+        if (instance.prototype == null || instance.prototype.constructor == null) {
+>instance.prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>instance : Symbol(instance, Decl(typeGuardConstructorClassAndNumber.ts, 122, 13))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>instance.prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+>instance : Symbol(instance, Decl(typeGuardConstructorClassAndNumber.ts, 122, 13))
+>prototype : Symbol(Function.prototype, Decl(lib.es5.d.ts, --, --))
+
+            return instance.length;
+>instance.length : Symbol(Function.length, Decl(lib.es5.d.ts, --, --))
+>instance : Symbol(instance, Decl(typeGuardConstructorClassAndNumber.ts, 122, 13))
+>length : Symbol(Function.length, Decl(lib.es5.d.ts, --, --))
+        }
+    }
+}
+

--- a/tests/baselines/reference/typeGuardConstructorClassAndNumber.types
+++ b/tests/baselines/reference/typeGuardConstructorClassAndNumber.types
@@ -316,3 +316,38 @@ else {
 >var1 : C1
 }
 
+// Repro from #37660
+
+function foo(instance: Function | object) {
+>foo : (instance: object | Function) => number
+>instance : object | Function
+
+    if (typeof instance === 'function') {
+>typeof instance === 'function' : boolean
+>typeof instance : "string" | "number" | "bigint" | "boolean" | "symbol" | "undefined" | "object" | "function"
+>instance : object | Function
+>'function' : "function"
+
+        if (instance.prototype == null || instance.prototype.constructor == null) {
+>instance.prototype == null || instance.prototype.constructor == null : boolean
+>instance.prototype == null : boolean
+>instance.prototype : any
+>instance : Function
+>prototype : any
+>null : null
+>instance.prototype.constructor == null : boolean
+>instance.prototype.constructor : any
+>instance.prototype : any
+>instance : Function
+>prototype : any
+>constructor : any
+>null : null
+
+            return instance.length;
+>instance.length : number
+>instance : Function
+>length : number
+        }
+    }
+}
+

--- a/tests/cases/compiler/typeGuardConstructorClassAndNumber.ts
+++ b/tests/cases/compiler/typeGuardConstructorClassAndNumber.ts
@@ -117,3 +117,13 @@ if (C1 !== var1["constructor"]) {
 else {
     var1; // C1
 }
+
+// Repro from #37660
+
+function foo(instance: Function | object) {
+    if (typeof instance === 'function') {
+        if (instance.prototype == null || instance.prototype.constructor == null) {
+            return instance.length;
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes two issues in the narrow-by-constructor logic that was added in #32774:

* Removes unnecessary resetting of control flow type to the declared type.
* Reorganizes logic and adds a missing `isMatchingReference` check, the absence of which would cause constructor checks to erroneously narrow *all* references in the code path.

Fixes #37660.