### PR TITLE
Remove extraneous string escape from convert to template string refactor

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3465,9 +3465,8 @@ namespace ts {
     }
 
     function getReplacement(c: string, offset: number, input: string) {
-        const charCode = c.charCodeAt(0);
-        if (charCode === CharacterCodes.nullCharacter) {
-            const lookAhead = input.charCodeAt(offset + 1);
+        if (c.charCodeAt(0) === CharacterCodes.nullCharacter) {
+            const lookAhead = input.charCodeAt(offset + c.length);
             if (lookAhead >= CharacterCodes._0 && lookAhead <= CharacterCodes._9) {
                 // If the null character is followed by digits, print as a hex escape to prevent the result from parsing as an octal (which is forbidden in strict mode)
                 return "\\x00";

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3441,7 +3441,7 @@ namespace ts {
     const doubleQuoteEscapedCharsRegExp = /[\\\"\u0000-\u001f\t\v\f\b\r\n\u2028\u2029\u0085]/g;
     const singleQuoteEscapedCharsRegExp = /[\\\'\u0000-\u001f\t\v\f\b\r\n\u2028\u2029\u0085]/g;
     // Template strings should be preserved as much as possible
-    const backtickQuoteEscapedCharsRegExp = /[\\\`]/g;
+    const backtickQuoteEscapedCharsRegExp = /[\\`]/g;
     const escapedCharsMap = createMapFromTemplate({
         "\t": "\\t",
         "\v": "\\v",
@@ -3465,8 +3465,9 @@ namespace ts {
     }
 
     function getReplacement(c: string, offset: number, input: string) {
-        if (c.charCodeAt(0) === CharacterCodes.nullCharacter) {
-            const lookAhead = input.charCodeAt(offset + c.length);
+        const charCode = c.charCodeAt(0);
+        if (charCode === CharacterCodes.nullCharacter) {
+            const lookAhead = input.charCodeAt(offset + 1);
             if (lookAhead >= CharacterCodes._0 && lookAhead <= CharacterCodes._9) {
                 // If the null character is followed by digits, print as a hex escape to prevent the result from parsing as an octal (which is forbidden in strict mode)
                 return "\\x00";

--- a/src/services/refactors/convertStringOrTemplateLiteral.ts
+++ b/src/services/refactors/convertStringOrTemplateLiteral.ts
@@ -134,7 +134,6 @@ namespace ts.refactor.convertStringOrTemplateLiteral {
             index++;
         }
 
-        text = escapeString(text);
         return [index, text, indexes];
     }
 

--- a/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_escapedBackslashes.ts
+++ b/tests/cases/fourslash/refactorConvertStringOrTemplateLiteral_escapedBackslashes.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+//// console.log(/*0*/"\\[[" + text + "](" + link + ")\\]"/*1*/)
+
+goTo.select("0", "1");
+edit.applyRefactor({
+    refactorName: "Convert to template string",
+    actionName: "Convert to template string",
+    actionDescription: ts.Diagnostics.Convert_to_template_string.message,
+    // Four backslashes here
+    //   = two backslashes in the expected file content
+    //   = one backslash in the string data sent to console.log
+    //     (which is the same as what the user started with)
+    newContent: 'console.log(`\\\\[[${text}](${link})\\\\]`)',
+});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #37330

String literal `text` should be transferred to template head/tail `text` without modification—it gets escaped in the printer.