### PR TITLE
Fix emit of simple module.exports.C.prototype pattern

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5648,7 +5648,7 @@ namespace ts {
                         serializeEnum(symbol, symbolName, modifierFlags);
                     }
                     if (symbol.flags & SymbolFlags.Class) {
-                        if (symbol.flags & SymbolFlags.Property) {
+                        if (symbol.flags & SymbolFlags.Property && isBinaryExpression(symbol.valueDeclaration.parent) && isClassExpression(symbol.valueDeclaration.parent.right)) {
                             // Looks like a `module.exports.Sub = class {}` - if we serialize `symbol` as a class, the result will have no members,
                             // since the classiness is actually from the target of the effective alias the symbol is. yes. A BlockScopedVariable|Class|Property
                             // _really_ acts like an Alias, and none of a BlockScopedVariable, Class, or Property. This is the travesty of JS binding today.

--- a/tests/baselines/reference/jsDeclarationsExportAssignedConstructorFunction.js
+++ b/tests/baselines/reference/jsDeclarationsExportAssignedConstructorFunction.js
@@ -21,4 +21,6 @@ module.exports.MyClass.prototype = {
 
 
 //// [jsDeclarationsExportAssignedConstructorFunction.d.ts]
-export {};
+export class MyClass {
+    a: () => void;
+}


### PR DESCRIPTION
Extends the fix of #36108 so that the simple example gets correct emit; the complex test case I came up with still doesn't work correctly, but the actual code from #35228 is fixed.

The complex test needs a fix in the binder, and probably one in the symbol serialiser. The binder needs to treat these two the same, but currently doesn't:

```ts
module.exports.C.prototype = {
  a() { }
  b: function() { }
}
```

But this is a pretty big change, so I don't really want to ship it in the beta.

Fixes #35228
