### PR TITLE
Fix rename for type symbols imported as a different name

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -92,7 +92,11 @@ namespace ts {
         if (node.kind === SyntaxKind.SourceFile) {
             return SemanticMeaning.Value;
         }
-        else if (node.parent.kind === SyntaxKind.ExportAssignment || node.parent.kind === SyntaxKind.ExternalModuleReference) {
+        else if (node.parent.kind === SyntaxKind.ExportAssignment
+            || node.parent.kind === SyntaxKind.ExternalModuleReference
+            || node.parent.kind === SyntaxKind.ImportSpecifier
+            || node.parent.kind === SyntaxKind.ImportClause
+            || node.parent.kind === SyntaxKind.ImportEqualsDeclaration) {
             return SemanticMeaning.All;
         }
         else if (isInRightSideOfInternalImportEqualsDeclaration(node)) {

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -96,7 +96,7 @@ namespace ts {
             || node.parent.kind === SyntaxKind.ExternalModuleReference
             || node.parent.kind === SyntaxKind.ImportSpecifier
             || node.parent.kind === SyntaxKind.ImportClause
-            || node.parent.kind === SyntaxKind.ImportEqualsDeclaration) {
+            || isImportEqualsDeclaration(node.parent) && node === node.parent.name) {
             return SemanticMeaning.All;
         }
         else if (isInRightSideOfInternalImportEqualsDeclaration(node)) {

--- a/tests/baselines/reference/renameImportSpecifierPropertyName.baseline
+++ b/tests/baselines/reference/renameImportSpecifierPropertyName.baseline
@@ -1,0 +1,7 @@
+/*====== /tests/cases/fourslash/canada.ts ======*/
+
+export interface [|RENAME|] {}
+
+/*====== /tests/cases/fourslash/dry.ts ======*/
+
+import { RENAME as Ale } from './canada';

--- a/tests/cases/fourslash/renameImportSpecifierPropertyName.ts
+++ b/tests/cases/fourslash/renameImportSpecifierPropertyName.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: canada.ts
+////export interface /**/Ginger {}
+
+// @Filename: dry.ts
+////import { Ginger as Ale } from './canada';
+
+verify.baselineRename("", {});


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] There is an associated issue in the `Backlog` milestone (**required**)
* [ ] Code is up-to-date with the `master` branch
* [ ] You've successfully run `gulp runtests` locally
* [ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #37188 
